### PR TITLE
feat(org-lens): global project search in add-projects panel

### DIFF
--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -256,7 +256,7 @@ test.describe('Org Projects', () => {
   });
 
   test('keeps add-project search results ordered by the latest request', async ({ page }) => {
-    // Use a workspace that does NOT already contain kubernetes, so the Kubernetes search result is addable
+    // Use a workspace that does NOT already contain these results, so both are addable
     // (mapAddableOptions filters out projects already in the selected workspace).
     await gotoOrgProjectsPage(page, {
       workspaces: [DEFAULT_WORKSPACE, { id: 'custom', name: 'Custom Workspace', projectSlugs: ['existing'] }],
@@ -267,10 +267,15 @@ test.describe('Org Projects', () => {
       if (route.request().method() !== 'GET') return route.fallback();
       const url = new URL(route.request().url());
       const query = url.searchParams.get('q') ?? '';
-      if (!query) {
+      // On-open empty-query preload resolves instantly so the panel opens without waiting.
+      if (!query) return fulfillJson(route, { results: [] });
+      // The earlier, shorter query 'ku' is deliberately SLOW; the later 'kube' is fast, so the stale 'ku'
+      // response lands AFTER the latest one. Both results contain "kube" so PrimeNG's client-side filter
+      // keeps either visible — only the request-id guard, not client filtering, can drop the stale one.
+      if (query === 'ku') {
         await new Promise((resolve) => setTimeout(resolve, 2000));
         return fulfillJson(route, {
-          results: [{ slug: 'old-result', name: 'Old Result', logoUrl: '', foundation: { slug: 'old', name: 'Old', logoUrl: '' } }],
+          results: [{ slug: 'kube-stale', name: 'Kube Stale', logoUrl: '', foundation: { slug: 'old', name: 'Old', logoUrl: '' } }],
         });
       }
       return fulfillJson(route, {
@@ -279,22 +284,29 @@ test.describe('Org Projects', () => {
     });
 
     await expect(page.getByTestId('org-projects-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    // The dialog fires an on-open empty-query search; it's deliberately slow here. Wait for it to settle before
-    // opening the panel — clicking the multi-select while it's still loading doesn't open the overlay.
-    const onOpenSearch = page.waitForResponse((r) => /\/lens\/projects\/search/.test(r.url()) && r.request().method() === 'GET');
     await page.getByTestId('org-projects-add-project').click();
     await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
-    await onOpenSearch;
     // Single search affordance: no standalone search input in the dialog — search lives inside the multi-select's own filter.
     await expect(page.getByRole('dialog', { name: 'Add project(s)' }).getByRole('searchbox')).toHaveCount(0);
     await page.getByTestId('org-projects-add-projects-select').click();
     const filter = page.getByRole('searchbox', { name: 'Search and select projects' });
     await expect(filter).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    await filter.fill('ku');
 
-    await expect(page.getByText('Kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    await page.waitForTimeout(500);
-    await expect(page.getByText('Old Result')).toHaveCount(0);
+    // Fire the slow 'ku' request (waiting past the 300ms debounce so it actually dispatches and is in-flight),
+    // then refine to the fast 'kube' request while 'ku' is still pending — a genuine concurrent race.
+    await filter.fill('ku');
+    await page.waitForTimeout(400);
+    await filter.fill('kube');
+
+    // The fast 'kube' result renders first. Scope to the option list — the background projects table also
+    // has a "Kubernetes" row, so an unscoped getByText would be ambiguous.
+    const optionList = page.getByLabel('Option List');
+    await expect(optionList.getByText('Kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // Wait past the slow 'ku' response so a stale-invalidation regression would surface: its 'Kube Stale' row
+    // (which also matches the "kube" filter) must never replace the latest 'kube' results.
+    await page.waitForTimeout(2500);
+    await expect(optionList.getByText('Kube Stale')).toHaveCount(0);
+    await expect(optionList.getByText('Kubernetes')).toBeVisible();
   });
 
   test('shows add-project search and save failures without hiding the dialog', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -57,6 +57,7 @@ function noActivityProject(slug: string, name: string) {
     trend: { deltaPct: 0, technicalDeltaPct: 0, ecosystemDeltaPct: 0, direction: 'flat', series: [0, 0, 0, 0] },
     contributors: [],
     participants: [],
+    healthMetrics: [],
     noActivityYet: true,
   };
 }

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -288,7 +288,10 @@ test.describe('Org Projects', () => {
     await expect(page.getByTestId('org-projects-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await page.getByTestId('org-projects-add-project').click();
     await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
-    await expect(page.getByTestId('org-projects-add-projects-error')).toContainText('Could not load project matches', { timeout: DATA_LOAD_TIMEOUT });
+    // The search error now renders inside the body-appended select panel (as its empty message);
+    // recovery is by editing the search, not a Retry button.
+    await page.getByTestId('org-projects-add-projects-select').click();
+    await expect(page.getByText('Edit your search to try again')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await page.unroute(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/);
     await page.route(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/, (route) => {
@@ -297,8 +300,7 @@ test.describe('Org Projects', () => {
         results: [{ slug: 'kubernetes', name: 'Kubernetes', logoUrl: '', foundation: { slug: 'cncf', name: 'CNCF', logoUrl: '' } }],
       });
     });
-    await page.getByRole('button', { name: 'Retry' }).click();
-    await page.getByTestId('org-projects-add-projects-select').click();
+    await page.getByPlaceholder('Search and select projects').fill('ku');
     await page.getByLabel('Option List').getByText('Kubernetes').click();
     await page.keyboard.press('Escape');
 

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -256,7 +256,12 @@ test.describe('Org Projects', () => {
   });
 
   test('keeps add-project search results ordered by the latest request', async ({ page }) => {
-    await gotoOrgProjectsPage(page);
+    // Use a workspace that does NOT already contain kubernetes, so the Kubernetes search result is addable
+    // (mapAddableOptions filters out projects already in the selected workspace).
+    await gotoOrgProjectsPage(page, {
+      workspaces: [DEFAULT_WORKSPACE, { id: 'custom', name: 'Custom Workspace', projectSlugs: ['existing'] }],
+      url: `${ORG_PROJECTS_URL}?workspace=custom`,
+    });
     await page.unroute(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/);
     await page.route(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/, async (route) => {
       if (route.request().method() !== 'GET') return route.fallback();
@@ -274,12 +279,18 @@ test.describe('Org Projects', () => {
     });
 
     await expect(page.getByTestId('org-projects-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // The dialog fires an on-open empty-query search; it's deliberately slow here. Wait for it to settle before
+    // opening the panel — clicking the multi-select while it's still loading doesn't open the overlay.
+    const onOpenSearch = page.waitForResponse((r) => /\/lens\/projects\/search/.test(r.url()) && r.request().method() === 'GET');
     await page.getByTestId('org-projects-add-project').click();
     await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
+    await onOpenSearch;
     // Single search affordance: no standalone search input in the dialog — search lives inside the multi-select's own filter.
     await expect(page.getByRole('dialog', { name: 'Add project(s)' }).getByRole('searchbox')).toHaveCount(0);
     await page.getByTestId('org-projects-add-projects-select').click();
-    await page.getByPlaceholder('Search and select projects').fill('ku');
+    const filter = page.getByRole('searchbox', { name: 'Search and select projects' });
+    await expect(filter).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await filter.fill('ku');
 
     await expect(page.getByText('Kubernetes')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await page.waitForTimeout(500);
@@ -312,7 +323,7 @@ test.describe('Org Projects', () => {
         results: [{ slug: 'kubernetes', name: 'Kubernetes', logoUrl: '', foundation: { slug: 'cncf', name: 'CNCF', logoUrl: '' } }],
       });
     });
-    await page.getByPlaceholder('Search and select projects').fill('ku');
+    await page.getByRole('searchbox', { name: 'Search and select projects' }).fill('ku');
     await page.getByLabel('Option List').getByText('Kubernetes').click();
     await page.keyboard.press('Escape');
 
@@ -369,9 +380,44 @@ test.describe('Org Projects', () => {
     await page.getByTestId('org-projects-add-project').click();
     await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
     await page.getByTestId('org-projects-add-projects-select').click();
-    await page.getByPlaceholder('Search and select projects').fill('ku');
+    // Scope to the in-panel filter input by role — the host <lfx-multi-select> also carries the same placeholder.
+    await page.getByRole('searchbox', { name: 'Search and select projects' }).fill('ku');
 
-    await expect(page.getByText('Matching projects are already in this workspace.')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // The already-in-workspace status now renders in the always-visible panel footer, so a still-selected option
+    // matching the filter can't hide it (regression guard for the Bugbot "status hidden by selected options" bug).
+    await expect(page.getByTestId('multi-select-panel-status')).toHaveText('Matching projects are already in this workspace.');
+  });
+
+  test('keeps the panel status visible when a selected option still matches the filter', async ({ page }) => {
+    // Kubernetes must be addable (not already in the workspace) so it can be selected, so use a custom workspace.
+    await gotoOrgProjectsPage(page, {
+      workspaces: [DEFAULT_WORKSPACE, { id: 'custom', name: 'Custom Workspace', projectSlugs: ['existing'] }],
+      url: `${ORG_PROJECTS_URL}?workspace=custom`,
+    });
+    await page.unroute(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/);
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return fulfillJson(route, {
+        results: [{ slug: 'kubernetes', name: 'Kubernetes', logoUrl: '', foundation: { slug: 'cncf', name: 'CNCF', logoUrl: '' } }],
+      });
+    });
+
+    await expect(page.getByTestId('org-projects-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await page.getByTestId('org-projects-add-project').click();
+    await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
+    await page.getByTestId('org-projects-add-projects-select').click();
+
+    // Search, then select Kubernetes so it stays in the option list as a checked item.
+    const filter = page.getByRole('searchbox', { name: 'Search and select projects' });
+    await filter.fill('ku');
+    await page.getByLabel('Option List').getByText('Kubernetes').click();
+
+    // Drop below the min search length to a character the selected option still matches. The selected row keeps the
+    // list non-empty, but the min-length guidance must still show in the always-visible footer — the exact Bugbot
+    // "status hidden by selected options" regression this footer fixes.
+    await filter.fill('k');
+    await expect(page.getByTestId('multi-select-panel-status')).toHaveText('Type at least 2 characters to search projects.');
+    await expect(page.getByLabel('Option List').getByText('Kubernetes')).toBeVisible();
   });
 
   test('reloads the project table after adding projects to a workspace', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -50,6 +50,17 @@ function project(slug: string, name: string) {
   };
 }
 
+function noActivityProject(slug: string, name: string) {
+  return {
+    ...project(slug, name),
+    health: 'unavailable',
+    trend: { deltaPct: 0, technicalDeltaPct: 0, ecosystemDeltaPct: 0, direction: 'flat', series: [0, 0, 0, 0] },
+    contributors: [],
+    participants: [],
+    noActivityYet: true,
+  };
+}
+
 function projectsResponse(projects = [project('kubernetes', 'Kubernetes')]) {
   return {
     orgSlug: 'red-hat-llc',
@@ -314,6 +325,52 @@ test.describe('Org Projects', () => {
     await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
     await expect(page.getByTestId('org-projects-add-projects-save-error')).toContainText('Could not add the selected projects', { timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
+  });
+
+  test('renders no-activity rows as non-links with unavailable metrics', async ({ page }) => {
+    await stubOrgContext(page);
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects(?:\?.*)?$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return fulfillJson(route, projectsResponse([noActivityProject('kubernetes', 'Kubernetes')]));
+    });
+
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.goto(ORG_PROJECTS_URL, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    if (!page.url().includes('/org/projects')) {
+      test.skip(true, 'org-lens-enabled flag appears off — /org/projects redirected away');
+    }
+
+    const row = page.getByTestId('org-projects-row-kubernetes');
+    await expect(row).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // The "No activity yet" pill is shown and the project name is plain text (the detail page would 404).
+    await expect(page.getByTestId('org-projects-no-activity-kubernetes')).toBeVisible();
+    await expect(row.getByRole('link')).toHaveCount(0);
+    // Influence and trend read "Unavailable" instead of the misleading measured-looking fallbacks.
+    await expect(page.getByTestId('org-projects-trend-kubernetes')).toHaveText('Unavailable');
+    await expect(row.getByText('Unavailable').first()).toBeVisible();
+    // Contributor / participant counts are plain text (0), not links to the detail page.
+    await expect(page.getByTestId('org-projects-contributors-kubernetes')).toHaveText('0');
+    await expect(page.getByTestId('org-projects-participants-kubernetes')).toHaveText('0');
+  });
+
+  test('shows the already-in-workspace empty state when a search matches only existing projects', async ({ page }) => {
+    await gotoOrgProjectsPage(page);
+    await page.unroute(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/);
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/projects\/search(?:\?.*)?$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return fulfillJson(route, { results: [], hasMatchesAlreadyInWorkspace: true });
+    });
+
+    await expect(page.getByTestId('org-projects-table')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await page.getByTestId('org-projects-add-project').click();
+    await expect(page.getByRole('dialog', { name: 'Add project(s)' })).toBeVisible();
+    await page.getByTestId('org-projects-add-projects-select').click();
+    await page.getByPlaceholder('Search and select projects').fill('ku');
+
+    await expect(page.getByText('Matching projects are already in this workspace.')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
   test('reloads the project table after adding projects to a workspace', async ({ page }) => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -581,8 +581,9 @@
       [autofocusFilter]="true"
       scrollHeight="16rem"
       [loading]="addProjectsSearchLoading()"
-      [emptyMessage]="addProjectsPanelStatusMessage()"
-      [emptyFilterMessage]="addProjectsPanelStatusMessage()"
+      [emptyMessage]="addProjectsEmptyMessage()"
+      [emptyFilterMessage]="addProjectsEmptyMessage()"
+      [panelStatus]="addProjectsPanelStatus()"
       (filterChange)="onAddProjectsFilter($event)"
       data-testid="org-projects-add-projects-select" />
     @if (addProjectsSaveError()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -258,13 +258,21 @@
               <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'org-projects-row-' + project.slug">
                 <td>
                   <div class="flex items-center gap-2">
-                    <a
-                      [routerLink]="['/org/projects', project.slug]"
-                      class="flex items-center gap-2 text-left"
-                      [attr.aria-label]="'View ' + project.name + ' project detail'">
-                      <lfx-avatar [image]="project.logoUrl" [label]="project.name" shape="square" styleClass="w-7 h-7 text-xs" />
-                      <span class="text-sm font-medium text-blue-600 hover:underline">{{ project.name }}</span>
-                    </a>
+                    @if (project.noActivityYet) {
+                      <!-- No org-scoped row exists yet, so the project-detail page would 404 — render the name as plain text. -->
+                      <div class="flex items-center gap-2 text-left">
+                        <lfx-avatar [image]="project.logoUrl" [label]="project.name" shape="square" styleClass="w-7 h-7 text-xs" />
+                        <span class="text-sm font-medium text-gray-900">{{ project.name }}</span>
+                      </div>
+                    } @else {
+                      <a
+                        [routerLink]="['/org/projects', project.slug]"
+                        class="flex items-center gap-2 text-left"
+                        [attr.aria-label]="'View ' + project.name + ' project detail'">
+                        <lfx-avatar [image]="project.logoUrl" [label]="project.name" shape="square" styleClass="w-7 h-7 text-xs" />
+                        <span class="text-sm font-medium text-blue-600 hover:underline">{{ project.name }}</span>
+                      </a>
+                    }
                     @if (project.noActivityYet) {
                       <span
                         class="inline-flex items-center whitespace-nowrap rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500"
@@ -297,7 +305,7 @@
                       @for (bar of project.technicalBars; track bar.x) {
                         <rect [attr.x]="bar.x" [attr.y]="bar.y" [attr.width]="bar.w" [attr.height]="bar.h" rx="1" [class]="bar.colorClass"></rect>
                       }
-                      @if (project.technicalInfluence === 'non-lf') {
+                      @if (project.technicalInfluence === 'non-lf' && !project.noActivityYet) {
                         <line x1="0.5" y1="15.5" x2="15.5" y2="0.5" stroke-width="3.5" stroke-linecap="round" class="stroke-white"></line>
                         <line x1="1.5" y1="14.5" x2="14.5" y2="1.5" stroke-width="1.5" stroke-linecap="round" class="stroke-gray-400"></line>
                       }
@@ -311,7 +319,7 @@
                       @for (bar of project.ecosystemBars; track bar.x) {
                         <rect [attr.x]="bar.x" [attr.y]="bar.y" [attr.width]="bar.w" [attr.height]="bar.h" rx="1" [class]="bar.colorClass"></rect>
                       }
-                      @if (project.ecosystemInfluence === 'non-lf') {
+                      @if (project.ecosystemInfluence === 'non-lf' && !project.noActivityYet) {
                         <line x1="0.5" y1="15.5" x2="15.5" y2="0.5" stroke-width="3.5" stroke-linecap="round" class="stroke-white"></line>
                         <line x1="1.5" y1="14.5" x2="14.5" y2="1.5" stroke-width="1.5" stroke-linecap="round" class="stroke-gray-400"></line>
                       }
@@ -348,23 +356,35 @@
                   </div>
                 </td>
                 <td>
-                  <a
-                    [routerLink]="['/org/projects', project.slug]"
-                    [queryParams]="contributorsDrawerQueryParams"
-                    class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    [attr.aria-label]="project.contributorsAriaLabel"
-                    [attr.data-testid]="'org-projects-contributors-' + project.slug"
-                    >{{ project.contributors.length }}</a
-                  >
+                  @if (project.noActivityYet) {
+                    <span class="text-sm font-medium text-gray-900" [attr.data-testid]="'org-projects-contributors-' + project.slug">{{
+                      project.contributors.length
+                    }}</span>
+                  } @else {
+                    <a
+                      [routerLink]="['/org/projects', project.slug]"
+                      [queryParams]="contributorsDrawerQueryParams"
+                      class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      [attr.aria-label]="project.contributorsAriaLabel"
+                      [attr.data-testid]="'org-projects-contributors-' + project.slug"
+                      >{{ project.contributors.length }}</a
+                    >
+                  }
                 </td>
                 <td>
-                  <a
-                    [routerLink]="['/org/projects', project.slug]"
-                    class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                    [attr.aria-label]="project.participantsAriaLabel"
-                    [attr.data-testid]="'org-projects-participants-' + project.slug"
-                    >{{ project.participants.length }}</a
-                  >
+                  @if (project.noActivityYet) {
+                    <span class="text-sm font-medium text-gray-900" [attr.data-testid]="'org-projects-participants-' + project.slug">{{
+                      project.participants.length
+                    }}</span>
+                  } @else {
+                    <a
+                      [routerLink]="['/org/projects', project.slug]"
+                      class="rounded text-sm font-medium !text-gray-900 hover:!text-gray-900 hover:underline focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                      [attr.aria-label]="project.participantsAriaLabel"
+                      [attr.data-testid]="'org-projects-participants-' + project.slug"
+                      >{{ project.participants.length }}</a
+                    >
+                  }
                 </td>
                 <td class="text-right">
                   <lfx-button

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -257,13 +257,22 @@
             <ng-template #body let-project let-rowIndex="rowIndex">
               <tr [attr.data-row-index]="rowIndex" [attr.data-testid]="'org-projects-row-' + project.slug">
                 <td>
-                  <a
-                    [routerLink]="['/org/projects', project.slug]"
-                    class="flex items-center gap-2 text-left"
-                    [attr.aria-label]="'View ' + project.name + ' project detail'">
-                    <lfx-avatar [image]="project.logoUrl" [label]="project.name" shape="square" styleClass="w-7 h-7 text-xs" />
-                    <span class="text-sm font-medium text-blue-600 hover:underline">{{ project.name }}</span>
-                  </a>
+                  <div class="flex items-center gap-2">
+                    <a
+                      [routerLink]="['/org/projects', project.slug]"
+                      class="flex items-center gap-2 text-left"
+                      [attr.aria-label]="'View ' + project.name + ' project detail'">
+                      <lfx-avatar [image]="project.logoUrl" [label]="project.name" shape="square" styleClass="w-7 h-7 text-xs" />
+                      <span class="text-sm font-medium text-blue-600 hover:underline">{{ project.name }}</span>
+                    </a>
+                    @if (project.noActivityYet) {
+                      <span
+                        class="inline-flex items-center whitespace-nowrap rounded-full bg-gray-100 px-2 py-0.5 text-xs font-medium text-gray-500"
+                        [attr.data-testid]="'org-projects-no-activity-' + project.slug"
+                        >No activity yet</span
+                      >
+                    }
+                  </div>
                 </td>
                 <td>
                   <span
@@ -544,33 +553,14 @@
       placeholder="Search and select projects"
       styleClass="w-full"
       panelStyleClass="org-projects-add-projects-select-panel"
+      [matchTriggerWidth]="true"
+      [autofocusFilter]="true"
       scrollHeight="16rem"
+      [loading]="addProjectsSearchLoading()"
+      [emptyMessage]="addProjectsPanelStatusMessage()"
+      [emptyFilterMessage]="addProjectsPanelStatusMessage()"
       (filterChange)="onAddProjectsFilter($event)"
       data-testid="org-projects-add-projects-select" />
-    @if (addProjectsSearchLoading()) {
-      <div class="flex items-center gap-2 text-sm text-gray-500" data-testid="org-projects-add-projects-loading">
-        <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
-        <span>Searching projects…</span>
-      </div>
-    } @else if (addProjectsSearchError()) {
-      <div class="flex items-center justify-between gap-3 rounded-md border border-amber-200 bg-amber-50 p-3" data-testid="org-projects-add-projects-error">
-        <div class="flex items-start gap-2 text-sm text-amber-800">
-          <i class="fa-light fa-triangle-exclamation mt-0.5" aria-hidden="true"></i>
-          <span>Could not load project matches. Try again.</span>
-        </div>
-        <lfx-button
-          label="Retry"
-          icon="fa-light fa-rotate-right"
-          severity="secondary"
-          [outlined]="true"
-          size="small"
-          (onClick)="retryAddableProjectsSearch()" />
-      </div>
-    } @else if (addableProjectOptions().length === 0 && selectedAddProjectCount() === 0) {
-      <div class="rounded-md border border-gray-200 bg-gray-50 p-3 text-sm text-gray-600" data-testid="org-projects-add-projects-empty">
-        {{ addProjectsSearchEmptyTitle() }}
-      </div>
-    }
     @if (addProjectsSaveError()) {
       <div
         class="flex items-start gap-2 rounded-md border border-amber-200 bg-amber-50 p-3 text-sm text-amber-800"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -328,32 +328,36 @@
                   </span>
                 </td>
                 <td>
-                  <div class="flex flex-col items-start gap-1.5">
-                    <span
-                      class="block h-8 w-20 cursor-help rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
-                      tabindex="0"
-                      role="img"
-                      [attr.aria-label]="project.trendAriaLabel"
-                      [pTooltip]="project.trendTooltipHtml"
-                      [escape]="false"
-                      tooltipPosition="top"
-                      tooltipStyleClass="lfx-tooltip-trend"
-                      [attr.data-testid]="'org-projects-trend-' + project.slug">
-                      <lfx-chart type="line" [data]="project.sparklineDataset" [options]="sparklineOptions" height="32px" width="80px" />
-                    </span>
-                    @if (project.showTrendArrow) {
-                      <span class="inline-flex items-center gap-1.5 text-xs" [attr.data-testid]="'org-projects-trend-delta-' + project.slug">
-                        <span class="inline-flex h-[18px] w-[18px] items-center justify-center rounded-full" [class]="project.trendArrowBadgeClass">
-                          <i [class]="project.trendArrowIcon" aria-hidden="true"></i>
-                        </span>
-                        <span class="font-semibold" [class]="project.trendDeltaTextClass">{{ project.trendDeltaLabel }}</span>
+                  @if (project.noActivityYet) {
+                    <span class="text-sm text-gray-500" [attr.data-testid]="'org-projects-trend-' + project.slug">{{ metricUnavailableLabel }}</span>
+                  } @else {
+                    <div class="flex flex-col items-start gap-1.5">
+                      <span
+                        class="block h-8 w-20 cursor-help rounded focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
+                        tabindex="0"
+                        role="img"
+                        [attr.aria-label]="project.trendAriaLabel"
+                        [pTooltip]="project.trendTooltipHtml"
+                        [escape]="false"
+                        tooltipPosition="top"
+                        tooltipStyleClass="lfx-tooltip-trend"
+                        [attr.data-testid]="'org-projects-trend-' + project.slug">
+                        <lfx-chart type="line" [data]="project.sparklineDataset" [options]="sparklineOptions" height="32px" width="80px" />
                       </span>
-                    } @else {
-                      <span class="text-xs font-semibold text-gray-500" [attr.data-testid]="'org-projects-trend-delta-' + project.slug">{{
-                        project.trendDeltaLabel
-                      }}</span>
-                    }
-                  </div>
+                      @if (project.showTrendArrow) {
+                        <span class="inline-flex items-center gap-1.5 text-xs" [attr.data-testid]="'org-projects-trend-delta-' + project.slug">
+                          <span class="inline-flex h-[18px] w-[18px] items-center justify-center rounded-full" [class]="project.trendArrowBadgeClass">
+                            <i [class]="project.trendArrowIcon" aria-hidden="true"></i>
+                          </span>
+                          <span class="font-semibold" [class]="project.trendDeltaTextClass">{{ project.trendDeltaLabel }}</span>
+                        </span>
+                      } @else {
+                        <span class="text-xs font-semibold text-gray-500" [attr.data-testid]="'org-projects-trend-delta-' + project.slug">{{
+                          project.trendDeltaLabel
+                        }}</span>
+                      }
+                    </div>
+                  }
                 </td>
                 <td>
                   @if (project.noActivityYet) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.scss
@@ -3,8 +3,30 @@
 
 ::ng-deep {
   .p-multiselect-overlay.org-projects-add-projects-select-panel {
+    // The panel width is pinned to the trigger at runtime by MultiSelectComponent (matchTriggerWidth),
+    // because PrimeNG 20 does not size a body-appended overlay to its trigger. This just caps it to the
+    // viewport as a safety net and truncates long option labels so they can't spill past that width.
+    max-width: calc(100vw - 2rem);
+
     .p-multiselect-list-container {
       height: 16rem;
+    }
+
+    // Truncate a long option label to a single ellipsised line rather than overflowing the pinned width.
+    .p-multiselect-option {
+      overflow: hidden;
+
+      // The custom item template nests flex containers; let each level shrink so the text can ellipsis.
+      .flex {
+        min-width: 0;
+      }
+
+      span {
+        display: block;
+        overflow: hidden;
+        text-overflow: ellipsis;
+        white-space: nowrap;
+      }
     }
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -588,18 +588,20 @@ export class OrgProjectsComponent {
     // Flip loading synchronously (ahead of the 300ms debounce) when a search will actually run, so the panel
     // shows "Searching…" rather than PrimeNG's instantly-emptied list flashing a false "No projects match".
     const trimmed = query.trim();
-    if (this.accountContext.selectedAccount()?.uid && !(trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH)) {
-      this.addProjectsSearchLoading.set(true);
-    }
+    const shouldSearch = !!this.accountContext.selectedAccount()?.uid && !(trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH);
+    this.addProjectsSearchLoading.set(shouldSearch);
     this.searchAddableProjects(query);
   }
 
   protected searchAddableProjects(query: string): void {
+    // Advance the request token now (not after the debounce) so any in-flight response is immediately stale
+    // and cannot repopulate options or clear the loading flag late, re-flashing the false empty state.
+    const requestId = ++this.addableProjectsSearchRequestId;
     if (this.addableProjectsSearchDebounceTimer) {
       clearTimeout(this.addableProjectsSearchDebounceTimer);
     }
     this.addableProjectsSearchDebounceTimer = setTimeout(() => {
-      void this.runAddableProjectsSearch(query);
+      void this.runAddableProjectsSearch(query, requestId);
     }, 300);
   }
 
@@ -620,10 +622,9 @@ export class OrgProjectsComponent {
     return `${sign}${body}%`;
   }
 
-  private async runAddableProjectsSearch(query: string): Promise<void> {
+  private async runAddableProjectsSearch(query: string, requestId = ++this.addableProjectsSearchRequestId): Promise<void> {
     const account = this.accountContext.selectedAccount();
     const trimmed = query.trim();
-    const requestId = ++this.addableProjectsSearchRequestId;
     if (!account?.uid || (trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH)) {
       this.addableProjectOptions.set([]);
       this.addProjectsSearchError.set(false);
@@ -961,6 +962,12 @@ export class OrgProjectsComponent {
         return availability;
       }
     }
+    if (field === 'technicalInfluence' || field === 'ecosystemInfluence') {
+      const availability = this.compareInfluenceAvailability(a, b);
+      if (availability !== 0) {
+        return availability;
+      }
+    }
     const primary = this.compareByField(a, b, field);
     const directed = dir === 'asc' ? primary : -primary;
     if (directed !== 0) {
@@ -994,6 +1001,17 @@ export class OrgProjectsComponent {
 
   private normalizeHealth(health: HealthScore): HealthScore {
     return Object.prototype.hasOwnProperty.call(HEALTH_SCORE_BADGE, health) ? health : 'unavailable';
+  }
+
+  // No-activity rows have no measured influence (bands shown as "Unavailable"); keep them after measured
+  // rows regardless of sort direction, mirroring how health availability sinks unavailable rows.
+  private compareInfluenceAvailability(a: OrgLensProject, b: OrgLensProject): number {
+    const aUnavailable = a.noActivityYet ?? false;
+    const bUnavailable = b.noActivityYet ?? false;
+    if (aUnavailable === bUnavailable) {
+      return 0;
+    }
+    return aUnavailable ? 1 : -1;
   }
 
   private compareHealthAvailability(a: OrgLensProject['health'], b: OrgLensProject['health']): number {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -218,9 +218,12 @@ export class OrgProjectsComponent {
   protected readonly addProjectSelectOptions = computed(() =>
     this.mergeAddableOptions([...this.selectedAddableProjectOptions(), ...this.addableProjectOptions()])
   );
-  protected readonly addProjectsSearchEmptyTitle = computed(() => this.initAddProjectsSearchEmptyTitle());
-  /** Search status shown INSIDE the body-appended panel (as its empty message), not below the trigger where the open dropdown would cover it. */
-  protected readonly addProjectsPanelStatusMessage = computed(() => {
+  /**
+   * Always-visible panel status (searching / load error / all-matches-already-added / min-length). Rendered in the
+   * multi-select FOOTER, which shows regardless of list emptiness — so a still-selected option matching the filter
+   * can't keep the list non-empty and swallow the status (returns undefined when there's nothing to say).
+   */
+  protected readonly addProjectsPanelStatus = computed<string | undefined>(() => {
     if (this.addProjectsSearchLoading()) {
       return 'Searching projects…';
     }
@@ -232,7 +235,21 @@ export class OrgProjectsComponent {
     if (this.addProjectsMatchesAlreadyInWorkspace() && this.addableProjectOptions().length === 0) {
       return 'Matching projects are already in this workspace.';
     }
-    return this.addProjectsSearchEmptyTitle();
+    const query = this.addProjectsSearchQuery().trim();
+    if (query.length > 0 && query.length < ORG_PROJECTS_SEARCH_MIN_LENGTH) {
+      return `Type at least ${ORG_PROJECTS_SEARCH_MIN_LENGTH} characters to search projects.`;
+    }
+    return undefined;
+  });
+  /**
+   * Plain empty-list title for PrimeNG's emptyMessage/emptyFilterMessage. Blank while an always-visible status is
+   * active so the footer status isn't duplicated in the empty body; otherwise the ordinary "no matches" copy.
+   */
+  protected readonly addProjectsEmptyMessage = computed(() => {
+    if (this.addProjectsPanelStatus()) {
+      return '';
+    }
+    return this.addProjectsSearchQuery().trim() ? 'No projects match your search.' : 'No projects available to add.';
   });
   protected readonly tableEmptyState = computed<OrgProjectsEmptyState>(() => this.initTableEmptyState());
   protected readonly canDeleteEditingWorkspace = computed(() => {
@@ -594,8 +611,7 @@ export class OrgProjectsComponent {
     this.addProjectsSearchLoading.set(shouldSearch);
     if (!shouldSearch) {
       // Clear stale error / already-in-workspace flags AND the previous query's options now (not after the
-      // debounce). The status copy only renders when the option list is empty, so leaving stale options lets
-      // PrimeNG client-filter them and hides the "type at least N characters" guidance below the min length.
+      // debounce), so below the min length the panel doesn't keep offering stale search hits as pickable rows.
       this.addableProjectOptions.set([]);
       this.addProjectsSearchError.set(false);
       this.addProjectsMatchesAlreadyInWorkspace.set(false);
@@ -871,14 +887,6 @@ export class OrgProjectsComponent {
     if (this.error()) return 'Resolve the loading error first';
     if (!this.selectedWorkspace()) return 'No workspace is selected';
     return undefined;
-  }
-
-  private initAddProjectsSearchEmptyTitle(): string {
-    const query = this.addProjectsSearchQuery().trim();
-    if (query.length > 0 && query.length < ORG_PROJECTS_SEARCH_MIN_LENGTH) {
-      return `Type at least ${ORG_PROJECTS_SEARCH_MIN_LENGTH} characters to search projects.`;
-    }
-    return query ? 'No projects match your search.' : 'No projects available to add.';
   }
 
   private initTableEmptyState(): OrgProjectsEmptyState {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -23,6 +23,7 @@ import {
   INFLUENCE_TREND_COLOR,
   INFLUENCE_TREND_TEXT_CLASS,
   ORG_PROJECTS_ALL_FOUNDATIONS_FILTER,
+  ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL,
   ORG_PROJECTS_PAGE_SIZE_OPTIONS,
   ORG_PROJECTS_SEARCH_MIN_LENGTH,
   PD_CONTRIBUTORS_CARD_KEY,
@@ -507,8 +508,8 @@ export class OrgProjectsComponent {
     const body = rows.map((p) => [
       p.name,
       HEALTH_SCORE_LABELS[this.normalizeHealth(p.health)],
-      INFLUENCE_BAND_LABELS[p.technicalInfluence],
-      INFLUENCE_BAND_LABELS[p.ecosystemInfluence],
+      p.noActivityYet ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[p.technicalInfluence],
+      p.noActivityYet ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[p.ecosystemInfluence],
       p.trend.deltaPct,
       p.contributors.length,
       p.participants.length,
@@ -584,6 +585,12 @@ export class OrgProjectsComponent {
   /** The "Add project(s)" multi-select filter box drives the debounced server-side project search. */
   protected onAddProjectsFilter(query: string): void {
     this.addProjectsSearchQuery.set(query);
+    // Flip loading synchronously (ahead of the 300ms debounce) when a search will actually run, so the panel
+    // shows "Searching…" rather than PrimeNG's instantly-emptied list flashing a false "No projects match".
+    const trimmed = query.trim();
+    if (this.accountContext.selectedAccount()?.uid && !(trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH)) {
+      this.addProjectsSearchLoading.set(true);
+    }
     this.searchAddableProjects(query);
   }
 
@@ -753,10 +760,12 @@ export class OrgProjectsComponent {
       this.sortedProjects().map((project) => ({
         ...project,
         insightsUrl: buildInsightsUrl(`/project/${project.slug}`),
-        technicalBars: this.bandBars(project.technicalInfluence),
-        ecosystemBars: this.bandBars(project.ecosystemInfluence),
-        technicalBandLabel: INFLUENCE_BAND_LABELS[project.technicalInfluence],
-        ecosystemBandLabel: INFLUENCE_BAND_LABELS[project.ecosystemInfluence],
+        // No-activity rows have no org-scoped influence data; render neutral (no bars, "Unavailable") rather
+        // than mapProject's active-row fallbacks, which would misreport "Silent" / "Non-LF Project".
+        technicalBars: project.noActivityYet ? [] : this.bandBars(project.technicalInfluence),
+        ecosystemBars: project.noActivityYet ? [] : this.bandBars(project.ecosystemInfluence),
+        technicalBandLabel: project.noActivityYet ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[project.technicalInfluence],
+        ecosystemBandLabel: project.noActivityYet ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[project.ecosystemInfluence],
         healthLabel: HEALTH_SCORE_LABELS[this.normalizeHealth(project.health)],
         healthBadge: HEALTH_SCORE_BADGE[this.normalizeHealth(project.health)],
         sparklineDataset: {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -146,6 +146,8 @@ export class OrgProjectsComponent {
   protected readonly error = computed(() => this.workspaceError() || this.projectsError());
   protected readonly addProjectsSearchLoading = signal(false);
   protected readonly addProjectsSearchError = signal(false);
+  /** True when the last search matched only projects already in the workspace (so the empty panel can say so). */
+  protected readonly addProjectsMatchesAlreadyInWorkspace = signal(false);
   protected readonly addProjectsSaving = signal(false);
   protected readonly addProjectsSaveError = signal(false);
   protected readonly workspaceNameError = signal<string | null>(null);
@@ -214,6 +216,21 @@ export class OrgProjectsComponent {
     this.mergeAddableOptions([...this.selectedAddableProjectOptions(), ...this.addableProjectOptions()])
   );
   protected readonly addProjectsSearchEmptyTitle = computed(() => this.initAddProjectsSearchEmptyTitle());
+  /** Search status shown INSIDE the body-appended panel (as its empty message), not below the trigger where the open dropdown would cover it. */
+  protected readonly addProjectsPanelStatusMessage = computed(() => {
+    if (this.addProjectsSearchLoading()) {
+      return 'Searching projects…';
+    }
+    if (this.addProjectsSearchError()) {
+      return 'Couldn’t load matches. Edit your search to try again.';
+    }
+    // The query DID match, but every match is already in this workspace — say so rather than the
+    // misleading "No projects match your search." (only reachable when there are no addable results).
+    if (this.addProjectsMatchesAlreadyInWorkspace() && this.addableProjectOptions().length === 0) {
+      return 'Matching projects are already in this workspace.';
+    }
+    return this.addProjectsSearchEmptyTitle();
+  });
   protected readonly tableEmptyState = computed<OrgProjectsEmptyState>(() => this.initTableEmptyState());
   protected readonly canDeleteEditingWorkspace = computed(() => {
     const editing = this.editingWorkspace();
@@ -321,6 +338,7 @@ export class OrgProjectsComponent {
     this.addableProjectOptions.set([]);
     this.selectedAddableProjectOptions.set([]);
     this.addProjectsSearchError.set(false);
+    this.addProjectsMatchesAlreadyInWorkspace.set(false);
     this.addProjectsSaveError.set(false);
     this.addProjectsDialogOpen.set(true);
     void this.runAddableProjectsSearch('');
@@ -334,10 +352,6 @@ export class OrgProjectsComponent {
     } else if (action === 'retry') {
       this.retry();
     }
-  }
-
-  protected retryAddableProjectsSearch(): void {
-    void this.runAddableProjectsSearch(this.addProjectsSearchQuery());
   }
 
   protected async confirmAddProjects(): Promise<void> {
@@ -606,6 +620,7 @@ export class OrgProjectsComponent {
     if (!account?.uid || (trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH)) {
       this.addableProjectOptions.set([]);
       this.addProjectsSearchError.set(false);
+      this.addProjectsMatchesAlreadyInWorkspace.set(false);
       this.addProjectsSearchLoading.set(false);
       return;
     }
@@ -619,17 +634,19 @@ export class OrgProjectsComponent {
       // trimmed but the client did not, a stray leading/trailing space would let the client hide rows
       // the API already returned, leaving the panel misleadingly empty. `trimmed` is used only for the
       // min-length gate above.
-      const { results } = await firstValueFrom(this.projectsService.searchProjects(account.uid, query, excludeSlugs));
+      const { results, hasMatchesAlreadyInWorkspace } = await firstValueFrom(this.projectsService.searchProjects(account.uid, query, excludeSlugs));
       if (requestId !== this.addableProjectsSearchRequestId) {
         return;
       }
       this.addableProjectOptions.set(this.mapAddableOptions(results));
+      this.addProjectsMatchesAlreadyInWorkspace.set(hasMatchesAlreadyInWorkspace ?? false);
     } catch (err) {
       if (requestId !== this.addableProjectsSearchRequestId) {
         return;
       }
       console.error('Failed to search addable org projects', err);
       this.addableProjectOptions.set([]);
+      this.addProjectsMatchesAlreadyInWorkspace.set(false);
       this.addProjectsSearchError.set(true);
     } finally {
       if (requestId === this.addableProjectsSearchRequestId) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -593,8 +593,10 @@ export class OrgProjectsComponent {
     const shouldSearch = !!this.accountContext.selectedAccount()?.uid && !(trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH);
     this.addProjectsSearchLoading.set(shouldSearch);
     if (!shouldSearch) {
-      // Clear stale error / already-in-workspace flags now (not after the debounce) so the panel falls through
-      // to the "type more characters" guidance instead of showing the previous query's status.
+      // Clear stale error / already-in-workspace flags AND the previous query's options now (not after the
+      // debounce). The status copy only renders when the option list is empty, so leaving stale options lets
+      // PrimeNG client-filter them and hides the "type at least N characters" guidance below the min length.
+      this.addableProjectOptions.set([]);
       this.addProjectsSearchError.set(false);
       this.addProjectsMatchesAlreadyInWorkspace.set(false);
     }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -109,6 +109,8 @@ export class OrgProjectsComponent {
   // Configuration
   protected readonly pageSizeOptions = [...ORG_PROJECTS_PAGE_SIZE_OPTIONS];
   protected readonly contributorsDrawerQueryParams: Record<string, string> = { [PD_DRAWER_QUERY_PARAM]: PD_CONTRIBUTORS_CARD_KEY };
+  /** Label for metrics a "no activity yet" row cannot report (influence, trend). */
+  protected readonly metricUnavailableLabel = ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL;
   // Static explanatory hover for the Technical / Ecosystem influence column headers.
   protected readonly influenceColumnTooltipHtml = `<ul class="flex list-disc flex-col gap-1.5 pl-4 text-left"><li>Technical influence examines code activities (commits, PRs) while ecosystem influence examines non-code collaboration activities (documentation, committees, meetings, events).</li><li>Comparing our company's share of these activities to the project total indicates greater influence in the project.</li></ul>`;
   // Minimal Chart.js line config for the Influence Trend sparkline (no axes, points, legend, or tooltip).
@@ -510,7 +512,7 @@ export class OrgProjectsComponent {
       HEALTH_SCORE_LABELS[this.normalizeHealth(p.health)],
       p.noActivityYet ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[p.technicalInfluence],
       p.noActivityYet ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : INFLUENCE_BAND_LABELS[p.ecosystemInfluence],
-      p.trend.deltaPct,
+      p.noActivityYet ? ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL : p.trend.deltaPct,
       p.contributors.length,
       p.participants.length,
     ]);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -592,6 +592,12 @@ export class OrgProjectsComponent {
     const trimmed = query.trim();
     const shouldSearch = !!this.accountContext.selectedAccount()?.uid && !(trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH);
     this.addProjectsSearchLoading.set(shouldSearch);
+    if (!shouldSearch) {
+      // Clear stale error / already-in-workspace flags now (not after the debounce) so the panel falls through
+      // to the "type more characters" guidance instead of showing the previous query's status.
+      this.addProjectsSearchError.set(false);
+      this.addProjectsMatchesAlreadyInWorkspace.set(false);
+    }
     this.searchAddableProjects(query);
   }
 
@@ -964,7 +970,7 @@ export class OrgProjectsComponent {
         return availability;
       }
     }
-    if (field === 'technicalInfluence' || field === 'ecosystemInfluence') {
+    if (field === 'technicalInfluence' || field === 'ecosystemInfluence' || field === 'influenceTrend') {
       const availability = this.compareInfluenceAvailability(a, b);
       if (availability !== 0) {
         return availability;
@@ -1005,8 +1011,8 @@ export class OrgProjectsComponent {
     return Object.prototype.hasOwnProperty.call(HEALTH_SCORE_BADGE, health) ? health : 'unavailable';
   }
 
-  // No-activity rows have no measured influence (bands shown as "Unavailable"); keep them after measured
-  // rows regardless of sort direction, mirroring how health availability sinks unavailable rows.
+  // No-activity rows have no measured influence or trend (both shown as "Unavailable"); keep them after
+  // measured rows regardless of sort direction, mirroring how health availability sinks unavailable rows.
   private compareInfluenceAvailability(a: OrgLensProject, b: OrgLensProject): number {
     const aUnavailable = a.noActivityYet ?? false;
     const bUnavailable = b.noActivityYet ?? false;

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
@@ -25,6 +25,12 @@
     (onFilter)="filterChange.emit($event.filter ?? '')"
     (onPanelShow)="onPanelShow()"
     class="w-full">
+    @if (panelStatus(); as status) {
+      <!-- Footer renders regardless of whether the option list is empty, so a selected option matching the filter can't hide the status. -->
+      <ng-template #footer>
+        <div class="border-t border-gray-100 px-3 py-2 text-center text-sm text-gray-500" data-testid="multi-select-panel-status">{{ status }}</div>
+      </ng-template>
+    }
     @if (optionSubLabel() || optionImage()) {
       <ng-template let-option pTemplate="item">
         <div class="flex items-center gap-2">

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
@@ -28,7 +28,14 @@
     @if (panelStatus(); as status) {
       <!-- Footer renders regardless of whether the option list is empty, so a selected option matching the filter can't hide the status. -->
       <ng-template #footer>
-        <div class="border-t border-gray-100 px-3 py-2 text-center text-sm text-gray-500" data-testid="multi-select-panel-status">{{ status }}</div>
+        <!-- role="status" (aria-live polite) so screen readers announce searching / error / min-length changes. -->
+        <div
+          class="border-t border-gray-100 px-3 py-2 text-center text-sm text-gray-500"
+          role="status"
+          aria-live="polite"
+          data-testid="multi-select-panel-status">
+          {{ status }}
+        </div>
       </ng-template>
     }
     @if (optionSubLabel() || optionImage()) {

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
@@ -11,6 +11,7 @@
     [showToggleAll]="showToggleAll()"
     [appendTo]="appendTo()"
     [filter]="filter()"
+    [autofocusFilter]="autofocusFilter()"
     [resetFilterOnHide]="resetFilterOnHide()"
     [filterBy]="filterBy()"
     [filterPlaceHolder]="filterPlaceHolder()"
@@ -18,7 +19,11 @@
     [styleClass]="styleClass()"
     [panelStyleClass]="panelStyleClass()"
     [scrollHeight]="scrollHeight()"
+    [loading]="loading()"
+    [emptyMessage]="emptyMessage() ?? ''"
+    [emptyFilterMessage]="emptyFilterMessage() ?? ''"
     (onFilter)="filterChange.emit($event.filter ?? '')"
+    (onPanelShow)="onPanelShow()"
     class="w-full">
     @if (optionSubLabel() || optionImage()) {
       <ng-template let-option pTemplate="item">

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
@@ -20,8 +20,8 @@
     [panelStyleClass]="panelStyleClass()"
     [scrollHeight]="scrollHeight()"
     [loading]="loading()"
-    [emptyMessage]="emptyMessage() ?? ''"
-    [emptyFilterMessage]="emptyFilterMessage() ?? ''"
+    [emptyMessage]="emptyMessage()"
+    [emptyFilterMessage]="emptyFilterMessage()"
     (onFilter)="filterChange.emit($event.filter ?? '')"
     (onPanelShow)="onPanelShow()"
     class="w-full">

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input, output } from '@angular/core';
+import { Component, ElementRef, inject, input, output } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectModule } from 'primeng/multiselect';
 
@@ -12,6 +12,8 @@ import { MultiSelectModule } from 'primeng/multiselect';
   styleUrl: './multi-select.component.scss',
 })
 export class MultiSelectComponent {
+  private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+
   public readonly form = input.required<FormGroup>();
   public readonly control = input.required<string>();
   public readonly options = input.required<any[]>();
@@ -23,6 +25,8 @@ export class MultiSelectComponent {
   public readonly showToggleAll = input<boolean>(true);
   public readonly appendTo = input<any>('body');
   public readonly filter = input<boolean>(true);
+  /** Focus the in-panel filter input as soon as the overlay opens (PrimeNG defaults this to false). */
+  public readonly autofocusFilter = input<boolean>(false);
   /** Clear the filter box when the overlay hides so a reopened panel never shows stale filter text. */
   public readonly resetFilterOnHide = input<boolean>(false);
   public readonly filterBy = input<string | undefined>(undefined);
@@ -31,5 +35,39 @@ export class MultiSelectComponent {
   public readonly styleClass = input<string>('w-full');
   public readonly panelStyleClass = input<string | undefined>(undefined);
   public readonly scrollHeight = input<string>('14rem');
+  /** Show a spinner on the trigger while an async (e.g. server-side) option load is in flight. */
+  public readonly loading = input<boolean>(false);
+  /** Message shown INSIDE the panel when there are no options and no active filter — kept in-panel so the body-appended overlay never floats over it. */
+  public readonly emptyMessage = input<string | undefined>(undefined);
+  /** Message rendered INSIDE the panel when the active filter matches no options. */
+  public readonly emptyFilterMessage = input<string | undefined>(undefined);
+  /**
+   * Pin the body-appended overlay panel to the trigger's width. PrimeNG 20 doesn't size a body-appended MultiSelect
+   * overlay to its trigger (long labels/CSS floors mis-size it), so when true it's measured against the trigger and matched on each open.
+   */
+  public readonly matchTriggerWidth = input<boolean>(false);
   public readonly filterChange = output<string>();
+
+  /** On panel open, match the body-appended overlay's width to the trigger (opt-in). */
+  protected onPanelShow(): void {
+    if (!this.matchTriggerWidth()) {
+      return;
+    }
+
+    const trigger = this.host.nativeElement.querySelector<HTMLElement>('.p-multiselect');
+    const panelClass = this.panelStyleClass()?.trim().split(/\s+/)[0];
+    if (!trigger || !panelClass) {
+      return;
+    }
+
+    const width = trigger.getBoundingClientRect().width;
+    // The overlay is appended to <body>, so reach it via its unique panel class rather than a
+    // descendant query. Set on the next frame so the overlay element is in the DOM and laid out.
+    requestAnimationFrame(() => {
+      const panel = document.querySelector<HTMLElement>(`.p-multiselect-overlay.${panelClass}`);
+      if (panel && width > 0) {
+        panel.style.width = `${Math.round(width)}px`;
+      }
+    });
+  }
 }

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
@@ -40,9 +40,9 @@ export class MultiSelectComponent {
   /** Show a spinner on the trigger while an async (e.g. server-side) option load is in flight. */
   public readonly loading = input<boolean>(false);
   /** Message shown INSIDE the panel when there are no options and no active filter — kept in-panel so the body-appended overlay never floats over it. */
-  public readonly emptyMessage = input<string | undefined>(undefined);
+  public readonly emptyMessage = input<string>('No results found');
   /** Message rendered INSIDE the panel when the active filter matches no options. */
-  public readonly emptyFilterMessage = input<string | undefined>(undefined);
+  public readonly emptyFilterMessage = input<string>('No results found');
   /**
    * Pin the body-appended overlay panel to the trigger's width. PrimeNG 20 doesn't size a body-appended MultiSelect
    * overlay to its trigger (long labels/CSS floors mis-size it), so when true it's measured against the trigger and matched on each open.

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, ElementRef, inject, input, output } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, ElementRef, inject, input, output, PLATFORM_ID } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectModule } from 'primeng/multiselect';
 
@@ -13,6 +14,7 @@ import { MultiSelectModule } from 'primeng/multiselect';
 })
 export class MultiSelectComponent {
   private readonly host = inject<ElementRef<HTMLElement>>(ElementRef);
+  private readonly platformId = inject(PLATFORM_ID);
 
   public readonly form = input.required<FormGroup>();
   public readonly control = input.required<string>();
@@ -48,9 +50,9 @@ export class MultiSelectComponent {
   public readonly matchTriggerWidth = input<boolean>(false);
   public readonly filterChange = output<string>();
 
-  /** On panel open, match the body-appended overlay's width to the trigger (opt-in). */
+  /** On panel open, match the body-appended overlay's width to the trigger (opt-in). Browser-only (touches document/rAF). */
   protected onPanelShow(): void {
-    if (!this.matchTriggerWidth()) {
+    if (!this.matchTriggerWidth() || !isPlatformBrowser(this.platformId)) {
       return;
     }
 

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
@@ -72,6 +72,8 @@ export class MultiSelectComponent {
     const width = trigger.getBoundingClientRect().width;
     // The overlay is appended to <body>, so reach it via its unique panel class rather than a
     // descendant query. Set on the next frame so the overlay element is in the DOM and laid out.
+    // Assumes a given panelStyleClass identifies a single open overlay at a time — if two instances
+    // sharing the class were open simultaneously this would match the first one; callers keep the class unique.
     requestAnimationFrame(() => {
       const panel = document.querySelector<HTMLElement>(`.p-multiselect-overlay.${panelClass}`);
       if (panel && width > 0) {

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
@@ -44,6 +44,13 @@ export class MultiSelectComponent {
   /** Message rendered INSIDE the panel when the active filter matches no options. */
   public readonly emptyFilterMessage = input<string>('No results found');
   /**
+   * Always-visible status banner rendered in the panel FOOTER (e.g. searching / load error / min-length hint).
+   * Unlike emptyMessage/emptyFilterMessage — which PrimeNG only renders when the option list is empty — the footer
+   * shows regardless, so a still-selected option that matches the active filter can't keep the list non-empty and
+   * hide the status. Leave undefined for no banner.
+   */
+  public readonly panelStatus = input<string | undefined>(undefined);
+  /**
    * Pin the body-appended overlay panel to the trigger's width. PrimeNG 20 doesn't size a body-appended MultiSelect
    * overlay to its trigger (long labels/CSS floors mis-size it), so when true it's measured against the trigger and matched on each open.
    */

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -355,7 +355,12 @@ export class OrgLensProjectsService {
     // "no activity yet" row from the onboarded catalog instead of dropping it. Only for requested slugs, not the preload.
     const [peopleRows, noActivityProjects] = await Promise.all([
       projectSlugs.length ? this.fetchPeopleRows(accountId, projectSlugs) : Promise.resolve([]),
-      this.fetchNoActivityProjects(slugs, projectSlugs),
+      // No-activity hydration is a soft enhancement over the onboarded catalog (which may be mid-migration or
+      // absent); never let its failure fail the whole response — degrade to activity rows only, as before.
+      this.fetchNoActivityProjects(slugs, projectSlugs).catch((err) => {
+        console.error('Failed to hydrate no-activity org projects; returning activity rows only', err);
+        return [] as OrgLensProject[];
+      }),
     ]);
 
     return {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -68,6 +68,9 @@ export class OrgLensProjectsService {
     return response;
   }
 
+  // NOTE: accountId is intentionally unused — this search spans the GLOBAL onboarded catalog (an admin can add any
+  // project), not the caller's org-scoped ORG_LENS_PROJECTS. It's retained in the signature for parity with the
+  // other service methods and as the hook for a future org-scoped authorization gate.
   public async searchProjects(accountId: string, query: string, excludeSlugs: readonly string[] = []): Promise<OrgLensProjectSearchResponse> {
     const trimmed = query.trim();
     if (trimmed.length > 0 && trimmed.length < ORG_PROJECTS_SEARCH_MIN_LENGTH) {
@@ -479,6 +482,9 @@ export class OrgLensProjectsService {
       logoUrl: row.PROJECT_LOGO_URL ?? '',
       foundation: this.mapFoundation(row),
       health: hasHealthScore ? this.mapHealthScore(healthScore) : 'unavailable',
+      // These 'silent'/'non-lf' fallbacks are only user-visible for real (activity) rows. For no-activity rows the
+      // UI shows "Unavailable" and compareInfluenceAvailability sinks them past measured rows, so the fallback band
+      // is never compared against a measured one — it only affects the (tied) ordering of two no-activity rows.
       technicalInfluence: this.mapInfluence(row.TECHNICAL_INFLUENCE, 'silent'),
       ecosystemInfluence: this.mapInfluence(row.ECOSYSTEM_INFLUENCE, 'non-lf'),
       influenceScore: this.round1(row.INFLUENCE_SCORE ?? 0),

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -101,13 +101,15 @@ export class OrgLensProjectsService {
     // SELECT/WHERE binds) so a target like "k8s" isn't buried behind contains-matches. Empty-query preload falls back to catalog rank.
     // PROJECT_SLUG is the unique final tiebreaker so the 50/500 LIMIT cap is deterministic across requests
     // (rows tied on rank/name can't reshuffle in and out of the cap) — required for paginated ORDER BY/LIMIT.
-    let orderByClause = 'ORDER BY ALREADY_ADDED ASC, ONBOARDED_PROJECT_RANK ASC, PROJECT_NAME ASC, PROJECT_SLUG ASC';
+    // ONBOARDED_PROJECT_RANK is nullable: pin NULLS LAST so a session-level DEFAULT_NULL_ORDERING can't move
+    // null-rank rows in/out of the cap, and end on PROJECT_SLUG (unique) so the 50/500 LIMIT is deterministic.
+    let orderByClause = 'ORDER BY ALREADY_ADDED ASC, ONBOARDED_PROJECT_RANK ASC NULLS LAST, PROJECT_NAME ASC, PROJECT_SLUG ASC';
     if (trimmed.length) {
       const prefixLike = `${escapeSqlLikePattern(trimmed)}%`;
       orderByClause = `ORDER BY
         ALREADY_ADDED ASC,
         CASE WHEN PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!' THEN 0 ELSE 1 END ASC,
-        ONBOARDED_PROJECT_RANK ASC,
+        ONBOARDED_PROJECT_RANK ASC NULLS LAST,
         PROJECT_NAME ASC,
         PROJECT_SLUG ASC`;
       binds.push(prefixLike, prefixLike);

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -10,8 +10,9 @@ import {
   ORG_PROJECTS_MEMBER_SERVICE_BULK_ADD_CHUNK_SIZE,
   ORG_PROJECTS_OUTSIDE_LF_WAREHOUSE_SLUG,
   ORG_PROJECTS_OUTSIDE_LF_WIRE_SLUG,
-  ORG_PROJECTS_SEARCH_LIMIT,
+  ORG_PROJECTS_SEARCH_MAX_RESULTS,
   ORG_PROJECTS_SEARCH_MIN_LENGTH,
+  ORG_PROJECTS_SEARCH_PRELOAD_LIMIT,
   VALKEY_CACHE,
 } from '@lfx-one/shared/constants';
 import { classifyHealthScore } from '@lfx-one/shared/utils';
@@ -80,8 +81,35 @@ export class OrgLensProjectsService {
     // predicate identical to the PrimeNG multi-select's client-side filter, which matches % and _
     // literally (plain substring), so the client can't hide a row the server returned.
     const like = `%${escapeSqlLikePattern(query)}%`;
-    const searchFilter = trimmed.length ? "AND (PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!')" : '';
-    const excludeFilter = excluded.length ? `AND PROJECT_SLUG NOT IN (${excluded.map(() => '?').join(', ')})` : '';
+    // Global onboarded catalog (not org-scoped ORG_LENS_PROJECTS) so an admin can add any project. Already-added
+    // rows are marked via ALREADY_ADDED (bound first, positional) and dropped in code — not WHERE — so the UI can tell "already added" from a true no-match.
+    const binds: string[] = [];
+    let alreadyAddedExpr = '0';
+    if (excluded.length) {
+      alreadyAddedExpr = `CASE WHEN LOWER(PROJECT_SLUG) IN (${excluded.map(() => '?').join(', ')}) THEN 1 ELSE 0 END`;
+      binds.push(...excluded);
+    }
+    const conditions: string[] = [];
+    if (trimmed.length) {
+      conditions.push("(PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!')");
+      binds.push(like, like);
+    }
+    const whereClause = conditions.length ? `WHERE ${conditions.join('\n        AND ')}` : '';
+    // Relevance ordering: addable first (ALREADY_ADDED asc), then prefix matches (bound last, after SELECT/WHERE binds)
+    // so an exact target like "Kubernetes" isn't buried behind contains-matches. Empty-query preload falls back to catalog rank.
+    let orderByClause = 'ORDER BY ALREADY_ADDED ASC, ONBOARDED_PROJECT_RANK ASC, PROJECT_NAME ASC';
+    if (trimmed.length) {
+      const prefixLike = `${escapeSqlLikePattern(trimmed)}%`;
+      orderByClause = `ORDER BY
+        ALREADY_ADDED ASC,
+        CASE WHEN PROJECT_NAME ILIKE ? ESCAPE '!' THEN 0 ELSE 1 END ASC,
+        ONBOARDED_PROJECT_RANK ASC,
+        PROJECT_NAME ASC`;
+      binds.push(prefixLike);
+    }
+    // Preload keeps the initial panel light; a typed query returns up to the safety cap so the user
+    // can scroll the panel to the true end of the match list rather than hitting a hard 20-row wall.
+    const limit = trimmed.length ? ORG_PROJECTS_SEARCH_MAX_RESULTS : ORG_PROJECTS_SEARCH_PRELOAD_LIMIT;
     const sql = `
       SELECT
         PROJECT_SLUG,
@@ -89,24 +117,25 @@ export class OrgLensProjectsService {
         PROJECT_LOGO_URL,
         FOUNDATION_SLUG,
         FOUNDATION_NAME,
-        FOUNDATION_LOGO_URL
-      FROM ${this.projectsTable()}
-      WHERE ACCOUNT_ID = ?
-        ${searchFilter}
-        ${excludeFilter}
-      ORDER BY ORG_PROJECT_RANK ASC, PROJECT_NAME ASC
-      LIMIT ${ORG_PROJECTS_SEARCH_LIMIT}
+        FOUNDATION_LOGO_URL,
+        ${alreadyAddedExpr} AS ALREADY_ADDED
+      FROM ${this.onboardedProjectsTable()}
+      ${whereClause}
+      ${orderByClause}
+      LIMIT ${limit}
     `;
 
-    const binds = trimmed.length ? [accountId, like, like, ...excluded] : [accountId, ...excluded];
-    const result = await this.snowflakeService.execute<OrgLensProjectRow>(sql, binds);
+    const result = await this.snowflakeService.execute<OrgLensProjectRow & { ALREADY_ADDED?: number | string }>(sql, binds);
+    const addable = result.rows.filter((row) => Number(row.ALREADY_ADDED) !== 1);
     return {
-      results: result.rows.map((row) => ({
+      results: addable.map((row) => ({
         slug: row.PROJECT_SLUG,
         name: row.PROJECT_NAME,
         logoUrl: row.PROJECT_LOGO_URL ?? '',
         foundation: this.mapFoundation(row),
       })),
+      // Any returned row we dropped means the query matched a project that's already in the workspace.
+      hasMatchesAlreadyInWorkspace: result.rows.length > addable.length,
     };
   }
 
@@ -318,12 +347,42 @@ export class OrgLensProjectsService {
     const projectSlugs = projectRows.map((row) => row.PROJECT_SLUG);
     const peopleRows = projectSlugs.length ? await this.fetchPeopleRows(accountId, projectSlugs) : [];
 
+    // Workspace slugs with no org-scoped row (no activity yet): synthesize an identity-only project from the
+    // onboarded catalog as a "no activity yet" row instead of dropping it. Only for requested slugs, not the preload.
+    const noActivityProjects = await this.fetchNoActivityProjects(slugs, projectSlugs);
+
     return {
       orgSlug: this.slugify(orgName) || accountId,
       orgName: orgName || 'Your organization',
       dataUpdatedAt: this.latestTimestamp(projectRows) ?? new Date().toISOString(),
-      projects: projectRows.map((row) => this.mapProject(row, peopleRows)),
+      projects: [...projectRows.map((row) => this.mapProject(row, peopleRows)), ...noActivityProjects],
     };
+  }
+
+  private async fetchNoActivityProjects(requestedSlugs: string[] | null, returnedSlugs: string[]): Promise<OrgLensProject[]> {
+    if (!requestedSlugs?.length) {
+      return [];
+    }
+    const returned = new Set(returnedSlugs.map((slug) => slug.toLowerCase()));
+    const missing = [...new Set(requestedSlugs.map((slug) => slug.trim().toLowerCase()).filter(Boolean))].filter((slug) => !returned.has(slug));
+    if (!missing.length) {
+      return [];
+    }
+    const sql = `
+      SELECT
+        PROJECT_SLUG,
+        PROJECT_NAME,
+        PROJECT_LOGO_URL,
+        FOUNDATION_SLUG,
+        FOUNDATION_NAME,
+        FOUNDATION_LOGO_URL
+      FROM ${this.onboardedProjectsTable()}
+      WHERE PROJECT_SLUG IN (${missing.map(() => '?').join(', ')})
+    `;
+    const result = await this.snowflakeService.execute<OrgLensProjectRow>(sql, missing);
+    // mapProject fills every metric field the identity query does not select with its missing-data
+    // placeholder (health 'unavailable', influence fallbacks, zeroed trend, empty people arrays).
+    return result.rows.map((row) => ({ ...this.mapProject(row, []), noActivityYet: true }));
   }
 
   private buildProjectsQuery(slugs: string[] | null): string {
@@ -842,6 +901,10 @@ export class OrgLensProjectsService {
 
   private projectsTable(): string {
     return `${this.lfxOnePlatinumSchema()}.ORG_LENS_PROJECTS`;
+  }
+
+  private onboardedProjectsTable(): string {
+    return `${this.lfxOnePlatinumSchema()}.ONBOARDED_PROJECTS`;
   }
 
   private projectPeopleTable(): string {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -90,22 +90,24 @@ export class OrgLensProjectsService {
       binds.push(...excluded);
     }
     const conditions: string[] = [];
-    if (trimmed.length) {
+    // Gate on raw query.length (not trimmed) so a whitespace-only filter like " " applies server-side too,
+    // matching the client's raw-text predicate; `trimmed` still drives the min-length rule and typed-result cap.
+    if (query.length) {
       conditions.push("(PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!')");
       binds.push(like, like);
     }
     const whereClause = conditions.length ? `WHERE ${conditions.join('\n        AND ')}` : '';
-    // Relevance ordering: addable first (ALREADY_ADDED asc), then prefix matches (bound last, after SELECT/WHERE binds)
-    // so an exact target like "Kubernetes" isn't buried behind contains-matches. Empty-query preload falls back to catalog rank.
+    // Relevance ordering: addable first (ALREADY_ADDED asc), then prefix matches on name OR slug (bound last, after
+    // SELECT/WHERE binds) so a target like "k8s" isn't buried behind contains-matches. Empty-query preload falls back to catalog rank.
     let orderByClause = 'ORDER BY ALREADY_ADDED ASC, ONBOARDED_PROJECT_RANK ASC, PROJECT_NAME ASC';
     if (trimmed.length) {
       const prefixLike = `${escapeSqlLikePattern(trimmed)}%`;
       orderByClause = `ORDER BY
         ALREADY_ADDED ASC,
-        CASE WHEN PROJECT_NAME ILIKE ? ESCAPE '!' THEN 0 ELSE 1 END ASC,
+        CASE WHEN PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!' THEN 0 ELSE 1 END ASC,
         ONBOARDED_PROJECT_RANK ASC,
         PROJECT_NAME ASC`;
-      binds.push(prefixLike);
+      binds.push(prefixLike, prefixLike);
     }
     // Preload keeps the initial panel light; a typed query returns up to the safety cap so the user
     // can scroll the panel to the true end of the match list rather than hitting a hard 20-row wall.
@@ -345,11 +347,13 @@ export class OrgLensProjectsService {
     const projectsResult = await this.snowflakeService.execute<OrgLensProjectRow>(this.buildProjectsQuery(slugs), this.buildProjectsBinds(accountId, slugs));
     const projectRows = projectsResult.rows;
     const projectSlugs = projectRows.map((row) => row.PROJECT_SLUG);
-    const peopleRows = projectSlugs.length ? await this.fetchPeopleRows(accountId, projectSlugs) : [];
-
-    // Workspace slugs with no org-scoped row (no activity yet): synthesize an identity-only project from the
-    // onboarded catalog as a "no activity yet" row instead of dropping it. Only for requested slugs, not the preload.
-    const noActivityProjects = await this.fetchNoActivityProjects(slugs, projectSlugs);
+    // Both reads depend only on projectSlugs, so run them concurrently to avoid a second sequential Snowflake round trip.
+    // fetchNoActivityProjects: workspace slugs with no org-scoped row (no activity yet) → synthesize an identity-only
+    // "no activity yet" row from the onboarded catalog instead of dropping it. Only for requested slugs, not the preload.
+    const [peopleRows, noActivityProjects] = await Promise.all([
+      projectSlugs.length ? this.fetchPeopleRows(accountId, projectSlugs) : Promise.resolve([]),
+      this.fetchNoActivityProjects(slugs, projectSlugs),
+    ]);
 
     return {
       orgSlug: this.slugify(orgName) || accountId,

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -99,14 +99,17 @@ export class OrgLensProjectsService {
     const whereClause = conditions.length ? `WHERE ${conditions.join('\n        AND ')}` : '';
     // Relevance ordering: addable first (ALREADY_ADDED asc), then prefix matches on name OR slug (bound last, after
     // SELECT/WHERE binds) so a target like "k8s" isn't buried behind contains-matches. Empty-query preload falls back to catalog rank.
-    let orderByClause = 'ORDER BY ALREADY_ADDED ASC, ONBOARDED_PROJECT_RANK ASC, PROJECT_NAME ASC';
+    // PROJECT_SLUG is the unique final tiebreaker so the 50/500 LIMIT cap is deterministic across requests
+    // (rows tied on rank/name can't reshuffle in and out of the cap) — required for paginated ORDER BY/LIMIT.
+    let orderByClause = 'ORDER BY ALREADY_ADDED ASC, ONBOARDED_PROJECT_RANK ASC, PROJECT_NAME ASC, PROJECT_SLUG ASC';
     if (trimmed.length) {
       const prefixLike = `${escapeSqlLikePattern(trimmed)}%`;
       orderByClause = `ORDER BY
         ALREADY_ADDED ASC,
         CASE WHEN PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!' THEN 0 ELSE 1 END ASC,
         ONBOARDED_PROJECT_RANK ASC,
-        PROJECT_NAME ASC`;
+        PROJECT_NAME ASC,
+        PROJECT_SLUG ASC`;
       binds.push(prefixLike, prefixLike);
     }
     // Preload keeps the initial panel light; a typed query returns up to the safety cap so the user

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -381,7 +381,7 @@ export class OrgLensProjectsService {
         FOUNDATION_NAME,
         FOUNDATION_LOGO_URL
       FROM ${this.onboardedProjectsTable()}
-      WHERE PROJECT_SLUG IN (${missing.map(() => '?').join(', ')})
+      WHERE LOWER(PROJECT_SLUG) IN (${missing.map(() => '?').join(', ')})
     `;
     const result = await this.snowflakeService.execute<OrgLensProjectRow>(sql, missing);
     // mapProject fills every metric field the identity query does not select with its missing-data

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -50,7 +50,9 @@ export class OrgLensProjectsService {
   private readonly microserviceProxy = new MicroserviceProxyService();
 
   public async getProjects(accountId: string, orgName: string, slugs: string[] | null): Promise<OrgLensProjectsResponse> {
-    const cacheKey = `projects:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
+    // `v2` bump: entries cached before the no-activity hydration landed hold activity-only rows; versioning the
+    // sub-resource key drops them so freshly viewed workspaces don't omit no-activity rows for up to the TTL.
+    const cacheKey = `projects:v2:${this.paramSignature([orgName, ...(slugs ?? ['__top__'])])}`;
     const key = buildOrgCacheKey(accountId, cacheKey);
     if (key !== null) {
       const cached = await valkeyService.getJson<OrgLensProjectsResponse>(key, OrgLensProjectsService.isProjectsResponse);

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -358,7 +358,7 @@ export class OrgLensProjectsService {
       // No-activity hydration is a soft enhancement over the onboarded catalog (which may be mid-migration or
       // absent); never let its failure fail the whole response — degrade to activity rows only, as before.
       this.fetchNoActivityProjects(slugs, projectSlugs).catch((err) => {
-        console.error('Failed to hydrate no-activity org projects; returning activity rows only', err);
+        logger.warning(undefined, 'fetch_no_activity_org_projects', 'No-activity org project hydration failed; returning activity rows only', { err });
         return [] as OrgLensProject[];
       }),
     ]);

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -99,22 +99,31 @@ export class OrgLensProjectsService {
       binds.push(like, like);
     }
     const whereClause = conditions.length ? `WHERE ${conditions.join('\n        AND ')}` : '';
-    // Relevance ordering: addable first (ALREADY_ADDED asc), then prefix matches on name OR slug (bound last, after
-    // SELECT/WHERE binds) so a target like "k8s" isn't buried behind contains-matches. Empty-query preload falls back to catalog rank.
+    // Relevance ordering: addable first (ALREADY_ADDED asc), then the match-strength tier below (bound last, after
+    // SELECT/WHERE binds). Empty-query preload has no tier and falls back to catalog rank.
     // PROJECT_SLUG is the unique final tiebreaker so the 50/500 LIMIT cap is deterministic across requests
     // (rows tied on rank/name can't reshuffle in and out of the cap) — required for paginated ORDER BY/LIMIT.
     // ONBOARDED_PROJECT_RANK is nullable: pin NULLS LAST so a session-level DEFAULT_NULL_ORDERING can't move
     // null-rank rows in/out of the cap, and end on PROJECT_SLUG (unique) so the 50/500 LIMIT is deterministic.
     let orderByClause = 'ORDER BY ALREADY_ADDED ASC, ONBOARDED_PROJECT_RANK ASC NULLS LAST, PROJECT_NAME ASC, PROJECT_SLUG ASC';
     if (trimmed.length) {
-      const prefixLike = `${escapeSqlLikePattern(trimmed)}%`;
+      const exactLike = escapeSqlLikePattern(trimmed);
+      const prefixLike = `${exactLike}%`;
+      // Tier by match strength so name matches beat slug-only matches: exact name/slug, then name-prefix, then
+      // slug-prefix, then contains. Without the split, "kub" ranks the many kubernetes-sigs-* slug siblings
+      // above the actual "Kubernetes" project (slug "k8s"); exact-slug still surfaces "k8s" at the very top.
       orderByClause = `ORDER BY
         ALREADY_ADDED ASC,
-        CASE WHEN PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!' THEN 0 ELSE 1 END ASC,
+        CASE
+          WHEN PROJECT_NAME ILIKE ? ESCAPE '!' OR PROJECT_SLUG ILIKE ? ESCAPE '!' THEN 0
+          WHEN PROJECT_NAME ILIKE ? ESCAPE '!' THEN 1
+          WHEN PROJECT_SLUG ILIKE ? ESCAPE '!' THEN 2
+          ELSE 3
+        END ASC,
         ONBOARDED_PROJECT_RANK ASC NULLS LAST,
         PROJECT_NAME ASC,
         PROJECT_SLUG ASC`;
-      binds.push(prefixLike, prefixLike);
+      binds.push(exactLike, exactLike, prefixLike, prefixLike);
     }
     // Preload keeps the initial panel light; a typed query returns up to the safety cap so the user
     // can scroll the panel to the true end of the match list rather than hitting a hard 20-row wall.

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -33,6 +33,9 @@ export const INFLUENCE_BAND_LABELS: Record<InfluenceBand, string> = {
   'non-lf': 'Non-LF Project',
 };
 
+/** Metric label for a "no activity yet" row, whose influence bands are not computed (no org-scoped data). */
+export const ORG_PROJECTS_METRIC_UNAVAILABLE_LABEL = 'Unavailable';
+
 /** Sparkline / delta color per trend direction (brand scale values; never hard-coded hex). */
 export const INFLUENCE_TREND_COLOR: Record<InfluenceTrendDirection, string> = {
   up: lfxColors.emerald[500],

--- a/packages/shared/src/constants/org-lens-projects.constants.ts
+++ b/packages/shared/src/constants/org-lens-projects.constants.ts
@@ -128,5 +128,14 @@ export const DEFAULT_LFX_ONE_PLATINUM_SCHEMA = 'ANALYTICS.PLATINUM_LFX_ONE';
 export const ORG_PROJECTS_OUTSIDE_LF_WAREHOUSE_SLUG = '__outside_lf__';
 export const ORG_PROJECTS_OUTSIDE_LF_WIRE_SLUG = 'outside-lf';
 export const ORG_PROJECTS_SEARCH_MIN_LENGTH = 2;
-export const ORG_PROJECTS_SEARCH_LIMIT = 20;
+/**
+ * Rows for the empty-query preload (dropdown opened before typing). Kept small so the initial panel is
+ * fast; the user narrows the ~13.5k-project catalog by typing.
+ */
+export const ORG_PROJECTS_SEARCH_PRELOAD_LIMIT = 50;
+/**
+ * Safety cap on matches for a typed query, set well above realistic match counts so the user can scroll to the
+ * true end of the list. Results are relevance-ordered (prefix first), so the top items are most relevant even near the cap.
+ */
+export const ORG_PROJECTS_SEARCH_MAX_RESULTS = 500;
 export const ORG_PROJECTS_MEMBER_SERVICE_BULK_ADD_CHUNK_SIZE = 100;

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -88,6 +88,11 @@ export interface OrgLensProject {
   description: string;
   /** CHAOSS-style health sub-scores (0–100) shown in the health-detail popover. */
   healthMetrics: ProjectHealthMetric[];
+  /**
+   * True when the project is in the org's workspace but has no org activity yet — identity/foundation come from the
+   * onboarded catalog and every metric is a placeholder (health `unavailable`, zeroed trend, empty people). Drives the "no activity yet" row.
+   */
+  noActivityYet?: boolean;
 }
 
 /** A single CHAOSS health sub-score (0–100) shown in the health-detail popover. */
@@ -119,6 +124,11 @@ export interface OrgLensProjectSearchResult {
 
 export interface OrgLensProjectSearchResponse {
   results: OrgLensProjectSearchResult[];
+  /**
+   * True when the query matched onboarded projects omitted from `results` only because they're already in the workspace.
+   * Lets the UI distinguish "already added" from a genuine no-match so the empty panel isn't mislabelled "No projects match".
+   */
+  hasMatchesAlreadyInWorkspace?: boolean;
 }
 
 export interface AddableProjectOption {


### PR DESCRIPTION
Ticket: [LFXV2-2886](https://linuxfoundation.atlassian.net/browse/LFXV2-2886)

## Summary

Org Lens 'Add projects' search now queries the global onboarded-project catalog (`ONBOARDED_PROJECTS`) instead of the org-scoped table — relevance-ordered (addable-first, then by match strength: exact → name-prefix → slug-prefix → contains), with a 50-row preload / 500-row typed cap.

- Empty-panel messaging distinguishes 'already in this workspace' from a true no-match (new `hasMatchesAlreadyInWorkspace` response flag).
- Workspace projects with no org activity are hydrated as a 'No activity yet' row instead of vanishing (new `noActivityYet` flag).
- Add-projects status now renders inside the body-appended multi-select panel via new `matchTriggerWidth` + `autofocusFilter` + `loading`/`emptyMessage`/`emptyFilterMessage` inputs on the shared `multi-select` component.

**Why:** LFXV2-2886 — add project global search to Org Lens.

## Merge prerequisite (satisfied)

Reads prod table `ANALYTICS.PLATINUM_LFX_ONE.ONBOARDED_PROJECTS`. The producing dbt model merged and the table is now materialized in prod (verified 2026-07-30: 13,495 rows), so this prerequisite is met. The workspace no-activity hydration also degrades gracefully (non-fatal) if that read ever fails.

## Follow-up

After this PR merges, a separate DCO-signed umbrella pin-bump PR advances the `apps/lfx-self-serve` gitlink in the org-lens workspace.

## Test plan

- [ ] `yarn start`, open Org Lens → Projects → 'Add projects'.
- [ ] Type e.g. `kub`; confirm name matches (Kubernetes) rank above slug-only `kubernetes-sigs-*` siblings, and `k8s` surfaces Kubernetes first.
- [ ] Confirm 'already in this workspace' messaging on already-added matches.
- [ ] Confirm a no-activity workspace project renders with the 'No activity yet' pill.

[LFXV2-2886]: https://linuxfoundation.atlassian.net/browse/LFXV2-2886?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

