### PR TITLE
feat(weekly-brief): share to mailing list action

### DIFF
--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -41,7 +41,7 @@
 
 import { expect, Page, Route, test } from '@playwright/test';
 import { CommitteeMemberRole } from '@lfx-one/shared/enums';
-import { Committee, WeeklyBrief, WeeklyBriefCurrentResponse, WeeklyBriefThrottle } from '@lfx-one/shared/interfaces';
+import { Committee, ShareWeeklyBriefResult, WeeklyBrief, WeeklyBriefCurrentResponse, WeeklyBriefThrottle } from '@lfx-one/shared/interfaces';
 
 const TEST_COMMITTEE_UID = 'wb-card-e2e-committee-uid';
 // Committees are mounted under /groups, not /committees (see committee-about.helper.ts's
@@ -85,7 +85,7 @@ const USED_THROTTLE_AFTER_GENERATE: WeeklyBriefThrottle = {
   generates_used: 1,
 };
 
-function buildCommitteeFixture(): Committee {
+function buildCommitteeFixture(overrides: Partial<Committee> = {}): Committee {
   return {
     uid: TEST_COMMITTEE_UID,
     name: 'Weekly Brief Test WG',
@@ -105,6 +105,7 @@ function buildCommitteeFixture(): Committee {
     // Without a my_role here the card never renders regardless of the flag or canEdit —
     // matches committee-about.helper.ts's buildBaseCommittee, which sets this too.
     my_role: CommitteeMemberRole.CHAIR,
+    ...overrides,
   };
 }
 
@@ -118,7 +119,7 @@ function buildCommitteeFixture(): Committee {
  * explicitly mocked here (lens, project context, mailing lists, etc.) is left
  * to the dev backend — the card only reads `committee.uid` and `canEdit`.
  */
-async function mockCommitteeShell(page: Page): Promise<void> {
+async function mockCommitteeShell(page: Page, committeeOverrides: Partial<Committee> = {}): Promise<void> {
   await page.route(`**/api/committees/${TEST_COMMITTEE_UID}`, async (route) => {
     if (route.request().method() !== 'GET') {
       await route.fallback();
@@ -127,7 +128,7 @@ async function mockCommitteeShell(page: Page): Promise<void> {
     await route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify(buildCommitteeFixture()),
+      body: JSON.stringify(buildCommitteeFixture(committeeOverrides)),
     });
   });
 
@@ -226,6 +227,19 @@ async function mockCurrentBrief(page: Page, initial: WeeklyBriefCurrentResponse)
       current = next;
     },
   };
+}
+
+/**
+ * Mock POST /api/committees/:uid/weekly-briefs/share with a fixed status/body.
+ */
+async function mockShareBrief(
+  page: Page,
+  status: number,
+  body: ShareWeeklyBriefResult | { error: string; code: string; errors?: { field: string; message: string; code: string }[] }
+): Promise<void> {
+  await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/share`, async (route) => {
+    await route.fulfill({ status, contentType: 'application/json', body: JSON.stringify(body) });
+  });
 }
 
 /**
@@ -585,5 +599,187 @@ test.describe('WG Weekly Brief card — read failure (flag ON)', () => {
     await page.getByTestId('weekly-brief-card-unavailable-retry-button').click();
     await expect(page.getByTestId('weekly-brief-card-empty-state')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('weekly-brief-card-unavailable-state')).toHaveCount(0);
+  });
+});
+
+test.describe('WG Weekly Brief card — Share to Mailing List (flag ON)', () => {
+  test('sends the current brief and shows a success toast', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: true, mailing_list: 'wg-tsc@lists.example.org' });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+
+    let shareCalled = false;
+    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/share`, async (route) => {
+      shareCalled = true;
+      const result: ShareWeeklyBriefResult = { committee_name: 'Weekly Brief Test WG', total_recipients: 4 };
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    const shareBtn = page.getByTestId('weekly-brief-card-share-button');
+    await expect(shareBtn).toBeVisible();
+    await expect(shareBtn).toBeEnabled();
+    await shareBtn.click();
+
+    // Confirm dialog appears, describing the true recipient audience
+    // (committee members) — never the Groups.io mailing-list address, which
+    // is not who actually receives the email.
+    await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+    await expect(page.locator('.p-confirmdialog')).toContainText('all members of Weekly Brief Test WG');
+
+    const sharePromise = page.waitForRequest(
+      (req) => req.method() === 'POST' && req.url().includes(`/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/share`),
+      { timeout: DATA_LOAD_TIMEOUT }
+    );
+    await page.locator('.p-confirmdialog').getByRole('button', { name: /Send/i }).click();
+    await sharePromise;
+
+    expect(shareCalled).toBe(true);
+    await expect(page.getByText(/Brief queued for delivery to 4 recipients/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+});
+
+test.describe('WG Weekly Brief card — Share disabled (no mailing list)', () => {
+  test('Share button is visible but disabled, with a visible hint, when the committee has no mailing list', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: false });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    const shareBtn = page.getByTestId('weekly-brief-card-share-button');
+    await expect(shareBtn).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(shareBtn).toBeDisabled();
+
+    // The disabled reason is a plain visible hint (not a tooltip) so it's
+    // reachable without hover/focus for keyboard and screen-reader users.
+    const hint = page.getByTestId('weekly-brief-card-share-disabled-hint');
+    await expect(hint).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(hint).toContainText('No mailing list configured for this committee');
+  });
+});
+
+test.describe('WG Weekly Brief card — Share failure', () => {
+  test('a failed send surfaces an error toast (no silent drop)', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: true, mailing_list: 'wg-tsc@lists.example.org' });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+    await mockShareBrief(page, 409, { error: 'Committee has no mailing list configured', code: 'NO_MAILING_LIST' });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('weekly-brief-card-share-button').click();
+    await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+
+    const sharePromise = page.waitForRequest(
+      (req) => req.method() === 'POST' && req.url().includes(`/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/share`),
+      { timeout: DATA_LOAD_TIMEOUT }
+    );
+    await page.locator('.p-confirmdialog').getByRole('button', { name: /Send/i }).click();
+    await sharePromise;
+
+    await expect(page.getByText(/No mailing list configured for this committee/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test('a 400 validation error surfaces the actual field message, not the generic envelope text', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: true });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+    await mockShareBrief(page, 400, {
+      error: 'Validation failed for brief_text',
+      code: 'VALIDATION_ERROR',
+      errors: [
+        { field: 'brief_text', message: 'Brief is too long to share (must render to 100000 characters or fewer as HTML)', code: 'FIELD_VALIDATION_ERROR' },
+      ],
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('weekly-brief-card-share-button').click();
+    await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+    await page.locator('.p-confirmdialog').getByRole('button', { name: /Send/i }).click();
+
+    await expect(page.getByText(/Brief is too long to share/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByText('Validation failed for brief_text', { exact: true })).toHaveCount(0);
+  });
+
+  test('a 409 BACKEND_NOT_LIVE reports the environment reason distinctly from a no-mailing-list conflict', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: true });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+    await mockShareBrief(page, 409, { error: 'Sharing is not available in this environment', code: 'BACKEND_NOT_LIVE' });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('weekly-brief-card-share-button').click();
+    await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+    await page.locator('.p-confirmdialog').getByRole('button', { name: /Send/i }).click();
+
+    await expect(page.getByText(/Sharing is not available in this environment yet/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test('a 409 REVISION_MISMATCH prompts a reload instead of silently sending stale content', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: true });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+    await mockShareBrief(page, 409, { error: 'The brief has been updated since you last viewed it', code: 'REVISION_MISMATCH' });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('weekly-brief-card-share-button').click();
+    await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+
+    const sharePromise = page.waitForRequest(
+      (req) => req.method() === 'POST' && req.url().includes(`/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/share`),
+      { timeout: DATA_LOAD_TIMEOUT }
+    );
+    const sharedBody = sharePromise.then((req) => req.postDataJSON() as { revision?: number });
+    await page.locator('.p-confirmdialog').getByRole('button', { name: /Send/i }).click();
+    await sharePromise;
+
+    // The client sends back the revision it displayed — proves the confirmation was
+    // tied to a specific version of the brief, not just "whatever is current".
+    expect((await sharedBody).revision).toBe(GENERATED_BRIEF.revision);
+
+    await expect(page.getByText(/updated since you last viewed it.*Reload to review the latest version/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+
+  test('a 5xx/ambiguous failure warns that the send may already have gone out, instead of inviting a retry', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: true });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+    await mockShareBrief(page, 503, { error: 'Upstream newsletter service unavailable', code: 'SERVICE_UNAVAILABLE' });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('weekly-brief-card-share-button').click();
+    await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+    await page.locator('.p-confirmdialog').getByRole('button', { name: /Send/i }).click();
+
+    // This is the safeguard that prevents a duplicate send: a 5xx here must
+    // NOT render the generic "try again" copy, since the async send may
+    // already have been accepted upstream before the failure reached the client.
+    await expect(page.getByText(/The send may not have completed/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByText('Failed to share brief. Please try again.', { exact: true })).toHaveCount(0);
+  });
+});
+
+test.describe('WG Weekly Brief card — Regenerate disabled (throttle exhausted)', () => {
+  test('Regenerate button is visible but disabled, with a visible hint, when the weekly regeneration limit is reached', async ({ page }) => {
+    await mockCommitteeShell(page);
+    const exhaustedThrottle: WeeklyBriefThrottle = { ...DEFAULT_THROTTLE, regenerations_used: 3, regenerations_limit: 3 };
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: exhaustedThrottle });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    const regenerateBtn = page.getByTestId('weekly-brief-card-regenerate-button');
+    await expect(regenerateBtn).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(regenerateBtn).toBeDisabled();
+
+    const hint = page.getByTestId('weekly-brief-card-regenerate-disabled-hint');
+    await expect(hint).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(hint).toContainText('Weekly regeneration limit reached');
   });
 });

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -638,6 +638,32 @@ test.describe('WG Weekly Brief card — Share to Mailing List (flag ON)', () => 
     expect(shareCalled).toBe(true);
     await expect(page.getByText(/Brief queued for delivery to 4 recipients/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
+
+  test('a 200 response with zero recipients shows a warning toast, not a success toast', async ({ page }) => {
+    await mockCommitteeShell(page, { has_mailing_list: true, mailing_list: 'wg-tsc@lists.example.org' });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+
+    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/share`, async (route) => {
+      const result: ShareWeeklyBriefResult = { committee_name: 'Weekly Brief Test WG', total_recipients: 0 };
+      await route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(result) });
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('committee-overview-weekly-brief-card')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('weekly-brief-card-share-button').click();
+    await expect(page.locator('.p-confirmdialog')).toBeVisible({ timeout: 5000 });
+
+    const sharePromise = page.waitForRequest(
+      (req) => req.method() === 'POST' && req.url().includes(`/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/share`),
+      { timeout: DATA_LOAD_TIMEOUT }
+    );
+    await page.locator('.p-confirmdialog').getByRole('button', { name: /Send/i }).click();
+    await sharePromise;
+
+    await expect(page.getByText(/No recipients were found for this committee/i)).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByText(/Brief queued for delivery/i)).toHaveCount(0);
+  });
 });
 
 test.describe('WG Weekly Brief card — Share disabled (no mailing list)', () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -109,12 +109,29 @@
               severity="secondary"
               [outlined]="true"
               [disabled]="!canRegenerate()"
-              [tooltip]="canRegenerate() ? '' : 'Weekly regeneration limit reached'"
               (onClick)="onGenerate()"
               data-testid="weekly-brief-card-regenerate-button" />
             <lfx-button label="Edit" severity="secondary" (onClick)="onEdit()" data-testid="weekly-brief-card-edit-button" />
             <lfx-button label="Copy & Share" severity="info" icon="fa-light fa-copy" (onClick)="onCopyAndShare()" data-testid="weekly-brief-card-copy-button" />
+            <lfx-button
+              label="Share to Mailing List"
+              severity="info"
+              icon="fa-light fa-paper-plane"
+              [loading]="sharing()"
+              [disabled]="!committee().has_mailing_list"
+              (onClick)="onShareToMailingList()"
+              data-testid="weekly-brief-card-share-button" />
           </div>
+          <!-- Visible hints rather than tooltips on these disabled buttons: a
+               disabled native <button> never receives focus/hover, so a
+               tooltip-only explanation would be unreachable by keyboard and
+               screen-reader users. -->
+          @if (!canRegenerate()) {
+            <span class="text-xs text-gray-500" data-testid="weekly-brief-card-regenerate-disabled-hint">Weekly regeneration limit reached</span>
+          }
+          @if (!committee().has_mailing_list) {
+            <span class="text-xs text-gray-500" data-testid="weekly-brief-card-share-disabled-hint">No mailing list configured for this committee</span>
+          }
         }
 
         @if (throttle(); as t) {
@@ -149,4 +166,6 @@
       </div>
     </lfx-card>
   }
+
+  <p-confirmDialog />
 }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -283,13 +283,22 @@ export class WeeklyBriefCardComponent {
     // The Share action only renders outside edit mode (see the template's
     // @if (editMode()) branch), so there is never an unsaved-edit case to
     // guard here — the brief is always whatever was last saved.
+    //
+    // Captured here, not re-read in performShare at accept-time: the dialog's message
+    // names a specific committee/audience, so the request that follows Send must target
+    // that same snapshot — not whatever committee()/brief() happen to be current if the
+    // signals changed while the dialog was open (component reuse across a committee
+    // navigation, or a background poll landing mid-dialog).
+    const committeeUid = this.committee()?.uid;
+    const revision = this.brief()?.revision;
+    if (!committeeUid || revision === undefined) return;
     this.confirmationService.confirm({
       header: 'Share to Mailing List',
       message: `Send the current brief by email to ${this.shareAudienceLabel()}?`,
       icon: 'fa-light fa-paper-plane',
       acceptLabel: 'Send',
       rejectLabel: 'Cancel',
-      accept: () => this.performShare(),
+      accept: () => this.performShare(committeeUid, revision),
     });
   }
 
@@ -344,11 +353,14 @@ export class WeeklyBriefCardComponent {
     // between committees — without an explicit reset, a stale `editMode`/`editForm`
     // (edited text from the previous committee, rendered against the new committee's
     // brief), a leftover `generating` flag from a generate call cut off mid-flight (see
-    // the takeUntil guard in onGenerate), or a leftover `saving` flag from a save cut off
-    // mid-flight (see the same guard in onSave) would bleed onto the new committee's card.
+    // the takeUntil guard in onGenerate), a leftover `saving` flag from a save cut off
+    // mid-flight (see the same guard in onSave), or a leftover `sharing` flag from a
+    // share cut off mid-flight (see the same guard in performShare) would bleed onto
+    // the new committee's card.
     committeeUid$.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.generating.set(false);
       this.saving.set(false);
+      this.sharing.set(false);
       this.editMode.set(false);
       this.editForm.reset({ briefText: '' });
     });
@@ -498,15 +510,17 @@ export class WeeklyBriefCardComponent {
   }
 
   // Other private helpers
-  private performShare(): void {
-    const committeeUid = this.committee()?.uid;
-    const revision = this.brief()?.revision;
-    if (!committeeUid || revision === undefined) return;
+  private performShare(committeeUid: string, revision: number): void {
     this.sharing.set(true);
     this.weeklyBriefService
       .shareWeeklyBrief(committeeUid, revision)
       .pipe(
         take(1),
+        // Same guard as onGenerate/onSave: a share started on committee A whose response
+        // arrives after the user has already navigated to committee B must not clear B's
+        // sharing flag or trigger an unwanted refresh$ on B's card (dealako review).
+        takeUntil(this.committee$.pipe(filter((c) => c?.uid !== committeeUid))),
+        takeUntilDestroyed(this.destroyRef),
         finalize(() => this.sharing.set(false))
       )
       .subscribe({

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -5,7 +5,7 @@ import { isPlatformBrowser } from '@angular/common';
 import { HttpErrorResponse } from '@angular/common/http';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, input, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup } from '@angular/forms';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
@@ -15,9 +15,11 @@ import {
   WEEKLY_BRIEF_TERMINAL_STATES,
   WEEKLY_BRIEF_TEXT_MAX_LENGTH,
 } from '@lfx-one/shared/constants';
-import { Committee, WeeklyBrief, WeeklyBriefCurrentResponse, WeeklyBriefThrottle } from '@lfx-one/shared/interfaces';
+import { Committee, ShareWeeklyBriefResult, WeeklyBrief, WeeklyBriefCurrentResponse, WeeklyBriefThrottle } from '@lfx-one/shared/interfaces';
+import { formatUtcDateRangeLabel } from '@lfx-one/shared/utils';
 import { WeeklyBriefService } from '@services/weekly-brief.service';
-import { MessageService } from 'primeng/api';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import {
   BehaviorSubject,
@@ -42,7 +44,7 @@ import {
 
 @Component({
   selector: 'lfx-weekly-brief-card',
-  imports: [CardComponent, ButtonComponent, SkeletonModule, TextareaComponent],
+  imports: [CardComponent, ButtonComponent, SkeletonModule, ReactiveFormsModule, TextareaComponent, ConfirmDialogModule],
   templateUrl: './weekly-brief-card.component.html',
   styleUrl: './weekly-brief-card.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -51,6 +53,7 @@ export class WeeklyBriefCardComponent {
   // Injections
   private readonly weeklyBriefService = inject(WeeklyBriefService);
   private readonly messageService = inject(MessageService);
+  private readonly confirmationService = inject(ConfirmationService);
   private readonly destroyRef = inject(DestroyRef);
   private readonly platformId = inject(PLATFORM_ID);
 
@@ -76,6 +79,7 @@ export class WeeklyBriefCardComponent {
   // short of a page reload. See pollUntilTerminal.
   public readonly pollTimedOut = signal(false);
   public readonly saving = signal(false);
+  public readonly sharing = signal(false);
   public readonly editMode = signal(false);
 
   // Written by both the initial-load pipeline and the post-generate poll (see
@@ -125,18 +129,15 @@ export class WeeklyBriefCardComponent {
   public readonly weekLabel: Signal<string> = computed(() => {
     const b = this.brief();
     if (!b) return '';
-    // window_start / window_end are UTC ISO boundaries (Sun 00:00Z → Sat
-    // 23:59Z). Format with timeZone: 'UTC' so users in negative offsets
-    // don't see the start shift to the prior day.
-    const start = new Date(b.window_start);
-    const end = new Date(b.window_end);
-    return `${start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' })} – ${end.toLocaleDateString('en-US', {
-      month: 'short',
-      day: 'numeric',
-      year: 'numeric',
-      timeZone: 'UTC',
-    })}`;
+    // window_start / window_end are UTC ISO boundaries (Sun 00:00Z → Sat 23:59Z).
+    return formatUtcDateRangeLabel(b.window_start, b.window_end);
   });
+
+  // Recipients actually resolve from committee membership (via the newsletter
+  // send pipeline), not the Groups.io mailing list — the label must describe
+  // the real audience, not the list address, or the confirm dialog would
+  // promise a destination the send never uses.
+  public readonly shareAudienceLabel: Signal<string> = computed(() => `all members of ${this.committee()?.name ?? 'this committee'}`);
 
   public constructor() {
     this.initBriefResponseSubscription();
@@ -276,6 +277,20 @@ export class WeeklyBriefCardComponent {
           this.messageService.add({ severity: 'error', summary: 'Save failed', detail });
         },
       });
+  }
+
+  public onShareToMailingList(): void {
+    // The Share action only renders outside edit mode (see the template's
+    // @if (editMode()) branch), so there is never an unsaved-edit case to
+    // guard here — the brief is always whatever was last saved.
+    this.confirmationService.confirm({
+      header: 'Share to Mailing List',
+      message: `Send the current brief by email to ${this.shareAudienceLabel()}?`,
+      icon: 'fa-light fa-paper-plane',
+      acceptLabel: 'Send',
+      rejectLabel: 'Cancel',
+      accept: () => this.performShare(),
+    });
   }
 
   public async onCopyAndShare(): Promise<void> {
@@ -478,6 +493,74 @@ export class WeeklyBriefCardComponent {
               detail: 'This is taking longer than expected — check back in a bit, or refresh.',
             });
           }
+        },
+      });
+  }
+
+  // Other private helpers
+  private performShare(): void {
+    const committeeUid = this.committee()?.uid;
+    const revision = this.brief()?.revision;
+    if (!committeeUid || revision === undefined) return;
+    this.sharing.set(true);
+    this.weeklyBriefService
+      .shareWeeklyBrief(committeeUid, revision)
+      .pipe(
+        take(1),
+        finalize(() => this.sharing.set(false))
+      )
+      .subscribe({
+        next: (result: ShareWeeklyBriefResult) => {
+          if (result.total_recipients === 0) {
+            this.messageService.add({
+              severity: 'warn',
+              summary: 'No recipients',
+              detail: 'No recipients were found for this committee — nothing was sent.',
+            });
+            return;
+          }
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Queued',
+            detail: `Brief queued for delivery to ${result.total_recipients} recipient${result.total_recipients === 1 ? '' : 's'}.`,
+          });
+        },
+        error: (err: HttpErrorResponse) => {
+          const code = (err?.error as { code?: string } | undefined)?.code;
+          const status = err?.status;
+          let detail: string;
+          if (status === 404) {
+            detail = 'No brief available to share.';
+          } else if (status === 403) {
+            detail = 'Only project writers can share the weekly brief by email. Contact a project administrator.';
+          } else if (status === 409) {
+            if (code === 'NO_MAILING_LIST') {
+              detail = 'No mailing list configured for this committee.';
+            } else if (code === 'BACKEND_NOT_LIVE') {
+              detail = 'Sharing is not available in this environment yet.';
+            } else if (code === 'REVISION_MISMATCH') {
+              detail = 'This brief was updated since you last viewed it. Reload to review the latest version before sharing.';
+              this.refresh$.next();
+            } else {
+              detail = 'This brief is already being sent, or was already sent.';
+            }
+          } else if (status === 400) {
+            // ServiceValidationError's top-level `error` field is a generic
+            // "Validation failed for X" — the actionable text lives in the
+            // per-field `errors[]` array.
+            const fieldErrors = (err?.error as { errors?: { message?: string }[] } | undefined)?.errors;
+            detail = fieldErrors?.[0]?.message ?? 'Failed to share brief. Please try again.';
+          } else if (status === 0 || status === 408 || status >= 500) {
+            // The send is async — a dropped connection, timeout, or 5xx here
+            // may mean the newsletter was already accepted upstream before
+            // the failure reached the client. Don't invite a retry that
+            // could send the brief twice. (status === 0 covers network
+            // failures/aborts, which never surface an HTTP status.)
+            detail = 'The send may not have completed — check the project’s Newsletters list before trying again.';
+          } else {
+            detail = 'Failed to share brief. Please try again.';
+          }
+          this.messageService.add({ severity: 'error', summary: 'Share failed', detail });
         },
       });
   }

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -7,6 +7,7 @@ import {
   GenerateWeeklyBriefRequest,
   GenerateWeeklyBriefResponse,
   SaveWeeklyBriefRequest,
+  ShareWeeklyBriefResult,
   WeeklyBrief,
   WeeklyBriefCurrentResponse,
 } from '@lfx-one/shared/interfaces';
@@ -54,5 +55,10 @@ export class WeeklyBriefService {
    */
   public saveWeeklyBrief(committeeId: string, body: SaveWeeklyBriefRequest): Observable<WeeklyBrief> {
     return this.http.put<WeeklyBrief>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`, body).pipe(take(1));
+  }
+
+  public shareWeeklyBrief(committeeId: string, revision: number): Observable<ShareWeeklyBriefResult> {
+    return this.http.post<ShareWeeklyBriefResult>(`/api/committees/${committeeId}/weekly-briefs/share`, { revision });
+    // No catchError — caller handles 404 (no brief) / 409 (no mailing list / stale revision) states
   }
 }

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -57,8 +57,13 @@ export class WeeklyBriefService {
     return this.http.put<WeeklyBrief>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`, body).pipe(take(1));
   }
 
+  /**
+   * POST /api/committees/:committeeId/weekly-briefs/share
+   *
+   * No `catchError` — the caller handles 404 (no brief) / 409 (no mailing list / stale
+   * revision) states by classifying the error itself.
+   */
   public shareWeeklyBrief(committeeId: string, revision: number): Observable<ShareWeeklyBriefResult> {
-    return this.http.post<ShareWeeklyBriefResult>(`/api/committees/${committeeId}/weekly-briefs/share`, { revision });
-    // No catchError — caller handles 404 (no brief) / 409 (no mailing list / stale revision) states
+    return this.http.post<ShareWeeklyBriefResult>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs/share`, { revision }).pipe(take(1));
   }
 }

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -171,12 +171,15 @@ export class CommitteeController {
       // Get the committee by ID — include caller membership so the UI can render
       // visitor / member / chair states without a second round-trip, enrich with
       // project metadata so the detail page's Parent Project link can resolve project_uid
-      // -> project_slug for navigation, and include inherited (parent-project) permissions
-      // so the members roster can label foundation-level managers correctly (LFXV2-2059).
+      // -> project_slug for navigation, include inherited (parent-project) permissions
+      // so the members roster can label foundation-level managers correctly (LFXV2-2059),
+      // and include mailing-list status (upstream does not reliably populate
+      // has_mailing_list on this endpoint — LFXV2-2914).
       const committee = await this.committeeService.getCommitteeById(req, id, {
         includeMembership: true,
         includeProjectMetadata: true,
         includeInheritedPermissions: true,
+        includeMailingListStatus: true,
       });
 
       // Log the success

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -1,7 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { NEWSLETTER_RAW_CONTENT_MAX_LENGTH, NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH } from '@lfx-one/shared/constants';
+import {
+  NEWSLETTER_BODY_MAX_LENGTH,
+  NEWSLETTER_RAW_CONTENT_MAX_LENGTH,
+  NEWSLETTER_SUBJECT_MAX_LENGTH,
+  NEWSLETTER_SYSTEM_PROMPT_MAX_LENGTH,
+} from '@lfx-one/shared/constants';
 import {
   CreateNewsletterRequest,
   GenerateNewsletterRequest,
@@ -19,8 +24,6 @@ import { AiService } from '../services/ai.service';
 import { logger } from '../services/logger.service';
 import { NewsletterService } from '../services/newsletter.service';
 
-const SUBJECT_MAX_LENGTH = 200;
-const BODY_MAX_LENGTH = 100_000;
 const COMMITTEE_LIMIT = 50;
 const CONTEXT_NAME_MAX_LENGTH = 200;
 
@@ -436,14 +439,14 @@ export class NewsletterController {
 
     if (!payload?.subject || typeof payload.subject !== 'string' || payload.subject.trim().length === 0) {
       fieldErrors['subject'] = 'Subject is required';
-    } else if (payload.subject.length > SUBJECT_MAX_LENGTH) {
-      fieldErrors['subject'] = `Subject must be ${SUBJECT_MAX_LENGTH} characters or fewer`;
+    } else if (payload.subject.length > NEWSLETTER_SUBJECT_MAX_LENGTH) {
+      fieldErrors['subject'] = `Subject must be ${NEWSLETTER_SUBJECT_MAX_LENGTH} characters or fewer`;
     }
 
     if (!payload?.body_html || typeof payload.body_html !== 'string' || payload.body_html.trim().length === 0) {
       fieldErrors['body_html'] = 'Body is required';
-    } else if (payload.body_html.length > BODY_MAX_LENGTH) {
-      fieldErrors['body_html'] = `Body must be ${BODY_MAX_LENGTH} characters or fewer`;
+    } else if (payload.body_html.length > NEWSLETTER_BODY_MAX_LENGTH) {
+      fieldErrors['body_html'] = `Body must be ${NEWSLETTER_BODY_MAX_LENGTH} characters or fewer`;
     }
 
     if (!payload?.ed_reply_email || typeof payload.ed_reply_email !== 'string' || !payload.ed_reply_email.includes('@')) {
@@ -464,14 +467,14 @@ export class NewsletterController {
 
     if (!payload?.subject || typeof payload.subject !== 'string' || payload.subject.trim().length === 0) {
       fieldErrors['subject'] = 'Subject is required';
-    } else if (payload.subject.length > SUBJECT_MAX_LENGTH) {
-      fieldErrors['subject'] = `Subject must be ${SUBJECT_MAX_LENGTH} characters or fewer`;
+    } else if (payload.subject.length > NEWSLETTER_SUBJECT_MAX_LENGTH) {
+      fieldErrors['subject'] = `Subject must be ${NEWSLETTER_SUBJECT_MAX_LENGTH} characters or fewer`;
     }
 
     if (!payload?.body_html || typeof payload.body_html !== 'string' || payload.body_html.trim().length === 0) {
       fieldErrors['body_html'] = 'Body is required';
-    } else if (payload.body_html.length > BODY_MAX_LENGTH) {
-      fieldErrors['body_html'] = `Body must be ${BODY_MAX_LENGTH} characters or fewer`;
+    } else if (payload.body_html.length > NEWSLETTER_BODY_MAX_LENGTH) {
+      fieldErrors['body_html'] = `Body must be ${NEWSLETTER_BODY_MAX_LENGTH} characters or fewer`;
     }
 
     if (!payload?.to_email || typeof payload.to_email !== 'string' || !payload.to_email.includes('@')) {

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -71,6 +71,23 @@ function validateGenerateBriefBody(body: unknown): { ok: true; value: GenerateWe
 }
 
 /**
+ * Narrow `req.body` to `{ revision: number }` for the share endpoint. The confirmation
+ * dialog shows a specific rendered revision — the caller must send it back so the
+ * service can reject a stale approval (another writer saved an edit in between)
+ * instead of silently sharing content the caller never actually reviewed.
+ */
+function validateShareBriefBody(body: unknown): { ok: true; value: { revision: number } } | { ok: false; fieldErrors: Record<string, string> } {
+  if (!body || typeof body !== 'object') {
+    return { ok: false, fieldErrors: { body: 'Request body must be a JSON object' } };
+  }
+  const b = body as Record<string, unknown>;
+  if (typeof b['revision'] !== 'number' || !Number.isFinite(b['revision'] as number)) {
+    return { ok: false, fieldErrors: { revision: 'revision is required and must be a finite number' } };
+  }
+  return { ok: true, value: { revision: b['revision'] as number } };
+}
+
+/**
  * Controller for the WG Weekly Brief endpoints.
  *
  * Upstream HTTP status codes (202 accepted, 429 throttle, 409 edited-brief
@@ -227,6 +244,58 @@ export class WeeklyBriefController {
         brief_uid: result.uid,
         revision: result.revision,
         state: result.state,
+      });
+
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /api/committees/:committeeId/weekly-briefs/share
+   *
+   * Gated by `assertCommitteeRead` (committee#auditor) — `shareBrief` reads the current
+   * brief internally before doing anything else, same unguarded-proxy gap as
+   * getCurrentBrief without this. The actual send is authorized separately and more
+   * narrowly inside the service (`project:{project_uid}#writer`, not committee#auditor),
+   * since that's the newsletter service's real enforcement boundary; this gate only
+   * closes the existence/state read, not the write.
+   */
+  public async shareBrief(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { committeeId } = req.params;
+    const startTime = logger.startOperation(req, 'share_weekly_brief', {
+      committee_id: committeeId,
+    });
+
+    try {
+      if (
+        !validateUidParameter(committeeId, req, next, {
+          operation: 'share_weekly_brief',
+          service: 'weekly_brief_controller',
+        })
+      ) {
+        return;
+      }
+
+      await assertCommitteeRead(req, committeeId, 'share_weekly_brief');
+
+      const validation = validateShareBriefBody(req.body);
+      if (!validation.ok) {
+        return next(
+          ServiceValidationError.fromFieldErrors(validation.fieldErrors, 'Invalid share-weekly-brief request body', {
+            operation: 'share_weekly_brief',
+            service: 'weekly_brief_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      const result = await this.weeklyBriefService.shareBrief(req, committeeId, validation.value.revision);
+
+      logger.success(req, 'share_weekly_brief', startTime, {
+        committee_id: committeeId,
+        total_recipients: result.total_recipients,
       });
 
       res.json(result);

--- a/apps/lfx-one/src/server/errors/index.ts
+++ b/apps/lfx-one/src/server/errors/index.ts
@@ -4,7 +4,7 @@
 export { BaseApiError } from './base.error';
 export { AuthenticationError, AuthorizationError } from './authentication.error';
 export { MicroserviceError } from './microservice.error';
-export { ServiceValidationError, ResourceNotFoundError } from './service-validation.error';
+export { ServiceValidationError, ResourceNotFoundError, ConflictError } from './service-validation.error';
 
 // Type guards for error identification
 import { AuthenticationError } from './authentication.error';

--- a/apps/lfx-one/src/server/errors/service-validation.error.ts
+++ b/apps/lfx-one/src/server/errors/service-validation.error.ts
@@ -94,3 +94,21 @@ export class ResourceNotFoundError extends BaseApiError {
     super(message, 404, 'NOT_FOUND', options);
   }
 }
+
+/**
+ * Error class for precondition-failed scenarios (e.g. an action requires
+ * some dependent resource/configuration that doesn't exist yet).
+ */
+export class ConflictError extends BaseApiError {
+  public constructor(
+    message: string,
+    code: string,
+    options: {
+      operation?: string;
+      service?: string;
+      path?: string;
+    } = {}
+  ) {
+    super(message, 409, code, options);
+  }
+}

--- a/apps/lfx-one/src/server/routes/weekly-brief.route.ts
+++ b/apps/lfx-one/src/server/routes/weekly-brief.route.ts
@@ -18,4 +18,7 @@ router.post('/:committeeId/weekly-briefs/generate', (req, res, next) => weeklyBr
 // PUT /committees/:committeeId/weekly-briefs/current - save edits to the current brief
 router.put('/:committeeId/weekly-briefs/current', (req, res, next) => weeklyBriefController.saveBrief(req, res, next));
 
+// POST /committees/:committeeId/weekly-briefs/share - share the current brief to the committee mailing list
+router.post('/:committeeId/weekly-briefs/share', (req, res, next) => weeklyBriefController.shareBrief(req, res, next));
+
 export default router;

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1435,6 +1435,21 @@ export class CommitteeService {
   }
 
   /**
+   * Strict single-committee mailing-list check — unlike {@link getMailingListCountByCommittee}
+   * (fail-open-to-false via the batch/Promise.allSettled path, acceptable for a cosmetic list
+   * badge), this propagates a query-service failure instead of silently reporting "no mailing
+   * list". Used by `shareBrief`, where a false negative would misattribute a transient outage
+   * as a real precondition failure (409 NO_MAILING_LIST) instead of a retryable error.
+   */
+  public async hasMailingListStrict(req: Request, committeeId: string): Promise<boolean> {
+    const { count } = await this.microserviceProxy.proxyRequest<QueryServiceCountResponse>(req, 'LFX_V2_SERVICE', '/query/resources/count', 'GET', {
+      type: 'groupsio_mailing_list',
+      tags: `committee_uid:${committeeId}`,
+    });
+    return count > 0;
+  }
+
+  /**
    * Batch-fetches committee resources by UID from the query service.
    * Chunks UIDs at 100 per request (URL-length guard) using `filters_or=uid:X`
    * for OR semantics on data.uid. Returns a map keyed by `uid` for O(1) lookup.
@@ -1798,6 +1813,12 @@ export class CommitteeService {
    * result rather than the batch method's `Set`. `/committees/{uid}` does not reliably
    * populate `has_mailing_list` itself (verified false against real, populated
    * committees — LFXV2-2914), so this recomputes it the same way the list endpoints do.
+   *
+   * Inherits `getCommitteesWithMailingList`'s fail-open-to-false behavior on a transient
+   * query-service failure — acceptable here since this only feeds a cosmetic list/detail
+   * badge. Callers with a real precondition riding on the answer (e.g. `shareBrief`, which
+   * would otherwise misreport an outage as "no mailing list configured") should use
+   * {@link hasMailingListStrict} instead.
    */
   private async getMailingListCountByCommittee(req: Request, committeeId: string): Promise<number> {
     const found = await this.getCommitteesWithMailingList(req, [committeeId]);

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -341,8 +341,16 @@ export class CommitteeService {
        *  write paths (e.g. accept invite) where an unknown business_email_required must not
        *  be treated as false (fail-closed). */
       throwOnSettingsError?: boolean;
+      includeMailingListStatus?: boolean;
     } = {}
   ): Promise<Committee> {
+    // `/committees/{uid}` (get-committee-base) does NOT reliably populate
+    // `has_mailing_list` in practice, despite an illustrative example in the
+    // upstream OpenAPI spec suggesting otherwise (verified false against 5/5
+    // prod committees, including ones with real, populated mailing lists —
+    // LFXV2-2914). Compute it the same way the query-service-backed list
+    // endpoints (getCommittees/getMyCommittees) do: a direct count against
+    // the mailing-list index.
     const committee = await this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
 
     if (!committee) {
@@ -353,13 +361,14 @@ export class CommitteeService {
       });
     }
 
-    // Fetch settings, optional caller membership, access, and optional inherited
-    // (parent-project) permissions in parallel.
-    const [settings, membership, withAccess, inheritedPermissions] = await Promise.all([
+    // Fetch settings, optional caller membership, access, optional inherited
+    // (parent-project) permissions, and optional mailing-list status in parallel.
+    const [settings, membership, withAccess, inheritedPermissions, mlCount] = await Promise.all([
       this.getCommitteeSettings(req, committeeId, { throwOnError: options.throwOnSettingsError }),
       options.includeMembership ? this.getCallerMembership(req, committeeId) : Promise.resolve(null),
       this.accessCheckService.addAccessToResource(req, committee, 'committee'),
       options.includeInheritedPermissions ? this.getInheritedPermissions(req, committee.project_uid) : Promise.resolve(null),
+      options.includeMailingListStatus ? this.getMailingListCountByCommittee(req, committeeId) : Promise.resolve(null),
     ]);
 
     const merged = {
@@ -367,6 +376,7 @@ export class CommitteeService {
       ...settings,
       ...(membership && { my_role: membership.role, my_member_uid: membership.member_uid }),
       ...(inheritedPermissions && { inherited_writers: inheritedPermissions.writers, inherited_auditors: inheritedPermissions.auditors }),
+      ...(mlCount !== null && { has_mailing_list: mlCount > 0 }),
     };
 
     if (!options.includeProjectMetadata) {
@@ -1780,6 +1790,18 @@ export class CommitteeService {
     }
 
     return found;
+  }
+
+  /**
+   * Single-committee count wrapper around {@link getCommitteesWithMailingList} — used by
+   * `getCommitteeById`'s `includeMailingListStatus` option, which needs a boolean-ish
+   * result rather than the batch method's `Set`. `/committees/{uid}` does not reliably
+   * populate `has_mailing_list` itself (verified false against real, populated
+   * committees — LFXV2-2914), so this recomputes it the same way the list endpoints do.
+   */
+  private async getMailingListCountByCommittee(req: Request, committeeId: string): Promise<number> {
+    const found = await this.getCommitteesWithMailingList(req, [committeeId]);
+    return found.has(committeeId) ? 1 : 0;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -19,8 +19,15 @@ const { proxyRequest, proxyRequestWithResponse, MOCK_THROTTLE } = vi.hoisted(() 
 
 vi.mock('@lfx-one/shared/constants', () => ({
   WEEKLY_BRIEF_DEFAULT_THROTTLE: MOCK_THROTTLE,
+  WEEKLY_BRIEF_SHAREABLE_STATES: ['generated', 'edited', 'approved'],
+  NEWSLETTER_SUBJECT_MAX_LENGTH: 200,
+  NEWSLETTER_BODY_MAX_LENGTH: 100_000,
 }));
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
+// `formatUtcDateRangeLabel` lives in the same `@lfx-one/shared/utils` barrel as
+// form.utils.ts, which imports `@angular/forms` — an unmocked import here would pull
+// in the real barrel and hit the same JIT-compilation failure the mocks above avoid.
+vi.mock('@lfx-one/shared/utils', () => ({ formatUtcDateRangeLabel: vi.fn(() => 'Jan 1 – Jan 7, 2026') }));
 
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
@@ -31,6 +38,12 @@ vi.mock('./microservice-proxy.service', () => ({
 vi.mock('./logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
 }));
+// shareBrief's collaborators — not exercised by this spec (no shareBrief tests here),
+// but WeeklyBriefService's constructor instantiates all three, so they must at least
+// be constructible without pulling in their own real import chains.
+vi.mock('./committee.service', () => ({ CommitteeService: class {} }));
+vi.mock('./newsletter.service', () => ({ NewsletterService: class {} }));
+vi.mock('./access-check.service', () => ({ AccessCheckService: class {} }));
 
 import type { Request } from 'express';
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1,20 +1,48 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { WEEKLY_BRIEF_DEFAULT_THROTTLE } from '@lfx-one/shared/constants';
+import {
+  NEWSLETTER_BODY_MAX_LENGTH,
+  NEWSLETTER_SUBJECT_MAX_LENGTH,
+  WEEKLY_BRIEF_DEFAULT_THROTTLE,
+  WEEKLY_BRIEF_SHAREABLE_STATES,
+} from '@lfx-one/shared/constants';
 import {
   GenerateWeeklyBriefRequest,
   GenerateWeeklyBriefResponse,
+  Newsletter,
+  NewsletterSendResult,
   SaveWeeklyBriefRequest,
+  ShareWeeklyBriefResult,
   WeeklyBrief,
   WeeklyBriefCurrentResponse,
 } from '@lfx-one/shared/interfaces';
+import { formatUtcDateRangeLabel } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { MicroserviceError } from '../errors';
+import { AuthorizationError, ConflictError, MicroserviceError, ResourceNotFoundError, ServiceValidationError } from '../errors';
+import { getEffectiveEmail } from '../utils/auth-helper';
 
+import { AccessCheckService } from './access-check.service';
+import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
+import { NewsletterService } from './newsletter.service';
+
+/**
+ * HTML-escapes a plain-text string, then converts blank-line-separated
+ * paragraphs into `<p>` blocks (single newlines become `<br>`). The weekly
+ * brief's `brief_text` is plain text today (rendered via a `<pre>` in the
+ * card), so this is a minimal plain-text → HTML bridge for the newsletter
+ * `body_html` field — not a markdown renderer.
+ */
+function briefTextToHtml(text: string): string {
+  const escape = (s: string): string => s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+  return text
+    .split(/\n{2,}/)
+    .map((paragraph) => `<p>${escape(paragraph).replace(/\n/g, '<br>')}</p>`)
+    .join('');
+}
 
 /**
  * Returns the ISO timestamp for the upcoming Sunday at 00:00:00 UTC.
@@ -114,13 +142,21 @@ function buildMockBrief(committeeId: string, overrides: Partial<WeeklyBrief> = {
 /**
  * Service for the WG Weekly Brief feature.
  *
- * Switches between mock data (default) and live committee-service proxy based on
- * `WEEKLY_BRIEF_BACKEND`. Mock mode lets the UI iterate without standing up the
- * upstream brief endpoints; flipping to 'live' proxies straight through. Mock
- * mode is refused outright when `NODE_ENV=production` — see `isLive()`.
+ * `getCurrentBrief` / `generateBrief` / `saveBrief` switch between mock data
+ * (default) and live committee-service proxy based on `WEEKLY_BRIEF_BACKEND`.
+ * Mock mode lets the UI iterate without standing up the upstream brief
+ * endpoints; flipping to 'live' proxies straight through. Mock mode is
+ * refused outright when `NODE_ENV=production` — see `isLive()`. `shareBrief`
+ * always enforces its precondition checks (brief exists, caller is a writer,
+ * committee has a mailing list) regardless of mode, but the send itself
+ * requires `WEEKLY_BRIEF_BACKEND=live` — it never fires against mock brief
+ * content.
  */
 export class WeeklyBriefService {
   private microserviceProxy: MicroserviceProxyService = new MicroserviceProxyService();
+  private committeeService: CommitteeService = new CommitteeService();
+  private newsletterService: NewsletterService = new NewsletterService();
+  private accessCheckService: AccessCheckService = new AccessCheckService();
 
   /**
    * GET /committees/:committeeId/weekly-briefs/current
@@ -261,6 +297,185 @@ export class WeeklyBriefService {
     } catch (error) {
       throw this.withConflictBody(error);
     }
+  }
+
+  /**
+   * POST /committees/:committeeId/weekly-briefs/share
+   *
+   * Sends the current saved brief to the committee's mailing list. There is no
+   * mailing-list send endpoint anywhere (this repo's mailing-list controller/
+   * service, nor the upstream lfx-v2-mailing-list-service) — this repurposes the
+   * newsletter send pipeline instead (create + send), whose recipients resolve
+   * from `committee_uids` rather than the Groups.io mailing list itself. See
+   * the LFXV2-2914 plan for the full rationale and trade-offs.
+   *
+   * The newsletter send is asynchronous (202 Accepted; fan-out completes in a
+   * detached background job upstream) — `total_recipients` is a snapshot taken
+   * at acceptance, not a delivered/failed count.
+   *
+   * Authorization is `project:{project_uid}#writer`, not `committee.writer` —
+   * the newsletter service only recognizes the former, and there's no delegated/
+   * on-behalf-of token mechanism in this codebase to bridge a direct-committee-
+   * grant-only writer through to it (see the isProjectWriter check below). This
+   * narrows who can share versus the ticket's original "chair/admin" framing;
+   * a committee chair who isn't also a project writer will get a 403.
+   *
+   * Requires `WEEKLY_BRIEF_BACKEND=live` — throws a 409 `BACKEND_NOT_LIVE`
+   * otherwise, after still enforcing the brief/writer/mailing-list
+   * preconditions below (so mock-mode testing exercises the same guards).
+   */
+  public async shareBrief(req: Request, committeeId: string, expectedRevision: number): Promise<ShareWeeklyBriefResult> {
+    const { brief } = await this.getCurrentBrief(req, committeeId);
+    if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) {
+      throw new ResourceNotFoundError('Weekly brief', committeeId, {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+      });
+    }
+    // The confirmation dialog shows whatever revision was rendered client-side at the
+    // time of confirmation — if another writer saved an edit since then, that's no
+    // longer the text the caller actually reviewed and approved sending. Same revision-
+    // conflict convention as saveBrief/generateBrief, applied here so a stale approval
+    // can't silently email newer, unreviewed content.
+    if (brief.revision !== expectedRevision) {
+      throw new ConflictError('The brief has been updated since you last viewed it. Reload to review the latest version before sharing.', 'REVISION_MISMATCH', {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+      });
+    }
+
+    const committee = await this.committeeService.getCommitteeById(req, committeeId, { includeMailingListStatus: true });
+    // committee.writer is a superset of what we need here — per committee.interface.ts's
+    // own doc comment, it's true for both a direct committee-level grant AND an inherited
+    // project writer, but the newsletter service (which this repurposes for delivery)
+    // only recognizes project:{project_uid}#writer. A direct-grant-only committee writer
+    // would pass committee.writer, then 403 from the newsletter service — and there's no
+    // delegated/on-behalf-of token mechanism in this codebase to bridge that gap without
+    // misattributing the send (the newsletter service resolves the sender's display name
+    // from the signed JWT principal; an M2M token has none). Check the actual boundary
+    // directly instead, with the caller's own bearer token.
+    const isProjectWriter = await this.accessCheckService.checkSingleAccess(req, {
+      resource: 'project',
+      id: committee.project_uid,
+      access: 'writer',
+    });
+    if (!isProjectWriter) {
+      throw new AuthorizationError('Only project writers can share the weekly brief by email', {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+        code: 'NOT_PROJECT_WRITER',
+      });
+    }
+    if (!committee.has_mailing_list) {
+      throw new ConflictError('Committee has no mailing list configured', 'NO_MAILING_LIST', {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+      });
+    }
+
+    // Preconditions above (brief exists, caller is a writer, committee has a
+    // mailing list) are enforced regardless of backend mode. Only the actual
+    // send is gated on isLive() — the read side is mock-backed by default
+    // (WEEKLY_BRIEF_BACKEND unset/!='live') and returns canned placeholder
+    // text, so a real send from mock content must never happen. Fails loudly
+    // rather than fabricating a success the caller can't distinguish from a
+    // real send.
+    if (!this.isLive(req)) {
+      throw new ConflictError('Sharing is not available in this environment (WEEKLY_BRIEF_BACKEND is not "live")', 'BACKEND_NOT_LIVE', {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+      });
+    }
+
+    const subject = `[Weekly Brief] ${committee.name} — ${formatUtcDateRangeLabel(brief.window_start, brief.window_end)}`;
+    const bodyHtml = briefTextToHtml(brief.brief_text);
+    const edReplyEmail = getEffectiveEmail(req);
+    if (!edReplyEmail) {
+      throw ServiceValidationError.forField('ed_reply_email', 'Unable to resolve your account email for the reply-to address', {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+      });
+    }
+    if (subject.length > NEWSLETTER_SUBJECT_MAX_LENGTH) {
+      throw ServiceValidationError.forField('subject', `Subject must be ${NEWSLETTER_SUBJECT_MAX_LENGTH} characters or fewer`, {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+      });
+    }
+    if (bodyHtml.length > NEWSLETTER_BODY_MAX_LENGTH) {
+      throw ServiceValidationError.forField(
+        'brief_text',
+        `Brief is too long to share (must render to ${NEWSLETTER_BODY_MAX_LENGTH} characters or fewer as HTML)`,
+        {
+          operation: 'share_weekly_brief',
+          service: 'weekly_brief_service',
+        }
+      );
+    }
+
+    // isProjectWriter (checked above) is the newsletter service's actual authorization
+    // boundary, so the caller's own bearer token is used as-is here — no token swap,
+    // and the sender's display name resolves correctly from the caller's own JWT
+    // principal (see NewsletterServiceClient#sendNewsletter's doc comment).
+    const newsletter: Newsletter = await this.newsletterService.createNewsletter(req, committee.project_uid, {
+      subject,
+      body_html: bodyHtml,
+      ed_reply_email: edReplyEmail,
+      committee_uids: [committeeId],
+    });
+
+    let sendResult: NewsletterSendResult;
+    try {
+      sendResult = await this.newsletterService.sendNewsletter(req, committee.project_uid, newsletter.id, newsletter.version);
+    } catch (error) {
+      // Only clean up on a deterministic rejection (draft validation failed,
+      // not found, etc). The send is asynchronous — a timeout or 5xx *after*
+      // upstream accepted it is indistinguishable from a real rejection here,
+      // and deleting the draft in that case would desync us from a send that
+      // actually went out. Ambiguous failures are left in place and logged.
+      const isDeterministicRejection =
+        error instanceof MicroserviceError && error.statusCode >= 400 && error.statusCode < 500 && ![408, 409, 429].includes(error.statusCode);
+      if (isDeterministicRejection) {
+        try {
+          await this.newsletterService.deleteNewsletter(req, committee.project_uid, newsletter.id);
+        } catch (cleanupError) {
+          logger.warning(req, 'share_weekly_brief_cleanup_failed', 'Failed to delete orphaned draft newsletter after a failed send', {
+            committee_id: committeeId,
+            newsletter_id: newsletter.id,
+            error: cleanupError instanceof Error ? cleanupError.message : 'Unknown error',
+          });
+        }
+      } else {
+        // The original error is rethrown below and logged centrally by
+        // apiErrorHandler — no need to duplicate its message here, just the
+        // newsletter_id so an operator can find the orphaned draft.
+        logger.warning(
+          req,
+          'share_weekly_brief_ambiguous_send_failure',
+          'Send failed ambiguously (may have been accepted upstream) — leaving draft newsletter in place for manual review',
+          {
+            committee_id: committeeId,
+            newsletter_id: newsletter.id,
+          }
+        );
+      }
+      throw error;
+    }
+
+    // The newsletter API only accepts/queues the send here; upstream fan-out
+    // runs asynchronously in a detached job and can still fail completely
+    // afterward. Log as queued, not sent — an operator reading this event
+    // should not treat it as a delivery confirmation.
+    logger.info(req, 'share_weekly_brief_queued', 'Weekly brief queued for delivery via newsletter send pipeline', {
+      committee_id: committeeId,
+      newsletter_id: newsletter.id,
+      total_recipients: sendResult.total_recipients,
+    });
+
+    return {
+      committee_name: committee.name,
+      total_recipients: sendResult.total_recipients,
+    };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -344,7 +344,7 @@ export class WeeklyBriefService {
       });
     }
 
-    const committee = await this.committeeService.getCommitteeById(req, committeeId, { includeMailingListStatus: true });
+    const committee = await this.committeeService.getCommitteeById(req, committeeId);
     // committee.writer is a superset of what we need here — per committee.interface.ts's
     // own doc comment, it's true for both a direct committee-level grant AND an inherited
     // project writer, but the newsletter service (which this repurposes for delivery)
@@ -354,7 +354,15 @@ export class WeeklyBriefService {
     // misattributing the send (the newsletter service resolves the sender's display name
     // from the signed JWT principal; an M2M token has none). Check the actual boundary
     // directly instead, with the caller's own bearer token.
-    const isProjectWriter = await this.accessCheckService.checkSingleAccess(req, {
+    //
+    // checkSingleAccessStrict, not checkSingleAccess — the non-strict variant degrades a
+    // transient access-check outage to "no access", which would surface here as a
+    // misleading 403 NOT_PROJECT_WRITER instead of a retryable error. Sharing is a
+    // deliberate, low-frequency action (unlike a list-view access annotation, where
+    // fail-closed-to-false is an acceptable trade-off), so misattributing an outage as a
+    // permission denial is worse here — same rationale as committee-access.internal.helper.ts's
+    // existing use of the strict variant.
+    const isProjectWriter = await this.accessCheckService.checkSingleAccessStrict(req, {
       resource: 'project',
       id: committee.project_uid,
       access: 'writer',
@@ -366,7 +374,12 @@ export class WeeklyBriefService {
         code: 'NOT_PROJECT_WRITER',
       });
     }
-    if (!committee.has_mailing_list) {
+    // hasMailingListStrict, not the fail-open-to-false `has_mailing_list` field
+    // getCommitteeById's includeMailingListStatus would otherwise compute — a transient
+    // query-service failure here must not be misreported as "no mailing list configured"
+    // (409 NO_MAILING_LIST is a real, actionable precondition failure; an outage isn't).
+    const hasMailingList = await this.committeeService.hasMailingListStrict(req, committeeId);
+    if (!hasMailingList) {
       throw new ConflictError('Committee has no mailing list configured', 'NO_MAILING_LIST', {
         operation: 'share_weekly_brief',
         service: 'weekly_brief_service',

--- a/packages/shared/src/constants/newsletter.constants.ts
+++ b/packages/shared/src/constants/newsletter.constants.ts
@@ -13,6 +13,12 @@ export const NEWSLETTER_PROMPT_STORAGE_KEY = 'lfx-newsletter-ai-prompt';
 
 export const NEWSLETTER_RAW_CONTENT_MAX_LENGTH = 50_000;
 
+// Field limits enforced by NewsletterController.validateCommonPayload — shared
+// so any other caller building a CreateNewsletterRequest (e.g. the weekly-brief
+// share action) can validate up front instead of relying on an opaque upstream 400.
+export const NEWSLETTER_SUBJECT_MAX_LENGTH = 200;
+export const NEWSLETTER_BODY_MAX_LENGTH = 100_000;
+
 // Cap must exceed the default AI_NEWSLETTER_SYSTEM_PROMPT (~6.2k chars) plus reasonable
 // customization headroom — otherwise the default prompt fails the frontend validator on init
 // and the Generate button never enables.

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -4,6 +4,13 @@
 import { WeeklyBriefState } from '../interfaces/weekly-brief.interface';
 
 /**
+ * Brief states a "Share to Mailing List" action may fire from — i.e. states
+ * with saved brief_text worth sending. Excludes `empty`, `generating`, and
+ * `error`.
+ */
+export const WEEKLY_BRIEF_SHAREABLE_STATES: readonly WeeklyBriefState[] = ['generated', 'edited', 'approved'] as const;
+
+/**
  * Default WG Weekly Brief throttle counters.
  *
  * Used by the BFF (`apps/lfx-one/src/server/services/weekly-brief.service.ts`) for

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -75,3 +75,15 @@ export interface SaveWeeklyBriefRequest {
   brief_text: string;
   revision: number;
 }
+
+/**
+ * `total_recipients` is a recipient-count snapshot taken at send-acceptance
+ * time — the underlying newsletter send is asynchronous (202 Accepted; fan-out
+ * completes in a detached background job), so there is no synchronous
+ * sent/failed count to report here. The zero-recipient case settles
+ * synchronously with `total_recipients: 0` and no email dispatched.
+ */
+export interface ShareWeeklyBriefResult {
+  committee_name: string;
+  total_recipients: number;
+}

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -30,6 +30,21 @@ export const formatDateToISOString = (date: Date | null | undefined): string | u
 };
 
 /**
+ * Formats a UTC ISO datetime range as a short human-readable label, e.g.
+ * "May 17 – May 23, 2026". Pins `timeZone: 'UTC'` so callers in negative
+ * offsets don't see the start shift to the prior day — used for windows that
+ * are already UTC day boundaries (e.g. the WG Weekly Brief's Sunday–Saturday
+ * window), not for user-local display.
+ */
+export const formatUtcDateRangeLabel = (startIso: string, endIso: string): string => {
+  const start = new Date(startIso);
+  const end = new Date(endIso);
+  const startLabel = start.toLocaleDateString('en-US', { month: 'short', day: 'numeric', timeZone: 'UTC' });
+  const endLabel = end.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
+  return `${startLabel} – ${endLabel}`;
+};
+
+/**
  * Converts a Date object or parseable date string to a full ISO 8601 UTC datetime string
  * (e.g. "2019-02-28T11:49:27.000Z").
  * Use this when an API requires a complete datetime string rather than a date-only string.


### PR DESCRIPTION
## Summary

Adds a "Share to Mailing List" action to the weekly-brief card, sending the current saved brief via email. Authorization is project:{project_uid}#writer (not committee.writer, and not the ticket's original chair/admin framing — see below). Confirmation dialog shows the true recipient audience before sending; disabled with a visible reason when the committee has no mailing list configured.

## Key deviation from the ticket's stated premise

LFXV2-2914 assumes an "existing mailing-list send endpoint." **No such endpoint exists** — verified against this repo's `mailing-list.controller/service/route.ts` (CRUD only) and the upstream `lfx-v2-mailing-list-service` OpenAPI spec (no send/message operation). This PR instead repurposes the **newsletter** send pipeline (create + send), whose recipients resolve from `committee_uids` (committee membership), not the Groups.io mailing list. Full rationale in the branch's plan file / commit history.

**Known, accepted trade-off:** every share creates a real `Newsletter` record, visible in the project's Newsletters dashboard (subject prefixed `[Weekly Brief] ...` so it's at least self-identifying). Confirmed with the requester before implementing.

## Server-side safety guarantees added during review

- `shareBrief` enforces brief-exists / caller-is-project-writer / committee-has-mailing-list / revision-matches preconditions **before** the live/mock backend check — mock mode (the default, `WEEKLY_BRIEF_BACKEND` unset) now fails loudly (409 `BACKEND_NOT_LIVE`) instead of ever sending a real email from placeholder brief text.
- Orphaned draft newsletters are cleaned up only on deterministic 4xx rejections; ambiguous failures (timeouts, 5xx, network drops) leave the draft in place since the async send may have already been accepted upstream — client copy for those cases tells the user to check the Newsletters list rather than inviting a duplicate send.
- `has_mailing_list` is computed via a query-service count, not the native `GET /committees/{uid}` field (verified unreliable in prod — LFXV2-2914). `shareBrief` uses a strict variant (`hasMailingListStrict`) that propagates a transient query-service failure instead of misreporting it as "no mailing list configured"; the committee detail page's cosmetic badge keeps the existing fail-open-to-false batch check.
- Authorization uses `checkSingleAccessStrict`, not `checkSingleAccess` — same rationale: a transient access-check outage must surface as a retryable error, not a misleading 403.

## Out of scope / pre-existing (flagged, not fixed here)

- The Angular `WeeklyBriefService.getWeeklyBrief` swallows all GET failures into a fake success, making the card's existing "unavailable" retry state (from the base branch) currently unreachable. Pre-existing, not touched by this diff — worth a follow-up ticket.
- No `-robust.spec.ts` structural companion exists for this card — pre-existing gap from the base branch's original spec.

## Test plan

- [x] `yarn lint && yarn format && yarn check-types && yarn build` all pass
- [x] `yarn test` — shared package and `apps/lfx-one` (vitest, server-scoped) both pass; `weekly-brief.service.spec.ts` covers the mock/live-mode and revision-conflict paths for getCurrentBrief/generateBrief/saveBrief
- [ ] `yarn e2e --grep "weekly-brief-card"` — spec extended with 6 new scenarios (happy path, disabled state, send failure, 400 validation, BACKEND_NOT_LIVE, regenerate-disabled-hint parity); not run against a live dev server in this session
- [ ] Manual smoke via a running dev server: generate a brief, confirm Share disabled without a mailing list / enabled with one, confirm the resulting Newsletter appears (expected) in the project's Newsletters list

🤖 Generated with [Claude Code](https://claude.com/claude-code)
