### PR TITLE
feat(groups): dashboard rollup stats BFF + stat cards

### DIFF
--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -117,9 +117,10 @@ LENS_API_KEY=your-lens-api-key
 # Groups dashboard engagement stats (LFXV2-1711 / LFXV2-1705)
 # 'live' (default when unset) returns null fields until the dbt engagement model read path
 # exists — an unconfigured environment must fail to no-data, never to fabricated numbers.
-# Set 'mock' explicitly (as below) for local dev to serve deterministic fixtures instead.
+# Left commented out on purpose: a plain `cp .env.example .env` must default to 'live', not
+# silently serve fabricated numbers. Uncomment for local dev to see deterministic fixtures.
 # Keep this name identical across both tickets.
-ENGAGEMENT_BACKEND=mock
+# ENGAGEMENT_BACKEND=mock
 
 # Runtime Client IDs
 # These are injected at container runtime (not build time)

--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -114,6 +114,11 @@ TI_API_KEY=
 LENS_API_URL=https://lfx-ai.onrender.com
 LENS_API_KEY=your-lens-api-key
 
+# Groups dashboard engagement stats (LFXV2-1711 / LFXV2-1705)
+# 'mock' (default) serves deterministic fixtures; 'live' returns null fields until the
+# dbt engagement model read path exists. Keep this name identical across both tickets.
+ENGAGEMENT_BACKEND=mock
+
 # Runtime Client IDs
 # These are injected at container runtime (not build time)
 # allowing a single Docker image to be deployed to any environment

--- a/apps/lfx-one/.env.example
+++ b/apps/lfx-one/.env.example
@@ -115,8 +115,10 @@ LENS_API_URL=https://lfx-ai.onrender.com
 LENS_API_KEY=your-lens-api-key
 
 # Groups dashboard engagement stats (LFXV2-1711 / LFXV2-1705)
-# 'mock' (default) serves deterministic fixtures; 'live' returns null fields until the
-# dbt engagement model read path exists. Keep this name identical across both tickets.
+# 'live' (default when unset) returns null fields until the dbt engagement model read path
+# exists — an unconfigured environment must fail to no-data, never to fabricated numbers.
+# Set 'mock' explicitly (as below) for local dev to serve deterministic fixtures instead.
+# Keep this name identical across both tickets.
 ENGAGEMENT_BACKEND=mock
 
 # Runtime Client IDs

--- a/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
+++ b/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
@@ -1,0 +1,266 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Groups dashboard — engagement stats flag/lens gating — LFXV2-1711.
+ *
+ * Coverage:
+ *   - `wg-engagement-metrics` flag off (the default until the flag is created/enabled in
+ *     LaunchDarkly): Me lens renders the 3 always-on group-count cards only, and the
+ *     `/api/committees/engagement-stats` endpoint is never requested.
+ *   - Foundation lens never requests or renders the engagement cards, regardless of flag state —
+ *     the endpoint is caller-scoped ("mine semantics"), so it has no scoped card to render there.
+ *   - `wg-engagement-metrics` flag on: Me lens renders 5 cards, with Active Members / Meetings This
+ *     Month populated from the mocked engagement-stats response.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD
+ *   - The flag-on test additionally requires `wg-engagement-metrics` toggled ON for the test user
+ *     in LaunchDarkly — it skips gracefully (matching org-selector.spec.ts's precedent) if the
+ *     flag isn't configured, rather than failing CI on missing external LD setup.
+ */
+
+import type { Committee, MyCommittee, PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
+import { LENS_COOKIE_KEY, PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+
+const MOCK_FOUNDATION_SLUG = 'test-foundation';
+const MOCK_FOUNDATION_UID = 'f0000000-0000-0000-0000-00000000d001';
+const MOCK_COMMITTEE_UID = 'c0000000-0000-0000-0000-00000000d001';
+const ENGAGEMENT_STATS_PATH = '/api/committees/engagement-stats';
+
+function buildMyCommittees(): MyCommittee[] {
+  const now = new Date().toISOString();
+  return [
+    {
+      uid: MOCK_COMMITTEE_UID,
+      name: 'Technical Steering Committee',
+      category: 'Technical Steering Committee',
+      enable_voting: true,
+      public: true,
+      sso_group_enabled: false,
+      created_at: now,
+      updated_at: now,
+      total_members: 12,
+      total_voting_repos: 5,
+      project_uid: 'p0000000-0000-0000-0000-00000000d001',
+      project_name: 'Test Project',
+      my_role: 'Chair',
+    } as MyCommittee,
+  ];
+}
+
+function buildFoundationCommittees(): Committee[] {
+  const now = new Date().toISOString();
+  return [
+    {
+      uid: MOCK_COMMITTEE_UID,
+      name: 'Governing Board',
+      category: 'Board',
+      enable_voting: true,
+      public: true,
+      sso_group_enabled: false,
+      created_at: now,
+      updated_at: now,
+      total_members: 9,
+      total_voting_repos: 9,
+      project_uid: MOCK_FOUNDATION_UID,
+      project_name: 'Test Foundation',
+      is_foundation: true,
+    } as Committee,
+  ];
+}
+
+function buildProjectStub() {
+  return {
+    uid: MOCK_FOUNDATION_UID,
+    slug: MOCK_FOUNDATION_SLUG,
+    name: 'Test Foundation',
+    description: 'Test foundation for groups engagement-stats specs',
+    public: true,
+    parent_uid: '',
+    stage: 'Active',
+    category: 'project',
+    funding_model: [],
+    charter_url: '',
+    legal_entity_type: '',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '',
+    logo_url: '',
+    repository_url: '',
+    website_url: '',
+    created_at: '',
+    updated_at: new Date().toISOString(),
+    mailing_list_count: 0,
+    writer: true,
+  };
+}
+
+async function stubPersona(page: Page, personas: string[]): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ personas, personaProjects: {}, projects: [], organizations: [], isRootWriter: true }),
+    })
+  );
+}
+
+async function stubPendingInvitations(page: Page): Promise<void> {
+  await page.route('**/api/user/pending-invitations*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) }));
+}
+
+async function stubMyCommittees(page: Page, committees: MyCommittee[]): Promise<void> {
+  await page.route('**/api/committees/my-committees*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committees) })
+  );
+}
+
+async function stubFoundationCommittees(page: Page, committees: Committee[]): Promise<void> {
+  await page.route('**/api/committees/my-committee-uids*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify([]) })
+  );
+  await page.route('**/api/committees*', (route) => {
+    const pathname = new URL(route.request().url()).pathname;
+    if (pathname !== '/api/committees') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committees) });
+  });
+}
+
+async function stubProjectApi(page: Page): Promise<void> {
+  await page.route(`**/api/projects/${MOCK_FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(buildProjectStub()) })
+  );
+  await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
+}
+
+async function stubEngagementStats(page: Page): Promise<void> {
+  await page.route(`**${ENGAGEMENT_STATS_PATH}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ active_members: 7, meetings_this_month: 2, computed_at: new Date().toISOString(), source: 'live' }),
+    })
+  );
+}
+
+async function setCookies(page: Page, personas: string[], lens: 'me' | 'foundation'): Promise<void> {
+  const state: PersistedPersonaState = { primary: personas[0] as PersonaType, all: personas as PersonaType[] };
+  await page.context().addCookies([
+    { name: PERSONA_COOKIE_KEY, value: encodeURIComponent(JSON.stringify(state)), domain: 'localhost', path: '/', sameSite: 'Lax' },
+    { name: LENS_COOKIE_KEY, value: lens, domain: 'localhost', path: '/', sameSite: 'Lax' },
+  ]);
+}
+
+// Gated on env vars rather than on URL sniffing so genuine auth-flow regressions (expired
+// storageState, broken Auth0 login helper) still fail loudly when creds ARE configured.
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+async function gotoMyGroups(page: Page): Promise<void> {
+  skipWhenAuthMissing();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto('/groups', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('committees-me-stats')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+}
+
+async function gotoFoundationGroups(page: Page): Promise<void> {
+  skipWhenAuthMissing();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto(`/foundation/groups?project=${MOCK_FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('committees-foundation-stats')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+}
+
+test.describe('Groups dashboard — engagement stats (LFXV2-1711)', () => {
+  test.describe('Me lens', () => {
+    let engagementRequestCount = 0;
+
+    test.beforeEach(async ({ page }) => {
+      engagementRequestCount = 0;
+      page.on('request', (req) => {
+        if (req.url().includes(ENGAGEMENT_STATS_PATH)) engagementRequestCount++;
+      });
+
+      await setCookies(page, ['contributor'], 'me');
+      await stubPersona(page, ['contributor']);
+      await stubPendingInvitations(page);
+      await stubMyCommittees(page, buildMyCommittees());
+      await stubEngagementStats(page);
+      await gotoMyGroups(page);
+    });
+
+    test('flag off (default): renders the 3 always-on group-count cards and never requests engagement-stats', async ({ page }) => {
+      const grid = page.getByTestId('committees-me-stats');
+      await expect(grid.getByTestId('stat-card-Total Groups')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(grid.getByTestId('stat-card-Public Groups')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(grid.getByTestId('stat-card-Voting Enabled Groups')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+      const activeMembersCard = grid.getByTestId('stat-card-Active Members');
+      const flagAppearsOn = await activeMembersCard.isVisible().catch(() => false);
+      test.skip(flagAppearsOn, 'wg-engagement-metrics flag appears ON for this test user — covered by the flag-on test below instead');
+
+      await expect(activeMembersCard).toHaveCount(0);
+      await expect(grid.getByTestId('stat-card-Meetings This Month')).toHaveCount(0);
+
+      // Wait a moment for any async requests to fire, then assert the flag-gated fetch never ran.
+      await page.waitForTimeout(1_000);
+      expect(engagementRequestCount).toBe(0);
+    });
+
+    test('flag on: renders 5 cards, with Active Members / Meetings This Month populated from the response', async ({ page }) => {
+      const grid = page.getByTestId('committees-me-stats');
+      const activeMembersCard = grid.getByTestId('stat-card-Active Members');
+
+      const flagAppearsOn = await activeMembersCard.isVisible({ timeout: ELEMENT_TIMEOUT }).catch(() => false);
+      test.skip(!flagAppearsOn, 'wg-engagement-metrics flag appears OFF for this test user — see file header for the LD precondition');
+
+      await expect(activeMembersCard).toContainText('7', { timeout: ELEMENT_TIMEOUT });
+      await expect(grid.getByTestId('stat-card-Meetings This Month')).toContainText('2', { timeout: ELEMENT_TIMEOUT });
+      expect(engagementRequestCount).toBeGreaterThanOrEqual(1);
+    });
+  });
+
+  test.describe('Foundation lens', () => {
+    test.beforeEach(async ({ page }) => {
+      await setCookies(page, ['executive-director'], 'foundation');
+      await stubPersona(page, ['executive-director']);
+      await stubProjectApi(page);
+      await stubFoundationCommittees(page, buildFoundationCommittees());
+      await stubEngagementStats(page);
+    });
+
+    test('never requests or renders the engagement cards, regardless of flag state', async ({ page }) => {
+      let engagementRequestCount = 0;
+      page.on('request', (req) => {
+        if (req.url().includes(ENGAGEMENT_STATS_PATH)) engagementRequestCount++;
+      });
+
+      await gotoFoundationGroups(page);
+
+      const grid = page.getByTestId('committees-foundation-stats');
+      await expect(grid.getByTestId('stat-card-Total Groups')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await expect(grid.getByTestId('stat-card-Active Members')).toHaveCount(0);
+      await expect(grid.getByTestId('stat-card-Meetings This Month')).toHaveCount(0);
+
+      await page.waitForTimeout(1_000);
+      expect(engagementRequestCount).toBe(0);
+    });
+  });
+});

--- a/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
+++ b/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
@@ -23,7 +23,7 @@
 
 import type { Committee, MyCommittee, PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
 import { LENS_COOKIE_KEY, PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
-import { expect, Page, test } from '@playwright/test';
+import { expect, Locator, Page, test } from '@playwright/test';
 
 test.setTimeout(60_000);
 
@@ -170,6 +170,20 @@ function skipWhenAuthMissing(): void {
   }
 }
 
+/**
+ * Whether `locator` becomes visible within `timeout` — used to detect the LaunchDarkly flag's
+ * resolved state. `Locator.isVisible()`'s `timeout` option is deprecated and ignored (Playwright
+ * always returns immediately from `isVisible()`, regardless of any timeout passed), so checking
+ * "did the flag turn out on?" requires actually waiting via `waitFor()` — an immediate check can
+ * read `false` before the async flag client resolves, even when the card appears moments later.
+ */
+async function cardAppears(locator: Locator, timeout: number): Promise<boolean> {
+  return locator
+    .waitFor({ state: 'visible', timeout })
+    .then(() => true)
+    .catch(() => false);
+}
+
 async function gotoMyGroups(page: Page): Promise<void> {
   skipWhenAuthMissing();
   await page.goto('/', { waitUntil: 'domcontentloaded' });
@@ -213,7 +227,7 @@ test.describe('Groups dashboard — engagement stats (LFXV2-1711)', () => {
       await expect(grid.getByTestId('stat-card-Voting Enabled Groups')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
 
       const activeMembersCard = grid.getByTestId('stat-card-Active Members');
-      const flagAppearsOn = await activeMembersCard.isVisible().catch(() => false);
+      const flagAppearsOn = await cardAppears(activeMembersCard, ELEMENT_TIMEOUT);
       test.skip(flagAppearsOn, 'wg-engagement-metrics flag appears ON for this test user — covered by the flag-on test below instead');
 
       await expect(activeMembersCard).toHaveCount(0);
@@ -228,7 +242,7 @@ test.describe('Groups dashboard — engagement stats (LFXV2-1711)', () => {
       const grid = page.getByTestId('committees-me-stats');
       const activeMembersCard = grid.getByTestId('stat-card-Active Members');
 
-      const flagAppearsOn = await activeMembersCard.isVisible({ timeout: ELEMENT_TIMEOUT }).catch(() => false);
+      const flagAppearsOn = await cardAppears(activeMembersCard, ELEMENT_TIMEOUT);
       test.skip(!flagAppearsOn, 'wg-engagement-metrics flag appears OFF for this test user — see file header for the LD precondition');
 
       await expect(activeMembersCard).toContainText('7', { timeout: ELEMENT_TIMEOUT });

--- a/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
+++ b/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
@@ -178,10 +178,12 @@ function skipWhenAuthMissing(): void {
  * read `false` before the async flag client resolves, even when the card appears moments later.
  */
 async function cardAppears(locator: Locator, timeout: number): Promise<boolean> {
-  return locator
-    .waitFor({ state: 'visible', timeout })
-    .then(() => true)
-    .catch(() => false);
+  try {
+    await locator.waitFor({ state: 'visible', timeout });
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 async function gotoMyGroups(page: Page): Promise<void> {

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -47,7 +47,7 @@
 
       <!-- Summary Stat Cards (Me lens only) -->
       @if (isMeLens()) {
-        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myStatCardsLoading()" [columns]="myStatCardColumns()" data-testid="committees-me-stats" />
+        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" [columns]="myStatCardColumns()" data-testid="committees-me-stats" />
       }
 
       @let totalForChips = isMeLens() ? myCommittees().length : committees().length;

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -42,16 +42,12 @@
 
       <!-- Summary Stat Cards (Foundation/Project lens) -->
       @if (!isMeLens()) {
-        <lfx-stat-card-grid
-          [cards]="foundationStatCards()"
-          [loading]="committeesLoading()"
-          [columns]="statCardColumns()"
-          data-testid="committees-foundation-stats" />
+        <lfx-stat-card-grid [cards]="foundationStatCards()" [loading]="committeesLoading()" data-testid="committees-foundation-stats" />
       }
 
       <!-- Summary Stat Cards (Me lens only) -->
       @if (isMeLens()) {
-        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" [columns]="statCardColumns()" data-testid="committees-me-stats" />
+        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" [columns]="myStatCardColumns()" data-testid="committees-me-stats" />
       }
 
       @let totalForChips = isMeLens() ? myCommittees().length : committees().length;

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -42,12 +42,16 @@
 
       <!-- Summary Stat Cards (Foundation/Project lens) -->
       @if (!isMeLens()) {
-        <lfx-stat-card-grid [cards]="foundationStatCards()" [loading]="committeesLoading()" data-testid="committees-foundation-stats" />
+        <lfx-stat-card-grid
+          [cards]="foundationStatCards()"
+          [loading]="committeesLoading()"
+          [columns]="statCardColumns()"
+          data-testid="committees-foundation-stats" />
       }
 
       <!-- Summary Stat Cards (Me lens only) -->
       @if (isMeLens()) {
-        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" data-testid="committees-me-stats" />
+        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" [columns]="statCardColumns()" data-testid="committees-me-stats" />
       }
 
       @let totalForChips = isMeLens() ? myCommittees().length : committees().length;

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.html
@@ -47,7 +47,7 @@
 
       <!-- Summary Stat Cards (Me lens only) -->
       @if (isMeLens()) {
-        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myCommitteesLoading()" [columns]="myStatCardColumns()" data-testid="committees-me-stats" />
+        <lfx-stat-card-grid [cards]="myStatCards()" [loading]="myStatCardsLoading()" [columns]="myStatCardColumns()" data-testid="committees-me-stats" />
       }
 
       @let totalForChips = isMeLens() ? myCommittees().length : committees().length;

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -9,18 +9,20 @@ import { Router } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
-import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL, GROUPS_VIEW_MODE_STORAGE_KEY } from '@lfx-one/shared/constants';
+import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL, GROUPS_VIEW_MODE_STORAGE_KEY, WG_ENGAGEMENT_METRICS_FLAG } from '@lfx-one/shared/constants';
 import {
   Committee,
   CommitteeFoundationGroup,
   GroupBehavioralClass,
+  GroupsEngagementStats,
   GroupsViewMode,
   MyCommittee,
   ProjectContext,
   StatCardItem,
 } from '@lfx-one/shared/interfaces';
-import { getGroupBehavioralClass, groupCommitteesByFoundation } from '@lfx-one/shared/utils';
+import { buildEngagementStatCards, getGroupBehavioralClass, groupCommitteesByFoundation } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
+import { FeatureFlagService } from '@services/feature-flag.service';
 import { InvitationService } from '@services/invitation.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
@@ -75,6 +77,7 @@ export class CommitteeDashboardComponent {
   private readonly lensService = inject(LensService);
   private readonly messageService = inject(MessageService);
   private readonly invitationService = inject(InvitationService);
+  private readonly featureFlagService = inject(FeatureFlagService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly destroyRef = inject(DestroyRef);
 
@@ -89,7 +92,9 @@ export class CommitteeDashboardComponent {
   public projectFilter = signal<string | null>(null);
   public behavioralClassFilter = signal<GroupBehavioralClass | null>(null);
   public viewMode = signal<GroupsViewMode>('list');
+  public engagementStatsLoading = signal<boolean>(true);
   private readonly groupExpansion = signal<Record<string, boolean>>({});
+  private readonly engagementStatsSignal = signal<GroupsEngagementStats | null>(null);
 
   protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
   protected readonly behavioralClassKeys = Object.keys(BEHAVIORAL_CLASS_CONFIG) as GroupBehavioralClass[];
@@ -115,6 +120,7 @@ export class CommitteeDashboardComponent {
   private readonly isFoundationContext: Signal<boolean> = this.projectContextService.isFoundationContext;
   protected readonly canWrite = this.projectContextService.canWrite;
   protected readonly personaLoaded = this.personaService.personaLoaded;
+  protected readonly isEngagementMetricsEnabled = this.featureFlagService.getBooleanFlag(WG_ENGAGEMENT_METRICS_FLAG, false);
   public showFoundationFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasBoardRole() && this.foundationOptions().length > 1);
   public showProjectFilter: Signal<boolean> = computed(() => this.isMeLens() && this.personaService.hasProjectRole() && this.projectOptions().length > 1);
 
@@ -144,6 +150,10 @@ export class CommitteeDashboardComponent {
   // Stat card arrays for the shared <lfx-stat-card-grid> component
   public foundationStatCards: Signal<StatCardItem[]>;
   public myStatCards: Signal<StatCardItem[]>;
+  public readonly statCardColumns: Signal<2 | 3 | 4 | 5> = computed(() => (this.isEngagementMetricsEnabled() ? 5 : 3));
+
+  // Engagement rollup (LFXV2-1711) — flag-gated, mocked pending the LFXV2-1705 dbt model
+  public engagementStats: Signal<GroupsEngagementStats | null>;
 
   private searchTerm: Signal<string>;
 
@@ -185,11 +195,16 @@ export class CommitteeDashboardComponent {
     this.myPublicGroups = computed(() => this.myCommittees().filter((c) => c.public).length);
     this.myActiveVoting = computed(() => this.myCommittees().filter((c) => c.enable_voting).length);
 
+    // Engagement rollup — fetched once the flag first turns on; failures degrade to null and never
+    // block the group-count cards or the groups list below (independent HTTP call).
+    this.engagementStats = this.initializeEngagementStats();
+
     // Stat card arrays consumed by <lfx-stat-card-grid>
     this.foundationStatCards = computed<StatCardItem[]>(() => [
       { value: this.totalCommittees(), label: 'Total Groups', icon: 'fa-light fa-users-rectangle', iconContainerClass: 'bg-gray-200 text-gray-500' },
       { value: this.publicCommittees(), label: 'Public Groups', icon: 'fa-light fa-globe', iconContainerClass: 'bg-blue-100 text-blue-600' },
       { value: this.activeVoting(), label: 'Voting Enabled Groups', icon: 'fa-light fa-check-to-slot', iconContainerClass: 'bg-emerald-100 text-emerald-600' },
+      ...(this.isEngagementMetricsEnabled() ? buildEngagementStatCards(this.engagementStats(), this.engagementStatsLoading()) : []),
     ]);
     this.myStatCards = computed<StatCardItem[]>(() => [
       { value: this.myTotalGroups(), label: 'Total Groups', icon: 'fa-light fa-users-rectangle', iconContainerClass: 'bg-gray-200 text-gray-500' },
@@ -200,6 +215,7 @@ export class CommitteeDashboardComponent {
         icon: 'fa-light fa-check-to-slot',
         iconContainerClass: 'bg-emerald-100 text-emerald-600',
       },
+      ...(this.isEngagementMetricsEnabled() ? buildEngagementStatCards(this.engagementStats(), this.engagementStatsLoading()) : []),
     ]);
 
     this.behavioralClassCounts = this.initializeBehavioralClassCounts();
@@ -409,6 +425,32 @@ export class CommitteeDashboardComponent {
       ),
       { initialValue: new Set<string>() }
     );
+  }
+
+  /**
+   * Fetches the engagement rollup once the flag first turns on (browser-only, one-shot — mirrors
+   * the `loadPendingInvitations()` gate above). A fetch failure resolves to `null` rather than
+   * propagating: `buildEngagementStatCards` renders the degraded "Unavailable" state, and the
+   * always-on group-count cards / groups list below are on entirely separate HTTP calls, so a
+   * stats failure here never blocks them.
+   */
+  private initializeEngagementStats(): Signal<GroupsEngagementStats | null> {
+    if (isPlatformBrowser(this.platformId)) {
+      toObservable(this.isEngagementMetricsEnabled)
+        .pipe(
+          filter((enabled) => enabled),
+          take(1),
+          switchMap(() =>
+            this.committeeService.getGroupsEngagementStats().pipe(
+              catchError(() => of(null)),
+              finalize(() => this.engagementStatsLoading.set(false))
+            )
+          ),
+          takeUntilDestroyed(this.destroyRef)
+        )
+        .subscribe((stats) => this.engagementStatsSignal.set(stats));
+    }
+    return this.engagementStatsSignal;
   }
 
   private initializeSearchForm(): FormGroup {

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -153,16 +153,6 @@ export class CommitteeDashboardComponent {
   public myStatCards: Signal<StatCardItem[]>;
   /** Me-lens stat grid only — the engagement cards (Foundation/Project lens stays a fixed 3). */
   public readonly myStatCardColumns: Signal<StatCardGridColumns> = computed(() => (this.isEngagementMetricsEnabled() ? 5 : 3));
-  /**
-   * Grid-wide loading flag for the Me-lens stat row. `<lfx-stat-card-grid>` only gates its
-   * `card.value` em-dash on this single boolean — `card.subLine` always renders unconditionally
-   * (see `stat-card-grid.component.html`) — so if this were `myCommitteesLoading()` alone, a fast
-   * engagement fetch resolving before `myCommittees` would show a real "Updated Xm ago" sub-line
-   * next to a still-em-dash value. Combining both keeps every card's value/sub-line pair consistent.
-   */
-  public readonly myStatCardsLoading: Signal<boolean> = computed(
-    () => this.myCommitteesLoading() || (this.isEngagementMetricsEnabled() && this.engagementStatsLoading())
-  );
 
   // Engagement rollup (LFXV2-1711) — flag-gated, mocked pending the LFXV2-1705 dbt model
   public engagementStats: Signal<GroupsEngagementStats | null>;
@@ -443,17 +433,20 @@ export class CommitteeDashboardComponent {
   }
 
   /**
-   * Fetches the engagement rollup once the flag first turns on (browser-only, one-shot — mirrors
-   * the `loadPendingInvitations()` gate above). `CommitteeService.getGroupsEngagementStats()` is the
-   * single error-handling site (logs, resolves to `null`) — `buildEngagementStatCards` renders the
-   * degraded "Unavailable" state on a `null`, and the always-on group-count cards / groups list below
-   * are on entirely separate HTTP calls, so a stats failure here never blocks them.
+   * Fetches the engagement rollup once the flag is on AND the Me lens is active (browser-only,
+   * one-shot — mirrors the `loadPendingInvitations()` gate above). Gating on `isMeLens()` too, not
+   * just the flag, matters because the cards it feeds only render in `myStatCards` — without it,
+   * every Foundation/Project-lens visit would fire a request whose result can never be displayed.
+   * `CommitteeService.getGroupsEngagementStats()` is the single error-handling site (logs, resolves
+   * to `null`) — `buildEngagementStatCards` renders the degraded "Unavailable" state on a `null`, and
+   * the always-on group-count cards / groups list below are on entirely separate HTTP calls, so a
+   * stats failure here never blocks them.
    */
   private initializeEngagementStats(): Signal<GroupsEngagementStats | null> {
     if (isPlatformBrowser(this.platformId)) {
-      toObservable(this.isEngagementMetricsEnabled)
+      toObservable(computed(() => this.isMeLens() && this.isEngagementMetricsEnabled()))
         .pipe(
-          filter((enabled) => enabled),
+          filter((ready) => ready),
           take(1),
           switchMap(() => this.committeeService.getGroupsEngagementStats().pipe(finalize(() => this.engagementStatsLoading.set(false)))),
           takeUntilDestroyed(this.destroyRef)

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -18,6 +18,7 @@ import {
   GroupsViewMode,
   MyCommittee,
   ProjectContext,
+  StatCardGridColumns,
   StatCardItem,
 } from '@lfx-one/shared/interfaces';
 import { buildEngagementStatCards, getGroupBehavioralClass, groupCommitteesByFoundation } from '@lfx-one/shared/utils';
@@ -150,7 +151,8 @@ export class CommitteeDashboardComponent {
   // Stat card arrays for the shared <lfx-stat-card-grid> component
   public foundationStatCards: Signal<StatCardItem[]>;
   public myStatCards: Signal<StatCardItem[]>;
-  public readonly statCardColumns: Signal<2 | 3 | 4 | 5> = computed(() => (this.isEngagementMetricsEnabled() ? 5 : 3));
+  /** Me-lens stat grid only — the engagement cards (Foundation/Project lens stays a fixed 3). */
+  public readonly myStatCardColumns: Signal<StatCardGridColumns> = computed(() => (this.isEngagementMetricsEnabled() ? 5 : 3));
 
   // Engagement rollup (LFXV2-1711) — flag-gated, mocked pending the LFXV2-1705 dbt model
   public engagementStats: Signal<GroupsEngagementStats | null>;
@@ -199,12 +201,15 @@ export class CommitteeDashboardComponent {
     // block the group-count cards or the groups list below (independent HTTP call).
     this.engagementStats = this.initializeEngagementStats();
 
-    // Stat card arrays consumed by <lfx-stat-card-grid>
+    // Stat card arrays consumed by <lfx-stat-card-grid>. The engagement cards are Me-lens only:
+    // GroupsEngagementStatsService is explicitly "mine semantics, no scope param" (caller-wide, not
+    // project/foundation-scoped), so surfacing it in the Foundation/Project lens row — which is
+    // otherwise entirely scoped to the active project — would misrepresent an all-groups personal
+    // number as if it belonged to the foundation/project being viewed.
     this.foundationStatCards = computed<StatCardItem[]>(() => [
       { value: this.totalCommittees(), label: 'Total Groups', icon: 'fa-light fa-users-rectangle', iconContainerClass: 'bg-gray-200 text-gray-500' },
       { value: this.publicCommittees(), label: 'Public Groups', icon: 'fa-light fa-globe', iconContainerClass: 'bg-blue-100 text-blue-600' },
       { value: this.activeVoting(), label: 'Voting Enabled Groups', icon: 'fa-light fa-check-to-slot', iconContainerClass: 'bg-emerald-100 text-emerald-600' },
-      ...(this.isEngagementMetricsEnabled() ? buildEngagementStatCards(this.engagementStats(), this.engagementStatsLoading()) : []),
     ]);
     this.myStatCards = computed<StatCardItem[]>(() => [
       { value: this.myTotalGroups(), label: 'Total Groups', icon: 'fa-light fa-users-rectangle', iconContainerClass: 'bg-gray-200 text-gray-500' },
@@ -429,10 +434,10 @@ export class CommitteeDashboardComponent {
 
   /**
    * Fetches the engagement rollup once the flag first turns on (browser-only, one-shot — mirrors
-   * the `loadPendingInvitations()` gate above). A fetch failure resolves to `null` rather than
-   * propagating: `buildEngagementStatCards` renders the degraded "Unavailable" state, and the
-   * always-on group-count cards / groups list below are on entirely separate HTTP calls, so a
-   * stats failure here never blocks them.
+   * the `loadPendingInvitations()` gate above). `CommitteeService.getGroupsEngagementStats()` is the
+   * single error-handling site (logs, resolves to `null`) — `buildEngagementStatCards` renders the
+   * degraded "Unavailable" state on a `null`, and the always-on group-count cards / groups list below
+   * are on entirely separate HTTP calls, so a stats failure here never blocks them.
    */
   private initializeEngagementStats(): Signal<GroupsEngagementStats | null> {
     if (isPlatformBrowser(this.platformId)) {
@@ -440,12 +445,7 @@ export class CommitteeDashboardComponent {
         .pipe(
           filter((enabled) => enabled),
           take(1),
-          switchMap(() =>
-            this.committeeService.getGroupsEngagementStats().pipe(
-              catchError(() => of(null)),
-              finalize(() => this.engagementStatsLoading.set(false))
-            )
-          ),
+          switchMap(() => this.committeeService.getGroupsEngagementStats().pipe(finalize(() => this.engagementStatsLoading.set(false)))),
           takeUntilDestroyed(this.destroyRef)
         )
         .subscribe((stats) => this.engagementStatsSignal.set(stats));

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -153,6 +153,16 @@ export class CommitteeDashboardComponent {
   public myStatCards: Signal<StatCardItem[]>;
   /** Me-lens stat grid only — the engagement cards (Foundation/Project lens stays a fixed 3). */
   public readonly myStatCardColumns: Signal<StatCardGridColumns> = computed(() => (this.isEngagementMetricsEnabled() ? 5 : 3));
+  /**
+   * Grid-wide loading flag for the Me-lens stat row. `<lfx-stat-card-grid>` only gates its
+   * `card.value` em-dash on this single boolean — `card.subLine` always renders unconditionally
+   * (see `stat-card-grid.component.html`) — so if this were `myCommitteesLoading()` alone, a fast
+   * engagement fetch resolving before `myCommittees` would show a real "Updated Xm ago" sub-line
+   * next to a still-em-dash value. Combining both keeps every card's value/sub-line pair consistent.
+   */
+  public readonly myStatCardsLoading: Signal<boolean> = computed(
+    () => this.myCommitteesLoading() || (this.isEngagementMetricsEnabled() && this.engagementStatsLoading())
+  );
 
   // Engagement rollup (LFXV2-1711) — flag-gated, mocked pending the LFXV2-1705 dbt model
   public engagementStats: Signal<GroupsEngagementStats | null>;

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
@@ -15,7 +15,7 @@
             <p class="text-xl font-medium text-gray-900">{{ card.value }}</p>
           }
           <p class="text-sm font-normal text-gray-900">{{ card.label }}</p>
-          @if (card.subLine) {
+          @if (card.subLine && !loading()) {
             <p class="text-xs text-gray-400">{{ card.subLine }}</p>
           }
           @if (card.delta && !loading()) {

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
@@ -15,7 +15,7 @@ import { StatCardItem } from '@lfx-one/shared/interfaces';
 export class StatCardGridComponent {
   public readonly cards = input.required<StatCardItem[]>();
   public readonly loading = input<boolean>(false);
-  public readonly columns = input<2 | 3 | 4>(3);
+  public readonly columns = input<2 | 3 | 4 | 5>(3);
 
   protected readonly gridColsClass = computed(() => GRID_COLS_CLASS[this.columns()]);
   protected readonly gridDividerClass = computed(() => GRID_DIVIDER_CLASS[this.columns()]);

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
@@ -4,7 +4,7 @@
 import { Component, computed, input } from '@angular/core';
 import { CardComponent } from '@components/card/card.component';
 import { DELTA_DIRECTION_ICON, DELTA_DIRECTION_TEXT_CLASS, GRID_COLS_CLASS, GRID_DIVIDER_CLASS } from '@lfx-one/shared/constants';
-import { StatCardItem } from '@lfx-one/shared/interfaces';
+import { StatCardGridColumns, StatCardItem } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-stat-card-grid',
@@ -15,7 +15,7 @@ import { StatCardItem } from '@lfx-one/shared/interfaces';
 export class StatCardGridComponent {
   public readonly cards = input.required<StatCardItem[]>();
   public readonly loading = input<boolean>(false);
-  public readonly columns = input<2 | 3 | 4 | 5>(3);
+  public readonly columns = input<StatCardGridColumns>(3);
 
   protected readonly gridColsClass = computed(() => GRID_COLS_CLASS[this.columns()]);
   protected readonly gridDividerClass = computed(() => GRID_DIVIDER_CLASS[this.columns()]);

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -16,6 +16,7 @@ import {
   CreateCommitteeJoinApplicationRequest,
   CreateCommitteeMemberOptions,
   CreateCommitteeMemberRequest,
+  GroupsEngagementStats,
   MyCommittee,
   QueryServiceCountResponse,
 } from '@lfx-one/shared/interfaces';
@@ -31,6 +32,15 @@ export class CommitteeService {
 
   public getCommittees(params?: HttpParams): Observable<Committee[]> {
     return this.http.get<Committee[]>('/api/committees', { params }).pipe(catchError(() => of([])));
+  }
+
+  /**
+   * Groups dashboard engagement rollup (Active Members, Meetings This Month) for the caller's
+   * visible set. Mocked pending the LFXV2-1705 dbt model — callers should degrade gracefully on
+   * error (see `buildEngagementStatCards`) rather than let a failure here block the groups list.
+   */
+  public getGroupsEngagementStats(): Observable<GroupsEngagementStats> {
+    return this.http.get<GroupsEngagementStats>('/api/committees/engagement-stats');
   }
 
   public getCommitteesByProject(uid: string): Observable<Committee[]> {

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -36,11 +36,17 @@ export class CommitteeService {
 
   /**
    * Groups dashboard engagement rollup (Active Members, Meetings This Month) for the caller's
-   * visible set. Mocked pending the LFXV2-1705 dbt model — callers should degrade gracefully on
-   * error (see `buildEngagementStatCards`) rather than let a failure here block the groups list.
+   * visible set. Mocked pending the LFXV2-1705 dbt model. Resolves to `null` on error — logged here
+   * (the single error-handling site, matching `getMyCommittees` above) — so the caller can degrade
+   * gracefully (see `buildEngagementStatCards`) rather than let a failure block the groups list.
    */
-  public getGroupsEngagementStats(): Observable<GroupsEngagementStats> {
-    return this.http.get<GroupsEngagementStats>('/api/committees/engagement-stats');
+  public getGroupsEngagementStats(): Observable<GroupsEngagementStats | null> {
+    return this.http.get<GroupsEngagementStats>('/api/committees/engagement-stats').pipe(
+      catchError((error) => {
+        console.error('Failed to load groups engagement stats:', error);
+        return of(null);
+      })
+    );
   }
 
   public getCommitteesByProject(uid: string): Observable<Committee[]> {

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -37,7 +37,7 @@ export class CommitteeService {
   /**
    * Groups dashboard engagement rollup (Active Members, Meetings This Month) for the caller's
    * visible set. Mocked pending the LFXV2-1705 dbt model. Resolves to `null` on error — logged here
-   * (the single error-handling site, matching `getMyCommittees` above) — so the caller can degrade
+   * (the single error-handling site, matching `getMyCommittees` below) — so the caller can degrade
    * gracefully (see `buildEngagementStatCards`) rather than let a failure block the groups list.
    */
   public getGroupsEngagementStats(): Observable<GroupsEngagementStats | null> {

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -23,6 +23,7 @@ import { ServiceValidationError } from '../errors';
 import { contentDispositionAttachment } from '../helpers/content-disposition.helper';
 import { buildVCalendar, fetchAllMeetingPages, meetingsToVEvents } from '../helpers/ics.helper';
 import { getStringQueryParam } from '../helpers/validation.helper';
+import { GroupsEngagementStatsService } from '../services/groups-engagement-stats.service';
 import { logger } from '../services/logger.service';
 import { getEffectiveEmail } from '../utils/auth-helper';
 import { CommitteeService } from '../services/committee.service';
@@ -37,6 +38,7 @@ const FOLDER_UID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-
 export class CommitteeController {
   private committeeService: CommitteeService = new CommitteeService();
   private meetingService: MeetingService = new MeetingService();
+  private groupsEngagementStatsService: GroupsEngagementStatsService = new GroupsEngagementStatsService();
 
   /**
    * GET /committees
@@ -75,6 +77,28 @@ export class CommitteeController {
       });
 
       res.json({ count });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /committees/engagement-stats
+   * Groups dashboard rollup for the caller's visible set (Active Members, Meetings This Month).
+   * Mocked pending the LFXV2-1705 dbt engagement model — see GroupsEngagementStatsService.
+   */
+  public async getGroupsEngagementStats(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_groups_engagement_stats', {});
+
+    try {
+      const stats = await this.groupsEngagementStatsService.getEngagementStats(req);
+
+      logger.success(req, 'get_groups_engagement_stats', startTime, {
+        active_members: stats.active_members,
+        meetings_this_month: stats.meetings_this_month,
+      });
+
+      res.json(stats);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/routes/committees.route.ts
+++ b/apps/lfx-one/src/server/routes/committees.route.ts
@@ -12,6 +12,7 @@ const committeeController = new CommitteeController();
 // Committee CRUD routes - using new controller pattern
 router.get('/', (req, res, next) => committeeController.getCommittees(req, res, next));
 router.get('/count', (req, res, next) => committeeController.getCommitteesCount(req, res, next));
+router.get('/engagement-stats', (req, res, next) => committeeController.getGroupsEngagementStats(req, res, next));
 router.get('/my-committees', (req, res, next) => committeeController.getMyCommittees(req, res, next));
 router.get('/my-committee-uids', (req, res, next) => committeeController.getMyCommitteeUids(req, res, next));
 router.get('/:id', (req, res, next) => committeeController.getCommitteeById(req, res, next));

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -55,6 +55,7 @@ function buildReq(): Request {
 describe('GroupsEngagementStatsService', () => {
   let service: GroupsEngagementStatsService;
   const originalBackend = process.env['ENGAGEMENT_BACKEND'];
+  const originalNodeEnv = process.env['NODE_ENV'];
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -65,15 +66,20 @@ describe('GroupsEngagementStatsService', () => {
     // Fail-safe default: any environment that doesn't explicitly opt in gets 'live' (null fields),
     // never fabricated numbers — so tests must opt into 'mock' explicitly, matching production.
     process.env['ENGAGEMENT_BACKEND'] = 'mock';
+    process.env['NODE_ENV'] = 'test';
   });
 
   afterEach(() => {
-    // Restore the ambient env var so this spec never leaks state to siblings run in the same process.
-    if (originalBackend === undefined) {
-      delete process.env['ENGAGEMENT_BACKEND'];
-    } else {
-      process.env['ENGAGEMENT_BACKEND'] = originalBackend;
-    }
+    // Restore the ambient env vars so this spec never leaks state to siblings run in the same process.
+    const restore = (key: string, original: string | undefined): void => {
+      if (original === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = original;
+      }
+    };
+    restore('ENGAGEMENT_BACKEND', originalBackend);
+    restore('NODE_ENV', originalNodeEnv);
   });
 
   describe('mock mode (default)', () => {
@@ -153,6 +159,18 @@ describe('GroupsEngagementStatsService', () => {
       expect(result.active_members).toBeNull();
       expect(result.meetings_this_month).toBeNull();
       expect(typeof result.computed_at).toBe('string');
+    });
+  });
+
+  describe('production hard-block', () => {
+    it('ignores ENGAGEMENT_BACKEND=mock and returns null fields when NODE_ENV=production', async () => {
+      process.env['ENGAGEMENT_BACKEND'] = 'mock';
+      process.env['NODE_ENV'] = 'production';
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(result.active_members).toBeNull();
+      expect(result.meetings_this_month).toBeNull();
     });
   });
 });

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -162,6 +162,24 @@ describe('GroupsEngagementStatsService', () => {
       expect(typeof result.computed_at).toBe('string');
       expect(result.active_members).not.toBeNull();
     });
+
+    it('does not serve a stale mock-sourced entry once the backend switches to live (production hard-block cannot be bypassed by a cache hit)', async () => {
+      const mockResult = await service.getEngagementStats(buildReq());
+      expect(mockResult.source).toBe('mock');
+      expect(fetcherCalls.count).toBe(1);
+
+      // Simulate the config correction the reviewer's scenario describes: ENGAGEMENT_BACKEND
+      // stays 'mock' (or gets unset — either way), but NODE_ENV flips to production. Without the
+      // backend-aware accept validator, this would return the still-cached `source: 'mock'` entry.
+      process.env['NODE_ENV'] = 'production';
+
+      const liveResult = await service.getEngagementStats(buildReq());
+
+      expect(liveResult.source).toBe('live');
+      expect(liveResult.active_members).toBeNull();
+      expect(liveResult.meetings_this_month).toBeNull();
+      expect(fetcherCalls.count).toBe(2);
+    });
   });
 
   describe('live mode', () => {

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -32,9 +32,14 @@ const { getEffectiveUsernameMock, withUserCacheMock, cacheStore, fetcherCalls } 
 
 vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: getEffectiveUsernameMock }));
 vi.mock('./valkey.service', () => ({ withUserCache: withUserCacheMock }));
-vi.mock('@lfx-one/shared/constants', () => ({
-  VALKEY_CACHE: { GROUPS_ENGAGEMENT_NAMESPACE: 'groups-engagement:v1', GROUPS_ENGAGEMENT_TTL_SECONDS: 60 },
-}));
+// Source the real VALKEY_CACHE values by importing the underlying file directly (not the
+// `@lfx-one/shared/constants` barrel, which transitively pulls in Angular — see the import-rationale
+// comment in date-time.utils.ts) so a namespace/TTL rename can't silently desync this mock from the
+// value the test asserts against below.
+vi.mock('@lfx-one/shared/constants', async () => {
+  const { VALKEY_CACHE } = await import('../../../../../packages/shared/src/constants/valkey-cache.constants');
+  return { VALKEY_CACHE };
+});
 vi.mock('./logger.service', () => ({
   logger: {
     startOperation: vi.fn(() => 0),
@@ -45,6 +50,8 @@ vi.mock('./logger.service', () => ({
     info: vi.fn(),
   },
 }));
+
+import { VALKEY_CACHE } from '@lfx-one/shared/constants';
 
 import { GroupsEngagementStatsService } from './groups-engagement-stats.service';
 
@@ -109,6 +116,11 @@ describe('GroupsEngagementStatsService', () => {
       expect(typeof result.computed_at).toBe('string');
       expect(Number.isNaN(Date.parse(result.computed_at))).toBe(false);
     });
+
+    it('marks the response source as mock', async () => {
+      const result = await service.getEngagementStats(buildReq());
+      expect(result.source).toBe('mock');
+    });
   });
 
   describe('caching', () => {
@@ -133,8 +145,10 @@ describe('GroupsEngagementStatsService', () => {
       expect(fetcherCalls.count).toBe(1);
 
       // Corrupt the stored entry directly, bypassing the service — simulates a stale/incompatible
-      // shape left behind by a prior schema version sharing the same cache key.
-      cacheStore.set('groups-engagement:v1:alice', { active_members: 'not-a-number' });
+      // shape left behind by a prior schema version sharing the same cache key. Derives the key from
+      // the real VALKEY_CACHE namespace (not a hardcoded duplicate) so a `:v1` → `:v2` bump can't
+      // leave this assertion silently checking a key the service no longer writes to.
+      cacheStore.set(`${VALKEY_CACHE.GROUPS_ENGAGEMENT_NAMESPACE}:alice`, { active_members: 'not-a-number' });
 
       await service.getEngagementStats(buildReq());
       expect(fetcherCalls.count).toBe(2);
@@ -151,7 +165,7 @@ describe('GroupsEngagementStatsService', () => {
   });
 
   describe('live mode', () => {
-    it('returns null engagement fields without throwing, plus a computed_at timestamp', async () => {
+    it('returns null engagement fields without throwing, plus a computed_at timestamp and source=live', async () => {
       process.env['ENGAGEMENT_BACKEND'] = 'live';
 
       const result = await service.getEngagementStats(buildReq());
@@ -159,11 +173,12 @@ describe('GroupsEngagementStatsService', () => {
       expect(result.active_members).toBeNull();
       expect(result.meetings_this_month).toBeNull();
       expect(typeof result.computed_at).toBe('string');
+      expect(result.source).toBe('live');
     });
   });
 
   describe('production hard-block', () => {
-    it('ignores ENGAGEMENT_BACKEND=mock and returns null fields when NODE_ENV=production', async () => {
+    it('ignores ENGAGEMENT_BACKEND=mock and returns null fields (source=live) when NODE_ENV=production', async () => {
       process.env['ENGAGEMENT_BACKEND'] = 'mock';
       process.env['NODE_ENV'] = 'production';
 
@@ -171,6 +186,7 @@ describe('GroupsEngagementStatsService', () => {
 
       expect(result.active_members).toBeNull();
       expect(result.meetings_this_month).toBeNull();
+      expect(result.source).toBe('live');
     });
   });
 });

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -5,20 +5,28 @@ import type { Request } from 'express';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { getEffectiveUsernameMock, withUserCacheMock, cacheStore } = vi.hoisted(() => {
+const { getEffectiveUsernameMock, withUserCacheMock, cacheStore, fetcherCalls } = vi.hoisted(() => {
   const store = new Map<string, unknown>();
+  const calls = { count: 0 };
   return {
     getEffectiveUsernameMock: vi.fn<() => string | null>(),
     // Simulates the real read-through cache well enough to test this service's cache-key plumbing
-    // (same key → fetcher runs once) without depending on valkey.service's Redis-backed internals.
-    withUserCacheMock: vi.fn(async (namespace: string, username: string, _ttlSeconds: number, fetcher: () => Promise<unknown>) => {
-      const key = `${namespace}:${username}`;
-      if (store.has(key)) return store.get(key);
-      const value = await fetcher();
-      store.set(key, value);
-      return value;
-    }),
+    // (same key → fetcher runs once, and a stored value must pass `accept`) without depending on
+    // valkey.service's Redis-backed internals. Counts actual fetcher invocations (not just
+    // withUserCache calls, which happen on every read) so cache-hit behavior is verified through the
+    // public surface instead of spying on a private method.
+    withUserCacheMock: vi.fn(
+      async (namespace: string, username: string, _ttlSeconds: number, fetcher: () => Promise<unknown>, accept?: (value: unknown) => boolean) => {
+        const key = `${namespace}:${username}`;
+        if (store.has(key) && (!accept || accept(store.get(key)))) return store.get(key);
+        calls.count += 1;
+        const value = await fetcher();
+        store.set(key, value);
+        return value;
+      }
+    ),
     cacheStore: store,
+    fetcherCalls: calls,
   };
 });
 
@@ -51,9 +59,12 @@ describe('GroupsEngagementStatsService', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     cacheStore.clear();
+    fetcherCalls.count = 0;
     service = new GroupsEngagementStatsService();
     getEffectiveUsernameMock.mockReturnValue('alice');
-    delete process.env['ENGAGEMENT_BACKEND'];
+    // Fail-safe default: any environment that doesn't explicitly opt in gets 'live' (null fields),
+    // never fabricated numbers — so tests must opt into 'mock' explicitly, matching production.
+    process.env['ENGAGEMENT_BACKEND'] = 'mock';
   });
 
   afterEach(() => {
@@ -96,23 +107,40 @@ describe('GroupsEngagementStatsService', () => {
 
   describe('caching', () => {
     it('does not recompute on a cache hit for the same caller within the TTL', async () => {
-      const computeSpy = vi.spyOn(service as unknown as { computeEngagementStats: (...args: unknown[]) => unknown }, 'computeEngagementStats' as never);
-
       await service.getEngagementStats(buildReq());
       await service.getEngagementStats(buildReq());
 
-      expect(computeSpy).toHaveBeenCalledTimes(1);
+      expect(fetcherCalls.count).toBe(1);
     });
 
     it('recomputes for a different caller (distinct cache key)', async () => {
-      const computeSpy = vi.spyOn(service as unknown as { computeEngagementStats: (...args: unknown[]) => unknown }, 'computeEngagementStats' as never);
-
       getEffectiveUsernameMock.mockReturnValueOnce('alice');
       await service.getEngagementStats(buildReq());
       getEffectiveUsernameMock.mockReturnValueOnce('bob');
       await service.getEngagementStats(buildReq());
 
-      expect(computeSpy).toHaveBeenCalledTimes(2);
+      expect(fetcherCalls.count).toBe(2);
+    });
+
+    it('treats a malformed cached entry as a miss and recomputes (accept validator)', async () => {
+      await service.getEngagementStats(buildReq());
+      expect(fetcherCalls.count).toBe(1);
+
+      // Corrupt the stored entry directly, bypassing the service — simulates a stale/incompatible
+      // shape left behind by a prior schema version sharing the same cache key.
+      cacheStore.set('groups-engagement:v1:alice', { active_members: 'not-a-number' });
+
+      await service.getEngagementStats(buildReq());
+      expect(fetcherCalls.count).toBe(2);
+    });
+
+    it('still produces a valid response when getEffectiveUsername resolves to null', async () => {
+      getEffectiveUsernameMock.mockReturnValue(null);
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(typeof result.computed_at).toBe('string');
+      expect(result.active_members).not.toBeNull();
     });
   });
 

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -1,0 +1,130 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Request } from 'express';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { getEffectiveUsernameMock, withUserCacheMock, cacheStore } = vi.hoisted(() => {
+  const store = new Map<string, unknown>();
+  return {
+    getEffectiveUsernameMock: vi.fn<() => string | null>(),
+    // Simulates the real read-through cache well enough to test this service's cache-key plumbing
+    // (same key → fetcher runs once) without depending on valkey.service's Redis-backed internals.
+    withUserCacheMock: vi.fn(async (namespace: string, username: string, _ttlSeconds: number, fetcher: () => Promise<unknown>) => {
+      const key = `${namespace}:${username}`;
+      if (store.has(key)) return store.get(key);
+      const value = await fetcher();
+      store.set(key, value);
+      return value;
+    }),
+    cacheStore: store,
+  };
+});
+
+vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: getEffectiveUsernameMock }));
+vi.mock('./valkey.service', () => ({ withUserCache: withUserCacheMock }));
+vi.mock('@lfx-one/shared/constants', () => ({
+  VALKEY_CACHE: { GROUPS_ENGAGEMENT_NAMESPACE: 'groups-engagement:v1', GROUPS_ENGAGEMENT_TTL_SECONDS: 60 },
+}));
+vi.mock('./logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { GroupsEngagementStatsService } from './groups-engagement-stats.service';
+
+function buildReq(): Request {
+  return {} as Request;
+}
+
+describe('GroupsEngagementStatsService', () => {
+  let service: GroupsEngagementStatsService;
+  const originalBackend = process.env['ENGAGEMENT_BACKEND'];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    cacheStore.clear();
+    service = new GroupsEngagementStatsService();
+    getEffectiveUsernameMock.mockReturnValue('alice');
+    delete process.env['ENGAGEMENT_BACKEND'];
+  });
+
+  afterEach(() => {
+    // Restore the ambient env var so this spec never leaks state to siblings run in the same process.
+    if (originalBackend === undefined) {
+      delete process.env['ENGAGEMENT_BACKEND'];
+    } else {
+      process.env['ENGAGEMENT_BACKEND'] = originalBackend;
+    }
+  });
+
+  describe('mock mode (default)', () => {
+    it('returns deterministic values for the same caller across separate calls', async () => {
+      const first = await service.getEngagementStats(buildReq());
+      cacheStore.clear(); // bypass the cache to prove determinism comes from the fixture, not the cache
+      const second = await service.getEngagementStats(buildReq());
+
+      expect(first.active_members).toEqual(second.active_members);
+      expect(first.meetings_this_month).toEqual(second.meetings_this_month);
+      expect(first.active_members).not.toBeNull();
+      expect(first.meetings_this_month).not.toBeNull();
+    });
+
+    it('returns different values for different callers', async () => {
+      getEffectiveUsernameMock.mockReturnValueOnce('alice');
+      const alice = await service.getEngagementStats(buildReq());
+      cacheStore.clear();
+      getEffectiveUsernameMock.mockReturnValueOnce('bob');
+      const bob = await service.getEngagementStats(buildReq());
+
+      expect([alice.active_members, alice.meetings_this_month]).not.toEqual([bob.active_members, bob.meetings_this_month]);
+    });
+
+    it('always includes a computed_at timestamp', async () => {
+      const result = await service.getEngagementStats(buildReq());
+      expect(typeof result.computed_at).toBe('string');
+      expect(Number.isNaN(Date.parse(result.computed_at))).toBe(false);
+    });
+  });
+
+  describe('caching', () => {
+    it('does not recompute on a cache hit for the same caller within the TTL', async () => {
+      const computeSpy = vi.spyOn(service as unknown as { computeEngagementStats: (...args: unknown[]) => unknown }, 'computeEngagementStats' as never);
+
+      await service.getEngagementStats(buildReq());
+      await service.getEngagementStats(buildReq());
+
+      expect(computeSpy).toHaveBeenCalledTimes(1);
+    });
+
+    it('recomputes for a different caller (distinct cache key)', async () => {
+      const computeSpy = vi.spyOn(service as unknown as { computeEngagementStats: (...args: unknown[]) => unknown }, 'computeEngagementStats' as never);
+
+      getEffectiveUsernameMock.mockReturnValueOnce('alice');
+      await service.getEngagementStats(buildReq());
+      getEffectiveUsernameMock.mockReturnValueOnce('bob');
+      await service.getEngagementStats(buildReq());
+
+      expect(computeSpy).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('live mode', () => {
+    it('returns null engagement fields without throwing, plus a computed_at timestamp', async () => {
+      process.env['ENGAGEMENT_BACKEND'] = 'live';
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(result.active_members).toBeNull();
+      expect(result.meetings_this_month).toBeNull();
+      expect(typeof result.computed_at).toBe('string');
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -24,9 +24,11 @@ function isGroupsEngagementStats(value: unknown): boolean {
  * Groups dashboard engagement rollup (Active Members, Meetings This Month) for the caller's visible
  * set only — mine semantics, no scope param (LFXV2-1711). Backed by the same dbt engagement model as
  * LFXV2-1705, which isn't readable yet, so both stats are mocked behind `ENGAGEMENT_BACKEND` until
- * that read path exists. Defaults to `live` (null fields, never fabricated numbers) unless
- * `ENGAGEMENT_BACKEND=mock` is explicitly set — an unconfigured environment (including a production
- * deploy that forgot to set the var) must fail to "no data," never to invented-looking data.
+ * that read path exists — a deliberate interim shim (flag-gated in the UI, TODO-marked here) pending
+ * LFXV2-1705, not a permanent stand-in for the real upstream contract. Defaults to `live` (null
+ * fields, never fabricated numbers) unless `ENGAGEMENT_BACKEND=mock` is explicitly set, and `mock` is
+ * additionally hard-blocked outside `NODE_ENV=production` — an unconfigured or production environment
+ * must fail to "no data," never to invented-looking data.
  */
 export class GroupsEngagementStatsService {
   /**
@@ -48,18 +50,20 @@ export class GroupsEngagementStatsService {
   }
 
   private async computeEngagementStats(req: Request, username: string): Promise<GroupsEngagementStats> {
-    const backend = process.env['ENGAGEMENT_BACKEND'] === 'mock' ? 'mock' : 'live';
+    // Mock is opt-in and additionally hard-blocked in production, so a stray `ENGAGEMENT_BACKEND=mock`
+    // left in a prod-like environment's config can't silently serve fabricated numbers as real data.
+    const backend = process.env['ENGAGEMENT_BACKEND'] === 'mock' && process.env['NODE_ENV'] !== 'production' ? 'mock' : 'live';
     const computedAt = new Date().toISOString();
 
     if (backend === 'live') {
       // TODO(LFXV2-1711): read from the dbt engagement model (same source as LFXV2-1705) once its
       // read path exists. Until then, always return null fields rather than fabricating live-looking
       // data — the client renders an "Unavailable" degraded state for these two cards.
-      logger.debug(req, 'get_groups_engagement_stats', 'ENGAGEMENT_BACKEND=live has no dbt read path yet — returning null fields', { username });
+      logger.debug(req, 'get_groups_engagement_stats', 'ENGAGEMENT_BACKEND=live has no dbt read path yet — returning null fields');
       return { active_members: null, meetings_this_month: null, computed_at: computedAt };
     }
 
-    logger.debug(req, 'get_groups_engagement_stats', 'Serving deterministic mock engagement stats', { username });
+    logger.debug(req, 'get_groups_engagement_stats', 'Serving deterministic mock engagement stats');
     return { ...deterministicMockStats(username), computed_at: computedAt };
   }
 }

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -9,7 +9,15 @@ import { getEffectiveUsername } from '../utils/auth-helper';
 import { logger } from './logger.service';
 import { withUserCache } from './valkey.service';
 
-function isGroupsEngagementStats(value: unknown): boolean {
+/**
+ * `expectedSource` must match the backend resolved for *this* request — not just any valid
+ * `source` value — so a cached entry from a since-changed `ENGAGEMENT_BACKEND`/`NODE_ENV`
+ * config is treated as a miss and recomputed immediately, rather than being served as a false
+ * hit for up to `GROUPS_ENGAGEMENT_TTL_SECONDS`. Without this, a stray `mock` entry cached
+ * before a switch to `live`/production would keep answering "Sample data" for up to 60s after
+ * the switch, undermining the production hard-block's guarantee.
+ */
+function isGroupsEngagementStats(value: unknown, expectedSource: 'mock' | 'live'): boolean {
   const v = value as Partial<GroupsEngagementStats>;
   return (
     !!value &&
@@ -17,8 +25,17 @@ function isGroupsEngagementStats(value: unknown): boolean {
     (v.active_members === null || typeof v.active_members === 'number') &&
     (v.meetings_this_month === null || typeof v.meetings_this_month === 'number') &&
     typeof v.computed_at === 'string' &&
-    (v.source === 'mock' || v.source === 'live')
+    v.source === expectedSource
   );
+}
+
+/** Mock is opt-in and additionally hard-blocked in production, so a stray `ENGAGEMENT_BACKEND=mock`
+ * left in a prod-like environment's config can't silently serve fabricated numbers as real data.
+ * Resolved once per request, before the cache lookup, so the cache-key validator above can reject
+ * a cached entry from a different backend instead of serving it stale.
+ */
+function resolveBackend(): 'mock' | 'live' {
+  return process.env['ENGAGEMENT_BACKEND'] === 'mock' && process.env['NODE_ENV'] !== 'production' ? 'mock' : 'live';
 }
 
 // Per-process guard: the `live` no-dbt-path branch is the *expected steady state* in every
@@ -46,20 +63,18 @@ export class GroupsEngagementStatsService {
    */
   public async getEngagementStats(req: Request): Promise<GroupsEngagementStats> {
     const username = getEffectiveUsername(req) ?? '';
+    const backend = resolveBackend();
 
     return withUserCache(
       VALKEY_CACHE.GROUPS_ENGAGEMENT_NAMESPACE,
       username,
       VALKEY_CACHE.GROUPS_ENGAGEMENT_TTL_SECONDS,
-      () => this.computeEngagementStats(req, username),
-      isGroupsEngagementStats
+      () => this.computeEngagementStats(req, username, backend),
+      (value) => isGroupsEngagementStats(value, backend)
     );
   }
 
-  private async computeEngagementStats(req: Request, username: string): Promise<GroupsEngagementStats> {
-    // Mock is opt-in and additionally hard-blocked in production, so a stray `ENGAGEMENT_BACKEND=mock`
-    // left in a prod-like environment's config can't silently serve fabricated numbers as real data.
-    const backend = process.env['ENGAGEMENT_BACKEND'] === 'mock' && process.env['NODE_ENV'] !== 'production' ? 'mock' : 'live';
+  private async computeEngagementStats(req: Request, username: string, backend: 'mock' | 'live'): Promise<GroupsEngagementStats> {
     const computedAt = new Date().toISOString();
 
     if (backend === 'live') {

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -27,7 +27,7 @@ function isGroupsEngagementStats(value: unknown): boolean {
  * that read path exists — a deliberate interim shim (flag-gated in the UI, TODO-marked here) pending
  * LFXV2-1705, not a permanent stand-in for the real upstream contract. Defaults to `live` (null
  * fields, never fabricated numbers) unless `ENGAGEMENT_BACKEND=mock` is explicitly set, and `mock` is
- * additionally hard-blocked outside `NODE_ENV=production` — an unconfigured or production environment
+ * additionally hard-blocked when `NODE_ENV=production` — an unconfigured or production environment
  * must fail to "no data," never to invented-looking data.
  */
 export class GroupsEngagementStatsService {
@@ -58,12 +58,16 @@ export class GroupsEngagementStatsService {
     if (backend === 'live') {
       // TODO(LFXV2-1711): read from the dbt engagement model (same source as LFXV2-1705) once its
       // read path exists. Until then, always return null fields rather than fabricating live-looking
-      // data — the client renders an "Unavailable" degraded state for these two cards.
-      logger.debug(req, 'get_groups_engagement_stats', 'ENGAGEMENT_BACKEND=live has no dbt read path yet — returning null fields');
+      // data — the client renders an "Unavailable" degraded state for these two cards. WARN (not
+      // DEBUG), matching the LFXV2-2874 precedent (project.service.ts's getFoundationTotalMembers):
+      // graceful degradation to null/empty is operationally significant, not routine tracing.
+      logger.warning(req, 'get_groups_engagement_stats', 'Engagement dbt model has no read path yet — returning null fields');
       return { active_members: null, meetings_this_month: null, computed_at: computedAt };
     }
 
-    logger.debug(req, 'get_groups_engagement_stats', 'Serving deterministic mock engagement stats');
+    // WARN, not DEBUG: serving a fixture instead of real data is fallback behavior an on-call
+    // engineer needs visible when someone reports the dashboard numbers look wrong.
+    logger.warning(req, 'get_groups_engagement_stats', 'ENGAGEMENT_BACKEND=mock — serving fixture engagement stats, not real data');
     return { ...deterministicMockStats(username), computed_at: computedAt };
   }
 }

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -16,9 +16,16 @@ function isGroupsEngagementStats(value: unknown): boolean {
     typeof value === 'object' &&
     (v.active_members === null || typeof v.active_members === 'number') &&
     (v.meetings_this_month === null || typeof v.meetings_this_month === 'number') &&
-    typeof v.computed_at === 'string'
+    typeof v.computed_at === 'string' &&
+    (v.source === 'mock' || v.source === 'live')
   );
 }
+
+// Per-process guard: the `live` no-dbt-path branch is the *expected steady state* in every
+// deployed environment until LFXV2-1705 ships (weeks/months, not an exceptional blip), so logging
+// it at WARN on every cache miss (~1/user/minute at the 60s TTL) would be sustained log noise
+// rather than an actionable signal. One WARN per process is enough to be discoverable on-call.
+let liveModeWarned = false;
 
 /**
  * Groups dashboard engagement rollup (Active Members, Meetings This Month) for the caller's visible
@@ -58,17 +65,22 @@ export class GroupsEngagementStatsService {
     if (backend === 'live') {
       // TODO(LFXV2-1711): read from the dbt engagement model (same source as LFXV2-1705) once its
       // read path exists. Until then, always return null fields rather than fabricating live-looking
-      // data — the client renders an "Unavailable" degraded state for these two cards. WARN (not
-      // DEBUG), matching the LFXV2-2874 precedent (project.service.ts's getFoundationTotalMembers):
-      // graceful degradation to null/empty is operationally significant, not routine tracing.
-      logger.warning(req, 'get_groups_engagement_stats', 'Engagement dbt model has no read path yet — returning null fields');
-      return { active_members: null, meetings_this_month: null, computed_at: computedAt };
+      // data — the client renders an "Unavailable" degraded state for these two cards. WARN once per
+      // process (see `liveModeWarned` above), matching the graceful-degradation intent of the
+      // LFXV2-2874 precedent without turning the permanent pre-dbt-deploy steady state into
+      // sustained per-request log noise.
+      if (!liveModeWarned) {
+        liveModeWarned = true;
+        logger.warning(req, 'get_groups_engagement_stats', 'Engagement dbt model has no read path yet — returning null fields');
+      }
+      return { active_members: null, meetings_this_month: null, computed_at: computedAt, source: 'live' };
     }
 
-    // WARN, not DEBUG: serving a fixture instead of real data is fallback behavior an on-call
-    // engineer needs visible when someone reports the dashboard numbers look wrong.
+    // WARN, not DEBUG, on every call: unlike the live branch above, mock should essentially never
+    // run in a real deployment, so each occurrence is worth surfacing — an on-call engineer needs
+    // this the moment someone reports the dashboard numbers look wrong.
     logger.warning(req, 'get_groups_engagement_stats', 'ENGAGEMENT_BACKEND=mock — serving fixture engagement stats, not real data');
-    return { ...deterministicMockStats(username), computed_at: computedAt };
+    return { ...deterministicMockStats(username), computed_at: computedAt, source: 'mock' };
   }
 }
 

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -24,7 +24,9 @@ function isGroupsEngagementStats(value: unknown): boolean {
  * Groups dashboard engagement rollup (Active Members, Meetings This Month) for the caller's visible
  * set only — mine semantics, no scope param (LFXV2-1711). Backed by the same dbt engagement model as
  * LFXV2-1705, which isn't readable yet, so both stats are mocked behind `ENGAGEMENT_BACKEND` until
- * that read path exists.
+ * that read path exists. Defaults to `live` (null fields, never fabricated numbers) unless
+ * `ENGAGEMENT_BACKEND=mock` is explicitly set — an unconfigured environment (including a production
+ * deploy that forgot to set the var) must fail to "no data," never to invented-looking data.
  */
 export class GroupsEngagementStatsService {
   /**
@@ -46,7 +48,7 @@ export class GroupsEngagementStatsService {
   }
 
   private async computeEngagementStats(req: Request, username: string): Promise<GroupsEngagementStats> {
-    const backend = process.env['ENGAGEMENT_BACKEND'] === 'live' ? 'live' : 'mock';
+    const backend = process.env['ENGAGEMENT_BACKEND'] === 'mock' ? 'mock' : 'live';
     const computedAt = new Date().toISOString();
 
     if (backend === 'live') {

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { VALKEY_CACHE } from '@lfx-one/shared/constants';
+import { GroupsEngagementStats } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { getEffectiveUsername } from '../utils/auth-helper';
+import { logger } from './logger.service';
+import { withUserCache } from './valkey.service';
+
+function isGroupsEngagementStats(value: unknown): boolean {
+  const v = value as Partial<GroupsEngagementStats>;
+  return (
+    !!value &&
+    typeof value === 'object' &&
+    (v.active_members === null || typeof v.active_members === 'number') &&
+    (v.meetings_this_month === null || typeof v.meetings_this_month === 'number') &&
+    typeof v.computed_at === 'string'
+  );
+}
+
+/**
+ * Groups dashboard engagement rollup (Active Members, Meetings This Month) for the caller's visible
+ * set only — mine semantics, no scope param (LFXV2-1711). Backed by the same dbt engagement model as
+ * LFXV2-1705, which isn't readable yet, so both stats are mocked behind `ENGAGEMENT_BACKEND` until
+ * that read path exists.
+ */
+export class GroupsEngagementStatsService {
+  /**
+   * Returns the caller's engagement rollup, cached ~60s per user (see `withUserCache`) to absorb
+   * repeated dashboard refreshes. Never throws — `live` mode returns null fields pre-dbt-deploy
+   * rather than failing the request, matching the graceful-degradation precedent used elsewhere for
+   * not-yet-available dbt models (LFXV2-2874).
+   */
+  public async getEngagementStats(req: Request): Promise<GroupsEngagementStats> {
+    const username = getEffectiveUsername(req) ?? '';
+
+    return withUserCache(
+      VALKEY_CACHE.GROUPS_ENGAGEMENT_NAMESPACE,
+      username,
+      VALKEY_CACHE.GROUPS_ENGAGEMENT_TTL_SECONDS,
+      () => this.computeEngagementStats(req, username),
+      isGroupsEngagementStats
+    );
+  }
+
+  private async computeEngagementStats(req: Request, username: string): Promise<GroupsEngagementStats> {
+    const backend = process.env['ENGAGEMENT_BACKEND'] === 'live' ? 'live' : 'mock';
+    const computedAt = new Date().toISOString();
+
+    if (backend === 'live') {
+      // TODO(LFXV2-1711): read from the dbt engagement model (same source as LFXV2-1705) once its
+      // read path exists. Until then, always return null fields rather than fabricating live-looking
+      // data — the client renders an "Unavailable" degraded state for these two cards.
+      logger.debug(req, 'get_groups_engagement_stats', 'ENGAGEMENT_BACKEND=live has no dbt read path yet — returning null fields', { username });
+      return { active_members: null, meetings_this_month: null, computed_at: computedAt };
+    }
+
+    logger.debug(req, 'get_groups_engagement_stats', 'Serving deterministic mock engagement stats', { username });
+    return { ...deterministicMockStats(username), computed_at: computedAt };
+  }
+}
+
+/**
+ * Deterministic fixture keyed off the caller's identity — same user always sees the same numbers
+ * across requests/instances (no randomness), so the mock behaves predictably in manual testing and
+ * screenshots without needing a backing store.
+ */
+function deterministicMockStats(username: string): Pick<GroupsEngagementStats, 'active_members' | 'meetings_this_month'> {
+  const hash = hashString(username || 'anonymous');
+  return {
+    active_members: 1 + (hash % 50),
+    meetings_this_month: hash % 8,
+  };
+}
+
+/** Simple, stable string hash (djb2 variant) — not cryptographic, only needs to be deterministic. */
+function hashString(value: string): number {
+  let hash = 5381;
+  for (let i = 0; i < value.length; i++) {
+    hash = (hash * 33) ^ value.charCodeAt(i);
+  }
+  return Math.abs(hash);
+}

--- a/apps/lfx-one/src/server/services/valkey.service.ts
+++ b/apps/lfx-one/src/server/services/valkey.service.ts
@@ -295,6 +295,12 @@ export function buildPerUserOrgKey(namespace: string, username: string, orgUid: 
   return `${keyPrefix()}:${namespace}:${username}:${orgUid}`;
 }
 
+/** Per-user cache key with no org scoping (caller username only, under a caller-chosen namespace); null (fail-closed → direct fetch) when the username isn't filter-safe. For "mine semantics" data that isn't scoped to any org/project. */
+export function buildUserCacheKey(namespace: string, username: string): string | null {
+  if (!isFilterSafeUsername(username)) return null;
+  return `${keyPrefix()}:${namespace}:${username}`;
+}
+
 /** Read-through helper for the per-org Snowflake-backed namespace; a null key (unsafe account id) fetches directly. */
 export function withOrgCache<T>(
   accountId: string,
@@ -321,6 +327,17 @@ export function withPerUserCache<T>(
   accept?: (value: unknown) => boolean
 ): Promise<T> {
   return valkeyService.withCache(buildPerUserOrgKey(namespace, username, orgUid), ttlSeconds, fetcher, accept);
+}
+
+/** Read-through helper for a per-user, org-independent namespace; a null key (unsafe username) fetches directly. */
+export function withUserCache<T>(
+  namespace: string,
+  username: string,
+  ttlSeconds: number,
+  fetcher: () => Promise<T>,
+  accept?: (value: unknown) => boolean
+): Promise<T> {
+  return valkeyService.withCache(buildUserCacheKey(namespace, username), ttlSeconds, fetcher, accept);
 }
 
 /** Shared accessor — forwards to the current singleton so resetInstance() is always honored (no stale binding). */

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -10,6 +10,7 @@ import {
   DELTA_DIRECTION_TEXT_CLASS,
   GRID_COLS_CLASS,
   GRID_DIVIDER_CLASS,
+  GROUPS_ENGAGEMENT_ICON_CLASS,
   lfxColors,
   lfxFontSizes,
   ORG_MEETINGS_KPI_ICON_CLASS,
@@ -36,6 +37,8 @@ export default {
     // DELTA_DIRECTION_TEXT_CLASS in @lfx-one/shared, not scanned here)
     ...Object.values(ORG_MEETINGS_KPI_ICON_CLASS).flatMap((classes) => classes.split(' ')),
     ...Object.values(DELTA_DIRECTION_TEXT_CLASS),
+    // Groups dashboard engagement stat cards (GROUPS_ENGAGEMENT_ICON_CLASS in @lfx-one/shared, not scanned here)
+    ...Object.values(GROUPS_ENGAGEMENT_ICON_CLASS).flatMap((classes) => classes.split(' ')),
     // Meeting summary modal — dynamic section border/icon colors (applied via [ngClass])
     'border-l-blue-400',
     'border-l-emerald-400',

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -620,3 +620,15 @@ export const OTHER_GROUPS_LABEL = 'Other Groups';
 
 /** Cards revealed per "Show more" click on the My Groups card grid — a grid-friendly count (divisible by 1/2/3/4 columns). */
 export const GROUPS_CARD_GRID_PAGE_SIZE = 12;
+
+/**
+ * Icon-tile tints for the Groups dashboard engagement stat cards (LFXV2-1711). A dedicated constant
+ * rather than reusing `ORG_MEETINGS_KPI_ICON_CLASS`'s coincidentally-identical values: this package's
+ * classes aren't scanned by `apps/lfx-one/tailwind.config.js`'s `content` glob, so they must be
+ * spread into its `safelist` explicitly (see the Tailwind config comment) — coupling to an unrelated
+ * constant's values would silently break if that constant ever changed.
+ */
+export const GROUPS_ENGAGEMENT_ICON_CLASS = {
+  activeMembers: 'bg-violet-100 text-violet-600',
+  meetingsThisMonth: 'bg-amber-100 text-amber-600',
+} as const;

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -4,3 +4,4 @@
 export const ORG_LENS_ENABLED_FLAG = 'org-lens-enabled';
 export const AKRITES_ENABLED_FLAG = 'akrites-enabled';
 export const MKTG_OS_AGENTS_ENABLED_FLAG = 'mktg-os-agents-enabled';
+export const WG_ENGAGEMENT_METRICS_FLAG = 'wg-engagement-metrics';

--- a/packages/shared/src/constants/stat-card-grid.constants.ts
+++ b/packages/shared/src/constants/stat-card-grid.constants.ts
@@ -2,10 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 /** Tailwind grid-column classes for `lfx-stat-card-grid`, keyed by its `columns` input. */
-export const GRID_COLS_CLASS: Record<2 | 3 | 4, string> = {
+export const GRID_COLS_CLASS: Record<2 | 3 | 4 | 5, string> = {
   2: 'sm:grid-cols-2',
   3: 'sm:grid-cols-3',
   4: 'sm:grid-cols-2 lg:grid-cols-4',
+  5: 'sm:grid-cols-2 lg:grid-cols-5',
 };
 
 /**
@@ -17,7 +18,7 @@ export const GRID_COLS_CLASS: Record<2 | 3 | 4, string> = {
  * the two cards within each row; both are cleared again at `lg`, where `divide-x` takes over
  * for the single-row 4-column layout.
  */
-export const GRID_DIVIDER_CLASS: Record<2 | 3 | 4, string> = {
+export const GRID_DIVIDER_CLASS: Record<2 | 3 | 4 | 5, string> = {
   2: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
   3: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
   // The `!` (important) modifiers are required: Tailwind's `divide-y-0` reset compiles to
@@ -26,4 +27,8 @@ export const GRID_DIVIDER_CLASS: Record<2 | 3 | 4, string> = {
   // `sm` left border is left in place (not reset) at `lg`: `lg:divide-x` needs that same left
   // border on cards 2/4 for the single-row layout, and card 3 gets it from `divide-x` itself.
   4: 'divide-y divide-gray-200 sm:divide-y-0 sm:[&>*:nth-child(n+3)]:!border-t sm:[&>*:nth-child(n+3)]:!border-gray-200 sm:[&>*:nth-child(even)]:!border-l sm:[&>*:nth-child(even)]:!border-gray-200 lg:[&>*:nth-child(n+3)]:!border-t-0 lg:divide-x',
+  // Same `nth-child(n+3)`/`nth-child(even)` 2-col-wrap logic as 4 — column-count-agnostic (it only
+  // depends on the wrap pairing, not the final column count), so it generalizes to 5 cards (rows of
+  // 2, 2, 1) unchanged; only `lg:divide-x` differs by relying on GRID_COLS_CLASS[5]'s `lg:grid-cols-5`.
+  5: 'divide-y divide-gray-200 sm:divide-y-0 sm:[&>*:nth-child(n+3)]:!border-t sm:[&>*:nth-child(n+3)]:!border-gray-200 sm:[&>*:nth-child(even)]:!border-l sm:[&>*:nth-child(even)]:!border-gray-200 lg:[&>*:nth-child(n+3)]:!border-t-0 lg:divide-x',
 };

--- a/packages/shared/src/constants/stat-card-grid.constants.ts
+++ b/packages/shared/src/constants/stat-card-grid.constants.ts
@@ -20,17 +20,20 @@ export const GRID_COLS_CLASS: Record<StatCardGridColumns, string> = {
  * the two cards within each row; both are cleared again at `lg`, where `divide-x` takes over
  * for the single-row 4-column layout.
  */
+// The `!` (important) modifiers are required: Tailwind's `divide-y-0` reset compiles to
+// `:not([hidden]) ~ :not([hidden])`, whose specificity beats a plain `nth-child(...)` selector, so
+// without `!` it silently cancels the row divider below regardless of source order. The `sm` left
+// border is left in place (not reset) at `lg`: `lg:divide-x` needs that same left border on cards
+// 2/4 for the single-row layout, and card 3 gets it from `divide-x` itself. Shared by columns 4 and
+// 5 — the `nth-child(n+3)`/`nth-child(even)` 2-col-wrap logic is column-count-agnostic (it only
+// depends on the wrap pairing, not the final column count); only `lg:grid-cols-4` vs. `-5` in
+// `GRID_COLS_CLASS` differs between them, not this divider string.
+const WRAP_PAIRED_DIVIDER =
+  'divide-y divide-gray-200 sm:divide-y-0 sm:[&>*:nth-child(n+3)]:!border-t sm:[&>*:nth-child(n+3)]:!border-gray-200 sm:[&>*:nth-child(even)]:!border-l sm:[&>*:nth-child(even)]:!border-gray-200 lg:[&>*:nth-child(n+3)]:!border-t-0 lg:divide-x';
+
 export const GRID_DIVIDER_CLASS: Record<StatCardGridColumns, string> = {
   2: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
   3: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
-  // The `!` (important) modifiers are required: Tailwind's `divide-y-0` reset compiles to
-  // `:not([hidden]) ~ :not([hidden])`, whose specificity beats a plain `nth-child(...)` selector,
-  // so without `!` it silently cancels the row divider below regardless of source order. The
-  // `sm` left border is left in place (not reset) at `lg`: `lg:divide-x` needs that same left
-  // border on cards 2/4 for the single-row layout, and card 3 gets it from `divide-x` itself.
-  4: 'divide-y divide-gray-200 sm:divide-y-0 sm:[&>*:nth-child(n+3)]:!border-t sm:[&>*:nth-child(n+3)]:!border-gray-200 sm:[&>*:nth-child(even)]:!border-l sm:[&>*:nth-child(even)]:!border-gray-200 lg:[&>*:nth-child(n+3)]:!border-t-0 lg:divide-x',
-  // Same `nth-child(n+3)`/`nth-child(even)` 2-col-wrap logic as 4 — column-count-agnostic (it only
-  // depends on the wrap pairing, not the final column count), so it generalizes to 5 cards (rows of
-  // 2, 2, 1) unchanged; only `lg:divide-x` differs by relying on GRID_COLS_CLASS[5]'s `lg:grid-cols-5`.
-  5: 'divide-y divide-gray-200 sm:divide-y-0 sm:[&>*:nth-child(n+3)]:!border-t sm:[&>*:nth-child(n+3)]:!border-gray-200 sm:[&>*:nth-child(even)]:!border-l sm:[&>*:nth-child(even)]:!border-gray-200 lg:[&>*:nth-child(n+3)]:!border-t-0 lg:divide-x',
+  4: WRAP_PAIRED_DIVIDER,
+  5: WRAP_PAIRED_DIVIDER,
 };

--- a/packages/shared/src/constants/stat-card-grid.constants.ts
+++ b/packages/shared/src/constants/stat-card-grid.constants.ts
@@ -1,8 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { StatCardGridColumns } from '../interfaces/stat-card.interface';
+
 /** Tailwind grid-column classes for `lfx-stat-card-grid`, keyed by its `columns` input. */
-export const GRID_COLS_CLASS: Record<2 | 3 | 4 | 5, string> = {
+export const GRID_COLS_CLASS: Record<StatCardGridColumns, string> = {
   2: 'sm:grid-cols-2',
   3: 'sm:grid-cols-3',
   4: 'sm:grid-cols-2 lg:grid-cols-4',
@@ -18,7 +20,7 @@ export const GRID_COLS_CLASS: Record<2 | 3 | 4 | 5, string> = {
  * the two cards within each row; both are cleared again at `lg`, where `divide-x` takes over
  * for the single-row 4-column layout.
  */
-export const GRID_DIVIDER_CLASS: Record<2 | 3 | 4 | 5, string> = {
+export const GRID_DIVIDER_CLASS: Record<StatCardGridColumns, string> = {
   2: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
   3: 'divide-y divide-gray-200 sm:divide-y-0 sm:divide-x',
   // The `!` (important) modifiers are required: Tailwind's `divide-y-0` reset compiles to

--- a/packages/shared/src/constants/valkey-cache.constants.ts
+++ b/packages/shared/src/constants/valkey-cache.constants.ts
@@ -30,6 +30,9 @@ export const VALKEY_CACHE = {
   /** Domain + schema-version segment for the express-openid-connect session store (server-side session data keyed by opaque session id). */
   SESSION_NAMESPACE: 'session:v1',
 
+  /** Domain + schema-version segment for the per-user Groups dashboard engagement-stats cache (org-independent — mine semantics only). */
+  GROUPS_ENGAGEMENT_NAMESPACE: 'groups-engagement:v1',
+
   /** Default freshness window for membership entries (carried over from the prior 30_000 ms memo). */
   ORG_MEMBERSHIP_TTL_SECONDS: 30,
 
@@ -38,6 +41,9 @@ export const VALKEY_CACHE = {
 
   /** Freshness window for the per-user Org Lens caches (seats, key-contacts, access-list, people directory). */
   ORG_LENS_PERUSER_TTL_SECONDS: 30,
+
+  /** Freshness window for the Groups dashboard engagement-stats cache — absorbs repeated dashboard refreshes. */
+  GROUPS_ENGAGEMENT_TTL_SECONDS: 60,
 
   /** Fallback session TTL when express-openid-connect doesn't supply a per-session expiry (matches its `session.absoluteDuration` default of 7 days). Normally the store derives the actual TTL from the session's own `cookie.maxAge` instead. */
   SESSION_FALLBACK_TTL_SECONDS: 7 * 24 * 60 * 60,

--- a/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
+++ b/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Engagement rollup for the caller's visible set of groups (mine semantics, no scope param).
+ * Backed by the same dbt engagement model as LFXV2-1705; fields are `null` when that model
+ * isn't readable yet (see `ENGAGEMENT_BACKEND=live` stub in `groups-engagement-stats.service.ts`).
+ */
+export interface GroupsEngagementStats {
+  /** Distinct members who attended at least one meeting in the trailing 30 days. `null` when not computable. */
+  active_members: number | null;
+  /** Meeting occurrences within the current calendar month. `null` when not computable. */
+  meetings_this_month: number | null;
+  /** ISO timestamp this rollup was computed — used to render a freshness label client-side. */
+  computed_at: string;
+}

--- a/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
+++ b/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
@@ -13,4 +13,10 @@ export interface GroupsEngagementStats {
   meetings_this_month: number | null;
   /** ISO timestamp this rollup was computed — used to render a freshness label client-side. */
   computed_at: string;
+  /**
+   * Which backend produced this response. `'mock'` values are deterministic fixtures, not real
+   * data — the client renders a visible "Sample data" marker when this is `'mock'` so fabricated
+   * numbers can never be mistaken for live ones during local/synced-prod-data validation.
+   */
+  source: 'mock' | 'live';
 }

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -121,6 +121,9 @@ export * from './committee-application.interface';
 // Public committee interfaces
 export * from './public-committee.interface';
 
+// Groups dashboard engagement-stats rollup (LFXV2-1711)
+export * from './groups-engagement-stats.interface';
+
 // Lens interfaces
 export * from './lens.interface';
 

--- a/packages/shared/src/interfaces/stat-card.interface.ts
+++ b/packages/shared/src/interfaces/stat-card.interface.ts
@@ -4,6 +4,9 @@
 /** Direction of a period-over-period delta on a stat card, drives arrow icon + color. */
 export type StatCardDeltaDirection = 'up' | 'down' | 'flat';
 
+/** Valid column counts for `lfx-stat-card-grid`'s `columns` input — keys `GRID_COLS_CLASS`/`GRID_DIVIDER_CLASS`. */
+export type StatCardGridColumns = 2 | 3 | 4 | 5;
+
 /** Optional period-over-period delta rendered below a stat card's value. */
 export interface StatCardDelta {
   /** Text rendered next to the delta arrow (e.g., "+8% vs. prior period"). */

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -445,4 +445,12 @@ describe('buildEngagementStatCards', () => {
       expect(card.subLine).toBe('Unavailable');
     });
   });
+
+  it('degrades each card independently — one null field does not blank the other', () => {
+    const partial: GroupsEngagementStats = { active_members: 9, meetings_this_month: null, computed_at: new Date().toISOString() };
+    const cards = buildEngagementStatCards(partial, false);
+    expect(cards[0]).toMatchObject({ label: 'Active Members', value: 9 });
+    expect(cards[0].subLine).toMatch(/^Updated /);
+    expect(cards[1]).toMatchObject({ label: 'Meetings This Month', value: '—', subLine: 'Unavailable' });
+  });
 });

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -410,7 +410,7 @@ describe('countVotingReps', () => {
 });
 
 describe('buildEngagementStatCards', () => {
-  const stats: GroupsEngagementStats = { active_members: 12, meetings_this_month: 3, computed_at: new Date().toISOString() };
+  const stats: GroupsEngagementStats = { active_members: 12, meetings_this_month: 3, computed_at: new Date().toISOString(), source: 'live' };
 
   it('renders em-dash placeholders with no sub-line while loading, regardless of stats', () => {
     const cards = buildEngagementStatCards(stats, true);
@@ -422,11 +422,18 @@ describe('buildEngagementStatCards', () => {
     });
   });
 
-  it('renders the real values with a freshness sub-line once stats resolve', () => {
+  it('renders the real values with a freshness sub-line once live stats resolve', () => {
     const cards = buildEngagementStatCards(stats, false);
     expect(cards[0]).toMatchObject({ label: 'Active Members', value: 12 });
     expect(cards[1]).toMatchObject({ label: 'Meetings This Month', value: 3 });
     cards.forEach((card) => expect(card.subLine).toMatch(/^Updated /));
+  });
+
+  it('renders "Sample data" instead of a freshness label for mock-sourced values', () => {
+    const mockStats: GroupsEngagementStats = { ...stats, source: 'mock' };
+    const cards = buildEngagementStatCards(mockStats, false);
+    expect(cards[0]).toMatchObject({ label: 'Active Members', value: 12, subLine: 'Sample data' });
+    expect(cards[1]).toMatchObject({ label: 'Meetings This Month', value: 3, subLine: 'Sample data' });
   });
 
   it('degrades to "Unavailable" em-dash cards when stats is null (fetch failed)', () => {
@@ -438,7 +445,7 @@ describe('buildEngagementStatCards', () => {
   });
 
   it('degrades to "Unavailable" em-dash cards when the live backend returns null engagement fields', () => {
-    const liveStub: GroupsEngagementStats = { active_members: null, meetings_this_month: null, computed_at: new Date().toISOString() };
+    const liveStub: GroupsEngagementStats = { active_members: null, meetings_this_month: null, computed_at: new Date().toISOString(), source: 'live' };
     const cards = buildEngagementStatCards(liveStub, false);
     cards.forEach((card) => {
       expect(card.value).toBe('—');
@@ -447,7 +454,7 @@ describe('buildEngagementStatCards', () => {
   });
 
   it('degrades each card independently — one null field does not blank the other', () => {
-    const partial: GroupsEngagementStats = { active_members: 9, meetings_this_month: null, computed_at: new Date().toISOString() };
+    const partial: GroupsEngagementStats = { active_members: 9, meetings_this_month: null, computed_at: new Date().toISOString(), source: 'live' };
     const cards = buildEngagementStatCards(partial, false);
     expect(cards[0]).toMatchObject({ label: 'Active Members', value: 9 });
     expect(cards[0].subLine).toMatch(/^Updated /);

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -2,21 +2,23 @@
 // SPDX-License-Identifier: MIT
 
 // Unit tests for committee.utils.ts — `yarn test` (this file runs under the packages/shared Vitest project).
-// Includes the committee member permission resolver (LFXV2-2059) and the All Groups
-// foundation-grouping helper (LFXV2-1715). `apps/lfx-one` has no Angular component-test runner
-// (no `ng test` target), so component-level logic that needs coverage lives here as a pure,
-// dependency-free function and is tested by this package's own Vitest runner instead.
+// Includes the committee member permission resolver (LFXV2-2059), the All Groups
+// foundation-grouping helper (LFXV2-1715), and the Groups dashboard engagement stat-card builder
+// (LFXV2-1711). `apps/lfx-one` has no Angular component-test runner (no `ng test` target), so
+// component-level logic that needs coverage lives here as a pure, dependency-free function and is
+// tested by this package's own Vitest runner instead.
 //
 // All fixtures use synthetic placeholder identities — never real user data.
 
 import { describe, expect, it } from 'vitest';
 
 import { CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { Committee, CommitteeMember } from '../interfaces';
+import { Committee, CommitteeMember, GroupsEngagementStats } from '../interfaces';
 import { FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL } from '../constants/committees.constants';
 import { CommitteeMemberRole } from '../enums/committee-member.enum';
 import {
   buildCommitteeCreateQueryParams,
+  buildEngagementStatCards,
   canManageCommitteeMembers,
   countVotingReps,
   groupCommitteesByFoundation,
@@ -404,5 +406,43 @@ describe('countVotingReps', () => {
 
   it('is 0 for an empty member list', () => {
     expect(countVotingReps([])).toBe(0);
+  });
+});
+
+describe('buildEngagementStatCards', () => {
+  const stats: GroupsEngagementStats = { active_members: 12, meetings_this_month: 3, computed_at: new Date().toISOString() };
+
+  it('renders em-dash placeholders with no sub-line while loading, regardless of stats', () => {
+    const cards = buildEngagementStatCards(stats, true);
+    expect(cards).toHaveLength(2);
+    expect(cards.map((c) => c.label)).toEqual(['Active Members', 'Meetings This Month']);
+    cards.forEach((card) => {
+      expect(card.value).toBe('—');
+      expect(card.subLine).toBeUndefined();
+    });
+  });
+
+  it('renders the real values with a freshness sub-line once stats resolve', () => {
+    const cards = buildEngagementStatCards(stats, false);
+    expect(cards[0]).toMatchObject({ label: 'Active Members', value: 12 });
+    expect(cards[1]).toMatchObject({ label: 'Meetings This Month', value: 3 });
+    cards.forEach((card) => expect(card.subLine).toMatch(/^Updated /));
+  });
+
+  it('degrades to "Unavailable" em-dash cards when stats is null (fetch failed)', () => {
+    const cards = buildEngagementStatCards(null, false);
+    cards.forEach((card) => {
+      expect(card.value).toBe('—');
+      expect(card.subLine).toBe('Unavailable');
+    });
+  });
+
+  it('degrades to "Unavailable" em-dash cards when the live backend returns null engagement fields', () => {
+    const liveStub: GroupsEngagementStats = { active_members: null, meetings_this_month: null, computed_at: new Date().toISOString() };
+    const cards = buildEngagementStatCards(liveStub, false);
+    cards.forEach((card) => {
+      expect(card.value).toBe('—');
+      expect(card.subLine).toBe('Unavailable');
+    });
   });
 });

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -379,7 +379,7 @@ export function buildEngagementStatCards(stats: GroupsEngagementStats | null, lo
   // than a subtle provenance flag, since the whole point is that a fabricated fixture number must
   // never be mistaken for live data during manual validation (including against synced prod data,
   // where NODE_ENV isn't 'production' but a stray ENGAGEMENT_BACKEND=mock could still be set).
-  const subLineForValue = stats && stats.source === 'mock' ? 'Sample data' : stats ? `Updated ${formatRelativeTime(new Date(stats.computed_at))}` : undefined;
+  const subLineForValue = resolveEngagementSubLine(stats);
 
   // Each card degrades independently: active_members and meetings_this_month are separate
   // aggregates (trailing-30-day attendance vs. current-month occurrences), so a partially-deployed
@@ -389,4 +389,11 @@ export function buildEngagementStatCards(stats: GroupsEngagementStats | null, lo
     value === null ? { ...base, subLine: 'Unavailable' } : { ...base, value, subLine: subLineForValue };
 
   return [resolveCard(activeMembersCard, stats?.active_members ?? null), resolveCard(meetingsThisMonthCard, stats?.meetings_this_month ?? null)];
+}
+
+/** Extracted to avoid nesting a ternary inside another ternary's branch (`stats && source === 'mock' ? … : stats ? … : …`). */
+function resolveEngagementSubLine(stats: GroupsEngagementStats | null): string | undefined {
+  if (!stats) return undefined;
+  if (stats.source === 'mock') return 'Sample data';
+  return `Updated ${formatRelativeTime(new Date(stats.computed_at))}`;
 }

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -7,7 +7,12 @@ import { GroupsEngagementStats } from '../interfaces/groups-engagement-stats.int
 import { CommitteeMember } from '../interfaces/member.interface';
 import { BadgeSeverity } from '../interfaces/components.interface';
 import { StatCardItem } from '../interfaces/stat-card.interface';
-import { CATEGORY_BEHAVIORAL_CLASS, FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL, OTHER_GROUPS_LABEL } from '../constants/committees.constants';
+import {
+  CATEGORY_BEHAVIORAL_CLASS,
+  FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL,
+  GROUPS_ENGAGEMENT_ICON_CLASS,
+  OTHER_GROUPS_LABEL,
+} from '../constants/committees.constants';
 import { formatRelativeTime } from './date-time.utils';
 import { slugify } from './string.utils';
 
@@ -355,13 +360,13 @@ export function buildEngagementStatCards(stats: GroupsEngagementStats | null, lo
   const activeMembersCard: StatCardItem = {
     label: 'Active Members',
     icon: 'fa-light fa-user-group',
-    iconContainerClass: 'bg-violet-100 text-violet-600',
+    iconContainerClass: GROUPS_ENGAGEMENT_ICON_CLASS.activeMembers,
     value: '—',
   };
   const meetingsThisMonthCard: StatCardItem = {
     label: 'Meetings This Month',
     icon: 'fa-light fa-calendar-check',
-    iconContainerClass: 'bg-amber-100 text-amber-600',
+    iconContainerClass: GROUPS_ENGAGEMENT_ICON_CLASS.meetingsThisMonth,
     value: '—',
   };
 

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -351,10 +351,11 @@ function compareCodeUnits(a: string, b: string): number {
 /**
  * Builds the Active Members / Meetings This Month stat cards from the engagement-stats rollup.
  * Extracted as a pure function (no Angular component-test runner exists in this repo — see
- * `resolveGroupsCardRoleSeverity` above) so all three render states are unit-tested directly:
- * loading (em-dash, no sub-line), populated (value + relative-time freshness label), and
- * degraded (fetch failed, or the `live` backend hasn't got a dbt read path yet — em-dash +
- * "Unavailable", never throws, never blocks the rest of the dashboard).
+ * `resolveGroupsCardRoleSeverity` above) so all four render states are unit-tested directly:
+ * loading (em-dash, no sub-line), populated (value + relative-time freshness label), mock-sourced
+ * (value + a "Sample data" marker instead of a freshness label, so fabricated fixture numbers can
+ * never be mistaken for live ones), and degraded (fetch failed, or the `live` backend hasn't got a
+ * dbt read path yet — em-dash + "Unavailable", never throws, never blocks the rest of the dashboard).
  */
 export function buildEngagementStatCards(stats: GroupsEngagementStats | null, loading: boolean): StatCardItem[] {
   const activeMembersCard: StatCardItem = {
@@ -374,14 +375,18 @@ export function buildEngagementStatCards(stats: GroupsEngagementStats | null, lo
     return [activeMembersCard, meetingsThisMonthCard];
   }
 
-  const freshness = stats ? `Updated ${formatRelativeTime(new Date(stats.computed_at))}` : undefined;
+  // Mock-sourced values get "Sample data" instead of a freshness label — deliberately more visible
+  // than a subtle provenance flag, since the whole point is that a fabricated fixture number must
+  // never be mistaken for live data during manual validation (including against synced prod data,
+  // where NODE_ENV isn't 'production' but a stray ENGAGEMENT_BACKEND=mock could still be set).
+  const subLineForValue = stats && stats.source === 'mock' ? 'Sample data' : stats ? `Updated ${formatRelativeTime(new Date(stats.computed_at))}` : undefined;
 
   // Each card degrades independently: active_members and meetings_this_month are separate
   // aggregates (trailing-30-day attendance vs. current-month occurrences), so a partially-deployed
   // dbt model could plausibly resolve one without the other — neither field's availability implies
   // the other's.
   const resolveCard = (base: StatCardItem, value: number | null): StatCardItem =>
-    value === null ? { ...base, subLine: 'Unavailable' } : { ...base, value, subLine: freshness };
+    value === null ? { ...base, subLine: 'Unavailable' } : { ...base, value, subLine: subLineForValue };
 
   return [resolveCard(activeMembersCard, stats?.active_members ?? null), resolveCard(meetingsThisMonthCard, stats?.meetings_this_month ?? null)];
 }

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -8,6 +8,7 @@ import { CommitteeMember } from '../interfaces/member.interface';
 import { BadgeSeverity } from '../interfaces/components.interface';
 import { StatCardItem } from '../interfaces/stat-card.interface';
 import { CATEGORY_BEHAVIORAL_CLASS, FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL, OTHER_GROUPS_LABEL } from '../constants/committees.constants';
+import { formatRelativeTime } from './date-time.utils';
 import { slugify } from './string.utils';
 
 /**
@@ -368,37 +369,14 @@ export function buildEngagementStatCards(stats: GroupsEngagementStats | null, lo
     return [activeMembersCard, meetingsThisMonthCard];
   }
 
-  if (!stats || stats.active_members === null || stats.meetings_this_month === null) {
-    return [
-      { ...activeMembersCard, subLine: 'Unavailable' },
-      { ...meetingsThisMonthCard, subLine: 'Unavailable' },
-    ];
-  }
+  const freshness = stats ? `Updated ${formatRelativeTime(new Date(stats.computed_at))}` : undefined;
 
-  const freshness = formatEngagementFreshness(stats.computed_at);
-  return [
-    { ...activeMembersCard, value: stats.active_members, subLine: `Updated ${freshness}` },
-    { ...meetingsThisMonthCard, value: stats.meetings_this_month, subLine: `Updated ${freshness}` },
-  ];
-}
+  // Each card degrades independently: active_members and meetings_this_month are separate
+  // aggregates (trailing-30-day attendance vs. current-month occurrences), so a partially-deployed
+  // dbt model could plausibly resolve one without the other — neither field's availability implies
+  // the other's.
+  const resolveCard = (base: StatCardItem, value: number | null): StatCardItem =>
+    value === null ? { ...base, subLine: 'Unavailable' } : { ...base, value, subLine: freshness };
 
-/**
- * Minimal relative-time label ("just now", "5 min ago", "2 hr ago", "3 days ago") for the
- * engagement stat cards' freshness sub-line. Deliberately self-contained rather than reusing
- * `formatRelativeTime` from `date-time.utils.ts`: that file imports the `../constants` barrel,
- * which transitively pulls in `colors.constants.ts` → `@linuxfoundation/lfx-ui-core`, a package
- * that needs the Angular JIT compiler — harmless inside the Angular app, but it crashes this
- * package's plain-Node Vitest run (no `@angular/compiler` loaded) the moment anything in this
- * file's import graph reaches it.
- */
-function formatEngagementFreshness(isoTimestamp: string): string {
-  const diffMs = Date.now() - new Date(isoTimestamp).getTime();
-  if (!Number.isFinite(diffMs)) return 'recently';
-  const diffMin = Math.floor(diffMs / 60_000);
-  if (diffMin < 1) return 'just now';
-  if (diffMin < 60) return `${diffMin} min ago`;
-  const diffHr = Math.floor(diffMs / 3_600_000);
-  if (diffHr < 24) return `${diffHr} hr ago`;
-  const diffDay = Math.floor(diffMs / 86_400_000);
-  return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
+  return [resolveCard(activeMembersCard, stats?.active_members ?? null), resolveCard(meetingsThisMonthCard, stats?.meetings_this_month ?? null)];
 }

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -3,8 +3,10 @@
 
 import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
 import { Committee, CommitteeFoundationGroup, CommitteeMemberPermissionInfo, GroupBehavioralClass } from '../interfaces/committee.interface';
+import { GroupsEngagementStats } from '../interfaces/groups-engagement-stats.interface';
 import { CommitteeMember } from '../interfaces/member.interface';
 import { BadgeSeverity } from '../interfaces/components.interface';
+import { StatCardItem } from '../interfaces/stat-card.interface';
 import { CATEGORY_BEHAVIORAL_CLASS, FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL, OTHER_GROUPS_LABEL } from '../constants/committees.constants';
 import { slugify } from './string.utils';
 
@@ -336,4 +338,67 @@ function compareCodeUnits(a: string, b: string): number {
   if (a < b) return -1;
   if (a > b) return 1;
   return 0;
+}
+
+// ── Groups dashboard engagement stat cards (LFXV2-1711) ─────────────────────
+
+/**
+ * Builds the Active Members / Meetings This Month stat cards from the engagement-stats rollup.
+ * Extracted as a pure function (no Angular component-test runner exists in this repo — see
+ * `resolveGroupsCardRoleSeverity` above) so all three render states are unit-tested directly:
+ * loading (em-dash, no sub-line), populated (value + relative-time freshness label), and
+ * degraded (fetch failed, or the `live` backend hasn't got a dbt read path yet — em-dash +
+ * "Unavailable", never throws, never blocks the rest of the dashboard).
+ */
+export function buildEngagementStatCards(stats: GroupsEngagementStats | null, loading: boolean): StatCardItem[] {
+  const activeMembersCard: StatCardItem = {
+    label: 'Active Members',
+    icon: 'fa-light fa-user-group',
+    iconContainerClass: 'bg-violet-100 text-violet-600',
+    value: '—',
+  };
+  const meetingsThisMonthCard: StatCardItem = {
+    label: 'Meetings This Month',
+    icon: 'fa-light fa-calendar-check',
+    iconContainerClass: 'bg-amber-100 text-amber-600',
+    value: '—',
+  };
+
+  if (loading) {
+    return [activeMembersCard, meetingsThisMonthCard];
+  }
+
+  if (!stats || stats.active_members === null || stats.meetings_this_month === null) {
+    return [
+      { ...activeMembersCard, subLine: 'Unavailable' },
+      { ...meetingsThisMonthCard, subLine: 'Unavailable' },
+    ];
+  }
+
+  const freshness = formatEngagementFreshness(stats.computed_at);
+  return [
+    { ...activeMembersCard, value: stats.active_members, subLine: `Updated ${freshness}` },
+    { ...meetingsThisMonthCard, value: stats.meetings_this_month, subLine: `Updated ${freshness}` },
+  ];
+}
+
+/**
+ * Minimal relative-time label ("just now", "5 min ago", "2 hr ago", "3 days ago") for the
+ * engagement stat cards' freshness sub-line. Deliberately self-contained rather than reusing
+ * `formatRelativeTime` from `date-time.utils.ts`: that file imports the `../constants` barrel,
+ * which transitively pulls in `colors.constants.ts` → `@linuxfoundation/lfx-ui-core`, a package
+ * that needs the Angular JIT compiler — harmless inside the Angular app, but it crashes this
+ * package's plain-Node Vitest run (no `@angular/compiler` loaded) the moment anything in this
+ * file's import graph reaches it.
+ */
+function formatEngagementFreshness(isoTimestamp: string): string {
+  const diffMs = Date.now() - new Date(isoTimestamp).getTime();
+  if (!Number.isFinite(diffMs)) return 'recently';
+  const diffMin = Math.floor(diffMs / 60_000);
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin} min ago`;
+  const diffHr = Math.floor(diffMs / 3_600_000);
+  if (diffHr < 24) return `${diffHr} hr ago`;
+  const diffDay = Math.floor(diffMs / 86_400_000);
+  return `${diffDay} day${diffDay === 1 ? '' : 's'} ago`;
 }

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -3,7 +3,14 @@
 
 import { fromZonedTime, getTimezoneOffset, toZonedTime } from 'date-fns-tz';
 
-import { DAYS_IN_WEEK, DEFAULT_REPEAT_INTERVAL, MINUTES_IN_HOUR, MS_IN_DAY, TIME_ROUNDING_MINUTES, TIMEZONES, WEEKDAY_CODES } from '../constants';
+// Direct file imports (not the '../constants' barrel): the barrel transitively re-exports
+// dashboard-metrics.constants.ts, which imports the '../utils' barrel, which re-exports
+// meeting.utils.ts / activity-feed.utils.ts — both import '@angular/common' directly. That chain
+// needs the Angular JIT compiler to load, which crashes any plain-Node Vitest run (e.g. this
+// package's own test suite) the moment something imports date-time.utils.ts. Importing the two
+// underlying files directly sidesteps that chain entirely — behaviorally identical re-exports.
+import { DAYS_IN_WEEK, DEFAULT_REPEAT_INTERVAL, MINUTES_IN_HOUR, MS_IN_DAY, TIME_ROUNDING_MINUTES, WEEKDAY_CODES } from '../constants/meeting.constants';
+import { TIMEZONES } from '../constants/timezones.constants';
 import { RecurrenceType } from '../enums';
 import { MeetingRecurrence, TimezoneOption } from '../interfaces';
 

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -5,10 +5,10 @@ import { fromZonedTime, getTimezoneOffset, toZonedTime } from 'date-fns-tz';
 
 // Direct file imports (not the '../constants' barrel): the barrel transitively re-exports
 // dashboard-metrics.constants.ts, which imports the '../utils' barrel, which re-exports
-// meeting.utils.ts / activity-feed.utils.ts — both import '@angular/common' directly. That chain
-// needs the Angular JIT compiler to load, which crashes any plain-Node Vitest run (e.g. this
-// package's own test suite) the moment something imports date-time.utils.ts. Importing the two
-// underlying files directly sidesteps that chain entirely — behaviorally identical re-exports.
+// meeting.utils.ts — which imports HttpParams from '@angular/common/http'. That chain needs the
+// Angular JIT compiler to load, which crashes any plain-Node Vitest run (e.g. this package's own
+// test suite) the moment something imports date-time.utils.ts. Importing the two underlying
+// constant files directly sidesteps that chain entirely — behaviorally identical re-exports.
 import { DAYS_IN_WEEK, DEFAULT_REPEAT_INTERVAL, MINUTES_IN_HOUR, MS_IN_DAY, TIME_ROUNDING_MINUTES, WEEKDAY_CODES } from '../constants/meeting.constants';
 import { TIMEZONES } from '../constants/timezones.constants';
 import { RecurrenceType } from '../enums';


### PR DESCRIPTION
## Summary

Adds a top-row rollup stats block to the Groups dashboard (LFXV2-1711).

**Ticket:** [LFXV2-1711](https://linuxfoundation.atlassian.net/browse/LFXV2-1711)

**Live today (unflagged):** Total Groups / Public Groups / Voting-Enabled Groups / My Groups counts are **not new** — they already shipped in #1223 as client-side `computed()` signals on `CommitteeDashboardComponent`, derived from the already-fully-paginated `/api/committees` and `/api/committees/my-committees` responses. This PR does not touch that code path.

**New in this PR, mocked pending LFXV2-1705:** Two additional stat cards — **Active Members** and **Meetings This Month** — via a new `GET /api/committees/engagement-stats` BFF endpoint, gated behind a new `wg-engagement-metrics` LaunchDarkly flag and rendered only in the Me lens (the endpoint is explicitly "mine semantics, no scope param," so it doesn't belong in the project/foundation-scoped Foundation lens row). Both stats depend on the same dbt engagement model as LFXV2-1705, which isn't readable yet.

`wg-engagement-metrics` does not exist as a flag in LaunchDarkly yet — `FeatureFlagService.getBooleanFlag(WG_ENGAGEMENT_METRICS_FLAG, false)` evaluates to its `false` default until someone creates it there, so the two engagement cards stay hidden (3-card grid) in every environment today. When the fields aren't computable (the default `live` backend, pre-dbt-deploy), each card degrades independently to an "Unavailable" em-dash state rather than blocking the other or the group-count cards.

### Mock/live backend switch — deliberate trade-off, please read

`ENGAGEMENT_BACKEND` controls the source:
- **`live` (default when unset)** — returns `null` for both fields; the client renders an "Unavailable" degraded state. This is what every deployed environment gets today.
- **`mock`** — deterministic fixtures keyed off the caller's identity, for local dev only. **Additionally hard-blocked when `NODE_ENV=production`** regardless of the env var, and left **commented out by default** in `.env.example` so `cp .env.example .env` can't silently inherit it. The response carries a `source: 'mock' | 'live'` field, and the client renders a visible **"Sample data"** marker (instead of a freshness label) whenever `source === 'mock'` — so fabricated numbers can never be mistaken for real ones, including during local validation against synced prod data (`/lfx-serve`), where `NODE_ENV` isn't `'production'` but a stray `ENGAGEMENT_BACKEND=mock` could still be set.

This shipped as a mock/live switch per the ticket's explicit design (mirroring the LFXV2-1705 approach), even though it sits in tension with this repo's documented "no mock data / no placeholder APIs" policy (`docs/architecture/placement.md`). That tension was surfaced during review and the mock switch was kept **by explicit decision**, on the basis that it's flag-gated, env-var-gated, production-hard-blocked, `TODO(LFXV2-1711)`-marked, and now visually self-disclosing via the "Sample data" marker — not a permanent stand-in for the real upstream contract.

### Caching

The engagement-stats read is cached per caller for `VALKEY_CACHE.GROUPS_ENGAGEMENT_TTL_SECONDS` (60s) via `withUserCache`, to absorb repeated dashboard refreshes without recomputing. Cache-hit behavior — a repeat call within the TTL doesn't re-invoke the underlying compute — is unit-tested (`groups-engagement-stats.service.spec.ts`, "does not recompute on a cache hit"); no wall-clock latency benchmark was run as part of this PR.

### Known, accepted minor trade-off

The freshness sub-line ("Updated Xm ago") is computed once when the engagement fetch resolves and does not tick live on a long-lived dashboard tab. This matches the existing pattern already used elsewhere in this app (e.g. `my-groups-card-grid.component.ts`), so it wasn't changed here.

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] BFF unit tests: mock determinism, cache-hit/miss + `accept`-validator rejection of a malformed cache entry, live-mode null-field response, `NODE_ENV=production` hard-block, `source` field on both branches
- [x] Shared-package unit tests for the pure `buildEngagementStatCards` card-builder: loading, populated, mock-sourced ("Sample data"), null-degraded, and independent per-card degradation (one field null doesn't blank the other) — substituting for a component test, since this repo has no Angular component-test runner (confirmed: no `*.component.spec.ts` files exist; `apps/lfx-one/vitest.config.ts` scopes to `src/server/**/*.spec.ts` only)
- [x] Playwright e2e coverage (`groups-engagement-stats.spec.ts`): flag off (default) → 3 cards, no `/engagement-stats` request; flag on → 5 cards populated from the mocked response; Foundation lens → never requests or renders the engagement cards regardless of flag state
- [ ] Manual: toggle `wg-engagement-metrics` on/off against a real browser session to visually confirm the 3-card ↔ 5-card transition and the "Sample data"/"Unavailable" states — not performed as part of this PR; the automated e2e spec above covers the same behavior programmatically, but no one has eyeballed it in a running browser yet

🤖 Generated with [Claude Code](https://claude.com/claude-code)


[LFXV2-1711]: https://linuxfoundation.atlassian.net/browse/LFXV2-1711?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ