### PR TITLE
fix(meetings): calendar occurrence links and event colors

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -14,7 +14,15 @@ import { SelectComponent } from '@components/select/select.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { MEETING_TYPE_CONFIGS, PAST_MEETING_SORT, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
 import { Committee, Meeting, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
-import { addMinutesToDate, buildMeetingOccurrenceRoute, getCurrentOrNextOccurrence, hasMeetingEnded, isMeetingOccurrenceCancelled, resolveMeetingCalendarColors, sortPastMeetingsDescending } from '@lfx-one/shared/utils';
+import {
+  addMinutesToDate,
+  buildMeetingOccurrenceRoute,
+  getCurrentOrNextOccurrence,
+  hasMeetingEnded,
+  isMeetingOccurrenceCancelled,
+  resolveMeetingCalendarColors,
+  sortPastMeetingsDescending,
+} from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
@@ -179,7 +187,12 @@ export class CommitteeMeetingsComponent {
       return;
     }
 
-    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, props.password ? { password: props.password } : undefined);
+    const route = buildMeetingOccurrenceRoute(
+      props.meetingId,
+      startTime,
+      props.durationMinutes ?? 60,
+      props.password ? { password: props.password } : undefined
+    );
     void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : undefined);
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -286,7 +286,9 @@ export class CommitteeMeetingsComponent {
 
       const meetingEvents = allMeetings.flatMap((m) => meetingToCalendarEvents(m) as EventInput[]);
       const voteEvents = votes.filter((v) => !!v.end_time).map((v) => voteToCalendarEvent(v) as EventInput);
-      const surveyEvents = surveys.filter((s) => !!s.survey_cutoff_date).map((s) => surveyToCalendarEvent(s) as EventInput);
+      const surveyEvents = surveys
+        .filter((s): s is Survey & { survey_cutoff_date: string } => !!s.survey_cutoff_date)
+        .map((s) => surveyToCalendarEvent(s) as EventInput);
 
       return [...meetingEvents, ...voteEvents, ...surveyEvents];
     });

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -333,7 +333,7 @@ export class CommitteeMeetingsComponent {
           end: addMinutesToDate(occ.start_time, occ.duration ?? meeting.duration).toISOString(),
           backgroundColor: colors.bg,
           borderColor: colors.border,
-          textColor: '#ffffff',
+          textColor: colors.text,
           display: 'block',
           classNames,
           extendedProps: {
@@ -364,7 +364,7 @@ export class CommitteeMeetingsComponent {
         end: addMinutesToDate(startTime, meeting.duration).toISOString(),
         backgroundColor: colors.bg,
         borderColor: colors.border,
-        textColor: '#ffffff',
+        textColor: colors.text,
         display: 'block',
         classNames: ['meeting-event'],
         extendedProps: {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -18,8 +18,11 @@ import {
   addMinutesToDate,
   buildMeetingOccurrenceRoute,
   getCurrentOrNextOccurrence,
+  getPastMeetingResourceId,
+  getPastMeetingStartTimeMs,
   hasMeetingEnded,
   isMeetingOccurrenceCancelled,
+  isPastMeetingCalendarRow,
   resolveMeetingCalendarColors,
   sortPastMeetingsDescending,
 } from '@lfx-one/shared/utils';
@@ -176,6 +179,7 @@ export class CommitteeMeetingsComponent {
       password?: string;
       startTime?: string;
       durationMinutes?: number;
+      pastMeetingResourceId?: string;
     };
     if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
       return;
@@ -187,12 +191,10 @@ export class CommitteeMeetingsComponent {
       return;
     }
 
-    const route = buildMeetingOccurrenceRoute(
-      props.meetingId,
-      startTime,
-      props.durationMinutes ?? 60,
-      props.password ? { password: props.password } : undefined
-    );
+    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, {
+      password: props.password,
+      pastMeetingResourceId: props.pastMeetingResourceId,
+    });
     void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : undefined);
   }
 
@@ -316,15 +318,13 @@ export class CommitteeMeetingsComponent {
     // Recurring meetings — expand each occurrence as a separate calendar event
     if (meeting.occurrences && meeting.occurrences.length > 0) {
       return meeting.occurrences.map((occ) => {
+        const occurrenceDuration = occ.duration ?? meeting.duration;
         const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
-        const isPast = !isCancelled && hasMeetingEnded(meeting, occ);
-        const colors = resolveMeetingCalendarColors(isCancelled);
+        const isPast = !isCancelled && hasMeetingEnded(meeting, { ...occ, duration: occurrenceDuration });
+        const colors = resolveMeetingCalendarColors(isCancelled, isPast);
         const classNames = ['meeting-event'];
         if (isCancelled) {
           classNames.push('cursor-default');
-        }
-        if (isPast) {
-          classNames.push('meeting-event-past');
         }
         return {
           id: `${meeting.id}-${occ.occurrence_id}`,
@@ -348,30 +348,31 @@ export class CommitteeMeetingsComponent {
       });
     }
 
-    const isPast = hasMeetingEnded(meeting);
-    const colors = resolveMeetingCalendarColors(false);
-    const classNames = ['meeting-event'];
-    if (isPast) {
-      classNames.push('meeting-event-past');
-    }
+    const pastRow = isPastMeetingCalendarRow(meeting);
+    const startTimeMs = pastRow ? getPastMeetingStartTimeMs(meeting) : null;
+    const startTime = startTimeMs !== null ? new Date(startTimeMs).toISOString() : meeting.start_time;
+    const isPast = pastRow || hasMeetingEnded(meeting);
+    const colors = resolveMeetingCalendarColors(false, isPast);
+    const pastResourceId = pastRow ? getPastMeetingResourceId(meeting) : undefined;
 
     // Non-recurring — single event
     return [
       {
-        id: meeting.id,
+        id: pastResourceId ?? meeting.id,
         title: meeting.title,
-        start: meeting.start_time,
-        end: addMinutesToDate(meeting.start_time, meeting.duration).toISOString(),
+        start: startTime,
+        end: addMinutesToDate(startTime, meeting.duration).toISOString(),
         backgroundColor: colors.bg,
         borderColor: colors.border,
         textColor: '#ffffff',
         display: 'block',
-        classNames,
+        classNames: ['meeting-event'],
         extendedProps: {
           type: 'meeting',
-          meetingId: meeting.id,
+          meetingId: pastResourceId ?? meeting.id,
+          pastMeetingResourceId: pastResourceId,
           password: meeting.password,
-          startTime: meeting.start_time,
+          startTime,
           durationMinutes: meeting.duration,
         },
       },

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -12,9 +12,9 @@ import { CardComponent } from '@components/card/card.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { CANCELLED_COLOR, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS, PAST_MEETING_SORT, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
+import { MEETING_TYPE_CONFIGS, PAST_MEETING_SORT, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
 import { Committee, Meeting, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
-import { addMinutesToDate, getCurrentOrNextOccurrence, hasMeetingEnded, sortPastMeetingsDescending } from '@lfx-one/shared/utils';
+import { addMinutesToDate, buildMeetingOccurrenceRoute, getCurrentOrNextOccurrence, hasMeetingEnded, isMeetingOccurrenceCancelled, resolveMeetingCalendarColors, sortPastMeetingsDescending } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { MeetingService } from '@services/meeting.service';
@@ -161,11 +161,26 @@ export class CommitteeMeetingsComponent {
 
   /** Handles FullCalendar event click — navigates to meeting detail. Cancelled occurrences are inert. */
   public onCalendarEventClick(arg: EventClickArg): void {
-    const props = arg.event.extendedProps as { type: string; meetingId?: string; cancelled?: boolean };
-    if (props.cancelled) return;
-    if (props.type === 'meeting' && props.meetingId) {
-      void this.router.navigate(['/meetings', props.meetingId]);
+    const props = arg.event.extendedProps as {
+      type: string;
+      meetingId?: string;
+      cancelled?: boolean;
+      password?: string;
+      startTime?: string;
+      durationMinutes?: number;
+    };
+    if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
+      return;
     }
+
+    const startTime = props.startTime ?? arg.event.start?.toISOString();
+    if (!startTime) {
+      void this.router.navigate(['/meetings', props.meetingId], props.password ? { queryParams: { password: props.password } } : undefined);
+      return;
+    }
+
+    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, props.password ? { password: props.password } : undefined);
+    void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : undefined);
   }
 
   /** Checks writer permission fresh before navigating — prevents a demoted member from reaching /meetings/create. */
@@ -285,28 +300,46 @@ export class CommitteeMeetingsComponent {
   }
 
   private meetingToEvents(meeting: Meeting | PastMeeting): EventInput[] {
-    const typeKey = (meeting.meeting_type ?? 'default').toLowerCase();
-    const colors = MEETING_TYPE_COLORS[typeKey] ?? MEETING_TYPE_COLORS['default'];
-
     // Recurring meetings — expand each occurrence as a separate calendar event
     if (meeting.occurrences && meeting.occurrences.length > 0) {
       return meeting.occurrences.map((occ) => {
-        const isCancelled = occ.status === 'cancel';
-        const c = isCancelled ? CANCELLED_COLOR : colors;
+        const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
+        const isPast = !isCancelled && hasMeetingEnded(meeting, occ);
+        const colors = resolveMeetingCalendarColors(isCancelled);
+        const classNames = ['meeting-event'];
+        if (isCancelled) {
+          classNames.push('cursor-default');
+        }
+        if (isPast) {
+          classNames.push('meeting-event-past');
+        }
         return {
           id: `${meeting.id}-${occ.occurrence_id}`,
           title: occ.title || meeting.title,
           start: occ.start_time,
           end: addMinutesToDate(occ.start_time, occ.duration ?? meeting.duration).toISOString(),
-          backgroundColor: c.bg,
-          borderColor: c.border,
+          backgroundColor: colors.bg,
+          borderColor: colors.border,
           textColor: '#ffffff',
           display: 'block',
-          // meeting-event scopes the shared dimming/future-event styles; cursor-default disables the click affordance on cancelled occurrences.
-          classNames: isCancelled ? ['meeting-event', 'cursor-default'] : ['meeting-event'],
-          extendedProps: { type: 'meeting', meetingId: meeting.id, cancelled: isCancelled },
+          classNames,
+          extendedProps: {
+            type: 'meeting',
+            meetingId: meeting.id,
+            cancelled: isCancelled,
+            password: meeting.password,
+            startTime: occ.start_time,
+            durationMinutes: occ.duration ?? meeting.duration,
+          },
         };
       });
+    }
+
+    const isPast = hasMeetingEnded(meeting);
+    const colors = resolveMeetingCalendarColors(false);
+    const classNames = ['meeting-event'];
+    if (isPast) {
+      classNames.push('meeting-event-past');
     }
 
     // Non-recurring — single event
@@ -320,8 +353,14 @@ export class CommitteeMeetingsComponent {
         borderColor: colors.border,
         textColor: '#ffffff',
         display: 'block',
-        classNames: ['meeting-event'],
-        extendedProps: { type: 'meeting', meetingId: meeting.id },
+        classNames,
+        extendedProps: {
+          type: 'meeting',
+          meetingId: meeting.id,
+          password: meeting.password,
+          startTime: meeting.start_time,
+          durationMinutes: meeting.duration,
+        },
       },
     ];
   }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -13,17 +13,12 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { MEETING_TYPE_CONFIGS, PAST_MEETING_SORT, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
-import { Committee, Meeting, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
+import { Committee, Meeting, MeetingCalendarClickProps, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
 import {
-  addMinutesToDate,
-  buildMeetingOccurrenceRoute,
   getCurrentOrNextOccurrence,
-  getPastMeetingResourceId,
-  getPastMeetingStartTimeMs,
   hasMeetingEnded,
-  isMeetingOccurrenceCancelled,
-  isPastMeetingCalendarRow,
-  resolveMeetingCalendarColors,
+  meetingToCalendarEvents,
+  resolveMeetingCalendarClickRoute,
   sortPastMeetingsDescending,
 } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
@@ -172,29 +167,10 @@ export class CommitteeMeetingsComponent {
 
   /** Handles FullCalendar event click — navigates to meeting detail. Cancelled occurrences are inert. */
   public onCalendarEventClick(arg: EventClickArg): void {
-    const props = arg.event.extendedProps as {
-      type: string;
-      meetingId?: string;
-      cancelled?: boolean;
-      password?: string;
-      startTime?: string;
-      durationMinutes?: number;
-      pastMeetingResourceId?: string;
-    };
-    if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
+    const route = resolveMeetingCalendarClickRoute(arg.event.extendedProps as MeetingCalendarClickProps, arg.event.start);
+    if (!route) {
       return;
     }
-
-    const startTime = props.startTime ?? arg.event.start?.toISOString();
-    if (!startTime) {
-      void this.router.navigate(['/meetings', props.meetingId], props.password ? { queryParams: { password: props.password } } : undefined);
-      return;
-    }
-
-    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, {
-      password: props.password,
-      pastMeetingResourceId: props.pastMeetingResourceId,
-    });
     void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : undefined);
   }
 
@@ -306,77 +282,12 @@ export class CommitteeMeetingsComponent {
       const allMeetings: (Meeting | PastMeeting)[] = [...this.upcomingMeetings(), ...externalData().pastMeetings];
       const { votes, surveys } = externalData();
 
-      const meetingEvents = allMeetings.flatMap((m) => this.meetingToEvents(m));
+      const meetingEvents = allMeetings.flatMap((m) => meetingToCalendarEvents(m));
       const voteEvents = votes.filter((v) => !!v.end_time).map((v) => this.voteToEvent(v));
       const surveyEvents = surveys.filter((s) => !!s.survey_cutoff_date).map((s) => this.surveyToEvent(s));
 
       return [...meetingEvents, ...voteEvents, ...surveyEvents];
     });
-  }
-
-  private meetingToEvents(meeting: Meeting | PastMeeting): EventInput[] {
-    // Recurring meetings — expand each occurrence as a separate calendar event
-    if (meeting.occurrences && meeting.occurrences.length > 0) {
-      return meeting.occurrences.map((occ) => {
-        const occurrenceDuration = occ.duration ?? meeting.duration;
-        const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
-        const isPast = !isCancelled && hasMeetingEnded(meeting, { ...occ, duration: occurrenceDuration });
-        const colors = resolveMeetingCalendarColors(isCancelled, isPast);
-        const classNames = ['meeting-event'];
-        if (isCancelled) {
-          classNames.push('cursor-default');
-        }
-        return {
-          id: `${meeting.id}-${occ.occurrence_id}`,
-          title: occ.title || meeting.title,
-          start: occ.start_time,
-          end: addMinutesToDate(occ.start_time, occ.duration ?? meeting.duration).toISOString(),
-          backgroundColor: colors.bg,
-          borderColor: colors.border,
-          textColor: colors.text,
-          display: 'block',
-          classNames,
-          extendedProps: {
-            type: 'meeting',
-            meetingId: meeting.id,
-            cancelled: isCancelled,
-            password: meeting.password,
-            startTime: occ.start_time,
-            durationMinutes: occ.duration ?? meeting.duration,
-          },
-        };
-      });
-    }
-
-    const pastRow = isPastMeetingCalendarRow(meeting);
-    const startTimeMs = pastRow ? getPastMeetingStartTimeMs(meeting) : null;
-    const startTime = startTimeMs !== null ? new Date(startTimeMs).toISOString() : meeting.start_time;
-    const isPast = pastRow || hasMeetingEnded(meeting);
-    const colors = resolveMeetingCalendarColors(false, isPast);
-    const pastResourceId = pastRow ? getPastMeetingResourceId(meeting) : undefined;
-
-    // Non-recurring — single event
-    return [
-      {
-        id: pastResourceId ?? meeting.id,
-        title: meeting.title,
-        start: startTime,
-        end: addMinutesToDate(startTime, meeting.duration).toISOString(),
-        backgroundColor: colors.bg,
-        borderColor: colors.border,
-        textColor: colors.text,
-        display: 'block',
-        classNames: ['meeting-event'],
-        extendedProps: {
-          type: 'meeting',
-          meetingId: pastResourceId ?? meeting.id,
-          pastMeetingResourceId: pastResourceId,
-          password: meeting.password,
-          startTime,
-          durationMinutes: meeting.duration,
-        },
-      },
-    ];
   }
 
   private voteToEvent(vote: Vote): EventInput {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -12,7 +12,7 @@ import { CardComponent } from '@components/card/card.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { MEETING_TYPE_CONFIGS, PAST_MEETING_SORT, SURVEY_COLOR, VOTE_COLOR } from '@lfx-one/shared/constants';
+import { MEETING_TYPE_CONFIGS, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
 import { Committee, Meeting, MeetingCalendarClickProps, PastMeeting, Survey, TimeFilter, ViewMode, Vote } from '@lfx-one/shared/interfaces';
 import {
   getCurrentOrNextOccurrence,
@@ -20,6 +20,8 @@ import {
   meetingToCalendarEvents,
   resolveMeetingCalendarClickRoute,
   sortPastMeetingsDescending,
+  surveyToCalendarEvent,
+  voteToCalendarEvent,
 } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
@@ -283,38 +285,10 @@ export class CommitteeMeetingsComponent {
       const { votes, surveys } = externalData();
 
       const meetingEvents = allMeetings.flatMap((m) => meetingToCalendarEvents(m) as EventInput[]);
-      const voteEvents = votes.filter((v) => !!v.end_time).map((v) => this.voteToEvent(v));
-      const surveyEvents = surveys.filter((s) => !!s.survey_cutoff_date).map((s) => this.surveyToEvent(s));
+      const voteEvents = votes.filter((v) => !!v.end_time).map((v) => voteToCalendarEvent(v) as EventInput);
+      const surveyEvents = surveys.filter((s) => !!s.survey_cutoff_date).map((s) => surveyToCalendarEvent(s) as EventInput);
 
       return [...meetingEvents, ...voteEvents, ...surveyEvents];
     });
-  }
-
-  private voteToEvent(vote: Vote): EventInput {
-    return {
-      id: `vote-${vote.uid}`,
-      title: `Vote closes: ${vote.name}`,
-      start: vote.end_time,
-      allDay: true,
-      backgroundColor: VOTE_COLOR.bg,
-      borderColor: VOTE_COLOR.border,
-      textColor: '#ffffff',
-      classNames: ['cursor-default'],
-      extendedProps: { type: 'vote', voteId: vote.uid },
-    };
-  }
-
-  private surveyToEvent(survey: Survey): EventInput {
-    return {
-      id: `survey-${survey.uid}`,
-      title: `Survey: ${survey.survey_title}`,
-      start: survey.survey_cutoff_date ?? undefined,
-      allDay: true,
-      backgroundColor: SURVEY_COLOR.bg,
-      borderColor: SURVEY_COLOR.border,
-      textColor: '#ffffff',
-      classNames: ['cursor-default'],
-      extendedProps: { type: 'survey', surveyId: survey.uid },
-    };
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-meetings/committee-meetings.component.ts
@@ -282,7 +282,7 @@ export class CommitteeMeetingsComponent {
       const allMeetings: (Meeting | PastMeeting)[] = [...this.upcomingMeetings(), ...externalData().pastMeetings];
       const { votes, surveys } = externalData();
 
-      const meetingEvents = allMeetings.flatMap((m) => meetingToCalendarEvents(m));
+      const meetingEvents = allMeetings.flatMap((m) => meetingToCalendarEvents(m) as EventInput[]);
       const voteEvents = votes.filter((v) => !!v.end_time).map((v) => this.voteToEvent(v));
       const surveyEvents = surveys.filter((s) => !!s.survey_cutoff_date).map((s) => this.surveyToEvent(s));
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -51,7 +51,7 @@ import {
   TagSeverity,
   User,
 } from '@lfx-one/shared';
-import { getUserTimezone, isHostKeyVisible } from '@lfx-one/shared/utils';
+import { getUserTimezone, isHostKeyVisible, isPastMeetingCompositeId } from '@lfx-one/shared/utils';
 import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
@@ -671,7 +671,7 @@ export class MeetingJoinComponent implements OnInit {
           }
 
           // Check if this is a past meeting occurrence ID (format: meetingId-timestamp)
-          if (this.isPastMeetingOccurrenceId(meetingId)) {
+          if (isPastMeetingCompositeId(meetingId)) {
             this.loadedViaPastMeetingId.set(true);
             return this.meetingService.getPublicPastMeeting(meetingId).pipe(
               tap((res: PublicPastMeetingResponse) => {
@@ -724,11 +724,6 @@ export class MeetingJoinComponent implements OnInit {
         })
       )
     ) as Signal<Meeting & { project: Partial<Project> }>;
-  }
-
-  private isPastMeetingOccurrenceId(id: string): boolean {
-    const parts = id.split('-');
-    return parts.length === 2 && /^\d+$/.test(parts[0]) && /^\d{13}$/.test(parts[1]);
   }
 
   private initializeCurrentOccurrence(): Signal<MeetingOccurrence | null> {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -999,7 +999,7 @@ export class MeetingsDashboardComponent {
               viewerUsername: this.userService.viewerUsername(),
             })
           : this.filterBySearchAndType([...this.rawFpUpcomingMeetings(), ...this.rawFpPastMeetings()], search, meetingType);
-      return filtered.flatMap((m) => meetingToCalendarEvents(m));
+      return filtered.flatMap((m) => meetingToCalendarEvents(m) as EventInput[]);
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -1043,7 +1043,7 @@ export class MeetingsDashboardComponent {
           end: addMinutesToDate(occ.start_time, occ.duration ?? meeting.duration).toISOString(),
           backgroundColor: colors.bg,
           borderColor: colors.border,
-          textColor: '#ffffff',
+          textColor: colors.text,
           display: 'block',
           classNames,
           extendedProps: {
@@ -1073,7 +1073,7 @@ export class MeetingsDashboardComponent {
         end: addMinutesToDate(startTime, meeting.duration).toISOString(),
         backgroundColor: colors.bg,
         borderColor: colors.border,
-        textColor: '#ffffff',
+        textColor: colors.text,
         display: 'block',
         classNames: ['meeting-event'],
         extendedProps: {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -14,19 +14,16 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
-import { Lens, MeLensMeetingFilters, Meeting, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
+import { Lens, MeLensMeetingFilters, Meeting, MeetingCalendarClickProps, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
 import {
-  addMinutesToDate,
-  buildMeetingOccurrenceRoute,
   getCurrentOrNextOccurrence,
   getLargestSessionShareUrl,
   getPastMeetingResourceId,
   getPastMeetingStartTimeMs,
   hasMeetingEnded,
-  isMeetingOccurrenceCancelled,
   isMeetingOrganizedByViewer,
-  isPastMeetingCalendarRow,
-  resolveMeetingCalendarColors,
+  meetingToCalendarEvents,
+  resolveMeetingCalendarClickRoute,
   sortPastMeetingsDescending,
 } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
@@ -266,30 +263,11 @@ export class MeetingsDashboardComponent {
 
   /** FullCalendar event click → navigate to the meeting detail. Cancelled occurrences are inert. */
   public onCalendarEventClick(arg: EventClickArg): void {
-    const props = arg.event.extendedProps as {
-      type: string;
-      meetingId?: string;
-      cancelled?: boolean;
-      password?: string;
-      startTime?: string;
-      durationMinutes?: number;
-      pastMeetingResourceId?: string;
-    };
-    if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
+    const route = resolveMeetingCalendarClickRoute(arg.event.extendedProps as MeetingCalendarClickProps, arg.event.start);
+    if (!route) {
       return;
     }
-
-    const startTime = props.startTime ?? arg.event.start?.toISOString();
-    if (!startTime) {
-      void this.router.navigate(['/meetings', props.meetingId], props.password ? { queryParams: { password: props.password } } : {});
-      return;
-    }
-
-    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, {
-      password: props.password,
-      pastMeetingResourceId: props.pastMeetingResourceId,
-    });
-    void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : {});
+    void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : undefined);
   }
 
   /** Opens iCal Subscribe modal — foundation/project lenses only; me/org lenses tracked separately. */
@@ -1021,70 +999,7 @@ export class MeetingsDashboardComponent {
               viewerUsername: this.userService.viewerUsername(),
             })
           : this.filterBySearchAndType([...this.rawFpUpcomingMeetings(), ...this.rawFpPastMeetings()], search, meetingType);
-      return filtered.flatMap((m) => this.meetingToEvents(m));
+      return filtered.flatMap((m) => meetingToCalendarEvents(m));
     });
-  }
-
-  private meetingToEvents(meeting: Meeting | PastMeeting): EventInput[] {
-    if (meeting.occurrences && meeting.occurrences.length > 0) {
-      return meeting.occurrences.map((occ) => {
-        const occurrenceDuration = occ.duration ?? meeting.duration;
-        const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
-        const isPast = !isCancelled && hasMeetingEnded(meeting, { ...occ, duration: occurrenceDuration });
-        const colors = resolveMeetingCalendarColors(isCancelled, isPast);
-        const classNames = ['meeting-event'];
-        if (isCancelled) {
-          classNames.push('cursor-default');
-        }
-        return {
-          id: `${meeting.id}-${occ.occurrence_id}`,
-          title: occ.title || meeting.title,
-          start: occ.start_time,
-          end: addMinutesToDate(occ.start_time, occ.duration ?? meeting.duration).toISOString(),
-          backgroundColor: colors.bg,
-          borderColor: colors.border,
-          textColor: colors.text,
-          display: 'block',
-          classNames,
-          extendedProps: {
-            type: 'meeting',
-            meetingId: meeting.id,
-            cancelled: isCancelled,
-            password: meeting.password,
-            startTime: occ.start_time,
-            durationMinutes: occ.duration ?? meeting.duration,
-          },
-        };
-      });
-    }
-
-    const pastRow = isPastMeetingCalendarRow(meeting);
-    const startTimeMs = pastRow ? getPastMeetingStartTimeMs(meeting) : null;
-    const startTime = startTimeMs !== null ? new Date(startTimeMs).toISOString() : meeting.start_time;
-    const isPast = pastRow || hasMeetingEnded(meeting);
-    const colors = resolveMeetingCalendarColors(false, isPast);
-    const pastResourceId = pastRow ? getPastMeetingResourceId(meeting) : undefined;
-
-    return [
-      {
-        id: pastResourceId ?? meeting.id,
-        title: meeting.title,
-        start: startTime,
-        end: addMinutesToDate(startTime, meeting.duration).toISOString(),
-        backgroundColor: colors.bg,
-        borderColor: colors.border,
-        textColor: colors.text,
-        display: 'block',
-        classNames: ['meeting-event'],
-        extendedProps: {
-          type: 'meeting',
-          meetingId: pastResourceId ?? meeting.id,
-          pastMeetingResourceId: pastResourceId,
-          password: meeting.password,
-          startTime,
-          durationMinutes: meeting.duration,
-        },
-      },
-    ];
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -13,16 +13,19 @@ import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { CANCELLED_COLOR, MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_COLORS, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
+import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
 import { Lens, MeLensMeetingFilters, Meeting, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
 import {
   addMinutesToDate,
+  buildMeetingOccurrenceRoute,
   getCurrentOrNextOccurrence,
   getLargestSessionShareUrl,
   getPastMeetingResourceId,
   getPastMeetingStartTimeMs,
   hasMeetingEnded,
+  isMeetingOccurrenceCancelled,
   isMeetingOrganizedByViewer,
+  resolveMeetingCalendarColors,
   sortPastMeetingsDescending,
 } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
@@ -262,11 +265,26 @@ export class MeetingsDashboardComponent {
 
   /** FullCalendar event click → navigate to the meeting detail. Cancelled occurrences are inert. */
   public onCalendarEventClick(arg: EventClickArg): void {
-    const props = arg.event.extendedProps as { type: string; meetingId?: string; cancelled?: boolean; password?: string };
-    if (props.cancelled) return;
-    if (props.type === 'meeting' && props.meetingId) {
-      void this.router.navigate(['/meetings', props.meetingId], props.password ? { queryParams: { password: props.password } } : {});
+    const props = arg.event.extendedProps as {
+      type: string;
+      meetingId?: string;
+      cancelled?: boolean;
+      password?: string;
+      startTime?: string;
+      durationMinutes?: number;
+    };
+    if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
+      return;
     }
+
+    const startTime = props.startTime ?? arg.event.start?.toISOString();
+    if (!startTime) {
+      void this.router.navigate(['/meetings', props.meetingId], props.password ? { queryParams: { password: props.password } } : {});
+      return;
+    }
+
+    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, props.password ? { password: props.password } : undefined);
+    void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : {});
   }
 
   /** Opens iCal Subscribe modal — foundation/project lenses only; me/org lenses tracked separately. */
@@ -1003,27 +1021,45 @@ export class MeetingsDashboardComponent {
   }
 
   private meetingToEvents(meeting: Meeting | PastMeeting): EventInput[] {
-    const typeKey = (meeting.meeting_type ?? 'default').toLowerCase();
-    const colors = MEETING_TYPE_COLORS[typeKey] ?? MEETING_TYPE_COLORS['default'];
-
     if (meeting.occurrences && meeting.occurrences.length > 0) {
       return meeting.occurrences.map((occ) => {
-        const isCancelled = occ.status === 'cancel';
-        const c = isCancelled ? CANCELLED_COLOR : colors;
+        const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
+        const isPast = !isCancelled && hasMeetingEnded(meeting, occ);
+        const colors = resolveMeetingCalendarColors(isCancelled);
+        const classNames = ['meeting-event'];
+        if (isCancelled) {
+          classNames.push('cursor-default');
+        }
+        if (isPast) {
+          classNames.push('meeting-event-past');
+        }
         return {
           id: `${meeting.id}-${occ.occurrence_id}`,
           title: occ.title || meeting.title,
           start: occ.start_time,
           end: addMinutesToDate(occ.start_time, occ.duration ?? meeting.duration).toISOString(),
-          backgroundColor: c.bg,
-          borderColor: c.border,
+          backgroundColor: colors.bg,
+          borderColor: colors.border,
           textColor: '#ffffff',
           display: 'block',
-          // meeting-event scopes the shared dimming/future-event styles; cursor-default disables the click affordance on cancelled occurrences.
-          classNames: isCancelled ? ['meeting-event', 'cursor-default'] : ['meeting-event'],
-          extendedProps: { type: 'meeting', meetingId: meeting.id, cancelled: isCancelled, password: meeting.password },
+          classNames,
+          extendedProps: {
+            type: 'meeting',
+            meetingId: meeting.id,
+            cancelled: isCancelled,
+            password: meeting.password,
+            startTime: occ.start_time,
+            durationMinutes: occ.duration ?? meeting.duration,
+          },
         };
       });
+    }
+
+    const isPast = hasMeetingEnded(meeting);
+    const colors = resolveMeetingCalendarColors(false);
+    const classNames = ['meeting-event'];
+    if (isPast) {
+      classNames.push('meeting-event-past');
     }
 
     return [
@@ -1036,8 +1072,14 @@ export class MeetingsDashboardComponent {
         borderColor: colors.border,
         textColor: '#ffffff',
         display: 'block',
-        classNames: ['meeting-event'],
-        extendedProps: { type: 'meeting', meetingId: meeting.id, password: meeting.password },
+        classNames,
+        extendedProps: {
+          type: 'meeting',
+          meetingId: meeting.id,
+          password: meeting.password,
+          startTime: meeting.start_time,
+          durationMinutes: meeting.duration,
+        },
       },
     ];
   }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -283,7 +283,12 @@ export class MeetingsDashboardComponent {
       return;
     }
 
-    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, props.password ? { password: props.password } : undefined);
+    const route = buildMeetingOccurrenceRoute(
+      props.meetingId,
+      startTime,
+      props.durationMinutes ?? 60,
+      props.password ? { password: props.password } : undefined
+    );
     void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : {});
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -25,6 +25,7 @@ import {
   hasMeetingEnded,
   isMeetingOccurrenceCancelled,
   isMeetingOrganizedByViewer,
+  isPastMeetingCalendarRow,
   resolveMeetingCalendarColors,
   sortPastMeetingsDescending,
 } from '@lfx-one/shared/utils';
@@ -272,6 +273,7 @@ export class MeetingsDashboardComponent {
       password?: string;
       startTime?: string;
       durationMinutes?: number;
+      pastMeetingResourceId?: string;
     };
     if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
       return;
@@ -283,12 +285,10 @@ export class MeetingsDashboardComponent {
       return;
     }
 
-    const route = buildMeetingOccurrenceRoute(
-      props.meetingId,
-      startTime,
-      props.durationMinutes ?? 60,
-      props.password ? { password: props.password } : undefined
-    );
+    const route = buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 60, {
+      password: props.password,
+      pastMeetingResourceId: props.pastMeetingResourceId,
+    });
     void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : {});
   }
 
@@ -1028,15 +1028,13 @@ export class MeetingsDashboardComponent {
   private meetingToEvents(meeting: Meeting | PastMeeting): EventInput[] {
     if (meeting.occurrences && meeting.occurrences.length > 0) {
       return meeting.occurrences.map((occ) => {
+        const occurrenceDuration = occ.duration ?? meeting.duration;
         const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
-        const isPast = !isCancelled && hasMeetingEnded(meeting, occ);
-        const colors = resolveMeetingCalendarColors(isCancelled);
+        const isPast = !isCancelled && hasMeetingEnded(meeting, { ...occ, duration: occurrenceDuration });
+        const colors = resolveMeetingCalendarColors(isCancelled, isPast);
         const classNames = ['meeting-event'];
         if (isCancelled) {
           classNames.push('cursor-default');
-        }
-        if (isPast) {
-          classNames.push('meeting-event-past');
         }
         return {
           id: `${meeting.id}-${occ.occurrence_id}`,
@@ -1060,29 +1058,30 @@ export class MeetingsDashboardComponent {
       });
     }
 
-    const isPast = hasMeetingEnded(meeting);
-    const colors = resolveMeetingCalendarColors(false);
-    const classNames = ['meeting-event'];
-    if (isPast) {
-      classNames.push('meeting-event-past');
-    }
+    const pastRow = isPastMeetingCalendarRow(meeting);
+    const startTimeMs = pastRow ? getPastMeetingStartTimeMs(meeting) : null;
+    const startTime = startTimeMs !== null ? new Date(startTimeMs).toISOString() : meeting.start_time;
+    const isPast = pastRow || hasMeetingEnded(meeting);
+    const colors = resolveMeetingCalendarColors(false, isPast);
+    const pastResourceId = pastRow ? getPastMeetingResourceId(meeting) : undefined;
 
     return [
       {
-        id: meeting.id,
+        id: pastResourceId ?? meeting.id,
         title: meeting.title,
-        start: meeting.start_time,
-        end: addMinutesToDate(meeting.start_time, meeting.duration).toISOString(),
+        start: startTime,
+        end: addMinutesToDate(startTime, meeting.duration).toISOString(),
         backgroundColor: colors.bg,
         borderColor: colors.border,
         textColor: '#ffffff',
         display: 'block',
-        classNames,
+        classNames: ['meeting-event'],
         extendedProps: {
           type: 'meeting',
-          meetingId: meeting.id,
+          meetingId: pastResourceId ?? meeting.id,
+          pastMeetingResourceId: pastResourceId,
           password: meeting.password,
-          startTime: meeting.start_time,
+          startTime,
           durationMinutes: meeting.duration,
         },
       },

--- a/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
+++ b/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
@@ -83,11 +83,11 @@
 
         &.meeting-event {
           .fc-event-title {
-            @apply font-medium leading-tight overflow-hidden line-clamp-2 text-white;
+            @apply font-medium leading-tight overflow-hidden line-clamp-2;
           }
 
           .fc-event-time {
-            @apply font-semibold mr-1 block mb-0.5 text-[11px] text-white;
+            @apply font-semibold mr-1 block mb-0.5 text-[11px];
           }
         }
       }

--- a/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
+++ b/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
@@ -20,39 +20,6 @@
         @apply mr-2;
       }
 
-      .fc-timegrid {
-        // Scope dimming to .meeting-event only — generic events use inline backgroundColor; !important override would hide their text.
-        .fc-timegrid-col-events {
-          .fc-timegrid-event.meeting-event {
-            &:not(.fc-event-future) {
-              @apply bg-gray-100 #{!important};
-
-              // Restore dark text — white-on-gray-100 is unreadable.
-              .fc-event-title {
-                @apply text-gray-500 #{!important};
-              }
-
-              .fc-event-time {
-                @apply text-gray-500 #{!important};
-              }
-            }
-
-            &.fc-event-future {
-              @apply bg-blue-50 #{!important};
-
-              // Restore dark text — white-on-blue-50 is unreadable.
-              .fc-event-title {
-                @apply text-blue-700 #{!important};
-              }
-
-              .fc-event-time {
-                @apply text-blue-900 #{!important};
-              }
-            }
-          }
-        }
-      }
-
       // Header toolbar styling
       .fc-toolbar {
         @apply mb-6;
@@ -123,14 +90,8 @@
             @apply font-semibold mr-1 block mb-0.5 text-[11px] text-white;
           }
 
-          &.fc-event-future {
-            .fc-event-title {
-              @apply font-medium leading-tight overflow-hidden line-clamp-2 text-white;
-            }
-
-            .fc-event-time {
-              @apply font-semibold mr-1 block mb-0.5 text-[11px] text-white;
-            }
+          &.meeting-event-past:not(.cursor-default) {
+            opacity: 0.55;
           }
         }
       }

--- a/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
+++ b/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
@@ -89,10 +89,6 @@
           .fc-event-time {
             @apply font-semibold mr-1 block mb-0.5 text-[11px] text-white;
           }
-
-          &.meeting-event-past:not(.cursor-default) {
-            opacity: 0.55;
-          }
         }
       }
     }

--- a/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
+++ b/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
@@ -83,11 +83,22 @@
 
         &.meeting-event {
           .fc-event-title {
-            @apply font-medium leading-tight overflow-hidden line-clamp-2;
+            @apply font-medium leading-tight overflow-hidden line-clamp-2 text-white;
           }
 
           .fc-event-time {
-            @apply font-semibold mr-1 block mb-0.5 text-[11px];
+            @apply font-semibold mr-1 block mb-0.5 text-[11px] text-white;
+          }
+
+          // FullCalendar 6 ignores event textColor on timed events — drive contrast via CSS.
+          &.meeting-event-past {
+            .fc-event-title {
+              @apply text-blue-700 #{!important};
+            }
+
+            .fc-event-time {
+              @apply text-blue-900 #{!important};
+            }
           }
         }
       }

--- a/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
+++ b/apps/lfx-one/src/app/shared/components/fullcalendar/fullcalendar.component.scss
@@ -101,6 +101,30 @@
             }
           }
         }
+
+        &.vote-event {
+          .fc-event-title {
+            @apply text-white;
+          }
+
+          &.vote-event-past {
+            .fc-event-title {
+              @apply text-amber-700 #{!important};
+            }
+          }
+        }
+
+        &.survey-event {
+          .fc-event-title {
+            @apply text-white;
+          }
+
+          &.survey-event-past {
+            .fc-event-title {
+              @apply text-violet-700 #{!important};
+            }
+          }
+        }
       }
     }
   }

--- a/packages/shared/src/constants/calendar-colors.constants.ts
+++ b/packages/shared/src/constants/calendar-colors.constants.ts
@@ -31,7 +31,29 @@ export const PAST_MEETING_CALENDAR_COLOR: CalendarColor = {
 };
 
 /** Calendar color for vote deadline events. */
-export const VOTE_COLOR: CalendarColorPair = { bg: lfxColors.amber[500], border: lfxColors.amber[600] };
+export const VOTE_COLOR: CalendarColor = {
+  bg: lfxColors.amber[500],
+  border: lfxColors.amber[600],
+  text: lfxColors.white,
+};
+
+/** Calendar color for past vote deadline events — light fill with dark text for WCAG contrast. */
+export const PAST_VOTE_CALENDAR_COLOR: CalendarColor = {
+  bg: lfxColors.amber[100],
+  border: lfxColors.amber[400],
+  text: lfxColors.amber[700],
+};
 
 /** Calendar color for survey cutoff events. */
-export const SURVEY_COLOR: CalendarColorPair = { bg: lfxColors.violet[500], border: lfxColors.violet[600] };
+export const SURVEY_COLOR: CalendarColor = {
+  bg: lfxColors.violet[500],
+  border: lfxColors.violet[600],
+  text: lfxColors.white,
+};
+
+/** Calendar color for past survey cutoff events — light fill with dark text for WCAG contrast. */
+export const PAST_SURVEY_CALENDAR_COLOR: CalendarColor = {
+  bg: lfxColors.violet[100],
+  border: lfxColors.violet[400],
+  text: lfxColors.violet[700],
+};

--- a/packages/shared/src/constants/calendar-colors.constants.ts
+++ b/packages/shared/src/constants/calendar-colors.constants.ts
@@ -13,10 +13,10 @@ export const MEETING_TYPE_COLORS: Record<string, { bg: string; border: string }>
 };
 
 /** Calendar color for cancelled meeting occurrences. */
-export const CANCELLED_COLOR = { bg: '#9ca3af', border: '#6b7280' };
+export const CANCELLED_COLOR = { bg: '#9ca3af', border: '#6b7280', text: '#ffffff' };
 
-/** Calendar color for past (ended) meeting occurrences — lighter blue, white text stays readable. */
-export const PAST_MEETING_CALENDAR_COLOR = { bg: '#60a5fa', border: '#3b82f6' };
+/** Calendar color for past (ended) meeting occurrences — light fill with dark text for WCAG contrast. */
+export const PAST_MEETING_CALENDAR_COLOR = { bg: '#dbeafe', border: '#60a5fa', text: '#1d4ed8' };
 
 /** Calendar color for vote deadline events. */
 export const VOTE_COLOR = { bg: '#f59e0b', border: '#d97706' };

--- a/packages/shared/src/constants/calendar-colors.constants.ts
+++ b/packages/shared/src/constants/calendar-colors.constants.ts
@@ -1,25 +1,37 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { CalendarColor, CalendarColorPair } from '../interfaces/calendar.interface';
+
+import { lfxColors } from './colors.constants';
+
 /** Hex color config per meeting type for FullCalendar events (Tailwind classes don't apply inside FullCalendar). */
-export const MEETING_TYPE_COLORS: Record<string, { bg: string; border: string }> = {
-  technical: { bg: '#7c3aed', border: '#6d28d9' },
-  maintainers: { bg: '#2563eb', border: '#1d4ed8' },
-  board: { bg: '#dc2626', border: '#b91c1c' },
-  marketing: { bg: '#059669', border: '#047857' },
-  legal: { bg: '#d97706', border: '#b45309' },
-  other: { bg: '#4b5563', border: '#374151' },
-  default: { bg: '#3b82f6', border: '#2563eb' },
+export const MEETING_TYPE_COLORS: Record<string, CalendarColorPair> = {
+  technical: { bg: lfxColors.violet[600], border: lfxColors.violet[700] },
+  maintainers: { bg: lfxColors.blue[600], border: lfxColors.blue[700] },
+  board: { bg: lfxColors.red[600], border: lfxColors.red[700] },
+  marketing: { bg: lfxColors.emerald[600], border: lfxColors.emerald[700] },
+  legal: { bg: lfxColors.amber[600], border: lfxColors.amber[700] },
+  other: { bg: lfxColors.gray[600], border: lfxColors.gray[700] },
+  default: { bg: lfxColors.blue[500], border: lfxColors.blue[600] },
 };
 
 /** Calendar color for cancelled meeting occurrences. */
-export const CANCELLED_COLOR = { bg: '#9ca3af', border: '#6b7280', text: '#ffffff' };
+export const CANCELLED_COLOR: CalendarColor = {
+  bg: lfxColors.gray[400],
+  border: lfxColors.gray[500],
+  text: lfxColors.white,
+};
 
 /** Calendar color for past (ended) meeting occurrences — light fill with dark text for WCAG contrast. */
-export const PAST_MEETING_CALENDAR_COLOR = { bg: '#dbeafe', border: '#60a5fa', text: '#1d4ed8' };
+export const PAST_MEETING_CALENDAR_COLOR: CalendarColor = {
+  bg: lfxColors.blue[100],
+  border: lfxColors.blue[400],
+  text: lfxColors.blue[700],
+};
 
 /** Calendar color for vote deadline events. */
-export const VOTE_COLOR = { bg: '#f59e0b', border: '#d97706' };
+export const VOTE_COLOR: CalendarColorPair = { bg: lfxColors.amber[500], border: lfxColors.amber[600] };
 
 /** Calendar color for survey cutoff events. */
-export const SURVEY_COLOR = { bg: '#a855f7', border: '#9333ea' };
+export const SURVEY_COLOR: CalendarColorPair = { bg: lfxColors.violet[500], border: lfxColors.violet[600] };

--- a/packages/shared/src/constants/calendar-colors.constants.ts
+++ b/packages/shared/src/constants/calendar-colors.constants.ts
@@ -15,6 +15,9 @@ export const MEETING_TYPE_COLORS: Record<string, { bg: string; border: string }>
 /** Calendar color for cancelled meeting occurrences. */
 export const CANCELLED_COLOR = { bg: '#9ca3af', border: '#6b7280' };
 
+/** Calendar color for past (ended) meeting occurrences — lighter blue, white text stays readable. */
+export const PAST_MEETING_CALENDAR_COLOR = { bg: '#60a5fa', border: '#3b82f6' };
+
 /** Calendar color for vote deadline events. */
 export const VOTE_COLOR = { bg: '#f59e0b', border: '#d97706' };
 

--- a/packages/shared/src/interfaces/calendar.interface.ts
+++ b/packages/shared/src/interfaces/calendar.interface.ts
@@ -14,7 +14,7 @@ export interface CalendarColor extends CalendarColorPair {
   text: string;
 }
 
-/** Extended props set on meeting calendar events for click routing. */
+/** Extended props set on committee calendar events for click routing. */
 export interface MeetingCalendarClickProps {
   type: string;
   meetingId?: string;
@@ -23,10 +23,12 @@ export interface MeetingCalendarClickProps {
   startTime?: string;
   durationMinutes?: number;
   pastMeetingResourceId?: string;
+  voteId?: string;
+  surveyId?: string;
 }
 
 /**
- * Structural FullCalendar event payload for meeting rows.
+ * Structural FullCalendar event payload for committee calendar rows.
  * Uses a plain interface so shared utils do not bind to a duplicate @fullcalendar/core copy.
  */
 export interface MeetingCalendarEventInput {
@@ -34,6 +36,7 @@ export interface MeetingCalendarEventInput {
   title: string;
   start: string;
   end?: string;
+  allDay?: boolean;
   backgroundColor?: string;
   borderColor?: string;
   textColor?: string;

--- a/packages/shared/src/interfaces/calendar.interface.ts
+++ b/packages/shared/src/interfaces/calendar.interface.ts
@@ -3,6 +3,28 @@
 
 import { EventInput } from '@fullcalendar/core';
 
+/** FullCalendar hex colors for event background and border. */
+export interface CalendarColorPair {
+  bg: string;
+  border: string;
+}
+
+/** FullCalendar hex colors including readable title/time text. */
+export interface CalendarColor extends CalendarColorPair {
+  text: string;
+}
+
+/** Extended props set on meeting calendar events for click routing. */
+export interface MeetingCalendarClickProps {
+  type: string;
+  meetingId?: string;
+  cancelled?: boolean;
+  password?: string;
+  startTime?: string;
+  durationMinutes?: number;
+  pastMeetingResourceId?: string;
+}
+
 /**
  * Calendar event interface extending FullCalendar's EventInput
  * @description Meeting events displayed in calendar components with LFX-specific properties

--- a/packages/shared/src/interfaces/calendar.interface.ts
+++ b/packages/shared/src/interfaces/calendar.interface.ts
@@ -26,6 +26,23 @@ export interface MeetingCalendarClickProps {
 }
 
 /**
+ * Structural FullCalendar event payload for meeting rows.
+ * Uses a plain interface so shared utils do not bind to a duplicate @fullcalendar/core copy.
+ */
+export interface MeetingCalendarEventInput {
+  id: string;
+  title: string;
+  start: string;
+  end?: string;
+  backgroundColor?: string;
+  borderColor?: string;
+  textColor?: string;
+  display?: string;
+  classNames?: string[];
+  extendedProps?: MeetingCalendarClickProps;
+}
+
+/**
  * Calendar event interface extending FullCalendar's EventInput
  * @description Meeting events displayed in calendar components with LFX-specific properties
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -750,6 +750,19 @@ export interface PastMeeting extends Meeting {
   user_attended?: boolean;
 }
 
+/** Angular router target for navigating to a specific meeting occurrence. */
+export interface MeetingOccurrenceRoute {
+  path: string[];
+  queryParams?: Record<string, string>;
+}
+
+/** Options when building a meeting occurrence route. */
+export interface BuildMeetingOccurrenceRouteOptions {
+  password?: string;
+  /** Canonical past-meeting composite id (`meeting_and_occurrence_id`); skips `{id}-{timestamp}` suffixing. */
+  pastMeetingResourceId?: string;
+}
+
 /**
  * Past meeting participant information
  * @description Individual participant who was invited/attended a past meeting

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -9,6 +9,7 @@ export * from './file.utils';
 export * from './form.utils';
 export * from './html-utils';
 export * from './iso-timestamp.utils';
+export * from './meeting-calendar.utils';
 export * from './meeting.utils';
 export * from './meeting-privacy.utils';
 export * from './past-meeting-summary.utils';

--- a/packages/shared/src/utils/meeting-calendar.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.spec.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import '@angular/compiler';
+
+import { describe, expect, it } from 'vitest';
+
+import { meetingToCalendarEvents } from './meeting-calendar.utils';
+
+describe('meetingToCalendarEvents', () => {
+  it('does not style in-progress v1_past_meeting rows as past', () => {
+    const events = meetingToCalendarEvents({
+      meeting_and_occurrence_id: '99152950841-1630560600000',
+      start_time: new Date(Date.now() - 30 * 60_000).toISOString(),
+      duration: 60,
+      title: 'Live sync',
+    } as never);
+
+    expect(events[0].classNames).not.toContain('meeting-event-past');
+  });
+
+  it('styles ended v1_past_meeting rows as past', () => {
+    const events = meetingToCalendarEvents({
+      meeting_and_occurrence_id: '99152950841-1630560600000',
+      start_time: new Date(Date.now() - 2 * 60 * 60_000).toISOString(),
+      duration: 60,
+      title: 'Completed sync',
+    } as never);
+
+    expect(events[0].classNames).toContain('meeting-event-past');
+  });
+});

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -22,6 +22,8 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): Meeting
       const classNames = ['meeting-event'];
       if (isCancelled) {
         classNames.push('cursor-default');
+      } else if (isPast) {
+        classNames.push('meeting-event-past');
       }
       return {
         id: `${meeting.id}-${occ.occurrence_id}`,
@@ -51,6 +53,10 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): Meeting
   const isPast = pastRow || hasMeetingEnded(meeting);
   const colors = resolveMeetingCalendarColors(false, isPast);
   const pastResourceId = pastRow ? getPastMeetingResourceId(meeting) : undefined;
+  const classNames = ['meeting-event'];
+  if (isPast) {
+    classNames.push('meeting-event-past');
+  }
 
   return [
     {
@@ -62,7 +68,7 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): Meeting
       borderColor: colors.border,
       textColor: colors.text,
       display: 'block',
-      classNames: ['meeting-event'],
+      classNames,
       extendedProps: {
         type: 'meeting',
         meetingId: pastResourceId ?? meeting.id,

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -1,0 +1,109 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { EventInput } from '@fullcalendar/core';
+
+import { CANCELLED_COLOR, MEETING_TYPE_COLORS } from '../constants';
+import { Meeting, MeetingOccurrenceRoute, PastMeeting } from '../interfaces';
+import type { MeetingCalendarClickProps } from '../interfaces/calendar.interface';
+
+import { addMinutesToDate } from './date-time.utils';
+import {
+  buildMeetingOccurrenceRoute,
+  hasMeetingEnded,
+  isMeetingOccurrenceCancelled,
+  resolveMeetingCalendarColors,
+} from './meeting.utils';
+import { getPastMeetingResourceId, getPastMeetingStartTimeMs, isPastMeetingCalendarRow } from './past-meeting.utils';
+
+/**
+ * Builds FullCalendar event inputs for a meeting or past-meeting row.
+ * Shared by committee and dashboard calendar surfaces.
+ */
+export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): EventInput[] {
+  if (meeting.occurrences && meeting.occurrences.length > 0) {
+    return meeting.occurrences.map((occ) => {
+      const occurrenceDuration = occ.duration ?? meeting.duration;
+      const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
+      const isPast = !isCancelled && hasMeetingEnded(meeting, { ...occ, duration: occurrenceDuration });
+      const colors = resolveMeetingCalendarColors(isCancelled, isPast);
+      const classNames = ['meeting-event'];
+      if (isCancelled) {
+        classNames.push('cursor-default');
+      }
+      return {
+        id: `${meeting.id}-${occ.occurrence_id}`,
+        title: occ.title || meeting.title,
+        start: occ.start_time,
+        end: addMinutesToDate(occ.start_time, occ.duration ?? meeting.duration).toISOString(),
+        backgroundColor: colors.bg,
+        borderColor: colors.border,
+        textColor: colors.text,
+        display: 'block',
+        classNames,
+        extendedProps: {
+          type: 'meeting',
+          meetingId: meeting.id,
+          cancelled: isCancelled,
+          password: meeting.password,
+          startTime: occ.start_time,
+          durationMinutes: occ.duration ?? meeting.duration,
+        },
+      };
+    });
+  }
+
+  const pastRow = isPastMeetingCalendarRow(meeting);
+  const startTimeMs = pastRow ? getPastMeetingStartTimeMs(meeting) : null;
+  const startTime = startTimeMs !== null ? new Date(startTimeMs).toISOString() : meeting.start_time;
+  const isPast = pastRow || hasMeetingEnded(meeting);
+  const colors = resolveMeetingCalendarColors(false, isPast);
+  const pastResourceId = pastRow ? getPastMeetingResourceId(meeting) : undefined;
+
+  return [
+    {
+      id: pastResourceId ?? meeting.id,
+      title: meeting.title,
+      start: startTime,
+      end: addMinutesToDate(startTime, meeting.duration).toISOString(),
+      backgroundColor: colors.bg,
+      borderColor: colors.border,
+      textColor: colors.text,
+      display: 'block',
+      classNames: ['meeting-event'],
+      extendedProps: {
+        type: 'meeting',
+        meetingId: pastResourceId ?? meeting.id,
+        pastMeetingResourceId: pastResourceId,
+        password: meeting.password,
+        startTime,
+        durationMinutes: meeting.duration,
+      },
+    },
+  ];
+}
+
+/**
+ * Resolves the router target for a meeting calendar click, or null when the event is inert.
+ */
+export function resolveMeetingCalendarClickRoute(
+  props: MeetingCalendarClickProps,
+  eventStart?: Date | null
+): MeetingOccurrenceRoute | null {
+  if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
+    return null;
+  }
+
+  const startTime = props.startTime ?? eventStart?.toISOString();
+  if (!startTime) {
+    return {
+      path: ['/meetings', props.meetingId],
+      queryParams: props.password ? { password: props.password } : undefined,
+    };
+  }
+
+  return buildMeetingOccurrenceRoute(props.meetingId, startTime, props.durationMinutes ?? 0, {
+    password: props.password,
+    pastMeetingResourceId: props.pastMeetingResourceId,
+  });
+}

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -12,6 +12,7 @@ import {
   hasMeetingEnded,
   isCalendarDeadlinePast,
   isMeetingOccurrenceCancelled,
+  isOccurrencePast,
   isVoteCalendarEventPast,
   resolveMeetingCalendarColors,
   resolveSurveyCalendarColors,
@@ -61,7 +62,7 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): Meeting
   const pastRow = isPastMeetingCalendarRow(meeting);
   const startTimeMs = pastRow ? getPastMeetingStartTimeMs(meeting) : null;
   const startTime = startTimeMs !== null ? new Date(startTimeMs).toISOString() : meeting.start_time;
-  const isPast = pastRow || hasMeetingEnded(meeting);
+  const isPast = isOccurrencePast(startTime, meeting.duration);
   const colors = resolveMeetingCalendarColors(false, isPast);
   const pastResourceId = pastRow ? getPastMeetingResourceId(meeting) : undefined;
   const classNames = ['meeting-event'];

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -3,9 +3,20 @@
 
 import { Meeting, MeetingOccurrenceRoute, PastMeeting } from '../interfaces';
 import type { MeetingCalendarClickProps, MeetingCalendarEventInput } from '../interfaces/calendar.interface';
+import { Vote } from '../interfaces/poll.interface';
+import { Survey } from '../interfaces/survey.interface';
 
 import { addMinutesToDate } from './date-time.utils';
-import { buildMeetingOccurrenceRoute, hasMeetingEnded, isMeetingOccurrenceCancelled, resolveMeetingCalendarColors } from './meeting.utils';
+import {
+  buildMeetingOccurrenceRoute,
+  hasMeetingEnded,
+  isCalendarDeadlinePast,
+  isMeetingOccurrenceCancelled,
+  isVoteCalendarEventPast,
+  resolveMeetingCalendarColors,
+  resolveSurveyCalendarColors,
+  resolveVoteCalendarColors,
+} from './meeting.utils';
 import { getPastMeetingResourceId, getPastMeetingStartTimeMs, isPastMeetingCalendarRow } from './past-meeting.utils';
 
 /**
@@ -101,4 +112,53 @@ export function resolveMeetingCalendarClickRoute(props: MeetingCalendarClickProp
     password: props.password,
     pastMeetingResourceId: props.pastMeetingResourceId,
   });
+}
+
+/** Returns true when a survey cutoff event should render with past calendar styling. */
+export function isSurveyCalendarEventPast(survey: Pick<Survey, 'survey_cutoff_date'>, now = new Date()): boolean {
+  return isCalendarDeadlinePast(survey.survey_cutoff_date, now);
+}
+
+/** Builds a FullCalendar event input for a committee vote deadline. */
+export function voteToCalendarEvent(vote: Pick<Vote, 'uid' | 'name' | 'end_time' | 'status' | 'early_end_time'>): MeetingCalendarEventInput {
+  const isPast = isVoteCalendarEventPast(vote);
+  const colors = resolveVoteCalendarColors(isPast);
+  const classNames = ['vote-event', 'cursor-default'];
+  if (isPast) {
+    classNames.push('vote-event-past');
+  }
+
+  return {
+    id: `vote-${vote.uid}`,
+    title: `Vote closes: ${vote.name}`,
+    start: vote.end_time,
+    allDay: true,
+    backgroundColor: colors.bg,
+    borderColor: colors.border,
+    textColor: colors.text,
+    classNames,
+    extendedProps: { type: 'vote', voteId: vote.uid },
+  };
+}
+
+/** Builds a FullCalendar event input for a committee survey cutoff. */
+export function surveyToCalendarEvent(survey: Pick<Survey, 'uid' | 'survey_title' | 'survey_cutoff_date'> & { survey_cutoff_date: string }): MeetingCalendarEventInput {
+  const isPast = isSurveyCalendarEventPast(survey);
+  const colors = resolveSurveyCalendarColors(isPast);
+  const classNames = ['survey-event', 'cursor-default'];
+  if (isPast) {
+    classNames.push('survey-event-past');
+  }
+
+  return {
+    id: `survey-${survey.uid}`,
+    title: `Survey: ${survey.survey_title}`,
+    start: survey.survey_cutoff_date,
+    allDay: true,
+    backgroundColor: colors.bg,
+    borderColor: colors.border,
+    textColor: colors.text,
+    classNames,
+    extendedProps: { type: 'survey', surveyId: survey.uid },
+  };
 }

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -142,7 +142,9 @@ export function voteToCalendarEvent(vote: Pick<Vote, 'uid' | 'name' | 'end_time'
 }
 
 /** Builds a FullCalendar event input for a committee survey cutoff. */
-export function surveyToCalendarEvent(survey: Pick<Survey, 'uid' | 'survey_title' | 'survey_cutoff_date'> & { survey_cutoff_date: string }): MeetingCalendarEventInput {
+export function surveyToCalendarEvent(
+  survey: Pick<Survey, 'uid' | 'survey_title' | 'survey_cutoff_date'> & { survey_cutoff_date: string }
+): MeetingCalendarEventInput {
   const isPast = isSurveyCalendarEventPast(survey);
   const colors = resolveSurveyCalendarColors(isPast);
   const classNames = ['survey-event', 'cursor-default'];

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -1,26 +1,18 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { EventInput } from '@fullcalendar/core';
-
-import { CANCELLED_COLOR, MEETING_TYPE_COLORS } from '../constants';
 import { Meeting, MeetingOccurrenceRoute, PastMeeting } from '../interfaces';
-import type { MeetingCalendarClickProps } from '../interfaces/calendar.interface';
+import type { MeetingCalendarClickProps, MeetingCalendarEventInput } from '../interfaces/calendar.interface';
 
 import { addMinutesToDate } from './date-time.utils';
-import {
-  buildMeetingOccurrenceRoute,
-  hasMeetingEnded,
-  isMeetingOccurrenceCancelled,
-  resolveMeetingCalendarColors,
-} from './meeting.utils';
+import { buildMeetingOccurrenceRoute, hasMeetingEnded, isMeetingOccurrenceCancelled, resolveMeetingCalendarColors } from './meeting.utils';
 import { getPastMeetingResourceId, getPastMeetingStartTimeMs, isPastMeetingCalendarRow } from './past-meeting.utils';
 
 /**
  * Builds FullCalendar event inputs for a meeting or past-meeting row.
  * Shared by committee and dashboard calendar surfaces.
  */
-export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): EventInput[] {
+export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): MeetingCalendarEventInput[] {
   if (meeting.occurrences && meeting.occurrences.length > 0) {
     return meeting.occurrences.map((occ) => {
       const occurrenceDuration = occ.duration ?? meeting.duration;
@@ -45,7 +37,7 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): EventIn
           type: 'meeting',
           meetingId: meeting.id,
           cancelled: isCancelled,
-          password: meeting.password,
+          password: meeting.password ?? undefined,
           startTime: occ.start_time,
           durationMinutes: occ.duration ?? meeting.duration,
         },
@@ -75,7 +67,7 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): EventIn
         type: 'meeting',
         meetingId: pastResourceId ?? meeting.id,
         pastMeetingResourceId: pastResourceId,
-        password: meeting.password,
+        password: meeting.password ?? undefined,
         startTime,
         durationMinutes: meeting.duration,
       },
@@ -86,10 +78,7 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): EventIn
 /**
  * Resolves the router target for a meeting calendar click, or null when the event is inert.
  */
-export function resolveMeetingCalendarClickRoute(
-  props: MeetingCalendarClickProps,
-  eventStart?: Date | null
-): MeetingOccurrenceRoute | null {
+export function resolveMeetingCalendarClickRoute(props: MeetingCalendarClickProps, eventStart?: Date | null): MeetingOccurrenceRoute | null {
   if (props.cancelled || props.type !== 'meeting' || !props.meetingId) {
     return null;
   }

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -6,12 +6,14 @@
 // compiler first provides that facade so the module can be imported.
 import '@angular/compiler';
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { RecurrenceType } from '../enums';
+import { CANCELLED_COLOR, MEETING_TYPE_COLORS, PAST_MEETING_CALENDAR_COLOR } from '../constants';
 import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, QueryServiceItem } from '../interfaces';
 import {
   buildCommitteeCadenceSummary,
+  buildMeetingOccurrenceRoute,
   buildMeetingOrganizerChip,
   buildMeetingOrganizerMailto,
   buildRecurrenceNeverEndDate,
@@ -24,6 +26,7 @@ import {
   isUnresolvableParticipantName,
   normalizeIndexedMeetingAiSummary,
   resolveMeetingOrganizer,
+  resolveMeetingCalendarColors,
   resolveOccurrenceRecurrence,
   resolveRsvpOccurrenceId,
   selectCommitteeCadenceMeeting,
@@ -790,5 +793,94 @@ describe('selectPrimaryPastMeetingSummary', () => {
     ];
 
     expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('newer-created');
+  });
+});
+
+describe('resolveMeetingCalendarColors', () => {
+  it('returns default blue for active meetings', () => {
+    expect(resolveMeetingCalendarColors(false)).toEqual(MEETING_TYPE_COLORS['default']);
+  });
+
+  it('returns lighter blue for past meetings', () => {
+    expect(resolveMeetingCalendarColors(false, true)).toEqual(PAST_MEETING_CALENDAR_COLOR);
+  });
+
+  it('returns cancelled grey regardless of past flag', () => {
+    expect(resolveMeetingCalendarColors(true, true)).toEqual(CANCELLED_COLOR);
+  });
+});
+
+describe('buildMeetingOccurrenceRoute', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('routes upcoming occurrences with ?occurrence=', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-01T12:00:00Z'));
+
+    const route = buildMeetingOccurrenceRoute('99152950841', '2026-07-15T15:00:00Z', 60);
+
+    expect(route).toEqual({
+      path: ['/meetings', '99152950841'],
+      queryParams: { occurrence: new Date('2026-07-15T15:00:00Z').getTime().toString() },
+    });
+  });
+
+  it('routes ended occurrences to the composite past URL', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-01T12:00:00Z'));
+
+    const start = '2026-07-01T15:00:00Z';
+    const route = buildMeetingOccurrenceRoute('99152950841', start, 60);
+
+    expect(route).toEqual({
+      path: ['/meetings', `99152950841-${new Date(start).getTime()}`],
+      queryParams: undefined,
+    });
+  });
+
+  it('treats the meeting as upcoming inside the 40-minute post-end buffer', () => {
+    vi.useFakeTimers();
+    const start = '2026-07-01T15:00:00Z';
+    vi.setSystemTime(new Date(new Date(start).getTime() + 60 * 60_000 + 30 * 60_000));
+
+    const route = buildMeetingOccurrenceRoute('99152950841', start, 60);
+
+    expect(route.path).toEqual(['/meetings', '99152950841']);
+    expect(route.queryParams?.['occurrence']).toBe(new Date(start).getTime().toString());
+  });
+
+  it('preserves password query params', () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-07-01T12:00:00Z'));
+
+    const route = buildMeetingOccurrenceRoute('99152950841', '2026-07-15T15:00:00Z', 60, { password: 'secret' });
+
+    expect(route.queryParams).toEqual({
+      password: 'secret',
+      occurrence: new Date('2026-07-15T15:00:00Z').getTime().toString(),
+    });
+  });
+
+  it('uses the canonical past-meeting resource id without double-encoding', () => {
+    const route = buildMeetingOccurrenceRoute('99152950841', '2026-07-01T15:00:00Z', 60, {
+      pastMeetingResourceId: '99152950841-1630560600000',
+      password: 'secret',
+    });
+
+    expect(route).toEqual({
+      path: ['/meetings', '99152950841-1630560600000'],
+      queryParams: { password: 'secret' },
+    });
+  });
+
+  it('detects an already-composite meeting id', () => {
+    const route = buildMeetingOccurrenceRoute('99152950841-1630560600000', '2026-07-01T15:00:00Z', 60);
+
+    expect(route).toEqual({
+      path: ['/meetings', '99152950841-1630560600000'],
+      queryParams: undefined,
+    });
   });
 });

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -874,12 +874,7 @@ describe('isVoteCalendarEventPast', () => {
   });
 
   it('returns true when the close time has passed', () => {
-    expect(
-      isVoteCalendarEventPast(
-        { end_time: '2026-01-01T00:00:00Z', status: PollStatus.ACTIVE } as Vote,
-        new Date('2026-01-02T00:00:00Z')
-      )
-    ).toBe(true);
+    expect(isVoteCalendarEventPast({ end_time: '2026-01-01T00:00:00Z', status: PollStatus.ACTIVE } as Vote, new Date('2026-01-02T00:00:00Z'))).toBe(true);
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -798,7 +798,7 @@ describe('selectPrimaryPastMeetingSummary', () => {
 
 describe('resolveMeetingCalendarColors', () => {
   it('returns default blue for active meetings', () => {
-    expect(resolveMeetingCalendarColors(false)).toEqual(MEETING_TYPE_COLORS['default']);
+    expect(resolveMeetingCalendarColors(false)).toEqual({ ...MEETING_TYPE_COLORS['default'], text: '#ffffff' });
   });
 
   it('returns lighter blue for past meetings', () => {

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -8,8 +8,17 @@ import '@angular/compiler';
 
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { RecurrenceType } from '../enums';
-import { CANCELLED_COLOR, lfxColors, MEETING_TYPE_COLORS, PAST_MEETING_CALENDAR_COLOR } from '../constants';
+import { PollStatus, RecurrenceType } from '../enums';
+import {
+  CANCELLED_COLOR,
+  lfxColors,
+  MEETING_TYPE_COLORS,
+  PAST_MEETING_CALENDAR_COLOR,
+  PAST_SURVEY_CALENDAR_COLOR,
+  PAST_VOTE_CALENDAR_COLOR,
+  SURVEY_COLOR,
+  VOTE_COLOR,
+} from '../constants';
 import {
   CustomRecurrencePattern,
   Meeting,
@@ -19,6 +28,7 @@ import {
   PastMeetingSummary,
   PastOccurrenceSummary,
   QueryServiceItem,
+  Vote,
 } from '../interfaces';
 import {
   buildCommitteeCadenceSummary,
@@ -33,16 +43,20 @@ import {
   compareMeetingPeopleByHostThenName,
   convertRecurrenceToPattern,
   getMeetingOrganizerDisplayName,
+  isCalendarDeadlinePast,
   isMeetingOccurrenceCancelled,
   isMeetingOrganizedByViewer,
   isOccurrencePast,
   isPastMeetingCompositeId,
   isUnresolvableParticipantName,
+  isVoteCalendarEventPast,
   normalizeIndexedMeetingAiSummary,
   resolveMeetingOrganizer,
   resolveMeetingCalendarColors,
   resolveOccurrenceRecurrence,
   resolveRsvpOccurrenceId,
+  resolveSurveyCalendarColors,
+  resolveVoteCalendarColors,
   selectCommitteeCadenceMeeting,
   selectPrimaryPastMeetingSummary,
   sortPastMeetingsDescending,
@@ -821,6 +835,51 @@ describe('resolveMeetingCalendarColors', () => {
 
   it('returns cancelled grey regardless of past flag', () => {
     expect(resolveMeetingCalendarColors(true, true)).toEqual(CANCELLED_COLOR);
+  });
+});
+
+describe('resolveVoteCalendarColors', () => {
+  it('returns amber for active vote deadlines', () => {
+    expect(resolveVoteCalendarColors(false)).toEqual(VOTE_COLOR);
+  });
+
+  it('returns lighter amber for past vote deadlines', () => {
+    expect(resolveVoteCalendarColors(true)).toEqual(PAST_VOTE_CALENDAR_COLOR);
+  });
+});
+
+describe('resolveSurveyCalendarColors', () => {
+  it('returns violet for active survey cutoffs', () => {
+    expect(resolveSurveyCalendarColors(false)).toEqual(SURVEY_COLOR);
+  });
+
+  it('returns lighter violet for past survey cutoffs', () => {
+    expect(resolveSurveyCalendarColors(true)).toEqual(PAST_SURVEY_CALENDAR_COLOR);
+  });
+});
+
+describe('isCalendarDeadlinePast', () => {
+  it('returns false for a future deadline', () => {
+    expect(isCalendarDeadlinePast('2099-01-01T00:00:00Z', new Date('2026-01-01T00:00:00Z'))).toBe(false);
+  });
+
+  it('returns true when the deadline has passed', () => {
+    expect(isCalendarDeadlinePast('2026-01-01T00:00:00Z', new Date('2026-01-02T00:00:00Z'))).toBe(true);
+  });
+});
+
+describe('isVoteCalendarEventPast', () => {
+  it('returns true for ended votes', () => {
+    expect(isVoteCalendarEventPast({ end_time: '2099-01-01T00:00:00Z', status: PollStatus.ENDED } as Vote)).toBe(true);
+  });
+
+  it('returns true when the close time has passed', () => {
+    expect(
+      isVoteCalendarEventPast(
+        { end_time: '2026-01-01T00:00:00Z', status: PollStatus.ACTIVE } as Vote,
+        new Date('2026-01-02T00:00:00Z')
+      )
+    ).toBe(true);
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -9,7 +9,7 @@ import '@angular/compiler';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { RecurrenceType } from '../enums';
-import { CANCELLED_COLOR, MEETING_TYPE_COLORS, PAST_MEETING_CALENDAR_COLOR } from '../constants';
+import { CANCELLED_COLOR, lfxColors, MEETING_TYPE_COLORS, PAST_MEETING_CALENDAR_COLOR } from '../constants';
 import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, QueryServiceItem } from '../interfaces';
 import {
   buildCommitteeCadenceSummary,
@@ -22,7 +22,10 @@ import {
   compareMeetingPeopleByHostThenName,
   convertRecurrenceToPattern,
   getMeetingOrganizerDisplayName,
+  isMeetingOccurrenceCancelled,
   isMeetingOrganizedByViewer,
+  isOccurrencePast,
+  isPastMeetingCompositeId,
   isUnresolvableParticipantName,
   normalizeIndexedMeetingAiSummary,
   resolveMeetingOrganizer,
@@ -798,7 +801,7 @@ describe('selectPrimaryPastMeetingSummary', () => {
 
 describe('resolveMeetingCalendarColors', () => {
   it('returns default blue for active meetings', () => {
-    expect(resolveMeetingCalendarColors(false)).toEqual({ ...MEETING_TYPE_COLORS['default'], text: '#ffffff' });
+    expect(resolveMeetingCalendarColors(false)).toEqual({ ...MEETING_TYPE_COLORS['default'], text: lfxColors.white });
   });
 
   it('returns lighter blue for past meetings', () => {
@@ -807,6 +810,43 @@ describe('resolveMeetingCalendarColors', () => {
 
   it('returns cancelled grey regardless of past flag', () => {
     expect(resolveMeetingCalendarColors(true, true)).toEqual(CANCELLED_COLOR);
+  });
+});
+
+describe('isMeetingOccurrenceCancelled', () => {
+  const occurrence = { occurrence_id: '123', start_time: '2026-07-01T15:00:00Z', duration: 60, status: 'active' } as MeetingOccurrence;
+
+  it('returns true when occurrence status is cancel', () => {
+    expect(isMeetingOccurrenceCancelled({ ...occurrence, status: 'cancel' }, [])).toBe(true);
+  });
+
+  it('returns true when occurrence id is in cancelled_occurrences', () => {
+    expect(isMeetingOccurrenceCancelled(occurrence, ['123'])).toBe(true);
+  });
+
+  it('returns false for active occurrences with no cancelled ids', () => {
+    expect(isMeetingOccurrenceCancelled(occurrence, ['999'])).toBe(false);
+  });
+});
+
+describe('isPastMeetingCompositeId', () => {
+  it('matches composite past-meeting ids', () => {
+    expect(isPastMeetingCompositeId('99152950841-1630560600000')).toBe(true);
+  });
+
+  it('rejects plain meeting ids and malformed composites', () => {
+    expect(isPastMeetingCompositeId('99152950841')).toBe(false);
+    expect(isPastMeetingCompositeId('99152950841-1630560600000-extra')).toBe(false);
+  });
+});
+
+describe('isOccurrencePast', () => {
+  it('uses the same 40-minute post-end buffer as buildMeetingOccurrenceRoute', () => {
+    vi.useFakeTimers();
+    const start = '2026-07-01T15:00:00Z';
+    vi.setSystemTime(new Date(new Date(start).getTime() + 60 * 60_000 + 30 * 60_000));
+    expect(isOccurrencePast(start, 60)).toBe(false);
+    vi.useRealTimers();
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -8,11 +8,16 @@ import {
   MEETING_ORGANIZER_SKIP_IDENTIFIERS,
   MEETING_TYPE_COLORS,
   PAST_MEETING_CALENDAR_COLOR,
+  PAST_SURVEY_CALENDAR_COLOR,
+  PAST_VOTE_CALENDAR_COLOR,
   RECURRENCE_DAYS_OF_WEEK,
   RECURRENCE_WEEKLY_ORDINALS,
+  SURVEY_COLOR,
+  VOTE_COLOR,
 } from '../constants';
 import { lfxColors } from '../constants/colors.constants';
 import { RecurrenceType } from '../enums';
+import { PollStatus } from '../enums/poll.enum';
 import {
   BuildMeetingOccurrenceRouteOptions,
   CalendarColor,
@@ -37,7 +42,9 @@ import {
   User,
   V1PastMeetingSummary,
   V1SummaryDetail,
+  Vote,
 } from '../interfaces';
+import { normalizePollStatus } from './poll.utils';
 
 const RECURRENCE_NEVER_ENDS_YEARS_OFFSET = 100;
 const FIFTY_YEARS_MS = 50 * 365.25 * 24 * 60 * 60 * 1000;
@@ -571,6 +578,36 @@ export function resolveMeetingCalendarColors(isCancelled: boolean, isPast = fals
     return PAST_MEETING_CALENDAR_COLOR;
   }
   return { ...MEETING_TYPE_COLORS['default'], text: lfxColors.white };
+}
+
+/** Returns true when a calendar deadline timestamp is invalid or already passed. */
+export function isCalendarDeadlinePast(deadlineIso: string | null | undefined, now = new Date()): boolean {
+  if (!deadlineIso) {
+    return false;
+  }
+  const ms = new Date(deadlineIso).getTime();
+  if (Number.isNaN(ms)) {
+    return true;
+  }
+  return now.getTime() >= ms;
+}
+
+/** Resolves FullCalendar hex colors for a vote deadline event. */
+export function resolveVoteCalendarColors(isPast = false): CalendarColor {
+  return isPast ? PAST_VOTE_CALENDAR_COLOR : VOTE_COLOR;
+}
+
+/** Resolves FullCalendar hex colors for a survey cutoff event. */
+export function resolveSurveyCalendarColors(isPast = false): CalendarColor {
+  return isPast ? PAST_SURVEY_CALENDAR_COLOR : SURVEY_COLOR;
+}
+
+/** Returns true when a vote deadline event should render with past calendar styling. */
+export function isVoteCalendarEventPast(vote: Pick<Vote, 'end_time' | 'status' | 'early_end_time'>, now = new Date()): boolean {
+  if (normalizePollStatus(vote.status) === PollStatus.ENDED) {
+    return true;
+  }
+  return isCalendarDeadlinePast(vote.early_end_time ?? vote.end_time, now);
 }
 
 /** Composite past-meeting route id: `{meetingId}-{13-digit-ms}`. */

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -3,7 +3,7 @@
 
 import { HttpParams } from '@angular/common/http';
 
-import { MEETING_ORGANIZER_SKIP_IDENTIFIERS, RECURRENCE_DAYS_OF_WEEK, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
+import { CANCELLED_COLOR, MEETING_ORGANIZER_SKIP_IDENTIFIERS, MEETING_TYPE_COLORS, RECURRENCE_DAYS_OF_WEEK, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
 import { RecurrenceType } from '../enums';
 import {
   CustomRecurrencePattern,
@@ -460,6 +460,73 @@ export function hasMeetingEnded(meeting: Meeting, occurrence?: MeetingOccurrence
   const startTime = new Date(meeting.start_time);
   const endTime = new Date(startTime.getTime() + meeting.duration * 60000 + buffer);
   return now > endTime;
+}
+
+/** Angular router target for navigating to a specific meeting occurrence. */
+export interface MeetingOccurrenceRoute {
+  path: string[];
+  queryParams?: Record<string, string>;
+}
+
+/** Options when building a meeting occurrence route. */
+export interface BuildMeetingOccurrenceRouteOptions {
+  password?: string;
+}
+
+/**
+ * Returns true when an occurrence is cancelled, honouring both per-occurrence status and the
+ * list endpoint's `cancelled_occurrences` IDs (see {@link getActiveOccurrences}).
+ */
+export function isMeetingOccurrenceCancelled(occurrence: MeetingOccurrence, cancelledOccurrences?: string[] | null): boolean {
+  if (occurrence.status === 'cancel') {
+    return true;
+  }
+  const cancelledIds = cancelledOccurrences ?? [];
+  return cancelledIds.length > 0 && cancelledIds.includes(occurrence.occurrence_id);
+}
+
+/**
+ * Resolves FullCalendar hex colors for a meeting occurrence.
+ * Active meetings use the default blue; cancelled occurrences use cancelled grey.
+ */
+export function resolveMeetingCalendarColors(isCancelled: boolean): { bg: string; border: string } {
+  if (isCancelled) {
+    return CANCELLED_COLOR;
+  }
+  return MEETING_TYPE_COLORS['default'];
+}
+
+/**
+ * Builds an Angular router command for a specific meeting occurrence, mirroring the join page URL
+ * contract (`?occurrence=` for upcoming, `/meetings/{id}-{timestamp}` for past).
+ */
+export function buildMeetingOccurrenceRoute(
+  meetingId: string,
+  startTime: string,
+  durationMinutes: number,
+  options?: BuildMeetingOccurrenceRouteOptions
+): MeetingOccurrenceRoute {
+  const timestamp = new Date(startTime).getTime();
+  const occurrence = { start_time: startTime, duration: durationMinutes } as MeetingOccurrence;
+  const isPast = hasMeetingEnded({ duration: durationMinutes } as Meeting, occurrence);
+  const queryParams: Record<string, string> = {};
+
+  if (options?.password) {
+    queryParams['password'] = options.password;
+  }
+
+  if (isPast) {
+    return {
+      path: ['/meetings', `${meetingId}-${timestamp}`],
+      queryParams: Object.keys(queryParams).length > 0 ? queryParams : undefined,
+    };
+  }
+
+  queryParams['occurrence'] = timestamp.toString();
+  return {
+    path: ['/meetings', meetingId],
+    queryParams,
+  };
 }
 
 /**

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -3,13 +3,22 @@
 
 import { HttpParams } from '@angular/common/http';
 
-import { CANCELLED_COLOR, MEETING_ORGANIZER_SKIP_IDENTIFIERS, MEETING_TYPE_COLORS, RECURRENCE_DAYS_OF_WEEK, RECURRENCE_WEEKLY_ORDINALS } from '../constants';
+import {
+  CANCELLED_COLOR,
+  MEETING_ORGANIZER_SKIP_IDENTIFIERS,
+  MEETING_TYPE_COLORS,
+  PAST_MEETING_CALENDAR_COLOR,
+  RECURRENCE_DAYS_OF_WEEK,
+  RECURRENCE_WEEKLY_ORDINALS,
+} from '../constants';
 import { RecurrenceType } from '../enums';
 import {
+  BuildMeetingOccurrenceRouteOptions,
   CustomRecurrencePattern,
   Meeting,
   MeetingHostCandidate,
   MeetingOccurrence,
+  MeetingOccurrenceRoute,
   MeetingOrganizerChipModel,
   MeetingOrganizerLink,
   MeetingRecurrence,
@@ -462,17 +471,6 @@ export function hasMeetingEnded(meeting: Meeting, occurrence?: MeetingOccurrence
   return now > endTime;
 }
 
-/** Angular router target for navigating to a specific meeting occurrence. */
-export interface MeetingOccurrenceRoute {
-  path: string[];
-  queryParams?: Record<string, string>;
-}
-
-/** Options when building a meeting occurrence route. */
-export interface BuildMeetingOccurrenceRouteOptions {
-  password?: string;
-}
-
 /**
  * Returns true when an occurrence is cancelled, honouring both per-occurrence status and the
  * list endpoint's `cancelled_occurrences` IDs (see {@link getActiveOccurrences}).
@@ -487,14 +485,20 @@ export function isMeetingOccurrenceCancelled(occurrence: MeetingOccurrence, canc
 
 /**
  * Resolves FullCalendar hex colors for a meeting occurrence.
- * Active meetings use the default blue; cancelled occurrences use cancelled grey.
+ * Active meetings use the default blue; past use a lighter blue; cancelled use cancelled grey.
  */
-export function resolveMeetingCalendarColors(isCancelled: boolean): { bg: string; border: string } {
+export function resolveMeetingCalendarColors(isCancelled: boolean, isPast = false): { bg: string; border: string } {
   if (isCancelled) {
     return CANCELLED_COLOR;
   }
+  if (isPast) {
+    return PAST_MEETING_CALENDAR_COLOR;
+  }
   return MEETING_TYPE_COLORS['default'];
 }
+
+/** Composite past-meeting route id: `{meetingId}-{13-digit-ms}`. */
+const PAST_MEETING_COMPOSITE_ID = /^\d+-\d{13}$/;
 
 /**
  * Builds an Angular router command for a specific meeting occurrence, mirroring the join page URL
@@ -506,14 +510,22 @@ export function buildMeetingOccurrenceRoute(
   durationMinutes: number,
   options?: BuildMeetingOccurrenceRouteOptions
 ): MeetingOccurrenceRoute {
-  const timestamp = new Date(startTime).getTime();
-  const occurrence = { start_time: startTime, duration: durationMinutes } as MeetingOccurrence;
-  const isPast = hasMeetingEnded({ duration: durationMinutes } as Meeting, occurrence);
   const queryParams: Record<string, string> = {};
-
   if (options?.password) {
     queryParams['password'] = options.password;
   }
+
+  const pastResourceId = options?.pastMeetingResourceId ?? (PAST_MEETING_COMPOSITE_ID.test(meetingId) ? meetingId : undefined);
+  if (pastResourceId) {
+    return {
+      path: ['/meetings', pastResourceId],
+      queryParams: Object.keys(queryParams).length > 0 ? queryParams : undefined,
+    };
+  }
+
+  const timestamp = new Date(startTime).getTime();
+  const occurrence = { start_time: startTime, duration: durationMinutes } as MeetingOccurrence;
+  const isPast = hasMeetingEnded({ duration: durationMinutes } as Meeting, occurrence);
 
   if (isPast) {
     return {

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -487,14 +487,14 @@ export function isMeetingOccurrenceCancelled(occurrence: MeetingOccurrence, canc
  * Resolves FullCalendar hex colors for a meeting occurrence.
  * Active meetings use the default blue; past use a lighter blue; cancelled use cancelled grey.
  */
-export function resolveMeetingCalendarColors(isCancelled: boolean, isPast = false): { bg: string; border: string } {
+export function resolveMeetingCalendarColors(isCancelled: boolean, isPast = false): { bg: string; border: string; text: string } {
   if (isCancelled) {
     return CANCELLED_COLOR;
   }
   if (isPast) {
     return PAST_MEETING_CALENDAR_COLOR;
   }
-  return MEETING_TYPE_COLORS['default'];
+  return { ...MEETING_TYPE_COLORS['default'], text: '#ffffff' };
 }
 
 /** Composite past-meeting route id: `{meetingId}-{13-digit-ms}`. */

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -11,9 +11,11 @@ import {
   RECURRENCE_DAYS_OF_WEEK,
   RECURRENCE_WEEKLY_ORDINALS,
 } from '../constants';
+import { lfxColors } from '../constants/colors.constants';
 import { RecurrenceType } from '../enums';
 import {
   BuildMeetingOccurrenceRouteOptions,
+  CalendarColor,
   CustomRecurrencePattern,
   Meeting,
   MeetingHostCandidate,
@@ -281,17 +283,16 @@ export function buildCommitteeCadenceSummary(meetings: Meeting[]): string {
  * @param cancelledOccurrences Cancelled occurrence IDs (10-digit Unix-second timestamp keys)
  * @returns Array of active (non-cancelled) occurrences
  */
-export function getActiveOccurrences(occurrences: MeetingOccurrence[], cancelledOccurrences?: string[] | null): MeetingOccurrence[] {
-  const cancelledIds = new Set(cancelledOccurrences ?? []);
-  return occurrences.filter((occurrence) => {
-    if (occurrence.status === 'cancel') {
-      return false;
-    }
-    if (cancelledIds.size > 0 && cancelledIds.has(occurrence.occurrence_id)) {
-      return false;
-    }
+export function isMeetingOccurrenceCancelled(occurrence: MeetingOccurrence, cancelledOccurrences?: string[] | null): boolean {
+  if (occurrence.status === 'cancel') {
     return true;
-  });
+  }
+  const cancelledIds = cancelledOccurrences ?? [];
+  return cancelledIds.length > 0 && cancelledIds.includes(occurrence.occurrence_id);
+}
+
+export function getActiveOccurrences(occurrences: MeetingOccurrence[], cancelledOccurrences?: string[] | null): MeetingOccurrence[] {
+  return occurrences.filter((occurrence) => !isMeetingOccurrenceCancelled(occurrence, cancelledOccurrences));
 }
 
 /**
@@ -471,34 +472,39 @@ export function hasMeetingEnded(meeting: Meeting, occurrence?: MeetingOccurrence
   return now > endTime;
 }
 
+/** Post-meeting buffer before an occurrence is treated as past (matches {@link hasMeetingEnded}). */
+export const MEETING_END_BUFFER_MS = 40 * 60_000;
+
 /**
- * Returns true when an occurrence is cancelled, honouring both per-occurrence status and the
- * list endpoint's `cancelled_occurrences` IDs (see {@link getActiveOccurrences}).
+ * Returns true when an occurrence's end time plus buffer has passed.
+ * Used for calendar click routing without relying on a partial Meeting cast.
  */
-export function isMeetingOccurrenceCancelled(occurrence: MeetingOccurrence, cancelledOccurrences?: string[] | null): boolean {
-  if (occurrence.status === 'cancel') {
-    return true;
-  }
-  const cancelledIds = cancelledOccurrences ?? [];
-  return cancelledIds.length > 0 && cancelledIds.includes(occurrence.occurrence_id);
+export function isOccurrencePast(startTime: string, durationMinutes: number, now = new Date()): boolean {
+  const endTime = new Date(new Date(startTime).getTime() + durationMinutes * 60_000 + MEETING_END_BUFFER_MS);
+  return now.getTime() > endTime.getTime();
 }
 
 /**
  * Resolves FullCalendar hex colors for a meeting occurrence.
  * Active meetings use the default blue; past use a lighter blue; cancelled use cancelled grey.
  */
-export function resolveMeetingCalendarColors(isCancelled: boolean, isPast = false): { bg: string; border: string; text: string } {
+export function resolveMeetingCalendarColors(isCancelled: boolean, isPast = false): CalendarColor {
   if (isCancelled) {
     return CANCELLED_COLOR;
   }
   if (isPast) {
     return PAST_MEETING_CALENDAR_COLOR;
   }
-  return { ...MEETING_TYPE_COLORS['default'], text: '#ffffff' };
+  return { ...MEETING_TYPE_COLORS['default'], text: lfxColors.white };
 }
 
 /** Composite past-meeting route id: `{meetingId}-{13-digit-ms}`. */
-const PAST_MEETING_COMPOSITE_ID = /^\d+-\d{13}$/;
+export const PAST_MEETING_COMPOSITE_ID = /^\d+-\d{13}$/;
+
+/** Returns true when the id matches the past-meeting composite URL shape. */
+export function isPastMeetingCompositeId(id: string): boolean {
+  return PAST_MEETING_COMPOSITE_ID.test(id);
+}
 
 /**
  * Builds an Angular router command for a specific meeting occurrence, mirroring the join page URL
@@ -515,7 +521,7 @@ export function buildMeetingOccurrenceRoute(
     queryParams['password'] = options.password;
   }
 
-  const pastResourceId = options?.pastMeetingResourceId ?? (PAST_MEETING_COMPOSITE_ID.test(meetingId) ? meetingId : undefined);
+  const pastResourceId = options?.pastMeetingResourceId ?? (isPastMeetingCompositeId(meetingId) ? meetingId : undefined);
   if (pastResourceId) {
     return {
       path: ['/meetings', pastResourceId],
@@ -524,8 +530,7 @@ export function buildMeetingOccurrenceRoute(
   }
 
   const timestamp = new Date(startTime).getTime();
-  const occurrence = { start_time: startTime, duration: durationMinutes } as MeetingOccurrence;
-  const isPast = hasMeetingEnded({ duration: durationMinutes } as Meeting, occurrence);
+  const isPast = isOccurrencePast(startTime, durationMinutes);
 
   if (isPast) {
     return {

--- a/packages/shared/src/utils/past-meeting.utils.spec.ts
+++ b/packages/shared/src/utils/past-meeting.utils.spec.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { EnrichedPastMeetingParticipant, PastMeetingRecording, RecordingSession } from '../interfaces';
-import { filterPastMeetingParticipants, getLargestSessionShareUrl, getPastMeetingResourceId, getPastMeetingStartTimeMs } from './past-meeting.utils';
+import { filterPastMeetingParticipants, getLargestSessionShareUrl, getPastMeetingResourceId, getPastMeetingStartTimeMs, isPastMeetingCalendarRow } from './past-meeting.utils';
 
 /** Builds an EnrichedPastMeetingParticipant fixture, defaulting every field so tests set only what they assert on. */
 function participant(partial: Partial<EnrichedPastMeetingParticipant>): EnrichedPastMeetingParticipant {
@@ -202,6 +202,16 @@ describe('getPastMeetingResourceId', () => {
 
   it('falls back to id when meeting_and_occurrence_id is absent', () => {
     expect(getPastMeetingResourceId({ id: 'row-id' })).toBe('row-id');
+  });
+});
+
+describe('isPastMeetingCalendarRow', () => {
+  it('returns true for past-meeting rows with scheduled_start_time', () => {
+    expect(isPastMeetingCalendarRow({ scheduled_start_time: '2026-07-01T15:00:00Z' } as never)).toBe(true);
+  });
+
+  it('returns false for live meeting rows', () => {
+    expect(isPastMeetingCalendarRow({ start_time: '2026-07-01T15:00:00Z', duration: 60 } as never)).toBe(false);
   });
 });
 

--- a/packages/shared/src/utils/past-meeting.utils.spec.ts
+++ b/packages/shared/src/utils/past-meeting.utils.spec.ts
@@ -4,7 +4,13 @@
 import { describe, expect, it } from 'vitest';
 
 import { EnrichedPastMeetingParticipant, PastMeetingRecording, RecordingSession } from '../interfaces';
-import { filterPastMeetingParticipants, getLargestSessionShareUrl, getPastMeetingResourceId, getPastMeetingStartTimeMs, isPastMeetingCalendarRow } from './past-meeting.utils';
+import {
+  filterPastMeetingParticipants,
+  getLargestSessionShareUrl,
+  getPastMeetingResourceId,
+  getPastMeetingStartTimeMs,
+  isPastMeetingCalendarRow,
+} from './past-meeting.utils';
 
 /** Builds an EnrichedPastMeetingParticipant fixture, defaulting every field so tests set only what they assert on. */
 function participant(partial: Partial<EnrichedPastMeetingParticipant>): EnrichedPastMeetingParticipant {

--- a/packages/shared/src/utils/past-meeting.utils.spec.ts
+++ b/packages/shared/src/utils/past-meeting.utils.spec.ts
@@ -216,6 +216,20 @@ describe('isPastMeetingCalendarRow', () => {
     expect(isPastMeetingCalendarRow({ scheduled_start_time: '2026-07-01T15:00:00Z' } as never)).toBe(true);
   });
 
+  it('returns true for v1_past_meeting rows that omit scheduled_start_time', () => {
+    expect(
+      isPastMeetingCalendarRow({
+        meeting_and_occurrence_id: '99152950841-1630560600000',
+        start_time: '2026-07-01T15:00:00Z',
+        meeting_id: '99152950841',
+      } as never)
+    ).toBe(true);
+  });
+
+  it('returns true when only meeting_id identifies a past row', () => {
+    expect(isPastMeetingCalendarRow({ meeting_id: '99152950841', id: '99152950841-1630560600000' } as never)).toBe(true);
+  });
+
   it('returns false for live meeting rows', () => {
     expect(isPastMeetingCalendarRow({ start_time: '2026-07-01T15:00:00Z', duration: 60 } as never)).toBe(false);
   });

--- a/packages/shared/src/utils/past-meeting.utils.ts
+++ b/packages/shared/src/utils/past-meeting.utils.ts
@@ -25,9 +25,19 @@ export function getPastMeetingResourceId(meeting: Pick<PastMeeting, 'id' | 'meet
   return meeting.meeting_and_occurrence_id ?? meeting.id;
 }
 
-/** Past-meeting list rows carry scheduled_start_time; live Meeting rows do not. */
+/** Past-meeting list rows carry scheduled_start_time and/or past-only identity fields. */
 export function isPastMeetingCalendarRow(meeting: Meeting | PastMeeting): meeting is PastMeeting {
-  return typeof (meeting as PastMeeting).scheduled_start_time === 'string';
+  const row = meeting as PastMeeting;
+  if (typeof row.scheduled_start_time === 'string') {
+    return true;
+  }
+  if (row.meeting_and_occurrence_id) {
+    return true;
+  }
+  if ('meeting_id' in meeting && typeof row.meeting_id === 'string' && row.meeting_id) {
+    return true;
+  }
+  return false;
 }
 
 /**

--- a/packages/shared/src/utils/past-meeting.utils.ts
+++ b/packages/shared/src/utils/past-meeting.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { EnrichedPastMeetingParticipant, PastMeeting, PastMeetingRecording, PastParticipantFilters } from '../interfaces';
+import { EnrichedPastMeetingParticipant, Meeting, PastMeeting, PastMeetingRecording, PastParticipantFilters } from '../interfaces';
 import { firstValidTimestampMs } from './iso-timestamp.utils';
 
 // Zoom/ITX rows sometimes carry a Go zero-date on scheduled_start_time; fall back to start_time.
@@ -23,6 +23,11 @@ export function getLargestSessionShareUrl(recording: PastMeetingRecording | null
 // still expose a distinct id while Me-lens rows normalize id to the composite value.
 export function getPastMeetingResourceId(meeting: Pick<PastMeeting, 'id' | 'meeting_and_occurrence_id'>): string {
   return meeting.meeting_and_occurrence_id ?? meeting.id;
+}
+
+/** Past-meeting list rows carry scheduled_start_time; live Meeting rows do not. */
+export function isPastMeetingCalendarRow(meeting: Meeting | PastMeeting): meeting is PastMeeting {
+  return typeof (meeting as PastMeeting).scheduled_start_time === 'string';
 }
 
 /**


### PR DESCRIPTION
## Context

Connie reported two issues on the **Committee → Meetings → Calendar** view ([Slack thread](https://linuxfoundation.slack.com/archives/C092UM0JHS9/p1785366352163159?thread_ts=1785189391.701009&cid=C092UM0JHS9)):

1. Some meeting blocks appeared **dark grey** when users expected the typical **blue**
2. Clicking a calendar occurrence opened the **wrong date** (current/next occurrence instead of the one clicked)

The same calendar logic is shared with the **Meetings dashboard** calendar (Me / Foundation / Project lenses), so both surfaces are updated here.

Jira: https://linuxfoundation.atlassian.net/browse/LFXV2-2916

---

## UI changes (what users will see)

### Meeting colors

| Event state | Before | After |
|---|---|---|
| **Upcoming / active meeting** | Type-based colors (maintainers blue, Other dark grey, etc.) — week view also forced pale blue/grey overrides | Consistent **default blue** (`#3b82f6`) |
| **Past meeting** | Week view forced **light grey** blocks; month view same strong color as future | **Lighter blue** (`#60a5fa`) — clearly “already happened” but still readable white text |
| **Cancelled occurrence** | Grey only when `occ.status === 'cancel'` | Grey when cancelled via **status or `cancelled_occurrences`**; still non-clickable |
| **Vote close date** | Amber (committee calendar only) | Unchanged |
| **Survey cutoff** | Purple (committee calendar only) | Unchanged |

**Why the same series looked blue and grey before:** recurring meetings render **each occurrence separately**. Past dates were styled differently from future dates (especially in week view), and cancelled dates were grey. That looked like inconsistent coloring on one series even though it reflected per-date state.

### Click behavior

| Action | Before | After |
|---|---|---|
| Click **future** occurrence | `/meetings/{id}` → join page picked **current/next** occurrence | `/meetings/{id}?occurrence={timestamp}` → opens **that** occurrence |
| Click **past** occurrence | Same wrong fallback | `/meetings/{id}-{timestamp}` → opens **that** past slot |
| Click **past-meeting list row** on calendar | Could double-encode id (`{id}-{ts}-{ts}`) → not-found | Uses `getPastMeetingResourceId` → canonical composite id |
| Click vote / survey block | Not clickable | Still not clickable (display-only) |

---

## Technical changes

- Added shared helpers in `@lfx-one/shared`:
  - `buildMeetingOccurrenceRoute()` — occurrence URL contract for calendar clicks
  - `isMeetingOccurrenceCancelled()` — honours `cancelled_occurrences` IDs from list API
  - `resolveMeetingCalendarColors()` — blue / past-blue / cancelled-grey
  - `isPastMeetingCalendarRow()` — distinguishes PastMeeting rows from live Meeting rows
- Updated `meetingToEvents()` + click handlers in:
  - `committee-meetings.component.ts`
  - `meetings-dashboard.component.ts`
- Removed week-view FullCalendar CSS that overrode meeting colors with grey/pale-blue regardless of event data
- Added `PAST_MEETING_CALENDAR_COLOR` constant and Vitest coverage for route building (upcoming, past, 40-min buffer, password, composite ids)

---

## Out of scope

- Vote/survey calendar overlays on the committee Meetings tab (amber/purple) — kept as-is
- Meeting list/card links that intentionally resolve to current/next occurrence
- ICS Subscribe feed (meetings only; no vote/survey events)

---

## Test plan

- [x] **Committee → Meetings → Calendar:** recurring series shows blue future blocks and lighter-blue past blocks; cancelled dates stay grey
- [x] Click a **future** occurrence → URL has `?occurrence=` matching clicked date; join page shows that slot
- [x] Click a **past** occurrence → URL is `/meetings/{id}-{timestamp}` (or canonical past resource id); correct past slot loads
- [x] Click a **past-meeting row** from Me-lens past data → no double-encoded id / not-found
- [x] **Cancelled** occurrence → grey, cursor default, no navigation
- [x] **Vote** (amber) and **survey** (purple) events still render on committee calendar
- [x] **Meetings dashboard → Calendar** (Me / Foundation / Project): same color and click behavior
- [x] Week and month views both show consistent meeting colors (no grey override on past meetings)