### PR TITLE
feat(newsletters): reframe my newsletters for readers

### DIFF
--- a/apps/lfx-one/e2e/my-newsletters.spec.ts
+++ b/apps/lfx-one/e2e/my-newsletters.spec.ts
@@ -7,8 +7,8 @@
  * Members see the sent newsletters whose recipient committees include a
  * committee they currently belong to. The BFF derives the feed from live
  * committee membership (leaving a group hides its newsletters; joining
- * reveals past ones), so the UI just renders the flat list: subject, sent
- * date, project/foundation, client-side search + filters, and a preview
+ * reveals past ones), so the UI just renders the flat list: title, received
+ * date, project/foundation, client-side search + filters, and a reader
  * drawer that fetches the rendered body on demand.
  *
  * Prerequisites:
@@ -136,8 +136,13 @@ test.describe('My Newsletters — Me-lens feed', () => {
     await stubNewsletterDetailApi(page);
   });
 
-  test('lists sent newsletters with subject, sent date, and project name', async ({ page }) => {
+  test('lists sent newsletters with title, received date, and project name', async ({ page }) => {
     await gotoMyNewsletters(page);
+
+    // Reader-framed column headers (not the sender-side Subject / Sent).
+    const table = page.getByTestId('my-newsletters-table');
+    await expect(table.locator('th').nth(0)).toHaveText('Title');
+    await expect(table.locator('th').nth(1)).toHaveText('Received');
 
     const firstRow = page.getByTestId(`my-newsletters-row-${MOCK_NEWSLETTERS[0].id}`);
     await expect(firstRow).toBeVisible({ timeout: ELEMENT_TIMEOUT });
@@ -159,7 +164,7 @@ test.describe('My Newsletters — Me-lens feed', () => {
     await expect(page.getByTestId(`my-newsletters-row-${MOCK_NEWSLETTERS[0].id}`)).toHaveCount(0);
   });
 
-  test('clicking a newsletter opens the preview drawer with the rendered body', async ({ page }) => {
+  test('clicking a newsletter opens the reader drawer with the rendered body', async ({ page }) => {
     await gotoMyNewsletters(page);
 
     await page.getByTestId(`my-newsletters-row-${MOCK_NEWSLETTERS[0].id}`).click();
@@ -167,6 +172,13 @@ test.describe('My Newsletters — Me-lens feed', () => {
     const drawer = page.getByTestId('my-newsletters-preview-drawer');
     await expect(drawer.locator('[data-e2e="newsletter-body-marker"]')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
     await expect(drawer).toContainText('TAC July Update');
+
+    // Reader-framed drawer header: project + received date, no sender-side
+    // "Preview / As your recipients will see it" text.
+    const drawerHeader = page.getByTestId('newsletter-preview-drawer-header');
+    await expect(drawerHeader).toContainText('Test Project');
+    await expect(drawerHeader).toContainText('Received Jul 15, 2026');
+    await expect(drawerHeader).not.toContainText('Preview');
   });
 
   test('shows the empty state when the user has no reachable newsletters', async ({ page }) => {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
@@ -11,8 +11,10 @@
   <ng-template #header>
     <div class="flex items-center justify-between w-full pr-4" data-testid="newsletter-preview-drawer-header">
       <div class="flex flex-col gap-0.5">
-        <h2 class="text-lg font-semibold text-slate-900">Preview</h2>
-        <p class="text-xs text-slate-500">As your recipients will see it</p>
+        <h2 class="text-lg font-semibold text-slate-900">{{ headerTitle() }}</h2>
+        @if (headerSubtitle()) {
+          <p class="text-xs text-slate-500">{{ headerSubtitle() }}</p>
+        }
       </div>
       <button
         type="button"

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
@@ -19,6 +19,12 @@ export class NewsletterPreviewDrawerComponent {
   public readonly logoUrl = input<string | undefined>(undefined);
   public readonly displayName = input.required<string>();
 
+  // === Inputs (drawer header) ===
+  // Defaults keep the sender-side "Preview" framing used by the manage and
+  // list pages; reader-side pages (My Newsletters) pass their own text.
+  public readonly headerTitle = input<string>('Preview');
+  public readonly headerSubtitle = input<string>('As your recipients will see it');
+
   // === Model Signals (two-way) ===
   public readonly visible = model<boolean>(false);
 

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -145,7 +145,7 @@
   [(visible)]="previewVisible"
   [subject]="selected()?.subject ?? ''"
   [bodyHtml]="previewBody()"
-  [displayName]="selected()?.project_name ?? 'Newsletter'"
-  [headerTitle]="selected()?.project_name ?? 'Newsletter'"
+  [displayName]="selected()?.project_name || 'Newsletter'"
+  [headerTitle]="selected()?.project_name || 'Newsletter'"
   [headerSubtitle]="drawerSubtitle()"
   data-testid="my-newsletters-preview-drawer"></lfx-newsletter-preview-drawer>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -97,8 +97,8 @@
               data-testid="my-newsletters-table">
               <ng-template #header>
                 <tr>
-                  <th class="w-[50%]">Subject</th>
-                  <th class="w-[20%]">Sent</th>
+                  <th class="w-[50%]">Title</th>
+                  <th class="w-[20%]">Received</th>
                   <th class="w-[30%]">Project / Foundation</th>
                 </tr>
               </ng-template>
@@ -138,11 +138,14 @@
   }
 </div>
 
-<!-- Preview drawer: renders the newsletter as recipients saw it. Opened once
-     the body fetch resolves in onOpenNewsletter. -->
+<!-- Reader drawer: renders the newsletter as recipients saw it. Opened once
+     the body fetch resolves in onOpenNewsletter. Header is reader-framed
+     (project + received date) rather than the sender-side "Preview" default. -->
 <lfx-newsletter-preview-drawer
   [(visible)]="previewVisible"
   [subject]="selected()?.subject ?? ''"
   [bodyHtml]="previewBody()"
   [displayName]="selected()?.project_name ?? 'Newsletter'"
+  [headerTitle]="selected()?.project_name ?? 'Newsletter'"
+  [headerSubtitle]="drawerSubtitle()"
   data-testid="my-newsletters-preview-drawer"></lfx-newsletter-preview-drawer>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe } from '@angular/common';
+import { DatePipe, formatDate } from '@angular/common';
 import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -77,6 +77,11 @@ export class MyNewslettersComponent {
   protected readonly showFoundationFilter: Signal<boolean> = computed(() => this.foundationOptions().length > 1);
   protected readonly showProjectFilter: Signal<boolean> = computed(() => this.projectOptions().length > 1);
   protected readonly hasActiveFilters: Signal<boolean> = computed(() => !!(this.searchTerm().trim() || this.foundationFilter() || this.projectFilter()));
+  /** Reader-framed drawer subtitle, e.g. "Received Jul 29, 2026". */
+  protected readonly drawerSubtitle: Signal<string> = computed(() => {
+    const sentAt = this.selected()?.sent_at;
+    return sentAt ? `Received ${formatDate(sentAt, 'MMM d, y', 'en-US')}` : '';
+  });
 
   // === Constructor ===
   public constructor() {


### PR DESCRIPTION
## Summary

My Newsletters (`/newsletters/my`) is a reader-facing feed, but it shipped with sender-side framing. This PR reframes it for readers:

- **Table columns renamed** (My Newsletters only): `Subject` → **Title**, `Sent` → **Received**. The admin/ED newsletter list keeps `Subject`/`Sent` — accurate sender-side language.
- **Reader drawer header**: opening a newsletter from My Newsletters now shows the project/foundation name with a `Received Jul 29, 2026` subtitle instead of the sender-side "Preview / As your recipients will see it".
- The shared `NewsletterPreviewDrawerComponent` gains optional `headerTitle` / `headerSubtitle` inputs whose **defaults preserve the existing "Preview" header** on the admin newsletter list and manage/editor pages — those two consumers are unchanged (verified: they pass neither input).
- Row-click behavior, search, filters, and pagination are untouched.

## Personas

Affects the reader personas (Contributor / Maintainer / Board Member) on the Me-lens feed only. ED/Admin Mode sender surfaces (newsletter list, manage/editor preview) are intentionally unchanged.

## Testing

- `yarn lint`, `yarn build`, `yarn check-types` pass; license headers pass.
- `e2e/my-newsletters.spec.ts` extended: asserts the new `Title`/`Received` column headers and the reader drawer header (project name + `Received <date>`, and that "Preview" no longer appears).

## Notes / trade-offs

- Branch name carries a descriptive suffix (`feat/LFXV2-2912-reader-framing`), consistent with prior newsletter branches (e.g. `feat/LFXV2-2912-my-newsletters`).
- The e2e date assertions render in the runner's local timezone (mock timestamps are noon UTC, safe through UTC±11; CI runs UTC) — matches the file's pre-existing assertion style.
- Drawer subtitle uses `formatDate(..., 'en-US')`, matching the existing repo idiom (`vote-results-drawer`).

JIRA: [LFXV2-2912](https://linuxfoundation.atlassian.net/browse/LFXV2-2912)

[LFXV2-2912]: https://linuxfoundation.atlassian.net/browse/LFXV2-2912?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ