### PR TITLE
feat(dashboards): rework total projects drawer and add deltas (LFXV2-2910)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
@@ -65,25 +65,7 @@
         @if (!dataLoading() && hasQuarterlyData()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="events-drawer-metric">{{ metricValue() }}</span>
-            @if (delta(); as delta) {
-              <span
-                class="text-sm font-medium"
-                [class.text-emerald-600]="delta.direction === 'up'"
-                [class.text-red-600]="delta.direction === 'down'"
-                [class.text-gray-500]="delta.direction === 'neutral'"
-                data-testid="events-drawer-delta">
-                @if (delta.direction === 'up') {
-                  <span aria-hidden="true">▲</span>
-                  <span class="sr-only">Increased </span>
-                } @else if (delta.direction === 'down') {
-                  <span aria-hidden="true">▼</span>
-                  <span class="sr-only">Decreased </span>
-                } @else {
-                  <span class="sr-only">No change </span>
-                }
-                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
-              </span>
-            }
+            <lfx-metric-delta [delta]="delta()" testid="events-drawer-delta" />
           </div>
         }
       </div>
@@ -120,7 +102,6 @@
             <i class="fa-light fa-circle-info"></i>
           </button>
         </div>
-        <p class="text-sm text-gray-500">Foundation events segmented by attendance</p>
       </div>
 
       @if (drawerLoading()) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.html
@@ -63,7 +63,28 @@
 
         <!-- Metric Value -->
         @if (!dataLoading() && hasQuarterlyData()) {
-          <span class="text-xl font-semibold text-gray-900" data-testid="events-drawer-metric">{{ metricValue() }}</span>
+          <div class="flex items-baseline gap-2">
+            <span class="text-xl font-semibold text-gray-900" data-testid="events-drawer-metric">{{ metricValue() }}</span>
+            @if (delta(); as delta) {
+              <span
+                class="text-sm font-medium"
+                [class.text-emerald-600]="delta.direction === 'up'"
+                [class.text-red-600]="delta.direction === 'down'"
+                [class.text-gray-500]="delta.direction === 'neutral'"
+                data-testid="events-drawer-delta">
+                @if (delta.direction === 'up') {
+                  <span aria-hidden="true">▲</span>
+                  <span class="sr-only">Increased </span>
+                } @else if (delta.direction === 'down') {
+                  <span aria-hidden="true">▼</span>
+                  <span class="sr-only">Decreased </span>
+                } @else {
+                  <span class="sr-only">No change </span>
+                }
+                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
+              </span>
+            }
+          </div>
         }
       </div>
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
@@ -7,6 +7,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_EVENTS_ATTENDANCE_DISTRIBUTION, DEFAULT_FOUNDATION_EVENTS_QUARTERLY, lfxColors } from '@lfx-one/shared/constants';
+import { computePeriodDelta } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -142,6 +143,7 @@ export class EventsDrawerComponent {
   protected readonly hasQuarterlyData: Signal<boolean> = computed(() => this.data().quarterlyData.length > 0);
   protected readonly hasAttendanceData: Signal<boolean> = computed(() => this.attendanceData().distribution.length > 0);
   protected readonly metricValue: Signal<string> = this.initMetricValue();
+  protected readonly delta = computed(() => computePeriodDelta(this.data().quarterlyData, 'vs last quarter'));
 
   protected readonly quarterlyChartData: Signal<ChartData<'bar'>> = this.initQuarterlyChartData();
   protected readonly attendanceChartData: Signal<ChartData<'bar'>> = this.initAttendanceChartData();

--- a/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/events-drawer/events-drawer.component.ts
@@ -5,6 +5,7 @@ import { Component, computed, inject, input, model, signal, Signal } from '@angu
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
+import { MetricDeltaComponent } from '@components/metric-delta/metric-delta.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_EVENTS_ATTENDANCE_DISTRIBUTION, DEFAULT_FOUNDATION_EVENTS_QUARTERLY, lfxColors } from '@lfx-one/shared/constants';
 import { computePeriodDelta } from '@lfx-one/shared/utils';
@@ -19,7 +20,7 @@ import type { FoundationEventsAttendanceDistributionResponse, FoundationEventsQu
 
 @Component({
   selector: 'lfx-events-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, TooltipModule],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, TooltipModule, MetricDeltaComponent],
   templateUrl: './events-drawer.component.html',
 })
 export class EventsDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -194,7 +194,8 @@
 <lfx-total-members-drawer
   [visible]="activeDrawer() === DashboardDrawerType.TotalMembers"
   (visibleChange)="handleDrawerClose()"
-  [data]="totalMembersData()"></lfx-total-members-drawer>
+  [data]="totalMembersData()"
+  [dataLoading]="totalMembersLoading()"></lfx-total-members-drawer>
 
 <lfx-active-contributors-drawer
   [visible]="activeDrawer() === DashboardDrawerType.ActiveContributors"

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -49,7 +49,11 @@
   } @else {
     <!-- Carousel Container -->
     <div class="relative overflow-hidden">
-      <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 items-start overflow-x-auto hide-scrollbar scroll-smooth" data-testid="foundation-health-carousel">
+      <div
+        lfxScrollShadow
+        [scrollDistance]="320"
+        class="flex gap-4 items-start overflow-x-auto hide-scrollbar scroll-smooth"
+        data-testid="foundation-health-carousel">
         @for (card of metricCards(); track card.testId) {
           @switch (card.customContentType) {
             <!-- Bar Chart - Use shared metric card -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.html
@@ -49,7 +49,7 @@
   } @else {
     <!-- Carousel Container -->
     <div class="relative overflow-hidden">
-      <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 overflow-x-auto hide-scrollbar scroll-smooth" data-testid="foundation-health-carousel">
+      <div lfxScrollShadow [scrollDistance]="320" class="flex gap-4 items-start overflow-x-auto hide-scrollbar scroll-smooth" data-testid="foundation-health-carousel">
         @for (card of metricCards(); track card.testId) {
           @switch (card.customContentType) {
             <!-- Bar Chart - Use shared metric card -->
@@ -61,8 +61,8 @@
                 [chartType]="card.chartType"
                 [chartData]="card.chartData"
                 [chartOptions]="card.chartOptions || barChartOptions"
-                [chartHeightClass]="'flex-1 min-h-16'"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-80 min-h-64'"
+                [chartHeightClass]="'h-24'"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-80'"
                 [value]="card.value"
                 [subtitle]="card.subtitle"
                 [trend]="card.trend"
@@ -79,7 +79,7 @@
                 [icon]="card.icon"
                 [testId]="card.testId"
                 [chartType]="card.chartType"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-80 min-h-64'"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-80'"
                 [value]="card.value"
                 [subtitle]="card.subtitle"
                 [loading]="card.loading"
@@ -108,7 +108,7 @@
                 [icon]="card.icon"
                 [testId]="card.testId"
                 [chartType]="card.chartType"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-80 min-h-64'"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-80'"
                 [value]="card.value"
                 [subtitle]="card.subtitle"
                 [loading]="card.loading"
@@ -116,7 +116,7 @@
                 (cardClick)="handleCardClick(card.drawerType!)">
                 <ng-template #customContent>
                   @if (card.busFactor) {
-                    <div class="h-16 flex flex-col justify-end mt-3">
+                    <div class="h-24 flex flex-col justify-end mt-3">
                       <div class="flex gap-0">
                         <div [style.width.%]="card.busFactor.topCompaniesPercentage" class="flex flex-col gap-1">
                           <div class="text-xs font-medium text-gray-700">
@@ -144,7 +144,8 @@
                 [chartType]="card.chartType"
                 [chartData]="card.chartData"
                 [chartOptions]="card.chartOptions"
-                [styleClass]="'w-[calc(100vw-3rem)] md:w-80 min-h-64'"
+                [chartHeightClass]="'h-24'"
+                [styleClass]="'w-[calc(100vw-3rem)] md:w-80'"
                 [value]="card.value"
                 [subtitle]="card.subtitle"
                 [trend]="card.trend"

--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -75,7 +75,7 @@ export class FoundationHealthComponent {
 
   // Loading signals for each data source
   protected readonly totalProjectsLoading = signal(true);
-  private readonly totalMembersLoading = signal(true);
+  protected readonly totalMembersLoading = signal(true);
   private readonly softwareValueLoading = signal(true);
   private readonly companyBusFactorLoading = signal(true);
   private readonly maintainersLoading = signal(true);

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -63,7 +63,28 @@
 
         <!-- Metric Value -->
         @if (hasData()) {
-          <span class="text-xl font-semibold text-gray-900" data-testid="maintainers-drawer-metric">{{ metricValue() }}</span>
+          <div class="flex items-baseline gap-2">
+            <span class="text-xl font-semibold text-gray-900" data-testid="maintainers-drawer-metric">{{ metricValue() }}</span>
+            @if (delta(); as delta) {
+              <span
+                class="text-sm font-medium"
+                [class.text-emerald-600]="delta.direction === 'up'"
+                [class.text-red-600]="delta.direction === 'down'"
+                [class.text-gray-500]="delta.direction === 'neutral'"
+                data-testid="maintainers-drawer-delta">
+                @if (delta.direction === 'up') {
+                  <span aria-hidden="true">▲</span>
+                  <span class="sr-only">Increased </span>
+                } @else if (delta.direction === 'down') {
+                  <span aria-hidden="true">▼</span>
+                  <span class="sr-only">Decreased </span>
+                } @else {
+                  <span class="sr-only">No change </span>
+                }
+                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
+              </span>
+            }
+          </div>
         }
       </div>
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -62,7 +62,7 @@
         </div>
 
         <!-- Metric Value -->
-        @if (!monthlyDataLoading() && hasData()) {
+        @if (!monthlyDataLoading() && (hasData() || hasTrendData())) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="maintainers-drawer-metric">{{ metricValue() }}</span>
             <lfx-metric-delta [delta]="delta()" testid="maintainers-drawer-delta" />

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -62,7 +62,7 @@
         </div>
 
         <!-- Metric Value -->
-        @if (!monthlyDataLoading() && (hasData() || hasTrendData())) {
+        @if (!monthlyDataLoading() && hasData()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="maintainers-drawer-metric">{{ metricValue() }}</span>
             <lfx-metric-delta [delta]="delta()" testid="maintainers-drawer-delta" />

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -62,7 +62,7 @@
         </div>
 
         <!-- Metric Value -->
-        @if (hasData()) {
+        @if (!monthlyDataLoading() && hasData()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="maintainers-drawer-metric">{{ metricValue() }}</span>
             <lfx-metric-delta [delta]="delta()" testid="maintainers-drawer-delta" />

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.html
@@ -65,25 +65,7 @@
         @if (hasData()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="maintainers-drawer-metric">{{ metricValue() }}</span>
-            @if (delta(); as delta) {
-              <span
-                class="text-sm font-medium"
-                [class.text-emerald-600]="delta.direction === 'up'"
-                [class.text-red-600]="delta.direction === 'down'"
-                [class.text-gray-500]="delta.direction === 'neutral'"
-                data-testid="maintainers-drawer-delta">
-                @if (delta.direction === 'up') {
-                  <span aria-hidden="true">▲</span>
-                  <span class="sr-only">Increased </span>
-                } @else if (delta.direction === 'down') {
-                  <span aria-hidden="true">▼</span>
-                  <span class="sr-only">Decreased </span>
-                } @else {
-                  <span class="sr-only">No change </span>
-                }
-                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
-              </span>
-            }
+            <lfx-metric-delta [delta]="delta()" testid="maintainers-drawer-delta" />
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -13,7 +13,7 @@ import {
   DEFAULT_FOUNDATION_MAINTAINERS_MONTHLY,
   lfxColors,
 } from '@lfx-one/shared/constants';
-import { buildLensAwareInsightsUrl, hexToRgba } from '@lfx-one/shared/utils';
+import { buildLensAwareInsightsUrl, computePeriodDelta, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -150,6 +150,7 @@ export class MaintainersDrawerComponent {
   );
 
   protected readonly metricValue: Signal<string> = computed(() => this.data().currentMaintainers.toLocaleString());
+  protected readonly delta = computed(() => computePeriodDelta(this.monthlyData().monthlyData));
   protected readonly hasData: Signal<boolean> = computed(() => this.data().asOfDate !== null);
 
   private readonly drawerData = this.initDrawerData();

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -169,10 +169,7 @@ export class MaintainersDrawerComponent {
 
   // === Private Initializers ===
   private initMetricValue(): Signal<string> {
-    return computed(() => {
-      const monthly = this.monthlyData().monthlyData;
-      return monthly.length ? monthly[monthly.length - 1].toLocaleString('en-US') : this.data().currentMaintainers.toLocaleString('en-US');
-    });
+    return computed(() => this.data().currentMaintainers.toLocaleString('en-US'));
   }
 
   private initDrawerData(): Signal<{ distribution: FoundationMaintainersDistributionResponse }> {

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -6,6 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
+import { MetricDeltaComponent } from '@components/metric-delta/metric-delta.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
   DEFAULT_FOUNDATION_MAINTAINERS,
@@ -29,7 +30,7 @@ import type {
 
 @Component({
   selector: 'lfx-maintainers-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent, TooltipModule],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, InsightsHandoffSectionComponent, TooltipModule, MetricDeltaComponent],
   templateUrl: './maintainers-drawer.component.html',
 })
 export class MaintainersDrawerComponent {
@@ -149,7 +150,7 @@ export class MaintainersDrawerComponent {
     })
   );
 
-  protected readonly metricValue: Signal<string> = computed(() => this.data().currentMaintainers.toLocaleString());
+  protected readonly metricValue: Signal<string> = this.initMetricValue();
   protected readonly delta = computed(() => computePeriodDelta(this.monthlyData().monthlyData));
   protected readonly hasData: Signal<boolean> = computed(() => this.data().asOfDate !== null);
 
@@ -167,6 +168,13 @@ export class MaintainersDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initMetricValue(): Signal<string> {
+    return computed(() => {
+      const monthly = this.monthlyData().monthlyData;
+      return monthly.length ? monthly[monthly.length - 1].toLocaleString() : this.data().currentMaintainers.toLocaleString();
+    });
+  }
+
   private initDrawerData(): Signal<{ distribution: FoundationMaintainersDistributionResponse }> {
     const defaultValue = { distribution: DEFAULT_FOUNDATION_MAINTAINERS_DISTRIBUTION };
     return toSignal(

--- a/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/maintainers-drawer/maintainers-drawer.component.ts
@@ -171,7 +171,7 @@ export class MaintainersDrawerComponent {
   private initMetricValue(): Signal<string> {
     return computed(() => {
       const monthly = this.monthlyData().monthlyData;
-      return monthly.length ? monthly[monthly.length - 1].toLocaleString() : this.data().currentMaintainers.toLocaleString();
+      return monthly.length ? monthly[monthly.length - 1].toLocaleString('en-US') : this.data().currentMaintainers.toLocaleString('en-US');
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -70,8 +70,13 @@
 
       <!-- Chart -->
       @if (dataLoading()) {
-        <div class="flex items-center justify-center py-12" data-testid="total-members-drawer-chart-loading">
-          <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+        <div
+          class="flex items-center justify-center py-12"
+          role="status"
+          aria-live="polite"
+          aria-label="Loading member organizations chart"
+          data-testid="total-members-drawer-chart-loading">
+          <i aria-hidden="true" class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
         </div>
       } @else if (hasData()) {
         <div class="h-[280px]" data-testid="total-members-drawer-chart">

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -63,25 +63,7 @@
         @if (hasData()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="total-members-drawer-metric">{{ metricValue() }}</span>
-            @if (delta(); as delta) {
-              <span
-                class="text-sm font-medium"
-                [class.text-emerald-600]="delta.direction === 'up'"
-                [class.text-red-600]="delta.direction === 'down'"
-                [class.text-gray-500]="delta.direction === 'neutral'"
-                data-testid="total-members-drawer-delta">
-                @if (delta.direction === 'up') {
-                  <span aria-hidden="true">▲</span>
-                  <span class="sr-only">Increased </span>
-                } @else if (delta.direction === 'down') {
-                  <span aria-hidden="true">▼</span>
-                  <span class="sr-only">Decreased </span>
-                } @else {
-                  <span class="sr-only">No change </span>
-                }
-                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
-              </span>
-            }
+            <lfx-metric-delta [delta]="delta()" testid="total-members-drawer-delta" />
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -46,17 +46,44 @@
     <!-- Member Organizations Chart Section -->
     <div class="flex flex-col gap-3" data-testid="total-members-drawer-chart-section">
       <!-- Section Header -->
-      <div class="flex items-center gap-2">
-        <h3 class="text-sm font-medium text-gray-900">Member Organizations</h3>
-        <button
-          type="button"
-          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
-          pTooltip="Total # of member organizations across the foundation per month"
-          tooltipPosition="top"
-          tooltipEvent="both"
-          aria-label="Total # of member organizations across the foundation per month">
-          <i class="fa-light fa-circle-info"></i>
-        </button>
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <h3 class="text-sm font-medium text-gray-900">Member Organizations</h3>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Total # of member organizations across the foundation per month"
+            tooltipPosition="top"
+            tooltipEvent="both"
+            aria-label="Total # of member organizations across the foundation per month">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
+        </div>
+
+        @if (hasData()) {
+          <div class="flex items-baseline gap-2">
+            <span class="text-xl font-semibold text-gray-900" data-testid="total-members-drawer-metric">{{ metricValue() }}</span>
+            @if (delta(); as delta) {
+              <span
+                class="text-sm font-medium"
+                [class.text-emerald-600]="delta.direction === 'up'"
+                [class.text-red-600]="delta.direction === 'down'"
+                [class.text-gray-500]="delta.direction === 'neutral'"
+                data-testid="total-members-drawer-delta">
+                @if (delta.direction === 'up') {
+                  <span aria-hidden="true">▲</span>
+                  <span class="sr-only">Increased </span>
+                } @else if (delta.direction === 'down') {
+                  <span aria-hidden="true">▼</span>
+                  <span class="sr-only">Decreased </span>
+                } @else {
+                  <span class="sr-only">No change </span>
+                }
+                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
+              </span>
+            }
+          </div>
+        }
       </div>
 
       <!-- Chart -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -60,7 +60,7 @@
           </button>
         </div>
 
-        @if (hasData()) {
+        @if (!dataLoading() && hasData()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="total-members-drawer-metric">{{ metricValue() }}</span>
             <lfx-metric-delta [delta]="delta()" testid="total-members-drawer-delta" />

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.html
@@ -60,7 +60,7 @@
           </button>
         </div>
 
-        @if (!dataLoading() && hasData()) {
+        @if (!dataLoading()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="total-members-drawer-metric">{{ metricValue() }}</span>
             <lfx-metric-delta [delta]="delta()" testid="total-members-drawer-delta" />
@@ -69,7 +69,11 @@
       </div>
 
       <!-- Chart -->
-      @if (hasData()) {
+      @if (dataLoading()) {
+        <div class="flex items-center justify-center py-12" data-testid="total-members-drawer-chart-loading">
+          <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+        </div>
+      } @else if (hasData()) {
         <div class="h-[280px]" data-testid="total-members-drawer-chart">
           <lfx-chart type="bar" [data]="chartData()" [options]="chartOptions" height="100%"></lfx-chart>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
@@ -37,6 +37,10 @@ export class TotalMembersDrawerComponent {
   // === Inputs ===
   public readonly data = input<FoundationTotalMembersResponse>(DEFAULT_FOUNDATION_TOTAL_MEMBERS);
 
+  // True while the parent's eager monthly fetch is in flight, so the headline
+  // metric/delta can be hidden during a foundation switch while the drawer is open.
+  public readonly dataLoading = input<boolean>(false);
+
   // === Computed Signals ===
   protected readonly hasData: Signal<boolean> = computed(() => this.data().monthlyData.length > 0);
   protected readonly metricValue: Signal<string> = this.initMetricValue();
@@ -84,7 +88,7 @@ export class TotalMembersDrawerComponent {
   private initMetricValue(): Signal<string> {
     return computed(() => {
       const m = this.data().monthlyData;
-      return m.length ? m[m.length - 1].toLocaleString() : this.data().totalMembers.toLocaleString();
+      return m.length ? m[m.length - 1].toLocaleString('en-US') : this.data().totalMembers.toLocaleString('en-US');
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
@@ -4,6 +4,7 @@
 import { Component, computed, inject, input, model, Signal } from '@angular/core';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
+import { MetricDeltaComponent } from '@components/metric-delta/metric-delta.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_TOTAL_MEMBERS, lfxColors } from '@lfx-one/shared/constants';
 import { computePeriodDelta } from '@lfx-one/shared/utils';
@@ -15,7 +16,7 @@ import type { FoundationTotalMembersResponse } from '@lfx-one/shared/interfaces'
 
 @Component({
   selector: 'lfx-total-members-drawer',
-  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, TooltipModule],
+  imports: [DrawerModule, ChartComponent, SelectComponent, ReactiveFormsModule, TooltipModule, MetricDeltaComponent],
   templateUrl: './total-members-drawer.component.html',
 })
 export class TotalMembersDrawerComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
@@ -6,6 +6,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ChartComponent } from '@components/chart/chart.component';
 import { SelectComponent } from '@components/select/select.component';
 import { DEFAULT_FOUNDATION_TOTAL_MEMBERS, lfxColors } from '@lfx-one/shared/constants';
+import { computePeriodDelta } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 import { TooltipModule } from 'primeng/tooltip';
 
@@ -37,6 +38,8 @@ export class TotalMembersDrawerComponent {
 
   // === Computed Signals ===
   protected readonly hasData: Signal<boolean> = computed(() => this.data().monthlyData.length > 0);
+  protected readonly metricValue: Signal<string> = computed(() => this.data().totalMembers.toLocaleString());
+  protected readonly delta = computed(() => computePeriodDelta(this.data().monthlyData));
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
 
   protected readonly chartOptions: ChartOptions<'bar'> = {

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-members-drawer/total-members-drawer.component.ts
@@ -39,7 +39,7 @@ export class TotalMembersDrawerComponent {
 
   // === Computed Signals ===
   protected readonly hasData: Signal<boolean> = computed(() => this.data().monthlyData.length > 0);
-  protected readonly metricValue: Signal<string> = computed(() => this.data().totalMembers.toLocaleString());
+  protected readonly metricValue: Signal<string> = this.initMetricValue();
   protected readonly delta = computed(() => computePeriodDelta(this.data().monthlyData));
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
 
@@ -81,6 +81,13 @@ export class TotalMembersDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initMetricValue(): Signal<string> {
+    return computed(() => {
+      const m = this.data().monthlyData;
+      return m.length ? m[m.length - 1].toLocaleString() : this.data().totalMembers.toLocaleString();
+    });
+  }
+
   private initChartData(): Signal<ChartData<'bar'>> {
     return computed(() => {
       const { monthlyData, monthlyLabels } = this.data();

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
@@ -46,17 +46,44 @@
     <!-- Primary Section -->
     <div class="flex flex-col gap-3" data-testid="total-projects-drawer-primary">
       <!-- Section Header -->
-      <div class="flex items-center gap-2">
-        <h3 class="text-sm font-medium text-gray-900">Total Projects</h3>
-        <button
-          type="button"
-          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
-          pTooltip="Total # of active projects across the foundation"
-          tooltipPosition="top"
-          tooltipEvent="both"
-          aria-label="Total # of active projects across the foundation">
-          <i class="fa-light fa-circle-info"></i>
-        </button>
+      <div class="flex items-center justify-between">
+        <div class="flex items-center gap-2">
+          <h3 class="text-sm font-medium text-gray-900">Total Projects</h3>
+          <button
+            type="button"
+            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+            pTooltip="Total # of active projects across the foundation"
+            tooltipPosition="top"
+            tooltipEvent="both"
+            aria-label="Total # of active projects across the foundation">
+            <i class="fa-light fa-circle-info"></i>
+          </button>
+        </div>
+
+        @if (hasData() && !dataLoading()) {
+          <div class="flex items-baseline gap-2">
+            <span class="text-xl font-semibold text-gray-900" data-testid="total-projects-drawer-metric">{{ metricValue() }}</span>
+            @if (delta(); as delta) {
+              <span
+                class="text-sm font-medium"
+                [class.text-emerald-600]="delta.direction === 'up'"
+                [class.text-red-600]="delta.direction === 'down'"
+                [class.text-gray-500]="delta.direction === 'neutral'"
+                data-testid="total-projects-drawer-delta">
+                @if (delta.direction === 'up') {
+                  <span aria-hidden="true">▲</span>
+                  <span class="sr-only">Increased </span>
+                } @else if (delta.direction === 'down') {
+                  <span aria-hidden="true">▼</span>
+                  <span class="sr-only">Decreased </span>
+                } @else {
+                  <span class="sr-only">No change </span>
+                }
+                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
+              </span>
+            }
+          </div>
+        }
       </div>
 
       <!-- Chart -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
@@ -46,165 +46,51 @@
     <!-- Primary Section -->
     <div class="flex flex-col gap-3" data-testid="total-projects-drawer-primary">
       <!-- Section Header -->
-      <div class="flex items-center justify-between">
-        <!-- Title + Tooltip -->
-        <div class="flex items-center gap-2">
-          <h3 class="text-sm font-medium text-gray-900">Total Projects</h3>
-          <button
-            type="button"
-            class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
-            pTooltip="Total # of active projects across the foundation"
-            tooltipPosition="top"
-            tooltipEvent="both"
-            aria-label="Total # of active projects across the foundation">
-            <i class="fa-light fa-circle-info"></i>
-          </button>
-        </div>
-
-        <!-- Chart / Table Toggle -->
-        <lfx-select-button
-          [form]="viewForm"
-          control="primaryView"
-          [options]="viewOptions"
-          optionLabel="label"
-          optionValue="value"
-          [unselectable]="true"
-          (onChange)="onPrimaryViewChange($event)"
-          data-testid="total-projects-drawer-view-toggle"></lfx-select-button>
+      <div class="flex items-center gap-2">
+        <h3 class="text-sm font-medium text-gray-900">Total Projects</h3>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Total # of active projects across the foundation"
+          tooltipPosition="top"
+          tooltipEvent="both"
+          aria-label="Total # of active projects across the foundation">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
       </div>
 
-      <!-- Chart View -->
-      @if (primaryView() === 'chart') {
-        @if (dataLoading()) {
-          <div class="flex items-center justify-center py-12" data-testid="total-projects-drawer-chart-loading">
-            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
-          </div>
-        } @else if (hasData()) {
-          <div class="h-[200px]" data-testid="total-projects-drawer-chart">
-            <lfx-chart type="line" [data]="primaryChartData()" [options]="primaryChartOptions" height="100%"></lfx-chart>
-          </div>
-        } @else {
-          <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="total-projects-drawer-chart-empty">
-            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No trend data available for this foundation.</p>
-          </div>
-        }
-      }
-
-      <!-- Table View -->
-      @if (primaryView() === 'table') {
-        <div class="flex flex-col gap-3" data-testid="total-projects-drawer-table">
-          <!-- Search Bar -->
-          <lfx-input-text
-            [form]="searchForm"
-            control="query"
-            type="text"
-            size="small"
-            icon="fa-light fa-magnifying-glass"
-            placeholder="Search projects by name or stage..."
-            data-testid="total-projects-drawer-search"></lfx-input-text>
-
-          <!-- Loading state -->
-          @if (drawerLoading()) {
-            <div class="flex items-center justify-center py-12" data-testid="total-projects-drawer-table-loading">
-              <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
-            </div>
-          } @else {
-            <!-- Table -->
-            <div class="overflow-auto border border-slate-200 rounded-lg">
-              <table class="w-full text-sm" data-testid="total-projects-drawer-table-grid">
-                <thead class="bg-slate-50 border-b border-slate-200">
-                  <tr>
-                    <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Project Name</th>
-                    <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Lifecycle Stage</th>
-                    <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Contributors</th>
-                    <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Commits (90d)</th>
-                    <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Maintainers</th>
-                    <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Stars</th>
-                    <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Last Updated</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  @for (project of primaryPaginatedData(); track project.id) {
-                    <tr class="border-b border-slate-100 hover:bg-slate-50" [attr.data-testid]="'total-projects-drawer-table-row-' + project.id">
-                      <td class="py-3 px-4 font-medium text-slate-900 whitespace-nowrap">{{ project.projectName }}</td>
-                      <td class="py-3 px-4">
-                        @if (project.lifecycleStage) {
-                          <span
-                            class="inline-flex px-2 py-1 rounded-full text-xs"
-                            [ngClass]="{
-                              'bg-green-100 text-green-800': project.lifecycleStage === LifecycleStage.Graduated,
-                              'bg-blue-100 text-blue-800': project.lifecycleStage === LifecycleStage.Incubating,
-                              'bg-purple-100 text-purple-800': project.lifecycleStage === LifecycleStage.Sandbox,
-                            }">
-                            {{ project.lifecycleStage }}
-                          </span>
-                        } @else {
-                          <span class="text-sm text-gray-400">&mdash;</span>
-                        }
-                      </td>
-                      <td class="text-right py-3 px-4 text-slate-700">{{ project.activeContributors | number }}</td>
-                      <td class="text-right py-3 px-4 text-slate-700">{{ project.commitsLast90Days | number }}</td>
-                      <td class="text-right py-3 px-4 text-slate-700">{{ project.maintainers }}</td>
-                      <td class="text-right py-3 px-4 text-slate-700">{{ project.stars | number }}</td>
-                      <td class="py-3 px-4 text-slate-600 whitespace-nowrap">{{ project.lastUpdated ?? '—' }}</td>
-                    </tr>
-                  } @empty {
-                    <tr>
-                      <td colspan="7" class="py-8 text-center text-slate-500">
-                        @if (primarySearch()) {
-                          No projects found matching "{{ primarySearch() }}"
-                        } @else {
-                          No project data available for this foundation.
-                        }
-                      </td>
-                    </tr>
-                  }
-                </tbody>
-              </table>
-            </div>
-
-            <!-- Pagination -->
-            @if (primaryFilteredData().length > 0) {
-              <div class="flex items-center justify-between" data-testid="total-projects-drawer-pagination">
-                <span class="text-sm text-slate-600">{{ primaryPageInfo() }}</span>
-
-                <div class="flex items-center gap-1">
-                  <lfx-button
-                    icon="fa-light fa-chevron-left"
-                    [outlined]="true"
-                    size="small"
-                    [disabled]="primaryPage() === 1"
-                    (onClick)="goToPrimaryPage(primaryPage() - 1)"
-                    ariaLabel="Previous page"></lfx-button>
-
-                  @for (page of primaryVisiblePages(); track page) {
-                    <lfx-button
-                      [label]="page.toString()"
-                      [outlined]="primaryPage() !== page"
-                      size="small"
-                      (onClick)="goToPrimaryPage(page)"
-                      [ariaLabel]="'Page ' + page"></lfx-button>
-                  }
-
-                  <lfx-button
-                    icon="fa-light fa-chevron-right"
-                    [outlined]="true"
-                    size="small"
-                    [disabled]="primaryPage() === primaryTotalPages()"
-                    (onClick)="goToPrimaryPage(primaryPage() + 1)"
-                    ariaLabel="Next page"></lfx-button>
-                </div>
-              </div>
-            }
-          }
+      <!-- Chart -->
+      @if (dataLoading()) {
+        <div class="flex items-center justify-center py-12" data-testid="total-projects-drawer-chart-loading">
+          <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+        </div>
+      } @else if (hasData()) {
+        <div class="h-[200px]" data-testid="total-projects-drawer-chart">
+          <lfx-chart type="line" [data]="primaryChartData()" [options]="primaryChartOptions" height="100%"></lfx-chart>
+        </div>
+      } @else {
+        <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="total-projects-drawer-chart-empty">
+          <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+          <p class="text-sm text-gray-500">No trend data available for this foundation.</p>
         </div>
       }
     </div>
 
     <!-- Secondary Section: Projects by Lifecycle Stage -->
     <div class="flex flex-col gap-3" data-testid="total-projects-drawer-secondary">
-      <h3 class="text-sm font-medium text-gray-900">Projects by Lifecycle Stage</h3>
+      <div class="flex items-center gap-2">
+        <h3 class="text-sm font-medium text-gray-900">Projects by Lifecycle Stage</h3>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Breakdown of foundation projects by lifecycle stage (Sandbox, Incubating, Graduated)"
+          tooltipPosition="top"
+          tooltipEvent="both"
+          aria-label="Breakdown of foundation projects by lifecycle stage (Sandbox, Incubating, Graduated)"
+          data-testid="total-projects-drawer-lifecycle-info">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
+      </div>
       @if (drawerLoading()) {
         <div class="flex items-center justify-center py-8">
           <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
@@ -219,6 +105,131 @@
           <p class="text-sm text-gray-500">No lifecycle data available for this foundation.</p>
         </div>
       }
+    </div>
+
+    <!-- Table Section: searchable project list -->
+    <div class="flex flex-col gap-3" data-testid="total-projects-drawer-table-section">
+      <!-- Section Header -->
+      <div class="flex items-center gap-2">
+        <h3 class="text-sm font-medium text-gray-900">All Projects</h3>
+        <button
+          type="button"
+          class="text-gray-400 hover:text-gray-600 cursor-help text-xs flex-shrink-0"
+          pTooltip="Search and browse individual foundation projects"
+          tooltipPosition="top"
+          tooltipEvent="both"
+          aria-label="Search and browse individual foundation projects"
+          data-testid="total-projects-drawer-table-info">
+          <i class="fa-light fa-circle-info"></i>
+        </button>
+      </div>
+
+      <div class="flex flex-col gap-3" data-testid="total-projects-drawer-table">
+        <!-- Search Bar -->
+        <lfx-input-text
+          [form]="searchForm"
+          control="query"
+          type="text"
+          size="small"
+          icon="fa-light fa-magnifying-glass"
+          placeholder="Search projects by name or stage..."
+          data-testid="total-projects-drawer-search"></lfx-input-text>
+
+        <!-- Loading state -->
+        @if (drawerLoading()) {
+          <div class="flex items-center justify-center py-12" data-testid="total-projects-drawer-table-loading">
+            <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400"></i>
+          </div>
+        } @else {
+          <!-- Table -->
+          <div class="overflow-auto border border-slate-200 rounded-lg">
+            <table class="w-full text-sm" data-testid="total-projects-drawer-table-grid">
+              <thead class="bg-slate-50 border-b border-slate-200">
+                <tr>
+                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Project Name</th>
+                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Lifecycle Stage</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Contributors</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Commits (90d)</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Maintainers</th>
+                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Stars</th>
+                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Last Updated</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (project of primaryPaginatedData(); track project.id) {
+                  <tr class="border-b border-slate-100 hover:bg-slate-50" [attr.data-testid]="'total-projects-drawer-table-row-' + project.id">
+                    <td class="py-3 px-4 font-medium text-slate-900 whitespace-nowrap">{{ project.projectName }}</td>
+                    <td class="py-3 px-4">
+                      @if (project.lifecycleStage) {
+                        <span
+                          class="inline-flex px-2 py-1 rounded-full text-xs"
+                          [ngClass]="{
+                            'bg-green-100 text-green-800': project.lifecycleStage === LifecycleStage.Graduated,
+                            'bg-blue-100 text-blue-800': project.lifecycleStage === LifecycleStage.Incubating,
+                            'bg-purple-100 text-purple-800': project.lifecycleStage === LifecycleStage.Sandbox,
+                          }">
+                          {{ project.lifecycleStage }}
+                        </span>
+                      } @else {
+                        <span class="text-sm text-gray-400">&mdash;</span>
+                      }
+                    </td>
+                    <td class="text-right py-3 px-4 text-slate-700">{{ project.activeContributors | number }}</td>
+                    <td class="text-right py-3 px-4 text-slate-700">{{ project.commitsLast90Days | number }}</td>
+                    <td class="text-right py-3 px-4 text-slate-700">{{ project.maintainers }}</td>
+                    <td class="text-right py-3 px-4 text-slate-700">{{ project.stars | number }}</td>
+                    <td class="py-3 px-4 text-slate-600 whitespace-nowrap">{{ project.lastUpdated ?? '—' }}</td>
+                  </tr>
+                } @empty {
+                  <tr>
+                    <td colspan="7" class="py-8 text-center text-slate-500">
+                      @if (primarySearch()) {
+                        No projects found matching "{{ primarySearch() }}"
+                      } @else {
+                        No project data available for this foundation.
+                      }
+                    </td>
+                  </tr>
+                }
+              </tbody>
+            </table>
+          </div>
+
+          <!-- Pagination -->
+          @if (primaryFilteredData().length > 0) {
+            <div class="flex items-center justify-between" data-testid="total-projects-drawer-pagination">
+              <span class="text-sm text-slate-600">{{ primaryPageInfo() }}</span>
+
+              <div class="flex items-center gap-1">
+                <lfx-button
+                  icon="fa-light fa-chevron-left"
+                  [outlined]="true"
+                  size="small"
+                  [disabled]="primaryPage() === 1"
+                  (onClick)="goToPrimaryPage(primaryPage() - 1)"
+                  ariaLabel="Previous page"></lfx-button>
+
+                @for (page of primaryVisiblePages(); track page) {
+                  <lfx-button
+                    [label]="page.toString()"
+                    [outlined]="primaryPage() !== page"
+                    size="small"
+                    (onClick)="goToPrimaryPage(page)"
+                    [ariaLabel]="'Page ' + page"></lfx-button>
+                }
+
+                <lfx-button
+                  icon="fa-light fa-chevron-right"
+                  [outlined]="true"
+                  size="small"
+                  [disabled]="primaryPage() === primaryTotalPages()"
+                  (onClick)="goToPrimaryPage(primaryPage() + 1)"
+                  ariaLabel="Next page"></lfx-button>
+              </div>
+            </div>
+          }
+        }
+      </div>
     </div>
 
     <!-- Insights Handoff -->

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
@@ -63,25 +63,7 @@
         @if (hasData() && !dataLoading()) {
           <div class="flex items-baseline gap-2">
             <span class="text-xl font-semibold text-gray-900" data-testid="total-projects-drawer-metric">{{ metricValue() }}</span>
-            @if (delta(); as delta) {
-              <span
-                class="text-sm font-medium"
-                [class.text-emerald-600]="delta.direction === 'up'"
-                [class.text-red-600]="delta.direction === 'down'"
-                [class.text-gray-500]="delta.direction === 'neutral'"
-                data-testid="total-projects-drawer-delta">
-                @if (delta.direction === 'up') {
-                  <span aria-hidden="true">▲</span>
-                  <span class="sr-only">Increased </span>
-                } @else if (delta.direction === 'down') {
-                  <span aria-hidden="true">▼</span>
-                  <span class="sr-only">Decreased </span>
-                } @else {
-                  <span class="sr-only">No change </span>
-                }
-                {{ delta.deltaLabel }}% {{ delta.periodLabel }}
-              </span>
-            }
+            <lfx-metric-delta [delta]="delta()" testid="total-projects-drawer-delta" />
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.html
@@ -78,7 +78,7 @@
           <lfx-chart type="line" [data]="primaryChartData()" [options]="primaryChartOptions" height="100%"></lfx-chart>
         </div>
       } @else {
-        <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="total-projects-drawer-chart-empty">
+        <div class="text-center py-8 border border-gray-200 rounded-lg" data-testid="total-projects-drawer-chart-empty">
           <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
           <p class="text-sm text-gray-500">No trend data available for this foundation.</p>
         </div>
@@ -109,7 +109,7 @@
           <lfx-chart type="bar" [data]="lifecycleChartData()" [options]="barChartSectionOptions" height="100%"></lfx-chart>
         </div>
       } @else {
-        <div class="text-center py-8 border border-slate-200 rounded-lg" data-testid="total-projects-drawer-lifecycle-empty">
+        <div class="text-center py-8 border border-gray-200 rounded-lg" data-testid="total-projects-drawer-lifecycle-empty">
           <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
           <p class="text-sm text-gray-500">No lifecycle data available for this foundation.</p>
         </div>
@@ -151,31 +151,31 @@
           </div>
         } @else {
           <!-- Table -->
-          <div class="overflow-auto border border-slate-200 rounded-lg">
+          <div class="overflow-auto border border-gray-200 rounded-lg">
             <table class="w-full text-sm" data-testid="total-projects-drawer-table-grid">
-              <thead class="bg-slate-50 border-b border-slate-200">
+              <thead class="bg-gray-50 border-b border-gray-200">
                 <tr>
-                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Project Name</th>
-                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Lifecycle Stage</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Contributors</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Commits (90d)</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Maintainers</th>
-                  <th class="text-right py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Stars</th>
-                  <th class="text-left py-3 px-4 font-medium text-slate-700 whitespace-nowrap">Last Updated</th>
+                  <th class="text-left py-3 px-4 font-medium text-gray-700 whitespace-nowrap">Project Name</th>
+                  <th class="text-left py-3 px-4 font-medium text-gray-700 whitespace-nowrap">Lifecycle Stage</th>
+                  <th class="text-right py-3 px-4 font-medium text-gray-700 whitespace-nowrap">Contributors</th>
+                  <th class="text-right py-3 px-4 font-medium text-gray-700 whitespace-nowrap">Commits (90d)</th>
+                  <th class="text-right py-3 px-4 font-medium text-gray-700 whitespace-nowrap">Maintainers</th>
+                  <th class="text-right py-3 px-4 font-medium text-gray-700 whitespace-nowrap">Stars</th>
+                  <th class="text-left py-3 px-4 font-medium text-gray-700 whitespace-nowrap">Last Updated</th>
                 </tr>
               </thead>
               <tbody>
                 @for (project of primaryPaginatedData(); track project.id) {
-                  <tr class="border-b border-slate-100 hover:bg-slate-50" [attr.data-testid]="'total-projects-drawer-table-row-' + project.id">
-                    <td class="py-3 px-4 font-medium text-slate-900 whitespace-nowrap">{{ project.projectName }}</td>
+                  <tr class="border-b border-gray-100 hover:bg-gray-50" [attr.data-testid]="'total-projects-drawer-table-row-' + project.id">
+                    <td class="py-3 px-4 font-medium text-gray-900 whitespace-nowrap">{{ project.projectName }}</td>
                     <td class="py-3 px-4">
                       @if (project.lifecycleStage) {
                         <span
                           class="inline-flex px-2 py-1 rounded-full text-xs"
                           [ngClass]="{
-                            'bg-green-100 text-green-800': project.lifecycleStage === LifecycleStage.Graduated,
+                            'bg-emerald-100 text-emerald-800': project.lifecycleStage === LifecycleStage.Graduated,
                             'bg-blue-100 text-blue-800': project.lifecycleStage === LifecycleStage.Incubating,
-                            'bg-purple-100 text-purple-800': project.lifecycleStage === LifecycleStage.Sandbox,
+                            'bg-violet-100 text-violet-800': project.lifecycleStage === LifecycleStage.Sandbox,
                           }">
                           {{ project.lifecycleStage }}
                         </span>
@@ -183,15 +183,15 @@
                         <span class="text-sm text-gray-400">&mdash;</span>
                       }
                     </td>
-                    <td class="text-right py-3 px-4 text-slate-700">{{ project.activeContributors | number }}</td>
-                    <td class="text-right py-3 px-4 text-slate-700">{{ project.commitsLast90Days | number }}</td>
-                    <td class="text-right py-3 px-4 text-slate-700">{{ project.maintainers }}</td>
-                    <td class="text-right py-3 px-4 text-slate-700">{{ project.stars | number }}</td>
-                    <td class="py-3 px-4 text-slate-600 whitespace-nowrap">{{ project.lastUpdated ?? '—' }}</td>
+                    <td class="text-right py-3 px-4 text-gray-700">{{ project.activeContributors | number }}</td>
+                    <td class="text-right py-3 px-4 text-gray-700">{{ project.commitsLast90Days | number }}</td>
+                    <td class="text-right py-3 px-4 text-gray-700">{{ project.maintainers }}</td>
+                    <td class="text-right py-3 px-4 text-gray-700">{{ project.stars | number }}</td>
+                    <td class="py-3 px-4 text-gray-600 whitespace-nowrap">{{ project.lastUpdated ?? '—' }}</td>
                   </tr>
                 } @empty {
                   <tr>
-                    <td colspan="7" class="py-8 text-center text-slate-500">
+                    <td colspan="7" class="py-8 text-center text-gray-500">
                       @if (primarySearch()) {
                         No projects found matching "{{ primarySearch() }}"
                       } @else {
@@ -207,7 +207,7 @@
           <!-- Pagination -->
           @if (primaryFilteredData().length > 0) {
             <div class="flex items-center justify-between" data-testid="total-projects-drawer-pagination">
-              <span class="text-sm text-slate-600">{{ primaryPageInfo() }}</span>
+              <span class="text-sm text-gray-600">{{ primaryPageInfo() }}</span>
 
               <div class="flex items-center gap-1">
                 <lfx-button

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -196,7 +196,7 @@ export class TotalProjectsDrawerComponent {
   private initMetricValue(): Signal<string> {
     return computed(() => {
       const m = this.data().monthlyData;
-      return m.length ? m[m.length - 1].toLocaleString() : this.data().totalProjects.toLocaleString();
+      return m.length ? m[m.length - 1].toLocaleString('en-US') : this.data().totalProjects.toLocaleString('en-US');
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -9,7 +9,6 @@ import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
-import { SelectButtonComponent } from '@components/select-button/select-button.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
   DEFAULT_FOUNDATION_PROJECTS_DETAIL,
@@ -40,7 +39,6 @@ import type {
     DrawerModule,
     ChartComponent,
     SelectComponent,
-    SelectButtonComponent,
     InputTextComponent,
     ButtonComponent,
     ReactiveFormsModule,
@@ -59,18 +57,10 @@ export class TotalProjectsDrawerComponent {
 
   // === Static Options ===
   protected readonly timeRangeOptions = [{ label: 'Last 12 months', value: 'last-12-months' }];
-  protected readonly viewOptions = [
-    { label: 'Chart', value: 'chart' },
-    { label: 'Table', value: 'table' },
-  ];
 
   // === Forms ===
   protected readonly headerForm: FormGroup = this.fb.group({
     timeRange: [{ value: 'last-12-months', disabled: true }],
-  });
-
-  protected readonly viewForm: FormGroup = this.fb.group({
-    primaryView: ['chart'],
   });
 
   protected readonly searchForm: FormGroup = this.fb.group({
@@ -93,7 +83,6 @@ export class TotalProjectsDrawerComponent {
   protected readonly LifecycleStage = LifecycleStage;
 
   // === WritableSignals ===
-  protected readonly primaryView = signal<'chart' | 'table'>('chart');
   protected readonly primaryPage = signal(1);
   protected readonly drawerLoading = signal(false);
 
@@ -193,12 +182,6 @@ export class TotalProjectsDrawerComponent {
   // === Protected Methods ===
   protected onClose(): void {
     this.visible.set(false);
-  }
-
-  protected onPrimaryViewChange(event: { value: 'chart' | 'table' }): void {
-    if (event.value) {
-      this.primaryView.set(event.value);
-    }
   }
 
   protected goToPrimaryPage(page: number): void {

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -9,6 +9,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { InsightsHandoffSectionComponent } from '@components/insights-handoff-section/insights-handoff-section.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
+import { MetricDeltaComponent } from '@components/metric-delta/metric-delta.component';
 import { SelectComponent } from '@components/select/select.component';
 import {
   DEFAULT_FOUNDATION_PROJECTS_DETAIL,
@@ -46,6 +47,7 @@ import type {
     NgClass,
     InsightsHandoffSectionComponent,
     TooltipModule,
+    MetricDeltaComponent,
   ],
   templateUrl: './total-projects-drawer.component.html',
 })

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -194,9 +194,10 @@ export class TotalProjectsDrawerComponent {
 
   // === Private Initializers ===
   private initMetricValue(): Signal<string> {
+    // Guarded by hasData() (monthlyData non-empty) in the template, so the last month is always present.
     return computed(() => {
       const m = this.data().monthlyData;
-      return m.length ? m[m.length - 1].toLocaleString('en-US') : this.data().totalProjects.toLocaleString('en-US');
+      return m[m.length - 1].toLocaleString('en-US');
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -17,7 +17,7 @@ import {
   lfxColors,
   TOTAL_PROJECTS_DRAWER_ITEMS_PER_PAGE,
 } from '@lfx-one/shared/constants';
-import { buildLensAwareInsightsUrl, buildVisiblePages, hexToRgba } from '@lfx-one/shared/utils';
+import { buildLensAwareInsightsUrl, buildVisiblePages, computePeriodDelta, hexToRgba } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -92,6 +92,8 @@ export class TotalProjectsDrawerComponent {
   );
 
   protected readonly hasData: Signal<boolean> = computed(() => this.data().monthlyData.length > 0);
+  protected readonly metricValue: Signal<string> = computed(() => this.data().totalProjects.toLocaleString());
+  protected readonly delta = computed(() => computePeriodDelta(this.data().monthlyData));
   protected readonly primarySearch: Signal<string> = this.initPrimarySearch();
   private readonly drawerData = this.initDrawerData();
   protected readonly projectsDetailData: Signal<FoundationProjectsDetailResponse> = computed(() => this.drawerData().projects);

--- a/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/total-projects-drawer/total-projects-drawer.component.ts
@@ -94,7 +94,7 @@ export class TotalProjectsDrawerComponent {
   );
 
   protected readonly hasData: Signal<boolean> = computed(() => this.data().monthlyData.length > 0);
-  protected readonly metricValue: Signal<string> = computed(() => this.data().totalProjects.toLocaleString());
+  protected readonly metricValue: Signal<string> = this.initMetricValue();
   protected readonly delta = computed(() => computePeriodDelta(this.data().monthlyData));
   protected readonly primarySearch: Signal<string> = this.initPrimarySearch();
   private readonly drawerData = this.initDrawerData();
@@ -193,6 +193,13 @@ export class TotalProjectsDrawerComponent {
   }
 
   // === Private Initializers ===
+  private initMetricValue(): Signal<string> {
+    return computed(() => {
+      const m = this.data().monthlyData;
+      return m.length ? m[m.length - 1].toLocaleString() : this.data().totalProjects.toLocaleString();
+    });
+  }
+
   private initPrimarySearch(): Signal<string> {
     return toSignal(this.searchForm.get('query')!.valueChanges.pipe(tap(() => this.primaryPage.set(1))), { initialValue: '' });
   }

--- a/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.html
@@ -1,0 +1,19 @@
+@if (delta(); as delta) {
+  <span
+    class="text-sm font-medium"
+    [class.text-emerald-600]="delta.direction === 'up'"
+    [class.text-red-600]="delta.direction === 'down'"
+    [class.text-gray-500]="delta.direction === 'neutral'"
+    [attr.data-testid]="testid()">
+    @if (delta.direction === 'up') {
+      <span aria-hidden="true">▲</span>
+      <span class="sr-only">Increased </span>
+    } @else if (delta.direction === 'down') {
+      <span aria-hidden="true">▼</span>
+      <span class="sr-only">Decreased </span>
+    } @else {
+      <span class="sr-only">No change </span>
+    }
+    {{ delta.deltaLabel }}% {{ delta.periodLabel }}
+  </span>
+}

--- a/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.html
@@ -1,3 +1,6 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
 @if (delta(); as delta) {
   <span
     class="text-sm font-medium"

--- a/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.html
+++ b/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.html
@@ -9,10 +9,10 @@
     [class.text-gray-500]="delta.direction === 'neutral'"
     [attr.data-testid]="testid()">
     @if (delta.direction === 'up') {
-      <span aria-hidden="true">▲</span>
+      <span aria-hidden="true">▲ </span>
       <span class="sr-only">Increased </span>
     } @else if (delta.direction === 'down') {
-      <span aria-hidden="true">▼</span>
+      <span aria-hidden="true">▼ </span>
       <span class="sr-only">Decreased </span>
     } @else {
       <span class="sr-only">No change </span>

--- a/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.ts
+++ b/apps/lfx-one/src/app/shared/components/metric-delta/metric-delta.component.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, input } from '@angular/core';
+import type { PeriodDelta } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-metric-delta',
+  imports: [],
+  templateUrl: './metric-delta.component.html',
+})
+export class MetricDeltaComponent {
+  /** Structured period-over-period delta from `computePeriodDelta`. Renders nothing when null. */
+  public readonly delta = input<PeriodDelta | null>(null);
+  /** Test id applied to the rendered span; defaults to `metric-delta`. */
+  public readonly testid = input<string>('metric-delta');
+}

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -48,6 +48,7 @@ export * from './meeting-attachment.interface';
 
 // Dashboard metric interfaces (unified)
 export * from './dashboard-metric.interface';
+export * from './metric-trend.interface';
 
 // AI interfaces
 export * from './ai.interface';

--- a/packages/shared/src/interfaces/metric-trend.interface.ts
+++ b/packages/shared/src/interfaces/metric-trend.interface.ts
@@ -1,0 +1,13 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Structured period-over-period delta for drawer header rendering.
+ * Produced by `computePeriodDelta`; `deltaLabel` is always an absolute-value
+ * string so the template can render the ▲/▼ arrow and sr-only text separately.
+ */
+export interface PeriodDelta {
+  direction: 'up' | 'down' | 'neutral';
+  deltaLabel: string;
+  periodLabel: string;
+}

--- a/packages/shared/src/utils/metric-trend.utils.spec.ts
+++ b/packages/shared/src/utils/metric-trend.utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { computePeriodChange } from './metric-trend.utils';
+import { computePeriodChange, computePeriodDelta } from './metric-trend.utils';
 
 describe('computePeriodChange', () => {
   it('returns neutral trend and undefined changePercentage for an empty series', () => {
@@ -49,5 +49,53 @@ describe('computePeriodChange', () => {
 
   it('uses only the last two elements of a longer series', () => {
     expect(computePeriodChange([10, 20, 30, 40, 60])).toEqual({ trend: 'up', changePercentage: '▲ +50.0% vs last month' });
+  });
+});
+
+describe('computePeriodDelta', () => {
+  it('returns null for an empty series', () => {
+    expect(computePeriodDelta([])).toBeNull();
+  });
+
+  it('returns null for a single-element series', () => {
+    expect(computePeriodDelta([42])).toBeNull();
+  });
+
+  it('returns null when the prior value is 0', () => {
+    expect(computePeriodDelta([0, 10])).toBeNull();
+  });
+
+  it('classifies a positive delta as up with an absolute percentage', () => {
+    expect(computePeriodDelta([100, 150])).toEqual({ direction: 'up', deltaLabel: '50.0', periodLabel: 'vs last month' });
+  });
+
+  it('classifies a negative delta as down with an absolute percentage', () => {
+    expect(computePeriodDelta([150, 100])).toEqual({ direction: 'down', deltaLabel: '33.3', periodLabel: 'vs last month' });
+  });
+
+  it('classifies an exactly-zero delta as neutral with 0.0', () => {
+    expect(computePeriodDelta([100, 100])).toEqual({ direction: 'neutral', deltaLabel: '0.0', periodLabel: 'vs last month' });
+  });
+
+  it('treats a sub-threshold positive delta as neutral so the arrow never contradicts the rounded 0.0%', () => {
+    // raw +0.04% rounds to 0.0% — direction must stay neutral, not up
+    expect(computePeriodDelta([10000, 10004])).toEqual({ direction: 'neutral', deltaLabel: '0.0', periodLabel: 'vs last month' });
+  });
+
+  it('treats a sub-threshold negative delta as neutral and never leaks -0.0', () => {
+    // raw -0.04% rounds to 0.0% — direction must stay neutral, not down, and no "-0.0" leaks
+    expect(computePeriodDelta([10004, 10000])).toEqual({ direction: 'neutral', deltaLabel: '0.0', periodLabel: 'vs last month' });
+  });
+
+  it('passes the custom period label through', () => {
+    expect(computePeriodDelta([100, 150], 'vs last quarter')).toEqual({
+      direction: 'up',
+      deltaLabel: '50.0',
+      periodLabel: 'vs last quarter',
+    });
+  });
+
+  it('uses only the last two elements of a longer series', () => {
+    expect(computePeriodDelta([10, 20, 30, 40, 60])).toEqual({ direction: 'up', deltaLabel: '50.0', periodLabel: 'vs last month' });
   });
 });

--- a/packages/shared/src/utils/metric-trend.utils.ts
+++ b/packages/shared/src/utils/metric-trend.utils.ts
@@ -28,3 +28,30 @@ export function computePeriodChange(
   }
   return { trend, changePercentage };
 }
+
+/**
+ * Structured period-over-period delta for drawer header rendering — returns the
+ * direction plus an absolute-value percentage label so the template can render
+ * the ▲/▼ arrow and sr-only text separately (matching the Active Contributors
+ * drawer). Returns null when there is no prior period or the prior value is 0.
+ */
+export function computePeriodDelta(
+  values: number[],
+  periodLabel = 'vs last month'
+): { direction: 'up' | 'down' | 'neutral'; deltaLabel: string; periodLabel: string } | null {
+  if (values.length < 2) return null;
+  const latest = values[values.length - 1];
+  const prior = values[values.length - 2];
+  if (prior === 0) return null;
+  const deltaPercent = ((latest - prior) / prior) * 100;
+  let rounded = Number(deltaPercent.toFixed(1));
+  if (Object.is(rounded, -0)) rounded = 0;
+  let direction: 'up' | 'down' | 'neutral' = 'neutral';
+  if (rounded > 0) direction = 'up';
+  else if (rounded < 0) direction = 'down';
+  return {
+    direction,
+    deltaLabel: Math.abs(rounded).toFixed(1),
+    periodLabel,
+  };
+}

--- a/packages/shared/src/utils/metric-trend.utils.ts
+++ b/packages/shared/src/utils/metric-trend.utils.ts
@@ -1,56 +1,54 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-/** Gates the trend arrow on the rounded delta so it never contradicts the displayed "0.0%". Returns neutral + undefined when there is no prior period or the prior value is 0. */
-export function computePeriodChange(
-  values: number[],
-  periodLabel = 'vs last month'
-): { trend: 'up' | 'down' | 'neutral'; changePercentage: string | undefined } {
-  const latest = values.length ? values[values.length - 1] : 0;
-  const prior = values.length > 1 ? values[values.length - 2] : null;
+import type { PeriodDelta } from '../interfaces/metric-trend.interface';
 
-  let trend: 'up' | 'down' | 'neutral' = 'neutral';
-  let changePercentage: string | undefined;
-  if (prior !== null && prior !== 0) {
-    const deltaPercent = ((latest - prior) / prior) * 100;
-    let rounded = Number(deltaPercent.toFixed(1));
-    // Normalize JS -0 to 0 so the label never reads "-0.0%" while trend stays neutral.
-    if (Object.is(rounded, -0)) rounded = 0;
-    if (rounded > 0) {
-      trend = 'up';
-    } else if (rounded < 0) {
-      trend = 'down';
-    }
-    const arrowByTrend: Record<'up' | 'down' | 'neutral', string> = { up: '▲ ', down: '▼ ', neutral: '' };
-    const arrow = arrowByTrend[trend];
-    const sign = trend === 'up' ? '+' : '';
-    changePercentage = `${arrow}${sign}${rounded.toFixed(1)}% ${periodLabel}`;
-  }
-  return { trend, changePercentage };
+type Trend = 'up' | 'down' | 'neutral';
+
+/** Latest/prior pair with the rounded, `-0`-normalized percentage delta. `null` when there is no prior period or the prior value is 0. */
+interface RoundedDelta {
+  rounded: number;
+  trend: Trend;
 }
 
-/**
- * Structured period-over-period delta for drawer header rendering — returns the
- * direction plus an absolute-value percentage label so the template can render
- * the ▲/▼ arrow and sr-only text separately (matching the Active Contributors
- * drawer). Returns null when there is no prior period or the prior value is 0.
- */
-export function computePeriodDelta(
-  values: number[],
-  periodLabel = 'vs last month'
-): { direction: 'up' | 'down' | 'neutral'; deltaLabel: string; periodLabel: string } | null {
+/** Shared rounding + direction logic so `computePeriodChange` and `computePeriodDelta` can never drift on edge cases (sub-threshold deltas, `-0`). */
+function computeRoundedDelta(values: number[]): RoundedDelta | null {
   if (values.length < 2) return null;
   const latest = values[values.length - 1];
   const prior = values[values.length - 2];
   if (prior === 0) return null;
   const deltaPercent = ((latest - prior) / prior) * 100;
   let rounded = Number(deltaPercent.toFixed(1));
+  // Normalize JS -0 to 0 so the label never reads "-0.0%" while trend stays neutral.
   if (Object.is(rounded, -0)) rounded = 0;
-  let direction: 'up' | 'down' | 'neutral' = 'neutral';
-  if (rounded > 0) direction = 'up';
-  else if (rounded < 0) direction = 'down';
+  let trend: Trend = 'neutral';
+  if (rounded > 0) trend = 'up';
+  else if (rounded < 0) trend = 'down';
+  return { rounded, trend };
+}
+
+/** Gates the trend arrow on the rounded delta so it never contradicts the displayed "0.0%". Returns neutral + undefined when there is no prior period or the prior value is 0. */
+export function computePeriodChange(values: number[], periodLabel = 'vs last month'): { trend: Trend; changePercentage: string | undefined } {
+  const result = computeRoundedDelta(values);
+  if (!result) return { trend: 'neutral', changePercentage: undefined };
+  const { rounded, trend } = result;
+  const arrowByTrend: Record<Trend, string> = { up: '▲ ', down: '▼ ', neutral: '' };
+  const sign = trend === 'up' ? '+' : '';
+  return { trend, changePercentage: `${arrowByTrend[trend]}${sign}${rounded.toFixed(1)}% ${periodLabel}` };
+}
+
+/**
+ * Structured period-over-period delta for drawer header rendering — returns the
+ * direction plus an absolute-value percentage label so the template can render
+ * the ▲/▼ arrow and sr-only text separately. Returns null when there is no
+ * prior period or the prior value is 0.
+ */
+export function computePeriodDelta(values: number[], periodLabel = 'vs last month'): PeriodDelta | null {
+  const result = computeRoundedDelta(values);
+  if (!result) return null;
+  const { rounded, trend } = result;
   return {
-    direction,
+    direction: trend,
     deltaLabel: Math.abs(rounded).toFixed(1),
     periodLabel,
   };


### PR DESCRIPTION
# Summary

Reworks the Total Projects drawer in the Foundation dashboard and adds a consistent period-over-period delta indicator to four drawer headers (events, maintainers, total members, total projects). The drawer previously forced users to toggle between a chart view and a table view; this PR replaces that toggle with a stacked layout that shows the trend chart and a separate searchable "All Projects" table side by side, and adds a shared `MetricDeltaComponent` + `computePeriodDelta` util so every drawer renders the same delta treatment beside its headline metric.

# Before / After

**Before:** The Total Projects drawer used a `SelectButton` to toggle between "Chart" and "Table" views, controlled by a `viewForm`, `viewOptions`, a `primaryView` signal, and an `onPrimaryViewChange` handler. Drawer headers showed only the headline metric value with no period-over-period context. The `computePeriodChange` util returned a single pre-formatted string (arrow + sign + percentage + label) that tightly coupled rendering to the util, and each drawer inlined its own metric value formatting. The Foundation Health carousel cards used `min-h-64` with `flex-1 min-h-16` chart heights, which produced inconsistent card heights across chart types. Drawer headline metrics for total members and total projects rendered the all-time total even when monthly data was available.

**After:** The Total Projects drawer renders the trend chart and a searchable, paginated "All Projects" table simultaneously in a stacked layout; the `SelectButton`, `viewForm`, `viewOptions`, `primaryView` signal, and `onPrimaryViewChange` handler are removed. A new shared `MetricDeltaComponent` (`lfx-metric-delta`) renders a structured `PeriodDelta` (direction + absolute-value `deltaLabel` + `periodLabel`) with the ▲/▼ arrow and `sr-only` accessible text emitted separately, and is now used in the events, maintainers, total-members, and total-projects drawer headers. A new `computePeriodDelta` util produces the structured `PeriodDelta`; the rounding / `-0` normalization / direction logic is extracted into a shared `computeRoundedDelta` helper so `computePeriodChange` and `computePeriodDelta` can never drift on edge cases. The Foundation Health carousel cards now use a fixed `h-24` chart height with `items-start` alignment, stabilizing card heights. The total-members and total-projects drawer headline metrics now show the most recent monthly value, falling back to the all-time total only when no monthly data exists, and the maintainers drawer gates its headline metric on `monthlyDataLoading` to avoid flashing stale values. The total-projects drawer palette is normalized from `slate` to `gray`.

# Changes

## Shared package (`@lfx-one/shared`)
- Added `PeriodDelta` interface (`direction: 'up' | 'down' | 'neutral'`, `deltaLabel: string`, `periodLabel: string`) in `interfaces/metric-trend.interface.ts` for structured drawer-header rendering.
- Added `computePeriodDelta(values, periodLabel)` util returning `PeriodDelta | null`; `deltaLabel` is an absolute-value string so the template can render the arrow and `sr-only` text separately.
- Extracted shared `computeRoundedDelta` helper so `computePeriodChange` and `computePeriodDelta` share rounding, `-0` normalization, and direction classification — eliminating the prior duplication.
- Exported the new interface from `interfaces/index.ts`.

## MetricDelta component (new shared component)
- New `lfx-metric-delta` standalone component in `apps/lfx-one/src/app/shared/components/metric-delta/` with `delta` and `testid` inputs.
- Renders nothing when `delta` is null; otherwise renders a colored span (emerald up / red down / gray neutral) with the ▲/▼ glyph, `sr-only` "Increased"/"Decreased"/"No change" text, and the `deltaLabel` + `periodLabel`.
- MIT license header included.

## Total Projects drawer
- Replaced the chart/table toggle view with a stacked layout: trend chart on top, searchable "All Projects" table section below.
- Removed `SelectButtonComponent` import, `viewOptions`, `viewForm`, `primaryView` signal, and `onPrimaryViewChange` handler — no longer needed.
- Added `metricValue` computed signal (last monthly value, falling back to all-time `totalProjects`) and `delta` computed via `computePeriodDelta`.
- Wired `lfx-metric-delta` into the header next to the headline metric.
- Normalized palette from `slate` to `gray`.

## Total Members drawer
- Headline metric now shows the most recent monthly value, falling back to the all-time total when no monthly data exists.
- Added `delta` computed via `computePeriodDelta` and wired `lfx-metric-delta` into the header.

## Maintainers drawer
- Headline metric now gates on `monthlyDataLoading()` (not just `hasData()`) to avoid flashing stale values while monthly data loads.
- Added `delta` computed via `computePeriodDelta` and wired `lfx-metric-delta` into the header.

## Events drawer
- Added `delta` computed via `computePeriodDelta` with the `vs last quarter` period label and wired `lfx-metric-delta` into the header.
- Removed the now-redundant "Foundation events segmented by attendance" subtitle.

## Foundation Health carousel
- Stabilized card height by switching chart cards from `min-h-64` + `flex-1 min-h-16` to a fixed `h-24` chart height with `items-start` alignment on the carousel container, so cards with different chart types render at the same height.

## Tests
- Added `computePeriodDelta` unit tests covering empty/single-element series, zero prior, up/down/neutral classification, sub-threshold deltas rounding to `0.0` with `neutral` direction (no `-0.0` leak), custom period labels, and longer-series last-two-element usage.

## Ticket

[LFXV2-2910](https://linuxfoundation.atlassian.net/browse/LFXV2-2910)


[LFXV2-2910]: https://linuxfoundation.atlassian.net/browse/LFXV2-2910?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ