### PR TITLE
fix(newsletters): keep my newsletters subject on one line

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -94,6 +94,7 @@
               [rows]="10"
               [rowsPerPageOptions]="[10, 25, 50]"
               dataKey="id"
+              tableStyleClass="table-fixed"
               data-testid="my-newsletters-table">
               <ng-template #header>
                 <tr>
@@ -108,17 +109,19 @@
                      Enter/Space); the row click is a supplementary pointer convenience. -->
                 <tr class="cursor-pointer" (click)="onOpenNewsletter(newsletter)" [attr.data-testid]="'my-newsletters-row-' + newsletter.id">
                   <td>
-                    <div class="flex items-center gap-2">
+                    <div class="flex items-center gap-2 min-w-0">
                       <button
                         type="button"
-                        class="lfx-table-name-link text-sm text-gray-900 font-medium text-left"
+                        class="lfx-table-name-link text-sm text-gray-900 font-medium text-left truncate min-w-0"
                         [attr.aria-label]="'Open newsletter ' + newsletter.subject"
+                        [pTooltip]="newsletter.subject"
+                        tooltipPosition="top"
                         (click)="onOpenSubject($event, newsletter)"
                         [attr.data-testid]="'my-newsletters-open-' + newsletter.id">
                         {{ newsletter.subject }}
                       </button>
                       @if (openingId() === newsletter.id) {
-                        <i class="fa-light fa-spinner-third fa-spin text-sm text-gray-400" aria-hidden="true"></i>
+                        <i class="fa-light fa-spinner-third fa-spin text-sm text-gray-400 flex-none" aria-hidden="true"></i>
                       }
                     </div>
                   </td>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -115,6 +115,7 @@
                         class="lfx-table-name-link text-sm text-gray-900 font-medium text-left truncate min-w-0"
                         [attr.aria-label]="'Open newsletter ' + newsletter.subject"
                         [pTooltip]="newsletter.subject"
+                        tooltipEvent="both"
                         tooltipPosition="top"
                         (click)="onOpenSubject($event, newsletter)"
                         [attr.data-testid]="'my-newsletters-open-' + newsletter.id">

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -15,6 +15,7 @@ import { NewsletterService } from '@services/newsletter.service';
 import { PersonaService } from '@services/persona.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, debounceTime, distinctUntilChanged, finalize, of } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
@@ -39,6 +40,7 @@ import { NewsletterPreviewDrawerComponent } from '../components/newsletter-previ
     SelectComponent,
     SkeletonModule,
     TableComponent,
+    TooltipModule,
   ],
   templateUrl: './my-newsletters.component.html',
   styleUrl: './my-newsletters.component.scss',


### PR DESCRIPTION
## Summary

On the My Newsletters page (`/newsletters/my`, Me lens), long newsletter subjects wrapped onto a second line, making the table look uneven. This PR keeps subjects on a single line and tightens the table layout.

- Subject cell: `truncate min-w-0` on the title button with a `pTooltip` (`tooltipEvent="both"`, so it shows on keyboard focus as well as hover) carrying the full subject; the pre-existing `aria-label` keeps the full subject for screen readers; sibling spinner marked `flex-none`.
- Table: `tableStyleClass="table-fixed"` on `lfx-table` so the existing `w-[50%]/w-[20%]/w-[30%]` header widths actually hold — without it, the nowrap subject stole width from the Received and Project/Foundation columns.

A sender/author column was considered and explicitly deferred: the member-facing committee-list DTO upstream (`lfx-v2-newsletter-service`) deliberately omits `created_by`, so it needs an upstream contract change first (noted in LFXV2-2925).

## Test plan

- `yarn lint`, `yarn build` (SSR) pass; `check-headers.sh` clean.
- Verified against the dev server at 1600px and 390px viewports: single-line ellipsized titles, tooltip on hover and on keyboard focus, no column overlap on mobile.
- Existing `e2e/my-newsletters.spec.ts` assertions are unaffected (truncation is CSS-only; testids unchanged); suite verified via CI due to the known local Playwright environment issue.

JIRA: [LFXV2-2925](https://linuxfoundation.atlassian.net/browse/LFXV2-2925)

[LFXV2-2925]: https://linuxfoundation.atlassian.net/browse/LFXV2-2925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ