### PR TITLE
fix(meetings): enable previous occurrence navigation on join page

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -179,8 +179,8 @@
                     </div>
                   }
 
-                  <!-- Occurrence Navigation (recurring meetings only) -->
-                  @if (meeting().recurrence && occurrenceLabel()) {
+                  <!-- Occurrence Navigation (recurring meetings; past pages key off the series timeline since ITX past payloads omit `recurrence`) -->
+                  @if (occurrenceLabel()) {
                     <div class="flex items-center gap-3" data-testid="occurrence-navigation">
                       @if (previousOccurrenceUrl(); as prevUrl) {
                         <a

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -39,11 +39,11 @@ import {
   MeetingHostCandidate,
   MeetingOccurrence,
   MeetingRecurrence,
+  getMeetingSeriesUid,
   MeetingRegistrant,
   MeetingRsvp,
   OccurrenceNavItem,
   resolveOccurrenceRecurrence,
-  PastMeeting,
   PastMeetingAttachment,
   PastMeetingParticipant,
   PastMeetingRecording,
@@ -765,7 +765,7 @@ export class MeetingJoinComponent implements OnInit {
     return toSignal(
       toObservable(this.meeting).pipe(
         filter((meeting) => !!meeting?.recurrence),
-        map((meeting) => this.getSeriesUid(meeting)),
+        map((meeting) => getMeetingSeriesUid(meeting)),
         distinctUntilChanged(),
         switchMap((seriesUid) => this.meetingService.getPublicMeetingOccurrences(seriesUid, this.password()))
       ),
@@ -830,18 +830,13 @@ export class MeetingJoinComponent implements OnInit {
     return `/meetings/${seriesUid}?${params.toString()}`;
   }
 
-  /** Series UID for occurrence URLs — on past pages `meeting.id` is the composite occurrence id, not the series. */
-  private getSeriesUid(meeting: Meeting): string {
-    return (meeting as unknown as PastMeeting).meeting_id || meeting.id;
-  }
-
   private initializePreviousOccurrenceUrl(): Signal<string | null> {
     return computed(() => {
       const meeting = this.meeting();
       if (!meeting?.recurrence) return null;
       const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx <= 0) return null;
-      return this.buildOccurrenceUrl(this.getSeriesUid(meeting), sorted[currentIdx - 1]);
+      return this.buildOccurrenceUrl(getMeetingSeriesUid(meeting), sorted[currentIdx - 1]);
     });
   }
 
@@ -851,7 +846,7 @@ export class MeetingJoinComponent implements OnInit {
       if (!meeting?.recurrence) return null;
       const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx < 0 || currentIdx >= sorted.length - 1) return null;
-      return this.buildOccurrenceUrl(this.getSeriesUid(meeting), sorted[currentIdx + 1]);
+      return this.buildOccurrenceUrl(getMeetingSeriesUid(meeting), sorted[currentIdx + 1]);
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -764,7 +764,10 @@ export class MeetingJoinComponent implements OnInit {
     }
     return toSignal(
       toObservable(this.meeting).pipe(
-        filter((meeting) => !!meeting?.recurrence),
+        // Recurring meetings always fetch. Past payloads (composite id ≠ series uid) fetch even
+        // without a recurrence rule — the ITX past_meetings payload omits `recurrence` entirely,
+        // and the timeline itself reveals whether there is anywhere to navigate.
+        filter((meeting) => !!meeting && (!!meeting.recurrence || getMeetingSeriesUid(meeting) !== meeting.id)),
         map((meeting) => getMeetingSeriesUid(meeting)),
         distinctUntilChanged(),
         switchMap((seriesUid) => this.meetingService.getPublicMeetingOccurrences(seriesUid, this.password()))
@@ -833,7 +836,7 @@ export class MeetingJoinComponent implements OnInit {
   private initializePreviousOccurrenceUrl(): Signal<string | null> {
     return computed(() => {
       const meeting = this.meeting();
-      if (!meeting?.recurrence) return null;
+      if (!meeting) return null;
       const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx <= 0) return null;
       return this.buildOccurrenceUrl(getMeetingSeriesUid(meeting), sorted[currentIdx - 1]);
@@ -843,7 +846,7 @@ export class MeetingJoinComponent implements OnInit {
   private initializeNextOccurrenceUrl(): Signal<string | null> {
     return computed(() => {
       const meeting = this.meeting();
-      if (!meeting?.recurrence) return null;
+      if (!meeting) return null;
       const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx < 0 || currentIdx >= sorted.length - 1) return null;
       return this.buildOccurrenceUrl(getMeetingSeriesUid(meeting), sorted[currentIdx + 1]);
@@ -853,9 +856,12 @@ export class MeetingJoinComponent implements OnInit {
   private initializeOccurrenceLabel(): Signal<string | null> {
     return computed(() => {
       const meeting = this.meeting();
-      if (!meeting?.recurrence) return null;
+      if (!meeting) return null;
       const { sorted, currentIdx } = this.occurrenceContext();
       if (sorted.length === 0) return null;
+      // Payloads without a recurrence rule (e.g. past pages) only surface the nav when the
+      // series timeline actually has somewhere to go.
+      if (!meeting.recurrence && sorted.length < 2) return null;
       return `${currentIdx + 1} of ${sorted.length}`;
     });
   }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -765,10 +765,9 @@ export class MeetingJoinComponent implements OnInit {
     return toSignal(
       toObservable(this.meeting).pipe(
         filter((meeting) => !!meeting?.recurrence),
-        // On past pages the payload is a PastMeeting whose id is the composite occurrence id — meeting_id is the series UID
-        map((meeting) => (meeting as unknown as PastMeeting).meeting_id || meeting.id),
+        map((meeting) => this.getSeriesUid(meeting)),
         distinctUntilChanged(),
-        switchMap((seriesUid) => this.meetingService.getPublicMeetingOccurrences(seriesUid))
+        switchMap((seriesUid) => this.meetingService.getPublicMeetingOccurrences(seriesUid, this.password()))
       ),
       { initialValue: empty }
     );

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -21,6 +21,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import { environment } from '@environments/environment';
 import {
   buildJoinUrlWithParams,
+  buildOccurrenceNavTimeline,
   canJoinMeeting,
   DEFAULT_MEETING_TYPE_CONFIG,
   getActiveOccurrences,
@@ -40,12 +41,15 @@ import {
   MeetingRecurrence,
   MeetingRegistrant,
   MeetingRsvp,
+  OccurrenceNavItem,
   resolveOccurrenceRecurrence,
+  PastMeeting,
   PastMeetingAttachment,
   PastMeetingParticipant,
   PastMeetingRecording,
   PastMeetingSummary,
   Project,
+  PublicMeetingOccurrencesResponse,
   PublicPastMeetingResponse,
   ROOT_PROJECT_SLUG,
   TagSeverity,
@@ -152,7 +156,9 @@ export class MeetingJoinComponent implements OnInit {
   // the per-occurrence override (occurrence.recurrence is null there), so this resolves to the
   // top-level rule until that backend path stamps the effective recurrence. Forward-compatible.
   public displayRecurrence: Signal<MeetingRecurrence | null>;
-  private occurrenceContext: Signal<{ sorted: MeetingOccurrence[]; currentIdx: number }>;
+  // Full series timeline (past + future) fetched from the public occurrences endpoint for recurring meetings.
+  private seriesOccurrences: Signal<PublicMeetingOccurrencesResponse>;
+  private occurrenceContext: Signal<{ sorted: OccurrenceNavItem[]; currentIdx: number }>;
   protected previousOccurrenceUrl: Signal<string | null>;
   protected nextOccurrenceUrl: Signal<string | null>;
   protected occurrenceLabel: Signal<string | null>;
@@ -307,6 +313,7 @@ export class MeetingJoinComponent implements OnInit {
     this.meeting = this.initializeMeeting();
     this.currentOccurrence = this.initializeCurrentOccurrence();
     this.displayRecurrence = computed(() => resolveOccurrenceRecurrence(this.meeting(), this.currentOccurrence()));
+    this.seriesOccurrences = this.initializeSeriesOccurrences();
     this.occurrenceContext = this.initializeOccurrenceContext();
     this.previousOccurrenceUrl = this.initializePreviousOccurrenceUrl();
     this.nextOccurrenceUrl = this.initializeNextOccurrenceUrl();
@@ -746,46 +753,87 @@ export class MeetingJoinComponent implements OnInit {
     });
   }
 
-  private initializeOccurrenceContext(): Signal<{ sorted: MeetingOccurrence[]; currentIdx: number }> {
+  /**
+   * Fetches the full series timeline (past + future occurrences) for recurring meetings.
+   * Skipped on the server — the nav is progressive enhancement; the client fetches at hydration.
+   */
+  private initializeSeriesOccurrences(): Signal<PublicMeetingOccurrencesResponse> {
+    const empty: PublicMeetingOccurrencesResponse = { past: [], future: [] };
+    if (isPlatformServer(this.platformId)) {
+      return signal(empty).asReadonly();
+    }
+    return toSignal(
+      toObservable(this.meeting).pipe(
+        filter((meeting) => !!meeting?.recurrence),
+        // On past pages the payload is a PastMeeting whose id is the composite occurrence id — meeting_id is the series UID
+        map((meeting) => (meeting as unknown as PastMeeting).meeting_id || meeting.id),
+        distinctUntilChanged(),
+        switchMap((seriesUid) => this.meetingService.getPublicMeetingOccurrences(seriesUid))
+      ),
+      { initialValue: empty }
+    );
+  }
+
+  private initializeOccurrenceContext(): Signal<{ sorted: OccurrenceNavItem[]; currentIdx: number }> {
     return computed(() => {
       const meeting = this.meeting();
-      if (!meeting?.occurrences?.length) return { sorted: [], currentIdx: -1 };
-      const sorted = getActiveOccurrences(meeting.occurrences, meeting.cancelled_occurrences).sort(
-        (a: MeetingOccurrence, b: MeetingOccurrence) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime()
-      );
+      if (!meeting) return { sorted: [], currentIdx: -1 };
+      // On past pages the payload's occurrences (if any) describe the live series, not the
+      // viewed occurrence — the merged timeline below supplies both directions instead.
+      const liveOccurrences = !this.loadedViaPastMeetingId() ? getActiveOccurrences(meeting.occurrences ?? [], meeting.cancelled_occurrences) : [];
+      const sorted = buildOccurrenceNavTimeline(liveOccurrences, this.seriesOccurrences(), meeting.duration);
+      if (sorted.length === 0) return { sorted, currentIdx: -1 };
+
+      const routeId = this.activatedRoute.snapshot.paramMap.get('id') ?? '';
+      if (this.loadedViaPastMeetingId()) {
+        // The route id IS the composite past-occurrence id — match it directly first
+        const idxById = sorted.findIndex((o: OccurrenceNavItem) => o.meeting_and_occurrence_id === routeId);
+        if (idxById >= 0) return { sorted, currentIdx: idxById };
+      }
+
       const current = this.currentOccurrence();
       let currentTime: number;
       if (current) {
         currentTime = new Date(current.start_time).getTime();
       } else {
         // For past meetings loaded via /meetings/{id}-{timestamp}, extract timestamp from route
-        const routeId = this.activatedRoute.snapshot.paramMap.get('id') ?? '';
         const parts = routeId.split('-');
         currentTime = parts.length === 2 && /^\d{13}$/.test(parts[1]) ? parseInt(parts[1], 10) : Date.now();
       }
-      let currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() === currentTime);
+      let currentIdx = sorted.findIndex((o: OccurrenceNavItem) => new Date(o.start_time).getTime() === currentTime);
       if (currentIdx < 0) {
-        currentIdx = sorted.findIndex((o: MeetingOccurrence) => new Date(o.start_time).getTime() >= currentTime);
+        currentIdx = sorted.findIndex((o: OccurrenceNavItem) => new Date(o.start_time).getTime() >= currentTime);
       }
       if (currentIdx < 0) currentIdx = sorted.length - 1;
       return { sorted, currentIdx };
     });
   }
 
-  private buildOccurrenceUrl(meetingId: string, occurrence: MeetingOccurrence): string {
-    const timestamp = new Date(occurrence.start_time).getTime();
-    const meeting = this.meeting();
-    const isPast = hasMeetingEnded(meeting, occurrence);
+  private buildOccurrenceUrl(seriesUid: string, occurrence: OccurrenceNavItem): string {
     const password = this.password();
     const params = new URLSearchParams();
     if (password) params.set('password', password);
+    // Past record: its composite id is the canonical past-meeting URL — never reconstruct from start_time
+    if (occurrence.meeting_and_occurrence_id) {
+      const base = `/meetings/${occurrence.meeting_and_occurrence_id}`;
+      const qs = params.toString();
+      return qs ? `${base}?${qs}` : base;
+    }
+    const timestamp = new Date(occurrence.start_time).getTime();
+    const meeting = this.meeting();
+    const isPast = hasMeetingEnded(meeting, occurrence);
     if (isPast) {
-      const base = `/meetings/${meetingId}-${timestamp}`;
+      const base = `/meetings/${seriesUid}-${timestamp}`;
       const qs = params.toString();
       return qs ? `${base}?${qs}` : base;
     }
     params.set('occurrence', timestamp.toString());
-    return `/meetings/${meetingId}?${params.toString()}`;
+    return `/meetings/${seriesUid}?${params.toString()}`;
+  }
+
+  /** Series UID for occurrence URLs — on past pages `meeting.id` is the composite occurrence id, not the series. */
+  private getSeriesUid(meeting: Meeting): string {
+    return (meeting as unknown as PastMeeting).meeting_id || meeting.id;
   }
 
   private initializePreviousOccurrenceUrl(): Signal<string | null> {
@@ -794,7 +842,7 @@ export class MeetingJoinComponent implements OnInit {
       if (!meeting?.recurrence) return null;
       const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx <= 0) return null;
-      return this.buildOccurrenceUrl(meeting.id, sorted[currentIdx - 1]);
+      return this.buildOccurrenceUrl(this.getSeriesUid(meeting), sorted[currentIdx - 1]);
     });
   }
 
@@ -804,7 +852,7 @@ export class MeetingJoinComponent implements OnInit {
       if (!meeting?.recurrence) return null;
       const { sorted, currentIdx } = this.occurrenceContext();
       if (currentIdx < 0 || currentIdx >= sorted.length - 1) return null;
-      return this.buildOccurrenceUrl(meeting.id, sorted[currentIdx + 1]);
+      return this.buildOccurrenceUrl(this.getSeriesUid(meeting), sorted[currentIdx + 1]);
     });
   }
 

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -4,7 +4,7 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
-import { LINKEDIN_PROFILE_PATTERN, PAST_MEETING_RECORDING_CACHE_TTL_MS, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
+import { LINKEDIN_PROFILE_PATTERN, MEETING_PASSWORD_HEADER, PAST_MEETING_RECORDING_CACHE_TTL_MS, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
 import {
   AttachmentDownloadUrlResponse,
   BatchRegistrantOperationResponse,
@@ -216,16 +216,14 @@ export class MeetingService {
 
   /**
    * Fetches the series timeline (past + future occurrences) for occurrence navigation.
-   * The password gates private/restricted series server-side. Degrades to empty on failure.
+   * The password gates private/restricted series server-side; it travels in a request
+   * header so it never appears in the GET URL. Degrades to empty on failure.
    */
   public getPublicMeetingOccurrences(id: string, password?: string | null): Observable<PublicMeetingOccurrencesResponse> {
-    let params = new HttpParams();
-    if (password) {
-      params = params.set('password', password);
-    }
+    const headers = password ? new HttpHeaders({ [MEETING_PASSWORD_HEADER]: password }) : undefined;
 
     return this.http
-      .get<PublicMeetingOccurrencesResponse>(`/public/api/meetings/${id}/occurrences`, { params })
+      .get<PublicMeetingOccurrencesResponse>(`/public/api/meetings/${id}/occurrences`, { headers })
       .pipe(catchError(() => of({ past: [], future: [] } as PublicMeetingOccurrencesResponse)));
   }
 

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -214,10 +214,18 @@ export class MeetingService {
     );
   }
 
-  /** Fetches the series timeline (past + future occurrences) for occurrence navigation. Degrades to empty on failure. */
-  public getPublicMeetingOccurrences(id: string): Observable<PublicMeetingOccurrencesResponse> {
+  /**
+   * Fetches the series timeline (past + future occurrences) for occurrence navigation.
+   * The password gates private/restricted series server-side. Degrades to empty on failure.
+   */
+  public getPublicMeetingOccurrences(id: string, password?: string | null): Observable<PublicMeetingOccurrencesResponse> {
+    let params = new HttpParams();
+    if (password) {
+      params = params.set('password', password);
+    }
+
     return this.http
-      .get<PublicMeetingOccurrencesResponse>(`/public/api/meetings/${id}/occurrences`)
+      .get<PublicMeetingOccurrencesResponse>(`/public/api/meetings/${id}/occurrences`, { params })
       .pipe(catchError(() => of({ past: [], future: [] } as PublicMeetingOccurrencesResponse)));
   }
 

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -31,6 +31,7 @@ import {
   PastMeetingSummary,
   PresignAttachmentRequest,
   PresignAttachmentResponse,
+  PublicMeetingOccurrencesResponse,
   PublicMeetingProject,
   PublicPastMeetingResponse,
   QueryServiceCountResponse,
@@ -211,6 +212,13 @@ export class MeetingService {
         return throwError(() => error);
       })
     );
+  }
+
+  /** Fetches the series timeline (past + future occurrences) for occurrence navigation. Degrades to empty on failure. */
+  public getPublicMeetingOccurrences(id: string): Observable<PublicMeetingOccurrencesResponse> {
+    return this.http
+      .get<PublicMeetingOccurrencesResponse>(`/public/api/meetings/${id}/occurrences`)
+      .pipe(catchError(() => of({ past: [], future: [] } as PublicMeetingOccurrencesResponse)));
   }
 
   public getPublicMeetingJoinUrl(

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -12,6 +12,7 @@ const PROJECT_UID = 'project-2222';
 // to for the host-key gate) reach these through the module mocks registered below.
 const {
   checkAccessMock,
+  addAccessToResourceMock,
   generateM2MTokenMock,
   getEffectiveEmailMock,
   getEffectiveUsernameMock,
@@ -21,6 +22,7 @@ const {
   addInvitedStatusToMeetingMock,
 } = vi.hoisted(() => ({
   checkAccessMock: vi.fn(),
+  addAccessToResourceMock: vi.fn(),
   generateM2MTokenMock: vi.fn(),
   getEffectiveEmailMock: vi.fn(),
   getEffectiveUsernameMock: vi.fn(),
@@ -67,7 +69,7 @@ vi.mock('../services/committee.service', () => ({
 }));
 vi.mock('../services/access-check.service', () => ({
   AccessCheckService: vi.fn(function () {
-    return { checkAccess: checkAccessMock };
+    return { checkAccess: checkAccessMock, addAccessToResource: addAccessToResourceMock };
   }),
 }));
 vi.mock('../services/logger.service', () => ({
@@ -339,18 +341,74 @@ describe('PublicMeetingController.getMeetingOccurrences', () => {
     expect(JSON.stringify(payload)).not.toContain('should not leak');
   });
 
-  it('degrades to an empty future list when the live series fetch fails (deleted/ended series)', async () => {
+  it('fails closed when the live series fetch fails (visibility cannot be verified)', async () => {
     meetingSvc.getPastOccurrencesForMeeting.mockResolvedValue(pastSummaries);
     meetingSvc.getMeetingById.mockRejectedValue(new Error('itx 404'));
     const { req, res, next } = buildReqRes(false);
 
     await controller.getMeetingOccurrences(req, res, next);
 
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0].statusCode).toBe(403);
+    expect(meetingSvc.getPastOccurrencesForMeeting).not.toHaveBeenCalled();
+  });
+
+  it('denies an anonymous caller for a private meeting without a password', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE } as Partial<Meeting>));
+    validatePasswordMock.mockReturnValue(false);
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingOccurrences(req, res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0].statusCode).toBe(403);
+    expect(meetingSvc.getPastOccurrencesForMeeting).not.toHaveBeenCalled();
+  });
+
+  it('allows a private meeting with a valid password', async () => {
+    meetingSvc.getPastOccurrencesForMeeting.mockResolvedValue(pastSummaries);
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE, password: 'pw' } as Partial<Meeting>));
+    validatePasswordMock.mockReturnValue(true);
+    const { req, res, next } = buildReqRes(false);
+    req.query.password = 'pw';
+
+    await controller.getMeetingOccurrences(req, res, next);
+
     expect(next).not.toHaveBeenCalled();
-    const payload = res.json.mock.calls[0][0];
-    expect(payload.past).toEqual(pastSummaries);
-    expect(payload.future).toEqual([]);
-    expect(payload.cancelled_occurrences).toBeUndefined();
+    expect(res.json.mock.calls[0][0].past).toEqual(pastSummaries);
+  });
+
+  it('allows an authenticated registrant on a restricted meeting via the M2M email check', async () => {
+    meetingSvc.getPastOccurrencesForMeeting.mockResolvedValue(pastSummaries);
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ restricted: true } as Partial<Meeting>));
+    validatePasswordMock.mockReturnValue(false);
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([{ email: 'user@example.com' }]);
+    const { req, res, next } = buildReqRes(true);
+
+    await controller.getMeetingOccurrences(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.getMeetingRegistrantsByEmail).toHaveBeenCalledWith(req, MEETING_ID, 'user@example.com', 'm2m-token');
+    expect(res.json.mock.calls[0][0].past).toEqual(pastSummaries);
+  });
+
+  it('allows an authenticated organizer on a private meeting and restores the M2M token', async () => {
+    meetingSvc.getPastOccurrencesForMeeting.mockResolvedValue(pastSummaries);
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE } as Partial<Meeting>));
+    validatePasswordMock.mockReturnValue(false);
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([]);
+    addAccessToResourceMock.mockImplementation(async (_req: any, resource: any) => ({ ...resource, organizer: true }));
+    const { req, res, next } = buildReqRes(true);
+
+    await controller.getMeetingOccurrences(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].past).toEqual(pastSummaries);
+    expect(req.bearerToken).toBe('m2m-token');
   });
 
   it('runs with an M2M token (public endpoint, no user session required)', async () => {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -32,6 +32,7 @@ const {
     // Called by enrichMeetingsWithCreatedBy (#1155); empty map => enrich is a no-op.
     resolveCreatedByForMeetings: vi.fn().mockResolvedValue(new Map()),
     getMeetingHostKey: vi.fn(),
+    getPastOccurrencesForMeeting: vi.fn(),
   },
   projectSvc: { getProjectById: vi.fn() },
   addInvitedStatusToMeetingMock: vi.fn(),
@@ -281,5 +282,86 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.invited).toBe(true);
     expect(payload.meeting.host_key).toBeUndefined();
+  });
+});
+
+describe('PublicMeetingController.getMeetingOccurrences', () => {
+  let controller: PublicMeetingController;
+
+  const T1 = Date.UTC(2026, 6, 16, 9, 30);
+  const T2 = Date.UTC(2026, 6, 30, 9, 30);
+
+  const pastSummaries = [
+    {
+      meeting_and_occurrence_id: `${MEETING_ID}-${T1}`,
+      scheduled_start_time: new Date(T1).toISOString(),
+      scheduled_end_time: new Date(T1 + 30 * 60000).toISOString(),
+    },
+  ];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicMeetingController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+  });
+
+  it('returns past summaries plus a minimal projection of live occurrences without leaking sensitive fields', async () => {
+    meetingSvc.getPastOccurrencesForMeeting.mockResolvedValue(pastSummaries);
+    meetingSvc.getMeetingById.mockResolvedValue(
+      buildMeeting({
+        password: 'secret',
+        cancelled_occurrences: ['1784323800'],
+        occurrences: [
+          {
+            occurrence_id: String(Math.floor(T2 / 1000)),
+            start_time: new Date(T2).toISOString(),
+            duration: 30,
+            status: 'available',
+            title: 'should not leak',
+            description: 'should not leak',
+            registrant_count: 12,
+          },
+        ],
+      } as Partial<Meeting>)
+    );
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingOccurrences(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.past).toEqual(pastSummaries);
+    expect(payload.cancelled_occurrences).toEqual(['1784323800']);
+    expect(payload.future).toHaveLength(1);
+    // Minimal projection only — timestamps and status, no titles/descriptions/counts
+    expect(Object.keys(payload.future[0]).sort()).toEqual(['duration', 'occurrence_id', 'start_time', 'status']);
+    expect(JSON.stringify(payload)).not.toContain('secret');
+    expect(JSON.stringify(payload)).not.toContain('should not leak');
+  });
+
+  it('degrades to an empty future list when the live series fetch fails (deleted/ended series)', async () => {
+    meetingSvc.getPastOccurrencesForMeeting.mockResolvedValue(pastSummaries);
+    meetingSvc.getMeetingById.mockRejectedValue(new Error('itx 404'));
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingOccurrences(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.past).toEqual(pastSummaries);
+    expect(payload.future).toEqual([]);
+    expect(payload.cancelled_occurrences).toBeUndefined();
+  });
+
+  it('runs with an M2M token (public endpoint, no user session required)', async () => {
+    meetingSvc.getPastOccurrencesForMeeting.mockResolvedValue([]);
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    const { req, res } = buildReqRes(false);
+    const next = vi.fn();
+
+    await controller.getMeetingOccurrences(req, res, next);
+
+    expect(generateM2MTokenMock).toHaveBeenCalledTimes(1);
+    expect(req.bearerToken).toBe('m2m-token');
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -49,7 +49,7 @@ vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public',
 vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null) }));
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.
-vi.mock('@lfx-one/shared/constants', () => ({ HOST_KEY_EARLY_MINUTES: 70, HOST_KEY_LATE_MINUTES: 40 }));
+vi.mock('@lfx-one/shared/constants', () => ({ HOST_KEY_EARLY_MINUTES: 70, HOST_KEY_LATE_MINUTES: 40, MEETING_PASSWORD_HEADER: 'x-meeting-password' }));
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
 
 vi.mock('../services/meeting.service', () => ({
@@ -124,6 +124,7 @@ function buildReqRes(authenticated: boolean, hasUserToken = true) {
   const req = {
     params: { id: MEETING_ID },
     query: {},
+    headers: {},
     // Optional-auth routes can be authenticated with no user bearer token (refresh failure).
     bearerToken: hasUserToken ? 'user-token' : undefined,
     oidc: { isAuthenticated: () => authenticated },
@@ -372,7 +373,7 @@ describe('PublicMeetingController.getMeetingOccurrences', () => {
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE, password: 'pw' } as Partial<Meeting>));
     validatePasswordMock.mockReturnValue(true);
     const { req, res, next } = buildReqRes(false);
-    req.query.password = 'pw';
+    req.headers['x-meeting-password'] = 'pw';
 
     await controller.getMeetingOccurrences(req, res, next);
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -3,7 +3,7 @@
 
 import { Meeting } from '@lfx-one/shared';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
-import { CreateMeetingRegistrantRequest, MeetingRegistrant } from '@lfx-one/shared/interfaces';
+import { CreateMeetingRegistrantRequest, MeetingOccurrence, MeetingRegistrant, PublicMeetingOccurrencesResponse } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -352,6 +352,62 @@ export class PublicMeetingController {
         full_access: fullAccess,
       });
     } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /public/api/meetings/:id/occurrences
+   * Returns the series timeline for a meeting: past occurrences (from v1_past_meeting
+   * records) plus a minimal projection of the live series' current/future occurrences.
+   * Timestamps only — no titles, passwords, or join info.
+   */
+  public async getMeetingOccurrences(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id } = req.params;
+
+    const startTime = logger.startOperation(req, 'get_public_meeting_occurrences', {
+      meeting_id: id,
+    });
+
+    try {
+      if (!this.validateMeetingId(id, 'get_public_meeting_occurrences', req, next)) {
+        return;
+      }
+
+      await this.setupM2MToken(req);
+
+      // Live series fetch degrades to null (deleted/ended series still has past occurrences)
+      const [past, liveMeeting] = await Promise.all([
+        this.meetingService.getPastOccurrencesForMeeting(req, id),
+        this.meetingService.getMeetingById(req, id, 'v1_meeting', false).catch(() => null),
+      ]);
+
+      // Minimal projection only — the full ITX payload carries sensitive fields (e.g. password)
+      const future: MeetingOccurrence[] = (liveMeeting?.occurrences ?? []).map(
+        (o) =>
+          ({
+            occurrence_id: o.occurrence_id,
+            start_time: o.start_time,
+            duration: o.duration,
+            status: o.status,
+          }) as MeetingOccurrence
+      );
+
+      const response: PublicMeetingOccurrencesResponse = {
+        past,
+        future,
+        cancelled_occurrences: liveMeeting?.cancelled_occurrences ?? undefined,
+      };
+
+      logger.success(req, 'get_public_meeting_occurrences', startTime, {
+        meeting_id: id,
+        past_count: past.length,
+        future_count: future.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      // Error handler will log
       next(error);
     }
   }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Meeting } from '@lfx-one/shared';
+import { MEETING_PASSWORD_HEADER } from '@lfx-one/shared/constants';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import { CreateMeetingRegistrantRequest, MeetingOccurrenceSummary, MeetingRegistrant, PublicMeetingOccurrencesResponse } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
@@ -629,7 +630,9 @@ export class PublicMeetingController {
       return true;
     }
 
-    const { password } = req.query;
+    // The passcode arrives in a request header (never the GET query string, which lands
+    // in access logs and caches — CodeQL js/sensitive-get-query).
+    const password = req.headers[MEETING_PASSWORD_HEADER];
     if (typeof password === 'string' && password && validatePassword(password, meeting.password as string)) {
       return true;
     }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -3,7 +3,7 @@
 
 import { Meeting } from '@lfx-one/shared';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
-import { CreateMeetingRegistrantRequest, MeetingOccurrence, MeetingRegistrant, PublicMeetingOccurrencesResponse } from '@lfx-one/shared/interfaces';
+import { CreateMeetingRegistrantRequest, MeetingOccurrenceSummary, MeetingRegistrant, PublicMeetingOccurrencesResponse } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -360,7 +360,8 @@ export class PublicMeetingController {
    * GET /public/api/meetings/:id/occurrences
    * Returns the series timeline for a meeting: past occurrences (from v1_past_meeting
    * records) plus a minimal projection of the live series' current/future occurrences.
-   * Timestamps only — no titles, passwords, or join info.
+   * Timestamps only — no titles, passwords, or join info. Private/restricted series are
+   * gated by the same access chain as getMeetingById (password, registrant, organizer).
    */
   public async getMeetingOccurrences(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
@@ -374,24 +375,35 @@ export class PublicMeetingController {
         return;
       }
 
-      await this.setupM2MToken(req);
+      // Save the user's original token before setting M2M token (needed for the organizer check)
+      const originalToken = req.bearerToken;
+      const m2mToken = await this.setupM2MToken(req);
 
-      // Live series fetch degrades to null (deleted/ended series still has past occurrences)
-      const [past, liveMeeting] = await Promise.all([
-        this.meetingService.getPastOccurrencesForMeeting(req, id),
-        this.meetingService.getMeetingById(req, id, 'v1_meeting', false).catch(() => null),
-      ]);
+      const liveMeeting = await this.meetingService.getMeetingById(req, id, 'v1_meeting', false).catch(() => null);
+
+      // Fail closed: when the live series can't be loaded, its visibility can't be
+      // verified, so the timeline is not exposed.
+      const allowed = liveMeeting ? await this.canViewSeriesTimeline(req, liveMeeting, m2mToken, originalToken) : false;
+      if (!allowed) {
+        next(
+          new AuthorizationError('Not authorized to view this meeting series', {
+            operation: 'get_public_meeting_occurrences',
+            service: 'public_meeting_controller',
+            path: req.path,
+          })
+        );
+        return;
+      }
+
+      const past = await this.meetingService.getPastOccurrencesForMeeting(req, id);
 
       // Minimal projection only — the full ITX payload carries sensitive fields (e.g. password)
-      const future: MeetingOccurrence[] = (liveMeeting?.occurrences ?? []).map(
-        (o) =>
-          ({
-            occurrence_id: o.occurrence_id,
-            start_time: o.start_time,
-            duration: o.duration,
-            status: o.status,
-          }) as MeetingOccurrence
-      );
+      const future: MeetingOccurrenceSummary[] = (liveMeeting?.occurrences ?? []).map((o) => ({
+        occurrence_id: o.occurrence_id,
+        start_time: o.start_time,
+        duration: o.duration,
+        status: o.status,
+      }));
 
       const response: PublicMeetingOccurrencesResponse = {
         past,
@@ -603,6 +615,64 @@ export class PublicMeetingController {
       operation,
       service: 'public_meeting_controller',
     });
+  }
+
+  /**
+   * Access gate for the public series-timeline endpoint, mirroring getMeetingById's chain:
+   * public non-restricted series are open; private/restricted series require a valid
+   * password, a registrant record (checked via M2M, matching the invited fallback), or an
+   * organizer relation (checked with the user's own token — never the M2M identity).
+   * Restores the M2M token on req before returning.
+   */
+  private async canViewSeriesTimeline(req: Request, meeting: Meeting, m2mToken: string, originalToken: string | undefined): Promise<boolean> {
+    if (meeting.visibility === MeetingVisibility.PUBLIC && !meeting.restricted) {
+      return true;
+    }
+
+    const { password } = req.query;
+    if (typeof password === 'string' && password && validatePassword(password, meeting.password as string)) {
+      return true;
+    }
+
+    if (!req.oidc?.isAuthenticated()) {
+      return false;
+    }
+
+    const email = getEffectiveEmail(req);
+    if (email) {
+      try {
+        const registrants = await this.meetingService.getMeetingRegistrantsByEmail(req, meeting.id, email, m2mToken);
+        if (registrants.length > 0) {
+          return true;
+        }
+      } catch (error) {
+        logger.warning(req, 'get_public_meeting_occurrences', 'Registrant check failed, continuing to organizer check', {
+          meeting_id: meeting.id,
+          err: error,
+        });
+      }
+    }
+
+    // Guard on originalToken, not just isAuthenticated: running the access check while the
+    // M2M token is active would evaluate the application identity and could leak access.
+    if (originalToken !== undefined) {
+      req.bearerToken = originalToken;
+      try {
+        const meetingWithAccess = await this.accessCheckService.addAccessToResource(req, { ...meeting }, 'v1_meeting', 'organizer');
+        if (meetingWithAccess.organizer) {
+          return true;
+        }
+      } catch (error) {
+        logger.warning(req, 'get_public_meeting_occurrences', 'Organizer check failed, denying series timeline access', {
+          meeting_id: meeting.id,
+          err: error,
+        });
+      } finally {
+        req.bearerToken = m2mToken;
+      }
+    }
+
+    return false;
   }
 
   /**

--- a/apps/lfx-one/src/server/routes/public-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/public-meetings.route.ts
@@ -14,6 +14,9 @@ router.post('/register', (req, res, next) => publicMeetingController.registerFor
 // GET /public/api/meetings/past/:id - get a past meeting with tiered access (public access, no authentication required)
 router.get('/past/:id', (req, res, next) => publicMeetingController.getPublicPastMeetingById(req, res, next));
 
+// GET /public/api/meetings/:id/occurrences - get the series timeline (past + future occurrences) for a meeting (public access, no authentication required)
+router.get('/:id/occurrences', (req, res, next) => publicMeetingController.getMeetingOccurrences(req, res, next));
+
 // GET /public/api/meetings/:id - get a single meeting (public access, no authentication required)
 router.get('/:id', (req, res, next) => publicMeetingController.getMeetingById(req, res, next));
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -229,16 +229,33 @@ describe('MeetingService.getPastOccurrencesForMeeting', () => {
     expect(Object.keys(result[0]).sort()).toEqual(['meeting_and_occurrence_id', 'scheduled_end_time', 'scheduled_start_time']);
   });
 
-  it('drops records missing meeting_and_occurrence_id or scheduled_start_time', async () => {
+  it('drops records missing meeting_and_occurrence_id or any start time', async () => {
     const t1 = Date.UTC(2026, 6, 16, 9, 30);
     proxyRequest.mockResolvedValueOnce({
-      resources: [pastRecord(t1), pastRecord(t1 + 1, { meeting_and_occurrence_id: undefined }), pastRecord(t1 + 2, { scheduled_start_time: undefined })],
+      resources: [
+        pastRecord(t1),
+        pastRecord(t1 + 1, { meeting_and_occurrence_id: undefined }),
+        pastRecord(t1 + 2, { scheduled_start_time: undefined, start_time: undefined }),
+      ],
     });
 
     const result = await service.getPastOccurrencesForMeeting(req, 'series-1');
 
     expect(result).toHaveLength(1);
     expect(result[0].meeting_and_occurrence_id).toBe(`series-1-${t1}`);
+  });
+
+  it('falls back to start_time when the indexed record omits scheduled_start_time', async () => {
+    const t1 = Date.UTC(2026, 6, 16, 9, 30);
+    proxyRequest.mockResolvedValueOnce({
+      resources: [pastRecord(t1, { scheduled_start_time: undefined, scheduled_end_time: undefined, start_time: new Date(t1).toISOString() })],
+    });
+
+    const result = await service.getPastOccurrencesForMeeting(req, 'series-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].scheduled_start_time).toBe(new Date(t1).toISOString());
+    expect(result[0].scheduled_end_time).toBeUndefined();
   });
 
   it('follows page_token pagination across pages', async () => {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -184,3 +184,80 @@ describe('MeetingService.getMeetingHostKey', () => {
     expect(result).toBeNull();
   });
 });
+
+describe('MeetingService.getPastOccurrencesForMeeting', () => {
+  let service: MeetingService;
+
+  const pastRecord = (ms: number, overrides: Record<string, unknown> = {}) => ({
+    id: `v1_past_meeting:series-1-${ms}`,
+    data: {
+      meeting_id: 'series-1',
+      meeting_and_occurrence_id: `series-1-${ms}`,
+      scheduled_start_time: new Date(ms).toISOString(),
+      scheduled_end_time: new Date(ms + 30 * 60000).toISOString(),
+      title: 'should not leak',
+      ...overrides,
+    },
+  });
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('queries v1_past_meeting filtered by the series meeting_id without filter_grants', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [] });
+
+    await service.getPastOccurrencesForMeeting(req, 'series-1');
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    const params = proxyRequest.mock.calls[0][4];
+    expect(params.type).toBe('v1_past_meeting');
+    expect(params.filters).toEqual(['meeting_id:series-1']);
+    expect(params).not.toHaveProperty('filter_grants');
+  });
+
+  it('maps records to minimal summaries sorted ascending by scheduled start', async () => {
+    const t1 = Date.UTC(2026, 6, 16, 9, 30);
+    const t2 = Date.UTC(2026, 6, 23, 9, 30);
+    proxyRequest.mockResolvedValueOnce({ resources: [pastRecord(t2), pastRecord(t1)] });
+
+    const result = await service.getPastOccurrencesForMeeting(req, 'series-1');
+
+    expect(result.map((r) => r.meeting_and_occurrence_id)).toEqual([`series-1-${t1}`, `series-1-${t2}`]);
+    // Minimal projection only — no title or other past-meeting fields
+    expect(Object.keys(result[0]).sort()).toEqual(['meeting_and_occurrence_id', 'scheduled_end_time', 'scheduled_start_time']);
+  });
+
+  it('drops records missing meeting_and_occurrence_id or scheduled_start_time', async () => {
+    const t1 = Date.UTC(2026, 6, 16, 9, 30);
+    proxyRequest.mockResolvedValueOnce({
+      resources: [pastRecord(t1), pastRecord(t1 + 1, { meeting_and_occurrence_id: undefined }), pastRecord(t1 + 2, { scheduled_start_time: undefined })],
+    });
+
+    const result = await service.getPastOccurrencesForMeeting(req, 'series-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].meeting_and_occurrence_id).toBe(`series-1-${t1}`);
+  });
+
+  it('follows page_token pagination across pages', async () => {
+    const t1 = Date.UTC(2026, 6, 16, 9, 30);
+    const t2 = Date.UTC(2026, 6, 23, 9, 30);
+    proxyRequest.mockResolvedValueOnce({ resources: [pastRecord(t1)], page_token: 'next' }).mockResolvedValueOnce({ resources: [pastRecord(t2)] });
+
+    const result = await service.getPastOccurrencesForMeeting(req, 'series-1');
+
+    expect(proxyRequest).toHaveBeenCalledTimes(2);
+    expect(proxyRequest.mock.calls[1][4].page_token).toBe('next');
+    expect(result).toHaveLength(2);
+  });
+
+  it('returns an empty list when the query service call fails', async () => {
+    proxyRequest.mockRejectedValueOnce(new Error('query service down'));
+
+    const result = await service.getPastOccurrencesForMeeting(req, 'series-1');
+
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -27,6 +27,7 @@ import {
   PastMeetingSummary,
   PastMeetingTranscript,
   PastMeetingTranscriptContent,
+  PastOccurrenceSummary,
   PresignAttachmentRequest,
   PresignAttachmentResponse,
   QueryServiceCountResponse,
@@ -287,6 +288,60 @@ export class MeetingService {
     });
 
     return meeting;
+  }
+
+  /**
+   * Fetches all past occurrences of a meeting series as a minimal timestamp projection.
+   *
+   * Each past occurrence is its own v1_past_meeting record keyed by the series UID
+   * (`meeting_id`). No `filter_grants` — callers run this in a public/M2M context and
+   * the projection carries timestamps only.
+   */
+  public async getPastOccurrencesForMeeting(req: Request, meetingUid: string): Promise<PastOccurrenceSummary[]> {
+    logger.debug(req, 'get_past_occurrences_for_meeting', 'Fetching past occurrences', {
+      meeting_id: meetingUid,
+    });
+
+    const records = await fetchAllQueryResources<PastMeeting>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<PastMeeting>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type: 'v1_past_meeting',
+        filters: [`meeting_id:${meetingUid}`],
+        page_size: 500,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    ).catch((error) => {
+      logger.warning(req, 'get_past_occurrences_for_meeting', 'Failed to fetch past occurrences, returning empty list', {
+        meeting_id: meetingUid,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      });
+      return [] as PastMeeting[];
+    });
+
+    const dropped = records.filter((r) => !r.meeting_and_occurrence_id || !r.scheduled_start_time);
+    if (dropped.length > 0) {
+      logger.warning(req, 'get_past_occurrences_for_meeting', 'Dropping past occurrences missing composite id or start time', {
+        meeting_id: meetingUid,
+        dropped_count: dropped.length,
+      });
+    }
+
+    const summaries = records
+      .filter((r): r is PastMeeting & { meeting_and_occurrence_id: string } => !!r.meeting_and_occurrence_id && !!r.scheduled_start_time)
+      .map(
+        (r): PastOccurrenceSummary => ({
+          meeting_and_occurrence_id: r.meeting_and_occurrence_id,
+          scheduled_start_time: r.scheduled_start_time,
+          scheduled_end_time: r.scheduled_end_time,
+        })
+      )
+      .sort((a, b) => new Date(a.scheduled_start_time).getTime() - new Date(b.scheduled_start_time).getTime());
+
+    logger.debug(req, 'get_past_occurrences_for_meeting', 'Completed past occurrences fetch', {
+      meeting_id: meetingUid,
+      count: summaries.length,
+    });
+
+    return summaries;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -295,7 +295,8 @@ export class MeetingService {
    *
    * Each past occurrence is its own v1_past_meeting record keyed by the series UID
    * (`meeting_id`). No `filter_grants` — callers run this in a public/M2M context and
-   * the projection carries timestamps only.
+   * the projection carries timestamps only. Completeness is not guaranteed: a later-page
+   * fetch failure returns the pages already accumulated (acceptable for navigation).
    */
   public async getPastOccurrencesForMeeting(req: Request, meetingUid: string): Promise<PastOccurrenceSummary[]> {
     logger.debug(req, 'get_past_occurrences_for_meeting', 'Fetching past occurrences', {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -318,7 +318,9 @@ export class MeetingService {
       return [] as PastMeeting[];
     });
 
-    const dropped = records.filter((r) => !r.meeting_and_occurrence_id || !r.scheduled_start_time);
+    // The indexed v1_past_meeting projection frequently omits scheduled_start_time and only
+    // carries start_time (same reality sortPastMeetingsDescending handles) — accept either.
+    const dropped = records.filter((r) => !r.meeting_and_occurrence_id || !(r.scheduled_start_time || r.start_time));
     if (dropped.length > 0) {
       logger.warning(req, 'get_past_occurrences_for_meeting', 'Dropping past occurrences missing composite id or start time', {
         meeting_id: meetingUid,
@@ -327,12 +329,12 @@ export class MeetingService {
     }
 
     const summaries = records
-      .filter((r): r is PastMeeting & { meeting_and_occurrence_id: string } => !!r.meeting_and_occurrence_id && !!r.scheduled_start_time)
+      .filter((r): r is PastMeeting & { meeting_and_occurrence_id: string } => !!r.meeting_and_occurrence_id && !!(r.scheduled_start_time || r.start_time))
       .map(
         (r): PastOccurrenceSummary => ({
           meeting_and_occurrence_id: r.meeting_and_occurrence_id,
-          scheduled_start_time: r.scheduled_start_time,
-          scheduled_end_time: r.scheduled_end_time,
+          scheduled_start_time: r.scheduled_start_time || r.start_time,
+          scheduled_end_time: r.scheduled_end_time || undefined,
         })
       )
       .sort((a, b) => new Date(a.scheduled_start_time).getTime() - new Date(b.scheduled_start_time).getTime());

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -15,6 +15,14 @@ export const DEFAULT_QUERY_PARAMS: Record<string, string> = {
 };
 
 /**
+ * Request header carrying a meeting passcode to public endpoints.
+ * @description Keeps the passcode out of GET query strings, where it would land in
+ * access logs and caches (CodeQL js/sensitive-get-query). Lowercase to match
+ * Express's normalized req.headers keys.
+ */
+export const MEETING_PASSWORD_HEADER = 'x-meeting-password';
+
+/**
  * Maximum number of `filters_or` clauses per query-service request.
  * @description URL-length guard for batched lookups on `/query/resources`. When the caller has
  * more than this many IDs/values to OR together, split into chunks of this size to keep each

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -751,6 +751,43 @@ export interface PastMeeting extends Meeting {
 }
 
 /**
+ * Minimal projection of a v1_past_meeting record for occurrence navigation
+ * @description Timestamps only — safe to expose on the public occurrences endpoint
+ */
+export interface PastOccurrenceSummary {
+  /** Composite meeting and occurrence ID (e.g., "99152950841-1630560600000") */
+  meeting_and_occurrence_id: string;
+  /** Scheduled start time of the past occurrence */
+  scheduled_start_time: string;
+  /** Scheduled end time of the past occurrence */
+  scheduled_end_time?: string;
+}
+
+/**
+ * Series timeline for the public meeting occurrences endpoint
+ * @description Past occurrences from v1_past_meeting records plus a minimal
+ * projection of the live series' current/future occurrences
+ */
+export interface PublicMeetingOccurrencesResponse {
+  /** Past occurrences, ascending by scheduled start time */
+  past: PastOccurrenceSummary[];
+  /** Current/future occurrences (minimal projection); empty when the series no longer exists */
+  future: MeetingOccurrence[];
+  /** Cancelled occurrence IDs from the live series (10-digit Unix-second keys) */
+  cancelled_occurrences?: string[];
+}
+
+/**
+ * Occurrence navigation entry on the meeting join page
+ * @description A live/future occurrence, or a past occurrence when the
+ * composite meeting_and_occurrence_id is present
+ */
+export interface OccurrenceNavItem extends MeetingOccurrence {
+  /** Composite past-meeting ID — present only for past occurrences; links directly to /meetings/{id} */
+  meeting_and_occurrence_id?: string;
+}
+
+/**
  * Past meeting participant information
  * @description Individual participant who was invited/attended a past meeting
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -764,6 +764,13 @@ export interface PastOccurrenceSummary {
 }
 
 /**
+ * Minimal projection of a live occurrence for the public occurrences endpoint
+ * @description Timestamps and status only — titles, descriptions, and counts are
+ * deliberately excluded from the public payload
+ */
+export type MeetingOccurrenceSummary = Pick<MeetingOccurrence, 'occurrence_id' | 'start_time' | 'duration' | 'status'>;
+
+/**
  * Series timeline for the public meeting occurrences endpoint
  * @description Past occurrences from v1_past_meeting records plus a minimal
  * projection of the live series' current/future occurrences
@@ -772,7 +779,7 @@ export interface PublicMeetingOccurrencesResponse {
   /** Past occurrences, ascending by scheduled start time */
   past: PastOccurrenceSummary[];
   /** Current/future occurrences (minimal projection); empty when the series no longer exists */
-  future: MeetingOccurrence[];
+  future: MeetingOccurrenceSummary[];
   /** Cancelled occurrence IDs from the live series (10-digit Unix-second keys) */
   cancelled_occurrences?: string[];
 }

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -9,9 +9,10 @@ import '@angular/compiler';
 import { describe, expect, it, vi } from 'vitest';
 
 import { RecurrenceType } from '../enums';
-import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, QueryServiceItem } from '../interfaces';
+import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, PastOccurrenceSummary, QueryServiceItem } from '../interfaces';
 import {
   buildCommitteeCadenceSummary,
+  buildOccurrenceNavTimeline,
   buildMeetingOrganizerChip,
   buildMeetingOrganizerMailto,
   buildRecurrenceNeverEndDate,
@@ -790,5 +791,92 @@ describe('selectPrimaryPastMeetingSummary', () => {
     ];
 
     expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('newer-created');
+  });
+});
+
+describe('buildOccurrenceNavTimeline', () => {
+  const T1 = Date.UTC(2026, 6, 16, 9, 30); // Jul 16
+  const T2 = Date.UTC(2026, 6, 23, 9, 30); // Jul 23
+  const T3 = Date.UTC(2026, 6, 30, 9, 30); // Jul 30 (current)
+  const T4 = Date.UTC(2026, 7, 6, 9, 30); // Aug 6
+
+  const live = (instant: number, overrides: Partial<MeetingOccurrence> = {}): MeetingOccurrence => ({
+    occurrence_id: String(Math.floor(instant / 1000)),
+    start_time: new Date(instant).toISOString(),
+    duration: 30,
+    ...overrides,
+  });
+
+  const pastRecord = (instant: number, overrides: Partial<PastOccurrenceSummary> = {}): PastOccurrenceSummary => ({
+    meeting_and_occurrence_id: `series-uid-${instant}`,
+    scheduled_start_time: new Date(instant).toISOString(),
+    scheduled_end_time: new Date(instant + 30 * 60000).toISOString(),
+    ...overrides,
+  });
+
+  it('merges past records before live occurrences in ascending order', () => {
+    const result = buildOccurrenceNavTimeline([live(T3), live(T4)], { past: [pastRecord(T2), pastRecord(T1)], future: [] });
+
+    expect(result.map((o) => new Date(o.start_time).getTime())).toEqual([T1, T2, T3, T4]);
+    expect(result[0].meeting_and_occurrence_id).toBe(`series-uid-${T1}`);
+    expect(result[2].meeting_and_occurrence_id).toBeUndefined();
+  });
+
+  it('prefers the live entry when a past record exists for the same instant (in-progress occurrence)', () => {
+    const result = buildOccurrenceNavTimeline([live(T3)], { past: [pastRecord(T3)], future: [] });
+
+    expect(result).toHaveLength(1);
+    expect(result[0].meeting_and_occurrence_id).toBeUndefined();
+  });
+
+  it('uses endpoint future occurrences when no live payload is available (past page)', () => {
+    const result = buildOccurrenceNavTimeline([], { past: [pastRecord(T1)], future: [live(T3), live(T4)] });
+
+    expect(result.map((o) => new Date(o.start_time).getTime())).toEqual([T1, T3, T4]);
+  });
+
+  it('filters cancelled endpoint future occurrences via cancelled_occurrences ids', () => {
+    const cancelled = live(T4);
+    const result = buildOccurrenceNavTimeline([], {
+      past: [],
+      future: [live(T3), cancelled],
+      cancelled_occurrences: [cancelled.occurrence_id],
+    });
+
+    expect(result.map((o) => new Date(o.start_time).getTime())).toEqual([T3]);
+  });
+
+  it('derives the past instant from the composite id suffix, not scheduled_start_time', () => {
+    // Composite suffix and scheduled_start_time disagree — the suffix is authoritative
+    const result = buildOccurrenceNavTimeline([], {
+      past: [pastRecord(T1, { meeting_and_occurrence_id: `series-uid-${T2}` })],
+      future: [],
+    });
+
+    expect(new Date(result[0].start_time).getTime()).toBe(T2);
+    expect(result[0].occurrence_id).toBe(String(Math.floor(T2 / 1000)));
+  });
+
+  it('skips past records whose composite id has no 13-digit millisecond suffix', () => {
+    const result = buildOccurrenceNavTimeline([], {
+      past: [pastRecord(T1, { meeting_and_occurrence_id: 'series-uid-only' })],
+      future: [],
+    });
+
+    expect(result).toHaveLength(0);
+  });
+
+  it('computes past duration from scheduled times with a fallback for missing end times', () => {
+    const result = buildOccurrenceNavTimeline(
+      [],
+      {
+        past: [pastRecord(T1), pastRecord(T2, { scheduled_end_time: undefined })],
+        future: [],
+      },
+      45
+    );
+
+    expect(result[0].duration).toBe(30);
+    expect(result[1].duration).toBe(45);
   });
 });

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -9,10 +9,20 @@ import '@angular/compiler';
 import { describe, expect, it, vi } from 'vitest';
 
 import { RecurrenceType } from '../enums';
-import { CustomRecurrencePattern, Meeting, MeetingOccurrence, MeetingRecurrence, PastMeeting, PastMeetingSummary, PastOccurrenceSummary, QueryServiceItem } from '../interfaces';
+import {
+  CustomRecurrencePattern,
+  Meeting,
+  MeetingOccurrence,
+  MeetingRecurrence,
+  PastMeeting,
+  PastMeetingSummary,
+  PastOccurrenceSummary,
+  QueryServiceItem,
+} from '../interfaces';
 import {
   buildCommitteeCadenceSummary,
   buildOccurrenceNavTimeline,
+  getMeetingSeriesUid,
   buildMeetingOrganizerChip,
   buildMeetingOrganizerMailto,
   buildRecurrenceNeverEndDate,
@@ -791,6 +801,26 @@ describe('selectPrimaryPastMeetingSummary', () => {
     ];
 
     expect(selectPrimaryPastMeetingSummary(resources)?.uid).toBe('newer-created');
+  });
+});
+
+describe('getMeetingSeriesUid', () => {
+  it('returns meeting_id for past-meeting payloads whose id is the composite occurrence id', () => {
+    const past = { id: 'series-1-1789551000000', meeting_id: 'series-1' } as PastMeeting;
+
+    expect(getMeetingSeriesUid(past)).toBe('series-1');
+  });
+
+  it('returns id for live meeting payloads without meeting_id', () => {
+    const meeting = { id: 'series-1' } as Meeting;
+
+    expect(getMeetingSeriesUid(meeting)).toBe('series-1');
+  });
+
+  it('falls back to id when meeting_id is present but empty', () => {
+    const past = { id: 'series-1', meeting_id: '' } as PastMeeting;
+
+    expect(getMeetingSeriesUid(past)).toBe('series-1');
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -336,6 +336,8 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
  * Entries are deduped by their Unix-millisecond start instant with priority
  * live > endpoint future > past record, so an in-progress occurrence whose
  * v1_past_meeting record is already forming keeps its joinable live entry.
+ * `cancelled_occurrences` filtering applies to future entries only — a cancelled
+ * occurrence never runs, so no v1_past_meeting record exists to filter.
  * Past entries derive their canonical instant from the composite
  * `meeting_and_occurrence_id` suffix (authoritative for past-meeting URLs),
  * not from `scheduled_start_time`.

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -330,6 +330,18 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
 }
 
 /**
+ * Resolves the series UID for a meeting payload without casting: past-meeting
+ * payloads carry the originating series UID in `meeting_id` while their `id` is
+ * the composite occurrence id (`{uid}-{ms-timestamp}`); live payloads use `id`.
+ */
+export function getMeetingSeriesUid(meeting: Meeting): string {
+  if ('meeting_id' in meeting && typeof meeting.meeting_id === 'string' && meeting.meeting_id) {
+    return meeting.meeting_id;
+  }
+  return meeting.id;
+}
+
+/**
  * Merges a meeting's live occurrences with the series timeline from the public
  * occurrences endpoint into one ascending navigation list.
  *

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -14,9 +14,11 @@ import {
   MeetingOrganizerLink,
   MeetingRecurrence,
   MeetingUserInfo,
+  OccurrenceNavItem,
   PastMeeting,
   PastMeetingSummary,
   PastMeetingTranscript,
+  PublicMeetingOccurrencesResponse,
   QueryServiceItem,
   RecurrenceSummary,
   SummaryData,
@@ -325,6 +327,65 @@ export function getCurrentOrNextOccurrence(meeting: Meeting): MeetingOccurrence 
     .sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
 
   return futureOccurrences.length > 0 ? futureOccurrences[0] : null;
+}
+
+/**
+ * Merges a meeting's live occurrences with the series timeline from the public
+ * occurrences endpoint into one ascending navigation list.
+ *
+ * Entries are deduped by their Unix-millisecond start instant with priority
+ * live > endpoint future > past record, so an in-progress occurrence whose
+ * v1_past_meeting record is already forming keeps its joinable live entry.
+ * Past entries derive their canonical instant from the composite
+ * `meeting_and_occurrence_id` suffix (authoritative for past-meeting URLs),
+ * not from `scheduled_start_time`.
+ *
+ * @param liveOccurrences Active (non-cancelled) occurrences from the live meeting payload
+ * @param series Timeline from the public occurrences endpoint
+ * @param fallbackDuration Duration (minutes) for past entries lacking an end time
+ * @returns Merged occurrence list sorted ascending by start instant
+ */
+export function buildOccurrenceNavTimeline(
+  liveOccurrences: MeetingOccurrence[],
+  series: PublicMeetingOccurrencesResponse,
+  fallbackDuration?: number
+): OccurrenceNavItem[] {
+  const byInstant = new Map<number, OccurrenceNavItem>();
+
+  const addIfAbsent = (instant: number, item: OccurrenceNavItem): void => {
+    if (!Number.isFinite(instant) || byInstant.has(instant)) {
+      return;
+    }
+    byInstant.set(instant, item);
+  };
+
+  for (const occurrence of liveOccurrences) {
+    addIfAbsent(new Date(occurrence.start_time).getTime(), occurrence);
+  }
+
+  for (const occurrence of getActiveOccurrences(series.future, series.cancelled_occurrences)) {
+    addIfAbsent(new Date(occurrence.start_time).getTime(), occurrence);
+  }
+
+  for (const past of series.past) {
+    const suffix = past.meeting_and_occurrence_id.split('-').pop() ?? '';
+    const instant = /^\d{13}$/.test(suffix) ? parseInt(suffix, 10) : NaN;
+    if (!Number.isFinite(instant)) {
+      continue;
+    }
+    const scheduledDuration =
+      past.scheduled_end_time && past.scheduled_start_time
+        ? Math.round((new Date(past.scheduled_end_time).getTime() - new Date(past.scheduled_start_time).getTime()) / 60000)
+        : 0;
+    addIfAbsent(instant, {
+      meeting_and_occurrence_id: past.meeting_and_occurrence_id,
+      occurrence_id: String(Math.floor(instant / 1000)),
+      start_time: new Date(instant).toISOString(),
+      duration: scheduledDuration > 0 ? scheduledDuration : (fallbackDuration ?? 0),
+    });
+  }
+
+  return [...byInstant.values()].sort((a, b) => new Date(a.start_time).getTime() - new Date(b.start_time).getTime());
 }
 
 /**


### PR DESCRIPTION
## Summary

On the public meeting join page, the Previous/Next occurrence navigation for recurring meetings always showed the current occurrence as "1 of N" with Previous permanently disabled. The nav logic was correct — the upstream `GET /itx/meetings/:id` payload only carries current + future occurrences, so the page never knew any past occurrences existed.

Fixes [LFXV2-2926](https://linuxfoundation.atlassian.net/browse/LFXV2-2926) (introduced with the original nav in LFXV2-1470).

## Changes

- **New public endpoint** `GET /public/api/meetings/:id/occurrences` — returns the series timeline: `past` (minimal projection of `v1_past_meeting` records queried by series `meeting_id` under M2M) + `future` (minimal `MeetingOccurrenceSummary` projection of the live series) + `cancelled_occurrences`. Timestamps only; no titles, passwords, or join info.
- **Access gate** — private/restricted series are gated by the same chain as the public meeting detail endpoint: valid password → registrant record (M2M email check) → organizer relation (checked with the user's own token, restored to M2M in `finally`). Fails closed with an opaque 403 when the live series can't be loaded.
- **Join page** merges the timeline into its occurrence nav via a new shared `buildOccurrenceNavTimeline` util (dedupe by start instant, priority live > future > past). Past entries link directly to `/meetings/{meeting_and_occurrence_id}` — no timestamp reconstruction. The nav now also works on past-meeting pages (`/meetings/{id}-{ts}`), which previously had no series context.
- New shared types (`PastOccurrenceSummary`, `PublicMeetingOccurrencesResponse`, `MeetingOccurrenceSummary`, `OccurrenceNavItem`) and a cast-free `getMeetingSeriesUid` accessor.

## Documented trade-offs

- **Fail-closed on unloadable series:** if the live `v1_meeting` is gone (deleted/fully-ended series), the endpoint returns 403 rather than serving past occurrences whose visibility can't be verified. The frontend degrades gracefully (nav simply absent). Security-over-feature by design.
- **Partial pagination tolerated:** a later-page query failure returns the accumulated pages (navigation is progressive enhancement); documented in the service JSDoc.
- **Upstream filter dependency:** `filters=meeting_id:{uid}` on `v1_past_meeting` follows the query service's standard `term` filter mechanics (`data.*` fields; same pattern used on `v1_past_meeting_participant` and registrant types). Please confirm in dev that the filter returns rows before merge — if the field ever proves unindexed, the fallback is a `tags`-based scope.

## Testing

- 24 new unit tests: shared util (merge order, dedupe priority, composite-id authority, cancelled filtering, duration fallback, series-uid accessor), BFF service (filter shape, no `filter_grants`, pagination, drop-invalid, error→empty), controller (access matrix incl. anonymous-denied / password / registrant / organizer / fail-closed, sensitive-field leak assertions, M2M token restore).
- `yarn lint`, `yarn build` (SSR bundle), and both vitest suites pass; local Playwright e2e is broken environment-wide (known issue) — manual browser verification recommended on a recurring meeting: label should read e.g. "27 of 76" with Previous walking into past occurrence pages and Next walking back toward today.

[LFXV2-2926]: https://linuxfoundation.atlassian.net/browse/LFXV2-2926?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ