### PR TITLE
feat(org-lens): show meeting delta percentages, link to org projects

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-influence/org-meetings-influence.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/components/org-meetings-influence/org-meetings-influence.component.html
@@ -126,14 +126,13 @@
                 </span>
               </td>
               <td class="px-4 py-3 text-right align-middle">
-                <!-- The Project-lens meetings page is addressed by slug via a query param, not by uid
-                   on a path segment. It renders for any authenticated user, so the link needs no
-                   per-row access hint. -->
+                <!-- Sibling child of the same 'org' route parent as this page, so it is reachable by
+                   anyone who can see this table and needs no per-row access hint. Addressed by slug
+                   on a path segment, not by uid. -->
                 <a
                   class="inline-flex items-center gap-1 text-xs font-medium text-blue-700 hover:underline"
-                  routerLink="/project/meetings"
-                  [queryParams]="{ project: row.projectSlug }"
-                  [attr.aria-label]="'View ' + row.project + ' in Projects'"
+                  [routerLink]="['/org/projects', row.projectSlug]"
+                  [attr.aria-label]="'View ' + row.project + ' project detail'"
                   (click)="$event.stopPropagation()">
                   Projects
                   <i class="fa-light fa-arrow-up-right" aria-hidden="true"></i>

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.spec.ts
@@ -1,0 +1,180 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Request } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors project.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's vitest
+// config, so every runtime (non-type-only) import needs a stub.
+vi.mock('@lfx-one/shared/constants', () => ({
+  DEFAULT_LFX_ONE_PLATINUM_SCHEMA: 'ANALYTICS.PLATINUM_LFX_ONE',
+  VALKEY_CACHE: { ORG_LENS_SNOWFLAKE_TTL_SECONDS: 3600 },
+}));
+
+const { execute, withOrgCache } = vi.hoisted(() => ({
+  execute: vi.fn(),
+  withOrgCache: vi.fn(),
+}));
+
+vi.mock('./logger.service', () => ({ logger: { debug: vi.fn(), warning: vi.fn(), error: vi.fn() } }));
+vi.mock('./snowflake.service', () => ({ SnowflakeService: { getInstance: () => ({ execute }) } }));
+vi.mock('./valkey.service', () => ({ withOrgCache }));
+
+const { OrgLensMeetingsService } = await import('./org-lens-meetings.service');
+
+const req = {} as Request;
+
+/** The delta rules are only reachable through the public reads, so exercise them there. */
+function kpiRow(current: number, prior: number): Record<string, number> {
+  return {
+    EMPLOYEES_ACTIVE: current,
+    MEETINGS_ATTENDED: current,
+    PROJECTS_SUPPORTED: current,
+    FOUNDATIONS_SUPPORTED: current,
+    PRIOR_EMPLOYEES_ACTIVE: prior,
+    PRIOR_MEETINGS_ATTENDED: prior,
+    PRIOR_PROJECTS_SUPPORTED: prior,
+    PRIOR_FOUNDATIONS_SUPPORTED: prior,
+  };
+}
+
+function influenceRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    PROJECT_SLUG: 'bootc',
+    PROJECT_NAME: 'bootc',
+    ECOSYSTEM_INFLUENCE: 42,
+    BAND: 'leading',
+    RANK: 1,
+    RANK_TOTAL: 10,
+    FROM_ATTENDANCE_PCT: 46,
+    DELTA_PCT: 9.9,
+    PRIOR_YEAR_SCORE: 38,
+    TREND_DIRECTION: 'up',
+    BREAKDOWN: null,
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // Run the read-through factory directly so the mapping under test is what gets asserted.
+  withOrgCache.mockImplementation(async (_account: string, _key: string, _ttl: number, factory: () => Promise<unknown>) => factory());
+});
+
+describe('OrgLensMeetingsService — KPI delta labels', () => {
+  it.each([
+    { current: 108, prior: 100, expected: '+8% vs. prior period', direction: 'up' },
+    { current: 93, prior: 100, expected: '-7% vs. prior period', direction: 'down' },
+    { current: 100, prior: 100, expected: 'No change vs. prior period', direction: 'flat' },
+    // Rounds to zero rather than rendering "+0%".
+    { current: 1002, prior: 1000, expected: 'No change vs. prior period', direction: 'flat' },
+  ])('renders $expected for $current vs $prior', async ({ current, prior, expected, direction }) => {
+    execute.mockResolvedValue({ rows: [kpiRow(current, prior)] });
+
+    const summary = await new OrgLensMeetingsService().getKpiSummary(req, 'acc', 'past365d');
+
+    expect(summary.meetingsAttendedDeltaLabel).toBe(expected);
+    expect(summary.meetingsAttendedDeltaDirection).toBe(direction);
+  });
+
+  it('renders "New" from a zero baseline rather than an infinite percentage', async () => {
+    execute.mockResolvedValue({ rows: [kpiRow(12, 0)] });
+
+    const summary = await new OrgLensMeetingsService().getKpiSummary(req, 'acc', 'past365d');
+
+    expect(summary.meetingsAttendedDeltaLabel).toBe('New');
+    expect(summary.meetingsAttendedDeltaDirection).toBe('up');
+  });
+
+  it('reports no change when both periods are zero', async () => {
+    execute.mockResolvedValue({ rows: [kpiRow(0, 0)] });
+
+    const summary = await new OrgLensMeetingsService().getKpiSummary(req, 'acc', 'past365d');
+
+    expect(summary.meetingsAttendedDeltaLabel).toBe('No change vs. prior period');
+    expect(summary.meetingsAttendedDeltaDirection).toBe('flat');
+  });
+
+  // The case DR-020 turns on: a negligible prior period is no longer suppressed behind a phrase.
+  it.each([
+    { current: 1180, prior: 1, expected: '+117,900% vs. prior period' },
+    { current: 168, prior: 1, expected: '+16,700% vs. prior period' },
+    { current: 110, prior: 10, expected: '+1,000% vs. prior period' },
+  ])('renders the grouped percentage $expected instead of a phrase', async ({ current, prior, expected }) => {
+    execute.mockResolvedValue({ rows: [kpiRow(current, prior)] });
+
+    const summary = await new OrgLensMeetingsService().getKpiSummary(req, 'acc', 'past365d');
+
+    expect(summary.meetingsAttendedDeltaLabel).toBe(expected);
+    expect(summary.meetingsAttendedDeltaDirection).toBe('up');
+  });
+
+  it('groups a large decline too, and keeps the sign', async () => {
+    execute.mockResolvedValue({ rows: [kpiRow(100, 10000)] });
+
+    const summary = await new OrgLensMeetingsService().getKpiSummary(req, 'acc', 'past365d');
+
+    expect(summary.meetingsAttendedDeltaLabel).toBe('-99% vs. prior period');
+    expect(summary.meetingsAttendedDeltaDirection).toBe('down');
+  });
+});
+
+describe('OrgLensMeetingsService — influence row delta labels', () => {
+  async function firstRow(overrides: Record<string, unknown> = {}) {
+    execute.mockResolvedValue({ rows: [influenceRow(overrides)] });
+    const rows = await new OrgLensMeetingsService().getInfluenceRows(req, 'acc');
+    return rows[0];
+  }
+
+  it('renders the warehouse percentage with the warehouse trend direction', async () => {
+    const row = await firstRow({ DELTA_PCT: 9.9, TREND_DIRECTION: 'down' });
+
+    expect(row.deltaLabel).toBe('+9.9% YoY');
+    // DR-011: direction comes from TREND_DIRECTION, not the sign of the percentage.
+    expect(row.deltaDirection).toBe('down');
+  });
+
+  it('renders "New" from a zero prior-year score', async () => {
+    const row = await firstRow({ PRIOR_YEAR_SCORE: 0 });
+
+    expect(row.deltaLabel).toBe('New');
+    expect(row.deltaDirection).toBe('up');
+  });
+
+  it('treats a sub-epsilon prior score as zero rather than dividing by it', async () => {
+    const row = await firstRow({ PRIOR_YEAR_SCORE: 1e-9 });
+
+    expect(row.deltaLabel).toBe('New');
+  });
+
+  // An absent prior score is unknown, not small — the one case with no percentage to fall back to.
+  it.each([{ PRIOR_YEAR_SCORE: null }, { PRIOR_YEAR_SCORE: undefined }])(
+    'keeps the unknown-baseline label when the prior score is absent',
+    async (overrides) => {
+      const row = await firstRow(overrides);
+
+      expect(row.deltaLabel).toBe('No comparable prior period');
+      expect(row.deltaDirection).toBe('flat');
+    }
+  );
+
+  it('groups an oversized YoY percentage instead of suppressing it', async () => {
+    const row = await firstRow({ DELTA_PCT: 61328.8 });
+
+    expect(row.deltaLabel).toBe('+61,328.8% YoY');
+  });
+});
+
+describe('OrgLensMeetingsService — cache keys', () => {
+  it.each([
+    { surface: 'kpi', call: (s: InstanceType<typeof OrgLensMeetingsService>) => s.getKpiSummary(req, 'acc', 'past365d'), key: 'meetings-kpi:v2:past365d' },
+    { surface: 'influence', call: (s: InstanceType<typeof OrgLensMeetingsService>) => s.getInfluenceRows(req, 'acc'), key: 'meetings-influence:v2' },
+    { surface: 'spend', call: (s: InstanceType<typeof OrgLensMeetingsService>) => s.getSpendBreakdown(req, 'acc', 'past365d'), key: 'meetings-spend:past365d' },
+  ])('$surface reads from $key', async ({ call, key }) => {
+    execute.mockResolvedValue({ rows: [] });
+
+    await call(new OrgLensMeetingsService());
+
+    expect(withOrgCache).toHaveBeenCalledWith('acc', key, 3600, expect.any(Function), expect.anything());
+  });
+});

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
@@ -31,19 +31,13 @@ const TREND_DIRECTIONS: readonly OrgMeetingsDeltaDirection[] = ['up', 'down', 'f
 const KPI_NO_CHANGE_LABEL = 'No change vs. prior period';
 const INFLUENCE_NO_CHANGE_LABEL = 'No change YoY';
 const NEW_LABEL = 'New';
-const NO_COMPARABLE_BASELINE_LABEL = 'No comparable prior period';
 
 /**
- * Above this growth rate the prior period was too thin to be a baseline, and the ratio describes the
- * emptiness of that window rather than the organization's activity. Only ~3.5 years of attendance
- * history exist, so the long windows compare against a nearly-empty preceding period: prod holds 113
- * org/window rows above this line, most with a prior of exactly 1, topping out near +115,000%.
- *
- * Deliberately a ceiling on the computed ratio rather than a floor on the prior count. Suppressing
- * every small baseline would relabel ~3,090 rows to fix ~87 of them, discarding legitimate readings
- * like "2 meetings → 3" (+50%), and would still miss the priors of 3 and 6 that also explode.
+ * For an influence row whose `PRIOR_YEAR_SCORE` is absent — not zero, and not small. There is no
+ * percentage to render because there is no baseline to divide by. An oversized ratio is a different
+ * case and renders its number.
  */
-const MAX_MEANINGFUL_DELTA_PCT = 1000;
+const UNKNOWN_BASELINE_LABEL = 'No comparable prior period';
 
 /**
  * `PRIOR_YEAR_SCORE` is a continuous score, so an exact `=== 0` test would let a stored 1e-7 fall
@@ -60,7 +54,7 @@ type SpendBreakdownKind = 'foundation' | 'project' | 'meeting_type' | 'role';
  * time someone edits one of the label constants.
  */
 interface FormattedDelta {
-  kind: 'no-change' | 'runaway' | 'pct';
+  kind: 'no-change' | 'pct';
   label: string;
   direction: OrgMeetingsDeltaDirection;
 }
@@ -207,11 +201,10 @@ export class OrgLensMeetingsService {
 
   /**
    * A zero prior period has no percentage to express, so it renders "New" rather than an infinite
-   * one, and a near-zero one renders a statement rather than a ratio in the tens of thousands.
-   * Whole percents match the counts' own granularity, and a change that rounds to zero is reported
-   * as no change rather than as "+0%".
-   *
-   * Only the upside needs the ceiling: a decline is bounded at -100%, so it cannot run away.
+   * one. Every other delta renders its percentage, however large: a thin prior period produces a
+   * five-figure ratio, but that reflects ~3.5 years of attendance history rather than an error, and
+   * showing it keeps the coverage gap visible. Whole percents match the counts' own granularity, and
+   * a change that rounds to zero is reported as no change rather than as "+0%".
    */
   private kpiDelta(current: unknown, prior: unknown): { value: number; label: string; direction: OrgMeetingsDeltaDirection } {
     const value = this.toCount(current);
@@ -226,16 +219,10 @@ export class OrgLensMeetingsService {
     return { value, label, direction };
   }
 
-  /**
-   * Shared tail of both delta rules: no change, a runaway ratio, or a signed percentage. Only the
-   * upside is bounded — a decline cannot pass -100%, so it can never run away.
-   */
+  /** Shared tail of both delta rules: no change, or a signed percentage. */
   private formatDelta(pct: number, suffix: string, noChangeLabel: string): FormattedDelta {
     if (pct === 0) {
       return { kind: 'no-change', label: noChangeLabel, direction: 'flat' };
-    }
-    if (pct > MAX_MEANINGFUL_DELTA_PCT) {
-      return { kind: 'runaway', label: NO_COMPARABLE_BASELINE_LABEL, direction: 'up' };
     }
     return { kind: 'pct', label: `${this.signed(pct)}${suffix}`, direction: pct > 0 ? 'up' : 'down' };
   }
@@ -305,7 +292,7 @@ export class OrgLensMeetingsService {
     // direction is flat because there is no baseline to have moved from.
     const priorScoreRaw = row.PRIOR_YEAR_SCORE === null || row.PRIOR_YEAR_SCORE === undefined ? NaN : Number(row.PRIOR_YEAR_SCORE);
     if (!Number.isFinite(priorScoreRaw)) {
-      return { label: NO_COMPARABLE_BASELINE_LABEL, direction: 'flat' };
+      return { label: UNKNOWN_BASELINE_LABEL, direction: 'flat' };
     }
 
     if (priorScoreRaw < INFLUENCE_ZERO_SCORE_EPSILON) {
@@ -414,8 +401,13 @@ export class OrgLensMeetingsService {
     return direction && TREND_DIRECTIONS.includes(direction) ? direction : 'flat';
   }
 
+  /**
+   * Grouped because a thin prior period pushes the ratio into six figures, where "+115000" is hard to
+   * size at a glance. The locale is pinned so the server renders the same string everywhere.
+   */
   private signed(value: number): string {
-    return value > 0 ? `+${value}` : `${value}`;
+    const formatted = Math.abs(value).toLocaleString('en-US');
+    return value > 0 ? `+${formatted}` : `-${formatted}`;
   }
 
   private toFiniteNumber(value: unknown): number {

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
@@ -78,7 +78,11 @@ export class OrgLensMeetingsService {
   public async getKpiSummary(req: Request, accountId: string, range: OrgMeetingsSupportedTimeRange): Promise<OrgMeetingsKpiSummary> {
     return withOrgCache(
       accountId,
-      `meetings-kpi:${range}`,
+      // `v2`: entries written before the delta ceiling was retired hold the old "No comparable prior
+      // period" label. The shape is unchanged, so `isKpiSummary` accepts them and they would serve
+      // the retired label for up to a TTL. Versioning the sub-resource key moves reads to a fresh
+      // space without discarding the other Org Lens surfaces under the shared namespace.
+      `meetings-kpi:v2:${range}`,
       VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
       async () => {
         // Only logged on a miss, so the absence of this line in a trace means the cache served it —
@@ -145,7 +149,10 @@ export class OrgLensMeetingsService {
   public async getInfluenceRows(req: Request, accountId: string): Promise<OrgInfluenceRow[]> {
     return withOrgCache(
       accountId,
-      'meetings-influence',
+      // `v2`: same reason as the KPI key — the Δ-YoY column shares the delta formatter, so cached
+      // rows can carry the retired label. `meetings-spend` is deliberately left at v1; it has no
+      // delta labels, so evicting it would discard warm entries for no behaviour change.
+      'meetings-influence:v2',
       VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
       async () => {
         logger.debug(req, 'get_org_lens_meetings_influence', 'Cache miss; querying Snowflake', { account_id: accountId });


### PR DESCRIPTION
Jira: [LFXV2-2928](https://linuxfoundation.atlassian.net/browse/LFXV2-2928)

## Summary

Two behaviour changes to the **Org Lens → Meetings** page, both reversing a decision that was taken from endpoint output before the result had been seen rendered.

**1. The KPI delta shows its percentage instead of "No comparable prior period."**

Any increase above +1000% was replaced with that phrase, so Red Hat's default `past365d` view said nothing on all four cards. The oversized ratios come from only ~3.5 years of attendance history leaving the long windows a near-empty prior period — a data-coverage gap the label hid rather than fixed. The ceiling is retired and the percentage renders with thousand separators so six figures stay legible.

Unchanged: a zero prior period still reads **"New"** (there is no percentage to compute), and a zero change still reads "No change". The label itself is retained — renamed `UNKNOWN_BASELINE_LABEL` — for the genuinely different case of an influence row whose `PRIOR_YEAR_SCORE` is *absent* rather than small.

The formatter is shared, so the influence table's Δ-YoY column follows the same rule.

**2. The influence row's "Projects ↗" link targets the Org lens.**

It opened the Project-lens meetings page — a different lens showing a different subject (meetings the caller can see, not the org's involvement). It now goes to `/org/projects/{projectSlug}`, matching how the Org Lens Projects table already links to project detail.

This also simplifies the ADR-0039 position: the target is a sibling child of the same `org` route parent, behind the same guard and org grant as the page hosting the link, so a caller can never hold a weaker relation to the target than to the surface they are already on. No access-hint fields are needed, and the response stays fully caller-independent.

## Test plan

- [x] `yarn lint:check`, `yarn check-types`, `yarn format:check`, `yarn build` — all pass
- [x] **Verified live** against dev (`localhost:4200`, prod `ANALYTICS.PLATINUM_LFX_ONE`):
  - Red Hat, Inc. KPI strip renders `+16,700%` / `+117,900%` / `+7,600%` / `+3,400%` — separators applied, no phrase
  - Influence Δ-YoY still renders ordinary values (`+9.9% YoY`, `-13.5% YoY`, `New`)
  - Every influence row links to `/org/projects/{slug}` with an aria-label naming the destination
  - Click-through from `/org/meetings` → `/org/projects/bootc` renders the project detail page, confirming an influence-sourced slug resolves
- [ ] `yarn e2e` not run — the suite's mocked payloads use small deltas and assert nothing about the link target

## Notes for reviewers

- Decision records live in the umbrella workspace and are in a companion PR: DR-020 supersedes DR-019 (the ceiling), DR-021 supersedes DR-018 on the link target only — DR-018's withdrawal of `projectUid` / `canOpenProjectLens` is re-derived from the new target and still stands, so the contract is unchanged.
- The `lfx-skills` reviewer trio was not available in the session that produced this; a Bugbot review of the diff returned clean, but the repo-specific convention and learnings reviewers have not run.

Made with [Cursor](https://cursor.com)

[LFXV2-2928]: https://linuxfoundation.atlassian.net/browse/LFXV2-2928?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ