### PR TITLE
ci: add merge_group trigger to required checks

### DIFF
--- a/.github/workflows/license-header-check.yml
+++ b/.github/workflows/license-header-check.yml
@@ -7,6 +7,7 @@ name: License Header Check
 on:
   pull_request:
     types: [opened, synchronize, reopened]
+  merge_group:
   push:
     branches:
       - main

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  merge_group:
   push:
     branches:
       - main


### PR DESCRIPTION
## Summary

- Add `merge_group` trigger to `quality-check.yml` so code quality checks run in the merge queue
- Add `merge_group` trigger to `license-header-check.yml` so license checks run in the merge queue

Without these triggers, required status checks don't run for merge queue entries, blocking merges.

## Notes

The `e2e-tests` workflow is a reusable `workflow_call` workflow (currently commented out in quality-check). If uncommented, it would work correctly in merge queue context — the PR comment step is already gated on `github.event_name == 'pull_request'` and naturally skips.

Issue: [LFXV2-2817](https://linuxfoundation.atlassian.net/browse/LFXV2-2817)

[LFXV2-2817]: https://linuxfoundation.atlassian.net/browse/LFXV2-2817?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ