### PR TITLE
fix(documents): map Shared By from upstream audit user profiles

### DIFF
--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -910,9 +910,6 @@ export class CommitteeController {
 
       const data: CreateCommitteeDocumentRequest = req.body;
 
-      // Always override created_by_name from OIDC session — never trust client-provided values
-      data.created_by_name = (req.oidc?.user?.['name'] as string) || (req.oidc?.user?.['nickname'] as string) || '';
-
       // Validate required fields
       const validDocTypes = ['link', 'folder'];
       const fieldErrors: Record<string, string> = {};

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -542,9 +542,7 @@ export class ProjectController {
         return;
       }
 
-      // Reject null / array / primitive bodies before mutating — otherwise the
-      // `data.created_by_name = ...` assignment below would 500 instead of returning a
-      // typed validation error.
+      // Reject null / array / primitive bodies before building the request payload.
       if (req.body === null || typeof req.body !== 'object' || Array.isArray(req.body)) {
         next(
           ServiceValidationError.forField('body', 'Request body must be a JSON object', {
@@ -556,12 +554,7 @@ export class ProjectController {
         return;
       }
 
-      // Build a fresh object so we don't mutate `req.body`. Always override
-      // `created_by_name` from the OIDC session — never trust client-provided values.
-      const data: CreateProjectDocumentRequest = {
-        ...(req.body as CreateProjectDocumentRequest),
-        created_by_name: (req.oidc?.user?.['name'] as string) || (req.oidc?.user?.['nickname'] as string) || '',
-      };
+      const data: CreateProjectDocumentRequest = req.body as CreateProjectDocumentRequest;
 
       const validDocTypes = ['link', 'folder'];
       const fieldErrors: Record<string, string> = {};

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -6,9 +6,10 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors project.service.spec.ts / meeting.service.spec.ts: the `@lfx-one/shared/*` alias isn't
 // wired into this app's vitest config, so runtime (non-type-only) imports need stubs.
-const { proxyRequest, addAccessToResources } = vi.hoisted(() => ({
+const { proxyRequest, addAccessToResources, resolveAuditUserDisplayName } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   addAccessToResources: vi.fn(),
+  resolveAuditUserDisplayName: vi.fn(),
 }));
 
 vi.mock('@lfx-one/shared/enums', () => ({ CommitteeMemberRole: {} }));
@@ -25,13 +26,17 @@ vi.mock('./access-check.service', () => ({
 }));
 vi.mock('./etag.service', () => ({ ETagService: class {} }));
 vi.mock('./project.service', () => ({ ProjectService: class {} }));
-vi.mock('../utils/auth-helper', () => ({ resolveAuditUserDisplayName: vi.fn(), getUsernameFromAuth: vi.fn() }));
+vi.mock('../helpers/query-service.helper', () => ({
+  fetchAllQueryResources: vi.fn(),
+}));
+vi.mock('../utils/auth-helper', () => ({ resolveAuditUserDisplayName, getUsernameFromAuth: vi.fn() }));
 vi.mock('../services/logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
 }));
 
 import type { Request } from 'express';
 
+import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { CommitteeService } from './committee.service';
 
 const req = {} as unknown as Request;
@@ -46,6 +51,8 @@ describe('CommitteeService — create picker methods', () => {
   beforeEach(() => {
     proxyRequest.mockReset();
     addAccessToResources.mockReset();
+    resolveAuditUserDisplayName.mockReset();
+    vi.mocked(fetchAllQueryResources).mockReset();
     service = new CommitteeService();
   });
 
@@ -122,5 +129,44 @@ describe('CommitteeService — create picker methods', () => {
     for (const params of paramsSent) {
       expect(params['filter_grants'] === 'direct' || typeof params['name'] === 'string').toBe(true);
     }
+  });
+});
+
+describe('CommitteeService — getCommitteeDocuments', () => {
+  let service: CommitteeService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    resolveAuditUserDisplayName.mockReset();
+    vi.mocked(fetchAllQueryResources).mockReset();
+    resolveAuditUserDisplayName.mockReturnValue('Resolved Display Name');
+    service = new CommitteeService();
+  });
+
+  it('threads resolveAuditUserDisplayName into uploaded_by for folders, links, and files', async () => {
+    proxyRequest
+      .mockResolvedValueOnce([{ uid: 'folder-1', name: 'Folder', created_by: { name: 'Ada Lovelace' }, committee_uid: 'committee-1' }])
+      .mockResolvedValueOnce([
+        { uid: 'link-1', name: 'Link', url: 'https://example.com', created_by: { name: 'Bob Builder' }, committee_uid: 'committee-1' },
+      ]);
+    vi.mocked(fetchAllQueryResources).mockResolvedValueOnce([
+      {
+        uid: 'file-1',
+        name: 'File',
+        content_type: 'application/pdf',
+        created_by: { name: 'Carol Danvers' },
+        uploaded_by_username: 'legacyuser',
+        committee_uid: 'committee-1',
+      },
+    ]);
+
+    const result = await service.getCommitteeDocuments(req, 'committee-1');
+
+    expect(result).toHaveLength(3);
+    expect(result.every((doc) => doc.uploaded_by === 'Resolved Display Name')).toBe(true);
+    expect(resolveAuditUserDisplayName).toHaveBeenCalledTimes(3);
+    expect(resolveAuditUserDisplayName).toHaveBeenCalledWith({ name: 'Ada Lovelace' }, undefined);
+    expect(resolveAuditUserDisplayName).toHaveBeenCalledWith({ name: 'Bob Builder' }, undefined);
+    expect(resolveAuditUserDisplayName).toHaveBeenCalledWith({ name: 'Carol Danvers' }, 'legacyuser');
   });
 });

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -146,9 +146,7 @@ describe('CommitteeService — getCommitteeDocuments', () => {
   it('threads resolveAuditUserDisplayName into uploaded_by for folders, links, and files', async () => {
     proxyRequest
       .mockResolvedValueOnce([{ uid: 'folder-1', name: 'Folder', created_by: { name: 'Ada Lovelace' }, committee_uid: 'committee-1' }])
-      .mockResolvedValueOnce([
-        { uid: 'link-1', name: 'Link', url: 'https://example.com', created_by: { name: 'Bob Builder' }, committee_uid: 'committee-1' },
-      ]);
+      .mockResolvedValueOnce([{ uid: 'link-1', name: 'Link', url: 'https://example.com', created_by: { name: 'Bob Builder' }, committee_uid: 'committee-1' }]);
     vi.mocked(fetchAllQueryResources).mockResolvedValueOnce([
       {
         uid: 'file-1',

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -26,9 +26,12 @@ vi.mock('./access-check.service', () => ({
 }));
 vi.mock('./etag.service', () => ({ ETagService: class {} }));
 vi.mock('./project.service', () => ({ ProjectService: class {} }));
-vi.mock('../helpers/query-service.helper', () => ({
-  fetchAllQueryResources: vi.fn(),
-}));
+vi.mock('../helpers/query-service.helper', async () => {
+  const actual = await vi.importActual<typeof import('../helpers/query-service.helper')>('../helpers/query-service.helper');
+  return {
+    fetchAllQueryResources: vi.fn(actual.fetchAllQueryResources),
+  };
+});
 vi.mock('../utils/auth-helper', () => ({ resolveAuditUserDisplayName, getUsernameFromAuth: vi.fn() }));
 vi.mock('../services/logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -25,7 +25,7 @@ vi.mock('./access-check.service', () => ({
 }));
 vi.mock('./etag.service', () => ({ ETagService: class {} }));
 vi.mock('./project.service', () => ({ ProjectService: class {} }));
-vi.mock('../utils/auth-helper', () => ({ cleanUserDisplayName: vi.fn(), getUsernameFromAuth: vi.fn() }));
+vi.mock('../utils/auth-helper', () => ({ resolveAuditUserDisplayName: vi.fn(), getUsernameFromAuth: vi.fn() }));
 vi.mock('../services/logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
 }));

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -13,6 +13,7 @@ import {
   CommitteeSettingsData,
   CommitteeUpdateData,
   CommitteeUser,
+  AuditUserProfile,
   CreateCommitteeDocumentRequest,
   CreateCommitteeInviteRequest,
   CreateCommitteeJoinApplicationRequest,
@@ -46,7 +47,7 @@ interface CommitteeFolder {
   uid: string;
   committee_uid?: string;
   name: string;
-  created_by?: CommitteeUser;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
@@ -61,7 +62,7 @@ interface CommitteeLink {
   url?: string;
   description?: string;
   folder_uid?: string;
-  created_by?: CommitteeUser;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
@@ -79,7 +80,7 @@ interface CommitteeDocumentUpstreamResponse {
   committee_uid?: string;
   created_at?: string;
   updated_at?: string;
-  created_by?: CommitteeUser;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional records. */
   uploaded_by_username?: string;
 }
@@ -111,7 +112,7 @@ interface CommitteeDocumentQueryResult {
   folder_uid?: string;
   created_at?: string;
   updated_at?: string;
-  created_by?: CommitteeUser;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional indexer records. */
   uploaded_by_username?: string;
 }
@@ -1152,7 +1153,6 @@ export class CommitteeService {
       name: f.name,
       created_at: f.created_at,
       updated_at: f.updated_at,
-      created_by: f.created_by?.username,
       uploaded_by: resolveAuditUserDisplayName(f.created_by, f.created_by_username),
       committee_uid: f.committee_uid,
     }));
@@ -1166,7 +1166,6 @@ export class CommitteeService {
       description: l.description,
       created_at: l.created_at,
       updated_at: l.updated_at,
-      created_by: l.created_by?.username,
       uploaded_by: resolveAuditUserDisplayName(l.created_by, l.created_by_username),
       parent_uid: l.folder_uid,
       committee_uid: l.committee_uid,
@@ -1222,7 +1221,6 @@ export class CommitteeService {
         name: folder.name,
         created_at: folder.created_at,
         updated_at: folder.updated_at,
-        created_by: folder.created_by?.username,
         uploaded_by: resolveAuditUserDisplayName(folder.created_by, folder.created_by_username),
         committee_uid: folder.committee_uid,
       };
@@ -1256,7 +1254,6 @@ export class CommitteeService {
       description: link.description,
       created_at: link.created_at,
       updated_at: link.updated_at,
-      created_by: link.created_by?.username,
       uploaded_by: resolveAuditUserDisplayName(link.created_by, link.created_by_username),
       parent_uid: link.folder_uid,
       committee_uid: link.committee_uid,

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -35,7 +35,7 @@ import { ResourceNotFoundError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { logger } from '../services/logger.service';
-import { cleanUserDisplayName, getUsernameFromAuth } from '../utils/auth-helper';
+import { resolveAuditUserDisplayName, getUsernameFromAuth } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
 import { ETagService } from './etag.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -46,8 +46,8 @@ interface CommitteeFolder {
   uid: string;
   committee_uid?: string;
   name: string;
-  created_by_uid?: string;
-  /** LF username of the creator, auto-populated by upstream from the JWT. */
+  created_by?: CommitteeUser;
+  /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
   updated_at?: string;
@@ -61,8 +61,8 @@ interface CommitteeLink {
   url?: string;
   description?: string;
   folder_uid?: string;
-  created_by_uid?: string;
-  /** LF username of the creator, auto-populated by upstream from the JWT. */
+  created_by?: CommitteeUser;
+  /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
   updated_at?: string;
@@ -79,6 +79,8 @@ interface CommitteeDocumentUpstreamResponse {
   committee_uid?: string;
   created_at?: string;
   updated_at?: string;
+  created_by?: CommitteeUser;
+  /** Legacy flat username field; retained for transitional records. */
   uploaded_by_username?: string;
 }
 
@@ -109,6 +111,8 @@ interface CommitteeDocumentQueryResult {
   folder_uid?: string;
   created_at?: string;
   updated_at?: string;
+  created_by?: CommitteeUser;
+  /** Legacy flat username field; retained for transitional indexer records. */
   uploaded_by_username?: string;
 }
 
@@ -1148,8 +1152,8 @@ export class CommitteeService {
       name: f.name,
       created_at: f.created_at,
       updated_at: f.updated_at,
-      created_by: f.created_by_uid,
-      uploaded_by: cleanUserDisplayName(f.created_by_username),
+      created_by: f.created_by?.username,
+      uploaded_by: resolveAuditUserDisplayName(f.created_by, f.created_by_username),
       committee_uid: f.committee_uid,
     }));
 
@@ -1162,8 +1166,8 @@ export class CommitteeService {
       description: l.description,
       created_at: l.created_at,
       updated_at: l.updated_at,
-      created_by: l.created_by_uid,
-      uploaded_by: cleanUserDisplayName(l.created_by_username),
+      created_by: l.created_by?.username,
+      uploaded_by: resolveAuditUserDisplayName(l.created_by, l.created_by_username),
       parent_uid: l.folder_uid,
       committee_uid: l.committee_uid,
     }));
@@ -1178,7 +1182,7 @@ export class CommitteeService {
       mime_type: f.content_type,
       created_at: f.created_at,
       updated_at: f.updated_at,
-      uploaded_by: cleanUserDisplayName(f.uploaded_by_username),
+      uploaded_by: resolveAuditUserDisplayName(f.created_by, f.uploaded_by_username),
       parent_uid: f.folder_uid,
       committee_uid: f.committee_uid,
     }));
@@ -1204,7 +1208,6 @@ export class CommitteeService {
         {},
         {
           name: data.name,
-          created_by_name: data.created_by_name,
         }
       );
 
@@ -1219,8 +1222,8 @@ export class CommitteeService {
         name: folder.name,
         created_at: folder.created_at,
         updated_at: folder.updated_at,
-        created_by: folder.created_by_uid,
-        uploaded_by: cleanUserDisplayName(folder.created_by_username),
+        created_by: folder.created_by?.username,
+        uploaded_by: resolveAuditUserDisplayName(folder.created_by, folder.created_by_username),
         committee_uid: folder.committee_uid,
       };
     }
@@ -1237,7 +1240,6 @@ export class CommitteeService {
         url: data.url,
         description: data.description,
         folder_uid: data.parent_uid,
-        created_by_name: data.created_by_name,
       }
     );
 
@@ -1254,8 +1256,8 @@ export class CommitteeService {
       description: link.description,
       created_at: link.created_at,
       updated_at: link.updated_at,
-      created_by: link.created_by_uid,
-      uploaded_by: cleanUserDisplayName(link.created_by_username),
+      created_by: link.created_by?.username,
+      uploaded_by: resolveAuditUserDisplayName(link.created_by, link.created_by_username),
       parent_uid: link.folder_uid,
       committee_uid: link.committee_uid,
     };
@@ -1342,7 +1344,7 @@ export class CommitteeService {
       mime_type: result.content_type,
       created_at: result.created_at,
       updated_at: result.updated_at,
-      uploaded_by: cleanUserDisplayName(result.uploaded_by_username),
+      uploaded_by: resolveAuditUserDisplayName(result.created_by, result.uploaded_by_username),
       committee_uid: result.committee_uid,
     };
   }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -121,7 +121,7 @@ import {
   UniqueContributorsWeeklyResponse,
   UniqueContributorsWeeklyRow,
   UploadProjectDocumentRequest,
-  UserInfo,
+  AuditUserProfile,
   WebActivitiesSummaryResponse,
   WebActivityDomainDetail,
 } from '@lfx-one/shared/interfaces';
@@ -158,7 +158,7 @@ interface ProjectFolder {
   uid: string;
   project_uid?: string;
   name: string;
-  created_by?: UserInfo;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
@@ -173,7 +173,7 @@ interface ProjectLink {
   url?: string;
   description?: string;
   folder_uid?: string;
-  created_by?: UserInfo;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
@@ -189,7 +189,7 @@ interface ProjectFolderQueryResult {
   uid: string;
   name: string;
   project_uid?: string;
-  created_by?: UserInfo;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional indexer records. */
   created_by_username?: string;
   created_at?: string;
@@ -207,7 +207,7 @@ interface ProjectLinkQueryResult {
   description?: string;
   folder_uid?: string;
   project_uid?: string;
-  created_by?: UserInfo;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional indexer records. */
   created_by_username?: string;
   created_at?: string;
@@ -6460,7 +6460,6 @@ export class ProjectService {
       name: f.name,
       created_at: f.created_at,
       updated_at: f.updated_at,
-      created_by: f.created_by?.username,
       uploaded_by: resolveAuditUserDisplayName(f.created_by, f.created_by_username),
       project_uid: f.project_uid,
     }));
@@ -6473,7 +6472,6 @@ export class ProjectService {
       description: l.description,
       created_at: l.created_at,
       updated_at: l.updated_at,
-      created_by: l.created_by?.username,
       uploaded_by: resolveAuditUserDisplayName(l.created_by, l.created_by_username),
       parent_uid: l.folder_uid,
       project_uid: l.project_uid,
@@ -6556,7 +6554,6 @@ export class ProjectService {
         name: folder.name,
         created_at: folder.created_at,
         updated_at: folder.updated_at,
-        created_by: folder.created_by?.username,
         uploaded_by: resolveAuditUserDisplayName(folder.created_by, folder.created_by_username),
         project_uid: folder.project_uid,
       };
@@ -6612,7 +6609,6 @@ export class ProjectService {
       description: link.description,
       created_at: link.created_at,
       updated_at: link.updated_at,
-      created_by: link.created_by?.username,
       uploaded_by: resolveAuditUserDisplayName(link.created_by, link.created_by_username),
       parent_uid: link.folder_uid,
       project_uid: link.project_uid,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -121,6 +121,7 @@ import {
   UniqueContributorsWeeklyResponse,
   UniqueContributorsWeeklyRow,
   UploadProjectDocumentRequest,
+  UserInfo,
   WebActivitiesSummaryResponse,
   WebActivityDomainDetail,
 } from '@lfx-one/shared/interfaces';
@@ -132,7 +133,7 @@ import FormData from 'form-data';
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
-import { cleanUserDisplayName } from '../utils/auth-helper';
+import { resolveAuditUserDisplayName } from '../utils/auth-helper';
 import { AccessCheckService } from './access-check.service';
 import { ETagService } from './etag.service';
 import { logger } from './logger.service';
@@ -157,8 +158,8 @@ interface ProjectFolder {
   uid: string;
   project_uid?: string;
   name: string;
-  created_by_uid?: string;
-  /** LF username of the creator, auto-populated by upstream from the JWT. */
+  created_by?: UserInfo;
+  /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
   updated_at?: string;
@@ -172,8 +173,8 @@ interface ProjectLink {
   url?: string;
   description?: string;
   folder_uid?: string;
-  created_by_uid?: string;
-  /** LF username of the creator, auto-populated by upstream from the JWT. */
+  created_by?: UserInfo;
+  /** Legacy flat username field; retained for transitional records. */
   created_by_username?: string;
   created_at?: string;
   updated_at?: string;
@@ -188,8 +189,8 @@ interface ProjectFolderQueryResult {
   uid: string;
   name: string;
   project_uid?: string;
-  created_by_uid?: string;
-  /** LF username of the creator, indexed from the upstream domain model. */
+  created_by?: UserInfo;
+  /** Legacy flat username field; retained for transitional indexer records. */
   created_by_username?: string;
   created_at?: string;
   updated_at?: string;
@@ -206,8 +207,8 @@ interface ProjectLinkQueryResult {
   description?: string;
   folder_uid?: string;
   project_uid?: string;
-  created_by_uid?: string;
-  /** LF username of the creator, indexed from the upstream domain model. */
+  created_by?: UserInfo;
+  /** Legacy flat username field; retained for transitional indexer records. */
   created_by_username?: string;
   created_at?: string;
   updated_at?: string;
@@ -6459,8 +6460,8 @@ export class ProjectService {
       name: f.name,
       created_at: f.created_at,
       updated_at: f.updated_at,
-      created_by: f.created_by_uid,
-      uploaded_by: cleanUserDisplayName(f.created_by_username),
+      created_by: f.created_by?.username,
+      uploaded_by: resolveAuditUserDisplayName(f.created_by, f.created_by_username),
       project_uid: f.project_uid,
     }));
 
@@ -6472,8 +6473,8 @@ export class ProjectService {
       description: l.description,
       created_at: l.created_at,
       updated_at: l.updated_at,
-      created_by: l.created_by_uid,
-      uploaded_by: cleanUserDisplayName(l.created_by_username),
+      created_by: l.created_by?.username,
+      uploaded_by: resolveAuditUserDisplayName(l.created_by, l.created_by_username),
       parent_uid: l.folder_uid,
       project_uid: l.project_uid,
     }));
@@ -6487,7 +6488,7 @@ export class ProjectService {
       mime_type: f.content_type,
       created_at: f.created_at,
       updated_at: f.updated_at,
-      uploaded_by: cleanUserDisplayName(f.uploaded_by_username),
+      uploaded_by: resolveAuditUserDisplayName(f.created_by, f.uploaded_by_username),
       parent_uid: f.folder_uid,
       project_uid: f.project_uid,
     }));
@@ -6517,7 +6518,6 @@ export class ProjectService {
         undefined,
         {
           name: data.name,
-          created_by_name: data.created_by_name,
         },
         { 'X-Sync': 'true' }
       );
@@ -6556,8 +6556,8 @@ export class ProjectService {
         name: folder.name,
         created_at: folder.created_at,
         updated_at: folder.updated_at,
-        created_by: folder.created_by_uid,
-        uploaded_by: cleanUserDisplayName(folder.created_by_username),
+        created_by: folder.created_by?.username,
+        uploaded_by: resolveAuditUserDisplayName(folder.created_by, folder.created_by_username),
         project_uid: folder.project_uid,
       };
     }
@@ -6574,7 +6574,6 @@ export class ProjectService {
         url: data.url,
         description: data.description,
         folder_uid: data.parent_uid,
-        created_by_name: data.created_by_name,
       },
       { 'X-Sync': 'true' }
     );
@@ -6613,8 +6612,8 @@ export class ProjectService {
       description: link.description,
       created_at: link.created_at,
       updated_at: link.updated_at,
-      created_by: link.created_by_uid,
-      uploaded_by: cleanUserDisplayName(link.created_by_username),
+      created_by: link.created_by?.username,
+      uploaded_by: resolveAuditUserDisplayName(link.created_by, link.created_by_username),
       parent_uid: link.folder_uid,
       project_uid: link.project_uid,
     };
@@ -6696,7 +6695,7 @@ export class ProjectService {
       mime_type: result.content_type,
       created_at: result.created_at,
       updated_at: result.updated_at,
-      uploaded_by: cleanUserDisplayName(result.uploaded_by_username),
+      uploaded_by: resolveAuditUserDisplayName(result.created_by, result.uploaded_by_username),
       project_uid: result.project_uid,
     };
   }

--- a/apps/lfx-one/src/server/utils/auth-helper.spec.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.spec.ts
@@ -78,11 +78,11 @@ describe('getEffectiveSub', () => {
 
 describe('resolveAuditUserDisplayName', () => {
   it('returns the audit user name when present', () => {
-    expect(resolveAuditUserDisplayName({ name: 'Manish Dixit', username: 'manishdixitlfx' })).toBe('Manish Dixit');
+    expect(resolveAuditUserDisplayName({ name: 'Ada Lovelace', username: 'alovelace' })).toBe('Ada Lovelace');
   });
 
   it('falls back to stripped username on a partial audit user object', () => {
-    expect(resolveAuditUserDisplayName({ username: 'auth0|manishdixitlfx' })).toBe('manishdixitlfx');
+    expect(resolveAuditUserDisplayName({ username: 'auth0|alovelace' })).toBe('alovelace');
   });
 
   it('falls back to a legacy flat username field', () => {

--- a/apps/lfx-one/src/server/utils/auth-helper.spec.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.spec.ts
@@ -4,7 +4,7 @@
 import type { Request } from 'express';
 import { describe, expect, it } from 'vitest';
 
-import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername } from './auth-helper';
+import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername, resolveAuditUserDisplayName } from './auth-helper';
 
 interface TargetUser {
   email?: string;
@@ -73,5 +73,24 @@ describe('getEffectiveSub', () => {
   it('returns the OIDC sub when not impersonating', () => {
     const req = buildReq({ oidc: { sub: 'auth0|user' } });
     expect(getEffectiveSub(req)).toBe('auth0|user');
+  });
+});
+
+describe('resolveAuditUserDisplayName', () => {
+  it('returns the audit user name when present', () => {
+    expect(resolveAuditUserDisplayName({ name: 'Manish Dixit', username: 'manishdixitlfx' })).toBe('Manish Dixit');
+  });
+
+  it('falls back to stripped username on a partial audit user object', () => {
+    expect(resolveAuditUserDisplayName({ username: 'auth0|manishdixitlfx' })).toBe('manishdixitlfx');
+  });
+
+  it('falls back to a legacy flat username field', () => {
+    expect(resolveAuditUserDisplayName(undefined, 'auth0|legacyuser')).toBe('legacyuser');
+  });
+
+  it('returns undefined when no name or username is available', () => {
+    expect(resolveAuditUserDisplayName(undefined, undefined)).toBeUndefined();
+    expect(resolveAuditUserDisplayName({ name: '  ', username: '' }, '')).toBeUndefined();
   });
 });

--- a/apps/lfx-one/src/server/utils/auth-helper.spec.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.spec.ts
@@ -89,6 +89,11 @@ describe('resolveAuditUserDisplayName', () => {
     expect(resolveAuditUserDisplayName(undefined, 'auth0|legacyuser')).toBe('legacyuser');
   });
 
+  it('falls back to legacy username when audit username is whitespace-only', () => {
+    expect(resolveAuditUserDisplayName({ username: '   ' }, 'auth0|legacyuser')).toBe('legacyuser');
+    expect(resolveAuditUserDisplayName(undefined, '   ')).toBeUndefined();
+  });
+
   it('returns undefined when no name or username is available', () => {
     expect(resolveAuditUserDisplayName(undefined, undefined)).toBeUndefined();
     expect(resolveAuditUserDisplayName({ name: '  ', username: '' }, '')).toBeUndefined();

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -28,6 +28,27 @@ export function cleanUserDisplayName(value: string | null | undefined): string |
   return stripAuthPrefix(value);
 }
 
+/** Minimal audit-user shape returned by upstream document resources and the indexer. */
+export interface AuditUserLike {
+  name?: string;
+  username?: string;
+}
+
+/**
+ * Resolves a human-friendly Shared By label from an upstream audit user object,
+ * with fallbacks for partial profiles and legacy flat username fields.
+ */
+export function resolveAuditUserDisplayName(
+  user?: AuditUserLike | null,
+  legacyUsername?: string | null
+): string | undefined {
+  const name = user?.name?.trim();
+  if (name) return name;
+  const fromUser = cleanUserDisplayName(user?.username);
+  if (fromUser) return fromUser;
+  return cleanUserDisplayName(legacyUsername);
+}
+
 /**
  * Gets the username from the current authentication context
  * Supports both Authelia token authentication and OIDC claims authentication

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -38,10 +38,7 @@ export interface AuditUserLike {
  * Resolves a human-friendly Shared By label from an upstream audit user object,
  * with fallbacks for partial profiles and legacy flat username fields.
  */
-export function resolveAuditUserDisplayName(
-  user?: AuditUserLike | null,
-  legacyUsername?: string | null
-): string | undefined {
+export function resolveAuditUserDisplayName(user?: AuditUserLike | null, legacyUsername?: string | null): string | undefined {
   const name = user?.name?.trim();
   if (name) return name;
   const fromUser = cleanUserDisplayName(user?.username);

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -3,7 +3,7 @@
 
 import { Request } from 'express';
 
-import { LfxAccessTokenClaims } from '@lfx-one/shared/interfaces';
+import { LfxAccessTokenClaims, AuditUserProfile } from '@lfx-one/shared/interfaces';
 
 /**
  * Strips the auth provider prefix (e.g. "auth0|") from a username/sub claim.
@@ -28,17 +28,11 @@ export function cleanUserDisplayName(value: string | null | undefined): string |
   return stripAuthPrefix(value);
 }
 
-/** Minimal audit-user shape returned by upstream document resources and the indexer. */
-export interface AuditUserLike {
-  name?: string;
-  username?: string;
-}
-
 /**
  * Resolves a human-friendly Shared By label from an upstream audit user object,
  * with fallbacks for partial profiles and legacy flat username fields.
  */
-export function resolveAuditUserDisplayName(user?: AuditUserLike | null, legacyUsername?: string | null): string | undefined {
+export function resolveAuditUserDisplayName(user?: AuditUserProfile | null, legacyUsername?: string | null): string | undefined {
   const name = user?.name?.trim();
   if (name) return name;
   const fromUser = cleanUserDisplayName(user?.username);

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -25,7 +25,8 @@ export function stripAuthPrefix(username: string): string {
  */
 export function cleanUserDisplayName(value: string | null | undefined): string | undefined {
   if (!value) return undefined;
-  return stripAuthPrefix(value);
+  const cleaned = stripAuthPrefix(value).trim();
+  return cleaned || undefined;
 }
 
 /**

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -808,8 +808,6 @@ export interface CreateCommitteeDocumentRequest {
   description?: string;
   /** Parent folder UID (to place a link inside a folder) */
   parent_uid?: string;
-  /** Display name of the creator (populated by BFF from session) */
-  created_by_name?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -51,6 +51,14 @@ export interface UserInfo {
   avatar?: string;
 }
 
+/** Partial user profile on upstream document audit-user fields (`created_by` / `updated_by`). */
+export interface AuditUserProfile {
+  name?: string;
+  email?: string;
+  username?: string;
+  avatar?: string;
+}
+
 export interface ProjectSettings {
   uid: string;
   announcement_date: string;
@@ -175,7 +183,7 @@ export interface ProjectDocumentUpstreamResponse {
   project_uid?: string;
   created_at?: string;
   updated_at?: string;
-  created_by?: UserInfo;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional indexer records. */
   uploaded_by_username?: string;
 }
@@ -200,7 +208,7 @@ export interface ProjectDocumentQueryResult {
   folder_uid?: string;
   created_at?: string;
   updated_at?: string;
-  created_by?: UserInfo;
+  created_by?: AuditUserProfile;
   /** Legacy flat username field; retained for transitional indexer records. */
   uploaded_by_username?: string;
 }

--- a/packages/shared/src/interfaces/project.interface.ts
+++ b/packages/shared/src/interfaces/project.interface.ts
@@ -135,8 +135,6 @@ export interface CreateProjectDocumentRequest {
   description?: string;
   /** Parent folder UID (to place a link inside a folder) */
   parent_uid?: string;
-  /** Display name of the creator (populated by BFF from session) */
-  created_by_name?: string;
 }
 
 /**
@@ -177,6 +175,8 @@ export interface ProjectDocumentUpstreamResponse {
   project_uid?: string;
   created_at?: string;
   updated_at?: string;
+  created_by?: UserInfo;
+  /** Legacy flat username field; retained for transitional indexer records. */
   uploaded_by_username?: string;
 }
 
@@ -200,6 +200,8 @@ export interface ProjectDocumentQueryResult {
   folder_uid?: string;
   created_at?: string;
   updated_at?: string;
+  created_by?: UserInfo;
+  /** Legacy flat username field; retained for transitional indexer records. */
   uploaded_by_username?: string;
 }
 


### PR DESCRIPTION
## Summary

- Maps the project and committee documents **Shared By** column from upstream `created_by` audit user objects (`name`, `username`) instead of removed flat username fields.
- Adds `resolveAuditUserDisplayName()` in the BFF auth helper with fallbacks for partial profiles and legacy indexer records.
- Removes dead `created_by_name` forwarding on document create — upstream services now stamp audit users from the JWT.

## Why

[LFXV2-1718](https://linuxfoundation.atlassian.net/browse/LFXV2-1718) landed in `lfx-v2-project-service` and `lfx-v2-committee-service`. Those services (and the indexer/query layer) now return structured audit users on folders, links, and files:

```json
"created_by": { "name": "Manish Dixit", "username": "manishdixitlfx", "email": "...", "avatar": "..." }
```

The BFF was still reading `created_by_username` / `uploaded_by_username` and passing them through `cleanUserDisplayName()`, which only strips the `auth0|` prefix. After the backend deploy:

- **New records** — flat fields are gone, so Shared By renders blank.
- **Legacy records** — still show an LFID username instead of a full display name.

The committee service CLI README explicitly notes that the `document-audit-users` backfill prepares OpenSearch **ahead of this BFF mapping follow-up**. This PR completes that handoff.

## What changed

| Area | Change |
|---|---|
| `auth-helper.ts` | New `resolveAuditUserDisplayName()` — prefers `created_by.name`, falls back to stripped username from the audit object or legacy flat field |
| `project.service.ts` / `committee.service.ts` | Updated upstream/query TypeScript shapes; switched all 12 document list/create/upload mapping sites to the resolver |
| Shared interfaces | Added `created_by?: UserInfo` on query/upstream document types; removed `created_by_name` from create request types |
| Controllers | Removed OIDC `created_by_name` injection — no longer consumed upstream |

## What did NOT change

- No Angular component or template edits — UI already binds `doc.uploaded_by`.
- No change to the public `ProjectDocument.uploaded_by` / `CommitteeDocument.uploaded_by` contract (`string | undefined`).
- `cleanUserDisplayName()` kept as a safety net for orphan legacy values.

## Deployment notes

Ship alongside (or after) the merged backend services. For existing records, run the one-time backfill in each environment:

```bash
project-cli sync document-audit-users --update --sleep=200ms
committee-cli sync document-audit-users --update --sleep=200ms
```

## Test plan

- [ ] `GET /api/projects/:uid/documents` — folders, links, and files show full display name in Shared By
- [ ] `GET /api/committees/:id/documents` — same for committee documents
- [ ] Create project/committee folder or link — immediate response shows display name
- [ ] Upload project/committee file — immediate response shows display name
- [ ] Legacy records (pre-backfill or username-only audit objects) still show a stripped username rather than blank
- [x] `yarn lint:check` and `yarn check-types` pass locally
- [x] Unit tests added for `resolveAuditUserDisplayName` in `auth-helper.spec.ts`

**Jira:** https://linuxfoundation.atlassian.net/browse/LFXV2-1718

Made with [Cursor](https://cursor.com)

[LFXV2-1718]: https://linuxfoundation.atlassian.net/browse/LFXV2-1718?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ