### PR TITLE
feat(meetings): make meeting card title and date chip clickable

### DIFF
--- a/apps/lfx-one/e2e/meeting-card-title-datetime-link.spec.ts
+++ b/apps/lfx-one/e2e/meeting-card-title-datetime-link.spec.ts
@@ -211,5 +211,11 @@ test.describe('Meeting card — clickable title and date/time chip', () => {
     await upcomingCard.getByTestId('delete-meeting-button').click();
     expect(await deletePopup).toBeNull();
     await expect(page).toHaveURL(/\/meetings(\?.*)?$/);
+
+    // Delete opens a confirmation dialog rather than deleting outright — assert that's the actual
+    // side effect (not just "nothing navigated"), then dismiss it so the test doesn't leave it open.
+    await expect(page.getByRole('dialog')).toBeVisible();
+    await page.getByRole('button', { name: 'Cancel' }).click();
+    await expect(page.getByRole('dialog')).toHaveCount(0);
   });
 });

--- a/apps/lfx-one/e2e/meeting-card-title-datetime-link.spec.ts
+++ b/apps/lfx-one/e2e/meeting-card-title-datetime-link.spec.ts
@@ -67,7 +67,13 @@ async function stubMeLensContext(page: Page): Promise<void> {
   await page.route('**/api/past-meetings/**', (route) => route.fulfill({ status: 404, body: '{}' }));
 }
 
-function upcomingMeeting(id: string, title: string, createdBy: { name: string; username: string; email: string }, extra: Record<string, unknown> = {}) {
+interface MeetingCreator {
+  name: string;
+  username: string;
+  email: string;
+}
+
+function upcomingMeeting(id: string, title: string, createdBy: MeetingCreator, extra: Record<string, unknown> = {}) {
   return {
     id,
     uid: id,
@@ -90,7 +96,7 @@ function upcomingMeeting(id: string, title: string, createdBy: { name: string; u
   };
 }
 
-function pastMeeting(id: string, title: string, createdBy: { name: string; username: string; email: string }, extra: Record<string, unknown> = {}) {
+function pastMeeting(id: string, title: string, createdBy: MeetingCreator, extra: Record<string, unknown> = {}) {
   return {
     ...upcomingMeeting(id, title, createdBy, extra),
     start_time: PAST_START,
@@ -133,7 +139,7 @@ const pastTab = (page: Page) => page.getByTestId('time-filter-tabs').getByTestId
 const card = (page: Page, id: string) => page.locator(`#meeting-${id}`);
 
 test.describe('Meeting card — clickable title and date/time chip', () => {
-  test('upcoming card: title and date chip are real anchors that open the meeting page in a new tab', async ({ page }) => {
+  test('upcoming card: title and date chip are real anchors that open the meeting page in a new tab', async ({ page, context }) => {
     await gotoMyMeetings(page);
 
     const upcomingCard = card(page, 'link-up-1');
@@ -149,6 +155,17 @@ test.describe('Meeting card — clickable title and date/time chip', () => {
     await expect(chip).toHaveJSProperty('tagName', 'A');
     await expect(chip).toHaveAttribute('href', '/meetings/link-up-1');
     await expect(chip).toHaveAttribute('target', '_blank');
+
+    // Activate both anchors — proves they're functional links, not just correctly-attributed markup.
+    // The destination page is real and unmocked, so we only assert a tab actually opened (not its
+    // final URL/content, which could redirect for a fixture id the downstream page doesn't know about).
+    const [titlePopup] = await Promise.all([context.waitForEvent('page'), title.click()]);
+    expect(titlePopup).toBeTruthy();
+    await titlePopup.close();
+
+    const [chipPopup] = await Promise.all([context.waitForEvent('page'), chip.click()]);
+    expect(chipPopup).toBeTruthy();
+    await chipPopup.close();
   });
 
   test('past card: title and date chip navigate in-app (routerLink), not a new tab', async ({ page }) => {
@@ -168,18 +185,31 @@ test.describe('Meeting card — clickable title and date/time chip', () => {
     await expect(chip).toHaveJSProperty('tagName', 'A');
     await expect(chip).toHaveAttribute('href', '/meetings/link-past-1');
     await expect(chip).not.toHaveAttribute('target', '_blank');
+
+    // Activate the title anchor — same-tab SPA nav, so only one of the two anchors is clicked here
+    // (clicking both would require navigating back and re-deriving the past-tab state in between).
+    // Chip's routerLink is already proven equivalent via the identical href assertion above.
+    await title.click();
+    await page.waitForURL((url) => !/^\/meetings\/?$/.test(url.pathname));
+    expect(page.url()).toContain('/meetings/link-past-1');
   });
 
-  test('clicking inner card actions does not trigger a details navigation', async ({ page }) => {
+  test('clicking inner card actions does not trigger a details navigation or open a new tab', async ({ page, context }) => {
     await gotoMyMeetings(page);
 
     const upcomingCard = card(page, 'link-up-1');
     await expect(upcomingCard).toBeVisible();
 
+    const expectNoPopup = () => context.waitForEvent('page', { timeout: 500 }).catch(() => null);
+
+    const copyPopup = expectNoPopup();
     await upcomingCard.getByTestId('copy-meeting-button').click();
+    expect(await copyPopup).toBeNull();
     await expect(page).toHaveURL(/\/meetings(\?.*)?$/);
 
+    const deletePopup = expectNoPopup();
     await upcomingCard.getByTestId('delete-meeting-button').click();
+    expect(await deletePopup).toBeNull();
     await expect(page).toHaveURL(/\/meetings(\?.*)?$/);
   });
 });

--- a/apps/lfx-one/e2e/meeting-card-title-datetime-link.spec.ts
+++ b/apps/lfx-one/e2e/meeting-card-title-datetime-link.spec.ts
@@ -1,0 +1,185 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+const MEETINGS_URL = '/meetings';
+const LENS_COOKIE = 'lfx-active-lens';
+
+// Deterministic, far-future start so `hasMeetingEnded` never drops the upcoming fixture.
+const FUTURE_START = '2099-03-04T15:00:00Z';
+const PAST_START = '2020-03-04T15:00:00Z';
+
+test.setTimeout(120_000);
+
+function fulfillJson(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Let malformed URLs fail naturally.
+  }
+}
+
+async function seedMeLensCookie(page: Page): Promise<void> {
+  await page.context().addCookies([{ name: LENS_COOKIE, value: 'me', domain: 'localhost', path: '/' }]);
+}
+
+/**
+ * The signed-in user's LFID comes from the SSR auth context (TransferState), not an API the test
+ * can stub — so the fixtures have to be built around whoever is actually logged in. Reads it back
+ * out of the serialized state the same way the app does (`username`, then the namespaced claim).
+ */
+async function readViewerLfid(page: Page): Promise<string | null> {
+  const raw = await page.locator('#ng-state').textContent();
+  if (!raw) {
+    return null;
+  }
+  try {
+    const state = JSON.parse(raw) as Record<string, { user?: Record<string, string> }>;
+    const user = state['auth']?.user;
+    return user?.['username'] || user?.['https://sso.linuxfoundation.org/claims/username'] || null;
+  } catch {
+    return null;
+  }
+}
+
+async function stubMeLensContext(page: Page): Promise<void> {
+  await page.route('**/api/user/personas*', (route) =>
+    fulfillJson(route, {
+      personas: ['contributor'],
+      personaProjects: {},
+      projects: [],
+      organizations: [],
+      isRootWriter: false,
+    })
+  );
+
+  // Per-card lookups (materials, recordings, summaries, transcripts) are irrelevant here and each
+  // component already degrades on error — 404 keeps them off the real backend.
+  await page.route('**/api/meetings/*/attachments*', (route) => route.fulfill({ status: 404, body: '{}' }));
+  await page.route('**/api/past-meetings/**', (route) => route.fulfill({ status: 404, body: '{}' }));
+}
+
+function upcomingMeeting(id: string, title: string, createdBy: { name: string; username: string; email: string }, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    uid: id,
+    title,
+    description: title,
+    start_time: FUTURE_START,
+    duration: 60,
+    timezone: 'UTC',
+    meeting_type: 'Board',
+    visibility: 'public',
+    restricted: false,
+    project_uid: 'proj-e2e',
+    project_name: 'E2E Project',
+    is_foundation: false,
+    committees: [],
+    occurrences: [],
+    recurrence: null,
+    created_by: createdBy,
+    ...extra,
+  };
+}
+
+function pastMeeting(id: string, title: string, createdBy: { name: string; username: string; email: string }, extra: Record<string, unknown> = {}) {
+  return {
+    ...upcomingMeeting(id, title, createdBy, extra),
+    start_time: PAST_START,
+    scheduled_start_time: PAST_START,
+    meeting_and_occurrence_id: id,
+    meeting_id: `series-${id}`,
+  };
+}
+
+/** Loads the Me-lens meetings page with one upcoming and one past fixture owned by the signed-in user. */
+async function gotoMyMeetings(page: Page): Promise<{ viewerLfid: string }> {
+  await seedMeLensCookie(page);
+  await stubMeLensContext(page);
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  const viewerLfid = await readViewerLfid(page);
+  if (!viewerLfid) {
+    test.skip(true, 'Could not resolve the signed-in LFID from the SSR auth state');
+    return { viewerLfid: '' };
+  }
+
+  const viewer = { name: 'E2E Viewer', username: viewerLfid, email: 'viewer-e2e@example.com' };
+
+  await page.route('**/api/user/meetings*', (route) => fulfillJson(route, [upcomingMeeting('link-up-1', 'Clickable Upcoming', viewer, { organizer: true })]));
+  await page.route('**/api/user/past-meetings*', (route) => fulfillJson(route, [pastMeeting('link-past-1', 'Clickable Past', viewer, { organizer: true })]));
+
+  await page.goto(MEETINGS_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  if (!page.url().includes('/meetings')) {
+    test.skip(true, 'Me lens is not available for this user — /meetings redirected away');
+  }
+
+  return { viewerLfid };
+}
+
+const pastTab = (page: Page) => page.getByTestId('time-filter-tabs').getByTestId('filter-pill-past');
+const card = (page: Page, id: string) => page.locator(`#meeting-${id}`);
+
+test.describe('Meeting card — clickable title and date/time chip', () => {
+  test('upcoming card: title and date chip are real anchors that open the meeting page in a new tab', async ({ page }) => {
+    await gotoMyMeetings(page);
+
+    const upcomingCard = card(page, 'link-up-1');
+    await expect(upcomingCard).toBeVisible();
+
+    const title = upcomingCard.getByTestId('meeting-title');
+    const chip = upcomingCard.getByTestId('meeting-datetime');
+
+    await expect(title).toHaveJSProperty('tagName', 'A');
+    await expect(title).toHaveAttribute('href', '/meetings/link-up-1');
+    await expect(title).toHaveAttribute('target', '_blank');
+
+    await expect(chip).toHaveJSProperty('tagName', 'A');
+    await expect(chip).toHaveAttribute('href', '/meetings/link-up-1');
+    await expect(chip).toHaveAttribute('target', '_blank');
+  });
+
+  test('past card: title and date chip navigate in-app (routerLink), not a new tab', async ({ page }) => {
+    await gotoMyMeetings(page);
+    await pastTab(page).click();
+
+    const pastCard = card(page, 'link-past-1');
+    await expect(pastCard).toBeVisible();
+
+    const title = pastCard.getByTestId('meeting-title');
+    const chip = pastCard.getByTestId('meeting-datetime');
+
+    await expect(title).toHaveJSProperty('tagName', 'A');
+    await expect(title).toHaveAttribute('href', '/meetings/link-past-1');
+    await expect(title).not.toHaveAttribute('target', '_blank');
+
+    await expect(chip).toHaveJSProperty('tagName', 'A');
+    await expect(chip).toHaveAttribute('href', '/meetings/link-past-1');
+    await expect(chip).not.toHaveAttribute('target', '_blank');
+  });
+
+  test('clicking inner card actions does not trigger a details navigation', async ({ page }) => {
+    await gotoMyMeetings(page);
+
+    const upcomingCard = card(page, 'link-up-1');
+    await expect(upcomingCard).toBeVisible();
+
+    await upcomingCard.getByTestId('copy-meeting-button').click();
+    await expect(page).toHaveURL(/\/meetings(\?.*)?$/);
+
+    await upcomingCard.getByTestId('delete-meeting-button').click();
+    await expect(page).toHaveURL(/\/meetings(\?.*)?$/);
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -87,15 +87,12 @@
       @if (meetingTitle()) {
         <h3 class="text-base font-medium leading-tight tracking-tight">
           @if (pastMeeting()) {
-            <a
-              class="text-gray-900 hover:text-blue-600 hover:underline transition-colors cursor-pointer"
-              data-testid="meeting-title"
-              [routerLink]="meetingDetailUrl()">
+            <a class="text-gray-900 hover:text-blue-600 hover:underline transition-colors" data-testid="meeting-title" [routerLink]="meetingDetailUrl()">
               {{ meetingTitle() }}
             </a>
           } @else {
             <a
-              class="text-gray-900 hover:text-blue-600 hover:underline transition-colors cursor-pointer"
+              class="text-gray-900 hover:text-blue-600 hover:underline transition-colors"
               data-testid="meeting-title"
               [href]="meetingDetailUrl()"
               target="_blank"
@@ -111,7 +108,7 @@
     <div class="flex flex-wrap gap-1 mb-2" data-testid="feature-badges">
       @if (meetingStartTime()) {
         @if (pastMeeting()) {
-          <a class="hover:opacity-80 transition-opacity cursor-pointer" data-testid="meeting-datetime" [routerLink]="meetingDetailUrl()">
+          <a class="hover:opacity-80 transition-opacity" data-testid="meeting-datetime" [routerLink]="meetingDetailUrl()">
             <lfx-tag
               [value]="
                 (meetingStartTime() | meetingTime: meeting().duration : 'date') + ' • ' + (meetingStartTime() | meetingTime: meeting().duration : 'time')
@@ -120,12 +117,7 @@
               icon="fa-light fa-calendar-days"></lfx-tag>
           </a>
         } @else {
-          <a
-            class="hover:opacity-80 transition-opacity cursor-pointer"
-            data-testid="meeting-datetime"
-            [href]="meetingDetailUrl()"
-            target="_blank"
-            rel="noopener noreferrer">
+          <a class="hover:opacity-80 transition-opacity" data-testid="meeting-datetime" [href]="meetingDetailUrl()" target="_blank" rel="noopener noreferrer">
             <lfx-tag
               [value]="
                 (meetingStartTime() | meetingTime: meeting().duration : 'date') + ' • ' + (meetingStartTime() | meetingTime: meeting().duration : 'time')

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -85,8 +85,24 @@
     <!-- Meeting Title -->
     <div class="flex items-center gap-2 mb-2" data-testid="meeting-title-section">
       @if (meetingTitle()) {
-        <h3 class="text-base font-medium text-gray-900 leading-tight tracking-tight" data-testid="meeting-title">
-          {{ meetingTitle() }}
+        <h3 class="text-base font-medium leading-tight tracking-tight">
+          @if (pastMeeting()) {
+            <a
+              class="text-gray-900 hover:text-blue-600 hover:underline transition-colors cursor-pointer"
+              data-testid="meeting-title"
+              [routerLink]="meetingDetailUrl()">
+              {{ meetingTitle() }}
+            </a>
+          } @else {
+            <a
+              class="text-gray-900 hover:text-blue-600 hover:underline transition-colors cursor-pointer"
+              data-testid="meeting-title"
+              [href]="meetingDetailUrl()"
+              target="_blank"
+              rel="noopener noreferrer">
+              {{ meetingTitle() }}
+            </a>
+          }
         </h3>
       }
     </div>
@@ -94,11 +110,30 @@
     <!-- Feature Badges with Date/Time -->
     <div class="flex flex-wrap gap-1 mb-2" data-testid="feature-badges">
       @if (meetingStartTime()) {
-        <lfx-tag
-          [value]="(meetingStartTime() | meetingTime: meeting().duration : 'date') + ' • ' + (meetingStartTime() | meetingTime: meeting().duration : 'time')"
-          severity="secondary"
-          icon="fa-light fa-calendar-days"
-          data-testid="meeting-datetime"></lfx-tag>
+        @if (pastMeeting()) {
+          <a class="hover:opacity-80 transition-opacity cursor-pointer" data-testid="meeting-datetime" [routerLink]="meetingDetailUrl()">
+            <lfx-tag
+              [value]="
+                (meetingStartTime() | meetingTime: meeting().duration : 'date') + ' • ' + (meetingStartTime() | meetingTime: meeting().duration : 'time')
+              "
+              severity="secondary"
+              icon="fa-light fa-calendar-days"></lfx-tag>
+          </a>
+        } @else {
+          <a
+            class="hover:opacity-80 transition-opacity cursor-pointer"
+            data-testid="meeting-datetime"
+            [href]="meetingDetailUrl()"
+            target="_blank"
+            rel="noopener noreferrer">
+            <lfx-tag
+              [value]="
+                (meetingStartTime() | meetingTime: meeting().duration : 'date') + ' • ' + (meetingStartTime() | meetingTime: meeting().duration : 'time')
+              "
+              severity="secondary"
+              icon="fa-light fa-calendar-days"></lfx-tag>
+          </a>
+        }
       }
       <lfx-meeting-organizer
         [meeting]="meeting()"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -19,6 +19,7 @@ import {
   WritableSignal,
 } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
 
 import {
   MeetingDeleteConfirmationComponent,
@@ -88,6 +89,7 @@ import { PublicRegistrationModalComponent } from '../../components/public-regist
   selector: 'lfx-meeting-card',
   imports: [
     NgClass,
+    RouterLink,
     ButtonComponent,
     TagComponent,
     MeetingTimePipe,


### PR DESCRIPTION
## Summary
- Title and date/time chip on meeting cards only looked clickable — only the "See Meeting Details" button navigated. Both now wrap real `<a>` elements that mirror the button's existing `routerLink` (past meetings) / `href` + `target=_blank` (upcoming meetings) conditional, so the destination matches exactly and cmd/middle-click still opens a new tab.
- No full-card click surface was added — the two new anchors are small siblings, not ancestors, of the other ~20 interactive elements in the card (copy/edit/delete/RSVP/materials/recording/summary buttons etc.), so no `stopPropagation()` guards were needed and none of that existing behavior changes.
- Applies uniformly to every consumer of the shared `meeting-card` component (dashboard Me/Project lens, committee meetings tab) since only the shared template changed.

**Scope notes:**
- The public/unauthenticated meeting page (`meeting-join.component.html`) does not use `<lfx-meeting-card>` — it has its own bespoke markup, so there's no "public page variant" of this component to update.
- Preserved the pre-existing behavior where past meetings' target resolves to `/meetings/:id` (`MeetingJoinComponent`) rather than `/meetings/:id/details` — that's how the "See Meeting Details" button already worked; not something this PR changes.

JIRA: [LFXV2-2944](https://linuxfoundation.atlassian.net/browse/LFXV2-2944)

## Test plan
- [x] `yarn lint && yarn format:check && yarn check-types && yarn build` all green
- [x] Vitest suite green (268 + 578 tests, unrelated to this change — repo has no Angular component unit-test runner)
- [x] Added `apps/lfx-one/e2e/meeting-card-title-datetime-link.spec.ts` covering: upcoming card title/chip render as `<a href target=_blank>`, past card title/chip render as `<a routerLink>` with no new tab, and that clicking inner card actions (copy/delete) does not trigger a details navigation
- [ ] Playwright spec not yet run against a live server in this session (starting `yarn start` here risked colliding with another active worktree on port 4200) — pending integration validation pass
- [ ] Manual check in browser: hover affordance, cmd/middle-click opens new tab on upcoming cards, in-app nav on past cards, dashboard (Me/Project lens) + committee meetings tab

[LFXV2-2944]: https://linuxfoundation.atlassian.net/browse/LFXV2-2944?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ