### PR TITLE
feat(documents): support multi-file upload in document form

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.html
@@ -5,7 +5,7 @@
   @if (canEdit()) {
     <div class="flex items-center justify-end gap-2">
       <lfx-button
-        label="Upload File"
+        label="Upload Files"
         icon="fa-light fa-arrow-up-from-line"
         size="small"
         severity="secondary"

--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
@@ -133,7 +133,9 @@ export class CommitteeDocumentsComponent {
       modal: true,
       // File mode can partially succeed mid-batch; the header close icon bypasses the form's
       // own success-aware close result, so route dismissal only through Cancel/Done.
+      // closeOnEscape defaults to true independently of closable — must be disabled too.
       closable: false,
+      closeOnEscape: false,
       data: {
         mode: 'file',
         entityType: 'committee',

--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
@@ -131,7 +131,9 @@ export class CommitteeDocumentsComponent {
       header: 'Upload Files',
       width: '560px',
       modal: true,
-      closable: true,
+      // File mode can partially succeed mid-batch; the header close icon bypasses the form's
+      // own success-aware close result, so route dismissal only through Cancel/Done.
+      closable: false,
       data: {
         mode: 'file',
         entityType: 'committee',

--- a/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-documents/committee-documents.component.ts
@@ -128,7 +128,7 @@ export class CommitteeDocumentsComponent {
 
   public openUploadFileDialog(): void {
     const dialogRef: DynamicDialogRef | null = this.dialogService.open(DocumentFormComponent, {
-      header: 'Upload File',
+      header: 'Upload Files',
       width: '560px',
       modal: true,
       closable: true,

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.html
@@ -28,7 +28,7 @@
             @if (canUpload()) {
               <div class="flex items-center justify-end gap-2" data-testid="documents-dashboard-toolbar">
                 <lfx-button
-                  label="Upload File"
+                  label="Upload Files"
                   icon="fa-light fa-arrow-up-from-line"
                   size="small"
                   severity="secondary"

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
@@ -504,7 +504,9 @@ export class DocumentsDashboardComponent {
       header,
       width: '560px',
       modal: true,
-      closable: true,
+      // File mode can partially succeed mid-batch; the header close icon bypasses the form's
+      // own success-aware close result, so route dismissal only through Cancel/Done there.
+      closable: mode !== 'file',
       data: {
         mode,
         entityType: 'project',

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
@@ -506,7 +506,9 @@ export class DocumentsDashboardComponent {
       modal: true,
       // File mode can partially succeed mid-batch; the header close icon bypasses the form's
       // own success-aware close result, so route dismissal only through Cancel/Done there.
+      // closeOnEscape defaults to true independently of closable — must be disabled too.
       closable: mode !== 'file',
+      closeOnEscape: mode !== 'file',
       data: {
         mode,
         entityType: 'project',

--- a/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/documents/documents-dashboard/documents-dashboard.component.ts
@@ -175,7 +175,7 @@ export class DocumentsDashboardComponent {
   }
 
   protected openUploadFileDialog(): void {
-    this.openDocumentDialog('file', 'Upload File');
+    this.openDocumentDialog('file', 'Upload Files');
   }
 
   protected openNewFolderDialog(): void {

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
@@ -39,7 +39,7 @@
                   control="name"
                   placeholder="Document name"
                   styleClass="w-full"
-                  [dataTest]="'document-form-pending-file-name'"></lfx-input-text>
+                  [dataTest]="'document-form-pending-file-name-' + item.id"></lfx-input-text>
               </div>
               @if (item.status === 'uploading') {
                 <i class="fa-light fa-spinner-third fa-spin text-gray-400 flex-shrink-0"></i>
@@ -47,7 +47,7 @@
                 <button
                   type="button"
                   class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
-                  aria-label="Remove file"
+                  aria-label="Remove file {{ item.file.name }}"
                   title="Remove file"
                   (click)="removePendingFile(item.id)"
                   data-testid="document-form-remove-file">

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
@@ -29,14 +29,17 @@
           <div class="flex flex-col gap-1 px-3 py-2 rounded-lg border border-gray-200 bg-gray-50" data-testid="document-form-pending-file">
             <div class="flex items-center gap-2">
               <i class="fa-light fa-file-lines text-blue-500 flex-shrink-0"></i>
-              <input
-                type="text"
-                class="flex-1 min-w-0 text-sm text-gray-700 bg-transparent border-0 focus:outline-none focus:ring-0 truncate"
-                [value]="item.name"
-                [disabled]="item.status === 'uploading'"
-                (input)="updatePendingFileName(item.id, $any($event.target).value)"
-                [attr.aria-label]="'Document name for ' + item.file.name"
-                data-testid="document-form-pending-file-name" />
+              <div class="flex-1 min-w-0">
+                <label class="sr-only" [attr.for]="'pending-file-name-' + item.id">Document name for {{ item.file.name }}</label>
+                <lfx-input-text
+                  size="small"
+                  [id]="'pending-file-name-' + item.id"
+                  [form]="getNameForm(item.id)"
+                  control="name"
+                  placeholder="Document name"
+                  styleClass="w-full"
+                  [dataTest]="'document-form-pending-file-name'"></lfx-input-text>
+              </div>
               @if (item.status === 'uploading') {
                 <i class="fa-light fa-spinner-third fa-spin text-gray-400 flex-shrink-0"></i>
               } @else {
@@ -51,9 +54,12 @@
                 </button>
               }
             </div>
-            <span class="text-xs text-gray-400 truncate">{{ item.file.name }}</span>
+            @if (getNameForm(item.id).get('name')?.errors?.['required'] && getNameForm(item.id).get('name')?.touched) {
+              <p class="text-xs text-red-600 pl-6">Name is required</p>
+            }
+            <span class="text-xs text-gray-400 truncate pl-6">{{ item.file.name }}</span>
             @if (item.status === 'error' && item.errorMessage) {
-              <p class="text-xs text-red-600">{{ item.errorMessage }}</p>
+              <p class="text-xs text-red-600 pl-6">{{ item.errorMessage }}</p>
             }
           </div>
         }

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
@@ -14,6 +14,7 @@
         [customUpload]="true"
         [showUploadButton]="false"
         [showCancelButton]="false"
+        [disabled]="submitting()"
         chooseLabel="Click to upload files or drag and drop"
         dataTest="document-form-file-upload">
       </lfx-file-upload>
@@ -34,7 +35,7 @@
                 <lfx-input-text
                   size="small"
                   [id]="'pending-file-name-' + item.id"
-                  [form]="getNameForm(item.id)"
+                  [form]="item.nameForm"
                   control="name"
                   placeholder="Document name"
                   styleClass="w-full"
@@ -54,8 +55,10 @@
                 </button>
               }
             </div>
-            @if (getNameForm(item.id).get('name')?.errors?.['required'] && getNameForm(item.id).get('name')?.touched) {
+            @if (item.nameForm.get('name')?.errors?.['required'] && item.nameForm.get('name')?.touched) {
               <p class="text-xs text-red-600 pl-6">Name is required</p>
+            } @else if (item.nameForm.get('name')?.errors?.['maxlength'] && item.nameForm.get('name')?.touched) {
+              <p class="text-xs text-red-600 pl-6">Name must be 500 characters or less</p>
             }
             <span class="text-xs text-gray-400 truncate pl-6">{{ item.file.name }}</span>
             @if (item.status === 'error' && item.errorMessage) {
@@ -166,7 +169,14 @@
 
   <!-- Form Actions -->
   <div class="flex justify-end gap-3 pt-4 border-t">
-    <lfx-button [label]="cancelLabel()" severity="secondary" [outlined]="true" (onClick)="onCancel()" size="small" type="button"></lfx-button>
+    <lfx-button
+      [label]="cancelLabel()"
+      severity="secondary"
+      [outlined]="true"
+      [disabled]="submitting()"
+      (onClick)="onCancel()"
+      size="small"
+      type="button"></lfx-button>
     <lfx-button [label]="submitLabel()" [loading]="submitting()" [disabled]="submitting()" type="submit" size="small"></lfx-button>
   </div>
 </form>

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.html
@@ -5,55 +5,60 @@
   @if (isFile()) {
     <!-- File picker -->
     <div>
-      <label class="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1"> File <span class="text-red-500">*</span> </label>
-      @if (!selectedFile()) {
-        <lfx-file-upload
-          [multiple]="false"
-          [accept]="acceptString"
-          [maxFileSize]="MAX_FILE_SIZE_BYTES"
-          (onSelect)="onFileSelect($event)"
-          [customUpload]="true"
-          [showUploadButton]="false"
-          [showCancelButton]="false"
-          chooseLabel="Click to upload a file or drag and drop"
-          dataTest="document-form-file-upload">
-        </lfx-file-upload>
-      } @else {
-        <div class="flex items-center justify-between gap-3 px-3 py-2 rounded-lg border border-blue-200 bg-blue-50" data-testid="document-form-selected-file">
-          <div class="flex items-center gap-2 min-w-0">
-            <i class="fa-light fa-file-lines text-blue-500 flex-shrink-0"></i>
-            <span class="text-sm text-gray-700 truncate">{{ selectedFile()!.name }}</span>
-          </div>
-          <button
-            type="button"
-            class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
-            aria-label="Clear selected file"
-            title="Clear selected file"
-            (click)="clearSelectedFile()"
-            data-testid="document-form-clear-file">
-            <i class="fa-light fa-xmark"></i>
-          </button>
-        </div>
-      }
+      <label class="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1"> Files <span class="text-red-500">*</span> </label>
+      <lfx-file-upload
+        [multiple]="true"
+        [accept]="acceptString"
+        [maxFileSize]="MAX_FILE_SIZE_BYTES"
+        (onSelect)="onFileSelect($event)"
+        [customUpload]="true"
+        [showUploadButton]="false"
+        [showCancelButton]="false"
+        chooseLabel="Click to upload files or drag and drop"
+        dataTest="document-form-file-upload">
+      </lfx-file-upload>
       @if (fileError()) {
         <p class="mt-1 text-xs text-red-600">{{ fileError() }}</p>
       }
     </div>
 
-    <!-- Name -->
-    <div>
-      <label class="block text-[11px] font-semibold text-gray-500 uppercase tracking-wide mb-1">Name <span class="text-red-500">*</span></label>
-      <lfx-input-text
-        size="small"
-        [form]="form"
-        control="name"
-        placeholder="Display name for the document"
-        styleClass="w-full"
-        dataTest="document-form-name"></lfx-input-text>
-      @if (form.get('name')?.errors?.['required'] && form.get('name')?.touched) {
-        <p class="mt-1 text-xs text-red-600">Name is required</p>
-      }
-    </div>
+    <!-- Pending files -->
+    @if (pendingFiles().length > 0) {
+      <div class="flex flex-col gap-2" data-testid="document-form-pending-files">
+        @for (item of pendingFiles(); track item.id) {
+          <div class="flex flex-col gap-1 px-3 py-2 rounded-lg border border-gray-200 bg-gray-50" data-testid="document-form-pending-file">
+            <div class="flex items-center gap-2">
+              <i class="fa-light fa-file-lines text-blue-500 flex-shrink-0"></i>
+              <input
+                type="text"
+                class="flex-1 min-w-0 text-sm text-gray-700 bg-transparent border-0 focus:outline-none focus:ring-0 truncate"
+                [value]="item.name"
+                [disabled]="item.status === 'uploading'"
+                (input)="updatePendingFileName(item.id, $any($event.target).value)"
+                [attr.aria-label]="'Document name for ' + item.file.name"
+                data-testid="document-form-pending-file-name" />
+              @if (item.status === 'uploading') {
+                <i class="fa-light fa-spinner-third fa-spin text-gray-400 flex-shrink-0"></i>
+              } @else {
+                <button
+                  type="button"
+                  class="flex-shrink-0 text-gray-400 hover:text-red-500 transition-colors"
+                  aria-label="Remove file"
+                  title="Remove file"
+                  (click)="removePendingFile(item.id)"
+                  data-testid="document-form-remove-file">
+                  <i class="fa-light fa-xmark"></i>
+                </button>
+              }
+            </div>
+            <span class="text-xs text-gray-400 truncate">{{ item.file.name }}</span>
+            @if (item.status === 'error' && item.errorMessage) {
+              <p class="text-xs text-red-600">{{ item.errorMessage }}</p>
+            }
+          </div>
+        }
+      </div>
+    }
 
     <!-- Folder (optional) -->
     @if (folderOptions.length > 0) {
@@ -68,7 +73,7 @@
           [showClear]="true"
           styleClass="w-full"
           data-testid="document-form-folder"></lfx-select>
-        <p class="mt-1 text-[11px] text-gray-400">Place this file inside a folder</p>
+        <p class="mt-1 text-[11px] text-gray-400">Place these files inside a folder</p>
       </div>
     }
   } @else if (isLink()) {
@@ -155,7 +160,7 @@
 
   <!-- Form Actions -->
   <div class="flex justify-end gap-3 pt-4 border-t">
-    <lfx-button label="Cancel" severity="secondary" [outlined]="true" (onClick)="onCancel()" size="small" type="button"></lfx-button>
+    <lfx-button [label]="cancelLabel()" severity="secondary" [outlined]="true" (onClick)="onCancel()" size="small" type="button"></lfx-button>
     <lfx-button [label]="submitLabel()" [loading]="submitting()" [disabled]="submitting()" type="submit" size="small"></lfx-button>
   </div>
 </form>

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
@@ -17,11 +17,12 @@ import {
   CreateProjectDocumentType,
   DocumentFormEntityType,
   DocumentFormMode,
+  PendingDocumentFile,
 } from '@lfx-one/shared/interfaces';
 import { generateAcceptString, getAcceptedFileTypesDisplay, getMimeTypeDisplayName, isFileTypeAllowed } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectService } from '@services/project.service';
-import { Observable } from 'rxjs';
+import { catchError, from, map, mergeMap, Observable, of, toArray } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -45,8 +46,10 @@ export class DocumentFormComponent {
 
   // === Writable Signals ===
   public submitting = signal<boolean>(false);
-  public selectedFile = signal<File | null>(null);
+  public pendingFiles = signal<PendingDocumentFile[]>([]);
   public fileError = signal<string | null>(null);
+  /** Set once at least one file in this dialog session has uploaded successfully — drives the Cancel/Done label and close-on-cancel behavior. */
+  public anyUploadSucceeded = signal<boolean>(false);
 
   // Config-based properties
   /** Resource type this dialog targets — drives service dispatch + uniqueness scope copy. */
@@ -67,6 +70,7 @@ export class DocumentFormComponent {
   public isFolder: Signal<boolean> = this.initIsFolder();
   public isFile: Signal<boolean> = this.initIsFile();
   public submitLabel: Signal<string> = this.initSubmitLabel();
+  public cancelLabel: Signal<string> = this.initCancelLabel();
   public descriptionPlaceholder: Signal<string> = this.initDescriptionPlaceholder();
 
   public constructor() {
@@ -82,7 +86,7 @@ export class DocumentFormComponent {
   }
 
   public onCancel(): void {
-    this.dialogRef.close();
+    this.dialogRef.close(this.anyUploadSucceeded() || undefined);
   }
 
   public onSubmit(): void {
@@ -94,43 +98,18 @@ export class DocumentFormComponent {
     const formValue = this.form.getRawValue();
 
     if (this.isFile()) {
-      const file = this.selectedFile();
-      if (!file) {
-        this.fileError.set('Please select a file to upload.');
+      const itemsToUpload = this.pendingFiles().filter((item) => item.status === 'pending' || item.status === 'error');
+      if (itemsToUpload.length === 0) {
+        this.fileError.set('Please select at least one file to upload.');
+        return;
+      }
+      if (itemsToUpload.some((item) => !item.name.trim())) {
+        this.fileError.set('Every file needs a name before uploading.');
         return;
       }
 
-      const metadata = {
-        name: formValue.name,
-        description: formValue.description || undefined,
-        folder_uid: formValue.parent_uid || undefined,
-      };
-
-      this.submitting.set(true);
-      const upload$: Observable<unknown> =
-        this.entityType === 'project'
-          ? this.projectService.uploadProjectDocument(this.entityId, file, metadata)
-          : this.committeeService.uploadCommitteeDocument(this.entityId, file, metadata);
-
-      upload$.subscribe({
-        next: () => {
-          this.submitting.set(false);
-          this.messageService.add({
-            severity: 'success',
-            summary: 'Success',
-            detail: 'File uploaded successfully',
-          });
-          this.dialogRef.close(true);
-        },
-        error: (err: HttpErrorResponse) => {
-          this.submitting.set(false);
-          this.messageService.add({
-            severity: 'error',
-            summary: 'Error',
-            detail: this.extractErrorMessage(err, 'Failed to upload file'),
-          });
-        },
-      });
+      this.fileError.set(null);
+      this.uploadPendingFiles(itemsToUpload, formValue.description || undefined, formValue.parent_uid || undefined);
       return;
     }
 
@@ -180,28 +159,47 @@ export class DocumentFormComponent {
     }
     if (files.length === 0) return;
 
-    const file = files[0];
-    const error = this.validateFile(file);
-    if (error) {
-      this.fileError.set(error);
-      this.selectedFile.set(null);
-      return;
-    }
+    const existingNames = new Set(this.pendingFiles().map((item) => item.file.name));
+    const newItems: PendingDocumentFile[] = [];
+
+    files.forEach((file) => {
+      const error = this.validateFile(file);
+      if (error) {
+        this.messageService.add({ severity: 'error', summary: 'File Upload Error', detail: error, life: 5000 });
+        return;
+      }
+      if (existingNames.has(file.name)) {
+        this.messageService.add({
+          severity: 'error',
+          summary: 'File Upload Error',
+          detail: `A file named "${file.name}" is already in the list.`,
+          life: 5000,
+        });
+        return;
+      }
+
+      existingNames.add(file.name);
+      newItems.push({
+        id: crypto.randomUUID(),
+        file,
+        // Pre-fill from the basename (sans extension); user can edit inline before submit.
+        name: file.name.replace(/\.[^/.]+$/, ''),
+        status: 'pending',
+      });
+    });
+
+    if (newItems.length === 0) return;
 
     this.fileError.set(null);
-    this.selectedFile.set(file);
-
-    // Auto-fill the Name field from the file basename (sans extension) if empty
-    const nameControl = this.form.get('name');
-    if (nameControl && !nameControl.value) {
-      const baseName = file.name.replace(/\.[^/.]+$/, '');
-      nameControl.setValue(baseName);
-    }
+    this.pendingFiles.update((items) => [...items, ...newItems]);
   }
 
-  public clearSelectedFile(): void {
-    this.selectedFile.set(null);
-    this.fileError.set(null);
+  public updatePendingFileName(id: string, name: string): void {
+    this.pendingFiles.update((items) => items.map((item) => (item.id === id ? { ...item, name } : item)));
+  }
+
+  public removePendingFile(id: string): void {
+    this.pendingFiles.update((items) => items.filter((item) => item.id !== id));
   }
 
   /**
@@ -235,8 +233,8 @@ export class DocumentFormComponent {
     }
 
     if (this.isFile()) {
+      // No `name` control — per-file display name lives on each PendingDocumentFile instead.
       return new FormGroup({
-        name: new FormControl('', [Validators.required]),
         description: new FormControl(''),
         parent_uid: new FormControl<string | null>(this.defaultParentUid),
       });
@@ -247,6 +245,80 @@ export class DocumentFormComponent {
     return new FormGroup({
       name: new FormControl('', [Validators.required]),
     });
+  }
+
+  /**
+   * Uploads every given pending file in parallel (RxJS `mergeMap`, unbounded concurrency).
+   * Each call is individually `catchError`'d so one failure doesn't abort the others —
+   * successes are never rolled back on partial failure. Per-file status is updated as each
+   * settles (not just aggregated at the end) so the template can render live per-file state.
+   */
+  private uploadPendingFiles(items: PendingDocumentFile[], description: string | undefined, folderUid: string | undefined): void {
+    this.submitting.set(true);
+    const uploadingIds = new Set(items.map((item) => item.id));
+    this.pendingFiles.update((current) =>
+      current.map((item) => (uploadingIds.has(item.id) ? { ...item, status: 'uploading' as const, errorMessage: undefined } : item))
+    );
+
+    from(items)
+      .pipe(
+        mergeMap((item) => {
+          const metadata = { name: item.name, description, folder_uid: folderUid };
+          const upload$: Observable<unknown> =
+            this.entityType === 'project'
+              ? this.projectService.uploadProjectDocument(this.entityId, item.file, metadata)
+              : this.committeeService.uploadCommitteeDocument(this.entityId, item.file, metadata);
+
+          return upload$.pipe(
+            map(() => ({ id: item.id, ok: true as const })),
+            catchError((err: HttpErrorResponse) =>
+              of({ id: item.id, ok: false as const, message: this.extractErrorMessage(err, `Failed to upload "${item.name}"`) })
+            )
+          );
+        }),
+        toArray()
+      )
+      .subscribe((results) => {
+        this.submitting.set(false);
+
+        const succeededIds = new Set(results.filter((result) => result.ok).map((result) => result.id));
+        const failures = new Map(
+          results.filter((result): result is { id: string; ok: false; message: string } => !result.ok).map((result) => [result.id, result.message])
+        );
+
+        this.pendingFiles.update((current) =>
+          current
+            .filter((item) => !succeededIds.has(item.id))
+            .map((item) => (failures.has(item.id) ? { ...item, status: 'error' as const, errorMessage: failures.get(item.id) } : item))
+        );
+
+        const successCount = succeededIds.size;
+        const failureCount = failures.size;
+        if (successCount > 0) {
+          this.anyUploadSucceeded.set(true);
+        }
+
+        if (failureCount === 0) {
+          this.messageService.add({
+            severity: 'success',
+            summary: 'Success',
+            detail: successCount === 1 ? 'File uploaded successfully' : `${successCount} files uploaded successfully`,
+          });
+          this.dialogRef.close(true);
+        } else if (successCount > 0) {
+          this.messageService.add({
+            severity: 'warn',
+            summary: 'Partial Upload',
+            detail: `${successCount} of ${successCount + failureCount} files uploaded. Fix the errors below and try again.`,
+          });
+        } else {
+          this.messageService.add({
+            severity: 'error',
+            summary: 'Error',
+            detail: failureCount === 1 ? 'Failed to upload file. Please try again.' : 'Failed to upload files. Please try again.',
+          });
+        }
+      });
   }
 
   private validateFile(file: File): string | null {
@@ -296,6 +368,10 @@ export class DocumentFormComponent {
       if (this.isLink()) return 'Add Link';
       return 'Create Folder';
     });
+  }
+
+  private initCancelLabel(): Signal<string> {
+    return computed(() => (this.isFile() && this.anyUploadSucceeded() ? 'Done' : 'Cancel'));
   }
 
   private initDescriptionPlaceholder(): Signal<string> {

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
@@ -189,9 +189,10 @@ export class DocumentFormComponent {
       }
 
       existingNames.add(file.name);
-      // Pre-fill from the basename (sans extension); user can edit inline before submit.
-      const baseName = file.name.replace(/\.[^/.]+$/, '');
-      const nameForm = new FormGroup({ name: new FormControl(baseName, [Validators.required, Validators.maxLength(500)]) });
+      // Pre-fill with the full filename (extension included) so two files that share a basename
+      // (e.g. report.pdf, report.docx) don't pre-fill to the same display name and collide at
+      // submit — file.name uniqueness is already enforced by the duplicate check above.
+      const nameForm = new FormGroup({ name: new FormControl(file.name, [Validators.required, Validators.maxLength(500)]) });
       newItems.push({ id: crypto.randomUUID(), file, status: 'pending', nameForm });
     });
 

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
@@ -9,7 +9,7 @@ import { FileUploadComponent } from '@components/file-upload/file-upload.compone
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
-import { ALLOWED_FILE_TYPES, MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB } from '@lfx-one/shared/constants';
+import { ALLOWED_FILE_TYPES, DOCUMENT_UPLOAD_CONCURRENCY, MAX_FILE_SIZE_BYTES, MAX_FILE_SIZE_MB } from '@lfx-one/shared/constants';
 import {
   CreateCommitteeDocumentRequest,
   CreateCommitteeDocumentType,
@@ -22,7 +22,7 @@ import {
 import { generateAcceptString, getAcceptedFileTypesDisplay, getMimeTypeDisplayName, isFileTypeAllowed } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectService } from '@services/project.service';
-import { catchError, from, map, mergeMap, Observable, of, toArray } from 'rxjs';
+import { catchError, from, map, mergeMap, Observable, of, tap, toArray } from 'rxjs';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -46,7 +46,14 @@ export class DocumentFormComponent {
 
   // === Writable Signals ===
   public submitting = signal<boolean>(false);
-  public pendingFiles = signal<PendingDocumentFile[]>([]);
+  /**
+   * Each pending file carries its own `nameForm` directly (rather than a side Map keyed by id)
+   * so the template can bind `item.nameForm` — a plain property read — instead of calling a
+   * component method per change-detection pass (see `docs/reviews/frontend-checklist.md`'s "no
+   * template functions" rule). `PendingDocumentFile` itself stays in `@lfx-one/shared`, which has
+   * no Angular Forms dependency, so the FormGroup is only ever attached here, not on that type.
+   */
+  public pendingFiles = signal<(PendingDocumentFile & { nameForm: FormGroup })[]>([]);
   public fileError = signal<string | null>(null);
   /** Set once at least one file in this dialog session has uploaded successfully — drives the Cancel/Done label and close-on-cancel behavior. */
   public anyUploadSucceeded = signal<boolean>(false);
@@ -64,13 +71,6 @@ export class DocumentFormComponent {
   public readonly defaultParentUid: string | null;
 
   public form: FormGroup;
-  /**
-   * One `name` FormGroup per pending file, keyed by `PendingDocumentFile.id`. Kept out of
-   * `PendingDocumentFile` itself (that interface lives in `@lfx-one/shared`, which has no
-   * Angular Forms dependency) but wired in lockstep with `pendingFiles` so `lfx-input-text`
-   * has a real `[form]`/`control` pair to bind each row's editable name to.
-   */
-  private nameForms = new Map<string, FormGroup>();
 
   // Derived signals
   public isLink: Signal<boolean> = this.initIsLink();
@@ -110,8 +110,8 @@ export class DocumentFormComponent {
         this.fileError.set('Please select at least one file to upload.');
         return;
       }
-      if (itemsToUpload.some((item) => !this.getPendingFileName(item.id))) {
-        itemsToUpload.forEach((item) => this.nameForms.get(item.id)?.markAllAsTouched());
+      if (itemsToUpload.some((item) => item.nameForm.invalid)) {
+        itemsToUpload.forEach((item) => item.nameForm.markAllAsTouched());
         this.fileError.set('Every file needs a name before uploading.');
         return;
       }
@@ -168,7 +168,7 @@ export class DocumentFormComponent {
     if (files.length === 0) return;
 
     const existingNames = new Set(this.pendingFiles().map((item) => item.file.name));
-    const newItems: PendingDocumentFile[] = [];
+    const newItems: (PendingDocumentFile & { nameForm: FormGroup })[] = [];
 
     files.forEach((file) => {
       const error = this.validateFile(file);
@@ -187,11 +187,10 @@ export class DocumentFormComponent {
       }
 
       existingNames.add(file.name);
-      const id = crypto.randomUUID();
       // Pre-fill from the basename (sans extension); user can edit inline before submit.
       const baseName = file.name.replace(/\.[^/.]+$/, '');
-      this.nameForms.set(id, new FormGroup({ name: new FormControl(baseName, [Validators.required]) }));
-      newItems.push({ id, file, status: 'pending' });
+      const nameForm = new FormGroup({ name: new FormControl(baseName, [Validators.required, Validators.maxLength(500)]) });
+      newItems.push({ id: crypto.randomUUID(), file, status: 'pending', nameForm });
     });
 
     if (newItems.length === 0) return;
@@ -200,13 +199,7 @@ export class DocumentFormComponent {
     this.pendingFiles.update((items) => [...items, ...newItems]);
   }
 
-  /** FormGroup backing a pending file's editable name input — see `nameForms`. */
-  public getNameForm(id: string): FormGroup {
-    return this.nameForms.get(id) ?? new FormGroup({ name: new FormControl('') });
-  }
-
   public removePendingFile(id: string): void {
-    this.nameForms.delete(id);
     this.pendingFiles.update((items) => items.filter((item) => item.id !== id));
   }
 
@@ -255,21 +248,19 @@ export class DocumentFormComponent {
     });
   }
 
-  /** Trimmed current value of a pending file's editable name control. */
-  private getPendingFileName(id: string): string {
-    return ((this.nameForms.get(id)?.get('name')?.value as string | null) ?? '').trim();
-  }
-
   /**
-   * Uploads every given pending file in parallel (RxJS `mergeMap`, unbounded concurrency).
-   * Each call is individually `catchError`'d so one failure doesn't abort the others —
-   * successes are never rolled back on partial failure. Per-file status is updated as each
-   * settles (not just aggregated at the end) so the template can render live per-file state.
+   * Uploads every given pending file in parallel, capped at `DOCUMENT_UPLOAD_CONCURRENCY`
+   * concurrent requests — each upload's body is buffered fully in memory server-side, so
+   * unbounded concurrency would compound memory pressure on the BFF for large batches. Each
+   * call is individually `catchError`'d so one failure doesn't abort the others — successes
+   * are never rolled back on partial failure. Per-file status is applied via `tap` the moment
+   * each request settles, not just aggregated at the end, so the template reflects live
+   * per-file state; `toArray()` is used only for the final batch-level toast/close decision.
    */
-  private uploadPendingFiles(items: PendingDocumentFile[], description: string | undefined, folderUid: string | undefined): void {
+  private uploadPendingFiles(items: (PendingDocumentFile & { nameForm: FormGroup })[], description: string | undefined, folderUid: string | undefined): void {
     this.submitting.set(true);
     const uploadingIds = new Set(items.map((item) => item.id));
-    uploadingIds.forEach((id) => this.nameForms.get(id)?.disable());
+    items.forEach((item) => item.nameForm.disable());
     this.pendingFiles.update((current) =>
       current.map((item) => (uploadingIds.has(item.id) ? { ...item, status: 'uploading' as const, errorMessage: undefined } : item))
     );
@@ -277,7 +268,7 @@ export class DocumentFormComponent {
     from(items)
       .pipe(
         mergeMap((item) => {
-          const name = this.getPendingFileName(item.id);
+          const name = ((item.nameForm.get('name')?.value as string | null) ?? '').trim();
           const metadata = { name, description, folder_uid: folderUid };
           const upload$: Observable<unknown> =
             this.entityType === 'project'
@@ -288,29 +279,17 @@ export class DocumentFormComponent {
             map(() => ({ id: item.id, ok: true as const })),
             catchError((err: HttpErrorResponse) =>
               of({ id: item.id, ok: false as const, message: this.extractErrorMessage(err, `Failed to upload "${name}"`) })
-            )
+            ),
+            tap((result) => this.applyUploadResult(item, result))
           );
-        }),
+        }, DOCUMENT_UPLOAD_CONCURRENCY),
         toArray()
       )
       .subscribe((results) => {
         this.submitting.set(false);
 
-        const succeededIds = new Set(results.filter((result) => result.ok).map((result) => result.id));
-        const failures = new Map(
-          results.filter((result): result is { id: string; ok: false; message: string } => !result.ok).map((result) => [result.id, result.message])
-        );
-        succeededIds.forEach((id) => this.nameForms.delete(id));
-        failures.forEach((_message, id) => this.nameForms.get(id)?.enable());
-
-        this.pendingFiles.update((current) =>
-          current
-            .filter((item) => !succeededIds.has(item.id))
-            .map((item) => (failures.has(item.id) ? { ...item, status: 'error' as const, errorMessage: failures.get(item.id) } : item))
-        );
-
-        const successCount = succeededIds.size;
-        const failureCount = failures.size;
+        const successCount = results.filter((result) => result.ok).length;
+        const failureCount = results.length - successCount;
         if (successCount > 0) {
           this.anyUploadSucceeded.set(true);
         }
@@ -336,6 +315,21 @@ export class DocumentFormComponent {
           });
         }
       });
+  }
+
+  /** Applies one file's settled upload result to `pendingFiles` immediately — success removes the row, failure marks it for retry. */
+  private applyUploadResult(
+    target: PendingDocumentFile & { nameForm: FormGroup },
+    result: { id: string; ok: true } | { id: string; ok: false; message: string }
+  ): void {
+    if (result.ok) {
+      this.pendingFiles.update((current) => current.filter((item) => item.id !== result.id));
+      return;
+    }
+    target.nameForm.enable();
+    this.pendingFiles.update((current) =>
+      current.map((item) => (item.id === result.id ? { ...item, status: 'error' as const, errorMessage: result.message } : item))
+    );
   }
 
   private validateFile(file: File): string | null {

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
@@ -55,8 +55,8 @@ export class DocumentFormComponent {
    */
   public pendingFiles = signal<(PendingDocumentFile & { nameForm: FormGroup })[]>([]);
   public fileError = signal<string | null>(null);
-  /** Set once at least one file in this dialog session has uploaded successfully — drives the Cancel/Done label and close-on-cancel behavior. */
-  public anyUploadSucceeded = signal<boolean>(false);
+  /** Set once at least one file in this dialog session has uploaded successfully — drives the Cancel/Done label and close-on-cancel behavior. Not read in the template, so kept private. */
+  private anyUploadSucceeded = signal<boolean>(false);
 
   // Config-based properties
   /** Resource type this dialog targets — drives service dispatch + uniqueness scope copy. */
@@ -93,10 +93,12 @@ export class DocumentFormComponent {
   }
 
   public onCancel(): void {
+    if (this.submitting()) return;
     this.dialogRef.close(this.anyUploadSucceeded() || undefined);
   }
 
   public onSubmit(): void {
+    if (this.submitting()) return;
     if (!this.form.valid) {
       this.form.markAllAsTouched();
       return;
@@ -391,7 +393,7 @@ export class DocumentFormComponent {
 
   private initDescriptionPlaceholder(): Signal<string> {
     return computed(() => {
-      if (this.isFile()) return 'Brief description of this document';
+      if (this.isFile()) return 'Brief description of these documents';
       if (this.isLink()) return 'Brief description';
       return 'Brief description of what this folder contains';
     });

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
@@ -287,35 +287,57 @@ export class DocumentFormComponent {
         }, DOCUMENT_UPLOAD_CONCURRENCY),
         toArray()
       )
-      .subscribe((results) => {
-        this.submitting.set(false);
+      .subscribe({
+        next: (results) => {
+          this.submitting.set(false);
 
-        const successCount = results.filter((result) => result.ok).length;
-        const failureCount = results.length - successCount;
-        if (successCount > 0) {
-          this.anyUploadSucceeded.set(true);
-        }
+          const successCount = results.filter((result) => result.ok).length;
+          const failureCount = results.length - successCount;
+          if (successCount > 0) {
+            this.anyUploadSucceeded.set(true);
+          }
 
-        if (failureCount === 0) {
-          this.messageService.add({
-            severity: 'success',
-            summary: 'Success',
-            detail: successCount === 1 ? 'File uploaded successfully' : `${successCount} files uploaded successfully`,
-          });
-          this.dialogRef.close(true);
-        } else if (successCount > 0) {
-          this.messageService.add({
-            severity: 'warn',
-            summary: 'Partial Upload',
-            detail: `${successCount} of ${successCount + failureCount} files uploaded. Fix the errors below and try again.`,
-          });
-        } else {
+          if (failureCount === 0) {
+            this.messageService.add({
+              severity: 'success',
+              summary: 'Success',
+              detail: successCount === 1 ? 'File uploaded successfully' : `${successCount} files uploaded successfully`,
+            });
+            this.dialogRef.close(true);
+          } else if (successCount > 0) {
+            this.messageService.add({
+              severity: 'warn',
+              summary: 'Partial Upload',
+              detail: `${successCount} of ${successCount + failureCount} files uploaded. Fix the errors below and try again.`,
+            });
+          } else {
+            this.messageService.add({
+              severity: 'error',
+              summary: 'Error',
+              detail: failureCount === 1 ? 'Failed to upload file. Please try again.' : 'Failed to upload files. Please try again.',
+            });
+          }
+        },
+        // Every per-item HTTP failure is already caught inside the mergeMap via catchError, so
+        // this only fires on a genuinely unexpected stream failure (e.g. a bug in a downstream
+        // operator). Without this, `submitting` would stay true forever with no way to dismiss
+        // the dialog — Cancel and the file picker are both disabled while submitting, and
+        // file-mode dialogs disable closable/closeOnEscape too.
+        error: () => {
+          this.submitting.set(false);
+          this.pendingFiles.update((current) =>
+            current.map((item) => {
+              if (item.status !== 'uploading') return item;
+              item.nameForm.enable();
+              return { ...item, status: 'error' as const, errorMessage: 'Upload did not complete. Please try again.' };
+            })
+          );
           this.messageService.add({
             severity: 'error',
             summary: 'Error',
-            detail: failureCount === 1 ? 'Failed to upload file. Please try again.' : 'Failed to upload files. Please try again.',
+            detail: 'Something went wrong uploading these files. Please try again.',
           });
-        }
+        },
       });
   }
 

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
@@ -381,7 +381,11 @@ export class DocumentFormComponent {
 
   private initSubmitLabel(): Signal<string> {
     return computed(() => {
-      if (this.isFile()) return 'Upload File';
+      if (this.isFile()) {
+        const count = this.pendingFiles().length;
+        if (count === 0) return 'Upload Files';
+        return count === 1 ? 'Upload 1 File' : `Upload ${count} Files`;
+      }
       if (this.isLink()) return 'Add Link';
       return 'Create Folder';
     });

--- a/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
+++ b/apps/lfx-one/src/app/shared/components/document-form/document-form.component.ts
@@ -64,6 +64,13 @@ export class DocumentFormComponent {
   public readonly defaultParentUid: string | null;
 
   public form: FormGroup;
+  /**
+   * One `name` FormGroup per pending file, keyed by `PendingDocumentFile.id`. Kept out of
+   * `PendingDocumentFile` itself (that interface lives in `@lfx-one/shared`, which has no
+   * Angular Forms dependency) but wired in lockstep with `pendingFiles` so `lfx-input-text`
+   * has a real `[form]`/`control` pair to bind each row's editable name to.
+   */
+  private nameForms = new Map<string, FormGroup>();
 
   // Derived signals
   public isLink: Signal<boolean> = this.initIsLink();
@@ -103,7 +110,8 @@ export class DocumentFormComponent {
         this.fileError.set('Please select at least one file to upload.');
         return;
       }
-      if (itemsToUpload.some((item) => !item.name.trim())) {
+      if (itemsToUpload.some((item) => !this.getPendingFileName(item.id))) {
+        itemsToUpload.forEach((item) => this.nameForms.get(item.id)?.markAllAsTouched());
         this.fileError.set('Every file needs a name before uploading.');
         return;
       }
@@ -179,13 +187,11 @@ export class DocumentFormComponent {
       }
 
       existingNames.add(file.name);
-      newItems.push({
-        id: crypto.randomUUID(),
-        file,
-        // Pre-fill from the basename (sans extension); user can edit inline before submit.
-        name: file.name.replace(/\.[^/.]+$/, ''),
-        status: 'pending',
-      });
+      const id = crypto.randomUUID();
+      // Pre-fill from the basename (sans extension); user can edit inline before submit.
+      const baseName = file.name.replace(/\.[^/.]+$/, '');
+      this.nameForms.set(id, new FormGroup({ name: new FormControl(baseName, [Validators.required]) }));
+      newItems.push({ id, file, status: 'pending' });
     });
 
     if (newItems.length === 0) return;
@@ -194,11 +200,13 @@ export class DocumentFormComponent {
     this.pendingFiles.update((items) => [...items, ...newItems]);
   }
 
-  public updatePendingFileName(id: string, name: string): void {
-    this.pendingFiles.update((items) => items.map((item) => (item.id === id ? { ...item, name } : item)));
+  /** FormGroup backing a pending file's editable name input — see `nameForms`. */
+  public getNameForm(id: string): FormGroup {
+    return this.nameForms.get(id) ?? new FormGroup({ name: new FormControl('') });
   }
 
   public removePendingFile(id: string): void {
+    this.nameForms.delete(id);
     this.pendingFiles.update((items) => items.filter((item) => item.id !== id));
   }
 
@@ -247,6 +255,11 @@ export class DocumentFormComponent {
     });
   }
 
+  /** Trimmed current value of a pending file's editable name control. */
+  private getPendingFileName(id: string): string {
+    return ((this.nameForms.get(id)?.get('name')?.value as string | null) ?? '').trim();
+  }
+
   /**
    * Uploads every given pending file in parallel (RxJS `mergeMap`, unbounded concurrency).
    * Each call is individually `catchError`'d so one failure doesn't abort the others —
@@ -256,6 +269,7 @@ export class DocumentFormComponent {
   private uploadPendingFiles(items: PendingDocumentFile[], description: string | undefined, folderUid: string | undefined): void {
     this.submitting.set(true);
     const uploadingIds = new Set(items.map((item) => item.id));
+    uploadingIds.forEach((id) => this.nameForms.get(id)?.disable());
     this.pendingFiles.update((current) =>
       current.map((item) => (uploadingIds.has(item.id) ? { ...item, status: 'uploading' as const, errorMessage: undefined } : item))
     );
@@ -263,7 +277,8 @@ export class DocumentFormComponent {
     from(items)
       .pipe(
         mergeMap((item) => {
-          const metadata = { name: item.name, description, folder_uid: folderUid };
+          const name = this.getPendingFileName(item.id);
+          const metadata = { name, description, folder_uid: folderUid };
           const upload$: Observable<unknown> =
             this.entityType === 'project'
               ? this.projectService.uploadProjectDocument(this.entityId, item.file, metadata)
@@ -272,7 +287,7 @@ export class DocumentFormComponent {
           return upload$.pipe(
             map(() => ({ id: item.id, ok: true as const })),
             catchError((err: HttpErrorResponse) =>
-              of({ id: item.id, ok: false as const, message: this.extractErrorMessage(err, `Failed to upload "${item.name}"`) })
+              of({ id: item.id, ok: false as const, message: this.extractErrorMessage(err, `Failed to upload "${name}"`) })
             )
           );
         }),
@@ -285,6 +300,8 @@ export class DocumentFormComponent {
         const failures = new Map(
           results.filter((result): result is { id: string; ok: false; message: string } => !result.ok).map((result) => [result.id, result.message])
         );
+        succeededIds.forEach((id) => this.nameForms.delete(id));
+        failures.forEach((_message, id) => this.nameForms.get(id)?.enable());
 
         this.pendingFiles.update((current) =>
           current

--- a/packages/shared/src/constants/file-upload.constants.ts
+++ b/packages/shared/src/constants/file-upload.constants.ts
@@ -98,3 +98,11 @@ export const MAX_FILE_SIZE_BYTES = 100 * 1024 * 1024; // 100MB
  * <p>Maximum file size: {MAX_FILE_SIZE_MB}MB</p>
  */
 export const MAX_FILE_SIZE_MB = MAX_FILE_SIZE_BYTES / (1024 * 1024);
+
+/**
+ * Max number of files uploaded concurrently in a multi-file batch (e.g. the document form dialog).
+ * @description Caps `mergeMap` concurrency so large batches upload in waves instead of all at
+ * once — each upload's request body is buffered fully in memory server-side, so unbounded
+ * concurrency compounds memory pressure on the BFF for large selections.
+ */
+export const DOCUMENT_UPLOAD_CONCURRENCY = 3;

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -771,8 +771,12 @@ export type DocumentFormMode = CreateCommitteeDocumentType | 'file';
 /** Which resource type the shared document form dialog operates against. Drives service dispatch + copy. */
 export type DocumentFormEntityType = 'committee' | 'project';
 
-/** Upload status of a single file staged in the document form dialog's multi-file file-mode flow. */
-export type PendingDocumentFileStatus = 'pending' | 'uploading' | 'success' | 'error';
+/**
+ * Upload status of a single file staged in the document form dialog's multi-file file-mode flow.
+ * No `'success'` state — a successfully uploaded file is removed from the pending list entirely
+ * rather than rendered with a terminal status.
+ */
+export type PendingDocumentFileStatus = 'pending' | 'uploading' | 'error';
 
 /**
  * A file staged for upload in the document form dialog, tracked independently through parallel

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -774,14 +774,17 @@ export type DocumentFormEntityType = 'committee' | 'project';
 /** Upload status of a single file staged in the document form dialog's multi-file file-mode flow. */
 export type PendingDocumentFileStatus = 'pending' | 'uploading' | 'success' | 'error';
 
-/** A file staged for upload in the document form dialog, tracked independently through parallel upload. */
+/**
+ * A file staged for upload in the document form dialog, tracked independently through parallel
+ * upload. The editable display name is not modeled here — it lives in a per-item Angular
+ * `FormGroup` on the component (this package has no Angular Forms dependency, and is consumed
+ * by the Express BFF too).
+ */
 export interface PendingDocumentFile {
   /** Client-generated identifier — not a server UID, used for list tracking before upload. */
   id: string;
   /** The actual File object to be uploaded. */
   file: File;
-  /** Display name, pre-filled from the file basename and editable before submit. */
-  name: string;
   status: PendingDocumentFileStatus;
   /** Set when status is 'error' — surfaced inline under this file's row. */
   errorMessage?: string;

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -771,6 +771,22 @@ export type DocumentFormMode = CreateCommitteeDocumentType | 'file';
 /** Which resource type the shared document form dialog operates against. Drives service dispatch + copy. */
 export type DocumentFormEntityType = 'committee' | 'project';
 
+/** Upload status of a single file staged in the document form dialog's multi-file file-mode flow. */
+export type PendingDocumentFileStatus = 'pending' | 'uploading' | 'success' | 'error';
+
+/** A file staged for upload in the document form dialog, tracked independently through parallel upload. */
+export interface PendingDocumentFile {
+  /** Client-generated identifier — not a server UID, used for list tracking before upload. */
+  id: string;
+  /** The actual File object to be uploaded. */
+  file: File;
+  /** Display name, pre-filled from the file basename and editable before submit. */
+  name: string;
+  status: PendingDocumentFileStatus;
+  /** Set when status is 'error' — surfaced inline under this file's row. */
+  errorMessage?: string;
+}
+
 /**
  * A document or resource link associated with a committee.
  */


### PR DESCRIPTION
## Summary
- Documents tab upload (committee + project scopes) now supports multi-select and drag-drop of multiple files in a single dialog, instead of one file per dialog open — matching the existing meeting-materials multi-select pattern.
- Files upload in parallel; each file gets independent success/failure state. Successes are never rolled back on partial failure, and upstream duplicate-name (409) errors are surfaced per file rather than as a single generic toast.
- The file-mode UI is reworked from a single "selected file" chip to an editable multi-row pending list (name pre-filled from basename, editable inline, per-row remove). Link and folder modes are unchanged.
- No upstream/BFF API change — the upload endpoint is confirmed one-file-per-request; the frontend loops requests in parallel via RxJS `mergeMap`.

## Test plan
- [x] `yarn lint`, `yarn format`, `yarn build` green
- [x] `yarn test` green (268 + 578 existing tests unaffected; this repo's `vitest.config.ts` scopes tests to `src/server/**` only — no Angular component/template spec harness exists in `apps/lfx-one`, so no new unit spec was added for this UI-only change)
- [ ] Manual verification pending integration validation pass (per team workflow): committee Documents tab and project Documents tab — multi-select + drag-drop, duplicate-name file, oversized file, mixed success/failure, single-file flow, Add Link / New Folder dialogs unaffected

LFXV2-2942