### PR TITLE
feat(profile): add about me bio field to profile edit and panel

### DIFF
--- a/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
+++ b/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
@@ -132,4 +132,40 @@ test.describe('Profile edit drawer', () => {
     // The drawer must send a user_metadata envelope (not a flat body) carrying the edited field.
     expect(patchBody?.user_metadata?.given_name).toBe(uniqueName);
   });
+
+  test('S4: About Me saves, the drawer closes, and the panel reflects the bio', async ({ page }) => {
+    // Stub the write so the real profile is never mutated — assert on drawer-close + optimistic update,
+    // and lock in that the bio rides inside the user_metadata envelope.
+    let patchBody: { user_metadata?: { bio?: string } } | null = null;
+    await page.route('**/api/profile', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        patchBody = route.request().postDataJSON();
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await page.getByTestId('profile-edit-button').click();
+
+    const drawer = page.getByTestId('profile-edit-drawer-body');
+    await expect(drawer).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    const bio = page.getByTestId('profile-edit-drawer-about-me').locator('textarea');
+    const uniqueBio = `E2E bio ${Date.now()}`;
+    await bio.fill(uniqueBio);
+
+    const saveButton = page.getByTestId('profile-edit-drawer-save-button').locator('button');
+    await expect(saveButton, 'Save enables once the form is dirty').toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    await saveButton.click();
+
+    await expect(drawer, 'drawer should close after a successful save').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+    // Optimistic update: bio maps to the panel's About Me block without a refetch.
+    await expect(page.getByTestId('profile-panel-about'), 'panel should reflect the edited bio optimistically').toContainText(uniqueBio, {
+      timeout: ELEMENT_TIMEOUT,
+    });
+    // The drawer must send the bio inside the user_metadata envelope.
+    expect(patchBody?.user_metadata?.bio).toBe(uniqueBio);
+  });
 });

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -24,6 +24,7 @@
       [addressLines]="fullAddress()"
       [phone]="phoneInfo()"
       [tshirtSize]="tshirtSizeLabel()"
+      [aboutMe]="aboutMe()"
       [githubHandle]="githubHandle()"
       (editRequested)="openEditDrawer()" />
   </div>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -108,6 +108,8 @@ export class ProfileLayoutComponent {
 
   public readonly jobTitle = computed(() => this.profileData()?.jobTitle || '');
 
+  public readonly aboutMe = computed(() => this.profileData()?.aboutMe || '');
+
   public readonly organization = computed(() => this.profileData()?.organization || '');
 
   public readonly emailInfo = computed(() => this.profileData()?.email || '');
@@ -249,6 +251,7 @@ export class ProfileLayoutComponent {
       postal_code: formData.postal_code || undefined,
       phone_number: formData.phone_number || undefined,
       t_shirt_size: formData.t_shirt_size || undefined,
+      bio: formData.bio || undefined,
     };
 
     const updateData: ProfileUpdateRequest = {
@@ -357,6 +360,7 @@ export class ProfileLayoutComponent {
       postalCode: profile.profile?.postal_code || '',
       phoneNumber: profile.profile?.phone_number || '',
       tshirtSize: normalizeTShirtSize(profile.profile?.t_shirt_size),
+      aboutMe: profile.profile?.bio || '',
       avatarUrl: profile.profile?.picture || '',
     };
   }

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -68,7 +68,7 @@
             <i class="fa-light fa-file-lines"></i>
             <span>About me</span>
           </div>
-          <div class="whitespace-pre-line text-[12.5px] leading-relaxed text-slate-800">{{ aboutMe() }}</div>
+          <div class="whitespace-pre-line break-words text-[12.5px] leading-relaxed text-slate-800">{{ aboutMe() }}</div>
         </div>
       }
       @if (jobTitle()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -68,7 +68,7 @@
             <i class="fa-light fa-file-lines"></i>
             <span>About me</span>
           </div>
-          <div class="text-[12.5px] leading-relaxed text-slate-800">{{ aboutMe() }}</div>
+          <div class="whitespace-pre-line text-[12.5px] leading-relaxed text-slate-800">{{ aboutMe() }}</div>
         </div>
       }
       @if (jobTitle()) {

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.html
@@ -37,7 +37,7 @@
               control="bio"
               id="drawer-edit-about-me"
               [rows]="4"
-              [maxlength]="2000"
+              [maxlength]="bioMaxLength"
               placeholder="Tell the community a bit about yourself"
               styleClass="w-full about-me-textarea"
               data-testid="profile-edit-drawer-about-me">

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.html
@@ -29,6 +29,22 @@
         <h3 class="text-base font-semibold text-slate-900 mb-4" data-testid="profile-edit-drawer-personal-heading">Personal Information</h3>
 
         <div class="flex flex-col gap-4">
+          <!-- About Me — free-text bio, first field per the v2 prototype (LFXV2-2933) -->
+          <div>
+            <label for="drawer-edit-about-me" class="block text-sm text-slate-900 mb-2">About Me</label>
+            <lfx-textarea
+              [form]="profileForm"
+              control="bio"
+              id="drawer-edit-about-me"
+              [rows]="4"
+              [maxlength]="2000"
+              [autoResize]="true"
+              placeholder="Tell the community a bit about yourself"
+              styleClass="w-full"
+              data-testid="profile-edit-drawer-about-me">
+            </lfx-textarea>
+          </div>
+
           <!-- First & Last name — two-up on md+ (matches the retired dialog's layout) -->
           <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
             <div>

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.html
@@ -38,9 +38,8 @@
               id="drawer-edit-about-me"
               [rows]="4"
               [maxlength]="2000"
-              [autoResize]="true"
               placeholder="Tell the community a bit about yourself"
-              styleClass="w-full"
+              styleClass="w-full about-me-textarea"
               data-testid="profile-edit-drawer-about-me">
             </lfx-textarea>
           </div>

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.scss
@@ -4,7 +4,7 @@
 // About Me bio textarea — match the v2 prototype: a fixed-height box the user can
 // drag to resize vertically. Overrides the shared wrapper's default content
 // auto-sizing (field-sizing: content) for this instance only.
-::ng-deep .about-me-textarea.p-textarea {
+:host ::ng-deep .about-me-textarea.p-textarea {
   field-sizing: fixed;
   min-height: 80px;
   resize: vertical;

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.scss
@@ -1,0 +1,11 @@
+/* Copyright The Linux Foundation and each contributor to LFX. */
+/* SPDX-License-Identifier: MIT */
+
+// About Me bio textarea — match the v2 prototype: a fixed-height box the user can
+// drag to resize vertically. Overrides the shared wrapper's default content
+// auto-sizing (field-sizing: content) for this instance only.
+::ng-deep .about-me-textarea.p-textarea {
+  field-sizing: fixed;
+  min-height: 80px;
+  resize: vertical;
+}

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -10,7 +10,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
-import { COUNTRIES, normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared/constants';
+import { COUNTRIES, normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, PROFILE_BIO_MAX_LENGTH, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared/constants';
 import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata, WorkExperienceEntry } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { UserService } from '@services/user.service';
@@ -46,6 +46,9 @@ export class ProfileEditDrawerComponent {
   // Emits the saved metadata so the host layout can apply an optimistic profile update.
   public readonly saved = output<Partial<UserMetadata>>();
 
+  // Bio length cap, shared with the server validator so the template maxlength stays in sync.
+  protected readonly bioMaxLength = PROFILE_BIO_MAX_LENGTH;
+
   // Profile edit form
   public profileForm: FormGroup = this.fb.group({
     given_name: ['', [Validators.maxLength(50)]],
@@ -58,7 +61,7 @@ export class ProfileEditDrawerComponent {
     postal_code: ['', [Validators.maxLength(20)]],
     phone_number: ['', [Validators.maxLength(20)]],
     t_shirt_size: [''],
-    bio: ['', [Validators.maxLength(2000)]],
+    bio: ['', [Validators.maxLength(PROFILE_BIO_MAX_LENGTH)]],
     job_title: ['', [Validators.maxLength(100)]],
     // Organization is selected from work-history orgs (a constrained list); the only remaining
     // guard mirrors the backend limit (user.service.ts rejects organization > 200 chars).

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -31,6 +31,7 @@ import { ProfileEditDrawerService } from './profile-edit-drawer.service';
   selector: 'lfx-profile-edit-drawer',
   imports: [DrawerModule, ReactiveFormsModule, InputTextComponent, SelectComponent, TextareaComponent, ButtonComponent],
   templateUrl: './profile-edit-drawer.component.html',
+  styleUrl: './profile-edit-drawer.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
 export class ProfileEditDrawerComponent {

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -9,6 +9,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
+import { TextareaComponent } from '@components/textarea/textarea.component';
 import { COUNTRIES, normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, TSHIRT_SIZES, US_STATES } from '@lfx-one/shared/constants';
 import { CombinedProfile, ProfileUpdateRequest, UserEmail, UserMetadata, WorkExperienceEntry } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
@@ -28,7 +29,7 @@ import { ProfileEditDrawerService } from './profile-edit-drawer.service';
  */
 @Component({
   selector: 'lfx-profile-edit-drawer',
-  imports: [DrawerModule, ReactiveFormsModule, InputTextComponent, SelectComponent, ButtonComponent],
+  imports: [DrawerModule, ReactiveFormsModule, InputTextComponent, SelectComponent, TextareaComponent, ButtonComponent],
   templateUrl: './profile-edit-drawer.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })
@@ -56,6 +57,7 @@ export class ProfileEditDrawerComponent {
     postal_code: ['', [Validators.maxLength(20)]],
     phone_number: ['', [Validators.maxLength(20)]],
     t_shirt_size: [''],
+    bio: ['', [Validators.maxLength(2000)]],
     job_title: ['', [Validators.maxLength(100)]],
     // Organization is selected from work-history orgs (a constrained list); the only remaining
     // guard mirrors the backend limit (user.service.ts rejects organization > 200 chars).
@@ -213,6 +215,7 @@ export class ProfileEditDrawerComponent {
       postal_code: formValue.postal_code || undefined,
       phone_number: formValue.phone_number || undefined,
       t_shirt_size: formValue.t_shirt_size || undefined,
+      bio: formValue.bio || undefined,
     };
 
     const updateData: ProfileUpdateRequest = {
@@ -323,6 +326,7 @@ export class ProfileEditDrawerComponent {
         postal_code: profile.profile?.postal_code || '',
         phone_number: profile.profile?.phone_number || '',
         t_shirt_size: normalizeTShirtSize(profile.profile?.t_shirt_size),
+        bio: profile.profile?.bio || '',
         job_title: profile.profile?.job_title || '',
         // Trim so the form value matches the trimmed option values — otherwise a legacy saved
         // org with stray whitespace would fail to match any option and render an empty selection.

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -253,6 +253,11 @@ export class UserService {
       throw new Error('Job title is too long');
     }
 
+    // Validate bio if provided (basic length check)
+    if (metadata?.bio && metadata.bio.length > 2000) {
+      throw new Error('Bio is too long (max 2000 characters)');
+    }
+
     return true;
   }
 

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -6,6 +6,7 @@ import {
   LATEST_PAST_MEETINGS_RETURN_LIMIT,
   NATS_CONFIG,
   PENDING_ACTION_SEVERITY,
+  PROFILE_BIO_MAX_LENGTH,
   QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
   TSHIRT_SIZES,
 } from '@lfx-one/shared/constants';
@@ -254,8 +255,8 @@ export class UserService {
     }
 
     // Validate bio if provided (basic length check)
-    if (metadata?.bio && metadata.bio.length > 2000) {
-      throw new Error('Bio is too long (max 2000 characters)');
+    if (metadata?.bio && metadata.bio.length > PROFILE_BIO_MAX_LENGTH) {
+      throw new Error(`Bio is too long (max ${PROFILE_BIO_MAX_LENGTH} characters)`);
     }
 
     return true;

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -13,6 +13,13 @@ import { CdpIdentityType, IdentityProvider, IdentityProviderOption, ProfileTab }
 export const PENDING_PROFILE_SAVE_KEY = 'lfx_profile_pending_save';
 
 /**
+ * Maximum length of the free-text "About Me" (bio) profile field. Shared across
+ * the BFF validator, the reactive-form validator, and the textarea's maxlength
+ * so the client and server enforce a single contract.
+ */
+export const PROFILE_BIO_MAX_LENGTH = 2000;
+
+/**
  * Profile tab configuration
  */
 export const PROFILE_TABS: ProfileTab[] = [

--- a/packages/shared/src/interfaces/profile.interface.ts
+++ b/packages/shared/src/interfaces/profile.interface.ts
@@ -60,6 +60,7 @@ export interface ProfileHeaderData {
   postalCode?: string;
   phoneNumber?: string;
   tshirtSize?: string;
+  aboutMe?: string;
   avatarUrl?: string;
 }
 

--- a/packages/shared/src/interfaces/user-profile.interface.ts
+++ b/packages/shared/src/interfaces/user-profile.interface.ts
@@ -100,6 +100,7 @@ export interface UserMetadata {
   postal_code?: string;
   phone_number?: string;
   t_shirt_size?: string;
+  bio?: string;
   picture?: string;
   zoneinfo?: string;
 }


### PR DESCRIPTION
**Summary**

- Add a free-text **About Me** (`bio`) field to the LFX One profile, persisted in Auth0 `user_metadata` under the `bio` key (matches the `lfx-v2-auth-service` contract).
- Shared types: `bio?` on `UserMetadata`, `aboutMe?` on `ProfileHeaderData`.
- Server-side length guard in `validateUserMetadata()` and client-side `Validators.maxLength(...)` on the drawer control, both driven by a shared `PROFILE_BIO_MAX_LENGTH` constant.
- Edit drawer: `lfx-textarea` (fixed-height, vertically resizable per the v2 prototype), placed as the first field in Personal Information; wired through `onSubmit`, `populateForm`, and the Flow C management-token redirect path.
- Profile panel: bound the previously-unwired `[aboutMe]` input (renders with `whitespace-pre-line` so multi-line bios keep their line breaks).
- E2E: fill → save → drawer close → optimistic panel update → `user_metadata.bio` envelope assertion.

**External References**

- **Upstream contract (must merge + deploy first):** [`linuxfoundation/lfx-v2-auth-service#65`](https://github.com/linuxfoundation/lfx-v2-auth-service/pull/65) — `feat(user-metadata): add bio (About Me) field`. `bio` is not yet in auth-service `main`, so the NATS round-trip drops the value until #65 ships. This PR should merge/deploy **after** #65.

Fixes LFXV2-2933
