### PR TITLE
fix(meetings): remove YoY suffix from influence deltas

### DIFF
--- a/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
@@ -62,7 +62,7 @@ const MOCK_SPEND_BREAKDOWN = {
   byRole: [{ label: 'Participant', pct: 100, count: 2000 }],
 };
 
-function mockInfluenceRow(project: string, projectSlug: string): unknown {
+function mockInfluenceRow(project: string, projectSlug: string, deltaLabel = '+6%', deltaDirection = 'up'): unknown {
   return {
     project,
     projectSlug,
@@ -70,8 +70,8 @@ function mockInfluenceRow(project: string, projectSlug: string): unknown {
     band: 'leading',
     rankLabel: '#3 of 210',
     fromAttendancePct: 15,
-    deltaLabel: '+6% YoY',
-    deltaDirection: 'up',
+    deltaLabel,
+    deltaDirection,
     breakdown: [
       { label: 'Collaboration Activity', pct: 30 },
       { label: 'Meeting Attendance', pct: 15 },
@@ -180,6 +180,8 @@ test.describe('Org Meetings insights (6a redesign)', () => {
 
     const influence = page.getByTestId('org-meetings-influence');
     await expect(influence).toBeVisible();
+    await expect(influence).toContainText('+6%');
+    await expect(influence).not.toContainText('YoY');
 
     // All rows start collapsed, so no detail rows are rendered.
     await expect(page.getByTestId('org-meetings-influence-row-kubernetes-detail')).toHaveCount(0);
@@ -198,6 +200,18 @@ test.describe('Org Meetings insights (6a redesign)', () => {
     // Collapsing Kubernetes via its caret removes the detail row.
     await page.getByTestId('org-meetings-influence-row-kubernetes-caret').click();
     await expect(page.getByTestId('org-meetings-influence-row-kubernetes-detail')).toHaveCount(0);
+  });
+
+  test('renders no-change influence deltas without the YoY suffix', async ({ page }) => {
+    await stubOrgLensContext(page, {
+      influence: [mockInfluenceRow('Kubernetes', 'kubernetes', 'No change', 'flat')],
+    });
+    await gotoOrgMeetingsPage(page);
+
+    const influence = page.getByTestId('org-meetings-influence');
+    await expect(influence).toBeVisible();
+    await expect(influence).toContainText('No change');
+    await expect(influence).not.toContainText('YoY');
   });
 
   test('switching time range refetches with the selected window', async ({ page }) => {

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.spec.ts
@@ -129,7 +129,7 @@ describe('OrgLensMeetingsService — influence row delta labels', () => {
   it('renders the warehouse percentage with the warehouse trend direction', async () => {
     const row = await firstRow({ DELTA_PCT: 9.9, TREND_DIRECTION: 'down' });
 
-    expect(row.deltaLabel).toBe('+9.9% YoY');
+    expect(row.deltaLabel).toBe('+9.9%');
     // DR-011: direction comes from TREND_DIRECTION, not the sign of the percentage.
     expect(row.deltaDirection).toBe('down');
   });
@@ -147,6 +147,20 @@ describe('OrgLensMeetingsService — influence row delta labels', () => {
     expect(row.deltaLabel).toBe('New');
   });
 
+  it('renders "No change" when the influence score stays at zero', async () => {
+    const row = await firstRow({ ECOSYSTEM_INFLUENCE: 0, PRIOR_YEAR_SCORE: 0 });
+
+    expect(row.deltaLabel).toBe('No change');
+    expect(row.deltaDirection).toBe('flat');
+  });
+
+  it('renders "No change" when a non-zero baseline has no percentage delta', async () => {
+    const row = await firstRow({ DELTA_PCT: 0, PRIOR_YEAR_SCORE: 10 });
+
+    expect(row.deltaLabel).toBe('No change');
+    expect(row.deltaDirection).toBe('flat');
+  });
+
   // An absent prior score is unknown, not small — the one case with no percentage to fall back to.
   it.each([{ PRIOR_YEAR_SCORE: null }, { PRIOR_YEAR_SCORE: undefined }])(
     'keeps the unknown-baseline label when the prior score is absent',
@@ -158,17 +172,17 @@ describe('OrgLensMeetingsService — influence row delta labels', () => {
     }
   );
 
-  it('groups an oversized YoY percentage instead of suppressing it', async () => {
+  it('groups an oversized percentage instead of suppressing it', async () => {
     const row = await firstRow({ DELTA_PCT: 61328.8 });
 
-    expect(row.deltaLabel).toBe('+61,328.8% YoY');
+    expect(row.deltaLabel).toBe('+61,328.8%');
   });
 });
 
 describe('OrgLensMeetingsService — cache keys', () => {
   it.each([
     { surface: 'kpi', call: (s: InstanceType<typeof OrgLensMeetingsService>) => s.getKpiSummary(req, 'acc', 'past365d'), key: 'meetings-kpi:v2:past365d' },
-    { surface: 'influence', call: (s: InstanceType<typeof OrgLensMeetingsService>) => s.getInfluenceRows(req, 'acc'), key: 'meetings-influence:v2' },
+    { surface: 'influence', call: (s: InstanceType<typeof OrgLensMeetingsService>) => s.getInfluenceRows(req, 'acc'), key: 'meetings-influence:v3' },
     { surface: 'spend', call: (s: InstanceType<typeof OrgLensMeetingsService>) => s.getSpendBreakdown(req, 'acc', 'past365d'), key: 'meetings-spend:past365d' },
   ])('$surface reads from $key', async ({ call, key }) => {
     execute.mockResolvedValue({ rows: [] });

--- a/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-meetings.service.ts
@@ -29,7 +29,7 @@ const INFLUENCE_BANDS: readonly OrgLensProjectBand[] = ['silent', 'participating
 const TREND_DIRECTIONS: readonly OrgMeetingsDeltaDirection[] = ['up', 'down', 'flat'];
 
 const KPI_NO_CHANGE_LABEL = 'No change vs. prior period';
-const INFLUENCE_NO_CHANGE_LABEL = 'No change YoY';
+const INFLUENCE_NO_CHANGE_LABEL = 'No change';
 const NEW_LABEL = 'New';
 
 /**
@@ -149,10 +149,10 @@ export class OrgLensMeetingsService {
   public async getInfluenceRows(req: Request, accountId: string): Promise<OrgInfluenceRow[]> {
     return withOrgCache(
       accountId,
-      // `v2`: same reason as the KPI key — the Δ-YoY column shares the delta formatter, so cached
+      // `v3`: same reason as the KPI key — the Δ-YoY column shares the delta formatter, so cached
       // rows can carry the retired label. `meetings-spend` is deliberately left at v1; it has no
       // delta labels, so evicting it would discard warm entries for no behaviour change.
-      'meetings-influence:v2',
+      'meetings-influence:v3',
       VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
       async () => {
         logger.debug(req, 'get_org_lens_meetings_influence', 'Cache miss; querying Snowflake', { account_id: accountId });
@@ -307,7 +307,7 @@ export class OrgLensMeetingsService {
     }
 
     const pct = this.round1(row.DELTA_PCT);
-    const delta = this.formatDelta(pct, '% YoY', INFLUENCE_NO_CHANGE_LABEL);
+    const delta = this.formatDelta(pct, '%', INFLUENCE_NO_CHANGE_LABEL);
     // The direction is the warehouse's own `trend_direction` rather than the sign of `pct` (DR-011),
     // but only where an actual percentage was rendered.
     return delta.kind === 'pct'


### PR DESCRIPTION
## Summary
- Remove the `YoY` suffix from Org Meetings influence delta labels.
- Render zero/zero and zero-rounded influence deltas as `No change`.
- Version the influence cache key to prevent stale labels and add unit/E2E coverage.
- Tracks [LFXV2-2951](https://linuxfoundation.atlassian.net/browse/LFXV2-2951).

## Test plan
- [x] `yarn vitest run src/server/services/org-lens-meetings.service.spec.ts` (21 passed)
- [x] `yarn check-types`
- [x] `yarn lint:check`
- [x] `yarn format:check`
- [x] `yarn build`
- [x] Playwright test discovery for `e2e/org-meetings-dashboard.spec.ts`
- [ ] Full Playwright runtime against the local stack

All commits are DCO signed off with `git commit -s`.

Made with [Cursor](https://cursor.com)

[LFXV2-2951]: https://linuxfoundation.atlassian.net/browse/LFXV2-2951?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ