### PR TITLE
feat(committees): server-side activity feed aggregation

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -262,8 +262,14 @@ export class CommitteeOverviewComponent {
         // (`dashboard-meeting-card.component.ts`'s `initMeetingDetailQueryParams`) — a password-gated
         // committee meeting needs that param carried through, matching the established convention at
         // `meetings-dashboard.component.ts`'s `onCalendarEventClick`.
-        const meeting = this.pastMeetings().find((m) => m.id === action.meetingId);
-        void this.router.navigate(['/meetings', action.meetingId], meeting?.password ? { queryParams: { password: meeting.password } } : {});
+        //
+        // action.password comes from the source event's own payload, not a lookup against
+        // this.pastMeetings() — that signal is a separate, independently-windowed fetch, so a
+        // password-protected meeting recent enough to appear in the activity feed isn't guaranteed
+        // to be in pastMeetings()'s own window; a lookup-based password would silently be dropped on
+        // navigation for exactly the rows this matters most for (Copilot/Cursor Bugbot/dealako review
+        // on PR #1288).
+        void this.router.navigate(['/meetings', action.meetingId], action.password ? { queryParams: { password: action.password } } : {});
         break;
       }
       case 'vote-drawer': {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -285,9 +285,10 @@ export class CommitteeOverviewComponent {
         break;
       }
       case 'external-url':
-        // buildActivityFeed only emits this action for urls that pass isValidUrl, but re-check at
-        // this sink rather than trusting that comment-enforced invariant — the union is shared
-        // shape LFXV2-1707's server-fed activity items will also construct.
+        // mapActivityEventsToFeedItems only emits this action for urls that pass isValidUrl, but
+        // re-check at this sink rather than trusting that comment-enforced invariant — the action
+        // is constructed client-side from a server-fed ActivityEvent, not a value this component
+        // controls end-to-end.
         if (isValidUrl(action.url)) {
           window.open(action.url, '_blank', 'noopener,noreferrer');
         }
@@ -296,8 +297,8 @@ export class CommitteeOverviewComponent {
         this.navigateToTab(action.tab);
         break;
       default:
-        // assertNeverSilent: this runs inside a DOM click handler, and LFXV2-1707 will feed
-        // server-constructed actions into this same union, so an unrecognized future `kind` (e.g. a
+        // assertNeverSilent: this runs inside a DOM click handler, and this action is constructed
+        // from a server-fed ActivityEvent (LFXV2-1707), so an unrecognized future `kind` (e.g. a
         // version-skewed client) should no-op rather than throw uncaught from a click. The
         // compile-time guarantee is unchanged — a new unhandled kind still fails to compile, since
         // the call below only type-checks if `action` has narrowed to `never`. console.error (not
@@ -573,8 +574,11 @@ export class CommitteeOverviewComponent {
             // CommitteeService.getCommitteeActivity already falls back to of([]) on failure, so this
             // catchError is a belt-and-suspenders guard against that coupling changing underneath
             // this component — without it, an error here would kill this toSignal source permanently
-            // and pin activityFeedLoading() on its skeleton for the rest of the session.
-            catchError(() => {
+            // and pin activityFeedLoading() on its skeleton for the rest of the session. Logs (unlike
+            // the service's own silent fallback) specifically because reaching this handler at all
+            // would mean that upstream guarantee broke — worth knowing about, not just surviving.
+            catchError((error) => {
+              console.error('Failed to map committee activity feed:', error);
               this.activityFeedLoading.set(false);
               return of<ActivityFeedItem[]>([]);
             })

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -290,10 +290,13 @@ export class CommitteeOverviewComponent {
         break;
       }
       case 'survey-drawer': {
-        // Same independent-fetch mismatch and same recoverable-in-principle/toast-instead
-        // trade-off as the vote-drawer case above — SurveyResultsDrawerComponent's own
-        // initSurvey() has the identical startWith/re-fetch shape and the identical missing
-        // `@else` on its template's `@if`.
+        // Same class of independent-fetch mismatch as the vote-drawer case above — this.surveys()
+        // and the activity feed are two separate server fetches with different windows (unlike
+        // votes, getSurveysByCommittee sets no page_size or order at all, so its own window is
+        // whatever the underlying endpoint defaults to, not a pinned page_size=100) — and the same
+        // recoverable-in-principle/toast-instead trade-off: SurveyResultsDrawerComponent's own
+        // initSurvey() has the identical startWith/re-fetch shape and the identical missing `@else`
+        // on its template's `@if` as VoteResultsDrawerComponent.
         const survey = this.surveys().find((s) => s.uid === action.surveyUid);
         if (survey) {
           this.selectedSurveyId.set(survey.uid);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -574,9 +574,9 @@ export class CommitteeOverviewComponent {
             // CommitteeService.getCommitteeActivity already falls back to of([]) on failure, so this
             // catchError is a belt-and-suspenders guard against that coupling changing underneath
             // this component — without it, an error here would kill this toSignal source permanently
-            // and pin activityFeedLoading() on its skeleton for the rest of the session. Logs (unlike
-            // the service's own silent fallback) specifically because reaching this handler at all
-            // would mean that upstream guarantee broke — worth knowing about, not just surviving.
+            // and pin activityFeedLoading() on its skeleton for the rest of the session. Reaching this
+            // handler at all means the mapping step itself threw (not the upstream fetch, which the
+            // service already logs and degrades on its own) — worth its own log line, not just surviving.
             catchError((error) => {
               console.error('Failed to map committee activity feed:', error);
               this.activityFeedLoading.set(false);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -613,8 +613,11 @@ export class CommitteeOverviewComponent {
             // and pin activityFeedLoading() on its skeleton for the rest of the session. Reaching this
             // handler at all means the mapping step itself threw (not the upstream fetch, which the
             // service already logs and degrades on its own) — worth its own log line, not just surviving.
-            catchError((error) => {
-              console.error('Failed to map committee activity feed:', error);
+            catchError((error: unknown) => {
+              // A safe subset, not the raw error object — this is a synchronous mapping failure
+              // (not an HTTP error, so no HttpErrorResponse.status here), and the underlying
+              // upstream fetch failure (if any) is already logged server-side with more structure.
+              console.error('Failed to map committee activity feed:', { message: error instanceof Error ? error.message : String(error) });
               this.activityFeedLoading.set(false);
               return of<ActivityFeedItem[]>([]);
             })

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -19,7 +19,6 @@ import { CommitteeMemberRole, PollStatus, SurveyStatus } from '@lfx-one/shared/e
 import {
   ActivityFeedItem,
   Committee,
-  CommitteeDocument,
   CommitteeMember,
   CommitteePendingActionRow,
   Meeting,
@@ -28,7 +27,7 @@ import {
   Survey,
   Vote,
 } from '@lfx-one/shared/interfaces';
-import { assertNeverSilent, buildActivityFeed, countVotingReps, getSurveyDisplayStatus, isValidUrl } from '@lfx-one/shared/utils';
+import { assertNeverSilent, countVotingReps, getSurveyDisplayStatus, isValidUrl, mapActivityEventsToFeedItems } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { MeetingService } from '@services/meeting.service';
@@ -38,7 +37,7 @@ import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, of, switchMap, take, tap } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, filter, finalize, forkJoin, map, of, switchMap, take, tap } from 'rxjs';
 
 import { DashboardMeetingCardComponent } from '../../../dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component';
 import { SurveyResultsDrawerComponent } from '../../../surveys/components/survey-results-drawer/survey-results-drawer.component';
@@ -113,10 +112,13 @@ export class CommitteeOverviewComponent {
   public meetingsLoading = signal(true);
   public votesLoading = signal(true);
   public surveysLoading = signal(true);
-  public documentsLoading = signal(true);
 
   // Loading state for past meetings (upcoming meetings loading comes in as the input above)
   public pastMeetingsLoading = signal(true);
+
+  // Activity feed loading — own dedicated signal (LFXV2-1707): the feed is now a single
+  // server-merged fetch, no longer derived from four separate source-loading signals.
+  public activityFeedLoading = signal(true);
 
   // Section-level fade-out for "My Pending Actions": true while the CSS collapse animation is in flight;
   // isSectionHidden removes the section from the DOM once the last vote/survey is resolved.
@@ -158,26 +160,14 @@ export class CommitteeOverviewComponent {
   public pastMeetings: Signal<PastMeeting[]> = this.initPastMeetings();
   public votes: Signal<Vote[]> = this.initVotes();
   public surveys: Signal<Survey[]> = this.initSurveys();
-  // Documents aren't otherwise loaded on Overview — fetched here solely to seed the activity feed
-  // (which shows at most 5 document rows). Not cheap: getCommitteeDocuments fans out server-side to
-  // /folders, /links, and an unbounded fetchAllQueryResources page-token loop over every
-  // committee_document (committee.service.ts), repeated on every silent refresh and again when the
-  // user opens the Documents tab (no shared cache). Accepted as a stop-gap for this ticket's scope —
-  // lifting the fetch to committee-view.component.ts to share across tabs, or bounding it with a
-  // page_size/order param, is real follow-up work, not a change this branch makes.
-  public documents: Signal<CommitteeDocument[]> = this.initDocuments();
 
   // Computed stats from fetched data
   public activeVotesCount: Signal<number> = computed(() => this.votes().filter((v) => v.status === PollStatus.ACTIVE).length);
 
   public openSurveysCount: Signal<number> = computed(() => this.surveys().filter((s) => getSurveyDisplayStatus(s) === SurveyStatus.OPEN).length);
 
-  // Activity feed stop-gap: merges the latest items across past meetings, votes, surveys, and
-  // documents into one time-ordered list. Replaced by the real activity stream in LFXV2-1707.
-  public activityFeedLoading: Signal<boolean> = computed(
-    () => this.pastMeetingsLoading() || this.votesLoading() || this.surveysLoading() || this.documentsLoading()
-  );
-
+  // Server-merged "Recent Activity" feed (LFXV2-1707): fetched as one call, mapped to the UI
+  // view-model client-side. See mapActivityEventsToFeedItems for the label/icon/action mapping.
   public activityItems: Signal<ActivityFeedItem[]> = this.initActivityItems();
 
   // Feature flag: WG Weekly Brief AI Assistant card
@@ -553,64 +543,45 @@ export class CommitteeOverviewComponent {
     );
   }
 
-  private initDocuments(): Signal<CommitteeDocument[]> {
-    // Documents only seed the activity feed, which the template never renders for a visitor
-    // (behind !isVisitor()) — skip the fetch rather than issue a GET nothing will display.
-    // Derived from one combined computed (not combineLatest over three separate toObservable()
-    // sources) so committee/myRoleLoading/isVisitor — all recomputed together in the same signal
-    // flush — can't glitch through an inconsistent intermediate tick that fires then immediately
-    // cancels a request. distinctUntilChanged on (uid, roleLoading, visitor) only dedupes a
-    // same-tuple re-emission (e.g. an unrelated field on committee() changing identity without
-    // affecting uid/roleLoading/visitor) — it does NOT suppress a silent refresh: myRoleLoading is
-    // `loading() || committeeRefreshing()` (committee-view.component.ts), so a refresh flips
-    // roleLoading true then false, which — like pastMeetings/votes/surveys, none of which have any
-    // guard here — legitimately cancels and re-issues the documents fetch and flips
-    // activityFeedLoading() back to true for the duration.
+  private initActivityItems(): Signal<ActivityFeedItem[]> {
+    // Skip-for-visitor + distinctUntilChanged shape mirrors this component's other committee-scoped
+    // fetches: the feed (and everything else in the enclosing !isVisitor() block) never renders for
+    // a visitor, so this fetch should never fire for one either. Derived from one combined computed
+    // (not combineLatest over separate toObservable() sources) so committee/myRoleLoading/isVisitor —
+    // all recomputed together in the same signal flush — can't glitch through an inconsistent
+    // intermediate tick that fires then immediately cancels a request.
     return toSignal(
       toObservable(computed(() => ({ committee: this.committee(), roleLoading: this.myRoleLoading(), visitor: this.isVisitor() }))).pipe(
         filter(({ committee }) => !!committee?.uid),
         distinctUntilChanged((a, b) => a.committee.uid === b.committee.uid && a.roleLoading === b.roleLoading && a.visitor === b.visitor),
         switchMap(({ committee, roleLoading, visitor }) => {
           if (roleLoading) {
-            // Role still resolving (e.g. mid silent-refresh) — hold both the documents list and
-            // documentsLoading exactly as they are (no signal write here). Safe because the fetch
-            // branch below clears documentsLoading with tap (fires only on emission), not finalize
-            // (also fires on switchMap-driven cancellation) — so cancelling an in-flight fetch to
-            // enter this branch can't have already cleared it out from under us.
+            // Role still resolving (e.g. mid silent-refresh) — hold state as-is; the fetch branch
+            // below clears activityFeedLoading with tap (fires only on emission), not finalize (also
+            // fires on switchMap-driven cancellation), so cancelling in-flight to enter this branch
+            // can't have already cleared it out from under us.
             return EMPTY;
           }
           if (visitor) {
-            this.documentsLoading.set(false);
-            return of<CommitteeDocument[]>([]);
+            this.activityFeedLoading.set(false);
+            return of<ActivityFeedItem[]>([]);
           }
-          this.documentsLoading.set(true);
-          // CommitteeService.getCommitteeDocuments already falls back to of([]) on failure today, so
-          // this catchError is a belt-and-suspenders guard against that coupling changing underneath
-          // this component (e.g. a future interceptor rethrow) — without it, an error here would
-          // propagate past a next-only tap, kill this toSignal source permanently, and pin
-          // activityFeedLoading() on its skeleton for the rest of the session.
-          return this.committeeService.getCommitteeDocuments(committee.uid).pipe(
-            tap(() => this.documentsLoading.set(false)),
+          this.activityFeedLoading.set(true);
+          return this.committeeService.getCommitteeActivity(committee.uid).pipe(
+            map((events) => mapActivityEventsToFeedItems(events, { votingEnabled: !!committee.enable_voting })),
+            tap(() => this.activityFeedLoading.set(false)),
+            // CommitteeService.getCommitteeActivity already falls back to of([]) on failure, so this
+            // catchError is a belt-and-suspenders guard against that coupling changing underneath
+            // this component — without it, an error here would kill this toSignal source permanently
+            // and pin activityFeedLoading() on its skeleton for the rest of the session.
             catchError(() => {
-              this.documentsLoading.set(false);
-              return of<CommitteeDocument[]>([]);
+              this.activityFeedLoading.set(false);
+              return of<ActivityFeedItem[]>([]);
             })
           );
         })
       ),
       { initialValue: [] }
-    );
-  }
-
-  private initActivityItems(): Signal<ActivityFeedItem[]> {
-    return computed(() =>
-      buildActivityFeed({
-        pastMeetings: this.pastMeetings(),
-        votes: this.votes(),
-        surveys: this.surveys(),
-        documents: this.documents(),
-        votingEnabled: !!this.committee().enable_voting,
-      })
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -293,10 +293,14 @@ export class CommitteeOverviewComponent {
         // Different failure mode than the vote-drawer case above, same toast-instead remedy.
         // Unlike votes (a genuine window-size mismatch — getVotesByCommittee pins page_size=100),
         // the server's SurveyService.getSurveys drains every page via fetchAllQueryResources, so
-        // this.surveys() is the committee's complete survey set, not a windowed slice — the only
-        // realistic way this lookup misses is staleness between this fetch and the activity feed's
-        // independent one (a survey created/updated in the gap between the two requests), not a
-        // bounded-window gap. Same recoverable-in-principle/toast-instead trade-off regardless:
+        // this.surveys() is not a windowed slice — but "drains every page" isn't "always complete":
+        // fetchAllQueryResources defaults to failOnPartial=false (this call site doesn't override
+        // it), so a later page failing after retries returns what was fetched so far rather than
+        // throwing, and initSurveys' own catchError(() => of([])) yields an empty array on a
+        // failed/in-flight fetch regardless of drain completeness. So a miss here is normally
+        // fetch-timing staleness against the activity feed's independent request (the common case,
+        // since surveys() usually is complete) rather than a bounded-window gap like votes — but
+        // isn't guaranteed to be. Same recoverable-in-principle/toast-instead trade-off regardless:
         // SurveyResultsDrawerComponent's own initSurvey() has the identical startWith/re-fetch
         // shape and the identical missing `@else` on its template's `@if` as
         // VoteResultsDrawerComponent.

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -267,20 +267,29 @@ export class CommitteeOverviewComponent {
         break;
       }
       case 'vote-drawer': {
+        // this.votes() and the activity feed are two independent server fetches (the former
+        // page_size=100 by updated_at, the latter the 25 most recent by occurred_at) — a vote
+        // recent enough to appear in the feed isn't guaranteed to be within the former's window,
+        // so this lookup can miss. Surface that rather than a dead click with zero feedback.
         const vote = this.votes().find((v) => v.uid === action.voteUid);
         if (vote) {
           this.selectedVoteId.set(vote.uid);
           this.selectedVote.set(vote);
           this.voteDrawerVisible.set(true);
+        } else {
+          this.messageService.add({ severity: 'warn', summary: 'Vote unavailable', detail: 'This vote could not be found. Try the Votes tab instead.' });
         }
         break;
       }
       case 'survey-drawer': {
+        // Same independent-fetch mismatch as the vote-drawer case above.
         const survey = this.surveys().find((s) => s.uid === action.surveyUid);
         if (survey) {
           this.selectedSurveyId.set(survey.uid);
           this.selectedSurvey.set(survey);
           this.surveyDrawerVisible.set(true);
+        } else {
+          this.messageService.add({ severity: 'warn', summary: 'Survey unavailable', detail: 'This survey could not be found. Try the Surveys tab instead.' });
         }
         break;
       }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -268,9 +268,17 @@ export class CommitteeOverviewComponent {
       }
       case 'vote-drawer': {
         // this.votes() and the activity feed are two independent server fetches (the former
-        // page_size=100 by updated_at, the latter the 25 most recent by occurred_at) — a vote
-        // recent enough to appear in the feed isn't guaranteed to be within the former's window,
-        // so this lookup can miss. Surface that rather than a dead click with zero feedback.
+        // page_size=100 by updated_at; the latter defaults to ACTIVITY_FEED_DEFAULT_PAGE_SIZE most
+        // recent by occurred_at, unless this call ever starts passing page_size) — a vote recent
+        // enough to appear in the feed isn't guaranteed to be within the former's window, so this
+        // lookup can miss.
+        //
+        // A miss here is recoverable in principle — VoteResultsDrawerComponent's own initVote()
+        // re-fetches by voteId with a startWith(listVote) fallback, so opening the drawer with just
+        // voteId set (no local seed) would still resolve. Not done here: the drawer's template has
+        // no `@else` on `@if (vote(); as voteData)`, so a null seed renders an empty drawer with no
+        // loading or not-found state until (or unless) that fetch settles — worse than this toast
+        // for the genuinely-missing case, and out of this component's scope to add. Toast instead.
         const vote = this.votes().find((v) => v.uid === action.voteUid);
         if (vote) {
           this.selectedVoteId.set(vote.uid);
@@ -282,7 +290,10 @@ export class CommitteeOverviewComponent {
         break;
       }
       case 'survey-drawer': {
-        // Same independent-fetch mismatch as the vote-drawer case above.
+        // Same independent-fetch mismatch and same recoverable-in-principle/toast-instead
+        // trade-off as the vote-drawer case above — SurveyResultsDrawerComponent's own
+        // initSurvey() has the identical startWith/re-fetch shape and the identical missing
+        // `@else` on its template's `@if`.
         const survey = this.surveys().find((s) => s.uid === action.surveyUid);
         if (survey) {
           this.selectedSurveyId.set(survey.uid);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -290,13 +290,16 @@ export class CommitteeOverviewComponent {
         break;
       }
       case 'survey-drawer': {
-        // Same class of independent-fetch mismatch as the vote-drawer case above — this.surveys()
-        // and the activity feed are two separate server fetches with different windows (unlike
-        // votes, getSurveysByCommittee sets no page_size or order at all, so its own window is
-        // whatever the underlying endpoint defaults to, not a pinned page_size=100) — and the same
-        // recoverable-in-principle/toast-instead trade-off: SurveyResultsDrawerComponent's own
-        // initSurvey() has the identical startWith/re-fetch shape and the identical missing `@else`
-        // on its template's `@if` as VoteResultsDrawerComponent.
+        // Different failure mode than the vote-drawer case above, same toast-instead remedy.
+        // Unlike votes (a genuine window-size mismatch — getVotesByCommittee pins page_size=100),
+        // the server's SurveyService.getSurveys drains every page via fetchAllQueryResources, so
+        // this.surveys() is the committee's complete survey set, not a windowed slice — the only
+        // realistic way this lookup misses is staleness between this fetch and the activity feed's
+        // independent one (a survey created/updated in the gap between the two requests), not a
+        // bounded-window gap. Same recoverable-in-principle/toast-instead trade-off regardless:
+        // SurveyResultsDrawerComponent's own initSurvey() has the identical startWith/re-fetch
+        // shape and the identical missing `@else` on its template's `@if` as
+        // VoteResultsDrawerComponent.
         const survey = this.surveys().find((s) => s.uid === action.surveyUid);
         if (survey) {
           this.selectedSurveyId.set(survey.uid);

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
+import { HttpClient, HttpErrorResponse, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import {
   ActivityEvent,
@@ -194,8 +194,8 @@ export class CommitteeService {
   public getCommitteeActivity(committeeId: string): Observable<ActivityEvent[]> {
     return this.http.get<PaginatedResponse<ActivityEvent>>(`/api/committees/${encodeURIComponent(committeeId)}/activity`).pipe(
       map((response) => response.data),
-      catchError((error) => {
-        console.error('Failed to load committee activity feed:', error);
+      catchError((error: HttpErrorResponse) => {
+        console.error('Failed to load committee activity feed:', { status: error.status, message: error.message });
         return of([]);
       })
     );

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -194,7 +194,10 @@ export class CommitteeService {
   public getCommitteeActivity(committeeId: string): Observable<ActivityEvent[]> {
     return this.http.get<PaginatedResponse<ActivityEvent>>(`/api/committees/${committeeId}/activity`).pipe(
       map((response) => response.data),
-      catchError(() => of([]))
+      catchError((error) => {
+        console.error('Failed to load committee activity feed:', error);
+        return of([]);
+      })
     );
   }
 

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -4,6 +4,7 @@
 import { HttpClient, HttpHeaders, HttpParams } from '@angular/common/http';
 import { inject, Injectable, signal, WritableSignal } from '@angular/core';
 import {
+  ActivityEvent,
   Committee,
   CommitteeDocument,
   CommitteeDocumentType,
@@ -18,6 +19,7 @@ import {
   CreateCommitteeMemberRequest,
   GroupsEngagementStats,
   MyCommittee,
+  PaginatedResponse,
   QueryServiceCountResponse,
 } from '@lfx-one/shared/interfaces';
 import { catchError, map, Observable, of, take, tap, throwError } from 'rxjs';
@@ -180,6 +182,20 @@ export class CommitteeService {
   public submitApplication(committeeId: string, message?: string): Observable<CommitteeJoinApplication> {
     const body: CreateCommitteeJoinApplicationRequest = { message: message || '' };
     return this.http.post<CommitteeJoinApplication>(`/api/committees/${committeeId}/applications`, body).pipe(take(1));
+  }
+
+  // ── Activity Feed (LFXV2-1707) ──────────────────────────────────────────
+
+  /**
+   * Server-merged "Recent Activity" feed for the committee Overview widget (past meetings, votes,
+   * surveys, documents). Resolves to `[]` on error, matching every other Overview data source on
+   * this service — a feed failure must not break the rest of the page.
+   */
+  public getCommitteeActivity(committeeId: string): Observable<ActivityEvent[]> {
+    return this.http.get<PaginatedResponse<ActivityEvent>>(`/api/committees/${committeeId}/activity`).pipe(
+      map((response) => response.data),
+      catchError(() => of([]))
+    );
   }
 
   // ── Committee Documents ─────────────────────────────────────────────────

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -192,7 +192,7 @@ export class CommitteeService {
    * this service — a feed failure must not break the rest of the page.
    */
   public getCommitteeActivity(committeeId: string): Observable<ActivityEvent[]> {
-    return this.http.get<PaginatedResponse<ActivityEvent>>(`/api/committees/${committeeId}/activity`).pipe(
+    return this.http.get<PaginatedResponse<ActivityEvent>>(`/api/committees/${encodeURIComponent(committeeId)}/activity`).pipe(
       map((response) => response.data),
       catchError((error) => {
         console.error('Failed to load committee activity feed:', error);

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.spec.ts
@@ -1,0 +1,110 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { validateUidParameter, parseCommitteeActivityQuery, getCommitteeActivity, logger } = vi.hoisted(() => ({
+  validateUidParameter: vi.fn(),
+  parseCommitteeActivityQuery: vi.fn(),
+  getCommitteeActivity: vi.fn(),
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('../helpers/validation.helper', () => ({ validateUidParameter }));
+vi.mock('../helpers/committee-activity-query.helper', () => ({ parseCommitteeActivityQuery }));
+vi.mock('../services/committee-activity.service', () => ({
+  CommitteeActivityService: class {
+    public getCommitteeActivity = getCommitteeActivity;
+  },
+}));
+vi.mock('../services/logger.service', () => ({ logger }));
+
+import { CommitteeActivityController } from './committee-activity.controller';
+
+const COMMITTEE_UID = 'committee-1';
+
+function buildReq(query: Record<string, unknown> = {}): Request {
+  return { params: { uid: COMMITTEE_UID }, query, path: '/test' } as unknown as Request;
+}
+
+function buildRes(): Response {
+  return { json: vi.fn() } as unknown as Response;
+}
+
+describe('CommitteeActivityController.getActivity', () => {
+  let controller: CommitteeActivityController;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new CommitteeActivityController();
+    next = vi.fn();
+    validateUidParameter.mockReturnValue(true);
+    parseCommitteeActivityQuery.mockReturnValue({ since: undefined, before: undefined, limit: 8 });
+  });
+
+  it('validates the uid, parses the query, and calls the service — in that order', async () => {
+    const response = { data: [], page_token: undefined };
+    getCommitteeActivity.mockResolvedValueOnce(response);
+    const res = buildRes();
+
+    await controller.getActivity(buildReq(), res, next);
+
+    expect(validateUidParameter).toHaveBeenCalledWith(COMMITTEE_UID, expect.anything(), next, expect.objectContaining({ operation: 'get_committee_activity' }));
+    expect(parseCommitteeActivityQuery).toHaveBeenCalledWith(expect.anything(), 'get_committee_activity');
+    expect(getCommitteeActivity).toHaveBeenCalledWith(expect.anything(), COMMITTEE_UID, { since: undefined, before: undefined, limit: 8 });
+
+    const validateOrder = validateUidParameter.mock.invocationCallOrder[0];
+    const parseOrder = parseCommitteeActivityQuery.mock.invocationCallOrder[0];
+    const serviceOrder = getCommitteeActivity.mock.invocationCallOrder[0];
+    expect(validateOrder).toBeLessThan(parseOrder);
+    expect(parseOrder).toBeLessThan(serviceOrder);
+
+    expect(res.json).toHaveBeenCalledWith(response);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('stops after validateUidParameter returns false, without parsing the query or calling the service', async () => {
+    validateUidParameter.mockReturnValue(false);
+
+    await controller.getActivity(buildReq(), buildRes(), next);
+
+    expect(parseCommitteeActivityQuery).not.toHaveBeenCalled();
+    expect(getCommitteeActivity).not.toHaveBeenCalled();
+  });
+
+  it('propagates a query-validation error via next without calling the service', async () => {
+    const validationError = new Error('limit must be an integer between 1 and 50');
+    parseCommitteeActivityQuery.mockImplementation(() => {
+      throw validationError;
+    });
+
+    await controller.getActivity(buildReq({ limit: 'abc' }), buildRes(), next);
+
+    expect(getCommitteeActivity).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(validationError);
+  });
+
+  it('propagates a service error via next', async () => {
+    const upstreamError = new Error('circuit open');
+    getCommitteeActivity.mockRejectedValueOnce(upstreamError);
+    const res = buildRes();
+
+    await controller.getActivity(buildReq(), res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(upstreamError);
+  });
+
+  it('returns the response verbatim, including an undefined page_token, without reshaping it', async () => {
+    const response = { data: [{ type: 'meeting_held' }], page_token: 'token(2026-01-01T00:00:00Z)' };
+    getCommitteeActivity.mockResolvedValueOnce(response);
+    const res = buildRes();
+
+    await controller.getActivity(buildReq(), res, next);
+
+    expect(res.json).toHaveBeenCalledWith(response);
+  });
+});

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.spec.ts
@@ -30,7 +30,7 @@ function buildReq(query: Record<string, unknown> = {}): Request {
 }
 
 function buildRes(): Response {
-  return { json: vi.fn() } as unknown as Response;
+  return { json: vi.fn(), setHeader: vi.fn() } as unknown as Response;
 }
 
 describe('CommitteeActivityController.getActivity', () => {
@@ -62,6 +62,7 @@ describe('CommitteeActivityController.getActivity', () => {
     expect(validateOrder).toBeLessThan(parseOrder);
     expect(parseOrder).toBeLessThan(serviceOrder);
 
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     expect(res.json).toHaveBeenCalledWith(response);
     expect(next).not.toHaveBeenCalled();
   });

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.spec.ts
@@ -42,7 +42,7 @@ describe('CommitteeActivityController.getActivity', () => {
     controller = new CommitteeActivityController();
     next = vi.fn();
     validateUidParameter.mockReturnValue(true);
-    parseCommitteeActivityQuery.mockReturnValue({ since: undefined, before: undefined, limit: 8 });
+    parseCommitteeActivityQuery.mockReturnValue({ since: undefined, cursor: undefined, limit: 8 });
   });
 
   it('validates the uid, parses the query, and calls the service — in that order', async () => {
@@ -54,7 +54,7 @@ describe('CommitteeActivityController.getActivity', () => {
 
     expect(validateUidParameter).toHaveBeenCalledWith(COMMITTEE_UID, expect.anything(), next, expect.objectContaining({ operation: 'get_committee_activity' }));
     expect(parseCommitteeActivityQuery).toHaveBeenCalledWith(expect.anything(), 'get_committee_activity');
-    expect(getCommitteeActivity).toHaveBeenCalledWith(expect.anything(), COMMITTEE_UID, { since: undefined, before: undefined, limit: 8 });
+    expect(getCommitteeActivity).toHaveBeenCalledWith(expect.anything(), COMMITTEE_UID, { since: undefined, cursor: undefined, limit: 8 });
 
     const validateOrder = validateUidParameter.mock.invocationCallOrder[0];
     const parseOrder = parseCommitteeActivityQuery.mock.invocationCallOrder[0];

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
@@ -40,7 +40,7 @@ export class CommitteeActivityController {
       logger.success(req, operation, startTime, { committee_uid: committeeUid, returned: response.data.length, has_more: !!response.page_token });
       res.json(response);
     } catch (error) {
-      next(error);
+      return next(error);
     }
   }
 }

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
@@ -1,0 +1,46 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { NextFunction, Request, Response } from 'express';
+
+import { parseCommitteeActivityQuery } from '../helpers/committee-activity-query.helper';
+import { validateUidParameter } from '../helpers/validation.helper';
+import { CommitteeActivityService } from '../services/committee-activity.service';
+import { logger } from '../services/logger.service';
+
+/**
+ * HTTP boundary for `GET /api/committees/:uid/activity` (LFXV2-1707).
+ *
+ * No explicit access-check call, unlike `CommitteeEngagementController` — every leg this endpoint
+ * aggregates (past meetings, votes, surveys, documents) already goes through the same
+ * FGA-enforced `MicroserviceProxyService.proxyRequest` the four source endpoints being merged use
+ * on their own, forwarding `req.bearerToken` on every call. `committee-engagement` bypasses that
+ * proxy to hit Snowflake directly, which is why it needs its own `assertCommitteeRead` gate; this
+ * endpoint bypasses nothing, so the permission check is identical to the four reads it aggregates.
+ */
+export class CommitteeActivityController {
+  private readonly service: CommitteeActivityService;
+
+  public constructor() {
+    this.service = new CommitteeActivityService();
+  }
+
+  public async getActivity(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_committee_activity';
+    const committeeUid = req.params['uid'];
+    const startTime = logger.startOperation(req, operation, { committee_uid: committeeUid });
+    try {
+      if (!validateUidParameter(committeeUid, req, next, { operation, service: 'committee_activity_controller' })) {
+        return;
+      }
+      const { since, before, limit } = parseCommitteeActivityQuery(req, operation);
+
+      const response = await this.service.getCommitteeActivity(req, committeeUid, { since, before, limit });
+
+      logger.success(req, operation, startTime, { committee_uid: committeeUid, returned: response.data.length, has_more: !!response.page_token });
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
@@ -33,9 +33,9 @@ export class CommitteeActivityController {
       if (!validateUidParameter(committeeUid, req, next, { operation, service: 'committee_activity_controller' })) {
         return;
       }
-      const { since, before, limit } = parseCommitteeActivityQuery(req, operation);
+      const query = parseCommitteeActivityQuery(req, operation);
 
-      const response = await this.service.getCommitteeActivity(req, committeeUid, { since, before, limit });
+      const response = await this.service.getCommitteeActivity(req, committeeUid, query);
 
       logger.success(req, operation, startTime, { committee_uid: committeeUid, returned: response.data.length, has_more: !!response.page_token });
       res.json(response);

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
@@ -12,11 +12,14 @@ import { logger } from '../services/logger.service';
  * HTTP boundary for `GET /api/committees/:uid/activity` (LFXV2-1707).
  *
  * No explicit access-check call, unlike `CommitteeEngagementController` — every leg this endpoint
- * aggregates (past meetings, votes, surveys, documents) already goes through the same
- * FGA-enforced `MicroserviceProxyService.proxyRequest` the four source endpoints being merged use
- * on their own, forwarding `req.bearerToken` on every call. `committee-engagement` bypasses that
- * proxy to hit Snowflake directly, which is why it needs its own `assertCommitteeRead` gate; this
- * endpoint bypasses nothing, so the permission check is identical to the four reads it aggregates.
+ * aggregates (past meetings, votes, surveys, and documents — the last of which is itself 3 upstream
+ * calls: folders, links, files) already goes through the same FGA-enforced
+ * `MicroserviceProxyService.proxyRequest` the underlying source endpoints being merged use on their
+ * own, forwarding `req.bearerToken` on every call. `committee-engagement` bypasses that proxy to
+ * hit Snowflake directly, which is why it needs its own `assertCommitteeRead` gate; this endpoint
+ * bypasses nothing, so the permission check is identical to what the reads it aggregates already do
+ * on their own (see `CommitteeActivityService.fetchCommittee`'s docblock for exactly which of those
+ * calls this endpoint additionally treats as fail-closed).
  */
 export class CommitteeActivityController {
   private readonly service: CommitteeActivityService;

--- a/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee-activity.controller.ts
@@ -38,6 +38,10 @@ export class CommitteeActivityController {
       const response = await this.service.getCommitteeActivity(req, committeeUid, query);
 
       logger.success(req, operation, startTime, { committee_uid: committeeUid, returned: response.data.length, has_more: !!response.page_token });
+      // Per-user, FGA-filtered activity (meeting titles, vote/survey names, document names/URLs) —
+      // must not sit in a shared or intermediary cache, same rationale as the sibling
+      // CommitteeEngagementController.
+      res.setHeader('Cache-Control', 'no-store');
       res.json(response);
     } catch (error) {
       return next(error);

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
@@ -32,9 +32,18 @@ describe('parseCommitteeActivityQuery', () => {
     expect(parseCommitteeActivityQuery(mockRequest(), OPERATION)).toEqual({ since: undefined, cursor: undefined, limit: 8 });
   });
 
-  it('passes through a valid ISO since value', () => {
+  it('passes through a valid ISO since value, normalized to RFC3339 with milliseconds', () => {
     const result = parseCommitteeActivityQuery(mockRequest({ since: '2026-01-01T00:00:00Z' }), OPERATION);
-    expect(result.since).toBe('2026-01-01T00:00:00Z');
+    expect(result.since).toBe('2026-01-01T00:00:00.000Z');
+  });
+
+  it('normalizes a since value Date.parse accepts but upstream RFC3339 validation would reject', () => {
+    // Upstream (query-service) only accepts strict RFC3339 or date-only; Date.parse is more
+    // permissive (no zone designator, slash-separated, etc.) — an unnormalized value forwarded
+    // as-is would 400 upstream on every leg and silently degrade to an empty feed instead.
+    const result = parseCommitteeActivityQuery(mockRequest({ since: '2026-01-01T00:00:00' }), OPERATION);
+    expect(result.since).toBe(new Date('2026-01-01T00:00:00').toISOString());
+    expect(result.since).toMatch(/Z$/);
   });
 
   it('rejects an unparseable since value instead of silently ignoring it', () => {
@@ -53,10 +62,16 @@ describe('parseCommitteeActivityQuery', () => {
     expect(parseCommitteeActivityQuery(mockRequest({ page_size: '50' }), OPERATION).limit).toBe(50);
   });
 
-  it('round-trips a page_token produced by encodeActivityPageToken back to the same cursor', () => {
+  it('round-trips a page_token produced by encodeActivityPageToken back to the same cursor, normalized', () => {
     const token = encodeActivityPageToken({ before: '2026-01-05T00:00:00Z', key: 'vote:vote-1' });
     const result = parseCommitteeActivityQuery(mockRequest({ page_token: token }), OPERATION);
-    expect(result.cursor).toEqual({ before: '2026-01-05T00:00:00Z', key: 'vote:vote-1' });
+    expect(result.cursor).toEqual({ before: '2026-01-05T00:00:00.000Z', key: 'vote:vote-1' });
+  });
+
+  it('normalizes a decoded page_token before value the same way as since', () => {
+    const badToken = Buffer.from(JSON.stringify({ before: '2026-01-05T00:00:00', key: 'vote:vote-1' }), 'utf8').toString('base64url');
+    const result = parseCommitteeActivityQuery(mockRequest({ page_token: badToken }), OPERATION);
+    expect(result.cursor?.before).toBe(new Date('2026-01-05T00:00:00').toISOString());
   });
 
   it('rejects a malformed page_token instead of silently restarting the feed', () => {

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
@@ -21,7 +21,7 @@ import { Request } from 'express';
 import { ServiceValidationError } from '../errors';
 import { encodeActivityPageToken, parseCommitteeActivityQuery } from './committee-activity-query.helper';
 
-function mockRequest(query: Record<string, string> = {}): Request {
+function mockRequest(query: Record<string, string | string[]> = {}): Request {
   return { query } as unknown as Request;
 }
 
@@ -102,5 +102,13 @@ describe('parseCommitteeActivityQuery', () => {
 
     const emptyKey = Buffer.from(JSON.stringify({ before: '2026-01-05T00:00:00Z', key: '' }), 'utf8').toString('base64url');
     expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: emptyKey }), OPERATION)).toThrow(ServiceValidationError);
+  });
+
+  // Express's default `qs`-based query parser turns a repeated param (`?since=a&since=b`) into an
+  // array, not a string. Silently treating that the same as "absent" would restart pagination
+  // (page_token), ignore since, or fall back page_size to its default with no error surfaced —
+  // CodeRabbit flagged this independently, confirmed by dealako.
+  it.each(['since', 'page_size', 'page_token'])('rejects a repeated (array-valued) %s instead of silently treating it as absent', (param) => {
+    expect(() => parseCommitteeActivityQuery(mockRequest({ [param]: ['a', 'b'] }), OPERATION)).toThrow(ServiceValidationError);
   });
 });

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors committee-engagement-window.helper.spec.ts: `@lfx-one/shared/constants` resolves through
 // a barrel with transitive imports that don't survive outside an Angular build/test context, so the
@@ -28,6 +28,10 @@ function mockRequest(query: Record<string, string> = {}): Request {
 const OPERATION = 'get_committee_activity';
 
 describe('parseCommitteeActivityQuery', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   it('defaults limit to 8 and leaves since/cursor undefined when omitted', () => {
     expect(parseCommitteeActivityQuery(mockRequest(), OPERATION)).toEqual({ since: undefined, cursor: undefined, limit: 8 });
   });
@@ -37,13 +41,16 @@ describe('parseCommitteeActivityQuery', () => {
     expect(result.since).toBe('2026-01-01T00:00:00.000Z');
   });
 
-  it('normalizes a since value Date.parse accepts but upstream RFC3339 validation would reject', () => {
+  it('normalizes a zone-less since value (interpreted in the server timezone) to UTC RFC3339', () => {
     // Upstream (query-service) only accepts strict RFC3339 or date-only; Date.parse is more
     // permissive (no zone designator, slash-separated, etc.) — an unnormalized value forwarded
     // as-is would 400 upstream on every leg and silently degrade to an empty feed instead.
+    // Pinned against a literal (not `new Date(x).toISOString()`, which would just restate the
+    // implementation) and TZ stubbed explicitly, since a zone-less string is parsed in the
+    // server's local timezone — the exact behavior normalizeTimestamp's caller should know about.
+    vi.stubEnv('TZ', 'UTC');
     const result = parseCommitteeActivityQuery(mockRequest({ since: '2026-01-01T00:00:00' }), OPERATION);
-    expect(result.since).toBe(new Date('2026-01-01T00:00:00').toISOString());
-    expect(result.since).toMatch(/Z$/);
+    expect(result.since).toBe('2026-01-01T00:00:00.000Z');
   });
 
   it('rejects an unparseable since value instead of silently ignoring it', () => {
@@ -69,9 +76,10 @@ describe('parseCommitteeActivityQuery', () => {
   });
 
   it('normalizes a decoded page_token before value the same way as since', () => {
+    vi.stubEnv('TZ', 'UTC');
     const badToken = Buffer.from(JSON.stringify({ before: '2026-01-05T00:00:00', key: 'vote:vote-1' }), 'utf8').toString('base64url');
     const result = parseCommitteeActivityQuery(mockRequest({ page_token: badToken }), OPERATION);
-    expect(result.cursor?.before).toBe(new Date('2026-01-05T00:00:00').toISOString());
+    expect(result.cursor?.before).toBe('2026-01-05T00:00:00.000Z');
   });
 
   it('rejects a malformed page_token instead of silently restarting the feed', () => {

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
@@ -28,8 +28,8 @@ function mockRequest(query: Record<string, string> = {}): Request {
 const OPERATION = 'get_committee_activity';
 
 describe('parseCommitteeActivityQuery', () => {
-  it('defaults limit to 8 and leaves since/before undefined when omitted', () => {
-    expect(parseCommitteeActivityQuery(mockRequest(), OPERATION)).toEqual({ since: undefined, before: undefined, limit: 8 });
+  it('defaults limit to 8 and leaves since/cursor undefined when omitted', () => {
+    expect(parseCommitteeActivityQuery(mockRequest(), OPERATION)).toEqual({ since: undefined, cursor: undefined, limit: 8 });
   });
 
   it('passes through a valid ISO since value', () => {
@@ -53,10 +53,10 @@ describe('parseCommitteeActivityQuery', () => {
     expect(parseCommitteeActivityQuery(mockRequest({ page_size: '50' }), OPERATION).limit).toBe(50);
   });
 
-  it('round-trips a page_token produced by encodeActivityPageToken back to the same before value', () => {
-    const token = encodeActivityPageToken('2026-01-05T00:00:00Z');
+  it('round-trips a page_token produced by encodeActivityPageToken back to the same cursor', () => {
+    const token = encodeActivityPageToken({ before: '2026-01-05T00:00:00Z', key: 'vote:vote-1' });
     const result = parseCommitteeActivityQuery(mockRequest({ page_token: token }), OPERATION);
-    expect(result.before).toBe('2026-01-05T00:00:00Z');
+    expect(result.cursor).toEqual({ before: '2026-01-05T00:00:00Z', key: 'vote:vote-1' });
   });
 
   it('rejects a malformed page_token instead of silently restarting the feed', () => {
@@ -64,12 +64,20 @@ describe('parseCommitteeActivityQuery', () => {
   });
 
   it('rejects a page_token that decodes to valid JSON but the wrong shape', () => {
-    const badToken = Buffer.from(JSON.stringify({ before: 12345 }), 'utf8').toString('base64url');
+    const badToken = Buffer.from(JSON.stringify({ before: 12345, key: 'x' }), 'utf8').toString('base64url');
     expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: badToken }), OPERATION)).toThrow(ServiceValidationError);
   });
 
   it('rejects a page_token whose before value is not a valid timestamp', () => {
-    const badToken = Buffer.from(JSON.stringify({ before: 'not-a-timestamp' }), 'utf8').toString('base64url');
+    const badToken = Buffer.from(JSON.stringify({ before: 'not-a-timestamp', key: 'x' }), 'utf8').toString('base64url');
     expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: badToken }), OPERATION)).toThrow(ServiceValidationError);
+  });
+
+  it('rejects a page_token with a missing or empty key', () => {
+    const missingKey = Buffer.from(JSON.stringify({ before: '2026-01-05T00:00:00Z' }), 'utf8').toString('base64url');
+    expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: missingKey }), OPERATION)).toThrow(ServiceValidationError);
+
+    const emptyKey = Buffer.from(JSON.stringify({ before: '2026-01-05T00:00:00Z', key: '' }), 'utf8').toString('base64url');
+    expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: emptyKey }), OPERATION)).toThrow(ServiceValidationError);
   });
 });

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
@@ -1,0 +1,75 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+
+// Mirrors committee-engagement-window.helper.spec.ts: `@lfx-one/shared/constants` resolves through
+// a barrel with transitive imports that don't survive outside an Angular build/test context, so the
+// two values this helper needs are deep-imported from their real implementation instead.
+vi.mock('@lfx-one/shared/constants', async () => {
+  const actual = await vi.importActual<typeof import('../../../../../packages/shared/src/constants/activity-event.constants')>(
+    '../../../../../packages/shared/src/constants/activity-event.constants'
+  );
+  return {
+    ACTIVITY_FEED_DEFAULT_LIMIT: actual.ACTIVITY_FEED_DEFAULT_LIMIT,
+    ACTIVITY_FEED_MAX_LIMIT: actual.ACTIVITY_FEED_MAX_LIMIT,
+  };
+});
+
+import { Request } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { encodeActivityPageToken, parseCommitteeActivityQuery } from './committee-activity-query.helper';
+
+function mockRequest(query: Record<string, string> = {}): Request {
+  return { query } as unknown as Request;
+}
+
+const OPERATION = 'get_committee_activity';
+
+describe('parseCommitteeActivityQuery', () => {
+  it('defaults limit to 8 and leaves since/before undefined when omitted', () => {
+    expect(parseCommitteeActivityQuery(mockRequest(), OPERATION)).toEqual({ since: undefined, before: undefined, limit: 8 });
+  });
+
+  it('passes through a valid ISO since value', () => {
+    const result = parseCommitteeActivityQuery(mockRequest({ since: '2026-01-01T00:00:00Z' }), OPERATION);
+    expect(result.since).toBe('2026-01-01T00:00:00Z');
+  });
+
+  it('rejects an unparseable since value instead of silently ignoring it', () => {
+    expect(() => parseCommitteeActivityQuery(mockRequest({ since: 'not-a-timestamp' }), OPERATION)).toThrow(ServiceValidationError);
+  });
+
+  it('accepts a limit within bounds', () => {
+    expect(parseCommitteeActivityQuery(mockRequest({ limit: '25' }), OPERATION).limit).toBe(25);
+  });
+
+  it.each(['0', '51', 'abc', '3.5'])('rejects an out-of-range or non-integer limit value %s', (limit) => {
+    expect(() => parseCommitteeActivityQuery(mockRequest({ limit }), OPERATION)).toThrow(ServiceValidationError);
+  });
+
+  it('accepts limit at the upper bound (50)', () => {
+    expect(parseCommitteeActivityQuery(mockRequest({ limit: '50' }), OPERATION).limit).toBe(50);
+  });
+
+  it('round-trips a page_token produced by encodeActivityPageToken back to the same before value', () => {
+    const token = encodeActivityPageToken('2026-01-05T00:00:00Z');
+    const result = parseCommitteeActivityQuery(mockRequest({ page_token: token }), OPERATION);
+    expect(result.before).toBe('2026-01-05T00:00:00Z');
+  });
+
+  it('rejects a malformed page_token instead of silently restarting the feed', () => {
+    expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: 'not-base64-json' }), OPERATION)).toThrow(ServiceValidationError);
+  });
+
+  it('rejects a page_token that decodes to valid JSON but the wrong shape', () => {
+    const badToken = Buffer.from(JSON.stringify({ before: 12345 }), 'utf8').toString('base64url');
+    expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: badToken }), OPERATION)).toThrow(ServiceValidationError);
+  });
+
+  it('rejects a page_token whose before value is not a valid timestamp', () => {
+    const badToken = Buffer.from(JSON.stringify({ before: 'not-a-timestamp' }), 'utf8').toString('base64url');
+    expect(() => parseCommitteeActivityQuery(mockRequest({ page_token: badToken }), OPERATION)).toThrow(ServiceValidationError);
+  });
+});

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.spec.ts
@@ -11,8 +11,8 @@ vi.mock('@lfx-one/shared/constants', async () => {
     '../../../../../packages/shared/src/constants/activity-event.constants'
   );
   return {
-    ACTIVITY_FEED_DEFAULT_LIMIT: actual.ACTIVITY_FEED_DEFAULT_LIMIT,
-    ACTIVITY_FEED_MAX_LIMIT: actual.ACTIVITY_FEED_MAX_LIMIT,
+    ACTIVITY_FEED_DEFAULT_PAGE_SIZE: actual.ACTIVITY_FEED_DEFAULT_PAGE_SIZE,
+    ACTIVITY_FEED_MAX_PAGE_SIZE: actual.ACTIVITY_FEED_MAX_PAGE_SIZE,
   };
 });
 
@@ -41,16 +41,16 @@ describe('parseCommitteeActivityQuery', () => {
     expect(() => parseCommitteeActivityQuery(mockRequest({ since: 'not-a-timestamp' }), OPERATION)).toThrow(ServiceValidationError);
   });
 
-  it('accepts a limit within bounds', () => {
-    expect(parseCommitteeActivityQuery(mockRequest({ limit: '25' }), OPERATION).limit).toBe(25);
+  it('accepts a page_size within bounds', () => {
+    expect(parseCommitteeActivityQuery(mockRequest({ page_size: '25' }), OPERATION).limit).toBe(25);
   });
 
-  it.each(['0', '51', 'abc', '3.5'])('rejects an out-of-range or non-integer limit value %s', (limit) => {
-    expect(() => parseCommitteeActivityQuery(mockRequest({ limit }), OPERATION)).toThrow(ServiceValidationError);
+  it.each(['0', '51', 'abc', '3.5'])('rejects an out-of-range or non-integer page_size value %s', (pageSize) => {
+    expect(() => parseCommitteeActivityQuery(mockRequest({ page_size: pageSize }), OPERATION)).toThrow(ServiceValidationError);
   });
 
-  it('accepts limit at the upper bound (50)', () => {
-    expect(parseCommitteeActivityQuery(mockRequest({ limit: '50' }), OPERATION).limit).toBe(50);
+  it('accepts page_size at the upper bound (50)', () => {
+    expect(parseCommitteeActivityQuery(mockRequest({ page_size: '50' }), OPERATION).limit).toBe(50);
   });
 
   it('round-trips a page_token produced by encodeActivityPageToken back to the same before value', () => {

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
@@ -23,6 +23,20 @@ function isParseableTimestamp(value: string): boolean {
 }
 
 /**
+ * Normalizes an already-validated (`isParseableTimestamp`) timestamp to RFC3339. `Date.parse`
+ * accepts formats upstream doesn't — e.g. `2026-01-05T00:00:00` with no zone designator, or
+ * `2026/01/05` — and query-service's `date_from`/`date_to` require strict RFC3339 or date-only,
+ * rejecting anything else with a 400. Since every leg's `.catch()` degrades that 400 into an
+ * empty result for its source (LFXV2-1707's graceful-degradation-per-leg design), an unnormalized
+ * value wouldn't surface as an error at all — it would silently return a thinner feed. Normalizing
+ * once here, rather than validating against the stricter upstream grammar, keeps any
+ * currently-working caller working.
+ */
+function normalizeTimestamp(value: string): string {
+  return new Date(value).toISOString();
+}
+
+/**
  * Encodes a keyset pagination position as an opaque base64url string. `(before, key)` compound —
  * not a bare timestamp — matches the house cursor-pagination pattern
  * (`docs/architecture/backend/pagination.md`) while staying correct across a merge of 4
@@ -51,7 +65,7 @@ function decodePageToken(raw: string, operation: string): ActivityPageCursor {
   if (typeof candidate?.before !== 'string' || !isParseableTimestamp(candidate.before) || typeof candidate.key !== 'string' || candidate.key === '') {
     throw ServiceValidationError.forField('page_token', 'page_token is malformed', { operation });
   }
-  return { before: candidate.before, key: candidate.key };
+  return { before: normalizeTimestamp(candidate.before), key: candidate.key };
 }
 
 /**
@@ -68,7 +82,7 @@ export function parseCommitteeActivityQuery(req: Request, operation: string): Co
     if (!isParseableTimestamp(rawSince)) {
       throw ServiceValidationError.forField('since', 'since must be a valid ISO 8601 timestamp', { operation });
     }
-    since = rawSince;
+    since = normalizeTimestamp(rawSince);
   }
 
   const rawPageSize = getStringQueryParam(req, 'page_size');

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ACTIVITY_FEED_DEFAULT_LIMIT, ACTIVITY_FEED_MAX_LIMIT } from '@lfx-one/shared/constants';
+import { ACTIVITY_FEED_DEFAULT_PAGE_SIZE, ACTIVITY_FEED_MAX_PAGE_SIZE } from '@lfx-one/shared/constants';
+import type { ActivityPageTokenPayload, CommitteeActivityQuery } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
 import { ServiceValidationError } from '../errors';
@@ -15,20 +16,6 @@ import { ServiceValidationError } from '../errors';
 function getStringQueryParam(req: Request, name: string): string | undefined {
   const value = req.query[name];
   return typeof value === 'string' ? value : undefined;
-}
-
-/** Parsed, validated query for `GET /api/committees/:uid/activity`. */
-export interface CommitteeActivityQuery {
-  /** Inclusive lower bound on `occurred_at`, applied as `date_from` on every source that supports it. */
-  since?: string;
-  /** Exclusive upper bound on `occurred_at`, decoded from an incoming `page_token`. Undefined on page 1. */
-  before?: string;
-  limit: number;
-}
-
-/** Shape encoded into the opaque `page_token` string — see `encodeActivityPageToken`. */
-interface ActivityPageTokenPayload {
-  before: string;
 }
 
 function isParseableTimestamp(value: string): boolean {
@@ -66,9 +53,11 @@ function decodePageToken(raw: string, operation: string): string {
 }
 
 /**
- * Parses and validates `since`, `limit`, and `page_token` for the committee activity feed endpoint.
- * An omitted `since`/`limit` takes its default silently; an explicit-but-invalid value is a 400 —
- * answering a bad `?limit=abc` with the default would silently mask the caller's mistake.
+ * Parses and validates `since`, `page_size`, and `page_token` for the committee activity feed
+ * endpoint (`page_size`, not `limit` — matches the house pagination convention documented in
+ * `docs/architecture/backend/pagination.md`). An omitted `since`/`page_size` takes its default
+ * silently; an explicit-but-invalid value is a 400 — answering a bad `?page_size=abc` with the
+ * default would silently mask the caller's mistake.
  */
 export function parseCommitteeActivityQuery(req: Request, operation: string): CommitteeActivityQuery {
   const rawSince = getStringQueryParam(req, 'since');
@@ -80,14 +69,14 @@ export function parseCommitteeActivityQuery(req: Request, operation: string): Co
     since = rawSince;
   }
 
-  const rawLimit = getStringQueryParam(req, 'limit');
-  let limit = ACTIVITY_FEED_DEFAULT_LIMIT;
-  if (rawLimit !== undefined) {
-    const parsedLimit = Number(rawLimit);
-    if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > ACTIVITY_FEED_MAX_LIMIT) {
-      throw ServiceValidationError.forField('limit', `limit must be an integer between 1 and ${ACTIVITY_FEED_MAX_LIMIT}`, { operation });
+  const rawPageSize = getStringQueryParam(req, 'page_size');
+  let limit = ACTIVITY_FEED_DEFAULT_PAGE_SIZE;
+  if (rawPageSize !== undefined) {
+    const parsedPageSize = Number(rawPageSize);
+    if (!Number.isInteger(parsedPageSize) || parsedPageSize < 1 || parsedPageSize > ACTIVITY_FEED_MAX_PAGE_SIZE) {
+      throw ServiceValidationError.forField('page_size', `page_size must be an integer between 1 and ${ACTIVITY_FEED_MAX_PAGE_SIZE}`, { operation });
     }
-    limit = parsedLimit;
+    limit = parsedPageSize;
   }
 
   const rawPageToken = getStringQueryParam(req, 'page_token');

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
@@ -12,10 +12,23 @@ import { ServiceValidationError } from '../errors';
  * `@lfx-one/shared/utils`, which pulls in Angular-only runtime code that Vitest can't resolve
  * outside an Angular context (same issue documented in `activity-feed.utils.ts`). Inlined locally
  * to keep this helper's unit test importable without mocking half of `validation.helper.ts`.
+ *
+ * Rejects (not silently discards) a defined-but-non-string value. Express's default `qs`-based
+ * query parser (`express.urlencoded({ extended: true })` in `server.ts`) turns a repeated param
+ * (`?page_token=a&page_token=b`) into an array, not a string — treating that the same as "absent"
+ * would silently restart pagination (`page_token`), ignore `since`, or fall back `page_size` to its
+ * default, with no error surfaced to the caller. CodeRabbit flagged this independently; confirmed
+ * against `server.ts`'s parser config.
  */
-function getStringQueryParam(req: Request, name: string): string | undefined {
+function getStringQueryParam(req: Request, name: string, operation: string): string | undefined {
   const value = req.query[name];
-  return typeof value === 'string' ? value : undefined;
+  if (value === undefined) {
+    return undefined;
+  }
+  if (typeof value !== 'string') {
+    throw ServiceValidationError.forField(name, `${name} must be provided once, as a single string value`, { operation });
+  }
+  return value;
 }
 
 function isParseableTimestamp(value: string): boolean {
@@ -85,7 +98,7 @@ function decodePageToken(raw: string, operation: string): ActivityPageCursor {
  * default would silently mask the caller's mistake.
  */
 export function parseCommitteeActivityQuery(req: Request, operation: string): CommitteeActivityQuery {
-  const rawSince = getStringQueryParam(req, 'since');
+  const rawSince = getStringQueryParam(req, 'since', operation);
   let since: string | undefined;
   if (rawSince !== undefined) {
     if (!isParseableTimestamp(rawSince)) {
@@ -94,7 +107,7 @@ export function parseCommitteeActivityQuery(req: Request, operation: string): Co
     since = normalizeTimestamp(rawSince);
   }
 
-  const rawPageSize = getStringQueryParam(req, 'page_size');
+  const rawPageSize = getStringQueryParam(req, 'page_size', operation);
   let limit = ACTIVITY_FEED_DEFAULT_PAGE_SIZE;
   if (rawPageSize !== undefined) {
     const parsedPageSize = Number(rawPageSize);
@@ -104,7 +117,7 @@ export function parseCommitteeActivityQuery(req: Request, operation: string): Co
     limit = parsedPageSize;
   }
 
-  const rawPageToken = getStringQueryParam(req, 'page_token');
+  const rawPageToken = getStringQueryParam(req, 'page_token', operation);
   const cursor = rawPageToken !== undefined ? decodePageToken(rawPageToken, operation) : undefined;
 
   return { since, cursor, limit };

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
@@ -31,6 +31,11 @@ function isParseableTimestamp(value: string): boolean {
  * value wouldn't surface as an error at all — it would silently return a thinner feed. Normalizing
  * once here, rather than validating against the stricter upstream grammar, keeps any
  * currently-working caller working.
+ *
+ * A zone-less input (e.g. `2026-01-05T00:00:00`) is interpreted in the server process's local
+ * timezone, per `Date.parse`/`new Date()` semantics — this is a silent assumption on the caller's
+ * behalf, not just a format change, since the same string normalizes to a different instant
+ * depending on `TZ`. Callers that care about exact instants should always include a zone designator.
  */
 function normalizeTimestamp(value: string): string {
   return new Date(value).toISOString();

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
@@ -36,8 +36,12 @@ function isParseableTimestamp(value: string): boolean {
  * timezone, per `Date.parse`/`new Date()` semantics — this is a silent assumption on the caller's
  * behalf, not just a format change, since the same string normalizes to a different instant
  * depending on `TZ`. Callers that care about exact instants should always include a zone designator.
+ *
+ * Exported (not just used internally by `parseCommitteeActivityQuery`) so `CommitteeActivityService`
+ * can apply the identical normalization to `since` on its own validation path, for a caller that
+ * invokes the service directly and skips this file's HTTP-layer parsing.
  */
-function normalizeTimestamp(value: string): string {
+export function normalizeTimestamp(value: string): string {
   return new Date(value).toISOString();
 }
 

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ACTIVITY_FEED_DEFAULT_PAGE_SIZE, ACTIVITY_FEED_MAX_PAGE_SIZE } from '@lfx-one/shared/constants';
-import type { ActivityPageTokenPayload, CommitteeActivityQuery } from '@lfx-one/shared/interfaces';
+import type { ActivityPageCursor, CommitteeActivityQuery } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
 import { ServiceValidationError } from '../errors';
@@ -23,13 +23,15 @@ function isParseableTimestamp(value: string): boolean {
 }
 
 /**
- * Encodes the cursor for "the next page starts strictly before this timestamp" as an opaque
- * base64url string. Timestamp-based, not offset-based — matches the house cursor-pagination
- * pattern (`docs/architecture/backend/pagination.md`) while working across a merge of 4
- * independently-paginated upstream sources, which a single shared `page_token` per source could not.
+ * Encodes a keyset pagination position as an opaque base64url string. `(before, key)` compound —
+ * not a bare timestamp — matches the house cursor-pagination pattern
+ * (`docs/architecture/backend/pagination.md`) while staying correct across a merge of 4
+ * independently-paginated upstream sources: a bare timestamp cursor can't distinguish between
+ * multiple events sharing the exact same `occurred_at` (e.g. a batch of documents uploaded in one
+ * request), so `key` (see `eventKey` in `committee-activity.service.ts`) breaks the tie.
  */
-export function encodeActivityPageToken(before: string): string {
-  return Buffer.from(JSON.stringify({ before } satisfies ActivityPageTokenPayload), 'utf8').toString('base64url');
+export function encodeActivityPageToken(cursor: ActivityPageCursor): string {
+  return Buffer.from(JSON.stringify(cursor satisfies ActivityPageCursor), 'utf8').toString('base64url');
 }
 
 /**
@@ -38,18 +40,18 @@ export function encodeActivityPageToken(before: string): string {
  * "never a silent fallback for a bad explicit value" rule), since silently ignoring a bad token would
  * quietly restart the feed from the newest page instead of surfacing the client's stale/corrupt cursor.
  */
-function decodePageToken(raw: string, operation: string): string {
+function decodePageToken(raw: string, operation: string): ActivityPageCursor {
   let parsed: unknown;
   try {
     parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
   } catch {
     throw ServiceValidationError.forField('page_token', 'page_token is malformed', { operation });
   }
-  const before = (parsed as Partial<ActivityPageTokenPayload> | null)?.before;
-  if (typeof before !== 'string' || !isParseableTimestamp(before)) {
+  const candidate = parsed as Partial<ActivityPageCursor> | null;
+  if (typeof candidate?.before !== 'string' || !isParseableTimestamp(candidate.before) || typeof candidate.key !== 'string' || candidate.key === '') {
     throw ServiceValidationError.forField('page_token', 'page_token is malformed', { operation });
   }
-  return before;
+  return { before: candidate.before, key: candidate.key };
 }
 
 /**
@@ -80,7 +82,7 @@ export function parseCommitteeActivityQuery(req: Request, operation: string): Co
   }
 
   const rawPageToken = getStringQueryParam(req, 'page_token');
-  const before = rawPageToken !== undefined ? decodePageToken(rawPageToken, operation) : undefined;
+  const cursor = rawPageToken !== undefined ? decodePageToken(rawPageToken, operation) : undefined;
 
-  return { since, before, limit };
+  return { since, cursor, limit };
 }

--- a/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-activity-query.helper.ts
@@ -1,0 +1,97 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ACTIVITY_FEED_DEFAULT_LIMIT, ACTIVITY_FEED_MAX_LIMIT } from '@lfx-one/shared/constants';
+import type { Request } from 'express';
+
+import { ServiceValidationError } from '../errors';
+
+/**
+ * Not `validation.helper.ts`'s `getStringQueryParam` — that module also imports
+ * `@lfx-one/shared/utils`, which pulls in Angular-only runtime code that Vitest can't resolve
+ * outside an Angular context (same issue documented in `activity-feed.utils.ts`). Inlined locally
+ * to keep this helper's unit test importable without mocking half of `validation.helper.ts`.
+ */
+function getStringQueryParam(req: Request, name: string): string | undefined {
+  const value = req.query[name];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/** Parsed, validated query for `GET /api/committees/:uid/activity`. */
+export interface CommitteeActivityQuery {
+  /** Inclusive lower bound on `occurred_at`, applied as `date_from` on every source that supports it. */
+  since?: string;
+  /** Exclusive upper bound on `occurred_at`, decoded from an incoming `page_token`. Undefined on page 1. */
+  before?: string;
+  limit: number;
+}
+
+/** Shape encoded into the opaque `page_token` string — see `encodeActivityPageToken`. */
+interface ActivityPageTokenPayload {
+  before: string;
+}
+
+function isParseableTimestamp(value: string): boolean {
+  return !Number.isNaN(Date.parse(value));
+}
+
+/**
+ * Encodes the cursor for "the next page starts strictly before this timestamp" as an opaque
+ * base64url string. Timestamp-based, not offset-based — matches the house cursor-pagination
+ * pattern (`docs/architecture/backend/pagination.md`) while working across a merge of 4
+ * independently-paginated upstream sources, which a single shared `page_token` per source could not.
+ */
+export function encodeActivityPageToken(before: string): string {
+  return Buffer.from(JSON.stringify({ before } satisfies ActivityPageTokenPayload), 'utf8').toString('base64url');
+}
+
+/**
+ * Decodes a `page_token` produced by `encodeActivityPageToken`. Untrusted client input — malformed
+ * or tampered tokens are a 400, not a silently-ignored value (mirrors `parseCommitteeEngagementWindow`'s
+ * "never a silent fallback for a bad explicit value" rule), since silently ignoring a bad token would
+ * quietly restart the feed from the newest page instead of surfacing the client's stale/corrupt cursor.
+ */
+function decodePageToken(raw: string, operation: string): string {
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(Buffer.from(raw, 'base64url').toString('utf8'));
+  } catch {
+    throw ServiceValidationError.forField('page_token', 'page_token is malformed', { operation });
+  }
+  const before = (parsed as Partial<ActivityPageTokenPayload> | null)?.before;
+  if (typeof before !== 'string' || !isParseableTimestamp(before)) {
+    throw ServiceValidationError.forField('page_token', 'page_token is malformed', { operation });
+  }
+  return before;
+}
+
+/**
+ * Parses and validates `since`, `limit`, and `page_token` for the committee activity feed endpoint.
+ * An omitted `since`/`limit` takes its default silently; an explicit-but-invalid value is a 400 —
+ * answering a bad `?limit=abc` with the default would silently mask the caller's mistake.
+ */
+export function parseCommitteeActivityQuery(req: Request, operation: string): CommitteeActivityQuery {
+  const rawSince = getStringQueryParam(req, 'since');
+  let since: string | undefined;
+  if (rawSince !== undefined) {
+    if (!isParseableTimestamp(rawSince)) {
+      throw ServiceValidationError.forField('since', 'since must be a valid ISO 8601 timestamp', { operation });
+    }
+    since = rawSince;
+  }
+
+  const rawLimit = getStringQueryParam(req, 'limit');
+  let limit = ACTIVITY_FEED_DEFAULT_LIMIT;
+  if (rawLimit !== undefined) {
+    const parsedLimit = Number(rawLimit);
+    if (!Number.isInteger(parsedLimit) || parsedLimit < 1 || parsedLimit > ACTIVITY_FEED_MAX_LIMIT) {
+      throw ServiceValidationError.forField('limit', `limit must be an integer between 1 and ${ACTIVITY_FEED_MAX_LIMIT}`, { operation });
+    }
+    limit = parsedLimit;
+  }
+
+  const rawPageToken = getStringQueryParam(req, 'page_token');
+  const before = rawPageToken !== undefined ? decodePageToken(rawPageToken, operation) : undefined;
+
+  return { since, before, limit };
+}

--- a/apps/lfx-one/src/server/routes/committees.route.ts
+++ b/apps/lfx-one/src/server/routes/committees.route.ts
@@ -3,6 +3,7 @@
 
 import express, { Router } from 'express';
 
+import { CommitteeActivityController } from '../controllers/committee-activity.controller';
 import { CommitteeController } from '../controllers/committee.controller';
 import { CommitteeEngagementController } from '../controllers/committee-engagement.controller';
 
@@ -10,6 +11,7 @@ const router = Router();
 
 const committeeController = new CommitteeController();
 const committeeEngagementController = new CommitteeEngagementController();
+const committeeActivityController = new CommitteeActivityController();
 
 // Committee CRUD routes - using new controller pattern
 router.get('/', (req, res, next) => committeeController.getCommittees(req, res, next));
@@ -31,6 +33,9 @@ router.delete('/:id/members/:memberId', (req, res, next) => committeeController.
 
 // ── Member engagement/attendance rollup (LFXV2-1705) ──────────────────────────
 router.get('/:uid/engagement', (req, res, next) => committeeEngagementController.getEngagement(req, res, next));
+
+// ── Activity feed aggregation (LFXV2-1707) ────────────────────────────────────
+router.get('/:uid/activity', (req, res, next) => committeeActivityController.getActivity(req, res, next));
 
 // ── Invite routes (invite-by-email add-member) ───────────────────────────────
 router.get('/:id/invites', (req, res, next) => committeeController.getCommitteeInvites(req, res, next));

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -263,6 +263,35 @@ describe('CommitteeActivityService', () => {
       expect(getVotes).not.toHaveBeenCalled();
     });
 
+    it('rejects an unparseable since instead of silently degrading to an empty feed', async () => {
+      // Same policy, same reason, as the cursor.before test above — parseCommitteeActivityQuery
+      // validates `since` on the HTTP path, but this method is public and reachable directly.
+      // Without this check, isAtOrAfterSince's `ms >= Date.parse(since)` is `ms >= NaN` for every
+      // event, so an unparseable since would silently degrade to an empty feed instead of rejecting.
+      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { since: 'not-a-timestamp', limit: 8 })).rejects.toThrow(ServiceValidationError);
+
+      expect(getVotes).not.toHaveBeenCalled();
+    });
+
+    it('sets hasMore when a page_size-bounded leg is saturated, even though the merged pool itself is not over limit', async () => {
+      // Regression for a false negative traced in the full-branch review: `windowed.length > limit`
+      // alone can't see "more data exists" when a single dominant, page_size-bounded source (votes,
+      // here) returns exactly fetchSize rows and the in-memory since filter then drops all but one
+      // of them — the merged pool ends up at or under `limit`, but there could easily be more
+      // matching rows upstream that this page's fetch never reached. fetchSize = max(1+1, 25) = 25,
+      // so 25 votes here means the leg genuinely hit its upstream page bound.
+      const fetchSize = 25;
+      const votes = Array.from({ length: fetchSize }, (_, i) =>
+        vote({ uid: `v-${i}`, creation_time: i === 0 ? '2026-02-01T00:00:00Z' : '2020-01-01T00:00:00Z' })
+      );
+      getVotes.mockResolvedValue({ data: votes });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', limit: 1 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.page_token).toBeDefined();
+    });
+
     it('requests page_size = max(limit + 1, 25) from every source', async () => {
       await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 2 });
       expect(getMeetings).toHaveBeenCalledWith(req, expect.objectContaining({ page_size: 25 }), 'v1_past_meeting', false);

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -14,7 +14,7 @@ const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, d
   proxyRequest: vi.fn(),
   getMeetings: vi.fn(),
   getVotes: vi.fn(),
-  encodeActivityPageToken: vi.fn((before: string) => `token(${before})`),
+  encodeActivityPageToken: vi.fn((cursor: { before: string; key: string }) => `token(${cursor.before}|${cursor.key})`),
   warning: vi.fn(),
   debug: vi.fn(),
 }));
@@ -130,7 +130,7 @@ describe('CommitteeActivityService', () => {
     proxyRequest.mockImplementation(defaultProxyRequest);
     getMeetings.mockResolvedValue({ data: [] });
     getVotes.mockResolvedValue({ data: [] });
-    encodeActivityPageToken.mockImplementation((before: string) => `token(${before})`);
+    encodeActivityPageToken.mockImplementation((cursor: { before: string; key: string }) => `token(${cursor.before}|${cursor.key})`);
     service = new CommitteeActivityService();
   });
 
@@ -195,20 +195,30 @@ describe('CommitteeActivityService', () => {
     expect(result.data.map((e) => e.type)).toEqual(['meeting_held', 'survey_published']);
   });
 
-  describe('since/before/limit handling', () => {
-    it('passes since as date_from and before as date_to to the past-meetings, votes, and survey legs', async () => {
-      await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', before: '2026-02-01T00:00:00Z', limit: 8 });
+  describe('since/cursor/limit handling', () => {
+    it('sends since/date_to only to the surveys and documents legs — meetings and votes get no upstream date filter', async () => {
+      // Meetings' and votes' occurred_at is derived from a field-fallback (scheduled_start_time ??
+      // start_time; end_time/early_end_time/last_modified_time/creation_time depending on status)
+      // that a single upstream date_field can't represent — sending one anyway can silently exclude
+      // a row whose in-window value lives on a field NOT selected, with no way to recover it
+      // in-memory once upstream never returns it. Surveys/documents' primary derivation field IS
+      // what's filtered on, so upstream narrowing there is safe.
+      await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        since: '2026-01-01T00:00:00Z',
+        cursor: { before: '2026-02-01T00:00:00Z', key: 'vote:unrelated' },
+        limit: 8,
+      });
 
-      expect(getMeetings).toHaveBeenCalledWith(
-        req,
-        expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' }),
-        'v1_past_meeting',
-        false
-      );
-      expect(getVotes).toHaveBeenCalledWith(
-        req,
-        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' })
-      );
+      const meetingsQuery = getMeetings.mock.calls[0][1];
+      expect(meetingsQuery).not.toHaveProperty('date_field');
+      expect(meetingsQuery).not.toHaveProperty('date_from');
+      expect(meetingsQuery).not.toHaveProperty('date_to');
+
+      const votesQuery = getVotes.mock.calls[0][1];
+      expect(votesQuery).not.toHaveProperty('date_field');
+      expect(votesQuery).not.toHaveProperty('date_from');
+      expect(votesQuery).not.toHaveProperty('date_to');
+
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
@@ -227,7 +237,7 @@ describe('CommitteeActivityService', () => {
       expect(getMeetings).toHaveBeenCalledWith(req, expect.objectContaining({ page_size: 31 }), 'v1_past_meeting', false);
     });
 
-    it('caps the returned feed at limit and sets a page_token when more candidates exist', async () => {
+    it('caps the returned feed at limit and sets a (before, key) page_token when more candidates exist', async () => {
       getVotes.mockResolvedValue({
         data: [
           vote({ uid: 'v1', creation_time: '2026-01-05T00:00:00Z' }),
@@ -239,8 +249,8 @@ describe('CommitteeActivityService', () => {
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 2 });
       expect(result.data).toHaveLength(2);
       expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2']);
-      expect(encodeActivityPageToken).toHaveBeenCalledWith('2026-01-04T00:00:00Z');
-      expect(result.page_token).toBe('token(2026-01-04T00:00:00Z)');
+      expect(encodeActivityPageToken).toHaveBeenCalledWith({ before: '2026-01-04T00:00:00Z', key: 'vote:v2' });
+      expect(result.page_token).toBe('token(2026-01-04T00:00:00Z|vote:v2)');
     });
 
     it('omits page_token when every source is exhausted', async () => {
@@ -249,7 +259,7 @@ describe('CommitteeActivityService', () => {
       expect(result.page_token).toBeUndefined();
     });
 
-    it('applies the since/before window in-memory for folders and links, which have no upstream date param', async () => {
+    it('applies the since/before window in-memory for folders and links, which have no upstream date param at all', async () => {
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path.endsWith('/folders')) {
           return Promise.resolve([
@@ -260,29 +270,78 @@ describe('CommitteeActivityService', () => {
         return defaultProxyRequest(r, s, path, m, query);
       });
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', before: '2026-02-01T00:00:00Z', limit: 8 });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        since: '2026-01-01T00:00:00Z',
+        cursor: { before: '2026-02-01T00:00:00Z', key: 'document:none' },
+        limit: 8,
+      });
       expect(result.data).toHaveLength(1);
       expect(result.data[0]).toMatchObject({ type: 'document_uploaded', payload: { document_uid: 'f-in' } });
     });
 
-    it('applies the same in-memory window backstop to a query-service-backed leg, in case upstream date filtering under- or over-narrows it', async () => {
-      // Simulates the upstream date_field mismatch (e.g. a vote's real occurred_at falls outside
-      // the window even though the upstream date_field pre-filter returned it) — the merge itself
-      // must still exclude it, not just trust whatever each leg's upstream call narrowed to.
+    it('bounds an unbounded folders/links response to fetchSize before merging', async () => {
+      // GET /committees/:id/folders and /links accept no page_size param at all and return every
+      // folder/link unconditionally — this leg must bound the result itself rather than trust
+      // upstream to have already done so.
+      const manyFolders = Array.from({ length: 30 }, (_, i) => ({
+        uid: `f-${i}`,
+        name: `Folder ${i}`,
+        updated_at: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+      }));
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) return Promise.resolve(manyFolders);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(8);
+      expect(result.data[0]).toMatchObject({ payload: { document_uid: 'f-29' } });
+      // fetchSize = max(8+1, 25) = 25 — assert the leg itself was bounded before merging (not just
+      // that the final top-8 slice happens to look right regardless of whether bounding occurred).
+      const debugMetadata = debug.mock.calls.at(-1)?.[3] as { document_count: number };
+      expect(debugMetadata.document_count).toBe(25);
+    });
+
+    it('excludes an out-of-window vote purely via the in-memory since/cursor filter — votes get no upstream date narrowing to rely on', async () => {
       getVotes.mockResolvedValue({ data: [vote({ uid: 'v-out', creation_time: '2025-01-01T00:00:00Z', end_time: '2025-01-02T00:00:00Z' })] });
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', before: '2026-02-01T00:00:00Z', limit: 8 });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        since: '2026-01-01T00:00:00Z',
+        cursor: { before: '2026-02-01T00:00:00Z', key: 'document:none' },
+        limit: 8,
+      });
       expect(result.data).toEqual([]);
     });
 
-    it('excludes the previous page boundary item instead of re-returning it — the before cursor is strictly exclusive', async () => {
-      // Regression guard for the inclusive/exclusive mismatch against upstream's date_to
-      // semantics: the merge's own isWithinWindow pass must exclude occurred_at === before
-      // regardless of what date_to did upstream.
+    it('excludes the previous page boundary item instead of re-returning it — the exact (occurred_at, key) pair from the cursor is excluded', async () => {
       getVotes.mockResolvedValue({ data: [vote({ uid: 'v-boundary', creation_time: '2026-01-04T00:00:00Z' })] });
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { before: '2026-01-04T00:00:00Z', limit: 8 });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        cursor: { before: '2026-01-04T00:00:00Z', key: 'vote:v-boundary' },
+        limit: 8,
+      });
       expect(result.data).toEqual([]);
+    });
+
+    it('returns the other tied-timestamp item on the next page — a real two-page round trip through a shared occurred_at', async () => {
+      // Regression guard for the timestamp-only cursor bug: two events sharing the exact same
+      // occurred_at (e.g. a batch of documents uploaded in one request) must both be reachable
+      // across pages, not have one silently dropped.
+      getVotes.mockResolvedValue({
+        data: [vote({ uid: 'v-a', creation_time: '2026-01-04T00:00:00Z' }), vote({ uid: 'v-b', creation_time: '2026-01-04T00:00:00Z' })],
+      });
+
+      const page1 = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 1 });
+      expect(page1.data).toHaveLength(1);
+      expect(page1.page_token).toBeDefined();
+
+      const lastCursorArg = encodeActivityPageToken.mock.calls.at(-1)?.[0] as { before: string; key: string };
+      const page2 = await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor: lastCursorArg, limit: 1 });
+
+      expect(page2.data).toHaveLength(1);
+      expect(page2.page_token).toBeUndefined();
+      const combinedUids = [page1.data[0], page2.data[0]].map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null)).sort();
+      expect(combinedUids).toEqual(['v-a', 'v-b']);
     });
 
     it('falls back to the last item with a real timestamp for the cursor, when the returned page is short on valid timestamps', async () => {
@@ -302,7 +361,8 @@ describe('CommitteeActivityService', () => {
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 3 });
       expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2', 'v3']);
       // v3 (the tail of the returned page) has no valid timestamp — the cursor must fall back to v2's.
-      expect(result.page_token).toBe('token(2026-01-04T00:00:00Z)');
+      expect(encodeActivityPageToken).toHaveBeenCalledWith({ before: '2026-01-04T00:00:00Z', key: 'vote:v2' });
+      expect(result.page_token).toBe('token(2026-01-04T00:00:00Z|vote:v2)');
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -206,6 +206,23 @@ describe('CommitteeActivityService', () => {
 
     const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
     expect(result.data.map((e) => e.type)).toEqual(['meeting_held', 'survey_published']);
+    // Also the tripwire case: a real, differing scheduled_start_time on a returned row should fire
+    // the contract-change warning documented in getCommitteeActivity's fetchSize comment — this
+    // fixture's scheduled_start_time (2026-01-05) genuinely differs from its start_time (zero-date).
+    expect(warning).toHaveBeenCalledWith(
+      expect.anything(),
+      'get_committee_activity',
+      expect.stringContaining('scheduled_start_time'),
+      expect.objectContaining({ committee_uid: COMMITTEE_UID })
+    );
+  });
+
+  it('does not fire the scheduled_start_time tripwire for an ordinary meeting with no scheduled_start_time', async () => {
+    getMeetings.mockResolvedValue({ data: [pastMeeting({ start_time: '2026-01-05T00:00:00Z', scheduled_start_time: '' })] });
+
+    await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+
+    expect(warning).not.toHaveBeenCalledWith(expect.anything(), 'get_committee_activity', expect.stringContaining('scheduled_start_time'), expect.anything());
   });
 
   describe('since/cursor/limit handling', () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -580,9 +580,14 @@ describe('CommitteeActivityService', () => {
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
+      // Positive control for the null-body survey test's negative `not.toHaveBeenCalledWith(...)`
+      // assertion above — pins that the 'survey activity' substring is the real, current message a
+      // survey-leg failure logs, so a future rename of that message would fail loudly here instead
+      // of just letting the negative assertion pass for the wrong reason.
+      expect(warning).toHaveBeenCalledWith(expect.anything(), 'get_committee_activity', expect.stringContaining('survey activity'), expect.anything());
     });
 
-    it('renders the other three sources when documents fail', async () => {
+    it('renders the other three sources when documents (folders) fail', async () => {
       getMeetings.mockResolvedValue({ data: [pastMeeting()] });
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path.endsWith('/folders')) return Promise.reject(new Error('upstream down'));
@@ -591,6 +596,21 @@ describe('CommitteeActivityService', () => {
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
+    });
+
+    it('renders the other three sources when documents (files) fail', async () => {
+      getMeetings.mockResolvedValue({ data: [pastMeeting()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'committee_document') return Promise.reject(new Error('upstream down'));
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
+      // Positive control for the null-body files test's negative assertion — pins 'committee files'
+      // as the real, current message; the pre-existing folders-failure test above never exercised
+      // this leg's own message, so this substring was previously pinned nowhere in the suite.
+      expect(warning).toHaveBeenCalledWith(expect.anything(), 'get_committee_activity', expect.stringContaining('committee files'), expect.anything());
     });
   });
 
@@ -624,15 +644,24 @@ describe('CommitteeActivityService', () => {
     it('rejects with a typed ResourceNotFoundError when the committee body is null, rather than an untyped TypeError', async () => {
       // Same fail-closed contract as the test above, for the other real shape a committee lookup
       // can return: an empty-bodied 200 (proxyRequest parses that to null), not just a rejected
-      // promise. Asserting the specific error class matters here — an unguarded `.enable_voting`
-      // read off a null committee also rejects the whole request (via an untyped TypeError), so a
-      // bare `rejects.toThrow()` would pass identically whether the guard exists or not.
+      // promise. Asserting the specific error class (and its operation/service/path context, which
+      // BaseApiError.toResponse() surfaces in the actual HTTP response) matters here — an unguarded
+      // `.enable_voting` read off a null committee also rejects the whole request via an untyped
+      // TypeError, so a bare `rejects.toThrow()` would pass identically whether the guard exists or
+      // not, and asserting only the class would leave the context fields this same commit added
+      // just as untested as the guard itself was before this round.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (/^\/committees\/[^/]+$/.test(path)) return Promise.resolve(null);
         return defaultProxyRequest(r, s, path, m, query);
       });
 
-      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 })).rejects.toThrow(ResourceNotFoundError);
+      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 })).rejects.toBeInstanceOf(ResourceNotFoundError);
+      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 })).rejects.toMatchObject({
+        statusCode: 404,
+        operation: 'get_committee_activity',
+        service: 'committee_service',
+        path: `/committees/${COMMITTEE_UID}`,
+      });
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -344,25 +344,32 @@ describe('CommitteeActivityService', () => {
       expect(combinedUids).toEqual(['v-a', 'v-b']);
     });
 
-    it('sorts two events that both have no valid timestamp deterministically, not NaN-implementation-defined order', async () => {
+    it('sorts two events that both have no valid timestamp by key, independent of source-fetch order', async () => {
       // Regression guard: timestampValue(a) - timestampValue(b) on two -Infinity values is NaN,
-      // which would skip the key tiebreak and leave the pair's relative order (and therefore
-      // which one a slice() cuts off) non-deterministic. Run twice to catch an order that only
-      // sometimes flips.
-      getVotes.mockResolvedValue({
-        data: [
-          vote({ uid: 'v-x', creation_time: undefined, last_modified_time: undefined }),
-          vote({ uid: 'v-y', creation_time: undefined, last_modified_time: undefined }),
-        ],
-      });
+      // which is `!== 0` and would skip the key tiebreak — falling through to whatever order the
+      // comparator's NaN result happens to preserve, i.e. fetch/insertion order, not the intended
+      // key order. Asserting a single fixed input isn't a real guard (stable sort reproduces the
+      // same output for the same input either way) — feeding the pair in BOTH orders and requiring
+      // the same key-derived output regardless is what actually distinguishes "sorted by key" from
+      // "preserved fetch order".
+      const voteX = vote({ uid: 'v-x', creation_time: undefined, last_modified_time: undefined });
+      const voteY = vote({ uid: 'v-y', creation_time: undefined, last_modified_time: undefined });
+      const uidsOf = (r: Awaited<ReturnType<typeof service.getCommitteeActivity>>) => r.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null));
 
-      const first = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-      const second = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-      const uidsOf = (r: typeof first) => r.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null));
-      expect(uidsOf(first)).toEqual(uidsOf(second));
+      getVotes.mockResolvedValue({ data: [voteX, voteY] });
+      const forwardOrder = uidsOf(await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }));
+
+      getVotes.mockResolvedValue({ data: [voteY, voteX] });
+      const reversedOrder = uidsOf(await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }));
+
+      expect(forwardOrder).toEqual(reversedOrder);
     });
 
-    it('does not drop a folder and a file that happen to share the same uid — document keys are discriminated by type', async () => {
+    it('drops the sibling of a colliding-key event at a page boundary — the risk document_type-discrimination guards against', async () => {
+      // eventKey collisions matter specifically at the cursor boundary: compareEventsDesc treats
+      // two same-timestamp, same-key events as equal, so isAfterCursor excludes both once one has
+      // been returned. Paginating (not just checking both survive an unpaginated merge) is what
+      // actually exercises that path.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path.endsWith('/folders')) return Promise.resolve([{ uid: 'shared-uid', name: 'Folder', updated_at: '2026-01-05T00:00:00Z' }]);
         if (path === '/query/resources' && query?.['type'] === 'committee_document') {
@@ -373,10 +380,16 @@ describe('CommitteeActivityService', () => {
         return defaultProxyRequest(r, s, path, m, query);
       });
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-      expect(result.data).toHaveLength(2);
-      const types = result.data.map((e) => (e.type === 'document_uploaded' ? e.payload.document_type : null)).sort();
-      expect(types).toEqual(['file', 'folder']);
+      const page1 = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 1 });
+      expect(page1.data).toHaveLength(1);
+      expect(page1.page_token).toBeDefined();
+
+      const cursor = encodeActivityPageToken.mock.calls.at(-1)?.[0] as { before: string; key: string };
+      const page2 = await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor, limit: 1 });
+
+      expect(page2.data).toHaveLength(1);
+      const combinedTypes = [page1.data[0], page2.data[0]].map((e) => (e.type === 'document_uploaded' ? e.payload.document_type : null)).sort();
+      expect(combinedTypes).toEqual(['file', 'folder']);
     });
 
     it('falls back to the last item with a real timestamp for the cursor, when the returned page is short on valid timestamps', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -245,18 +245,30 @@ describe('CommitteeActivityService', () => {
       expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ date_to: '2026-02-01T00:00:01.000Z' }));
     });
 
-    it('omits upstream date_to (rather than throwing) when cursor.before is unparseable', async () => {
+    it('resolves an empty, logged feed (rather than throwing) when cursor.before is unparseable', async () => {
       // getCommitteeActivity is a public method — the controller always validates cursor.before via
       // decodePageToken first, but a future non-HTTP caller could invoke this directly with a bad
-      // value. Widening the fetch (no date_to) is safe, same direction as ceiling itself; 500ing
-      // the whole feed over one bad boundary would not be.
-      await service.getCommitteeActivity(req, COMMITTEE_UID, {
+      // value. The net result isn't "widened fetch, trimmed correctly" — isAfterCursor still
+      // compares every event against the original unparseable cursor.before, which resolves to
+      // -Infinity, so every real event is filtered out regardless of what the (wider) upstream
+      // fetch returned. That's still the right call over throwing (empty + logged beats a 500), but
+      // the test should pin the actual behavior, not just the outbound query shape.
+      getVotes.mockResolvedValue({ data: [vote({ uid: 'v1' })] });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, {
         cursor: { before: 'not-a-timestamp', key: 'vote:unrelated' },
         limit: 8,
       });
 
       const votesQuery = getVotes.mock.calls[0][1];
       expect(votesQuery).not.toHaveProperty('date_to');
+      expect(result.data).toEqual([]);
+      expect(warning).toHaveBeenCalledWith(
+        req,
+        'get_committee_activity',
+        expect.stringContaining('Unparseable cursor.before'),
+        expect.objectContaining({ committee_uid: COMMITTEE_UID })
+      );
     });
 
     it('requests page_size = max(limit + 1, 25) from every source', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -10,11 +10,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // `@lfx-one/shared/*` isn't wired into this app's vitest config (same issue documented in
 // committee-engagement-window.helper.spec.ts) — enums/utils need stubs; the interfaces import in
 // the service under test is `import type`, so it's erased and needs no mock at all.
-const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, debug } = vi.hoisted(() => ({
+const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, normalizeTimestamp, warning, debug } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   getMeetings: vi.fn(),
   getVotes: vi.fn(),
   encodeActivityPageToken: vi.fn((cursor: { before: string; key: string }) => `token(${cursor.before}|${cursor.key})`),
+  normalizeTimestamp: vi.fn((value: string) => new Date(value).toISOString()),
   warning: vi.fn(),
   debug: vi.fn(),
 }));
@@ -27,6 +28,7 @@ vi.mock('@lfx-one/shared/constants', async () => {
     '../../../../../packages/shared/src/constants/meeting.constants'
   );
   return {
+    ACTIVITY_FEED_MAX_PAGE_SIZE: activityEvent.ACTIVITY_FEED_MAX_PAGE_SIZE,
     ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE: activityEvent.ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE,
     PAST_MEETING_SORT: meeting.PAST_MEETING_SORT,
   };
@@ -52,7 +54,7 @@ vi.mock('@lfx-one/shared/utils', async () => {
     getSurveyDisplayStatus: surveyUtils.getSurveyDisplayStatus,
   };
 });
-vi.mock('../helpers/committee-activity-query.helper', () => ({ encodeActivityPageToken }));
+vi.mock('../helpers/committee-activity-query.helper', () => ({ encodeActivityPageToken, normalizeTimestamp }));
 vi.mock('./logger.service', () => ({ logger: { debug, warning, info: vi.fn(), startOperation: vi.fn(), success: vi.fn() } }));
 vi.mock('./meeting.service', () => ({
   MeetingService: class {
@@ -212,23 +214,25 @@ describe('CommitteeActivityService', () => {
 
       // date_to is ceiled to the next whole second before being sent upstream (see the dedicated
       // ceiling test below) — an already-whole-second cursor still round-trips through
-      // Date.toISOString(), which always emits milliseconds, hence the trailing `.000Z`.
+      // Date.toISOString(), which always emits milliseconds, hence the trailing `.000Z`. `since`
+      // round-trips through the same normalizeTimestamp/Date.toISOString() call on the way in
+      // (see the dedicated since-normalization test below), so it picks up the identical `.000Z`.
       expect(getMeetings).toHaveBeenCalledWith(
         req,
-        expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00.000Z' }),
+        expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' }),
         'v1_past_meeting',
         false
       );
       expect(getVotes).toHaveBeenCalledWith(
         req,
-        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00.000Z' })
+        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' })
       );
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
         '/query/resources',
         'GET',
-        expect.objectContaining({ type: 'survey', date_field: 'last_modified_at', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00.000Z' })
+        expect.objectContaining({ type: 'survey', date_field: 'last_modified_at', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' })
       );
     });
 
@@ -269,6 +273,21 @@ describe('CommitteeActivityService', () => {
       // Without this check, isAtOrAfterSince's `ms >= Date.parse(since)` is `ms >= NaN` for every
       // event, so an unparseable since would silently degrade to an empty feed instead of rejecting.
       await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { since: 'not-a-timestamp', limit: 8 })).rejects.toThrow(ServiceValidationError);
+
+      expect(getVotes).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ['zero', 0],
+      ['negative', -1],
+      ['non-integer', 1.5],
+      ['above the max', 51],
+    ])('rejects a limit that is %s instead of silently degrading to a wrong result', async (_label, limit) => {
+      // parseCommitteeActivityQuery already bounds page_size on the HTTP path, but this method is
+      // public and reachable directly. Without this check: limit=0 -> windowed.slice(0, 0) -> an
+      // empty feed with no error; a negative limit -> slice(0, -1) silently drops the newest item
+      // while still emitting a page_token; either way, a wrong result with no signal anything's off.
+      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit })).rejects.toThrow(ServiceValidationError);
 
       expect(getVotes).not.toHaveBeenCalled();
     });

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -412,6 +412,29 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0]).toMatchObject({ type: 'document_uploaded', payload: { document_uid: 'link-1', document_type: 'link' } });
     });
 
+    it('treats a null /query/resources body as empty for the survey leg instead of throwing on destructure', async () => {
+      // `const { resources } = await proxyRequest(...)` throws a TypeError if the whole response
+      // body is null (not just its resources field) — a real possible upstream shape, same as the
+      // folders/links case above, just for a `/query/resources` leg instead of a REST array leg.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') return Promise.resolve(null);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toEqual([]);
+    });
+
+    it('treats a null /query/resources body as empty for the files leg instead of throwing on property access', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'committee_document') return Promise.resolve(null);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toEqual([]);
+    });
+
     it('excludes an out-of-window vote purely via the in-memory since/cursor filter — votes get no upstream date narrowing to rely on', async () => {
       getVotes.mockResolvedValue({ data: [vote({ uid: 'v-out', creation_time: '2025-01-01T00:00:00Z', end_time: '2025-01-02T00:00:00Z' })] });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -19,6 +19,18 @@ const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, d
   debug: vi.fn(),
 }));
 
+vi.mock('@lfx-one/shared/constants', async () => {
+  const activityEvent = await vi.importActual<typeof import('../../../../../packages/shared/src/constants/activity-event.constants')>(
+    '../../../../../packages/shared/src/constants/activity-event.constants'
+  );
+  const meeting = await vi.importActual<typeof import('../../../../../packages/shared/src/constants/meeting.constants')>(
+    '../../../../../packages/shared/src/constants/meeting.constants'
+  );
+  return {
+    ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE: activityEvent.ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE,
+    PAST_MEETING_SORT: meeting.PAST_MEETING_SORT,
+  };
+});
 vi.mock('@lfx-one/shared/enums', () => ({
   PollStatus: { ACTIVE: 'active', DISABLED: 'disabled', ENDED: 'ended' },
   SurveyStatus: { OPEN: 'open', CLOSED: 'closed', SCHEDULED: 'scheduled', DRAFT: 'draft', SENT: 'sent' },
@@ -36,6 +48,7 @@ vi.mock('@lfx-one/shared/utils', async () => {
   return {
     firstValidTimestamp: iso.firstValidTimestamp,
     getPastMeetingStartTimeMs: pastMeetingUtils.getPastMeetingStartTimeMs,
+    getPastMeetingResourceId: pastMeetingUtils.getPastMeetingResourceId,
     getSurveyDisplayStatus: surveyUtils.getSurveyDisplayStatus,
   };
 });
@@ -66,7 +79,14 @@ const req = {} as unknown as Request;
 const COMMITTEE_UID = 'committee-1';
 
 function pastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {
-  return { id: 'pm-1', title: 'Weekly Sync', start_time: '2026-01-01T10:00:00Z', scheduled_start_time: '', ...overrides } as PastMeeting;
+  return {
+    id: 'pm-1',
+    meeting_and_occurrence_id: 'pm-1-occ-1',
+    title: 'Weekly Sync',
+    start_time: '2026-01-01T10:00:00Z',
+    scheduled_start_time: '',
+    ...overrides,
+  } as PastMeeting;
 }
 
 function vote(overrides: Partial<Vote> = {}): Vote {
@@ -151,6 +171,17 @@ describe('CommitteeActivityService', () => {
     expect(result.data.map((e) => e.type)).toEqual(['survey_published', 'vote_opened']);
   });
 
+  it('sorts past meetings by name_desc (start_time-ordered), not updated_desc (index-update-time-ordered)', async () => {
+    await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(getMeetings).toHaveBeenCalledWith(req, expect.objectContaining({ sort: 'name_desc' }), 'v1_past_meeting', false);
+  });
+
+  it('keys a meeting_held event on meeting_and_occurrence_id, not just meeting_id', async () => {
+    getMeetings.mockResolvedValue({ data: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] });
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(result.data[0]).toMatchObject({ type: 'meeting_held', payload: { meeting_id: 'pm-42', meeting_occurrence_id: 'pm-42-occ-9' } });
+  });
+
   it('does not sort a past meeting as ancient when start_time is a Go zero-date', async () => {
     getMeetings.mockResolvedValue({ data: [pastMeeting({ start_time: '0001-01-01T00:00:00Z', scheduled_start_time: '2026-01-05T00:00:00Z' })] });
     proxyRequest.mockImplementation((r, s, path, m, query) => {
@@ -232,6 +263,46 @@ describe('CommitteeActivityService', () => {
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', before: '2026-02-01T00:00:00Z', limit: 8 });
       expect(result.data).toHaveLength(1);
       expect(result.data[0]).toMatchObject({ type: 'document_uploaded', payload: { document_uid: 'f-in' } });
+    });
+
+    it('applies the same in-memory window backstop to a query-service-backed leg, in case upstream date filtering under- or over-narrows it', async () => {
+      // Simulates the upstream date_field mismatch (e.g. a vote's real occurred_at falls outside
+      // the window even though the upstream date_field pre-filter returned it) — the merge itself
+      // must still exclude it, not just trust whatever each leg's upstream call narrowed to.
+      getVotes.mockResolvedValue({ data: [vote({ uid: 'v-out', creation_time: '2025-01-01T00:00:00Z', end_time: '2025-01-02T00:00:00Z' })] });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', before: '2026-02-01T00:00:00Z', limit: 8 });
+      expect(result.data).toEqual([]);
+    });
+
+    it('excludes the previous page boundary item instead of re-returning it — the before cursor is strictly exclusive', async () => {
+      // Regression guard for the inclusive/exclusive mismatch against upstream's date_to
+      // semantics: the merge's own isWithinWindow pass must exclude occurred_at === before
+      // regardless of what date_to did upstream.
+      getVotes.mockResolvedValue({ data: [vote({ uid: 'v-boundary', creation_time: '2026-01-04T00:00:00Z' })] });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { before: '2026-01-04T00:00:00Z', limit: 8 });
+      expect(result.data).toEqual([]);
+    });
+
+    it('falls back to the last item with a real timestamp for the cursor, when the returned page is short on valid timestamps', async () => {
+      // Only 2 votes have a real timestamp; 2 more have none. Sorted desc, invalid-timestamp
+      // items sort last (timestampValue('') === -Infinity), so with limit=3 the returned page is
+      // [v1, v2, v3] — v3 (the tail) has no valid timestamp, while a 4th candidate (v4) still
+      // exists beyond the page, so hasMore is true and a page_token must still be issued.
+      getVotes.mockResolvedValue({
+        data: [
+          vote({ uid: 'v1', creation_time: '2026-01-05T00:00:00Z' }),
+          vote({ uid: 'v2', creation_time: '2026-01-04T00:00:00Z' }),
+          vote({ uid: 'v3', creation_time: undefined, last_modified_time: undefined }),
+          vote({ uid: 'v4', creation_time: undefined, last_modified_time: undefined }),
+        ],
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 3 });
+      expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2', 'v3']);
+      // v3 (the tail of the returned page) has no valid timestamp — the cursor must fall back to v2's.
+      expect(result.page_token).toBe('token(2026-01-04T00:00:00Z)');
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -245,6 +245,20 @@ describe('CommitteeActivityService', () => {
       expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ date_to: '2026-02-01T00:00:01.000Z' }));
     });
 
+    it('omits upstream date_to (rather than throwing) when cursor.before is unparseable', async () => {
+      // getCommitteeActivity is a public method — the controller always validates cursor.before via
+      // decodePageToken first, but a future non-HTTP caller could invoke this directly with a bad
+      // value. Widening the fetch (no date_to) is safe, same direction as ceiling itself; 500ing
+      // the whole feed over one bad boundary would not be.
+      await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        cursor: { before: 'not-a-timestamp', key: 'vote:unrelated' },
+        limit: 8,
+      });
+
+      const votesQuery = getVotes.mock.calls[0][1];
+      expect(votesQuery).not.toHaveProperty('date_to');
+    });
+
     it('requests page_size = max(limit + 1, 25) from every source', async () => {
       await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 2 });
       expect(getMeetings).toHaveBeenCalledWith(req, expect.objectContaining({ page_size: 25 }), 'v1_past_meeting', false);

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -73,7 +73,7 @@ vi.mock('./microservice-proxy.service', () => ({
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import type { ActivityPageCursor, PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
 
-import { ServiceValidationError } from '../errors';
+import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { CommitteeActivityService } from './committee-activity.service';
 
 const req = {} as unknown as Request;
@@ -413,14 +413,16 @@ describe('CommitteeActivityService', () => {
     });
 
     it('treats a null /query/resources body as a graceful empty survey leg, not an error-path degrade', async () => {
-      // Both the survey and files legs already sit inside their own per-leg `.catch()` in
-      // getCommitteeActivity, so `result.data` alone can't tell a guarded null response apart from
-      // an unguarded one — either way the leg contributes []. The `warning` log is what actually
-      // discriminates: without the `response?.resources ?? []` guard, the TypeError thrown reading
-      // `.resources` off a null response is caught by that outer per-leg `.catch()`, which DOES log
-      // a warning; the guard means this leg never throws at all, so no warning fires. Asserting only
-      // `result.data` here would pass identically whether the guard exists or not — proven by
-      // mutation testing the guard away and re-running this test.
+      // The survey leg already sits inside its own per-leg `.catch()` in getCommitteeActivity, so
+      // `result.data` alone can't tell a guarded null response apart from an unguarded one — either
+      // way the leg contributes []. The `warning` log is what actually discriminates: without the
+      // `response?.resources ?? []` guard, the TypeError thrown reading `.resources` off a null
+      // response propagates out of fetchSurveyEvents and is caught by that outer per-leg `.catch()`,
+      // which DOES log a warning; the guard means fetchSurveyEvents never throws at all, so no
+      // warning fires. Asserting only `result.data` here would pass identically whether the guard
+      // exists or not — proven by mutation testing the guard away and re-running this test. Scoped
+      // to the survey leg's own message (not `not.toHaveBeenCalled()` at all) so an unrelated
+      // warning from another leg can't make this assertion pass for the wrong reason.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'survey') return Promise.resolve(null);
         return defaultProxyRequest(r, s, path, m, query);
@@ -428,20 +430,22 @@ describe('CommitteeActivityService', () => {
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data).toEqual([]);
-      expect(warning).not.toHaveBeenCalled();
+      expect(warning).not.toHaveBeenCalledWith(expect.anything(), 'get_committee_activity', expect.stringContaining('survey activity'), expect.anything());
     });
 
     it('treats a null /query/resources body as a graceful empty files leg, not an error-path degrade', async () => {
-      // See the survey test above for why `warning` (not just result.data) is the assertion that
-      // actually discriminates a guarded null response from an unguarded one.
+      // Same mechanism as the survey test above, one layer earlier: the files leg's TypeError is
+      // caught by the `.catch()` chained directly onto its own proxyRequest call inside
+      // fetchDocumentEvents (not the outer per-leg catch in getCommitteeActivity), but the
+      // observable signal is identical — a warning fires only on the unguarded path.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'committee_document') return Promise.resolve(null);
         return defaultProxyRequest(r, s, path, m, query);
       });
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-      expect(warning).not.toHaveBeenCalled();
       expect(result.data).toEqual([]);
+      expect(warning).not.toHaveBeenCalledWith(expect.anything(), 'get_committee_activity', expect.stringContaining('committee files'), expect.anything());
     });
 
     it('excludes an out-of-window vote purely via the in-memory since/cursor filter — votes get no upstream date narrowing to rely on', async () => {
@@ -615,6 +619,20 @@ describe('CommitteeActivityService', () => {
       });
 
       await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 })).rejects.toThrow(upstreamError);
+    });
+
+    it('rejects with a typed ResourceNotFoundError when the committee body is null, rather than an untyped TypeError', async () => {
+      // Same fail-closed contract as the test above, for the other real shape a committee lookup
+      // can return: an empty-bodied 200 (proxyRequest parses that to null), not just a rejected
+      // promise. Asserting the specific error class matters here — an unguarded `.enable_voting`
+      // read off a null committee also rejects the whole request (via an untyped TypeError), so a
+      // bare `rejects.toThrow()` would pass identically whether the guard exists or not.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (/^\/committees\/[^/]+$/.test(path)) return Promise.resolve(null);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 })).rejects.toThrow(ResourceNotFoundError);
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -159,7 +159,7 @@ describe('CommitteeActivityService', () => {
     expect(result.data.map((e) => e.type)).toEqual(['document_uploaded', 'vote_closed', 'survey_published', 'meeting_held']);
   });
 
-  it('sorts an unparseable vote timestamp as the oldest item instead of throwing', async () => {
+  it('drops a vote with an unparseable timestamp instead of throwing or including it unordered', async () => {
     getVotes.mockResolvedValue({ data: [vote({ creation_time: 'not-a-timestamp', last_modified_time: undefined })] });
     proxyRequest.mockImplementation((r, s, path, m, query) => {
       if (path === '/query/resources' && query?.['type'] === 'survey') {
@@ -169,7 +169,7 @@ describe('CommitteeActivityService', () => {
     });
 
     const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-    expect(result.data.map((e) => e.type)).toEqual(['survey_published', 'vote_opened']);
+    expect(result.data.map((e) => e.type)).toEqual(['survey_published']);
   });
 
   it('sorts past meetings by name_desc (start_time-ordered), not updated_desc (index-update-time-ordered)', async () => {
@@ -379,29 +379,21 @@ describe('CommitteeActivityService', () => {
       expect(combinedUids).toEqual(['v-a', 'v-b']);
     });
 
-    it('sorts two events that both have no valid timestamp by key, independent of source-fetch order', async () => {
-      // Regression guard: timestampValue(a) - timestampValue(b) on two -Infinity values is NaN,
-      // which is `!== 0` and would skip the key tiebreak — falling through to whatever order the
-      // comparator's NaN result happens to preserve, i.e. fetch/insertion order, not the intended
-      // key order. Asserting a single fixed input isn't a real guard (stable sort reproduces the
-      // same output for the same input either way) — feeding the pair in BOTH orders and requiring
-      // the same key-derived output regardless is what actually distinguishes "sorted by key" from
-      // "preserved fetch order".
+    it('drops both events when neither has a valid timestamp, regardless of source-fetch order', async () => {
+      // Events with no valid timestamp are dropped entirely (see the windowed filter's comment) —
+      // this also means the NaN-tiebreak hazard compareEventsDesc guards against (timestampValue(a)
+      // - timestampValue(b) on two -Infinity values is NaN) is now structurally unreachable through
+      // the merge for genuinely-invalid timestamps: they never reach the sort. The tiebreak itself
+      // is still exercised by real, valid, tied timestamps — see the two-page round trip test above.
       const voteX = vote({ uid: 'v-x', creation_time: undefined, last_modified_time: undefined });
       const voteY = vote({ uid: 'v-y', creation_time: undefined, last_modified_time: undefined });
       const uidsOf = (r: Awaited<ReturnType<typeof service.getCommitteeActivity>>) => r.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null));
 
       getVotes.mockResolvedValue({ data: [voteX, voteY] });
-      const forwardOrder = uidsOf(await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }));
+      expect(uidsOf(await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }))).toEqual([]);
 
       getVotes.mockResolvedValue({ data: [voteY, voteX] });
-      const reversedOrder = uidsOf(await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }));
-
-      // 'vote:v-y' sorts before 'vote:v-x' under compareEventsDesc's descending key tiebreak
-      // (b.key.localeCompare(a.key)) — asserting the concrete order, not just forward/reversed
-      // agreement, pins down THAT the tiebreak is key-descending, not merely that it's stable.
-      expect(forwardOrder).toEqual(['v-y', 'v-x']);
-      expect(reversedOrder).toEqual(['v-y', 'v-x']);
+      expect(uidsOf(await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }))).toEqual([]);
     });
 
     it('keeps a folder and a file that share a uid across a page boundary — document_type discrimination prevents the cursor from dropping one', async () => {
@@ -431,13 +423,10 @@ describe('CommitteeActivityService', () => {
       expect(combinedTypes).toEqual(['file', 'folder']);
     });
 
-    it('falls back to the last item with a real timestamp for the cursor, when the returned page is short on valid timestamps', async () => {
-      // Only 2 votes have a real timestamp; 2 more have none. Sorted desc, invalid-timestamp items
-      // sort last (timestampValue('') === -Infinity) and tiebreak deterministically on key
-      // ('vote:v4' sorts before 'vote:v3' in the descending key order), so with limit=3 the
-      // returned page is [v1, v2, v4] — v4 (the tail) has no valid timestamp, while a 4th
-      // candidate (v3) still exists beyond the page, so hasMore is true and a page_token must
-      // still be issued, falling back past v4 to v2's timestamp.
+    it('excludes invalid-timestamp votes from both the page and the hasMore/page_token calculation', async () => {
+      // 2 votes have a real timestamp; 2 more have none and are dropped entirely (see the windowed
+      // filter). With limit=3, the 2 remaining valid candidates fit on one page — no page_token,
+      // even though 4 rows were fetched from the source.
       getVotes.mockResolvedValue({
         data: [
           vote({ uid: 'v1', creation_time: '2026-01-05T00:00:00Z' }),
@@ -448,10 +437,8 @@ describe('CommitteeActivityService', () => {
       });
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 3 });
-      expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2', 'v4']);
-      // v4 (the tail of the returned page) has no valid timestamp — the cursor must fall back to v2's.
-      expect(encodeActivityPageToken).toHaveBeenCalledWith({ before: '2026-01-04T00:00:00Z', key: 'vote:v2' });
-      expect(result.page_token).toBe('token(2026-01-04T00:00:00Z|vote:v2)');
+      expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2']);
+      expect(result.page_token).toBeUndefined();
     });
   });
 
@@ -509,15 +496,18 @@ describe('CommitteeActivityService', () => {
       expect(getVotes).toHaveBeenCalled();
     });
 
-    it('defaults votes to excluded when the committee lookup itself fails', async () => {
-      getVotes.mockResolvedValue({ data: [vote()] });
+    it('rejects the whole request when the committee lookup fails, rather than degrading to votes-excluded', async () => {
+      // GET /committees/:uid is committee-service's real per-request FGA gate (unlike the
+      // /query/resources legs, which filter per-resource and never reject the whole request) — a
+      // failure here (a real 403, or a transient 5xx) must propagate, not silently downgrade into
+      // "votes excluded, everything else renders" for what could be an unauthorized caller.
+      const upstreamError = new Error('upstream down');
       proxyRequest.mockImplementation((r, s, path, m, query) => {
-        if (/^\/committees\/[^/]+$/.test(path)) return Promise.reject(new Error('upstream down'));
+        if (/^\/committees\/[^/]+$/.test(path)) return Promise.reject(upstreamError);
         return defaultProxyRequest(r, s, path, m, query);
       });
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
-      expect(result.data).toEqual([]);
+      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 })).rejects.toThrow(upstreamError);
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -108,7 +108,11 @@ function vote(overrides: Partial<Vote> = {}): Vote {
     name: 'Q1 Budget',
     status: PollStatus.ACTIVE,
     creation_time: '2026-01-02T10:00:00Z',
-    end_time: '2026-01-10T00:00:00Z',
+    // Far future, deliberately — mapVoteToEvent now treats a passed end_time as an implicit close
+    // (isVoteDeadlinePast), so a fixture meant to default to "still open" can't use a fixed date
+    // that will eventually lapse into the past as real time passes. Tests exercising a
+    // deadline-passed closure override this explicitly with a past end_time.
+    end_time: '2099-01-01T00:00:00Z',
     ...overrides,
   } as Vote;
 }
@@ -861,6 +865,24 @@ describe('CommitteeActivityService', () => {
       getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ACTIVE, early_end_time: '2026-01-09T00:00:00Z' })] });
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data[0].type).toBe('vote_closed');
+    });
+
+    it('maps an ACTIVE vote whose end_time has already passed to vote_closed (deadline-passed regression)', async () => {
+      // An async backend job may not have flipped status to ENDED yet, but a vote whose end_time
+      // is in the past is effectively over — matching isVoteCalendarEventPast's established
+      // "deadline passed" semantics elsewhere in the app. Without this, it stayed vote_opened at
+      // creation_time indefinitely. Cursor Bugbot caught this as a follow-up to the casing fix.
+      getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ACTIVE, end_time: '2020-01-01T00:00:00Z' })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({ type: 'vote_closed', occurred_at: '2020-01-01T00:00:00Z' });
+    });
+
+    it('does not close an ACTIVE vote whose end_time is still in the future', async () => {
+      // Negative control for the deadline-passed test above.
+      getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ACTIVE, end_time: '2099-06-01T00:00:00Z' })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0].type).toBe('vote_opened');
     });
 
     it('maps a mixed-case ended vote status to vote_closed, not vote_opened (casing bug regression)', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -663,6 +663,24 @@ describe('CommitteeActivityService', () => {
         path: `/committees/${COMMITTEE_UID}`,
       });
     });
+
+    it('encodes the committee uid in the 404 path so it matches the path actually requested', async () => {
+      // COMMITTEE_UID ('committee-1') contains nothing encodeURIComponent transforms, so the
+      // toMatchObject assertion above can't tell an encoded path from an unencoded one — it stayed
+      // green when the encoding fix was mutated away. This uid needs real encoding to exercise it.
+      // The expected path is a hard-coded literal, not re-derived with encodeURIComponent — deriving
+      // it the same way the production code does would let a bug in which encoder is used cancel
+      // out on both sides of the assertion.
+      const uidNeedingEncoding = 'committee 1';
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (/^\/committees\/[^/]+$/.test(path)) return Promise.resolve(null);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      await expect(service.getCommitteeActivity(req, uidNeedingEncoding, { limit: 8 })).rejects.toMatchObject({
+        path: '/committees/committee%201',
+      });
+    });
   });
 
   describe('one-event-per-row mapping', () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -337,6 +337,53 @@ describe('CommitteeActivityService', () => {
       expect(debugMetadata.document_count).toBe(25);
     });
 
+    it('surfaces folders older than fetchSize once pagination reaches them — the window must be applied before bounding, not after', async () => {
+      // Regression guard: folders/links have no upstream page_size, so this leg always refetches
+      // every folder on every call and must bound locally. Bounding to fetchSize BEFORE applying
+      // the since/before window would recompute the same newest-25 slice on every page regardless
+      // of cursor, permanently hiding the 5 oldest of these 30 folders no matter how far pagination
+      // walked. Filtering first, then bounding, means each page's window narrows the candidate pool
+      // before the cap is applied, so the older folders become reachable once the cursor passes them.
+      const manyFolders = Array.from({ length: 30 }, (_, i) => ({
+        uid: `f-${i}`,
+        name: `Folder ${i}`,
+        updated_at: `2026-01-${String(i + 1).padStart(2, '0')}T00:00:00Z`,
+      }));
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) return Promise.resolve(manyFolders);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      let cursor: ActivityPageCursor | undefined;
+      const uids: string[] = [];
+      for (let i = 0; i < manyFolders.length; i++) {
+        const page = await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor, limit: 1 });
+        if (page.data.length === 0) break;
+        const event = page.data[0];
+        uids.push(event.type === 'document_uploaded' ? event.payload.document_uid : 'unexpected');
+        if (!page.page_token) break;
+        cursor = encodeActivityPageToken.mock.calls.at(-1)?.[0] as ActivityPageCursor;
+      }
+
+      expect(uids).toEqual(Array.from({ length: manyFolders.length }, (_, i) => `f-${manyFolders.length - 1 - i}`));
+    });
+
+    it('treats a null folders response as empty without discarding sibling links in the same leg', async () => {
+      // MicroserviceProxyService.proxyRequest returns the upstream body verbatim — a 204/empty
+      // response comes through as null, not []. Without a null guard, `folders.map(...)` throws
+      // before `links.map(...)` ever runs, so the outer per-leg `.catch()` in getCommitteeActivity
+      // discards the ENTIRE document leg (links and files included), not just the null folders source.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) return Promise.resolve(null);
+        if (path.endsWith('/links')) return Promise.resolve([{ uid: 'link-1', name: 'Spec doc', updated_at: '2026-01-05T00:00:00Z' }]);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({ type: 'document_uploaded', payload: { document_uid: 'link-1', document_type: 'link' } });
+    });
+
     it('excludes an out-of-window vote purely via the in-memory since/cursor filter — votes get no upstream date narrowing to rely on', async () => {
       getVotes.mockResolvedValue({ data: [vote({ uid: 'v-out', creation_time: '2025-01-01T00:00:00Z', end_time: '2025-01-02T00:00:00Z' })] });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -10,13 +10,13 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // `@lfx-one/shared/*` isn't wired into this app's vitest config (same issue documented in
 // committee-engagement-window.helper.spec.ts) — enums/utils need stubs; the interfaces import in
 // the service under test is `import type`, so it's erased and needs no mock at all.
-const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, debug } = vi.hoisted(() => ({
+const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, info } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   getMeetings: vi.fn(),
   getVotes: vi.fn(),
   encodeActivityPageToken: vi.fn((cursor: { before: string; key: string }) => `token(${cursor.before}|${cursor.key})`),
   warning: vi.fn(),
-  debug: vi.fn(),
+  info: vi.fn(),
 }));
 
 vi.mock('@lfx-one/shared/constants', async () => {
@@ -61,7 +61,7 @@ vi.mock('../helpers/committee-activity-query.helper', async (importOriginal) => 
   ...(await importOriginal<typeof import('../helpers/committee-activity-query.helper')>()),
   encodeActivityPageToken,
 }));
-vi.mock('./logger.service', () => ({ logger: { debug, warning, info: vi.fn(), startOperation: vi.fn(), success: vi.fn() } }));
+vi.mock('./logger.service', () => ({ logger: { debug: vi.fn(), warning, info, startOperation: vi.fn(), success: vi.fn() } }));
 vi.mock('./meeting.service', () => ({
   MeetingService: class {
     getMeetings = getMeetings;
@@ -419,8 +419,10 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0]).toMatchObject({ payload: { document_uid: 'f-29' } });
       // fetchSize = max(8+1, 25) = 25 — assert the leg itself was bounded before merging (not just
       // that the final top-8 slice happens to look right regardless of whether bounding occurred).
-      const debugMetadata = debug.mock.calls.at(-1)?.[3] as { document_count: number };
-      expect(debugMetadata.document_count).toBe(25);
+      // .at(-1) is the "Completed" log — "Starting" fires first each call, so this is still the
+      // last of the two `info` calls this invocation makes.
+      const completionMetadata = info.mock.calls.at(-1)?.[3] as { document_count: number };
+      expect(completionMetadata.document_count).toBe(25);
     });
 
     it('surfaces folders older than fetchSize once pagination reaches them — the window must be applied before bounding, not after', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -31,7 +31,7 @@ vi.mock('@lfx-one/shared/constants', async () => {
   // parseCommitteeActivityQuery, which reads ACTIVITY_FEED_DEFAULT_PAGE_SIZE) is reachable from
   // this spec; hand-listing only the constants this file's own tests happen to need would leave a
   // confusing "no export defined on the mock" trap for the next test that reaches further into it.
-  return { ...activityEvent, PAST_MEETING_SORT: meeting.PAST_MEETING_SORT };
+  return { ...activityEvent, ...meeting };
 });
 vi.mock('@lfx-one/shared/enums', () => ({
   PollStatus: { ACTIVE: 'active', DISABLED: 'disabled', ENDED: 'ended' },
@@ -290,11 +290,12 @@ describe('CommitteeActivityService', () => {
     });
 
     it('rejects an empty-string since rather than silently treating it as "no since"', async () => {
-      // `''` is neither undefined (skip validation) nor a valid timestamp (Number.isNaN(Date.parse('')))
-      // is true), so it's rejected the same way any other unparseable value is — not treated as
-      // an omitted `since`, which the earlier truthiness-based check (`rawSince ? ... : undefined`)
-      // used to do implicitly. Pins that the validation guard and the normalization call below it
-      // now agree on the same `!== undefined` predicate.
+      // `''` is neither undefined (skip validation) nor a valid timestamp (Number.isNaN(Date.parse(''))
+      // is true), so it's rejected the same way any other unparseable value is — not treated as an
+      // omitted `since`, which the earlier truthiness-based check (`rawSince ? ... : undefined`)
+      // used to do implicitly. Pins the guard's treatment of `''` as invalid, not omitted. The
+      // matching `!== undefined` predicate on the normalization line below is defensive only — it's
+      // unreachable while this guard stands, so it isn't (and can't be) covered by this test.
       await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { since: '', limit: 8 })).rejects.toThrow(ServiceValidationError);
 
       expect(getVotes).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -73,6 +73,7 @@ vi.mock('./microservice-proxy.service', () => ({
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 import type { ActivityPageCursor, PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
 
+import { ServiceValidationError } from '../errors';
 import { CommitteeActivityService } from './committee-activity.service';
 
 const req = {} as unknown as Request;
@@ -245,30 +246,21 @@ describe('CommitteeActivityService', () => {
       expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ date_to: '2026-02-01T00:00:01.000Z' }));
     });
 
-    it('resolves an empty, logged feed (rather than throwing) when cursor.before is unparseable', async () => {
+    it('rejects an unparseable cursor.before instead of silently degrading to an empty feed', async () => {
       // getCommitteeActivity is a public method — the controller always validates cursor.before via
       // decodePageToken first, but a future non-HTTP caller could invoke this directly with a bad
-      // value. The net result isn't "widened fetch, trimmed correctly" — isAfterCursor still
-      // compares every event against the original unparseable cursor.before, which resolves to
-      // -Infinity, so every real event is filtered out regardless of what the (wider) upstream
-      // fetch returned. That's still the right call over throwing (empty + logged beats a 500), but
-      // the test should pin the actual behavior, not just the outbound query shape.
-      getVotes.mockResolvedValue({ data: [vote({ uid: 'v1' })] });
+      // value. Matches decodePageToken's own policy for the identical input (a bad explicit cursor
+      // is a 400, not a silently-ignored value) rather than doing the full upstream fan-out for a
+      // result that isAfterCursor would filter to [] anyway (every event compares as before an
+      // unparseable, -Infinity-valued cursor position).
+      await expect(
+        service.getCommitteeActivity(req, COMMITTEE_UID, {
+          cursor: { before: 'not-a-timestamp', key: 'vote:unrelated' },
+          limit: 8,
+        })
+      ).rejects.toThrow(ServiceValidationError);
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, {
-        cursor: { before: 'not-a-timestamp', key: 'vote:unrelated' },
-        limit: 8,
-      });
-
-      const votesQuery = getVotes.mock.calls[0][1];
-      expect(votesQuery).not.toHaveProperty('date_to');
-      expect(result.data).toEqual([]);
-      expect(warning).toHaveBeenCalledWith(
-        req,
-        'get_committee_activity',
-        expect.stringContaining('Unparseable cursor.before'),
-        expect.objectContaining({ committee_uid: COMMITTEE_UID })
-      );
+      expect(getVotes).not.toHaveBeenCalled();
     });
 
     it('requests page_size = max(limit + 1, 25) from every source', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -71,7 +71,7 @@ vi.mock('./microservice-proxy.service', () => ({
 }));
 
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
-import type { PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
+import type { ActivityPageCursor, PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
 
 import { CommitteeActivityService } from './committee-activity.service';
 
@@ -209,23 +209,40 @@ describe('CommitteeActivityService', () => {
         limit: 8,
       });
 
+      // date_to is ceiled to the next whole second before being sent upstream (see the dedicated
+      // ceiling test below) — an already-whole-second cursor still round-trips through
+      // Date.toISOString(), which always emits milliseconds, hence the trailing `.000Z`.
       expect(getMeetings).toHaveBeenCalledWith(
         req,
-        expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' }),
+        expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00.000Z' }),
         'v1_past_meeting',
         false
       );
       expect(getVotes).toHaveBeenCalledWith(
         req,
-        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' })
+        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00.000Z' })
       );
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
         '/query/resources',
         'GET',
-        expect.objectContaining({ type: 'survey', date_field: 'last_modified_at', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' })
+        expect.objectContaining({ type: 'survey', date_field: 'last_modified_at', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00.000Z' })
       );
+    });
+
+    it('ceils a sub-second cursor to the next whole second before sending it upstream as date_to', async () => {
+      // query-service reformats date_to through Go's time.RFC3339 (no fractional-seconds layout),
+      // silently truncating sub-second precision — a raw cursor.before with milliseconds would
+      // shrink the upstream boundary below the true cursor position and permanently exclude
+      // same-second siblings before the in-memory isAfterCursor pass ever sees them. Ceiling
+      // guarantees the upstream boundary is never tighter than the true one.
+      await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        cursor: { before: '2026-02-01T00:00:00.123Z', key: 'vote:unrelated' },
+        limit: 8,
+      });
+
+      expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ date_to: '2026-02-01T00:00:01.000Z' }));
     });
 
     it('requests page_size = max(limit + 1, 25) from every source', async () => {
@@ -335,7 +352,7 @@ describe('CommitteeActivityService', () => {
       expect(page1.data).toHaveLength(1);
       expect(page1.page_token).toBeDefined();
 
-      const lastCursorArg = encodeActivityPageToken.mock.calls.at(-1)?.[0] as { before: string; key: string };
+      const lastCursorArg = encodeActivityPageToken.mock.calls.at(-1)?.[0] as ActivityPageCursor;
       const page2 = await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor: lastCursorArg, limit: 1 });
 
       expect(page2.data).toHaveLength(1);
@@ -362,10 +379,14 @@ describe('CommitteeActivityService', () => {
       getVotes.mockResolvedValue({ data: [voteY, voteX] });
       const reversedOrder = uidsOf(await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }));
 
-      expect(forwardOrder).toEqual(reversedOrder);
+      // 'vote:v-y' sorts before 'vote:v-x' under compareEventsDesc's descending key tiebreak
+      // (b.key.localeCompare(a.key)) — asserting the concrete order, not just forward/reversed
+      // agreement, pins down THAT the tiebreak is key-descending, not merely that it's stable.
+      expect(forwardOrder).toEqual(['v-y', 'v-x']);
+      expect(reversedOrder).toEqual(['v-y', 'v-x']);
     });
 
-    it('drops the sibling of a colliding-key event at a page boundary — the risk document_type-discrimination guards against', async () => {
+    it('keeps a folder and a file that share a uid across a page boundary — document_type discrimination prevents the cursor from dropping one', async () => {
       // eventKey collisions matter specifically at the cursor boundary: compareEventsDesc treats
       // two same-timestamp, same-key events as equal, so isAfterCursor excludes both once one has
       // been returned. Paginating (not just checking both survive an unpaginated merge) is what
@@ -384,7 +405,7 @@ describe('CommitteeActivityService', () => {
       expect(page1.data).toHaveLength(1);
       expect(page1.page_token).toBeDefined();
 
-      const cursor = encodeActivityPageToken.mock.calls.at(-1)?.[0] as { before: string; key: string };
+      const cursor = encodeActivityPageToken.mock.calls.at(-1)?.[0] as ActivityPageCursor;
       const page2 = await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor, limit: 1 });
 
       expect(page2.data).toHaveLength(1);

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -1,0 +1,348 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for committee-activity.service.ts. All fixtures use synthetic placeholder
+// identities — never real user data.
+
+import type { Request } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// `@lfx-one/shared/*` isn't wired into this app's vitest config (same issue documented in
+// committee-engagement-window.helper.spec.ts) — enums/utils need stubs; the interfaces import in
+// the service under test is `import type`, so it's erased and needs no mock at all.
+const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, debug } = vi.hoisted(() => ({
+  proxyRequest: vi.fn(),
+  getMeetings: vi.fn(),
+  getVotes: vi.fn(),
+  encodeActivityPageToken: vi.fn((before: string) => `token(${before})`),
+  warning: vi.fn(),
+  debug: vi.fn(),
+}));
+
+vi.mock('@lfx-one/shared/enums', () => ({
+  PollStatus: { ACTIVE: 'active', DISABLED: 'disabled', ENDED: 'ended' },
+  SurveyStatus: { OPEN: 'open', CLOSED: 'closed', SCHEDULED: 'scheduled', DRAFT: 'draft', SENT: 'sent' },
+}));
+vi.mock('@lfx-one/shared/utils', async () => {
+  const iso = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/iso-timestamp.utils')>(
+    '../../../../../packages/shared/src/utils/iso-timestamp.utils'
+  );
+  const pastMeetingUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/past-meeting.utils')>(
+    '../../../../../packages/shared/src/utils/past-meeting.utils'
+  );
+  const surveyUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/survey.utils')>(
+    '../../../../../packages/shared/src/utils/survey.utils'
+  );
+  return {
+    firstValidTimestamp: iso.firstValidTimestamp,
+    getPastMeetingStartTimeMs: pastMeetingUtils.getPastMeetingStartTimeMs,
+    getSurveyDisplayStatus: surveyUtils.getSurveyDisplayStatus,
+  };
+});
+vi.mock('../helpers/committee-activity-query.helper', () => ({ encodeActivityPageToken }));
+vi.mock('./logger.service', () => ({ logger: { debug, warning, info: vi.fn(), startOperation: vi.fn(), success: vi.fn() } }));
+vi.mock('./meeting.service', () => ({
+  MeetingService: class {
+    getMeetings = getMeetings;
+  },
+}));
+vi.mock('./vote.service', () => ({
+  VoteService: class {
+    getVotes = getVotes;
+  },
+}));
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    proxyRequest = proxyRequest;
+  },
+}));
+
+import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
+import type { PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
+
+import { CommitteeActivityService } from './committee-activity.service';
+
+const req = {} as unknown as Request;
+const COMMITTEE_UID = 'committee-1';
+
+function pastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {
+  return { id: 'pm-1', title: 'Weekly Sync', start_time: '2026-01-01T10:00:00Z', scheduled_start_time: '', ...overrides } as PastMeeting;
+}
+
+function vote(overrides: Partial<Vote> = {}): Vote {
+  return {
+    uid: 'vote-1',
+    name: 'Q1 Budget',
+    status: PollStatus.ACTIVE,
+    creation_time: '2026-01-02T10:00:00Z',
+    end_time: '2026-01-10T00:00:00Z',
+    ...overrides,
+  } as Vote;
+}
+
+function survey(overrides: Partial<Survey> = {}): Survey {
+  return {
+    uid: 'survey-1',
+    survey_title: 'Community Feedback',
+    survey_status: SurveyStatus.OPEN,
+    survey_cutoff_date: null,
+    created_at: '2026-01-03T10:00:00Z',
+    last_modified_at: '2026-01-03T10:00:00Z',
+    ...overrides,
+  } as Survey;
+}
+
+/** Default proxyRequest router: benign empty responses for every leg unless a test overrides it. */
+function defaultProxyRequest(_req: Request, _service: string, path: string, _method: string, query?: Record<string, unknown>): unknown {
+  if (path.endsWith('/folders')) return Promise.resolve([]);
+  if (path.endsWith('/links')) return Promise.resolve([]);
+  if (path === '/query/resources' && query?.['type'] === 'survey') return Promise.resolve({ resources: [] });
+  if (path === '/query/resources' && query?.['type'] === 'committee_document') return Promise.resolve({ resources: [] });
+  if (/^\/committees\/[^/]+$/.test(path)) return Promise.resolve({ uid: COMMITTEE_UID, enable_voting: true });
+  throw new Error(`Unhandled proxyRequest call in test: ${path}`);
+}
+
+describe('CommitteeActivityService', () => {
+  let service: CommitteeActivityService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    proxyRequest.mockImplementation(defaultProxyRequest);
+    getMeetings.mockResolvedValue({ data: [] });
+    getVotes.mockResolvedValue({ data: [] });
+    encodeActivityPageToken.mockImplementation((before: string) => `token(${before})`);
+    service = new CommitteeActivityService();
+  });
+
+  it('returns an empty feed when every source is empty', async () => {
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(result).toEqual({ data: [], page_token: undefined });
+  });
+
+  it('merges all four sources and sorts the result by occurred_at descending', async () => {
+    getMeetings.mockResolvedValue({ data: [pastMeeting({ start_time: '2026-01-01T00:00:00Z' })] });
+    getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ENDED, end_time: '2026-01-03T00:00:00Z' })] });
+    proxyRequest.mockImplementation((r, s, path, m, query) => {
+      if (path === '/query/resources' && query?.['type'] === 'survey') {
+        return Promise.resolve({ resources: [{ type: 'survey', id: 'survey-1', data: survey({ last_modified_at: '2026-01-02T00:00:00Z' }) }] });
+      }
+      if (path === '/query/resources' && query?.['type'] === 'committee_document') {
+        return Promise.resolve({
+          resources: [{ type: 'committee_document', id: 'doc-1', data: { uid: 'doc-1', name: 'Charter.pdf', updated_at: '2026-01-04T00:00:00Z' } }],
+        });
+      }
+      return defaultProxyRequest(r, s, path, m, query);
+    });
+
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(result.data.map((e) => e.type)).toEqual(['document_uploaded', 'vote_closed', 'survey_published', 'meeting_held']);
+  });
+
+  it('sorts an unparseable vote timestamp as the oldest item instead of throwing', async () => {
+    getVotes.mockResolvedValue({ data: [vote({ creation_time: 'not-a-timestamp', last_modified_time: undefined })] });
+    proxyRequest.mockImplementation((r, s, path, m, query) => {
+      if (path === '/query/resources' && query?.['type'] === 'survey') {
+        return Promise.resolve({ resources: [{ type: 'survey', id: 'survey-1', data: survey({ last_modified_at: '2026-01-01T00:00:00Z' }) }] });
+      }
+      return defaultProxyRequest(r, s, path, m, query);
+    });
+
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(result.data.map((e) => e.type)).toEqual(['survey_published', 'vote_opened']);
+  });
+
+  it('does not sort a past meeting as ancient when start_time is a Go zero-date', async () => {
+    getMeetings.mockResolvedValue({ data: [pastMeeting({ start_time: '0001-01-01T00:00:00Z', scheduled_start_time: '2026-01-05T00:00:00Z' })] });
+    proxyRequest.mockImplementation((r, s, path, m, query) => {
+      if (path === '/query/resources' && query?.['type'] === 'survey') {
+        return Promise.resolve({ resources: [{ type: 'survey', id: 'survey-1', data: survey({ last_modified_at: '2026-01-01T00:00:00Z' }) }] });
+      }
+      return defaultProxyRequest(r, s, path, m, query);
+    });
+
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(result.data.map((e) => e.type)).toEqual(['meeting_held', 'survey_published']);
+  });
+
+  describe('since/before/limit handling', () => {
+    it('passes since as date_from and before as date_to to the past-meetings, votes, and survey legs', async () => {
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', before: '2026-02-01T00:00:00Z', limit: 8 });
+
+      expect(getMeetings).toHaveBeenCalledWith(
+        req,
+        expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' }),
+        'v1_past_meeting',
+        false
+      );
+      expect(getVotes).toHaveBeenCalledWith(
+        req,
+        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' })
+      );
+      expect(proxyRequest).toHaveBeenCalledWith(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        expect.objectContaining({ type: 'survey', date_field: 'last_modified_at', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' })
+      );
+    });
+
+    it('requests page_size = max(limit + 1, 25) from every source', async () => {
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 2 });
+      expect(getMeetings).toHaveBeenCalledWith(req, expect.objectContaining({ page_size: 25 }), 'v1_past_meeting', false);
+      expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ page_size: 25 }));
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 30 });
+      expect(getMeetings).toHaveBeenCalledWith(req, expect.objectContaining({ page_size: 31 }), 'v1_past_meeting', false);
+    });
+
+    it('caps the returned feed at limit and sets a page_token when more candidates exist', async () => {
+      getVotes.mockResolvedValue({
+        data: [
+          vote({ uid: 'v1', creation_time: '2026-01-05T00:00:00Z' }),
+          vote({ uid: 'v2', creation_time: '2026-01-04T00:00:00Z' }),
+          vote({ uid: 'v3', creation_time: '2026-01-03T00:00:00Z' }),
+        ],
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 2 });
+      expect(result.data).toHaveLength(2);
+      expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2']);
+      expect(encodeActivityPageToken).toHaveBeenCalledWith('2026-01-04T00:00:00Z');
+      expect(result.page_token).toBe('token(2026-01-04T00:00:00Z)');
+    });
+
+    it('omits page_token when every source is exhausted', async () => {
+      getVotes.mockResolvedValue({ data: [vote({ uid: 'v1' })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.page_token).toBeUndefined();
+    });
+
+    it('applies the since/before window in-memory for folders and links, which have no upstream date param', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) {
+          return Promise.resolve([
+            { uid: 'f-in', name: 'In window', updated_at: '2026-01-15T00:00:00Z' },
+            { uid: 'f-out', name: 'Out of window', updated_at: '2025-01-01T00:00:00Z' },
+          ]);
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', before: '2026-02-01T00:00:00Z', limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({ type: 'document_uploaded', payload: { document_uid: 'f-in' } });
+    });
+  });
+
+  describe('one-source-fails-others-still-render', () => {
+    it('renders the other three sources when past meetings fail', async () => {
+      getMeetings.mockRejectedValue(new Error('upstream down'));
+      getVotes.mockResolvedValue({ data: [vote()] });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data.map((e) => e.type)).toEqual(['vote_opened']);
+      expect(warning).toHaveBeenCalled();
+    });
+
+    it('renders the other three sources when votes fail', async () => {
+      getVotes.mockRejectedValue(new Error('upstream down'));
+      getMeetings.mockResolvedValue({ data: [pastMeeting()] });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
+    });
+
+    it('renders the other three sources when surveys fail', async () => {
+      getMeetings.mockResolvedValue({ data: [pastMeeting()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') return Promise.reject(new Error('upstream down'));
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
+    });
+
+    it('renders the other three sources when documents fail', async () => {
+      getMeetings.mockResolvedValue({ data: [pastMeeting()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) return Promise.reject(new Error('upstream down'));
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
+    });
+  });
+
+  describe('voting_enabled gating', () => {
+    it('excludes vote events from the result when the committee has voting disabled, but still fetches them', async () => {
+      getVotes.mockResolvedValue({ data: [vote()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (/^\/committees\/[^/]+$/.test(path)) return Promise.resolve({ uid: COMMITTEE_UID, enable_voting: false });
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toEqual([]);
+      expect(getVotes).toHaveBeenCalled();
+    });
+
+    it('defaults votes to excluded when the committee lookup itself fails', async () => {
+      getVotes.mockResolvedValue({ data: [vote()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (/^\/committees\/[^/]+$/.test(path)) return Promise.reject(new Error('upstream down'));
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toEqual([]);
+    });
+  });
+
+  describe('one-event-per-row mapping', () => {
+    it('maps an ended vote to vote_closed only', async () => {
+      getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ENDED, end_time: '2026-01-10T00:00:00Z' })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].type).toBe('vote_closed');
+    });
+
+    it('maps an active vote to vote_opened only', async () => {
+      getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ACTIVE })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].type).toBe('vote_opened');
+    });
+
+    it('maps a vote with an early_end_time to vote_closed even if status lags behind', async () => {
+      getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ACTIVE, early_end_time: '2026-01-09T00:00:00Z' })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0].type).toBe('vote_closed');
+    });
+
+    it('maps a closed survey to survey_closed and an open survey to survey_published', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') {
+          return Promise.resolve({
+            resources: [
+              { type: 'survey', id: 'survey-closed', data: survey({ uid: 'survey-closed', survey_status: SurveyStatus.CLOSED }) },
+              {
+                type: 'survey',
+                id: 'survey-open',
+                data: survey({ uid: 'survey-open', survey_status: SurveyStatus.OPEN, last_modified_at: '2026-01-02T00:00:00Z' }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      const byType = Object.fromEntries(result.data.map((e) => [e.type, e]));
+      expect(byType['survey_closed']).toMatchObject({ payload: { survey_uid: 'survey-closed' } });
+      expect(byType['survey_published']).toMatchObject({ payload: { survey_uid: 'survey-open' } });
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -47,11 +47,15 @@ vi.mock('@lfx-one/shared/utils', async () => {
   const surveyUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/survey.utils')>(
     '../../../../../packages/shared/src/utils/survey.utils'
   );
+  const pollUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/poll.utils')>(
+    '../../../../../packages/shared/src/utils/poll.utils'
+  );
   return {
     firstValidTimestamp: iso.firstValidTimestamp,
     getPastMeetingStartTimeMs: pastMeetingUtils.getPastMeetingStartTimeMs,
     getPastMeetingResourceId: pastMeetingUtils.getPastMeetingResourceId,
     getSurveyDisplayStatus: surveyUtils.getSurveyDisplayStatus,
+    normalizePollStatus: pollUtils.normalizePollStatus,
   };
 });
 // Real normalizeTimestamp (not a hand-copied stub) — its exact Date.parse/new Date().toISOString()
@@ -193,6 +197,22 @@ describe('CommitteeActivityService', () => {
     getMeetings.mockResolvedValue({ data: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] });
     const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
     expect(result.data[0]).toMatchObject({ type: 'meeting_held', payload: { meeting_id: 'pm-42', meeting_occurrence_id: 'pm-42-occ-9' } });
+  });
+
+  it('carries the meeting password in the event payload, not just its own pastMeetings() signal', async () => {
+    // The activity feed is a separately-windowed fetch from the client's own pastMeetings()
+    // signal — a password-protected meeting recent enough for this feed isn't guaranteed to be
+    // in that signal's window, so the event needs its own password, not a client-side lookup.
+    // Regression for Copilot/Cursor Bugbot/dealako's PR #1288 review.
+    getMeetings.mockResolvedValue({ data: [pastMeeting({ password: 'sesame' })] });
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(result.data[0]).toMatchObject({ type: 'meeting_held', payload: { password: 'sesame' } });
+  });
+
+  it('carries a null password when the meeting has none', async () => {
+    getMeetings.mockResolvedValue({ data: [pastMeeting({ password: null })] });
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    expect(result.data[0]).toMatchObject({ type: 'meeting_held', payload: { password: null } });
   });
 
   it('does not sort a past meeting as ancient when start_time is a Go zero-date', async () => {
@@ -351,13 +371,31 @@ describe('CommitteeActivityService', () => {
       expect(getVotes).not.toHaveBeenCalled();
     });
 
-    it('sets hasMore when a page_size-bounded leg is saturated, even though the merged pool itself is not over limit', async () => {
+    it("sets hasMore when a page_size-bounded leg's upstream page_token signals more data, even though the merged pool itself is not over limit", async () => {
       // Regression for a false negative traced in the full-branch review: `windowed.length > limit`
       // alone can't see "more data exists" when a single dominant, page_size-bounded source (votes,
-      // here) returns exactly fetchSize rows and the in-memory since filter then drops all but one
-      // of them — the merged pool ends up at or under `limit`, but there could easily be more
-      // matching rows upstream that this page's fetch never reached. fetchSize = max(1+1, 25) = 25,
-      // so 25 votes here means the leg genuinely hit its upstream page bound.
+      // here) has more rows upstream than fit in one page and the in-memory since filter then drops
+      // all but one of them — the merged pool ends up at or under `limit`, but there could easily be
+      // more matching rows upstream that this page's fetch never reached. Saturation is driven by
+      // the leg's own real upstream `page_token` (see the paired "does NOT set hasMore" test below
+      // for the false-positive this replaced — Copilot/dealako flagged the original bare
+      // `votes.length >= fetchSize` heuristic).
+      const fetchSize = 25;
+      const votes = Array.from({ length: fetchSize }, (_, i) =>
+        vote({ uid: `v-${i}`, creation_time: i === 0 ? '2026-02-01T00:00:00Z' : '2020-01-01T00:00:00Z' })
+      );
+      getVotes.mockResolvedValue({ data: votes, page_token: 'more-votes-upstream' });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', limit: 1 });
+
+      expect(result.data).toHaveLength(1);
+      expect(result.page_token).toBeDefined();
+    });
+
+    it('does not set hasMore from row count alone when a leg returns a genuine final page with no upstream page_token', async () => {
+      // The exact false positive Copilot/dealako flagged: a leg can return exactly `fetchSize` rows
+      // as a real, final page — no further page_token means query-service has nothing more to give,
+      // so a row-count-only heuristic would wrongly hand back a cursor to an empty next page.
       const fetchSize = 25;
       const votes = Array.from({ length: fetchSize }, (_, i) =>
         vote({ uid: `v-${i}`, creation_time: i === 0 ? '2026-02-01T00:00:00Z' : '2020-01-01T00:00:00Z' })
@@ -367,7 +405,7 @@ describe('CommitteeActivityService', () => {
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', limit: 1 });
 
       expect(result.data).toHaveLength(1);
-      expect(result.page_token).toBeDefined();
+      expect(result.page_token).toBeUndefined();
     });
 
     it('requests page_size = max(limit + 1, 25) from every source', async () => {
@@ -811,6 +849,80 @@ describe('CommitteeActivityService', () => {
       getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ACTIVE, early_end_time: '2026-01-09T00:00:00Z' })] });
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data[0].type).toBe('vote_closed');
+    });
+
+    it('maps a mixed-case ended vote status to vote_closed, not vote_opened (casing bug regression)', async () => {
+      // Vote.status arrives with inconsistent casing (poll.utils.ts's normalizePollStatus doc
+      // comment) — a raw `status === PollStatus.ENDED` comparison misclassifies this as
+      // vote_opened, stamped at creation time instead of close time. Independently flagged by
+      // Copilot and Cursor Bugbot, confirmed by dealako.
+      getVotes.mockResolvedValue({ data: [vote({ status: 'Ended' as PollStatus, end_time: '2026-01-10T00:00:00Z' })] });
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].type).toBe('vote_closed');
+      expect(result.data[0].occurred_at).toBe('2026-01-10T00:00:00Z');
+    });
+
+    it('stamps a cutoff-driven survey closure at survey_cutoff_date, not the stale last_modified_at', async () => {
+      // getSurveyDisplayStatus reports CLOSED for a SENT survey whose cutoff has passed even
+      // though last_modified_at never changed (getEffectiveSurveyStatus's SENT/cutoff branch,
+      // survey.utils.ts) — falling back to last_modified_at/created_at in that case stamps
+      // survey_closed at the publish time instead of the real closure moment. Flagged by
+      // Copilot, confirmed by dealako.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') {
+          return Promise.resolve({
+            resources: [
+              {
+                type: 'survey',
+                id: 'survey-cutoff',
+                data: survey({
+                  uid: 'survey-cutoff',
+                  survey_status: SurveyStatus.SENT,
+                  survey_cutoff_date: '2026-01-05T00:00:00Z',
+                  last_modified_at: '2026-01-01T00:00:00Z',
+                  created_at: '2026-01-01T00:00:00Z',
+                }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0].type).toBe('survey_closed');
+      expect(result.data[0].occurred_at).toBe('2026-01-05T00:00:00Z');
+    });
+
+    it('uses last_modified_at, not survey_cutoff_date, for an explicitly-closed survey status (not cutoff-driven)', async () => {
+      // Negative control for the cutoff-driven test above: guards against a broader mutation of
+      // isCutoffDrivenClosure that would apply the cutoff timestamp to every CLOSED survey
+      // regardless of why it's closed.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') {
+          return Promise.resolve({
+            resources: [
+              {
+                type: 'survey',
+                id: 'survey-explicit-closed',
+                data: survey({
+                  uid: 'survey-explicit-closed',
+                  survey_status: SurveyStatus.CLOSED,
+                  survey_cutoff_date: '2020-01-01T00:00:00Z',
+                  last_modified_at: '2026-01-02T00:00:00Z',
+                }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0].type).toBe('survey_closed');
+      expect(result.data[0].occurred_at).toBe('2026-01-02T00:00:00Z');
     });
 
     it('maps a closed survey to survey_closed and an open survey to survey_published', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -213,15 +213,19 @@ describe('CommitteeActivityService', () => {
       expect.anything(),
       'get_committee_activity',
       expect.stringContaining('scheduled_start_time'),
-      expect.objectContaining({ committee_uid: COMMITTEE_UID })
+      expect.objectContaining({ committee_uid: COMMITTEE_UID, affected_row_count: 1, total_rows: 1 })
     );
   });
 
   it('does not fire the scheduled_start_time tripwire for an ordinary meeting with no scheduled_start_time', async () => {
     getMeetings.mockResolvedValue({ data: [pastMeeting({ start_time: '2026-01-05T00:00:00Z', scheduled_start_time: '' })] });
 
-    await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+    const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
 
+    // Positive control — without this, the assertion below would pass identically if the meetings
+    // leg failed and never ran at all (a bare "not called" doesn't prove the tripwire code path was
+    // exercised, only that nothing called it, which a leg failure would also produce).
+    expect(result.data.map((e) => e.type)).toEqual(['meeting_held']);
     expect(warning).not.toHaveBeenCalledWith(expect.anything(), 'get_committee_activity', expect.stringContaining('scheduled_start_time'), expect.anything());
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -280,13 +280,25 @@ describe('CommitteeActivityService', () => {
         req,
         expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' })
       );
-      expect(proxyRequest).toHaveBeenCalledWith(
-        req,
-        'LFX_V2_SERVICE',
-        '/query/resources',
-        'GET',
-        expect.objectContaining({ type: 'survey', date_field: 'last_modified_at', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' })
-      );
+    });
+
+    it('sends no date_field/date_from/date_to to the survey leg, even with since and cursor set', async () => {
+      // Surveys are the one leg deliberately excluded from upstream date narrowing — see
+      // fetchSurveyEvents's own comment for why (a cutoff-driven closure's occurred_at isn't
+      // bounded below by any field the survey row gets written to, so narrowing on last_modified_at
+      // would systematically exclude exactly the rows `since` is meant to include). Regression for
+      // the gap Copilot caught in the cutoff-driven-closure fix.
+      await service.getCommitteeActivity(req, COMMITTEE_UID, {
+        since: '2026-01-01T00:00:00Z',
+        cursor: { before: '2026-02-01T00:00:00Z', key: 'vote:unrelated' },
+        limit: 8,
+      });
+
+      const surveyCall = proxyRequest.mock.calls.find(([, , path, , query]) => path === '/query/resources' && query?.type === 'survey');
+      expect(surveyCall?.[4]).not.toHaveProperty('date_field');
+      expect(surveyCall?.[4]).not.toHaveProperty('date_from');
+      expect(surveyCall?.[4]).not.toHaveProperty('date_to');
+      expect(surveyCall?.[4]).toMatchObject({ page_size: 25, sort: 'updated_desc' });
     });
 
     it('ceils a sub-second cursor to the next whole second before sending it upstream as date_to', async () => {
@@ -894,6 +906,39 @@ describe('CommitteeActivityService', () => {
       expect(result.data).toHaveLength(1);
       expect(result.data[0].type).toBe('survey_closed');
       expect(result.data[0].occurred_at).toBe('2026-01-05T00:00:00Z');
+    });
+
+    it('includes a cutoff-driven survey closure when since falls between its last_modified_at and its real occurred_at', async () => {
+      // The exact gap Copilot caught: with upstream date_field narrowing on last_modified_at (the
+      // previous implementation), a survey last modified Jan 1 but closed by its Jan 5 cutoff would
+      // be excluded by an upstream `?since=Jan 4` filter, even though its emitted occurred_at (Jan
+      // 5) is inside that window. Now that the survey leg sends no upstream date narrowing at all
+      // (see fetchSurveyEvents), this must come through — the in-memory since pass is the only
+      // filter, applied against the corrected occurred_at, not last_modified_at.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') {
+          return Promise.resolve({
+            resources: [
+              {
+                type: 'survey',
+                id: 'survey-cutoff',
+                data: survey({
+                  uid: 'survey-cutoff',
+                  survey_status: SurveyStatus.SENT,
+                  survey_cutoff_date: '2026-01-05T00:00:00Z',
+                  last_modified_at: '2026-01-01T00:00:00Z',
+                  created_at: '2026-01-01T00:00:00Z',
+                }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-04T00:00:00Z', limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({ type: 'survey_closed', occurred_at: '2026-01-05T00:00:00Z' });
     });
 
     it('uses last_modified_at, not survey_cutoff_date, for an explicitly-closed survey status (not cutoff-driven)', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -10,12 +10,11 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // `@lfx-one/shared/*` isn't wired into this app's vitest config (same issue documented in
 // committee-engagement-window.helper.spec.ts) — enums/utils need stubs; the interfaces import in
 // the service under test is `import type`, so it's erased and needs no mock at all.
-const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, normalizeTimestamp, warning, debug } = vi.hoisted(() => ({
+const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, debug } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   getMeetings: vi.fn(),
   getVotes: vi.fn(),
   encodeActivityPageToken: vi.fn((cursor: { before: string; key: string }) => `token(${cursor.before}|${cursor.key})`),
-  normalizeTimestamp: vi.fn((value: string) => new Date(value).toISOString()),
   warning: vi.fn(),
   debug: vi.fn(),
 }));
@@ -54,7 +53,13 @@ vi.mock('@lfx-one/shared/utils', async () => {
     getSurveyDisplayStatus: surveyUtils.getSurveyDisplayStatus,
   };
 });
-vi.mock('../helpers/committee-activity-query.helper', () => ({ encodeActivityPageToken, normalizeTimestamp }));
+// Real normalizeTimestamp (not a hand-copied stub) — its exact Date.parse/new Date().toISOString()
+// behavior is precisely what the service's since-normalization tests below need to exercise; a
+// stub that merely mimics the same expression would validate the stub, not the shipped helper.
+vi.mock('../helpers/committee-activity-query.helper', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../helpers/committee-activity-query.helper')>()),
+  encodeActivityPageToken,
+}));
 vi.mock('./logger.service', () => ({ logger: { debug, warning, info: vi.fn(), startOperation: vi.fn(), success: vi.fn() } }));
 vi.mock('./meeting.service', () => ({
   MeetingService: class {
@@ -130,6 +135,7 @@ describe('CommitteeActivityService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.unstubAllEnvs();
     proxyRequest.mockImplementation(defaultProxyRequest);
     getMeetings.mockResolvedValue({ data: [] });
     getVotes.mockResolvedValue({ data: [] });
@@ -215,8 +221,9 @@ describe('CommitteeActivityService', () => {
       // date_to is ceiled to the next whole second before being sent upstream (see the dedicated
       // ceiling test below) — an already-whole-second cursor still round-trips through
       // Date.toISOString(), which always emits milliseconds, hence the trailing `.000Z`. `since`
-      // round-trips through the same normalizeTimestamp/Date.toISOString() call on the way in
-      // (see the dedicated since-normalization test below), so it picks up the identical `.000Z`.
+      // round-trips through the same normalizeTimestamp/Date.toISOString() call on the way in, so
+      // it picks up the identical `.000Z` — these three assertions are the normalization coverage,
+      // there's no separate dedicated test for it.
       expect(getMeetings).toHaveBeenCalledWith(
         req,
         expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' }),
@@ -277,6 +284,19 @@ describe('CommitteeActivityService', () => {
       expect(getVotes).not.toHaveBeenCalled();
     });
 
+    it('normalizes a zone-less since to RFC3339 before sending it upstream as date_from', async () => {
+      // Date.parse accepts a zone-less `2026-01-05T00:00:00` (parsed in the server's local
+      // timezone), but query-service's stricter RFC3339 parser 400s it — without normalization this
+      // would pass the parseability check above and then silently thin the feed once every leg's
+      // upstream call rejects it. Pinned against a literal, not `new Date(x).toISOString()` (which
+      // would just restate the implementation), with TZ stubbed explicitly since a zone-less string
+      // is parsed in the server's local timezone — the exact behavior this test needs to pin down.
+      vi.stubEnv('TZ', 'UTC');
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-05T00:00:00', limit: 8 });
+
+      expect(getVotes).toHaveBeenCalledWith(req, expect.objectContaining({ date_from: '2026-01-05T00:00:00.000Z' }));
+    });
+
     it.each([
       ['zero', 0],
       ['negative', -1],
@@ -285,8 +305,9 @@ describe('CommitteeActivityService', () => {
     ])('rejects a limit that is %s instead of silently degrading to a wrong result', async (_label, limit) => {
       // parseCommitteeActivityQuery already bounds page_size on the HTTP path, but this method is
       // public and reachable directly. Without this check: limit=0 -> windowed.slice(0, 0) -> an
-      // empty feed with no error; a negative limit -> slice(0, -1) silently drops the newest item
-      // while still emitting a page_token; either way, a wrong result with no signal anything's off.
+      // empty feed with no error; a negative limit -> slice(0, -1) silently drops the OLDEST item
+      // (windowed is sorted newest-first) while still emitting a page_token; either way, a wrong
+      // result with no signal anything's off.
       await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { limit })).rejects.toThrow(ServiceValidationError);
 
       expect(getVotes).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -5,7 +5,7 @@
 // identities — never real user data.
 
 import type { Request } from 'express';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // `@lfx-one/shared/*` isn't wired into this app's vitest config (same issue documented in
 // committee-engagement-window.helper.spec.ts) — enums/utils need stubs; the interfaces import in
@@ -26,11 +26,12 @@ vi.mock('@lfx-one/shared/constants', async () => {
   const meeting = await vi.importActual<typeof import('../../../../../packages/shared/src/constants/meeting.constants')>(
     '../../../../../packages/shared/src/constants/meeting.constants'
   );
-  return {
-    ACTIVITY_FEED_MAX_PAGE_SIZE: activityEvent.ACTIVITY_FEED_MAX_PAGE_SIZE,
-    ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE: activityEvent.ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE,
-    PAST_MEETING_SORT: meeting.PAST_MEETING_SORT,
-  };
+  // Spread the real module rather than hand-listing exports — since committee-activity-query.helper.ts
+  // is now mocked via importOriginal (see below), the whole real helper module (including
+  // parseCommitteeActivityQuery, which reads ACTIVITY_FEED_DEFAULT_PAGE_SIZE) is reachable from
+  // this spec; hand-listing only the constants this file's own tests happen to need would leave a
+  // confusing "no export defined on the mock" trap for the next test that reaches further into it.
+  return { ...activityEvent, PAST_MEETING_SORT: meeting.PAST_MEETING_SORT };
 });
 vi.mock('@lfx-one/shared/enums', () => ({
   PollStatus: { ACTIVE: 'active', DISABLED: 'disabled', ENDED: 'ended' },
@@ -135,12 +136,15 @@ describe('CommitteeActivityService', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.unstubAllEnvs();
     proxyRequest.mockImplementation(defaultProxyRequest);
     getMeetings.mockResolvedValue({ data: [] });
     getVotes.mockResolvedValue({ data: [] });
     encodeActivityPageToken.mockImplementation((cursor: { before: string; key: string }) => `token(${cursor.before}|${cursor.key})`);
     service = new CommitteeActivityService();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   it('returns an empty feed when every source is empty', async () => {
@@ -222,8 +226,9 @@ describe('CommitteeActivityService', () => {
       // ceiling test below) — an already-whole-second cursor still round-trips through
       // Date.toISOString(), which always emits milliseconds, hence the trailing `.000Z`. `since`
       // round-trips through the same normalizeTimestamp/Date.toISOString() call on the way in, so
-      // it picks up the identical `.000Z` — these three assertions are the normalization coverage,
-      // there's no separate dedicated test for it.
+      // it picks up the identical `.000Z` — these three assertions cover that round-trip shape for
+      // an already-well-formed `since`; the dedicated "normalizes a zone-less since" test below
+      // covers the actual reformatting case (a value Date.parse accepts but isn't RFC3339 yet).
       expect(getMeetings).toHaveBeenCalledWith(
         req,
         expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00.000Z', date_to: '2026-02-01T00:00:00.000Z' }),
@@ -280,6 +285,17 @@ describe('CommitteeActivityService', () => {
       // Without this check, isAtOrAfterSince's `ms >= Date.parse(since)` is `ms >= NaN` for every
       // event, so an unparseable since would silently degrade to an empty feed instead of rejecting.
       await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { since: 'not-a-timestamp', limit: 8 })).rejects.toThrow(ServiceValidationError);
+
+      expect(getVotes).not.toHaveBeenCalled();
+    });
+
+    it('rejects an empty-string since rather than silently treating it as "no since"', async () => {
+      // `''` is neither undefined (skip validation) nor a valid timestamp (Number.isNaN(Date.parse('')))
+      // is true), so it's rejected the same way any other unparseable value is — not treated as
+      // an omitted `since`, which the earlier truthiness-based check (`rawSince ? ... : undefined`)
+      // used to do implicitly. Pins that the validation guard and the normalization call below it
+      // now agree on the same `!== undefined` predicate.
+      await expect(service.getCommitteeActivity(req, COMMITTEE_UID, { since: '', limit: 8 })).rejects.toThrow(ServiceValidationError);
 
       expect(getVotes).not.toHaveBeenCalled();
     });

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -368,6 +368,34 @@ describe('CommitteeActivityService', () => {
       expect(uids).toEqual(Array.from({ length: manyFolders.length }, (_, i) => `f-${manyFolders.length - 1 - i}`));
     });
 
+    it('reaches every folder even when all of them share one exact timestamp — the per-leg pre-filter needs the cursor key tiebreak too', async () => {
+      // Same failure class as the previous test, one dimension over: there occurred_at alone gave
+      // too wide a window; here occurred_at alone can't distinguish these items at all. If more
+      // than fetchSize folders share one exact occurred_at second, an occurred_at-only pre-filter
+      // (isWithinFetchWindow) and an occurred_at-only bound (boundedSortDesc) would never actually
+      // shrink the pool across pages — the 25 that survive each call would depend on upstream
+      // response order, not the (occurred_at, key) order the cursor itself uses, permanently
+      // hiding whichever folders don't happen to sort first upstream.
+      const tiedFolders = Array.from({ length: 30 }, (_, i) => ({ uid: `f-${i}`, name: `Folder ${i}`, updated_at: '2026-01-01T00:00:00Z' }));
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) return Promise.resolve(tiedFolders);
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      let cursor: ActivityPageCursor | undefined;
+      const uids = new Set<string>();
+      for (let i = 0; i < tiedFolders.length; i++) {
+        const page = await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor, limit: 1 });
+        if (page.data.length === 0) break;
+        const event = page.data[0];
+        uids.add(event.type === 'document_uploaded' ? event.payload.document_uid : 'unexpected');
+        if (!page.page_token) break;
+        cursor = encodeActivityPageToken.mock.calls.at(-1)?.[0] as ActivityPageCursor;
+      }
+
+      expect(uids.size).toBe(tiedFolders.length);
+    });
+
     it('treats a null folders response as empty without discarding sibling links in the same leg', async () => {
       // MicroserviceProxyService.proxyRequest returns the upstream body verbatim — a 204/empty
       // response comes through as null, not []. Without a null guard, `folders.map(...)` throws

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -196,29 +196,29 @@ describe('CommitteeActivityService', () => {
   });
 
   describe('since/cursor/limit handling', () => {
-    it('sends since/date_to only to the surveys and documents legs — meetings and votes get no upstream date filter', async () => {
-      // Meetings' and votes' occurred_at is derived from a field-fallback (scheduled_start_time ??
-      // start_time; end_time/early_end_time/last_modified_time/creation_time depending on status)
-      // that a single upstream date_field can't represent — sending one anyway can silently exclude
-      // a row whose in-window value lives on a field NOT selected, with no way to recover it
-      // in-memory once upstream never returns it. Surveys/documents' primary derivation field IS
-      // what's filtered on, so upstream narrowing there is safe.
+    it('sends since as date_from and cursor.before as date_to to every source, as best-effort narrowing', async () => {
+      // Every leg's occurred_at is derived from a field-fallback a single upstream date_field can't
+      // fully represent (see the comments in fetchPastMeetingEvents/fetchVoteEvents/etc.) — the
+      // upstream date params are best-effort narrowing to keep the fetched volume small, not a
+      // correctness guarantee. The in-memory since/cursor filter in getCommitteeActivity is what
+      // actually enforces the window; dropping the upstream narrowing entirely (an earlier version
+      // of this fix) traded that rare miss for hard truncation at fetchSize on every page instead.
       await service.getCommitteeActivity(req, COMMITTEE_UID, {
         since: '2026-01-01T00:00:00Z',
         cursor: { before: '2026-02-01T00:00:00Z', key: 'vote:unrelated' },
         limit: 8,
       });
 
-      const meetingsQuery = getMeetings.mock.calls[0][1];
-      expect(meetingsQuery).not.toHaveProperty('date_field');
-      expect(meetingsQuery).not.toHaveProperty('date_from');
-      expect(meetingsQuery).not.toHaveProperty('date_to');
-
-      const votesQuery = getVotes.mock.calls[0][1];
-      expect(votesQuery).not.toHaveProperty('date_field');
-      expect(votesQuery).not.toHaveProperty('date_from');
-      expect(votesQuery).not.toHaveProperty('date_to');
-
+      expect(getMeetings).toHaveBeenCalledWith(
+        req,
+        expect.objectContaining({ date_field: 'start_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' }),
+        'v1_past_meeting',
+        false
+      );
+      expect(getVotes).toHaveBeenCalledWith(
+        req,
+        expect.objectContaining({ date_field: 'last_modified_time', date_from: '2026-01-01T00:00:00Z', date_to: '2026-02-01T00:00:00Z' })
+      );
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
@@ -344,11 +344,48 @@ describe('CommitteeActivityService', () => {
       expect(combinedUids).toEqual(['v-a', 'v-b']);
     });
 
+    it('sorts two events that both have no valid timestamp deterministically, not NaN-implementation-defined order', async () => {
+      // Regression guard: timestampValue(a) - timestampValue(b) on two -Infinity values is NaN,
+      // which would skip the key tiebreak and leave the pair's relative order (and therefore
+      // which one a slice() cuts off) non-deterministic. Run twice to catch an order that only
+      // sometimes flips.
+      getVotes.mockResolvedValue({
+        data: [
+          vote({ uid: 'v-x', creation_time: undefined, last_modified_time: undefined }),
+          vote({ uid: 'v-y', creation_time: undefined, last_modified_time: undefined }),
+        ],
+      });
+
+      const first = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      const second = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      const uidsOf = (r: typeof first) => r.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null));
+      expect(uidsOf(first)).toEqual(uidsOf(second));
+    });
+
+    it('does not drop a folder and a file that happen to share the same uid — document keys are discriminated by type', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path.endsWith('/folders')) return Promise.resolve([{ uid: 'shared-uid', name: 'Folder', updated_at: '2026-01-05T00:00:00Z' }]);
+        if (path === '/query/resources' && query?.['type'] === 'committee_document') {
+          return Promise.resolve({
+            resources: [{ type: 'committee_document', id: 'shared-uid', data: { uid: 'shared-uid', name: 'File', updated_at: '2026-01-05T00:00:00Z' } }],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(2);
+      const types = result.data.map((e) => (e.type === 'document_uploaded' ? e.payload.document_type : null)).sort();
+      expect(types).toEqual(['file', 'folder']);
+    });
+
     it('falls back to the last item with a real timestamp for the cursor, when the returned page is short on valid timestamps', async () => {
-      // Only 2 votes have a real timestamp; 2 more have none. Sorted desc, invalid-timestamp
-      // items sort last (timestampValue('') === -Infinity), so with limit=3 the returned page is
-      // [v1, v2, v3] — v3 (the tail) has no valid timestamp, while a 4th candidate (v4) still
-      // exists beyond the page, so hasMore is true and a page_token must still be issued.
+      // Only 2 votes have a real timestamp; 2 more have none. Sorted desc, invalid-timestamp items
+      // sort last (timestampValue('') === -Infinity) and tiebreak deterministically on key
+      // ('vote:v4' sorts before 'vote:v3' in the descending key order), so with limit=3 the
+      // returned page is [v1, v2, v4] — v4 (the tail) has no valid timestamp, while a 4th
+      // candidate (v3) still exists beyond the page, so hasMore is true and a page_token must
+      // still be issued, falling back past v4 to v2's timestamp.
       getVotes.mockResolvedValue({
         data: [
           vote({ uid: 'v1', creation_time: '2026-01-05T00:00:00Z' }),
@@ -359,8 +396,8 @@ describe('CommitteeActivityService', () => {
       });
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 3 });
-      expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2', 'v3']);
-      // v3 (the tail of the returned page) has no valid timestamp — the cursor must fall back to v2's.
+      expect(result.data.map((e) => (e.type === 'vote_opened' ? e.payload.vote_uid : null))).toEqual(['v1', 'v2', 'v4']);
+      // v4 (the tail of the returned page) has no valid timestamp — the cursor must fall back to v2's.
       expect(encodeActivityPageToken).toHaveBeenCalledWith({ before: '2026-01-04T00:00:00Z', key: 'vote:v2' });
       expect(result.page_token).toBe('token(2026-01-04T00:00:00Z|vote:v2)');
     });

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -412,10 +412,15 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0]).toMatchObject({ type: 'document_uploaded', payload: { document_uid: 'link-1', document_type: 'link' } });
     });
 
-    it('treats a null /query/resources body as empty for the survey leg instead of throwing on destructure', async () => {
-      // `const { resources } = await proxyRequest(...)` throws a TypeError if the whole response
-      // body is null (not just its resources field) — a real possible upstream shape, same as the
-      // folders/links case above, just for a `/query/resources` leg instead of a REST array leg.
+    it('treats a null /query/resources body as a graceful empty survey leg, not an error-path degrade', async () => {
+      // Both the survey and files legs already sit inside their own per-leg `.catch()` in
+      // getCommitteeActivity, so `result.data` alone can't tell a guarded null response apart from
+      // an unguarded one — either way the leg contributes []. The `warning` log is what actually
+      // discriminates: without the `response?.resources ?? []` guard, the TypeError thrown reading
+      // `.resources` off a null response is caught by that outer per-leg `.catch()`, which DOES log
+      // a warning; the guard means this leg never throws at all, so no warning fires. Asserting only
+      // `result.data` here would pass identically whether the guard exists or not — proven by
+      // mutation testing the guard away and re-running this test.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'survey') return Promise.resolve(null);
         return defaultProxyRequest(r, s, path, m, query);
@@ -423,15 +428,19 @@ describe('CommitteeActivityService', () => {
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(result.data).toEqual([]);
+      expect(warning).not.toHaveBeenCalled();
     });
 
-    it('treats a null /query/resources body as empty for the files leg instead of throwing on property access', async () => {
+    it('treats a null /query/resources body as a graceful empty files leg, not an error-path degrade', async () => {
+      // See the survey test above for why `warning` (not just result.data) is the assertion that
+      // actually discriminates a guarded null response from an unguarded one.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'committee_document') return Promise.resolve(null);
         return defaultProxyRequest(r, s, path, m, query);
       });
 
       const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(warning).not.toHaveBeenCalled();
       expect(result.data).toEqual([]);
     });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -137,6 +137,19 @@ function isCutoffDrivenClosure(survey: Survey): boolean {
   return cutoffDate !== null && !Number.isNaN(cutoffDate.getTime()) && new Date() >= cutoffDate;
 }
 
+/**
+ * True when `deadlineIso` is absent-but-invalid or already passed — mirrors meeting.utils.ts's
+ * `isCalendarDeadlinePast` (reimplemented, not imported; see mapVoteToEvent's doc comment for why).
+ * Unlike that helper, `undefined`/empty is treated as "not past" (`false`) rather than checked —
+ * `mapVoteToEvent` only calls this with `vote.end_time`, which the ENDED/early_end_time checks
+ * ahead of it already partially cover; an absent end_time here just means "no deadline to compare."
+ */
+function isVoteDeadlinePast(deadlineIso: string | null | undefined): boolean {
+  if (!deadlineIso) return false;
+  const ms = Date.parse(deadlineIso);
+  return Number.isNaN(ms) ? true : Date.now() >= ms;
+}
+
 function isAtOrAfterSince(occurredAt: string, since: string | undefined): boolean {
   if (!since) return true;
   const ms = Date.parse(occurredAt);
@@ -378,10 +391,26 @@ export class CommitteeActivityService {
     // Every item in `page` now has a real timestamp (windowed already dropped the ones that
     // don't), so the last page item is always a valid cursor position — no need to search backward
     // for one. `hasMore` still requires a real `lastPageItem` to anchor a cursor on — if saturation
-    // is detected but this page came back empty (every fetched row got filtered out), there is no
-    // position left to resume from, so this degrades to the same "nothing more to report" outcome
-    // as before; an over-fetch this narrow (an entire upstream page filtered to zero matches) is
-    // accepted as a known residual rather than solved by a second round-trip within this call.
+    // is detected but this page came back empty, there is no position left to resume from, so this
+    // degrades to the same "nothing more to report" outcome as before.
+    //
+    // This isn't just an in-memory-filter edge case: confirmed against `lfx-v2-query-service`'s own
+    // source (`internal/service/resource_search.go`) and documented contract
+    // (`docs/query-service-contract.md`), FGA access-checking runs AFTER OpenSearch paginates —
+    // `page_token` reflects the raw (pre-filter) OpenSearch page, so a leg's single fetched page can
+    // come back with fewer visible resources than `page_size`, including zero, while `page_token`
+    // is still present. `anyLegSaturated` (above) already correctly reflects this via each leg's
+    // real `page_token` (not row count) — but if EVERY leg's single page happens to filter down to
+    // zero visible rows, `windowed`/`page` end up empty too, `lastPageItem` is undefined, and
+    // `hasMore` forces `false` regardless of `anyLegSaturated`: this response looks terminal even
+    // though a later upstream page (of any saturated leg) could contain rows this caller is
+    // authorized to see. Closing this for real means looping a leg's own upstream call until a
+    // visible candidate or exhaustion — ruled out for v1 by the ticket's "bounded calls, no
+    // per-event follow-ups" requirement (same constraint documented at the top of this method).
+    // Accepted as a known residual (per-request, not per-response — a follow-up request with the
+    // same `since`/no cursor would simply re-run this same fetch and could still surface nothing
+    // new if the access-filtering pattern hasn't changed), not solved by a second round-trip within
+    // this call.
     const lastPageItem = page.at(-1);
     const hasMore = (windowed.length > limit || anyLegSaturated) && !!lastPageItem;
     const pageToken = hasMore && lastPageItem ? encodeActivityPageToken({ before: lastPageItem.event.occurred_at, key: lastPageItem.key }) : undefined;
@@ -595,7 +624,16 @@ export class CommitteeActivityService {
     // directly. Skipping it here misclassified a non-canonical-case "ENDED" vote as vote_opened,
     // stamped at creation time instead of close time — caught independently by Copilot and Cursor
     // Bugbot, confirmed against current code.
-    const isClosed = normalizePollStatus(vote.status) === PollStatus.ENDED || !!vote.early_end_time;
+    //
+    // isVoteDeadlinePast(vote.end_time) — mirrors isVoteCalendarEventPast's third check
+    // (isCalendarDeadlinePast(early_end_time ?? end_time)) rather than importing it: that helper
+    // lives in meeting.utils.ts, which imports @angular/common/http — the same Angular-runtime-leak
+    // this file already avoids importing (see activity-feed.utils.ts's identical avoidance).
+    // Reimplemented locally instead. An ACTIVE vote whose end_time has already passed (but hasn't
+    // been flipped to ENDED by an async backend job yet) is still effectively over — without this,
+    // it stayed vote_opened at creation_time indefinitely, sorting far from where it belongs in the
+    // feed. Cursor Bugbot caught this as a follow-up to the casing fix above.
+    const isClosed = normalizePollStatus(vote.status) === PollStatus.ENDED || !!vote.early_end_time || isVoteDeadlinePast(vote.end_time);
     const occurredAt = isClosed
       ? firstValidTimestamp(vote.early_end_time, vote.end_time, vote.last_modified_time, vote.creation_time)
       : firstValidTimestamp(vote.creation_time, vote.last_modified_time);

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -167,6 +167,20 @@ export class CommitteeActivityService {
     // closed vote with a recent end_time but a stale last_modified_time could fall outside the
     // fetched page. Same class of approximation as the per-leg date_field caveats below, just in
     // the sort dimension instead of the filter dimension.
+    //
+    // Known v1 limitation (accepted, not solved — see the wire-contract plan's "known edge case"):
+    // meetings/votes/surveys/files are each bounded to a single upstream page of `fetchSize` rows.
+    // If more than `fetchSize` rows on one of those legs share the exact same occurred_at second,
+    // rows beyond the upstream page are simply never fetched, on any page — unlike folders/links
+    // (which have no upstream bound at all and are paginated correctly via the in-memory cursor
+    // pre-filter below), fixing this for a page_size-bounded leg would mean looping that leg's own
+    // upstream query-service/meeting-service/vote-service call across multiple pages until the tie
+    // is exhausted, i.e. per-leg N+1 upstream calls — which the ticket's "bounded calls, no
+    // per-event follow-ups" requirement rules out for v1. Negligible in practice at committee scale
+    // (tens of items, not thousands sharing one second); resolved for real once the upstream event
+    // log (this endpoint's eventual replacement) makes every event independently, chronologically
+    // paginable at the source.
+
     const fetchSize = Math.max(limit + 1, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE);
     // Sent to every leg as an inclusive upstream `date_to` (query-service's date_to is documented
     // inclusive), ceiled to the next whole second — see ceilToWholeSecond's doc comment for why:
@@ -405,11 +419,13 @@ export class CommitteeActivityService {
     // Deliberately not SurveyService.getSurveys — that always fully drains every page via
     // fetchAllQueryResources and does an extra per-user "responded" join, neither of which this
     // bounded, presentation-only fetch needs.
-    const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
+    //
+    // The `| null` generic (not just an optimistic non-null type) is deliberate: proxyRequest
+    // returns the upstream body verbatim, and a 204/empty response comes through as a null body,
+    // not `{ resources: null }` — `response?.resources ?? []` is a real runtime guard against a
+    // real return value, not defensive noise the compiler should otherwise be flagging as dead.
+    const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
 
-    // response?. (not just resources ??) — a 204/empty upstream body comes through as a null
-    // response itself (MicroserviceProxyService.proxyRequest returns the body verbatim), which
-    // would otherwise throw destructuring `resources` off a null response before `?? []` ever runs.
     return (response?.resources ?? []).map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
   }
 
@@ -436,14 +452,17 @@ export class CommitteeActivityService {
     const hasWindow = !!since || !!before;
 
     const [folders, links, files] = await Promise.all([
+      // `| null`, not an optimistic non-null array type — proxyRequest returns the upstream body
+      // verbatim, and a 204/empty response comes through as a null body. `folders ?? []` below is a
+      // real runtime guard, not defensive noise.
       this.microserviceProxy
-        .proxyRequest<CommitteeActivityFolder[]>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}/folders`, 'GET')
+        .proxyRequest<CommitteeActivityFolder[] | null>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}/folders`, 'GET')
         .catch((err) => {
           logger.warning(req, 'get_committee_activity', 'Failed to fetch committee folders, continuing without them', { committee_uid: committeeUid, err });
           return [] as CommitteeActivityFolder[];
         }),
       this.microserviceProxy
-        .proxyRequest<CommitteeActivityLink[]>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}/links`, 'GET')
+        .proxyRequest<CommitteeActivityLink[] | null>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}/links`, 'GET')
         .catch((err) => {
           logger.warning(req, 'get_committee_activity', 'Failed to fetch committee links, continuing without them', { committee_uid: committeeUid, err });
           return [] as CommitteeActivityLink[];
@@ -452,7 +471,7 @@ export class CommitteeActivityService {
       // drain — this endpoint must stay bounded (no per-event follow-ups), so a page_size-limited
       // page is enough for a "recent activity" feed even though it isn't the complete file list.
       this.microserviceProxy
-        .proxyRequest<QueryServiceResponse<CommitteeActivityDocumentFile>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        .proxyRequest<QueryServiceResponse<CommitteeActivityDocumentFile> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'committee_document',
           tags: `committee_uid:${committeeUid}`,
           page_size: fetchSize,
@@ -471,7 +490,8 @@ export class CommitteeActivityService {
     ]);
 
     // GET /committees/:id/folders and /links accept no page_size/date param at all and return
-    // every folder/link on the committee unconditionally. Filter each to the since/before/cursor
+    // every folder/link on the committee unconditionally — unlike every other leg, which is at
+    // least bounded to one upstream page of fetchSize. Filter each to the since/before/cursor
     // window FIRST, then bound to fetchSize — bounding before filtering would keep only the newest
     // fetchSize folders/links by recency regardless of the window, silently and permanently
     // excluding older-but-in-window items once a caller pages deep enough that they'd otherwise
@@ -484,6 +504,11 @@ export class CommitteeActivityService {
     // pre-filtering with it here can only narrow the pool toward what the central pass would keep
     // anyway, never past it. The exact/final since+cursor enforcement still happens once,
     // centrally, in getCommitteeActivity — this pre-filter only needs to be a superset of that.
+    // This fully closes the tie-truncation failure for folders/links specifically, because nothing
+    // upstream ever caps what this leg can re-fetch. The sibling meetings/votes/surveys/files legs
+    // are each capped to one upstream page of fetchSize and can still hit the same failure if more
+    // than fetchSize of their own rows share one exact timestamp — see the caveat on `fetchSize`'s
+    // own comment above, in getCommitteeActivity.
     const folderEvents = boundedSortDesc(
       (folders ?? [])
         .map((folder) => this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at)))
@@ -544,8 +569,11 @@ function boundedSortDesc<T extends ActivityEvent>(events: T[], limit: number): T
  * Inclusive since/before window check for legs with no upstream date filtering (folders/links) —
  * must run BEFORE `boundedSortDesc` on those legs, not after. `since`/`before` mirror the same
  * inclusive bounds sent upstream to every other leg's `date_from`/`date_to`; an event with no
- * parseable `occurred_at` is let through so the central `getCommitteeActivity` pass (which already
- * drops unparseable timestamps deliberately, see its comment) is the single place that decides.
+ * parseable `occurred_at` is let through here, since this check alone isn't the whole gate — the
+ * call site also `&&`s in `isAfterCursor`, which does reject an unparseable timestamp outright once
+ * a cursor is present. Either way, the central `getCommitteeActivity` pass applies the same
+ * unparseable-timestamp drop independently, so the final "included or not" outcome is identical
+ * regardless of which layer catches it first.
  */
 function isWithinFetchWindow(occurredAt: string, since: string | undefined, before: string | undefined): boolean {
   const ms = Date.parse(occurredAt);

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -180,15 +180,20 @@ export class CommitteeActivityService {
     // "the scheduled start time"). occurred_at (getPastMeetingStartTimeMs, via
     // firstValidTimestampMs/isRealTimestamp) prefers `scheduled_start_time`, falling back to
     // `start_time`. The indexed `v1_past_meeting` type this leg reads is sourced exclusively from
-    // ITX/Zoom past-meeting-completion events (`docs/event-processing.md`'s `itx-zoom-past-meetings.`
-    // stream — a "past meeting" is a derived record generated when an occurrence completes, not
-    // something created directly); its source struct `PastMeetingEventData` has no
-    // `scheduled_start_time` JSON field at all (`internal/domain/models/event_models.go`), and the
-    // one handler that builds it populates `StartTime` FROM the raw record's own `ScheduledStartTime`
-    // (`past_meeting_event_handler.go`). So `scheduled_start_time` is never present on a row this leg
-    // can read, the fallback always fires, and `sort_name`/occurred_at are always built from the
-    // identical value — meetings is exact, not merely the best-behaved approximation, unlike the
-    // other three legs below.
+    // ITX/Zoom past-meeting-completion events, not created directly — verified in the
+    // `lfx-v2-meeting-service` repo: `docs/event-processing.md`'s `itx-zoom-past-meetings.` stream is
+    // the sole source; the source struct `PastMeetingEventData`
+    // (`internal/domain/models/event_models.go`) has no `scheduled_start_time` JSON field at all; and
+    // the one handler that builds it (`cmd/meeting-api/eventing/past_meeting_event_handler.go`)
+    // populates `StartTime` FROM the raw record's own `ScheduledStartTime`. So `scheduled_start_time`
+    // is never present on a row this leg can read, the fallback always fires, and
+    // `sort_name`/occurred_at are always built from the identical value — meetings is exact, not
+    // merely the best-behaved approximation, unlike the other three legs below. This holds against
+    // the contract as verified today, not as a law of nature: if `lfx-v2-meeting-service` ever adds
+    // `scheduled_start_time` to that struct, `getPastMeetingStartTimeMs` would start preferring it
+    // while `date_field: 'start_time'` (in fetchPastMeetingEvents below) keeps narrowing on the old
+    // field — a silent upstream-side regression with no test failure, since nothing here would
+    // observe the new field being added. `date_field` would need to change alongside it.
     //
     // Votes, surveys, and files are all in a different, genuinely-approximate bucket: query-service's
     // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/
@@ -200,7 +205,15 @@ export class CommitteeActivityService {
     // (`updated_at` == `updated_at`) despite resolving to a different actual field once `data.`
     // prefixing is applied; surveys' and votes' date_field names don't even coincide with `updated_at`.
     // Same class of approximation as the per-leg date_field caveats below, just in the sort dimension
-    // instead of the filter dimension.
+    // instead of the filter dimension: votes/surveys/files each filter on a single upstream
+    // `date_field` that only approximates their own multi-field occurred_at derivation (see each
+    // leg's own comment for which field and why) — sending that imperfect narrowing upstream still
+    // beats sending none at all, which was tried and reverted earlier in this file's history: it
+    // traded the rare filter-mismatch miss for hard truncation at `fetchSize` on every page instead,
+    // a strictly worse failure mode. The in-memory since/cursor pass in getCommitteeActivity is the
+    // correctness backstop against over-inclusion for all three legs, not under-inclusion — an
+    // imperfectly-narrowed leg can still exclude a real in-window row upstream before that pass ever
+    // sees it.
     //
     // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files
     // are each bounded to a single upstream page of `fetchSize` rows.
@@ -419,16 +432,21 @@ export class CommitteeActivityService {
     before: string | undefined,
     fetchSize: number
   ): Promise<ActivityEvent[]> {
-    // date_field: 'start_time' — unlike every other leg's date_field narrowing (all best-effort, see
-    // their own comments), this one IS a correctness guarantee, not just an approximation: occurred_at
-    // (getPastMeetingStartTimeMs) prefers scheduled_start_time, falling back to start_time — but the
-    // indexed v1_past_meeting projection this leg reads never carries scheduled_start_time at all
-    // (see the "Meetings" paragraph in getCommitteeActivity's fetchSize comment for the verified
-    // source), so that fallback always fires and occurred_at is always built from the same start_time
-    // field this date_field narrows on. The in-memory since/cursor pass in getCommitteeActivity is
-    // still the one place that enforces the exact boundary (this narrowing only bounds what's
-    // fetched), but for this leg specifically it can't under-fetch relative to occurred_at the way
-    // the other legs' single-field-vs-fallback-derivation approximations can.
+    // date_field: 'start_time' — unlike every other leg's date_field narrowing (best-effort; see the
+    // shared rationale at the top of getCommitteeActivity), this one is a correctness guarantee for
+    // the upstream contract as verified: occurred_at (getPastMeetingStartTimeMs) prefers
+    // scheduled_start_time, falling back to start_time — and the indexed v1_past_meeting projection
+    // this leg reads never carries scheduled_start_time at all (see the "Meetings" paragraph in
+    // getCommitteeActivity's fetchSize comment for the verified source), so that fallback always
+    // fires and occurred_at is always built from the same start_time field this date_field narrows
+    // on. "As verified" is doing real work in that sentence, not hedge-speak: getPastMeetingStartTimeMs
+    // and this leg's own test suite (committee-activity.service.spec.ts's "does not sort a past
+    // meeting as ancient when start_time is a Go zero-date" case) still handle a present-and-differing
+    // scheduled_start_time defensively, matching meeting.service.ts's identical posture — the code
+    // doesn't assume the verified-absent case stays absent forever, even though the correctness
+    // conclusion above holds against the contract as it exists today. The in-memory since/cursor
+    // pass in getCommitteeActivity is still the one place that enforces the exact boundary (this
+    // narrowing only bounds what's fetched).
     const hasWindow = !!since || !!before;
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
@@ -478,11 +496,11 @@ export class CommitteeActivityService {
     before: string | undefined,
     fetchSize: number
   ): Promise<(VoteOpenedActivityEvent | VoteClosedActivityEvent)[]> {
-    // date_field: 'last_modified_time' is best-effort narrowing, same caveat as
-    // fetchPastMeetingEvents — a vote's occurred_at is actually
+    // date_field: 'last_modified_time' is best-effort narrowing (see the filter-dimension paragraph
+    // in getCommitteeActivity's fetchSize comment for why narrowing imperfectly still beats not
+    // narrowing at all) — a vote's occurred_at is actually
     // end_time/early_end_time/last_modified_time/creation_time depending on status, not always
-    // last_modified_time. See fetchPastMeetingEvents's comment for why narrowing (imperfectly) beats
-    // not narrowing at all.
+    // last_modified_time.
     const hasWindow = !!since || !!before;
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
@@ -531,10 +549,11 @@ export class CommitteeActivityService {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
-      // Best-effort narrowing, same caveat as fetchPastMeetingEvents — occurred_at is
-      // firstValidTimestamp(survey.last_modified_at, survey.created_at), so a never-modified
-      // survey (last_modified_at is the Go zero-date, created_at is the real value) could be
-      // excluded upstream on this field before the in-memory backstop ever sees it.
+      // Best-effort narrowing (see the filter-dimension paragraph in getCommitteeActivity's
+      // fetchSize comment) — occurred_at is firstValidTimestamp(survey.last_modified_at,
+      // survey.created_at), so a never-modified survey (last_modified_at is the Go zero-date,
+      // created_at is the real value) could be excluded upstream on this field before the
+      // in-memory backstop ever sees it.
       ...(hasWindow && { date_field: 'last_modified_at' }),
       ...(since && { date_from: since }),
       ...(before && { date_to: before }),

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -179,21 +179,21 @@ export class CommitteeActivityService {
     // upstream `PastMeetingEventData.SortName()` confirms — its own doc comment calls `StartTime`
     // "the scheduled start time"). occurred_at (getPastMeetingStartTimeMs) prefers
     // `scheduled_start_time`, falling back to `start_time` — but the indexed `v1_past_meeting`
-    // projection this leg actually reads has no `scheduled_start_time` field at all
-    // (`PastMeetingEventData` upstream carries only `StartTime`), so that fallback almost always
-    // fires and resolves to the identical value `sort_name` was built from (see the existing
-    // `fetchPastMeetingEvents` comment below, and `meeting.service.ts`'s "frequently omits
-    // scheduled_start_time" note on the same projection). Meetings is effectively exact, not merely
-    // "closest" — the one residual is the rare row where `scheduled_start_time` IS present and
-    // diverges from `start_time`, which per that same "frequently omits" framing is the exception,
+    // projection this leg actually reads frequently omits `scheduled_start_time`, carrying only
+    // `start_time` (see the existing `fetchPastMeetingEvents` comment below, and
+    // `meeting.service.ts`'s identical "frequently omits scheduled_start_time" note on the same
+    // projection), so that fallback usually resolves to the identical value `sort_name` was built
+    // from. Meetings is the closest of the four legs to exact, not merely approximate like the
+    // other three — the residual is the row where `scheduled_start_time` IS present and diverges
+    // from `start_time`, which per that same "frequently omits" framing is the less common case,
     // not the rule.
     //
     // Votes, surveys, and files are all in a different, genuinely-approximate bucket: query-service's
     // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/
     // converters.go`: `SortBy = "updated_at"`, no `data.` prefix), which the indexer contract
     // documents as index-write/audit metadata, not a copy of any `data.*` domain field — distinct
-    // from the `date_field` values these three legs filter on (`data.last_modified_at` /
-    // `data.updated_at` / `data.last_modified_time`, each auto-prefixed with `data.` by
+    // from the `date_field` values these three legs filter on: votes' `data.last_modified_time`,
+    // surveys' `data.last_modified_at`, files' `data.updated_at` (each auto-prefixed with `data.` by
     // query-service, unlike `sort`). Files happens to share a field NAME with the sort target
     // (`updated_at` == `updated_at`) despite resolving to a different actual field once `data.`
     // prefixing is applied; surveys' and votes' date_field names don't even coincide with `updated_at`.

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -179,8 +179,8 @@ export class CommitteeActivityService {
     // fetched page. Same class of approximation as the per-leg date_field caveats below, just in
     // the sort dimension instead of the filter dimension.
     //
-    // Known v1 limitation (accepted, not solved — see the wire-contract plan's "known edge case"):
-    // meetings/votes/surveys/files are each bounded to a single upstream page of `fetchSize` rows.
+    // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files
+    // are each bounded to a single upstream page of `fetchSize` rows.
     // If more than `fetchSize` rows on one of those legs share the exact same occurred_at second,
     // rows beyond the upstream page are simply never fetched, on any page — unlike folders/links
     // (which have no upstream bound at all and are paginated correctly via the in-memory cursor
@@ -241,6 +241,13 @@ export class CommitteeActivityService {
     // means that stays true even if the guard above is ever relaxed, instead of the two silently
     // diverging on which falsy values count as "no since" vs. "invalid since".
     const since = rawSince !== undefined ? normalizeTimestamp(rawSince) : undefined;
+
+    // INFO, not DEBUG — matches DocumentService.getMyDocuments's "N-stage aggregation" logging
+    // (the closest precedent in this repo: a comparable multi-source read aggregation), not the
+    // single-source enrichment services that stay at DEBUG throughout. A merge across 4
+    // independently-paginated upstream sources with cursor/saturation logic is exactly the
+    // "complex multi-step orchestration" case logging-patterns.md reserves INFO for.
+    logger.info(req, 'get_committee_activity', 'Starting committee activity aggregation', { committee_uid: committeeUid, fetch_size: fetchSize });
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentResult] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
@@ -317,7 +324,7 @@ export class CommitteeActivityService {
     const hasMore = (windowed.length > limit || anyLegSaturated) && !!lastPageItem;
     const pageToken = hasMore && lastPageItem ? encodeActivityPageToken({ before: lastPageItem.event.occurred_at, key: lastPageItem.key }) : undefined;
 
-    logger.debug(req, 'get_committee_activity', 'Completed committee activity aggregation', {
+    logger.info(req, 'get_committee_activity', 'Completed committee activity aggregation', {
       committee_uid: committeeUid,
       meeting_count: pastMeetingEvents.length,
       vote_count: voteEvents.length,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -287,14 +287,14 @@ export class CommitteeActivityService {
   private async fetchCommittee(req: Request, committeeUid: string): Promise<Committee> {
     // `| null`, not an optimistic non-null type — MicroserviceProxyService.proxyRequest returns the
     // upstream body verbatim (api-client.service.ts parses an empty body to `null`), so a null
-    // response is a real, if rare, return value this service has already hit more than once (every
-    // `| null` generic in this file exists for the same reason — see the other call sites in
+    // response is a real return value this file guards at four other call sites too (see
     // fetchSurveyEvents/fetchDocumentEvents). `proxyRequest`'s own declared type doesn't reflect
-    // this repo-wide (every other caller still assumes non-null); annotating it per call site here
-    // is a local, in-scope fix, not a claim that the hazard is closed elsewhere. A null committee
-    // here would otherwise throw an untyped TypeError reading `.enable_voting` off it in
-    // getCommitteeActivity; throwing explicitly here keeps this leg's fail-closed behavior (see the
-    // docblock above) meaningful and typed rather than an accidental side effect of a property read.
+    // this repo-wide — every other caller still *declares* it non-null, though several (e.g.
+    // project.service.ts, survey.service.ts) already runtime-guard the same way this does, which is
+    // the established repo pattern this follows. A null committee here would otherwise throw an
+    // untyped TypeError reading `.enable_voting` off it in getCommitteeActivity; throwing explicitly
+    // here keeps this leg's fail-closed behavior (see the docblock above) meaningful and typed
+    // rather than an accidental side effect of a property read.
     const committee = await this.microserviceProxy.proxyRequest<Committee | null>(
       req,
       'LFX_V2_SERVICE',
@@ -302,7 +302,11 @@ export class CommitteeActivityService {
       'GET'
     );
     if (!committee) {
-      throw new ResourceNotFoundError('Committee', committeeUid, { operation: 'get_committee_activity' });
+      throw new ResourceNotFoundError('Committee', committeeUid, {
+        operation: 'get_committee_activity',
+        service: 'committee_service',
+        path: `/committees/${committeeUid}`,
+      });
     }
     return committee;
   }

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -201,8 +201,18 @@ export class CommitteeActivityService {
         operation: 'get_committee_activity',
       });
     }
+    // Same reject-not-degrade policy, same reason, for `since` — this method is public and
+    // reachable by a caller that skips parseCommitteeActivityQuery's own since validation. Without
+    // this check, an unparseable `since` does the full upstream fan-out, 400s every query-service
+    // leg's date_from (each swallowed into an empty leg by its own .catch), and isAtOrAfterSince
+    // then rejects every surviving event too (`ms >= Date.parse(since)` is `ms >= NaN`, always
+    // false) — a silent empty feed, not the clean rejection this method's cursor handling already
+    // guarantees for the equivalent bad-input case.
+    if (since && Number.isNaN(Date.parse(since))) {
+      throw ServiceValidationError.forField('since', 'since must be a valid ISO 8601 timestamp', { operation: 'get_committee_activity' });
+    }
 
-    const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([
+    const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentResult] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
       this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
@@ -218,14 +228,14 @@ export class CommitteeActivityService {
       }),
       this.fetchDocumentEvents(req, committeeUid, since, before, fetchSize, cursor).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch document activity, continuing without it', { committee_uid: committeeUid, err });
-        return [];
+        return { events: [], saturated: false };
       }),
     ]);
 
     // A committee-lookup failure already rejected the whole Promise.all above (see fetchCommittee's
     // doc comment) — by this line `committee` is always a resolved Committee.
     const votingEnabled = committee.enable_voting;
-    const sources: ActivityEvent[][] = [pastMeetingEvents, votingEnabled ? voteEvents : [], surveyEvents, documentEvents];
+    const sources: ActivityEvent[][] = [pastMeetingEvents, votingEnabled ? voteEvents : [], surveyEvents, documentResult.events];
 
     // Single pass: attach each event's sort key once, apply since/cursor, sort desc by
     // (occurred_at, key). No per-source pre-cap — a global sort+slice already picks the true top
@@ -247,13 +257,34 @@ export class CommitteeActivityService {
     );
     windowed.sort((a, b) => compareEventsDesc({ occurred_at: a.event.occurred_at, key: a.key }, { occurred_at: b.event.occurred_at, key: b.key }));
 
-    const hasMore = windowed.length > limit;
+    // `windowed.length > limit` alone under-detects "more data exists": each of
+    // meetings/votes/surveys/files is bounded to a single upstream page of `fetchSize` rows (see
+    // the caveat above), so once a page's fetch actually hits that bound, there could be more rows
+    // upstream than made it into `windowed` even though the merged pool itself isn't over `limit` —
+    // e.g. a single dominant source returning exactly `fetchSize` rows, several of which get
+    // dropped by the in-memory since/cursor/invalid-timestamp filters, can leave `windowed.length`
+    // at or under `limit` while real, unfetched rows remain beyond this page's upstream cutoff.
+    // Folders/links are excluded from this saturation check — they have no upstream page bound at
+    // all (fetched in full every call) and are already filtered+bounded correctly against the exact
+    // cursor inside fetchDocumentEvents, so a fetched length at `fetchSize` there reflects this
+    // leg's own internal cap, not an upstream truncation signal.
+    const anyLegSaturated =
+      pastMeetingEvents.length >= fetchSize ||
+      (votingEnabled && voteEvents.length >= fetchSize) ||
+      surveyEvents.length >= fetchSize ||
+      documentResult.saturated;
+
     const page = windowed.slice(0, limit);
     const data = page.map(({ event }) => event);
     // Every item in `page` now has a real timestamp (windowed already dropped the ones that
     // don't), so the last page item is always a valid cursor position — no need to search backward
-    // for one.
+    // for one. `hasMore` still requires a real `lastPageItem` to anchor a cursor on — if saturation
+    // is detected but this page came back empty (every fetched row got filtered out), there is no
+    // position left to resume from, so this degrades to the same "nothing more to report" outcome
+    // as before; an over-fetch this narrow (an entire upstream page filtered to zero matches) is
+    // accepted as a known residual rather than solved by a second round-trip within this call.
     const lastPageItem = page.at(-1);
+    const hasMore = (windowed.length > limit || anyLegSaturated) && !!lastPageItem;
     const pageToken = hasMore && lastPageItem ? encodeActivityPageToken({ before: lastPageItem.event.occurred_at, key: lastPageItem.key }) : undefined;
 
     logger.debug(req, 'get_committee_activity', 'Completed committee activity aggregation', {
@@ -261,7 +292,7 @@ export class CommitteeActivityService {
       meeting_count: pastMeetingEvents.length,
       vote_count: voteEvents.length,
       survey_count: surveyEvents.length,
-      document_count: documentEvents.length,
+      document_count: documentResult.events.length,
       voting_enabled: votingEnabled,
       returned: data.length,
       has_more: hasMore,
@@ -471,7 +502,7 @@ export class CommitteeActivityService {
     before: string | undefined,
     fetchSize: number,
     cursor: ActivityPageCursor | undefined
-  ): Promise<DocumentUploadedActivityEvent[]> {
+  ): Promise<{ events: DocumentUploadedActivityEvent[]; saturated: boolean }> {
     const hasWindow = !!since || !!before;
 
     const [folders, links, files] = await Promise.all([
@@ -551,7 +582,13 @@ export class CommitteeActivityService {
       this.buildDocumentEvent(committeeUid, file.uid, file.name, 'file', firstValidTimestamp(file.updated_at, file.created_at))
     );
 
-    return [...folderEvents, ...linkEvents, ...fileEvents];
+    // Only the files leg feeds `saturated` — it's the one document sub-leg bounded by an upstream
+    // page_size (like meetings/votes/surveys), so a fetched length at fetchSize is a real signal
+    // there could be more upstream. Folders/links are deliberately excluded: they have no upstream
+    // bound at all (fetched in full, every call) and are already filtered+bounded against the exact
+    // cursor above, so hitting fetchSize there reflects this leg's own correct internal cap, not an
+    // under-fetch.
+    return { events: [...folderEvents, ...linkEvents, ...fileEvents], saturated: files.length >= fetchSize };
   }
 
   private buildDocumentEvent(

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -27,6 +27,7 @@ import type {
 import { firstValidTimestamp, getPastMeetingResourceId, getPastMeetingStartTimeMs, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
+import { ServiceValidationError } from '../errors';
 import { encodeActivityPageToken } from '../helpers/committee-activity-query.helper';
 import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
@@ -104,16 +105,9 @@ function compareEventsDesc(a: { occurred_at: string; key: string }, b: { occurre
  *
  * Returns `undefined` for an unparseable `iso` rather than throwing — matches every other
  * timestamp helper in this file (`timestampValue`, `isAtOrAfterSince`, `isAfterCursor`) treating an
- * invalid timestamp as "can't reason about this" rather than a fatal error. Currently unreachable
- * through the HTTP path (`decodePageToken` validates `cursor.before` before this ever runs), but
- * `getCommitteeActivity` is a public method a future non-HTTP caller could invoke directly.
- *
- * The net result for that caller is an EMPTY feed, not a widened one: dropping `date_to` only
- * widens what gets *fetched upstream*, but `isAfterCursor` still compares every event against the
- * original (unparseable) `cursor.before`, which `timestampValue` resolves to `-Infinity` — no real
- * event can sort "after" that, so every event is filtered out downstream regardless of what came
- * back from the fetch. An empty page (with `logger.warning` at the call site) is still the correct
- * choice over throwing: the caller gets a clearly-wrong-looking-but-safe answer instead of a 500.
+ * invalid timestamp as "can't reason about this" rather than a fatal error itself. The caller
+ * (`getCommitteeActivity`) is the one that decides what an unparseable `cursor.before` means for
+ * the request as a whole — see the comment there.
  */
 function ceilToWholeSecond(iso: string): string | undefined {
   const ms = Date.parse(iso);
@@ -170,11 +164,15 @@ export class CommitteeActivityService {
     // only bounds what gets fetched, so a wider upstream window is always safe, a narrower one isn't.
     const before = cursor ? ceilToWholeSecond(cursor.before) : undefined;
     if (cursor && !before) {
-      // Matches every other graceful-degradation path in this method (each leg's .catch() below,
-      // fetchCommittee) in logging before falling back — otherwise this is the one degraded path
-      // with no production signal. See ceilToWholeSecond's doc comment for the (still-safe) outcome.
-      logger.warning(req, 'get_committee_activity', 'Unparseable cursor.before; feed will resolve empty for this request', {
-        committee_uid: committeeUid,
+      // Reject rather than degrade — matches decodePageToken's own policy for the identical input
+      // (committee-activity-query.helper.ts: a bad explicit cursor is a 400, not a silently-ignored
+      // value). This method is public and reachable directly by a future non-HTTP caller that
+      // skips that validation; degrading here would (a) diverge from the HTTP path's policy for the
+      // same bad input and (b) still do the full 7-call upstream fan-out below for a result that's
+      // provably empty anyway (isAfterCursor can't place any real event "after" an unparseable
+      // cursor position), which is pure waste. Failing fast avoids both.
+      throw ServiceValidationError.forField('cursor.before', 'cursor.before must be a valid ISO 8601 timestamp', {
+        operation: 'get_committee_activity',
       });
     }
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -407,7 +407,7 @@ export class CommitteeActivityService {
     // bounded, presentation-only fetch needs.
     const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
 
-    return resources.map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
+    return (resources ?? []).map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
   }
 
   private mapSurveyToEvent(survey: Survey, committeeUid: string): SurveyPublishedActivityEvent | SurveyClosedActivityEvent {
@@ -459,7 +459,7 @@ export class CommitteeActivityService {
           ...(since && { date_from: since }),
           ...(before && { date_to: before }),
         })
-        .then((response) => response.resources.map((resource) => resource.data))
+        .then((response) => (response.resources ?? []).map((resource) => resource.data))
         .catch((err) => {
           logger.warning(req, 'get_committee_activity', 'Failed to fetch committee files, continuing without them', { committee_uid: committeeUid, err });
           return [] as CommitteeActivityDocumentFile[];
@@ -467,17 +467,24 @@ export class CommitteeActivityService {
     ]);
 
     // GET /committees/:id/folders and /links accept no page_size/date param at all and return
-    // every folder/link on the committee unconditionally — bound each to fetchSize here (sorted
-    // by its own occurred_at desc) so this leg can't return an unbounded candidate pool. The
-    // since/cursor window itself is applied once, centrally, in getCommitteeActivity.
+    // every folder/link on the committee unconditionally. Filter each to the since/before window
+    // FIRST, then bound to fetchSize — bounding before filtering would keep only the newest
+    // fetchSize folders/links by recency regardless of the window, silently and permanently
+    // excluding older-but-in-window items once a caller pages deep enough that they'd otherwise
+    // surface (boundedSortDesc always keeps the same newest slice, no matter which page is asked
+    // for). The exact/final since+cursor enforcement still happens once, centrally, in
+    // getCommitteeActivity — this pre-filter only needs to be a superset of that, using the same
+    // inclusive since/before bounds already sent upstream to every other leg.
     const folderEvents = boundedSortDesc(
-      folders.map((folder) =>
-        this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at))
-      ),
+      (folders ?? [])
+        .map((folder) => this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at)))
+        .filter((event) => isWithinFetchWindow(event.occurred_at, since, before)),
       fetchSize
     );
     const linkEvents = boundedSortDesc(
-      links.map((link) => this.buildDocumentEvent(committeeUid, link.uid, link.name, 'link', firstValidTimestamp(link.updated_at, link.created_at), link.url)),
+      (links ?? [])
+        .map((link) => this.buildDocumentEvent(committeeUid, link.uid, link.name, 'link', firstValidTimestamp(link.updated_at, link.created_at), link.url))
+        .filter((event) => isWithinFetchWindow(event.occurred_at, since, before)),
       fetchSize
     );
     const fileEvents = files.map((file) =>
@@ -521,4 +528,19 @@ function boundedSortDesc<T extends { occurred_at: string }>(events: T[], limit: 
       return bTime > aTime ? 1 : -1;
     })
     .slice(0, limit);
+}
+
+/**
+ * Inclusive since/before window check for legs with no upstream date filtering (folders/links) —
+ * must run BEFORE `boundedSortDesc` on those legs, not after. `since`/`before` mirror the same
+ * inclusive bounds sent upstream to every other leg's `date_from`/`date_to`; an event with no
+ * parseable `occurred_at` is let through so the central `getCommitteeActivity` pass (which already
+ * drops unparseable timestamps deliberately, see its comment) is the single place that decides.
+ */
+function isWithinFetchWindow(occurredAt: string, since: string | undefined, before: string | undefined): boolean {
+  const ms = Date.parse(occurredAt);
+  if (Number.isNaN(ms)) return true;
+  if (since && ms < Date.parse(since)) return false;
+  if (before && ms > Date.parse(before)) return false;
+  return true;
 }

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -217,23 +217,28 @@ export class CommitteeActivityService {
     // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/
     // converters.go`: `SortBy = "updated_at"`, no `data.` prefix), which the indexer contract
     // documents as index-write/audit metadata, not a copy of any `data.*` domain field — distinct
-    // from the `date_field` values these three legs filter on: votes' `data.last_modified_time`,
-    // surveys' `data.last_modified_at`, files' `data.updated_at` (each auto-prefixed with `data.` by
-    // query-service, unlike `sort`). Files happens to share a field NAME with the sort target
-    // (`updated_at` == `updated_at`) despite resolving to a different actual field once `data.`
-    // prefixing is applied; surveys' and votes' date_field names don't even coincide with `updated_at`.
-    // Same class of approximation as the per-leg date_field (filter-dimension) caveats discussed
-    // next, just in the sort dimension instead.
+    // from the `date_field` values votes and files filter on: votes' `data.last_modified_time`,
+    // files' `data.updated_at` (each auto-prefixed with `data.` by query-service, unlike `sort`).
+    // Files happens to share a field NAME with the sort target (`updated_at` == `updated_at`)
+    // despite resolving to a different actual field once `data.` prefixing is applied; votes'
+    // date_field name doesn't even coincide with `updated_at`. Surveys is the exception here: it
+    // has no upstream date_field at all (see fetchSurveyEvents's own comment for why) — `sort:
+    // updated_desc` is the only upstream ordering this leg gets. Same class of approximation as the
+    // per-leg date_field (filter-dimension) caveats discussed next, just in the sort dimension
+    // instead.
     //
-    // Filter dimension: votes/surveys/files each filter on a single upstream `date_field` that only
+    // Filter dimension: votes/files each filter on a single upstream `date_field` that only
     // approximates their own multi-field occurred_at derivation (see each leg's own comment for
     // which field and why) — sending that imperfect narrowing upstream still beats sending none at
     // all, which was tried and reverted earlier in this file's history: it traded the rare
     // filter-mismatch miss for hard truncation at `fetchSize` on every page instead, a strictly worse
     // failure mode. The in-memory since/cursor pass in getCommitteeActivity is the correctness
-    // backstop against over-inclusion for all three legs, not under-inclusion — an
-    // imperfectly-narrowed leg can still exclude a real in-window row upstream before that pass ever
-    // sees it.
+    // backstop against over-inclusion for both legs, not under-inclusion — an imperfectly-narrowed
+    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys is
+    // the one exception where "sending none at all" IS the right call, not the failure mode this
+    // paragraph describes: unlike votes/files, a survey's cutoff-driven occurred_at isn't bounded
+    // below by any field the row gets written to, so date_field narrowing there would systematically
+    // (not rarely) exclude exactly the rows `since` is meant to include — see fetchSurveyEvents.
     //
     // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files
     // are each bounded to a single upstream page of `fetchSize` rows.
@@ -611,20 +616,25 @@ export class CommitteeActivityService {
     before: string | undefined,
     fetchSize: number
   ): Promise<{ events: (SurveyPublishedActivityEvent | SurveyClosedActivityEvent)[]; saturated: boolean }> {
-    const hasWindow = !!since || !!before;
+    // No date_field/date_from/date_to on this leg — unlike votes/files, surveys have a mode of
+    // occurred_at (a cutoff-driven closure, see isCutoffDrivenClosure/mapSurveyToEvent below) that
+    // is NOT bounded below by last_modified_at: a SENT survey can sit with an old last_modified_at
+    // while its real occurred_at (survey_cutoff_date) is still in the future relative to that
+    // write, with no upstream write ever marking the transition. Narrowing on
+    // date_field: 'last_modified_at' (the previous approach) would upstream-exclude exactly that
+    // row whenever `since` falls between its last_modified_at and its cutoff-driven occurred_at —
+    // not a rare-edge best-effort miss like the votes/files legs' narrowing, but a systematic one
+    // for every cutoff-driven closure `since` is meant to include (Copilot caught this on this
+    // leg's initial cutoff fix). Dropping upstream date narrowing here entirely closes that: this
+    // leg falls back to the same "Known v1 limitation" already documented at the top of
+    // getCommitteeActivity for every page_size-bounded leg (a survey outside the top-fetchSize
+    // slice by `sort: updated_desc` can still be missed), which is an honest, pre-existing
+    // trade-off rather than a newly-introduced correctness gap.
     const query: Record<string, unknown> = {
       type: 'survey',
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
-      // Best-effort narrowing (see the filter-dimension paragraph in getCommitteeActivity's
-      // fetchSize comment) — occurred_at is firstValidTimestamp(survey.last_modified_at,
-      // survey.created_at), so a never-modified survey (last_modified_at is the Go zero-date,
-      // created_at is the real value) could be excluded upstream on this field before the
-      // in-memory backstop ever sees it.
-      ...(hasWindow && { date_field: 'last_modified_at' }),
-      ...(since && { date_from: since }),
-      ...(before && { date_to: before }),
     };
 
     // Deliberately not SurveyService.getSurveys — that always fully drains every page via

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -387,14 +387,18 @@ export class CommitteeActivityService {
   /**
    * Unlike every other leg, a failure here is NOT caught-and-degraded by the caller — it's allowed
    * to reject `getCommitteeActivity`'s `Promise.all` and propagate to the controller's `next(error)`.
-   * `GET /committees/:uid` is the one leg in this fan-out backed by committee-service's real
-   * per-request FGA enforcement (the four `/query/resources` legs instead filter per-resource,
-   * never 403 the whole request — see the controller's docblock); catching a 403/404 here the same
-   * way as the other legs would silently downgrade "caller isn't authorized for this committee at
-   * all" into "votes excluded, everything else renders", which is a materially different, and
-   * wrong, outcome for that case. A transient failure (5xx/network) fails the whole request too —
-   * matching `committee-engagement`'s `assertCommitteeRead`, which fails closed on both a resolved
-   * `false` and a thrown upstream error, rather than treating "couldn't verify" as "verified false".
+   * `GET /committees/:uid` is the one leg in this 7-call fan-out (committee + 4 `/query/resources`
+   * legs — meetings, votes, surveys, files — + committee-service's folders/links legs) whose
+   * committee-service FGA rejection is allowed to fail the whole request. The 4 `/query/resources`
+   * legs filter per-resource and never 403 the whole request (see the controller's docblock); the
+   * folders/links legs are also committee-service-FGA-backed but are deliberately caught-and-degraded
+   * in fetchDocumentEvents rather than propagated, since a single missing/inaccessible committee's
+   * folders or links shouldn't sink the whole feed the way a genuine "not authorized for this
+   * committee at all" should. Catching a 403/404 here the same way as the other legs would silently
+   * downgrade that case into "votes excluded, everything else renders", which is materially
+   * different, and wrong. A transient failure (5xx/network) fails the whole request too — matching
+   * `committee-engagement`'s `assertCommitteeRead`, which fails closed on both a resolved `false`
+   * and a thrown upstream error, rather than treating "couldn't verify" as "verified false".
    */
   private async fetchCommittee(req: Request, committeeUid: string): Promise<Committee> {
     // `| null`, not an optimistic non-null type — MicroserviceProxyService.proxyRequest returns the

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -106,9 +106,14 @@ function compareEventsDesc(a: { occurred_at: string; key: string }, b: { occurre
  * timestamp helper in this file (`timestampValue`, `isAtOrAfterSince`, `isAfterCursor`) treating an
  * invalid timestamp as "can't reason about this" rather than a fatal error. Currently unreachable
  * through the HTTP path (`decodePageToken` validates `cursor.before` before this ever runs), but
- * `getCommitteeActivity` is a public method a future non-HTTP caller could invoke directly — a
- * missing upstream date_to just widens the fetch (over-fetch, trimmed in-memory), which is the
- * same safe direction ceiling itself takes, rather than 500ing the entire feed.
+ * `getCommitteeActivity` is a public method a future non-HTTP caller could invoke directly.
+ *
+ * The net result for that caller is an EMPTY feed, not a widened one: dropping `date_to` only
+ * widens what gets *fetched upstream*, but `isAfterCursor` still compares every event against the
+ * original (unparseable) `cursor.before`, which `timestampValue` resolves to `-Infinity` — no real
+ * event can sort "after" that, so every event is filtered out downstream regardless of what came
+ * back from the fetch. An empty page (with `logger.warning` at the call site) is still the correct
+ * choice over throwing: the caller gets a clearly-wrong-looking-but-safe answer instead of a 500.
  */
 function ceilToWholeSecond(iso: string): string | undefined {
   const ms = Date.parse(iso);
@@ -164,6 +169,14 @@ export class CommitteeActivityService {
     // exact, un-ceiled cursor.before) is what actually enforces the boundary; the ceiled value here
     // only bounds what gets fetched, so a wider upstream window is always safe, a narrower one isn't.
     const before = cursor ? ceilToWholeSecond(cursor.before) : undefined;
+    if (cursor && !before) {
+      // Matches every other graceful-degradation path in this method (each leg's .catch() below,
+      // fetchCommittee) in logging before falling back — otherwise this is the one degraded path
+      // with no production signal. See ceilToWholeSecond's doc comment for the (still-safe) outcome.
+      logger.warning(req, 'get_committee_activity', 'Unparseable cursor.before; feed will resolve empty for this request', {
+        committee_uid: committeeUid,
+      });
+    }
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([
       this.fetchCommittee(req, committeeUid),

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -1,0 +1,371 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
+// import type — erased entirely at compile time, so unlike the enums/utils imports below, this
+// one needs no vi.mock in the spec (same reasoning as activity-feed.utils.ts's own interfaces import).
+import type {
+  ActivityEvent,
+  Committee,
+  DocumentUploadedActivityEvent,
+  PaginatedResponse,
+  PastMeeting,
+  QueryServiceResponse,
+  Survey,
+  SurveyClosedActivityEvent,
+  SurveyPublishedActivityEvent,
+  Vote,
+  VoteClosedActivityEvent,
+  VoteOpenedActivityEvent,
+} from '@lfx-one/shared/interfaces';
+import { firstValidTimestamp, getPastMeetingStartTimeMs, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { Request } from 'express';
+
+import { encodeActivityPageToken } from '../helpers/committee-activity-query.helper';
+import { logger } from './logger.service';
+import { MeetingService } from './meeting.service';
+import { MicroserviceProxyService } from './microservice-proxy.service';
+import { VoteService } from './vote.service';
+
+/** Options resolved by `parseCommitteeActivityQuery` and passed straight through. */
+export interface CommitteeActivityOptions {
+  since?: string;
+  before?: string;
+  limit: number;
+}
+
+/**
+ * Lower bound on the per-source `page_size` requested from each upstream leg — independent of
+ * `limit` so a small `limit` (e.g. 1) still gives the k-way merge (see `getCommitteeActivity`)
+ * enough candidates per source to be correct, not just fast.
+ */
+const MIN_SOURCE_FETCH_SIZE = 25;
+
+/** Upstream response shape for a committee folder (mirrors CommitteeService's own local interface — not exported from there). */
+interface CommitteeActivityFolder {
+  uid: string;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Upstream response shape for a committee link. */
+interface CommitteeActivityLink {
+  uid: string;
+  name: string;
+  url?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Query-service shape for an indexed `committee_document` (file) resource. */
+interface CommitteeActivityDocumentFile {
+  uid: string;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+function timestampValue(timestamp: string): number {
+  const parsed = Date.parse(timestamp);
+  return Number.isNaN(parsed) ? -Infinity : parsed;
+}
+
+function sortDescByOccurredAt<T extends { occurred_at: string }>(events: T[]): T[] {
+  return [...events].sort((a, b) => timestampValue(b.occurred_at) - timestampValue(a.occurred_at));
+}
+
+/**
+ * True when `occurredAt` falls within `[since, before)`. Used to apply the activity window
+ * in-memory for the two committee-document legs (folders/links) that have no upstream date
+ * param. An unparseable/missing timestamp is excluded whenever a window is active — it can't be
+ * verified to belong in the window — but kept when there's no window (matches the old client-side
+ * feed, which sorted an invalid timestamp to the bottom rather than dropping it).
+ */
+function isWithinWindow(occurredAt: string, since: string | undefined, before: string | undefined): boolean {
+  if (!since && !before) return true;
+  const ms = Date.parse(occurredAt);
+  if (Number.isNaN(ms)) return false;
+  if (since && ms < Date.parse(since)) return false;
+  if (before && ms >= Date.parse(before)) return false;
+  return true;
+}
+
+/**
+ * Aggregates a committee's activity across existing sources (past meetings, votes, surveys,
+ * documents) into one time-ordered, cursor-paginated feed — LFXV2-1707 v1. No new upstream
+ * service: each source is an existing committee-scoped read, fetched in parallel and merged
+ * server-side. See `packages/shared/src/interfaces/activity-event.interface.ts` for which event
+ * types this emits vs. defers pending a real event log.
+ */
+export class CommitteeActivityService {
+  private readonly microserviceProxy: MicroserviceProxyService;
+  private readonly meetingService: MeetingService;
+  private readonly voteService: VoteService;
+
+  public constructor() {
+    this.microserviceProxy = new MicroserviceProxyService();
+    this.meetingService = new MeetingService();
+    this.voteService = new VoteService();
+  }
+
+  public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityOptions): Promise<PaginatedResponse<ActivityEvent>> {
+    const { since, before, limit } = options;
+    // Fetching `limit + 1` from EACH source (not just `limit`) guarantees the true global
+    // top-(limit+1) merged-by-occurred_at result is present in the fetched pool, even in the
+    // worst case where a single source contributes every one of the top items — a smaller
+    // per-source fetch could silently under-represent a dominant source. MIN_SOURCE_FETCH_SIZE
+    // keeps small `limit` values (e.g. 1) from starving that guarantee.
+    const fetchSize = Math.max(limit + 1, MIN_SOURCE_FETCH_SIZE);
+
+    const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([
+      this.fetchCommittee(req, committeeUid),
+      this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
+        return [];
+      }),
+      this.fetchVoteEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch vote activity, continuing without it', { committee_uid: committeeUid, err });
+        return [];
+      }),
+      this.fetchSurveyEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch survey activity, continuing without it', { committee_uid: committeeUid, err });
+        return [];
+      }),
+      this.fetchDocumentEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch document activity, continuing without it', { committee_uid: committeeUid, err });
+        return [];
+      }),
+    ]);
+
+    // Committee lookup failure defaults to voting excluded (conservative) rather than included —
+    // we can't confirm enable_voting, and showing vote activity for a committee we couldn't
+    // verify is worse than briefly under-showing it.
+    const votingEnabled = committee?.enable_voting ?? false;
+    const sources: ActivityEvent[][] = [pastMeetingEvents, votingEnabled ? voteEvents : [], surveyEvents, documentEvents];
+
+    // Pure chronological merge — no per-source pre-cap. Each source already carries at most
+    // fetchSize items (bounded above), and a global sort+slice already picks the true top `limit`
+    // by time regardless of which source they came from; an artificial per-source quota would only
+    // make this LESS "time-ordered", not more correct.
+    const merged = sortDescByOccurredAt(sources.flat());
+
+    const hasMore = merged.length > limit;
+    const data = merged.slice(0, limit);
+    const pageToken = hasMore ? encodeActivityPageToken(data[data.length - 1].occurred_at) : undefined;
+
+    logger.debug(req, 'get_committee_activity', 'Completed committee activity aggregation', {
+      committee_uid: committeeUid,
+      meeting_count: pastMeetingEvents.length,
+      vote_count: voteEvents.length,
+      survey_count: surveyEvents.length,
+      document_count: documentEvents.length,
+      voting_enabled: votingEnabled,
+      returned: data.length,
+      has_more: hasMore,
+    });
+
+    return { data, page_token: pageToken };
+  }
+
+  // ─── Committee (for enable_voting) ─────────────────────────────────────────
+
+  private async fetchCommittee(req: Request, committeeUid: string): Promise<Committee | null> {
+    return this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeUid}`, 'GET').catch((err) => {
+      logger.warning(req, 'get_committee_activity', 'Failed to fetch committee; defaulting votes to excluded', { committee_uid: committeeUid, err });
+      return null;
+    });
+  }
+
+  // ─── Past Meetings → meeting_held ──────────────────────────────────────────
+
+  private async fetchPastMeetingEvents(
+    req: Request,
+    committeeUid: string,
+    since: string | undefined,
+    before: string | undefined,
+    fetchSize: number
+  ): Promise<ActivityEvent[]> {
+    const hasWindow = !!since || !!before;
+    const query: Record<string, unknown> = {
+      tags: `committee_uid:${committeeUid}`,
+      page_size: fetchSize,
+      sort: 'updated_desc',
+      ...(hasWindow && { date_field: 'start_time' }),
+      ...(since && { date_from: since }),
+      ...(before && { date_to: before }),
+    };
+
+    // access=false — the activity row only needs title/start_time, not per-meeting writer flags,
+    // so skip the access-check call getMeetings otherwise makes for every returned meeting.
+    // Cast to PastMeeting[] — getMeetings' return type is generic Meeting[], but the actual shape
+    // is PastMeeting for meetingType 'v1_past_meeting' (same cast PastMeetingController itself uses).
+    const { data: meetings } = (await this.meetingService.getMeetings(req, query, 'v1_past_meeting', false)) as { data: PastMeeting[] };
+
+    return meetings.map((meeting) => {
+      const startMs = getPastMeetingStartTimeMs(meeting);
+      const occurredAt = startMs !== null ? new Date(startMs).toISOString() : '';
+      return {
+        type: 'meeting_held',
+        occurred_at: occurredAt,
+        committee_uid: committeeUid,
+        payload: { meeting_id: meeting.id, title: meeting.title },
+      };
+    });
+  }
+
+  // ─── Votes → vote_opened | vote_closed ─────────────────────────────────────
+
+  private async fetchVoteEvents(
+    req: Request,
+    committeeUid: string,
+    since: string | undefined,
+    before: string | undefined,
+    fetchSize: number
+  ): Promise<(VoteOpenedActivityEvent | VoteClosedActivityEvent)[]> {
+    const hasWindow = !!since || !!before;
+    const query: Record<string, unknown> = {
+      tags: `committee_uid:${committeeUid}`,
+      page_size: fetchSize,
+      sort: 'updated_desc',
+      // last_modified_time, not creation_time — a vote closed recently but created long ago
+      // must still fall inside a "recent activity" window; creation_time would wrongly exclude it.
+      ...(hasWindow && { date_field: 'last_modified_time' }),
+      ...(since && { date_from: since }),
+      ...(before && { date_to: before }),
+    };
+
+    const { data: votes } = await this.voteService.getVotes(req, query);
+    return votes.map((vote) => this.mapVoteToEvent(vote, committeeUid));
+  }
+
+  /**
+   * One event per vote row (not two) — deliberate: this is an aggregation over current state, not
+   * a real event log, so only the vote's most recent lifecycle point is known. Keeps the feed's
+   * row count/rendering identical to the old client-side widget (one row per vote). A real event
+   * log would naturally emit both `vote_opened` and `vote_closed` as they occur.
+   */
+  private mapVoteToEvent(vote: Vote, committeeUid: string): VoteOpenedActivityEvent | VoteClosedActivityEvent {
+    const isClosed = vote.status === PollStatus.ENDED || !!vote.early_end_time;
+    const occurredAt = isClosed
+      ? firstValidTimestamp(vote.early_end_time, vote.end_time, vote.last_modified_time, vote.creation_time)
+      : firstValidTimestamp(vote.creation_time, vote.last_modified_time);
+    return {
+      type: isClosed ? 'vote_closed' : 'vote_opened',
+      occurred_at: occurredAt,
+      committee_uid: committeeUid,
+      payload: { vote_uid: vote.uid, name: vote.name, status: vote.status },
+    };
+  }
+
+  // ─── Surveys → survey_published | survey_closed ────────────────────────────
+
+  private async fetchSurveyEvents(
+    req: Request,
+    committeeUid: string,
+    since: string | undefined,
+    before: string | undefined,
+    fetchSize: number
+  ): Promise<(SurveyPublishedActivityEvent | SurveyClosedActivityEvent)[]> {
+    const hasWindow = !!since || !!before;
+    const query: Record<string, unknown> = {
+      type: 'survey',
+      tags: `committee_uid:${committeeUid}`,
+      page_size: fetchSize,
+      sort: 'updated_desc',
+      ...(hasWindow && { date_field: 'last_modified_at' }),
+      ...(since && { date_from: since }),
+      ...(before && { date_to: before }),
+    };
+
+    // Deliberately not SurveyService.getSurveys — that always fully drains every page via
+    // fetchAllQueryResources and does an extra per-user "responded" join, neither of which this
+    // bounded, presentation-only fetch needs.
+    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
+
+    return resources.map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
+  }
+
+  private mapSurveyToEvent(survey: Survey, committeeUid: string): SurveyPublishedActivityEvent | SurveyClosedActivityEvent {
+    const displayStatus = getSurveyDisplayStatus(survey);
+    return {
+      type: displayStatus === SurveyStatus.CLOSED ? 'survey_closed' : 'survey_published',
+      occurred_at: firstValidTimestamp(survey.last_modified_at, survey.created_at),
+      committee_uid: committeeUid,
+      payload: { survey_uid: survey.uid, title: survey.survey_title, status: displayStatus },
+    };
+  }
+
+  // ─── Documents → document_uploaded ─────────────────────────────────────────
+
+  private async fetchDocumentEvents(
+    req: Request,
+    committeeUid: string,
+    since: string | undefined,
+    before: string | undefined,
+    fetchSize: number
+  ): Promise<DocumentUploadedActivityEvent[]> {
+    const hasWindow = !!since || !!before;
+
+    const [folders, links, files] = await Promise.all([
+      this.microserviceProxy.proxyRequest<CommitteeActivityFolder[]>(req, 'LFX_V2_SERVICE', `/committees/${committeeUid}/folders`, 'GET').catch((err) => {
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch committee folders, continuing without them', { committee_uid: committeeUid, err });
+        return [] as CommitteeActivityFolder[];
+      }),
+      this.microserviceProxy.proxyRequest<CommitteeActivityLink[]>(req, 'LFX_V2_SERVICE', `/committees/${committeeUid}/links`, 'GET').catch((err) => {
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch committee links, continuing without them', { committee_uid: committeeUid, err });
+        return [] as CommitteeActivityLink[];
+      }),
+      // Single bounded page, not CommitteeService.getCommitteeDocuments's fetchAllQueryResources
+      // drain — this endpoint must stay bounded (no per-event follow-ups), so a page_size-limited
+      // page is enough for a "recent activity" feed even though it isn't the complete file list.
+      this.microserviceProxy
+        .proxyRequest<QueryServiceResponse<CommitteeActivityDocumentFile>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          type: 'committee_document',
+          tags: `committee_uid:${committeeUid}`,
+          page_size: fetchSize,
+          sort: 'updated_desc',
+          ...(hasWindow && { date_field: 'updated_at' }),
+          ...(since && { date_from: since }),
+          ...(before && { date_to: before }),
+        })
+        .then((response) => response.resources.map((resource) => resource.data))
+        .catch((err) => {
+          logger.warning(req, 'get_committee_activity', 'Failed to fetch committee files, continuing without them', { committee_uid: committeeUid, err });
+          return [] as CommitteeActivityDocumentFile[];
+        }),
+    ]);
+
+    const folderEvents = folders.map((folder) =>
+      this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at))
+    );
+    const linkEvents = links.map((link) =>
+      this.buildDocumentEvent(committeeUid, link.uid, link.name, 'link', firstValidTimestamp(link.updated_at, link.created_at), link.url)
+    );
+    const fileEvents = files.map((file) =>
+      this.buildDocumentEvent(committeeUid, file.uid, file.name, 'file', firstValidTimestamp(file.updated_at, file.created_at))
+    );
+
+    // Folders/links have no upstream date param (confirmed gap — neither REST endpoint accepts
+    // one) — the window is applied here instead. Harmless no-op for the files leg, already
+    // upstream-filtered.
+    const merged = [...folderEvents, ...linkEvents, ...fileEvents];
+    return hasWindow ? merged.filter((event) => isWithinWindow(event.occurred_at, since, before)) : merged;
+  }
+
+  private buildDocumentEvent(
+    committeeUid: string,
+    documentUid: string,
+    name: string,
+    documentType: 'file' | 'link' | 'folder',
+    occurredAt: string,
+    url?: string
+  ): DocumentUploadedActivityEvent {
+    return {
+      type: 'document_uploaded',
+      occurred_at: occurredAt,
+      committee_uid: committeeUid,
+      payload: { document_uid: documentUid, name, document_type: documentType, url },
+    };
+  }
+}

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -192,8 +192,9 @@ export class CommitteeActivityService {
     // the contract as verified today, not as a law of nature: if `lfx-v2-meeting-service` ever adds
     // `scheduled_start_time` to that struct, `getPastMeetingStartTimeMs` would start preferring it
     // while `date_field: 'start_time'` (in fetchPastMeetingEvents below) keeps narrowing on the old
-    // field — a silent upstream-side regression with no test failure, since nothing here would
-    // observe the new field being added. `date_field` would need to change alongside it.
+    // field — an upstream-side regression that would otherwise be silent. fetchPastMeetingEvents has
+    // a runtime tripwire for exactly this: a warning log if a real, differing scheduled_start_time
+    // ever shows up on a returned row, rather than relying on this comment alone to catch it.
     //
     // Votes, surveys, and files are all in a different, genuinely-approximate bucket: query-service's
     // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/
@@ -204,14 +205,16 @@ export class CommitteeActivityService {
     // query-service, unlike `sort`). Files happens to share a field NAME with the sort target
     // (`updated_at` == `updated_at`) despite resolving to a different actual field once `data.`
     // prefixing is applied; surveys' and votes' date_field names don't even coincide with `updated_at`.
-    // Same class of approximation as the per-leg date_field caveats below, just in the sort dimension
-    // instead of the filter dimension: votes/surveys/files each filter on a single upstream
-    // `date_field` that only approximates their own multi-field occurred_at derivation (see each
-    // leg's own comment for which field and why) — sending that imperfect narrowing upstream still
-    // beats sending none at all, which was tried and reverted earlier in this file's history: it
-    // traded the rare filter-mismatch miss for hard truncation at `fetchSize` on every page instead,
-    // a strictly worse failure mode. The in-memory since/cursor pass in getCommitteeActivity is the
-    // correctness backstop against over-inclusion for all three legs, not under-inclusion — an
+    // Same class of approximation as the per-leg date_field (filter-dimension) caveats discussed
+    // next, just in the sort dimension instead.
+    //
+    // Filter dimension: votes/surveys/files each filter on a single upstream `date_field` that only
+    // approximates their own multi-field occurred_at derivation (see each leg's own comment for
+    // which field and why) — sending that imperfect narrowing upstream still beats sending none at
+    // all, which was tried and reverted earlier in this file's history: it traded the rare
+    // filter-mismatch miss for hard truncation at `fetchSize` on every page instead, a strictly worse
+    // failure mode. The in-memory since/cursor pass in getCommitteeActivity is the correctness
+    // backstop against over-inclusion for all three legs, not under-inclusion — an
     // imperfectly-narrowed leg can still exclude a real in-window row upstream before that pass ever
     // sees it.
     //
@@ -478,6 +481,19 @@ export class CommitteeActivityService {
     return meetings.map((meeting) => {
       const startMs = getPastMeetingStartTimeMs(meeting);
       const occurredAt = startMs !== null ? new Date(startMs).toISOString() : '';
+      // Tripwire for the "meetings is exact" claim in getCommitteeActivity's fetchSize comment —
+      // a documented-but-silent regression is worse than no documentation, so make it observable: if
+      // a real scheduled_start_time (not absent/zero-date/unparseable) ever shows up and differs from
+      // start_time, the upstream contract this leg's date_field narrowing relies on has changed.
+      const scheduledStartTime = firstValidTimestamp(meeting.scheduled_start_time);
+      if (scheduledStartTime && Date.parse(scheduledStartTime) !== Date.parse(meeting.start_time)) {
+        logger.warning(
+          req,
+          'get_committee_activity',
+          'v1_past_meeting row carries a real scheduled_start_time differing from start_time — date_field narrowing on start_time may no longer be exact for this leg',
+          { committee_uid: committeeUid, meeting_id: meeting.id }
+        );
+      }
       return {
         type: 'meeting_held',
         occurred_at: occurredAt,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -27,7 +27,7 @@ import type {
 import { firstValidTimestamp, getPastMeetingResourceId, getPastMeetingStartTimeMs, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
-import { ServiceValidationError } from '../errors';
+import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { encodeActivityPageToken } from '../helpers/committee-activity-query.helper';
 import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
@@ -285,7 +285,26 @@ export class CommitteeActivityService {
    * `false` and a thrown upstream error, rather than treating "couldn't verify" as "verified false".
    */
   private async fetchCommittee(req: Request, committeeUid: string): Promise<Committee> {
-    return this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}`, 'GET');
+    // `| null`, not an optimistic non-null type — MicroserviceProxyService.proxyRequest returns the
+    // upstream body verbatim (api-client.service.ts parses an empty body to `null`), so a null
+    // response is a real, if rare, return value this service has already hit more than once (every
+    // `| null` generic in this file exists for the same reason — see the other call sites in
+    // fetchSurveyEvents/fetchDocumentEvents). `proxyRequest`'s own declared type doesn't reflect
+    // this repo-wide (every other caller still assumes non-null); annotating it per call site here
+    // is a local, in-scope fix, not a claim that the hazard is closed elsewhere. A null committee
+    // here would otherwise throw an untyped TypeError reading `.enable_voting` off it in
+    // getCommitteeActivity; throwing explicitly here keeps this leg's fail-closed behavior (see the
+    // docblock above) meaningful and typed rather than an accidental side effect of a property read.
+    const committee = await this.microserviceProxy.proxyRequest<Committee | null>(
+      req,
+      'LFX_V2_SERVICE',
+      `/committees/${encodeURIComponent(committeeUid)}`,
+      'GET'
+    );
+    if (!committee) {
+      throw new ResourceNotFoundError('Committee', committeeUid, { operation: 'get_committee_activity' });
+    }
+    return committee;
   }
 
   // ─── Past Meetings → meeting_held ──────────────────────────────────────────
@@ -420,10 +439,7 @@ export class CommitteeActivityService {
     // fetchAllQueryResources and does an extra per-user "responded" join, neither of which this
     // bounded, presentation-only fetch needs.
     //
-    // The `| null` generic (not just an optimistic non-null type) is deliberate: proxyRequest
-    // returns the upstream body verbatim, and a 204/empty response comes through as a null body,
-    // not `{ resources: null }` — `response?.resources ?? []` is a real runtime guard against a
-    // real return value, not defensive noise the compiler should otherwise be flagging as dead.
+    // `| null` — see fetchCommittee's note above on why this file annotates it per call site.
     const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
 
     return (response?.resources ?? []).map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
@@ -452,9 +468,8 @@ export class CommitteeActivityService {
     const hasWindow = !!since || !!before;
 
     const [folders, links, files] = await Promise.all([
-      // `| null`, not an optimistic non-null array type — proxyRequest returns the upstream body
-      // verbatim, and a 204/empty response comes through as a null body. `folders ?? []` below is a
-      // real runtime guard, not defensive noise.
+      // `| null` on folders/links/files below — see fetchCommittee's note on why this file
+      // annotates it per call site.
       this.microserviceProxy
         .proxyRequest<CommitteeActivityFolder[] | null>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}/folders`, 'GET')
         .catch((err) => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -202,7 +202,7 @@ export class CommitteeActivityService {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch survey activity, continuing without it', { committee_uid: committeeUid, err });
         return [];
       }),
-      this.fetchDocumentEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+      this.fetchDocumentEvents(req, committeeUid, since, before, fetchSize, cursor).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch document activity, continuing without it', { committee_uid: committeeUid, err });
         return [];
       }),
@@ -405,9 +405,12 @@ export class CommitteeActivityService {
     // Deliberately not SurveyService.getSurveys — that always fully drains every page via
     // fetchAllQueryResources and does an extra per-user "responded" join, neither of which this
     // bounded, presentation-only fetch needs.
-    const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
+    const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
 
-    return (resources ?? []).map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
+    // response?. (not just resources ??) — a 204/empty upstream body comes through as a null
+    // response itself (MicroserviceProxyService.proxyRequest returns the body verbatim), which
+    // would otherwise throw destructuring `resources` off a null response before `?? []` ever runs.
+    return (response?.resources ?? []).map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
   }
 
   private mapSurveyToEvent(survey: Survey, committeeUid: string): SurveyPublishedActivityEvent | SurveyClosedActivityEvent {
@@ -427,7 +430,8 @@ export class CommitteeActivityService {
     committeeUid: string,
     since: string | undefined,
     before: string | undefined,
-    fetchSize: number
+    fetchSize: number,
+    cursor: ActivityPageCursor | undefined
   ): Promise<DocumentUploadedActivityEvent[]> {
     const hasWindow = !!since || !!before;
 
@@ -459,7 +463,7 @@ export class CommitteeActivityService {
           ...(since && { date_from: since }),
           ...(before && { date_to: before }),
         })
-        .then((response) => (response.resources ?? []).map((resource) => resource.data))
+        .then((response) => (response?.resources ?? []).map((resource) => resource.data))
         .catch((err) => {
           logger.warning(req, 'get_committee_activity', 'Failed to fetch committee files, continuing without them', { committee_uid: committeeUid, err });
           return [] as CommitteeActivityDocumentFile[];
@@ -467,24 +471,33 @@ export class CommitteeActivityService {
     ]);
 
     // GET /committees/:id/folders and /links accept no page_size/date param at all and return
-    // every folder/link on the committee unconditionally. Filter each to the since/before window
-    // FIRST, then bound to fetchSize — bounding before filtering would keep only the newest
+    // every folder/link on the committee unconditionally. Filter each to the since/before/cursor
+    // window FIRST, then bound to fetchSize — bounding before filtering would keep only the newest
     // fetchSize folders/links by recency regardless of the window, silently and permanently
     // excluding older-but-in-window items once a caller pages deep enough that they'd otherwise
     // surface (boundedSortDesc always keeps the same newest slice, no matter which page is asked
-    // for). The exact/final since+cursor enforcement still happens once, centrally, in
-    // getCommitteeActivity — this pre-filter only needs to be a superset of that, using the same
-    // inclusive since/before bounds already sent upstream to every other leg.
+    // for). isAfterCursor (not just isWithinFetchWindow) is included here too — since/before alone
+    // only narrow by timestamp, so a pool where more than fetchSize items share one exact
+    // occurred_at second (e.g. a bulk folder import) would never actually shrink across pages: the
+    // upstream response order, not (occurred_at, key), would silently decide which items are
+    // reachable at all. isAfterCursor is exactly the predicate the central pass applies, so
+    // pre-filtering with it here can only narrow the pool toward what the central pass would keep
+    // anyway, never past it. The exact/final since+cursor enforcement still happens once,
+    // centrally, in getCommitteeActivity — this pre-filter only needs to be a superset of that.
     const folderEvents = boundedSortDesc(
       (folders ?? [])
         .map((folder) => this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at)))
-        .filter((event) => isWithinFetchWindow(event.occurred_at, since, before)),
+        .filter(
+          (event) => isWithinFetchWindow(event.occurred_at, since, before) && isAfterCursor({ occurred_at: event.occurred_at, key: eventKey(event) }, cursor)
+        ),
       fetchSize
     );
     const linkEvents = boundedSortDesc(
       (links ?? [])
         .map((link) => this.buildDocumentEvent(committeeUid, link.uid, link.name, 'link', firstValidTimestamp(link.updated_at, link.created_at), link.url))
-        .filter((event) => isWithinFetchWindow(event.occurred_at, since, before)),
+        .filter(
+          (event) => isWithinFetchWindow(event.occurred_at, since, before) && isAfterCursor({ occurred_at: event.occurred_at, key: eventKey(event) }, cursor)
+        ),
       fetchSize
     );
     const fileEvents = files.map((file) =>
@@ -512,21 +525,18 @@ export class CommitteeActivityService {
 }
 
 /**
- * Pre-merge bound for a leg with no upstream page_size (folders/links) — sorts by occurred_at desc
- * and keeps the newest `limit`. Compares the two numeric timestamps explicitly rather than
- * subtracting them, same reasoning as `compareEventsDesc`: `a - b` on two `-Infinity` values
- * (both items have an unparseable/absent occurred_at) is `NaN`, not `0`, which would make the
- * relative order of same-invalid-timestamp items — and therefore which ones survive the slice —
- * implementation-defined instead of deterministic.
+ * Pre-merge bound for a leg with no upstream page_size (folders/links) — sorts by the same
+ * `(occurred_at, key)` order the cursor itself uses (via `compareEventsDesc`/`eventKey`) and keeps
+ * the newest `limit`. A plain occurred_at-only sort would tie-break same-timestamp events by
+ * whatever order the upstream array happened to return them in — harmless for a single unpaginated
+ * call, but if more than `limit` items share one exact timestamp (e.g. a bulk folder import), an
+ * occurred_at-only tie would let the survivors of each call vary independently of the cursor,
+ * reintroducing the exact permanent-omission failure this function's `since`/`before`/cursor
+ * pre-filtering exists to prevent — see the comment at its call site.
  */
-function boundedSortDesc<T extends { occurred_at: string }>(events: T[], limit: number): T[] {
+function boundedSortDesc<T extends ActivityEvent>(events: T[], limit: number): T[] {
   return [...events]
-    .sort((a, b) => {
-      const aTime = timestampValue(a.occurred_at);
-      const bTime = timestampValue(b.occurred_at);
-      if (aTime === bTime) return 0;
-      return bTime > aTime ? 1 : -1;
-    })
+    .sort((a, b) => compareEventsDesc({ occurred_at: a.occurred_at, key: eventKey(a) }, { occurred_at: b.occurred_at, key: eventKey(b) }))
     .slice(0, limit);
 }
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -101,9 +101,18 @@ function compareEventsDesc(a: { occurred_at: string; key: string }, b: { occurre
  * layer upstream). Ceiling instead of truncating guarantees the upstream boundary is never tighter
  * than the true one; the in-memory pass still applies the exact `(occurred_at, key)` comparison, so
  * the resulting over-fetch (at most ~1 second of extra rows) is trimmed correctly, not a correctness gap.
+ *
+ * Returns `undefined` for an unparseable `iso` rather than throwing — matches every other
+ * timestamp helper in this file (`timestampValue`, `isAtOrAfterSince`, `isAfterCursor`) treating an
+ * invalid timestamp as "can't reason about this" rather than a fatal error. Currently unreachable
+ * through the HTTP path (`decodePageToken` validates `cursor.before` before this ever runs), but
+ * `getCommitteeActivity` is a public method a future non-HTTP caller could invoke directly — a
+ * missing upstream date_to just widens the fetch (over-fetch, trimmed in-memory), which is the
+ * same safe direction ceiling itself takes, rather than 500ing the entire feed.
  */
-function ceilToWholeSecond(iso: string): string {
+function ceilToWholeSecond(iso: string): string | undefined {
   const ms = Date.parse(iso);
+  if (Number.isNaN(ms)) return undefined;
   return new Date(Math.ceil(ms / 1000) * 1000).toISOString();
 }
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -89,6 +89,24 @@ function compareEventsDesc(a: { occurred_at: string; key: string }, b: { occurre
   return b.key.localeCompare(a.key);
 }
 
+/**
+ * Ceils an ISO timestamp to the next whole second. query-service's `date_to` parameter round-trips
+ * through Go's `time.RFC3339` layout server-side (`cmd/service/converters.go`), which has no
+ * fractional-seconds component — sub-second precision is silently truncated before the range
+ * filter is applied. `cursor.before` can carry millisecond precision (`Date.toISOString()` always
+ * emits it, and some upstream sources' own timestamps do too), so sending it verbatim as `date_to`
+ * would shrink the upstream boundary below the true cursor position — under-fetching, not
+ * over-fetching, and permanently excluding same-second siblings before the in-memory `isAfterCursor`
+ * pass ever sees them (the exact failure the compound cursor exists to prevent, reintroduced one
+ * layer upstream). Ceiling instead of truncating guarantees the upstream boundary is never tighter
+ * than the true one; the in-memory pass still applies the exact `(occurred_at, key)` comparison, so
+ * the resulting over-fetch (at most ~1 second of extra rows) is trimmed correctly, not a correctness gap.
+ */
+function ceilToWholeSecond(iso: string): string {
+  const ms = Date.parse(iso);
+  return new Date(Math.ceil(ms / 1000) * 1000).toISOString();
+}
+
 function isAtOrAfterSince(occurredAt: string, since: string | undefined): boolean {
   if (!since) return true;
   const ms = Date.parse(occurredAt);
@@ -131,11 +149,12 @@ export class CommitteeActivityService {
     // keeps small `limit` values (e.g. 1) from starving that guarantee.
     const fetchSize = Math.max(limit + 1, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE);
     // Sent to every leg as an inclusive upstream `date_to` (query-service's date_to is documented
-    // inclusive) — this can over-fetch items exactly at the boundary timestamp, which is fine: the
-    // in-memory isAfterCursor pass below applies the real exclusive-compound-cursor comparison, so
-    // upstream over-inclusion just means a few extra rows get fetched and correctly trimmed, not a
-    // correctness gap.
-    const before = cursor?.before;
+    // inclusive), ceiled to the next whole second — see ceilToWholeSecond's doc comment for why:
+    // upstream truncates sub-second precision, so the raw cursor.before could otherwise shrink the
+    // boundary below the true cursor position. The in-memory isAfterCursor pass (which uses the
+    // exact, un-ceiled cursor.before) is what actually enforces the boundary; the ceiled value here
+    // only bounds what gets fetched, so a wider upstream window is always safe, a narrower one isn't.
+    const before = cursor ? ceilToWholeSecond(cursor.before) : undefined;
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([
       this.fetchCommittee(req, committeeUid),

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -478,29 +478,39 @@ export class CommitteeActivityService {
     // is PastMeeting for meetingType 'v1_past_meeting' (same cast PastMeetingController itself uses).
     const { data: meetings } = (await this.meetingService.getMeetings(req, query, 'v1_past_meeting', false)) as { data: PastMeeting[] };
 
-    return meetings.map((meeting) => {
+    // Tripwire for the "meetings is exact" claim in getCommitteeActivity's fetchSize comment — a
+    // documented-but-silent regression is worse than no documentation, so make it observable: if a
+    // real scheduled_start_time (not absent/zero-date/unparseable) ever shows up on a row and
+    // differs from start_time, the upstream contract this leg's date_field narrowing relies on has
+    // changed. Counted across the page and logged once, not once per row — the scenario this
+    // catches is upstream flipping a field on every future row of an entire resource type, so a
+    // per-row warning would mean up to `fetchSize` near-identical log lines per request, on every
+    // request, indefinitely, the moment it happened — noise that would bury the one signal it exists
+    // to surface, not amplify it.
+    let contractBreachCount = 0;
+    const events = meetings.map((meeting) => {
       const startMs = getPastMeetingStartTimeMs(meeting);
       const occurredAt = startMs !== null ? new Date(startMs).toISOString() : '';
-      // Tripwire for the "meetings is exact" claim in getCommitteeActivity's fetchSize comment —
-      // a documented-but-silent regression is worse than no documentation, so make it observable: if
-      // a real scheduled_start_time (not absent/zero-date/unparseable) ever shows up and differs from
-      // start_time, the upstream contract this leg's date_field narrowing relies on has changed.
       const scheduledStartTime = firstValidTimestamp(meeting.scheduled_start_time);
       if (scheduledStartTime && Date.parse(scheduledStartTime) !== Date.parse(meeting.start_time)) {
-        logger.warning(
-          req,
-          'get_committee_activity',
-          'v1_past_meeting row carries a real scheduled_start_time differing from start_time — date_field narrowing on start_time may no longer be exact for this leg',
-          { committee_uid: committeeUid, meeting_id: meeting.id }
-        );
+        contractBreachCount++;
       }
       return {
-        type: 'meeting_held',
+        type: 'meeting_held' as const,
         occurred_at: occurredAt,
         committee_uid: committeeUid,
         payload: { meeting_id: meeting.id, meeting_occurrence_id: getPastMeetingResourceId(meeting), title: meeting.title },
       };
     });
+    if (contractBreachCount > 0) {
+      logger.warning(
+        req,
+        'get_committee_activity',
+        'One or more v1_past_meeting rows carry a real scheduled_start_time differing from start_time — date_field narrowing on start_time may no longer be exact for this leg',
+        { committee_uid: committeeUid, affected_row_count: contractBreachCount, total_rows: meetings.length }
+      );
+    }
+    return events;
   }
 
   // ─── Votes → vote_opened | vote_closed ─────────────────────────────────────

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -305,7 +305,10 @@ export class CommitteeActivityService {
       throw new ResourceNotFoundError('Committee', committeeUid, {
         operation: 'get_committee_activity',
         service: 'committee_service',
-        path: `/committees/${committeeUid}`,
+        // encodeURIComponent — matches the request path above. BaseApiError.toResponse() spreads
+        // `path` into the 404 body, so an unencoded value here would diverge from what was actually
+        // requested in a field the client can see, not just in a log.
+        path: `/committees/${encodeURIComponent(committeeUid)}`,
       });
     }
     return committee;

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -44,7 +44,11 @@ function timestampValue(timestamp: string): number {
  * own natural uid, prefixed by source so ids from different sources can never collide. Documents
  * additionally discriminate by document_type — folders, links, and files are three distinct
  * upstream uid namespaces, so `document_uid` alone could collide across them (e.g. a folder and a
- * file coincidentally sharing a uid), which would silently drop one from the merge under a shared key.
+ * file coincidentally sharing a uid). A collision doesn't drop anything from a single unpaginated
+ * merge (nothing here dedups by key) — the real risk is at the cursor boundary:
+ * `compareEventsDesc` would treat two same-timestamp, same-key events as equal, so once one of
+ * them is returned, `isAfterCursor` excludes both on the next page, permanently dropping the
+ * other. See the paginated collision test in the spec.
  */
 function eventKey(event: ActivityEvent): string {
   switch (event.type) {
@@ -126,6 +130,11 @@ export class CommitteeActivityService {
     // per-source fetch could silently under-represent a dominant source. ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE
     // keeps small `limit` values (e.g. 1) from starving that guarantee.
     const fetchSize = Math.max(limit + 1, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE);
+    // Sent to every leg as an inclusive upstream `date_to` (query-service's date_to is documented
+    // inclusive) — this can over-fetch items exactly at the boundary timestamp, which is fine: the
+    // in-memory isAfterCursor pass below applies the real exclusive-compound-cursor comparison, so
+    // upstream over-inclusion just means a few extra rows get fetched and correctly trimmed, not a
+    // correctness gap.
     const before = cursor?.before;
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -41,7 +41,10 @@ function timestampValue(timestamp: string): number {
 /**
  * Stable per-event identifier for sort tiebreaking and cursor keying — NOT part of the
  * `ActivityEvent` wire contract, purely a server-internal sort/pagination detail. Each source's
- * own natural uid, prefixed by source so ids from different sources can never collide.
+ * own natural uid, prefixed by source so ids from different sources can never collide. Documents
+ * additionally discriminate by document_type — folders, links, and files are three distinct
+ * upstream uid namespaces, so `document_uid` alone could collide across them (e.g. a folder and a
+ * file coincidentally sharing a uid), which would silently drop one from the merge under a shared key.
  */
 function eventKey(event: ActivityEvent): string {
   switch (event.type) {
@@ -54,7 +57,7 @@ function eventKey(event: ActivityEvent): string {
     case 'survey_closed':
       return `survey:${event.payload.survey_uid}`;
     case 'document_uploaded':
-      return `document:${event.payload.document_uid}`;
+      return `document:${event.payload.document_type}:${event.payload.document_uid}`;
     default:
       // Deferred types are never constructed in v1 (see activity-event.interface.ts) — occurred_at
       // is the least-bad fallback key if one ever were.
@@ -69,10 +72,16 @@ function eventKey(event: ActivityEvent): string {
  * same-timestamp events is "first" would depend on source-fetch order, making the cursor
  * (`isAfterCursor` below) unable to draw a stable line between "already returned" and "not yet
  * returned" among them.
+ *
+ * Compares the two numeric timestamps explicitly rather than subtracting them — `a - b` on two
+ * `-Infinity` values (both events have an unparseable/absent occurred_at) is `NaN`, which is
+ * `!== 0` and would skip the key tiebreak entirely, leaving that pair's order non-deterministic
+ * exactly when the tiebreak matters most.
  */
 function compareEventsDesc(a: { occurred_at: string; key: string }, b: { occurred_at: string; key: string }): number {
-  const byTime = timestampValue(b.occurred_at) - timestampValue(a.occurred_at);
-  if (byTime !== 0) return byTime;
+  const aTime = timestampValue(a.occurred_at);
+  const bTime = timestampValue(b.occurred_at);
+  if (aTime !== bTime) return bTime > aTime ? 1 : -1;
   return b.key.localeCompare(a.key);
 }
 
@@ -121,11 +130,11 @@ export class CommitteeActivityService {
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
-      this.fetchPastMeetingEvents(req, committeeUid, fetchSize).catch((err) => {
+      this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
         return [];
       }),
-      this.fetchVoteEvents(req, committeeUid, fetchSize).catch((err) => {
+      this.fetchVoteEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch vote activity, continuing without it', { committee_uid: committeeUid, err });
         return [];
       }),
@@ -189,14 +198,22 @@ export class CommitteeActivityService {
 
   // ─── Past Meetings → meeting_held ──────────────────────────────────────────
 
-  private async fetchPastMeetingEvents(req: Request, committeeUid: string, fetchSize: number): Promise<ActivityEvent[]> {
-    // No date_field/date_from/date_to on this leg — occurred_at is derived via
-    // getPastMeetingStartTimeMs, which prefers scheduled_start_time and falls back to start_time,
-    // so a single upstream date_field can't represent that fallback and would silently exclude a
-    // row whose in-window value lives on the field NOT selected (this leg has no in-memory
-    // recovery path once upstream never returns the row at all). NAME_DESC already sorts by
-    // start_time (see the sort comment below), and fetchSize + the since/cursor filter in
-    // getCommitteeActivity bound and narrow the result correctly without it.
+  private async fetchPastMeetingEvents(
+    req: Request,
+    committeeUid: string,
+    since: string | undefined,
+    before: string | undefined,
+    fetchSize: number
+  ): Promise<ActivityEvent[]> {
+    // date_field: 'start_time' is best-effort narrowing, not a correctness guarantee — occurred_at
+    // is actually derived via getPastMeetingStartTimeMs, which prefers scheduled_start_time and
+    // falls back to start_time, so a row whose in-window value lives on scheduled_start_time while
+    // start_time is a Go zero-date could be excluded upstream before this leg ever sees it. Sending
+    // no upstream narrowing at all traded this rare miss for hard truncation at fetchSize on every
+    // page instead (a strictly worse failure mode) — every leg in this service carries some version
+    // of this same single-field-vs-fallback-derivation approximation; the in-memory since/cursor
+    // pass in getCommitteeActivity is the correctness backstop against over-inclusion, not under-inclusion.
+    const hasWindow = !!since || !!before;
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
@@ -205,6 +222,9 @@ export class CommitteeActivityService {
       // start_time-ordered sort this leg actually needs; UPDATED_DESC sorts by index update time,
       // unrelated to occurred_at.
       sort: PAST_MEETING_SORT.NAME_DESC,
+      ...(hasWindow && { date_field: 'start_time' }),
+      ...(since && { date_from: since }),
+      ...(before && { date_to: before }),
     };
 
     // access=false — the activity row only needs title/start_time, not per-meeting writer flags,
@@ -227,15 +247,26 @@ export class CommitteeActivityService {
 
   // ─── Votes → vote_opened | vote_closed ─────────────────────────────────────
 
-  private async fetchVoteEvents(req: Request, committeeUid: string, fetchSize: number): Promise<(VoteOpenedActivityEvent | VoteClosedActivityEvent)[]> {
-    // No date_field/date_from/date_to on this leg, same rationale as fetchPastMeetingEvents — a
-    // vote's occurred_at is end_time/early_end_time/last_modified_time/creation_time depending on
-    // status, not a single field a `date_field` param can represent. sort: 'updated_desc' + the
-    // since/cursor filter in getCommitteeActivity bound and narrow the result correctly instead.
+  private async fetchVoteEvents(
+    req: Request,
+    committeeUid: string,
+    since: string | undefined,
+    before: string | undefined,
+    fetchSize: number
+  ): Promise<(VoteOpenedActivityEvent | VoteClosedActivityEvent)[]> {
+    // date_field: 'last_modified_time' is best-effort narrowing, same caveat as
+    // fetchPastMeetingEvents — a vote's occurred_at is actually
+    // end_time/early_end_time/last_modified_time/creation_time depending on status, not always
+    // last_modified_time. See fetchPastMeetingEvents's comment for why narrowing (imperfectly) beats
+    // not narrowing at all.
+    const hasWindow = !!since || !!before;
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
+      ...(hasWindow && { date_field: 'last_modified_time' }),
+      ...(since && { date_from: since }),
+      ...(before && { date_to: before }),
     };
 
     const { data: votes } = await this.voteService.getVotes(req, query);
@@ -276,9 +307,10 @@ export class CommitteeActivityService {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
-      // Unlike meetings/votes, last_modified_at genuinely is occurred_at's primary field here
-      // (firstValidTimestamp(survey.last_modified_at, survey.created_at)) — no fallback-field
-      // mismatch, so upstream narrowing on it is safe, not just best-effort.
+      // Best-effort narrowing, same caveat as fetchPastMeetingEvents — occurred_at is
+      // firstValidTimestamp(survey.last_modified_at, survey.created_at), so a never-modified
+      // survey (last_modified_at is the Go zero-date, created_at is the real value) could be
+      // excluded upstream on this field before the in-memory backstop ever sees it.
       ...(hasWindow && { date_field: 'last_modified_at' }),
       ...(since && { date_from: since }),
       ...(before && { date_to: before }),
@@ -331,6 +363,8 @@ export class CommitteeActivityService {
           tags: `committee_uid:${committeeUid}`,
           page_size: fetchSize,
           sort: 'updated_desc',
+          // Best-effort narrowing, same caveat as the survey leg above — occurred_at is
+          // firstValidTimestamp(file.updated_at, file.created_at).
           ...(hasWindow && { date_field: 'updated_at' }),
           ...(since && { date_from: since }),
           ...(before && { date_to: before }),
@@ -380,6 +414,21 @@ export class CommitteeActivityService {
   }
 }
 
+/**
+ * Pre-merge bound for a leg with no upstream page_size (folders/links) — sorts by occurred_at desc
+ * and keeps the newest `limit`. Compares the two numeric timestamps explicitly rather than
+ * subtracting them, same reasoning as `compareEventsDesc`: `a - b` on two `-Infinity` values
+ * (both items have an unparseable/absent occurred_at) is `NaN`, not `0`, which would make the
+ * relative order of same-invalid-timestamp items — and therefore which ones survive the slice —
+ * implementation-defined instead of deterministic.
+ */
 function boundedSortDesc<T extends { occurred_at: string }>(events: T[], limit: number): T[] {
-  return [...events].sort((a, b) => timestampValue(b.occurred_at) - timestampValue(a.occurred_at)).slice(0, limit);
+  return [...events]
+    .sort((a, b) => {
+      const aTime = timestampValue(a.occurred_at);
+      const bTime = timestampValue(b.occurred_at);
+      if (aTime === bTime) return 0;
+      return bTime > aTime ? 1 : -1;
+    })
+    .slice(0, limit);
 }

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -172,12 +172,20 @@ export class CommitteeActivityService {
     // per-source fetch could silently under-represent a dominant source. ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE
     // keeps small `limit` values (e.g. 1) from starving that. This is NOT an airtight guarantee for
     // every leg, though: it only holds if each source's upstream page already contains its own true
-    // top-(limit+1) by occurred_at — true for meetings (NAME_DESC ≈ start_time) and surveys/files
-    // (sorted by the same field occurred_at derives from), but NOT for votes, which sort by
-    // `updated_desc` while occurred_at derives from end_time/early_end_time/creation_time — a
-    // closed vote with a recent end_time but a stale last_modified_time could fall outside the
-    // fetched page. Same class of approximation as the per-leg date_field caveats below, just in
-    // the sort dimension instead of the filter dimension.
+    // top-(limit+1) by occurred_at — true only for meetings (`sort: NAME_DESC` resolves to
+    // query-service's `sort_name`, which the meeting-service indexer populates from `start_time`,
+    // the same field `occurred_at` derives from). Votes, surveys, AND files are all in the opposite
+    // bucket: query-service's `sort=updated_desc` resolves to the INDEX's own root-level `updated_at`
+    // (verified against `cmd/service/converters.go` — `SortBy = "updated_at"`, no `data.` prefix),
+    // which the indexer contract documents as index-write/audit metadata, NOT a copy of any `data.*`
+    // domain field — completely distinct from the `date_field` values these same three legs filter
+    // on (`data.last_modified_at` / `data.updated_at` / vote's `data.last_modified_time`, each
+    // auto-prefixed with `data.` by query-service, unlike `sort`). So "sorted by the same field
+    // occurred_at derives from" was never true for surveys/files either — all three non-meeting legs
+    // share the identical sort-vs-filter mismatch, just via a coincidentally-matching field NAME for
+    // surveys/files (`updated_at`/`last_modified_at`) that resolves to a completely different actual
+    // field once query-service applies its `data.` prefixing rule. Same class of approximation as the
+    // per-leg date_field caveats below, just in the sort dimension instead of the filter dimension.
     //
     // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files
     // are each bounded to a single upstream page of `fetchSize` rows.

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -1,12 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 // import type — erased entirely at compile time, so unlike the enums/utils imports below, this
 // one needs no vi.mock in the spec (same reasoning as activity-feed.utils.ts's own interfaces import).
 import type {
   ActivityEvent,
   Committee,
+  CommitteeActivityDocumentFile,
+  CommitteeActivityFolder,
+  CommitteeActivityLink,
+  CommitteeActivityQuery,
   DocumentUploadedActivityEvent,
   PaginatedResponse,
   PastMeeting,
@@ -18,7 +23,7 @@ import type {
   VoteClosedActivityEvent,
   VoteOpenedActivityEvent,
 } from '@lfx-one/shared/interfaces';
-import { firstValidTimestamp, getPastMeetingStartTimeMs, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { firstValidTimestamp, getPastMeetingResourceId, getPastMeetingStartTimeMs, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { encodeActivityPageToken } from '../helpers/committee-activity-query.helper';
@@ -26,45 +31,6 @@ import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 import { VoteService } from './vote.service';
-
-/** Options resolved by `parseCommitteeActivityQuery` and passed straight through. */
-export interface CommitteeActivityOptions {
-  since?: string;
-  before?: string;
-  limit: number;
-}
-
-/**
- * Lower bound on the per-source `page_size` requested from each upstream leg — independent of
- * `limit` so a small `limit` (e.g. 1) still gives the k-way merge (see `getCommitteeActivity`)
- * enough candidates per source to be correct, not just fast.
- */
-const MIN_SOURCE_FETCH_SIZE = 25;
-
-/** Upstream response shape for a committee folder (mirrors CommitteeService's own local interface — not exported from there). */
-interface CommitteeActivityFolder {
-  uid: string;
-  name: string;
-  created_at?: string;
-  updated_at?: string;
-}
-
-/** Upstream response shape for a committee link. */
-interface CommitteeActivityLink {
-  uid: string;
-  name: string;
-  url?: string;
-  created_at?: string;
-  updated_at?: string;
-}
-
-/** Query-service shape for an indexed `committee_document` (file) resource. */
-interface CommitteeActivityDocumentFile {
-  uid: string;
-  name: string;
-  created_at?: string;
-  updated_at?: string;
-}
 
 function timestampValue(timestamp: string): number {
   const parsed = Date.parse(timestamp);
@@ -76,11 +42,18 @@ function sortDescByOccurredAt<T extends { occurred_at: string }>(events: T[]): T
 }
 
 /**
- * True when `occurredAt` falls within `[since, before)`. Used to apply the activity window
- * in-memory for the two committee-document legs (folders/links) that have no upstream date
- * param. An unparseable/missing timestamp is excluded whenever a window is active — it can't be
- * verified to belong in the window — but kept when there's no window (matches the old client-side
- * feed, which sorted an invalid timestamp to the bottom rather than dropping it).
+ * True when `occurredAt` falls within `[since, before)` — the single source of truth for window
+ * membership, applied to the full merged pool in `getCommitteeActivity` (not per-source). Per-leg
+ * upstream `date_from`/`date_to` are best-effort narrowing only: query-service's `date_to` is
+ * documented *inclusive*, while this endpoint's cursor contract is exclusive, and two legs
+ * (committee folders/links) accept no date param at all — relying on any single leg's upstream
+ * filtering for correctness would both re-return a page's boundary item forever (the inclusive/
+ * exclusive mismatch) and miss folders/links entirely. Applying this filter once, centrally, after
+ * every source has computed its real `occurred_at`, is correct regardless of what each leg's
+ * upstream filtering did or didn't narrow. An unparseable/missing timestamp is excluded whenever a
+ * window is active — it can't be verified to belong in the window — but kept when there's no
+ * window (matches the old client-side feed, which sorted an invalid timestamp to the bottom rather
+ * than dropping it).
  */
 function isWithinWindow(occurredAt: string, since: string | undefined, before: string | undefined): boolean {
   if (!since && !before) return true;
@@ -109,14 +82,14 @@ export class CommitteeActivityService {
     this.voteService = new VoteService();
   }
 
-  public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityOptions): Promise<PaginatedResponse<ActivityEvent>> {
+  public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityQuery): Promise<PaginatedResponse<ActivityEvent>> {
     const { since, before, limit } = options;
     // Fetching `limit + 1` from EACH source (not just `limit`) guarantees the true global
     // top-(limit+1) merged-by-occurred_at result is present in the fetched pool, even in the
     // worst case where a single source contributes every one of the top items — a smaller
-    // per-source fetch could silently under-represent a dominant source. MIN_SOURCE_FETCH_SIZE
+    // per-source fetch could silently under-represent a dominant source. ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE
     // keeps small `limit` values (e.g. 1) from starving that guarantee.
-    const fetchSize = Math.max(limit + 1, MIN_SOURCE_FETCH_SIZE);
+    const fetchSize = Math.max(limit + 1, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE);
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
@@ -147,12 +120,20 @@ export class CommitteeActivityService {
     // Pure chronological merge — no per-source pre-cap. Each source already carries at most
     // fetchSize items (bounded above), and a global sort+slice already picks the true top `limit`
     // by time regardless of which source they came from; an artificial per-source quota would only
-    // make this LESS "time-ordered", not more correct.
-    const merged = sortDescByOccurredAt(sources.flat());
+    // make this LESS "time-ordered", not more correct. The window filter runs here, once, against
+    // every source's computed occurred_at — see isWithinWindow's doc comment for why per-leg
+    // upstream filtering alone isn't sufficient.
+    const windowed = sources.flat().filter((event) => isWithinWindow(event.occurred_at, since, before));
+    const merged = sortDescByOccurredAt(windowed);
 
     const hasMore = merged.length > limit;
     const data = merged.slice(0, limit);
-    const pageToken = hasMore ? encodeActivityPageToken(data[data.length - 1].occurred_at) : undefined;
+    // Cursor from the last item with a real timestamp, not necessarily data[data.length - 1] —
+    // an event with no usable timestamp sorts last (timestampValue('') === -Infinity) but would
+    // produce a page_token that fails isParseableTimestamp on the very next request. Omitting the
+    // token entirely in that case is safer than a token the server itself can't decode.
+    const cursorTimestamp = [...data].reverse().find((event) => event.occurred_at)?.occurred_at;
+    const pageToken = hasMore && cursorTimestamp ? encodeActivityPageToken(cursorTimestamp) : undefined;
 
     logger.debug(req, 'get_committee_activity', 'Completed committee activity aggregation', {
       committee_uid: committeeUid,
@@ -190,7 +171,15 @@ export class CommitteeActivityService {
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
-      sort: 'updated_desc',
+      // NAME_DESC, not UPDATED_DESC — the meeting-service indexer populates sort_name from
+      // start_time (packages/shared/src/constants/meeting.constants.ts), so NAME_DESC is the
+      // start_time-ordered sort this leg actually needs; UPDATED_DESC sorts by index update time,
+      // unrelated to occurred_at.
+      sort: PAST_MEETING_SORT.NAME_DESC,
+      // Best-effort narrowing only — occurred_at is actually derived via getPastMeetingStartTimeMs
+      // (prefers scheduled_start_time, falls back to start_time), so filtering upstream on
+      // start_time alone can miss a row whose scheduled_start_time is the real, in-window value.
+      // The isWithinWindow pass in getCommitteeActivity is the correctness backstop.
       ...(hasWindow && { date_field: 'start_time' }),
       ...(since && { date_from: since }),
       ...(before && { date_to: before }),
@@ -209,7 +198,7 @@ export class CommitteeActivityService {
         type: 'meeting_held',
         occurred_at: occurredAt,
         committee_uid: committeeUid,
-        payload: { meeting_id: meeting.id, title: meeting.title },
+        payload: { meeting_id: meeting.id, meeting_occurrence_id: getPastMeetingResourceId(meeting), title: meeting.title },
       };
     });
   }
@@ -228,8 +217,9 @@ export class CommitteeActivityService {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
-      // last_modified_time, not creation_time — a vote closed recently but created long ago
-      // must still fall inside a "recent activity" window; creation_time would wrongly exclude it.
+      // Best-effort narrowing only (see fetchPastMeetingEvents) — a vote's occurred_at is derived
+      // from end_time/early_end_time when closed, creation_time when open, not always
+      // last_modified_time. The isWithinWindow pass in getCommitteeActivity is the backstop.
       ...(hasWindow && { date_field: 'last_modified_time' }),
       ...(since && { date_from: since }),
       ...(before && { date_to: before }),
@@ -336,6 +326,9 @@ export class CommitteeActivityService {
         }),
     ]);
 
+    // Folders/links have no upstream date param at all (confirmed gap — neither REST endpoint
+    // accepts one), so their window filtering happens entirely in getCommitteeActivity's
+    // isWithinWindow pass, same as every other source.
     const folderEvents = folders.map((folder) =>
       this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at))
     );
@@ -346,11 +339,7 @@ export class CommitteeActivityService {
       this.buildDocumentEvent(committeeUid, file.uid, file.name, 'file', firstValidTimestamp(file.updated_at, file.created_at))
     );
 
-    // Folders/links have no upstream date param (confirmed gap — neither REST endpoint accepts
-    // one) — the window is applied here instead. Harmless no-op for the files leg, already
-    // upstream-filtered.
-    const merged = [...folderEvents, ...linkEvents, ...fileEvents];
-    return hasWindow ? merged.filter((event) => isWithinWindow(event.occurred_at, since, before)) : merged;
+    return [...folderEvents, ...linkEvents, ...fileEvents];
   }
 
   private buildDocumentEvent(

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -172,29 +172,33 @@ export class CommitteeActivityService {
     // per-source fetch could silently under-represent a dominant source. ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE
     // keeps small `limit` values (e.g. 1) from starving that. This is NOT an airtight guarantee for
     // every leg, though: it only holds if each source's upstream page already contains its own true
-    // top-(limit+1) by occurred_at — closest to true for meetings, not exact even there:
-    // `sort: NAME_DESC` resolves to query-service's `sort_name`, which the meeting-service indexer
-    // populates from `start_time` only, while occurred_at (getPastMeetingStartTimeMs) prefers
-    // scheduled_start_time and falls back to start_time — upstream documents these as genuinely
-    // different values (scheduled vs. actual Zoom start), so a meeting that started late/early
-    // relative to its schedule sorts slightly off from its true occurred_at position. Meetings is
-    // still the best-behaved leg here because sort and occurred_at at least track the same
-    // underlying event (this meeting's own start), off by at most the schedule-vs-actual skew,
-    // unlike the other three legs. Votes, surveys, AND files are all in a categorically worse
-    // bucket: query-service's `sort=updated_desc` resolves to the INDEX's own root-level `updated_at`
-    // (verified against `cmd/service/converters.go` — `SortBy = "updated_at"`, no `data.` prefix),
-    // which the indexer contract documents as index-write/audit metadata, NOT a copy of any `data.*`
-    // domain field — completely distinct from the `date_field` values these same three legs filter
-    // on (`data.last_modified_at` / `data.updated_at` / vote's `data.last_modified_time`, each
-    // auto-prefixed with `data.` by query-service, unlike `sort`). So "sorted by the same field
-    // occurred_at derives from" was never true for surveys/files either — all three non-meeting legs
-    // share the identical sort-vs-filter mismatch. The old claim's plausible-looking half is files
-    // only, via a coincidentally-matching field NAME (`updated_at` == `updated_at`) that resolves to
-    // a completely different actual field once query-service's `data.` prefixing is applied; for
-    // surveys the field names never matched in the first place (`last_modified_at` vs. `updated_at`),
-    // so that leg's claim was unfounded from the start, not merely misled by a name coincidence.
-    // Same class of approximation as the per-leg date_field caveats below, just in the sort
-    // dimension instead of the filter dimension.
+    // top-(limit+1) by occurred_at.
+    //
+    // Meetings: `sort: NAME_DESC` resolves to query-service's `sort_name`, which the meeting-service
+    // indexer populates from `start_time` (`meeting.constants.ts`'s `PAST_MEETING_SORT` doc comment;
+    // upstream `PastMeetingEventData.SortName()` confirms — its own doc comment calls `StartTime`
+    // "the scheduled start time"). occurred_at (getPastMeetingStartTimeMs) prefers
+    // `scheduled_start_time`, falling back to `start_time` — but the indexed `v1_past_meeting`
+    // projection this leg actually reads has no `scheduled_start_time` field at all
+    // (`PastMeetingEventData` upstream carries only `StartTime`), so that fallback almost always
+    // fires and resolves to the identical value `sort_name` was built from (see the existing
+    // `fetchPastMeetingEvents` comment below, and `meeting.service.ts`'s "frequently omits
+    // scheduled_start_time" note on the same projection). Meetings is effectively exact, not merely
+    // "closest" — the one residual is the rare row where `scheduled_start_time` IS present and
+    // diverges from `start_time`, which per that same "frequently omits" framing is the exception,
+    // not the rule.
+    //
+    // Votes, surveys, and files are all in a different, genuinely-approximate bucket: query-service's
+    // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/
+    // converters.go`: `SortBy = "updated_at"`, no `data.` prefix), which the indexer contract
+    // documents as index-write/audit metadata, not a copy of any `data.*` domain field — distinct
+    // from the `date_field` values these three legs filter on (`data.last_modified_at` /
+    // `data.updated_at` / `data.last_modified_time`, each auto-prefixed with `data.` by
+    // query-service, unlike `sort`). Files happens to share a field NAME with the sort target
+    // (`updated_at` == `updated_at`) despite resolving to a different actual field once `data.`
+    // prefixing is applied; surveys' and votes' date_field names don't even coincide with `updated_at`.
+    // Same class of approximation as the per-leg date_field caveats below, just in the sort dimension
+    // instead of the filter dimension.
     //
     // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files
     // are each bounded to a single upstream page of `fetchSize` rows.

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -172,9 +172,15 @@ export class CommitteeActivityService {
     // per-source fetch could silently under-represent a dominant source. ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE
     // keeps small `limit` values (e.g. 1) from starving that. This is NOT an airtight guarantee for
     // every leg, though: it only holds if each source's upstream page already contains its own true
-    // top-(limit+1) by occurred_at — true only for meetings (`sort: NAME_DESC` resolves to
-    // query-service's `sort_name`, which the meeting-service indexer populates from `start_time`,
-    // the same field `occurred_at` derives from). Votes, surveys, AND files are all in the opposite
+    // top-(limit+1) by occurred_at — closest to true for meetings, not exact even there:
+    // `sort: NAME_DESC` resolves to query-service's `sort_name`, which the meeting-service indexer
+    // populates from `start_time` only, while occurred_at (getPastMeetingStartTimeMs) prefers
+    // scheduled_start_time and falls back to start_time — upstream documents these as genuinely
+    // different values (scheduled vs. actual Zoom start), so a meeting that started late/early
+    // relative to its schedule sorts slightly off from its true occurred_at position. Meetings is
+    // still the best-behaved leg here because sort and occurred_at at least track the same
+    // underlying event (this meeting's own start), off by at most the schedule-vs-actual skew,
+    // unlike the other three legs. Votes, surveys, AND files are all in a categorically worse
     // bucket: query-service's `sort=updated_desc` resolves to the INDEX's own root-level `updated_at`
     // (verified against `cmd/service/converters.go` — `SortBy = "updated_at"`, no `data.` prefix),
     // which the indexer contract documents as index-write/audit metadata, NOT a copy of any `data.*`
@@ -182,10 +188,13 @@ export class CommitteeActivityService {
     // on (`data.last_modified_at` / `data.updated_at` / vote's `data.last_modified_time`, each
     // auto-prefixed with `data.` by query-service, unlike `sort`). So "sorted by the same field
     // occurred_at derives from" was never true for surveys/files either — all three non-meeting legs
-    // share the identical sort-vs-filter mismatch, just via a coincidentally-matching field NAME for
-    // surveys/files (`updated_at`/`last_modified_at`) that resolves to a completely different actual
-    // field once query-service applies its `data.` prefixing rule. Same class of approximation as the
-    // per-leg date_field caveats below, just in the sort dimension instead of the filter dimension.
+    // share the identical sort-vs-filter mismatch. The old claim's plausible-looking half is files
+    // only, via a coincidentally-matching field NAME (`updated_at` == `updated_at`) that resolves to
+    // a completely different actual field once query-service's `data.` prefixing is applied; for
+    // surveys the field names never matched in the first place (`last_modified_at` vs. `updated_at`),
+    // so that leg's claim was unfounded from the start, not merely misled by a name coincidence.
+    // Same class of approximation as the per-leg date_field caveats below, just in the sort
+    // dimension instead of the filter dimension.
     //
     // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files
     // are each bounded to a single upstream page of `fetchSize` rows.

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
+import { ACTIVITY_FEED_MAX_PAGE_SIZE, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 // import type — erased entirely at compile time, so unlike the enums/utils imports below, this
 // one needs no vi.mock in the spec (same reasoning as activity-feed.utils.ts's own interfaces import).
@@ -28,7 +28,7 @@ import { firstValidTimestamp, getPastMeetingResourceId, getPastMeetingStartTimeM
 import { Request } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
-import { encodeActivityPageToken } from '../helpers/committee-activity-query.helper';
+import { encodeActivityPageToken, normalizeTimestamp } from '../helpers/committee-activity-query.helper';
 import { logger } from './logger.service';
 import { MeetingService } from './meeting.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -154,7 +154,17 @@ export class CommitteeActivityService {
   }
 
   public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityQuery): Promise<PaginatedResponse<ActivityEvent>> {
-    const { since, cursor, limit } = options;
+    const { since: rawSince, cursor, limit } = options;
+    // Same reject-not-degrade policy as the cursor/since checks below, for the same reason:
+    // parseCommitteeActivityQuery already bounds page_size on the HTTP path, but this method is
+    // public and reachable directly. An out-of-range `limit` here degrades silently instead of
+    // rejecting — `limit: 0` yields `windowed.slice(0, 0)`, an empty feed with no error; a negative
+    // `limit` (`slice(0, -1)`) silently drops the newest item while still emitting a page_token.
+    if (!Number.isInteger(limit) || limit < 1 || limit > ACTIVITY_FEED_MAX_PAGE_SIZE) {
+      throw ServiceValidationError.forField('limit', `limit must be an integer between 1 and ${ACTIVITY_FEED_MAX_PAGE_SIZE}`, {
+        operation: 'get_committee_activity',
+      });
+    }
     // Fetching `limit + 1` from EACH source (not just `limit`) is what makes the true global
     // top-(limit+1) merged-by-occurred_at result likely to be present in the fetched pool, even in
     // the worst case where a single source contributes every one of the top items — a smaller
@@ -208,9 +218,16 @@ export class CommitteeActivityService {
     // then rejects every surviving event too (`ms >= Date.parse(since)` is `ms >= NaN`, always
     // false) — a silent empty feed, not the clean rejection this method's cursor handling already
     // guarantees for the equivalent bad-input case.
-    if (since && Number.isNaN(Date.parse(since))) {
+    if (rawSince && Number.isNaN(Date.parse(rawSince))) {
       throw ServiceValidationError.forField('since', 'since must be a valid ISO 8601 timestamp', { operation: 'get_committee_activity' });
     }
+    // normalizeTimestamp — same reason as parseCommitteeActivityQuery's own use of it (see that
+    // function's doc comment): `Date.parse` accepts formats (e.g. a zone-less
+    // `2026-01-05T00:00:00`) that query-service's stricter RFC3339 parser 400s, and that 400 would
+    // otherwise be swallowed into an empty leg by each leg's own .catch — a passably-formatted but
+    // non-normalized `since` would silently thin the feed rather than error, on this direct-caller
+    // path specifically (the HTTP path already normalizes before this method ever sees `since`).
+    const since = rawSince ? normalizeTimestamp(rawSince) : undefined;
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentResult] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
@@ -296,6 +313,11 @@ export class CommitteeActivityService {
       voting_enabled: votingEnabled,
       returned: data.length,
       has_more: hasMore,
+      // Without these two, a line reading `returned: 1, has_more: true` is unexplainable from the
+      // log alone — has_more can now be true without windowed.length exceeding limit, and a leg
+      // count only signals saturation when compared against fetch_size (also not logged elsewhere).
+      any_leg_saturated: anyLegSaturated,
+      fetch_size: fetchSize,
     });
 
     return { data, page_token: pageToken };

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -87,7 +87,12 @@ function compareEventsDesc(a: { occurred_at: string; key: string }, b: { occurre
   const aTime = timestampValue(a.occurred_at);
   const bTime = timestampValue(b.occurred_at);
   if (aTime !== bTime) return bTime > aTime ? 1 : -1;
-  return b.key.localeCompare(a.key);
+  // Codepoint comparison, not localeCompare — locale-aware collation is ICU-build-dependent, so
+  // two server instances on different Node builds could tiebreak two same-timestamp events in a
+  // different order, which would let a cursor issued by one instance skip or repeat an item when
+  // the next page is served by the other.
+  if (b.key === a.key) return 0;
+  return b.key > a.key ? 1 : -1;
 }
 
 /**
@@ -150,11 +155,18 @@ export class CommitteeActivityService {
 
   public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityQuery): Promise<PaginatedResponse<ActivityEvent>> {
     const { since, cursor, limit } = options;
-    // Fetching `limit + 1` from EACH source (not just `limit`) guarantees the true global
-    // top-(limit+1) merged-by-occurred_at result is present in the fetched pool, even in the
-    // worst case where a single source contributes every one of the top items — a smaller
+    // Fetching `limit + 1` from EACH source (not just `limit`) is what makes the true global
+    // top-(limit+1) merged-by-occurred_at result likely to be present in the fetched pool, even in
+    // the worst case where a single source contributes every one of the top items — a smaller
     // per-source fetch could silently under-represent a dominant source. ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE
-    // keeps small `limit` values (e.g. 1) from starving that guarantee.
+    // keeps small `limit` values (e.g. 1) from starving that. This is NOT an airtight guarantee for
+    // every leg, though: it only holds if each source's upstream page already contains its own true
+    // top-(limit+1) by occurred_at — true for meetings (NAME_DESC ≈ start_time) and surveys/files
+    // (sorted by the same field occurred_at derives from), but NOT for votes, which sort by
+    // `updated_desc` while occurred_at derives from end_time/early_end_time/creation_time — a
+    // closed vote with a recent end_time but a stale last_modified_time could fall outside the
+    // fetched page. Same class of approximation as the per-leg date_field caveats below, just in
+    // the sort dimension instead of the filter dimension.
     const fetchSize = Math.max(limit + 1, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE);
     // Sent to every leg as an inclusive upstream `date_to` (query-service's date_to is documented
     // inclusive), ceiled to the next whole second — see ceilToWholeSecond's doc comment for why:
@@ -196,10 +208,9 @@ export class CommitteeActivityService {
       }),
     ]);
 
-    // Committee lookup failure defaults to voting excluded (conservative) rather than included —
-    // we can't confirm enable_voting, and showing vote activity for a committee we couldn't
-    // verify is worse than briefly under-showing it.
-    const votingEnabled = committee?.enable_voting ?? false;
+    // A committee-lookup failure already rejected the whole Promise.all above (see fetchCommittee's
+    // doc comment) — by this line `committee` is always a resolved Committee.
+    const votingEnabled = committee.enable_voting;
     const sources: ActivityEvent[][] = [pastMeetingEvents, votingEnabled ? voteEvents : [], surveyEvents, documentEvents];
 
     // Single pass: attach each event's sort key once, apply since/cursor, sort desc by
@@ -208,18 +219,28 @@ export class CommitteeActivityService {
     // would only make this LESS "time-ordered", not more correct.
     const keyed = sources.flat().map((event) => ({ event, key: eventKey(event) }));
     const windowed = keyed.filter(
-      ({ event, key }) => isAtOrAfterSince(event.occurred_at, since) && isAfterCursor({ occurred_at: event.occurred_at, key }, cursor)
+      ({ event, key }) =>
+        // Drop events with no usable timestamp entirely, rather than keeping them sorted last — an
+        // event that can't be placed in time carries no signal for a feed literally named "Recent
+        // Activity", and worse, isAfterCursor rejects an unparseable occurred_at unconditionally
+        // (correctly — it can't be placed relative to any cursor), so once pagination is in play
+        // such an event would be visible on an unfilled page 1 and then permanently unreachable on
+        // every later page. Dropping it up front means "included" is a stable property, not one
+        // that depends on how many pages the caller has already fetched.
+        timestampValue(event.occurred_at) !== -Infinity &&
+        isAtOrAfterSince(event.occurred_at, since) &&
+        isAfterCursor({ occurred_at: event.occurred_at, key }, cursor)
     );
     windowed.sort((a, b) => compareEventsDesc({ occurred_at: a.event.occurred_at, key: a.key }, { occurred_at: b.event.occurred_at, key: b.key }));
 
     const hasMore = windowed.length > limit;
     const page = windowed.slice(0, limit);
     const data = page.map(({ event }) => event);
-    // Cursor from the last item with a real (parseable) timestamp, not necessarily page's last
-    // entry — an event with no usable timestamp sorts last but would produce a page_token this
-    // server can't decode on the very next request (isParseableTimestamp would reject it).
-    const cursorSource = [...page].reverse().find(({ event }) => timestampValue(event.occurred_at) !== -Infinity);
-    const pageToken = hasMore && cursorSource ? encodeActivityPageToken({ before: cursorSource.event.occurred_at, key: cursorSource.key }) : undefined;
+    // Every item in `page` now has a real timestamp (windowed already dropped the ones that
+    // don't), so the last page item is always a valid cursor position — no need to search backward
+    // for one.
+    const lastPageItem = page.at(-1);
+    const pageToken = hasMore && lastPageItem ? encodeActivityPageToken({ before: lastPageItem.event.occurred_at, key: lastPageItem.key }) : undefined;
 
     logger.debug(req, 'get_committee_activity', 'Completed committee activity aggregation', {
       committee_uid: committeeUid,
@@ -237,11 +258,20 @@ export class CommitteeActivityService {
 
   // ─── Committee (for enable_voting) ─────────────────────────────────────────
 
-  private async fetchCommittee(req: Request, committeeUid: string): Promise<Committee | null> {
-    return this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeUid}`, 'GET').catch((err) => {
-      logger.warning(req, 'get_committee_activity', 'Failed to fetch committee; defaulting votes to excluded', { committee_uid: committeeUid, err });
-      return null;
-    });
+  /**
+   * Unlike every other leg, a failure here is NOT caught-and-degraded by the caller — it's allowed
+   * to reject `getCommitteeActivity`'s `Promise.all` and propagate to the controller's `next(error)`.
+   * `GET /committees/:uid` is the one leg in this fan-out backed by committee-service's real
+   * per-request FGA enforcement (the four `/query/resources` legs instead filter per-resource,
+   * never 403 the whole request — see the controller's docblock); catching a 403/404 here the same
+   * way as the other legs would silently downgrade "caller isn't authorized for this committee at
+   * all" into "votes excluded, everything else renders", which is a materially different, and
+   * wrong, outcome for that case. A transient failure (5xx/network) fails the whole request too —
+   * matching `committee-engagement`'s `assertCommitteeRead`, which fails closed on both a resolved
+   * `false` and a thrown upstream error, rather than treating "couldn't verify" as "verified false".
+   */
+  private async fetchCommittee(req: Request, committeeUid: string): Promise<Committee> {
+    return this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}`, 'GET');
   }
 
   // ─── Past Meetings → meeting_held ──────────────────────────────────────────
@@ -276,7 +306,15 @@ export class CommitteeActivityService {
     };
 
     // access=false — the activity row only needs title/start_time, not per-meeting writer flags,
-    // so skip the access-check call getMeetings otherwise makes for every returned meeting.
+    // so skip the access-check call getMeetings otherwise makes for every returned meeting. Unlike
+    // the survey/file legs below, this one still goes through the full MeetingService.getMeetings
+    // rather than a raw proxyRequest — getMeetings unconditionally enriches with project name and
+    // committee name (packages this leg discards), a known, accepted v1 inefficiency: reimplementing
+    // this leg as a raw query-service call would need to independently reproduce
+    // getPastMeetingStartTimeMs's scheduled_start_time/start_time fallback and the v1_past_meeting
+    // id-normalization getMeetings already does, and it wasn't confirmed those fields survive a raw
+    // (non-normalized) response — not worth that regression risk for a bounded (not per-event),
+    // O(1)-extra-calls efficiency gain.
     // Cast to PastMeeting[] — getMeetings' return type is generic Meeting[], but the actual shape
     // is PastMeeting for meetingType 'v1_past_meeting' (same cast PastMeetingController itself uses).
     const { data: meetings } = (await this.meetingService.getMeetings(req, query, 'v1_past_meeting', false)) as { data: PastMeeting[] };
@@ -394,14 +432,18 @@ export class CommitteeActivityService {
     const hasWindow = !!since || !!before;
 
     const [folders, links, files] = await Promise.all([
-      this.microserviceProxy.proxyRequest<CommitteeActivityFolder[]>(req, 'LFX_V2_SERVICE', `/committees/${committeeUid}/folders`, 'GET').catch((err) => {
-        logger.warning(req, 'get_committee_activity', 'Failed to fetch committee folders, continuing without them', { committee_uid: committeeUid, err });
-        return [] as CommitteeActivityFolder[];
-      }),
-      this.microserviceProxy.proxyRequest<CommitteeActivityLink[]>(req, 'LFX_V2_SERVICE', `/committees/${committeeUid}/links`, 'GET').catch((err) => {
-        logger.warning(req, 'get_committee_activity', 'Failed to fetch committee links, continuing without them', { committee_uid: committeeUid, err });
-        return [] as CommitteeActivityLink[];
-      }),
+      this.microserviceProxy
+        .proxyRequest<CommitteeActivityFolder[]>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}/folders`, 'GET')
+        .catch((err) => {
+          logger.warning(req, 'get_committee_activity', 'Failed to fetch committee folders, continuing without them', { committee_uid: committeeUid, err });
+          return [] as CommitteeActivityFolder[];
+        }),
+      this.microserviceProxy
+        .proxyRequest<CommitteeActivityLink[]>(req, 'LFX_V2_SERVICE', `/committees/${encodeURIComponent(committeeUid)}/links`, 'GET')
+        .catch((err) => {
+          logger.warning(req, 'get_committee_activity', 'Failed to fetch committee links, continuing without them', { committee_uid: committeeUid, err });
+          return [] as CommitteeActivityLink[];
+        }),
       // Single bounded page, not CommitteeService.getCommitteeDocuments's fetchAllQueryResources
       // drain — this endpoint must stay bounded (no per-event follow-ups), so a page_size-limited
       // page is enough for a "recent activity" feed even though it isn't the complete file list.

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -177,17 +177,18 @@ export class CommitteeActivityService {
     // Meetings: `sort: NAME_DESC` resolves to query-service's `sort_name`, which the meeting-service
     // indexer populates from `start_time` (`meeting.constants.ts`'s `PAST_MEETING_SORT` doc comment;
     // upstream `PastMeetingEventData.SortName()` confirms — its own doc comment calls `StartTime`
-    // "the scheduled start time"). occurred_at (getPastMeetingStartTimeMs) prefers
-    // `scheduled_start_time`, falling back to `start_time` when it's absent — `sort_name` and
-    // occurred_at coincide exactly whenever that fallback fires, and can diverge on any row where
-    // `scheduled_start_time` is present and different from `start_time`. How often each case occurs
-    // on the indexed `v1_past_meeting` projection this leg actually reads depends on which upstream
-    // sync path wrote a given row (verified at least one path — the legacy v1-to-v2 migration
-    // handler — populates `start_time` FROM the v1 record's own scheduled time, making the two
-    // identical for rows synced that way; not confirmed for meetings created natively in v2).
-    // Meetings is still the best-behaved of the four legs regardless — sort and occurred_at track
-    // the same underlying event (this meeting's own start) at worst, unlike the categorically
-    // different mismatch on the other three legs below.
+    // "the scheduled start time"). occurred_at (getPastMeetingStartTimeMs, via
+    // firstValidTimestampMs/isRealTimestamp) prefers `scheduled_start_time`, falling back to
+    // `start_time`. The indexed `v1_past_meeting` type this leg reads is sourced exclusively from
+    // ITX/Zoom past-meeting-completion events (`docs/event-processing.md`'s `itx-zoom-past-meetings.`
+    // stream — a "past meeting" is a derived record generated when an occurrence completes, not
+    // something created directly); its source struct `PastMeetingEventData` has no
+    // `scheduled_start_time` JSON field at all (`internal/domain/models/event_models.go`), and the
+    // one handler that builds it populates `StartTime` FROM the raw record's own `ScheduledStartTime`
+    // (`past_meeting_event_handler.go`). So `scheduled_start_time` is never present on a row this leg
+    // can read, the fallback always fires, and `sort_name`/occurred_at are always built from the
+    // identical value — meetings is exact, not merely the best-behaved approximation, unlike the
+    // other three legs below.
     //
     // Votes, surveys, and files are all in a different, genuinely-approximate bucket: query-service's
     // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/
@@ -418,14 +419,16 @@ export class CommitteeActivityService {
     before: string | undefined,
     fetchSize: number
   ): Promise<ActivityEvent[]> {
-    // date_field: 'start_time' is best-effort narrowing, not a correctness guarantee — occurred_at
-    // is actually derived via getPastMeetingStartTimeMs, which prefers scheduled_start_time and
-    // falls back to start_time, so a row whose in-window value lives on scheduled_start_time while
-    // start_time is a Go zero-date could be excluded upstream before this leg ever sees it. Sending
-    // no upstream narrowing at all traded this rare miss for hard truncation at fetchSize on every
-    // page instead (a strictly worse failure mode) — every leg in this service carries some version
-    // of this same single-field-vs-fallback-derivation approximation; the in-memory since/cursor
-    // pass in getCommitteeActivity is the correctness backstop against over-inclusion, not under-inclusion.
+    // date_field: 'start_time' — unlike every other leg's date_field narrowing (all best-effort, see
+    // their own comments), this one IS a correctness guarantee, not just an approximation: occurred_at
+    // (getPastMeetingStartTimeMs) prefers scheduled_start_time, falling back to start_time — but the
+    // indexed v1_past_meeting projection this leg reads never carries scheduled_start_time at all
+    // (see the "Meetings" paragraph in getCommitteeActivity's fetchSize comment for the verified
+    // source), so that fallback always fires and occurred_at is always built from the same start_time
+    // field this date_field narrows on. The in-memory since/cursor pass in getCommitteeActivity is
+    // still the one place that enforces the exact boundary (this narrowing only bounds what's
+    // fetched), but for this leg specifically it can't under-fetch relative to occurred_at the way
+    // the other legs' single-field-vs-fallback-derivation approximations can.
     const hasWindow = !!since || !!before;
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -7,6 +7,7 @@ import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 // one needs no vi.mock in the spec (same reasoning as activity-feed.utils.ts's own interfaces import).
 import type {
   ActivityEvent,
+  ActivityPageCursor,
   Committee,
   CommitteeActivityDocumentFile,
   CommitteeActivityFolder,
@@ -37,31 +38,57 @@ function timestampValue(timestamp: string): number {
   return Number.isNaN(parsed) ? -Infinity : parsed;
 }
 
-function sortDescByOccurredAt<T extends { occurred_at: string }>(events: T[]): T[] {
-  return [...events].sort((a, b) => timestampValue(b.occurred_at) - timestampValue(a.occurred_at));
+/**
+ * Stable per-event identifier for sort tiebreaking and cursor keying — NOT part of the
+ * `ActivityEvent` wire contract, purely a server-internal sort/pagination detail. Each source's
+ * own natural uid, prefixed by source so ids from different sources can never collide.
+ */
+function eventKey(event: ActivityEvent): string {
+  switch (event.type) {
+    case 'meeting_held':
+      return `meeting:${event.payload.meeting_occurrence_id}`;
+    case 'vote_opened':
+    case 'vote_closed':
+      return `vote:${event.payload.vote_uid}`;
+    case 'survey_published':
+    case 'survey_closed':
+      return `survey:${event.payload.survey_uid}`;
+    case 'document_uploaded':
+      return `document:${event.payload.document_uid}`;
+    default:
+      // Deferred types are never constructed in v1 (see activity-event.interface.ts) — occurred_at
+      // is the least-bad fallback key if one ever were.
+      return `deferred:${event.occurred_at}`;
+  }
 }
 
 /**
- * True when `occurredAt` falls within `[since, before)` — the single source of truth for window
- * membership, applied to the full merged pool in `getCommitteeActivity` (not per-source). Per-leg
- * upstream `date_from`/`date_to` are best-effort narrowing only: query-service's `date_to` is
- * documented *inclusive*, while this endpoint's cursor contract is exclusive, and two legs
- * (committee folders/links) accept no date param at all — relying on any single leg's upstream
- * filtering for correctness would both re-return a page's boundary item forever (the inclusive/
- * exclusive mismatch) and miss folders/links entirely. Applying this filter once, centrally, after
- * every source has computed its real `occurred_at`, is correct regardless of what each leg's
- * upstream filtering did or didn't narrow. An unparseable/missing timestamp is excluded whenever a
- * window is active — it can't be verified to belong in the window — but kept when there's no
- * window (matches the old client-side feed, which sorted an invalid timestamp to the bottom rather
- * than dropping it).
+ * Sorts descending by `(occurred_at, key)` — occurred_at first, key as a deterministic tiebreak
+ * when two events share the exact same timestamp (e.g. a batch of documents uploaded in one
+ * request, all sharing `created_at` to the second). Without a tiebreak, which of several
+ * same-timestamp events is "first" would depend on source-fetch order, making the cursor
+ * (`isAfterCursor` below) unable to draw a stable line between "already returned" and "not yet
+ * returned" among them.
  */
-function isWithinWindow(occurredAt: string, since: string | undefined, before: string | undefined): boolean {
-  if (!since && !before) return true;
+function compareEventsDesc(a: { occurred_at: string; key: string }, b: { occurred_at: string; key: string }): number {
+  const byTime = timestampValue(b.occurred_at) - timestampValue(a.occurred_at);
+  if (byTime !== 0) return byTime;
+  return b.key.localeCompare(a.key);
+}
+
+function isAtOrAfterSince(occurredAt: string, since: string | undefined): boolean {
+  if (!since) return true;
   const ms = Date.parse(occurredAt);
   if (Number.isNaN(ms)) return false;
-  if (since && ms < Date.parse(since)) return false;
-  if (before && ms >= Date.parse(before)) return false;
-  return true;
+  return ms >= Date.parse(since);
+}
+
+/** True when `event` sorts strictly after `cursor` in `compareEventsDesc` order — i.e. belongs on the next page. */
+function isAfterCursor(event: { occurred_at: string; key: string }, cursor: ActivityPageCursor | undefined): boolean {
+  if (!cursor) return true;
+  const ms = Date.parse(event.occurred_at);
+  if (Number.isNaN(ms)) return false;
+  return compareEventsDesc(event, { occurred_at: cursor.before, key: cursor.key }) > 0;
 }
 
 /**
@@ -83,21 +110,22 @@ export class CommitteeActivityService {
   }
 
   public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityQuery): Promise<PaginatedResponse<ActivityEvent>> {
-    const { since, before, limit } = options;
+    const { since, cursor, limit } = options;
     // Fetching `limit + 1` from EACH source (not just `limit`) guarantees the true global
     // top-(limit+1) merged-by-occurred_at result is present in the fetched pool, even in the
     // worst case where a single source contributes every one of the top items — a smaller
     // per-source fetch could silently under-represent a dominant source. ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE
     // keeps small `limit` values (e.g. 1) from starving that guarantee.
     const fetchSize = Math.max(limit + 1, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE);
+    const before = cursor?.before;
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentEvents] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
-      this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+      this.fetchPastMeetingEvents(req, committeeUid, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
         return [];
       }),
-      this.fetchVoteEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+      this.fetchVoteEvents(req, committeeUid, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch vote activity, continuing without it', { committee_uid: committeeUid, err });
         return [];
       }),
@@ -117,23 +145,24 @@ export class CommitteeActivityService {
     const votingEnabled = committee?.enable_voting ?? false;
     const sources: ActivityEvent[][] = [pastMeetingEvents, votingEnabled ? voteEvents : [], surveyEvents, documentEvents];
 
-    // Pure chronological merge — no per-source pre-cap. Each source already carries at most
-    // fetchSize items (bounded above), and a global sort+slice already picks the true top `limit`
-    // by time regardless of which source they came from; an artificial per-source quota would only
-    // make this LESS "time-ordered", not more correct. The window filter runs here, once, against
-    // every source's computed occurred_at — see isWithinWindow's doc comment for why per-leg
-    // upstream filtering alone isn't sufficient.
-    const windowed = sources.flat().filter((event) => isWithinWindow(event.occurred_at, since, before));
-    const merged = sortDescByOccurredAt(windowed);
+    // Single pass: attach each event's sort key once, apply since/cursor, sort desc by
+    // (occurred_at, key). No per-source pre-cap — a global sort+slice already picks the true top
+    // `limit` by time regardless of which source they came from; an artificial per-source quota
+    // would only make this LESS "time-ordered", not more correct.
+    const keyed = sources.flat().map((event) => ({ event, key: eventKey(event) }));
+    const windowed = keyed.filter(
+      ({ event, key }) => isAtOrAfterSince(event.occurred_at, since) && isAfterCursor({ occurred_at: event.occurred_at, key }, cursor)
+    );
+    windowed.sort((a, b) => compareEventsDesc({ occurred_at: a.event.occurred_at, key: a.key }, { occurred_at: b.event.occurred_at, key: b.key }));
 
-    const hasMore = merged.length > limit;
-    const data = merged.slice(0, limit);
-    // Cursor from the last item with a real timestamp, not necessarily data[data.length - 1] —
-    // an event with no usable timestamp sorts last (timestampValue('') === -Infinity) but would
-    // produce a page_token that fails isParseableTimestamp on the very next request. Omitting the
-    // token entirely in that case is safer than a token the server itself can't decode.
-    const cursorTimestamp = [...data].reverse().find((event) => event.occurred_at)?.occurred_at;
-    const pageToken = hasMore && cursorTimestamp ? encodeActivityPageToken(cursorTimestamp) : undefined;
+    const hasMore = windowed.length > limit;
+    const page = windowed.slice(0, limit);
+    const data = page.map(({ event }) => event);
+    // Cursor from the last item with a real (parseable) timestamp, not necessarily page's last
+    // entry — an event with no usable timestamp sorts last but would produce a page_token this
+    // server can't decode on the very next request (isParseableTimestamp would reject it).
+    const cursorSource = [...page].reverse().find(({ event }) => timestampValue(event.occurred_at) !== -Infinity);
+    const pageToken = hasMore && cursorSource ? encodeActivityPageToken({ before: cursorSource.event.occurred_at, key: cursorSource.key }) : undefined;
 
     logger.debug(req, 'get_committee_activity', 'Completed committee activity aggregation', {
       committee_uid: committeeUid,
@@ -160,14 +189,14 @@ export class CommitteeActivityService {
 
   // ─── Past Meetings → meeting_held ──────────────────────────────────────────
 
-  private async fetchPastMeetingEvents(
-    req: Request,
-    committeeUid: string,
-    since: string | undefined,
-    before: string | undefined,
-    fetchSize: number
-  ): Promise<ActivityEvent[]> {
-    const hasWindow = !!since || !!before;
+  private async fetchPastMeetingEvents(req: Request, committeeUid: string, fetchSize: number): Promise<ActivityEvent[]> {
+    // No date_field/date_from/date_to on this leg — occurred_at is derived via
+    // getPastMeetingStartTimeMs, which prefers scheduled_start_time and falls back to start_time,
+    // so a single upstream date_field can't represent that fallback and would silently exclude a
+    // row whose in-window value lives on the field NOT selected (this leg has no in-memory
+    // recovery path once upstream never returns the row at all). NAME_DESC already sorts by
+    // start_time (see the sort comment below), and fetchSize + the since/cursor filter in
+    // getCommitteeActivity bound and narrow the result correctly without it.
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
@@ -176,13 +205,6 @@ export class CommitteeActivityService {
       // start_time-ordered sort this leg actually needs; UPDATED_DESC sorts by index update time,
       // unrelated to occurred_at.
       sort: PAST_MEETING_SORT.NAME_DESC,
-      // Best-effort narrowing only — occurred_at is actually derived via getPastMeetingStartTimeMs
-      // (prefers scheduled_start_time, falls back to start_time), so filtering upstream on
-      // start_time alone can miss a row whose scheduled_start_time is the real, in-window value.
-      // The isWithinWindow pass in getCommitteeActivity is the correctness backstop.
-      ...(hasWindow && { date_field: 'start_time' }),
-      ...(since && { date_from: since }),
-      ...(before && { date_to: before }),
     };
 
     // access=false — the activity row only needs title/start_time, not per-meeting writer flags,
@@ -205,24 +227,15 @@ export class CommitteeActivityService {
 
   // ─── Votes → vote_opened | vote_closed ─────────────────────────────────────
 
-  private async fetchVoteEvents(
-    req: Request,
-    committeeUid: string,
-    since: string | undefined,
-    before: string | undefined,
-    fetchSize: number
-  ): Promise<(VoteOpenedActivityEvent | VoteClosedActivityEvent)[]> {
-    const hasWindow = !!since || !!before;
+  private async fetchVoteEvents(req: Request, committeeUid: string, fetchSize: number): Promise<(VoteOpenedActivityEvent | VoteClosedActivityEvent)[]> {
+    // No date_field/date_from/date_to on this leg, same rationale as fetchPastMeetingEvents — a
+    // vote's occurred_at is end_time/early_end_time/last_modified_time/creation_time depending on
+    // status, not a single field a `date_field` param can represent. sort: 'updated_desc' + the
+    // since/cursor filter in getCommitteeActivity bound and narrow the result correctly instead.
     const query: Record<string, unknown> = {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
-      // Best-effort narrowing only (see fetchPastMeetingEvents) — a vote's occurred_at is derived
-      // from end_time/early_end_time when closed, creation_time when open, not always
-      // last_modified_time. The isWithinWindow pass in getCommitteeActivity is the backstop.
-      ...(hasWindow && { date_field: 'last_modified_time' }),
-      ...(since && { date_from: since }),
-      ...(before && { date_to: before }),
     };
 
     const { data: votes } = await this.voteService.getVotes(req, query);
@@ -263,6 +276,9 @@ export class CommitteeActivityService {
       tags: `committee_uid:${committeeUid}`,
       page_size: fetchSize,
       sort: 'updated_desc',
+      // Unlike meetings/votes, last_modified_at genuinely is occurred_at's primary field here
+      // (firstValidTimestamp(survey.last_modified_at, survey.created_at)) — no fallback-field
+      // mismatch, so upstream narrowing on it is safe, not just best-effort.
       ...(hasWindow && { date_field: 'last_modified_at' }),
       ...(since && { date_from: since }),
       ...(before && { date_to: before }),
@@ -326,14 +342,19 @@ export class CommitteeActivityService {
         }),
     ]);
 
-    // Folders/links have no upstream date param at all (confirmed gap — neither REST endpoint
-    // accepts one), so their window filtering happens entirely in getCommitteeActivity's
-    // isWithinWindow pass, same as every other source.
-    const folderEvents = folders.map((folder) =>
-      this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at))
+    // GET /committees/:id/folders and /links accept no page_size/date param at all and return
+    // every folder/link on the committee unconditionally — bound each to fetchSize here (sorted
+    // by its own occurred_at desc) so this leg can't return an unbounded candidate pool. The
+    // since/cursor window itself is applied once, centrally, in getCommitteeActivity.
+    const folderEvents = boundedSortDesc(
+      folders.map((folder) =>
+        this.buildDocumentEvent(committeeUid, folder.uid, folder.name, 'folder', firstValidTimestamp(folder.updated_at, folder.created_at))
+      ),
+      fetchSize
     );
-    const linkEvents = links.map((link) =>
-      this.buildDocumentEvent(committeeUid, link.uid, link.name, 'link', firstValidTimestamp(link.updated_at, link.created_at), link.url)
+    const linkEvents = boundedSortDesc(
+      links.map((link) => this.buildDocumentEvent(committeeUid, link.uid, link.name, 'link', firstValidTimestamp(link.updated_at, link.created_at), link.url)),
+      fetchSize
     );
     const fileEvents = files.map((file) =>
       this.buildDocumentEvent(committeeUid, file.uid, file.name, 'file', firstValidTimestamp(file.updated_at, file.created_at))
@@ -357,4 +378,8 @@ export class CommitteeActivityService {
       payload: { document_uid: documentUid, name, document_type: documentType, url },
     };
   }
+}
+
+function boundedSortDesc<T extends { occurred_at: string }>(events: T[], limit: number): T[] {
+  return [...events].sort((a, b) => timestampValue(b.occurred_at) - timestampValue(a.occurred_at)).slice(0, limit);
 }

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -24,7 +24,7 @@ import type {
   VoteClosedActivityEvent,
   VoteOpenedActivityEvent,
 } from '@lfx-one/shared/interfaces';
-import { firstValidTimestamp, getPastMeetingResourceId, getPastMeetingStartTimeMs, getSurveyDisplayStatus } from '@lfx-one/shared/utils';
+import { firstValidTimestamp, getPastMeetingResourceId, getPastMeetingStartTimeMs, getSurveyDisplayStatus, normalizePollStatus } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -118,6 +118,23 @@ function ceilToWholeSecond(iso: string): string | undefined {
   const ms = Date.parse(iso);
   if (Number.isNaN(ms)) return undefined;
   return new Date(Math.ceil(ms / 1000) * 1000).toISOString();
+}
+
+/**
+ * True when `survey`'s CLOSED display status is driven purely by its cutoff date passing
+ * (`SurveyStatus.SENT` with `survey_cutoff_date` in the past — mirrors `getEffectiveSurveyStatus`'s
+ * own SENT/cutoff branch in `survey.utils.ts`), as opposed to an explicit "closed" `survey_status`
+ * or `response_status` write. Duplicated here rather than imported because
+ * `getSurveyDisplayStatus`/`getEffectiveSurveyStatus` only return the resulting status, not which
+ * branch produced it — this file needs that distinction to pick `occurred_at`.
+ */
+function isCutoffDrivenClosure(survey: Survey): boolean {
+  if (survey.survey_status?.toLowerCase() !== SurveyStatus.SENT) return false;
+  // Mirrors survey.utils.ts's private RESPONSE_STATUS_CLOSED_SENTINEL ('closed') — an explicit
+  // response_status closure isn't cutoff-driven even if the cutoff has also passed.
+  if (survey.response_status?.toLowerCase() === 'closed') return false;
+  const cutoffDate = survey.survey_cutoff_date ? new Date(survey.survey_cutoff_date) : null;
+  return cutoffDate !== null && !Number.isNaN(cutoffDate.getTime()) && new Date() >= cutoffDate;
 }
 
 function isAtOrAfterSince(occurredAt: string, since: string | undefined): boolean {
@@ -288,19 +305,19 @@ export class CommitteeActivityService {
     // "complex multi-step orchestration" case logging-patterns.md reserves INFO for.
     logger.info(req, 'get_committee_activity', 'Starting committee activity aggregation', { committee_uid: committeeUid, fetch_size: fetchSize });
 
-    const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentResult] = await Promise.all([
+    const [committee, pastMeetingResult, voteResult, surveyResult, documentResult] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
       this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
-        return [];
+        return { events: [], saturated: false };
       }),
       this.fetchVoteEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch vote activity, continuing without it', { committee_uid: committeeUid, err });
-        return [];
+        return { events: [], saturated: false };
       }),
       this.fetchSurveyEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch survey activity, continuing without it', { committee_uid: committeeUid, err });
-        return [];
+        return { events: [], saturated: false };
       }),
       this.fetchDocumentEvents(req, committeeUid, since, before, fetchSize, cursor).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch document activity, continuing without it', { committee_uid: committeeUid, err });
@@ -311,7 +328,7 @@ export class CommitteeActivityService {
     // A committee-lookup failure already rejected the whole Promise.all above (see fetchCommittee's
     // doc comment) — by this line `committee` is always a resolved Committee.
     const votingEnabled = committee.enable_voting;
-    const sources: ActivityEvent[][] = [pastMeetingEvents, votingEnabled ? voteEvents : [], surveyEvents, documentResult.events];
+    const sources: ActivityEvent[][] = [pastMeetingResult.events, votingEnabled ? voteResult.events : [], surveyResult.events, documentResult.events];
 
     // Single pass: attach each event's sort key once, apply since/cursor, sort desc by
     // (occurred_at, key). No per-source pre-cap — a global sort+slice already picks the true top
@@ -340,15 +357,16 @@ export class CommitteeActivityService {
     // e.g. a single dominant source returning exactly `fetchSize` rows, several of which get
     // dropped by the in-memory since/cursor/invalid-timestamp filters, can leave `windowed.length`
     // at or under `limit` while real, unfetched rows remain beyond this page's upstream cutoff.
-    // Folders/links are excluded from this saturation check — they have no upstream page bound at
-    // all (fetched in full every call) and are already filtered+bounded correctly against the exact
-    // cursor inside fetchDocumentEvents, so a fetched length at `fetchSize` there reflects this
-    // leg's own internal cap, not an upstream truncation signal.
-    const anyLegSaturated =
-      pastMeetingEvents.length >= fetchSize ||
-      (votingEnabled && voteEvents.length >= fetchSize) ||
-      surveyEvents.length >= fetchSize ||
-      documentResult.saturated;
+    // Each bounded leg's own `saturated` flag is derived from the upstream `page_token` it actually
+    // got back (see each fetch* method) — NOT from comparing its returned row count to `fetchSize`.
+    // A leg can return exactly `fetchSize` rows as a genuine final page with no further
+    // `page_token`; a row-count comparison alone would falsely flag that as saturated and hand back
+    // a cursor that only leads to an empty next page (independently flagged by Copilot and
+    // dealako). Folders/links are excluded from this saturation check — they have no upstream page
+    // bound at all (fetched in full every call) and are already filtered+bounded correctly against
+    // the exact cursor inside fetchDocumentEvents, so a fetched length at `fetchSize` there reflects
+    // this leg's own internal cap, not an upstream truncation signal.
+    const anyLegSaturated = pastMeetingResult.saturated || (votingEnabled && voteResult.saturated) || surveyResult.saturated || documentResult.saturated;
 
     const page = windowed.slice(0, limit);
     const data = page.map(({ event }) => event);
@@ -365,9 +383,9 @@ export class CommitteeActivityService {
 
     logger.info(req, 'get_committee_activity', 'Completed committee activity aggregation', {
       committee_uid: committeeUid,
-      meeting_count: pastMeetingEvents.length,
-      vote_count: voteEvents.length,
-      survey_count: surveyEvents.length,
+      meeting_count: pastMeetingResult.events.length,
+      vote_count: voteResult.events.length,
+      survey_count: surveyResult.events.length,
       document_count: documentResult.events.length,
       voting_enabled: votingEnabled,
       returned: data.length,
@@ -438,7 +456,7 @@ export class CommitteeActivityService {
     since: string | undefined,
     before: string | undefined,
     fetchSize: number
-  ): Promise<ActivityEvent[]> {
+  ): Promise<{ events: ActivityEvent[]; saturated: boolean }> {
     // date_field: 'start_time' — unlike every other leg's date_field narrowing (best-effort; see the
     // shared rationale at the top of getCommitteeActivity), this one is a correctness guarantee for
     // the upstream contract as verified: occurred_at (getPastMeetingStartTimeMs) prefers
@@ -480,7 +498,13 @@ export class CommitteeActivityService {
     // O(1)-extra-calls efficiency gain.
     // Cast to PastMeeting[] — getMeetings' return type is generic Meeting[], but the actual shape
     // is PastMeeting for meetingType 'v1_past_meeting' (same cast PastMeetingController itself uses).
-    const { data: meetings } = (await this.meetingService.getMeetings(req, query, 'v1_past_meeting', false)) as { data: PastMeeting[] };
+    // page_token — getMeetings' own PaginatedResponse already carries the real upstream signal for
+    // "more data exists on this leg"; see the saturation comment in getCommitteeActivity for why
+    // this is preferred over comparing `meetings.length` to `fetchSize`.
+    const { data: meetings, page_token: pageToken } = (await this.meetingService.getMeetings(req, query, 'v1_past_meeting', false)) as {
+      data: PastMeeting[];
+      page_token?: string;
+    };
 
     // Tripwire for the "meetings is exact" claim in getCommitteeActivity's fetchSize comment — a
     // documented-but-silent regression is worse than no documentation, so make it observable: if a
@@ -503,7 +527,12 @@ export class CommitteeActivityService {
         type: 'meeting_held' as const,
         occurred_at: occurredAt,
         committee_uid: committeeUid,
-        payload: { meeting_id: meeting.id, meeting_occurrence_id: getPastMeetingResourceId(meeting), title: meeting.title },
+        payload: {
+          meeting_id: meeting.id,
+          meeting_occurrence_id: getPastMeetingResourceId(meeting),
+          title: meeting.title,
+          password: meeting.password,
+        },
       };
     });
     if (contractBreachCount > 0) {
@@ -514,7 +543,7 @@ export class CommitteeActivityService {
         { committee_uid: committeeUid, affected_row_count: contractBreachCount, total_rows: meetings.length }
       );
     }
-    return events;
+    return { events, saturated: !!pageToken };
   }
 
   // ─── Votes → vote_opened | vote_closed ─────────────────────────────────────
@@ -525,7 +554,7 @@ export class CommitteeActivityService {
     since: string | undefined,
     before: string | undefined,
     fetchSize: number
-  ): Promise<(VoteOpenedActivityEvent | VoteClosedActivityEvent)[]> {
+  ): Promise<{ events: (VoteOpenedActivityEvent | VoteClosedActivityEvent)[]; saturated: boolean }> {
     // date_field: 'last_modified_time' is best-effort narrowing (see the filter-dimension paragraph
     // in getCommitteeActivity's fetchSize comment for why narrowing imperfectly still beats not
     // narrowing at all) — a vote's occurred_at is actually
@@ -541,8 +570,10 @@ export class CommitteeActivityService {
       ...(before && { date_to: before }),
     };
 
-    const { data: votes } = await this.voteService.getVotes(req, query);
-    return votes.map((vote) => this.mapVoteToEvent(vote, committeeUid));
+    // page_token — see the saturation comment in getCommitteeActivity for why this is preferred
+    // over comparing `votes.length` to `fetchSize`.
+    const { data: votes, page_token: pageToken } = await this.voteService.getVotes(req, query);
+    return { events: votes.map((vote) => this.mapVoteToEvent(vote, committeeUid)), saturated: !!pageToken };
   }
 
   /**
@@ -552,7 +583,14 @@ export class CommitteeActivityService {
    * log would naturally emit both `vote_opened` and `vote_closed` as they occur.
    */
   private mapVoteToEvent(vote: Vote, committeeUid: string): VoteOpenedActivityEvent | VoteClosedActivityEvent {
-    const isClosed = vote.status === PollStatus.ENDED || !!vote.early_end_time;
+    // normalizePollStatus, not a raw comparison — Vote.status arrives with inconsistent casing
+    // (poll.utils.ts's normalizePollStatus doc comment; poll.utils.spec.ts exercises 'Ended'/'ACTIVE'
+    // mixed-case inputs), which is exactly why isVoteCalendarEventPast (meeting.utils.ts) goes
+    // through the same normalization for its own ended check rather than comparing vote.status
+    // directly. Skipping it here misclassified a non-canonical-case "ENDED" vote as vote_opened,
+    // stamped at creation time instead of close time — caught independently by Copilot and Cursor
+    // Bugbot, confirmed against current code.
+    const isClosed = normalizePollStatus(vote.status) === PollStatus.ENDED || !!vote.early_end_time;
     const occurredAt = isClosed
       ? firstValidTimestamp(vote.early_end_time, vote.end_time, vote.last_modified_time, vote.creation_time)
       : firstValidTimestamp(vote.creation_time, vote.last_modified_time);
@@ -572,7 +610,7 @@ export class CommitteeActivityService {
     since: string | undefined,
     before: string | undefined,
     fetchSize: number
-  ): Promise<(SurveyPublishedActivityEvent | SurveyClosedActivityEvent)[]> {
+  ): Promise<{ events: (SurveyPublishedActivityEvent | SurveyClosedActivityEvent)[]; saturated: boolean }> {
     const hasWindow = !!since || !!before;
     const query: Record<string, unknown> = {
       type: 'survey',
@@ -596,14 +634,32 @@ export class CommitteeActivityService {
     // `| null` — see fetchCommittee's note above on why this file annotates it per call site.
     const response = await this.microserviceProxy.proxyRequest<QueryServiceResponse<Survey> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', query);
 
-    return (response?.resources ?? []).map((resource) => this.mapSurveyToEvent(resource.data, committeeUid));
+    // response?.page_token — see the saturation comment in getCommitteeActivity for why this is
+    // preferred over comparing the mapped array's length to `fetchSize`.
+    return {
+      events: (response?.resources ?? []).map((resource) => this.mapSurveyToEvent(resource.data, committeeUid)),
+      saturated: !!response?.page_token,
+    };
   }
 
   private mapSurveyToEvent(survey: Survey, committeeUid: string): SurveyPublishedActivityEvent | SurveyClosedActivityEvent {
     const displayStatus = getSurveyDisplayStatus(survey);
+    // A cutoff-driven closure (SENT past its survey_cutoff_date — see isCutoffDrivenClosure's own
+    // doc comment) has no corresponding last_modified_at write: the survey just sits SENT while
+    // time passes. Falling back to last_modified_at/created_at in that case stamps survey_closed at
+    // the publish/update time instead of the real closure moment, which can misorder the feed or
+    // let `since` filtering drop a closure that genuinely happened inside the requested window.
+    // Confirmed by Copilot, matches dealako's review.
+    let occurredAt = firstValidTimestamp(survey.last_modified_at, survey.created_at);
+    if (displayStatus === SurveyStatus.CLOSED && isCutoffDrivenClosure(survey)) {
+      const cutoffTimestamp = firstValidTimestamp(survey.survey_cutoff_date ?? undefined);
+      if (cutoffTimestamp) {
+        occurredAt = cutoffTimestamp;
+      }
+    }
     return {
       type: displayStatus === SurveyStatus.CLOSED ? 'survey_closed' : 'survey_published',
-      occurred_at: firstValidTimestamp(survey.last_modified_at, survey.created_at),
+      occurred_at: occurredAt,
       committee_uid: committeeUid,
       payload: { survey_uid: survey.uid, title: survey.survey_title, status: displayStatus },
     };
@@ -621,7 +677,7 @@ export class CommitteeActivityService {
   ): Promise<{ events: DocumentUploadedActivityEvent[]; saturated: boolean }> {
     const hasWindow = !!since || !!before;
 
-    const [folders, links, files] = await Promise.all([
+    const [folders, links, filesResult] = await Promise.all([
       // `| null` on folders/links/files below — see fetchCommittee's note on why this file
       // annotates it per call site.
       this.microserviceProxy
@@ -651,10 +707,12 @@ export class CommitteeActivityService {
           ...(since && { date_from: since }),
           ...(before && { date_to: before }),
         })
-        .then((response) => (response?.resources ?? []).map((resource) => resource.data))
+        // page_token, not just the mapped array — see the saturation comment below for why this
+        // leg's real upstream signal is preferred over comparing the array's length to `fetchSize`.
+        .then((response) => ({ files: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
         .catch((err) => {
           logger.warning(req, 'get_committee_activity', 'Failed to fetch committee files, continuing without them', { committee_uid: committeeUid, err });
-          return [] as CommitteeActivityDocumentFile[];
+          return { files: [] as CommitteeActivityDocumentFile[], pageToken: undefined as string | undefined };
         }),
     ]);
 
@@ -694,17 +752,19 @@ export class CommitteeActivityService {
         ),
       fetchSize
     );
-    const fileEvents = files.map((file) =>
+    const fileEvents = filesResult.files.map((file) =>
       this.buildDocumentEvent(committeeUid, file.uid, file.name, 'file', firstValidTimestamp(file.updated_at, file.created_at))
     );
 
     // Only the files leg feeds `saturated` — it's the one document sub-leg bounded by an upstream
-    // page_size (like meetings/votes/surveys), so a fetched length at fetchSize is a real signal
-    // there could be more upstream. Folders/links are deliberately excluded: they have no upstream
-    // bound at all (fetched in full, every call) and are already filtered+bounded against the exact
-    // cursor above, so hitting fetchSize there reflects this leg's own correct internal cap, not an
-    // under-fetch.
-    return { events: [...folderEvents, ...linkEvents, ...fileEvents], saturated: files.length >= fetchSize };
+    // page_size (like meetings/votes/surveys), so its own upstream `page_token` is a real signal
+    // there could be more data upstream (not a comparison of the fetched array's length to
+    // `fetchSize` — a leg can return exactly `fetchSize` rows as a genuine final page with no
+    // further `page_token`; see the saturation comment in getCommitteeActivity). Folders/links are
+    // deliberately excluded: they have no upstream bound at all (fetched in full, every call) and
+    // are already filtered+bounded against the exact cursor above, so hitting fetchSize there
+    // reflects this leg's own correct internal cap, not an under-fetch.
+    return { events: [...folderEvents, ...linkEvents, ...fileEvents], saturated: !!filesResult.pageToken };
   }
 
   private buildDocumentEvent(

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -178,15 +178,16 @@ export class CommitteeActivityService {
     // indexer populates from `start_time` (`meeting.constants.ts`'s `PAST_MEETING_SORT` doc comment;
     // upstream `PastMeetingEventData.SortName()` confirms — its own doc comment calls `StartTime`
     // "the scheduled start time"). occurred_at (getPastMeetingStartTimeMs) prefers
-    // `scheduled_start_time`, falling back to `start_time` — but the indexed `v1_past_meeting`
-    // projection this leg actually reads frequently omits `scheduled_start_time`, carrying only
-    // `start_time` (see the existing `fetchPastMeetingEvents` comment below, and
-    // `meeting.service.ts`'s identical "frequently omits scheduled_start_time" note on the same
-    // projection), so that fallback usually resolves to the identical value `sort_name` was built
-    // from. Meetings is the closest of the four legs to exact, not merely approximate like the
-    // other three — the residual is the row where `scheduled_start_time` IS present and diverges
-    // from `start_time`, which per that same "frequently omits" framing is the less common case,
-    // not the rule.
+    // `scheduled_start_time`, falling back to `start_time` when it's absent — `sort_name` and
+    // occurred_at coincide exactly whenever that fallback fires, and can diverge on any row where
+    // `scheduled_start_time` is present and different from `start_time`. How often each case occurs
+    // on the indexed `v1_past_meeting` projection this leg actually reads depends on which upstream
+    // sync path wrote a given row (verified at least one path — the legacy v1-to-v2 migration
+    // handler — populates `start_time` FROM the v1 record's own scheduled time, making the two
+    // identical for rows synced that way; not confirmed for meetings created natively in v2).
+    // Meetings is still the best-behaved of the four legs regardless — sort and occurred_at track
+    // the same underlying event (this meeting's own start) at worst, unlike the categorically
+    // different mismatch on the other three legs below.
     //
     // Votes, surveys, and files are all in a different, genuinely-approximate bucket: query-service's
     // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -235,7 +235,12 @@ export class CommitteeActivityService {
     // otherwise be swallowed into an empty leg by each leg's own .catch — a passably-formatted but
     // non-normalized `since` would silently thin the feed rather than error, on this direct-caller
     // path specifically (the HTTP path already normalizes before this method ever sees `since`).
-    const since = rawSince ? normalizeTimestamp(rawSince) : undefined;
+    // `!== undefined`, matching the guard above (not truthiness) — the guard above already rejects
+    // `since: ''` (an empty string fails `Number.isNaN(Date.parse(''))`), so by this line the only
+    // way to reach here with a falsy-but-defined `since` is already closed off; matching predicates
+    // means that stays true even if the guard above is ever relaxed, instead of the two silently
+    // diverging on which falsy values count as "no since" vs. "invalid since".
+    const since = rawSince !== undefined ? normalizeTimestamp(rawSince) : undefined;
 
     const [committee, pastMeetingEvents, voteEvents, surveyEvents, documentResult] = await Promise.all([
       this.fetchCommittee(req, committeeUid),

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -159,7 +159,8 @@ export class CommitteeActivityService {
     // parseCommitteeActivityQuery already bounds page_size on the HTTP path, but this method is
     // public and reachable directly. An out-of-range `limit` here degrades silently instead of
     // rejecting — `limit: 0` yields `windowed.slice(0, 0)`, an empty feed with no error; a negative
-    // `limit` (`slice(0, -1)`) silently drops the newest item while still emitting a page_token.
+    // `limit` (`slice(0, -1)`) silently drops the OLDEST item (windowed is sorted descending by
+    // (occurred_at, key), so index 0 is newest and -1 is oldest) while still emitting a page_token.
     if (!Number.isInteger(limit) || limit < 1 || limit > ACTIVITY_FEED_MAX_PAGE_SIZE) {
       throw ServiceValidationError.forField('limit', `limit must be an integer between 1 and ${ACTIVITY_FEED_MAX_PAGE_SIZE}`, {
         operation: 'get_committee_activity',
@@ -218,7 +219,14 @@ export class CommitteeActivityService {
     // then rejects every surviving event too (`ms >= Date.parse(since)` is `ms >= NaN`, always
     // false) — a silent empty feed, not the clean rejection this method's cursor handling already
     // guarantees for the equivalent bad-input case.
-    if (rawSince && Number.isNaN(Date.parse(rawSince))) {
+    //
+    // `typeof rawSince !== 'string'`, not just parseability — `CommitteeActivityQuery.since` is
+    // typed `string | undefined`, but this method is reachable by an untyped/direct caller that
+    // bypasses that guarantee, and Date.parse(x) coerces its argument via ToString before parsing
+    // while normalizeTimestamp's `new Date(x)` does not (a Number is instead read as epoch-ms) —
+    // so a non-string `since` could pass Date.parse's parseability check here and then normalize to
+    // a completely different instant below, silently corrupting the window instead of rejecting.
+    if (rawSince !== undefined && (typeof rawSince !== 'string' || Number.isNaN(Date.parse(rawSince)))) {
       throw ServiceValidationError.forField('since', 'since must be a valid ISO 8601 timestamp', { operation: 'get_committee_activity' });
     }
     // normalizeTimestamp — same reason as parseCommitteeActivityQuery's own use of it (see that

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -320,7 +320,8 @@ export class MeetingService {
 
     // The indexed v1_past_meeting projection never carries scheduled_start_time — its source
     // struct (upstream PastMeetingEventData) has no such field, only start_time (verified against
-    // event_models.go and past_meeting_event_handler.go; see the "Meetings" paragraph in
+    // `lfx-v2-meeting-service`'s internal/domain/models/event_models.go and
+    // cmd/meeting-api/eventing/past_meeting_event_handler.go; see the "Meetings" paragraph in
     // committee-activity.service.ts's fetchSize comment) — but this code still accepts either,
     // matching sortPastMeetingsDescending's defensive shape rather than assuming the verified
     // absence holds forever.

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -318,8 +318,12 @@ export class MeetingService {
       return [] as PastMeeting[];
     });
 
-    // The indexed v1_past_meeting projection frequently omits scheduled_start_time and only
-    // carries start_time (same reality sortPastMeetingsDescending handles) — accept either.
+    // The indexed v1_past_meeting projection never carries scheduled_start_time — its source
+    // struct (upstream PastMeetingEventData) has no such field, only start_time (verified against
+    // event_models.go and past_meeting_event_handler.go; see the "Meetings" paragraph in
+    // committee-activity.service.ts's fetchSize comment) — but this code still accepts either,
+    // matching sortPastMeetingsDescending's defensive shape rather than assuming the verified
+    // absence holds forever.
     const dropped = records.filter((r) => !r.meeting_and_occurrence_id || !(r.scheduled_start_time || r.start_time));
     if (dropped.length > 0) {
       logger.warning(req, 'get_past_occurrences_for_meeting', 'Dropping past occurrences missing composite id or start time', {

--- a/packages/shared/src/constants/activity-event.constants.ts
+++ b/packages/shared/src/constants/activity-event.constants.ts
@@ -1,0 +1,30 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { ActivityEventType } from '../interfaces/activity-event.interface';
+
+/**
+ * Event types the committee activity feed can actually emit today, derived purely from existing
+ * aggregation sources (past meetings, votes, surveys, documents) — see
+ * `apps/lfx-one/src/server/services/committee-activity.service.ts`.
+ */
+export const ACTIVITY_EVENT_TYPES_V1_EMITTED: readonly ActivityEventType[] = [
+  'meeting_held',
+  'vote_opened',
+  'vote_closed',
+  'survey_published',
+  'survey_closed',
+  'document_uploaded',
+];
+
+/**
+ * Event types with no upstream source yet: no document-delete tombstone (hard delete, unindexed),
+ * no committee-membership history tracking, no notes feature. Pending a real event log.
+ */
+export const ACTIVITY_EVENT_TYPES_DEFERRED: readonly ActivityEventType[] = ['document_deleted', 'member_joined', 'member_left', 'notes_added'];
+
+/** Default row count for `GET /api/committees/:uid/activity` — matches the old client-side FEED_LIMIT. */
+export const ACTIVITY_FEED_DEFAULT_LIMIT = 8;
+
+/** Upper bound on the `limit` query param, rejected (400) if exceeded. */
+export const ACTIVITY_FEED_MAX_LIMIT = 50;

--- a/packages/shared/src/constants/activity-event.constants.ts
+++ b/packages/shared/src/constants/activity-event.constants.ts
@@ -1,30 +1,20 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { ActivityEventType } from '../interfaces/activity-event.interface';
+/**
+ * Default row count for `GET /api/committees/:uid/activity`'s `page_size` param — matches the old
+ * client-side FEED_LIMIT. (v1-emitted vs. deferred `ActivityEventType` split is documented on the
+ * type itself, in `activity-event.interface.ts` — no separate runtime constant needed.)
+ */
+export const ACTIVITY_FEED_DEFAULT_PAGE_SIZE = 8;
+
+/** Upper bound on the `page_size` query param, rejected (400) if exceeded. */
+export const ACTIVITY_FEED_MAX_PAGE_SIZE = 50;
 
 /**
- * Event types the committee activity feed can actually emit today, derived purely from existing
- * aggregation sources (past meetings, votes, surveys, documents) — see
- * `apps/lfx-one/src/server/services/committee-activity.service.ts`.
+ * Floor on the per-source upstream fetch size (independent of the caller's `page_size`) — keeps a
+ * small `page_size` (e.g. 1) from starving the k-way-merge correctness guarantee in
+ * `CommitteeActivityService.getCommitteeActivity`, which needs `page_size + 1` genuine candidates
+ * per source, not just `page_size`.
  */
-export const ACTIVITY_EVENT_TYPES_V1_EMITTED: readonly ActivityEventType[] = [
-  'meeting_held',
-  'vote_opened',
-  'vote_closed',
-  'survey_published',
-  'survey_closed',
-  'document_uploaded',
-];
-
-/**
- * Event types with no upstream source yet: no document-delete tombstone (hard delete, unindexed),
- * no committee-membership history tracking, no notes feature. Pending a real event log.
- */
-export const ACTIVITY_EVENT_TYPES_DEFERRED: readonly ActivityEventType[] = ['document_deleted', 'member_joined', 'member_left', 'notes_added'];
-
-/** Default row count for `GET /api/committees/:uid/activity` — matches the old client-side FEED_LIMIT. */
-export const ACTIVITY_FEED_DEFAULT_LIMIT = 8;
-
-/** Upper bound on the `limit` query param, rejected (400) if exceeded. */
-export const ACTIVITY_FEED_MAX_LIMIT = 50;
+export const ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE = 25;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -47,6 +47,7 @@ export * from './meetups.constants';
 export * from './links.config';
 export * from './copilot.constants';
 export * from './committee-documents.constants';
+export * from './activity-event.constants';
 export * from './lens.constants';
 export * from './badge.constants';
 export * from './training.constants';

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -4,10 +4,12 @@
 import type { CommitteeDocumentType } from './committee.interface';
 
 /**
- * Full target lifecycle-event vocabulary for a committee's activity feed (LFXV2-1707). Only the
- * first six are actually emitted in v1 (aggregation-derived from existing sources: past meetings,
- * votes, surveys, documents — see `committee-activity.service.ts`). The last four are deferred:
- * no upstream source exists yet (no document-delete tombstone — hard delete, unindexed; no
+ * Full target lifecycle-event vocabulary for a committee's activity feed (LFXV2-1707). Only
+ * `meeting_held`, `vote_opened`/`vote_closed`, `survey_published`/`survey_closed`, and
+ * `document_uploaded` are actually emitted in v1 (aggregation-derived from existing sources: past
+ * meetings, votes, surveys, documents — see `committee-activity.service.ts`). `document_deleted`,
+ * `member_joined`, `member_left`, and `notes_added` (see `DeferredActivityEvent`) are deferred: no
+ * upstream source exists yet (no document-delete tombstone — hard delete, unindexed; no
  * committee-membership history tracking; no notes feature). The union stays complete now so the
  * wire contract doesn't grow a breaking change when a real event log starts emitting them.
  *

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -1,0 +1,107 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { CommitteeDocumentType } from './committee.interface';
+
+/**
+ * Full target lifecycle-event vocabulary for a committee's activity feed (LFXV2-1707). Only the
+ * first six are actually emitted in v1 — see `ACTIVITY_EVENT_TYPES_V1_EMITTED` /
+ * `ACTIVITY_EVENT_TYPES_DEFERRED` in `../constants/activity-event.constants` for the split and why
+ * each deferred type has no upstream source yet (no document-delete tombstone, no membership-history
+ * tracking, no notes feature). The union stays complete now so the wire contract doesn't grow a
+ * breaking change when a real event log starts emitting the deferred types.
+ */
+export type ActivityEventType =
+  | 'meeting_held'
+  | 'vote_opened'
+  | 'vote_closed'
+  | 'survey_published'
+  | 'survey_closed'
+  | 'document_uploaded'
+  | 'document_deleted'
+  | 'member_joined'
+  | 'member_left'
+  | 'notes_added';
+
+interface BaseActivityEvent {
+  /** ISO timestamp this event happened at — the feed's sort key. */
+  occurred_at: string;
+  committee_uid: string;
+}
+
+export interface MeetingHeldActivityEvent extends BaseActivityEvent {
+  type: 'meeting_held';
+  // No `password`: the client's click handler re-hydrates the full PastMeeting (including
+  // password) from its own already-fetched pastMeetings() signal via meeting_id, matching how
+  // ActivityFeedAction's `past-meeting` variant already carries only `meetingId`, not a password.
+  payload: { meeting_id: string; title: string };
+}
+
+/**
+ * Vote lifecycle payload — shared by both `vote_opened` and `vote_closed`. `status` carries the
+ * full upstream `PollStatus` value (not collapsed into the coarse event type) so a client can still
+ * render the exact status label ("Vote Disabled: X") the same way the old stop-gap did.
+ */
+export interface VoteActivityEventPayload {
+  vote_uid: string;
+  name: string;
+  status: string;
+}
+
+export interface VoteOpenedActivityEvent extends BaseActivityEvent {
+  type: 'vote_opened';
+  payload: VoteActivityEventPayload;
+}
+
+export interface VoteClosedActivityEvent extends BaseActivityEvent {
+  type: 'vote_closed';
+  payload: VoteActivityEventPayload;
+}
+
+/** Survey lifecycle payload — shared by `survey_published` and `survey_closed`, same rationale as votes. */
+export interface SurveyActivityEventPayload {
+  survey_uid: string;
+  title: string;
+  status: string;
+}
+
+export interface SurveyPublishedActivityEvent extends BaseActivityEvent {
+  type: 'survey_published';
+  payload: SurveyActivityEventPayload;
+}
+
+export interface SurveyClosedActivityEvent extends BaseActivityEvent {
+  type: 'survey_closed';
+  payload: SurveyActivityEventPayload;
+}
+
+export interface DocumentUploadedActivityEvent extends BaseActivityEvent {
+  type: 'document_uploaded';
+  payload: { document_uid: string; name: string; document_type: CommitteeDocumentType; url?: string };
+}
+
+/**
+ * Placeholder variant for the deferred event types — never constructed in v1 (no upstream source
+ * exists to populate it). Kept in the union so `ActivityEventType` stays the full target vocabulary
+ * without every consumer needing a separate "future type" case.
+ */
+export interface DeferredActivityEvent extends BaseActivityEvent {
+  type: 'document_deleted' | 'member_joined' | 'member_left' | 'notes_added';
+  payload: Record<string, never>;
+}
+
+/**
+ * A single row in a committee's activity feed (`GET /api/committees/:uid/activity`, LFXV2-1707).
+ * Each variant's payload is intentionally entity-shaped (raw fields), not presentation-shaped (no
+ * labels/icons/routes) — the client maps `ActivityEvent` -> `ActivityFeedItem` for rendering via
+ * `mapActivityEventsToFeedItems` (`../utils/activity-feed.utils`), so this contract stays stable
+ * across UI-label or route changes and is what a future real event-log source would also produce.
+ */
+export type ActivityEvent =
+  | MeetingHeldActivityEvent
+  | VoteOpenedActivityEvent
+  | VoteClosedActivityEvent
+  | SurveyPublishedActivityEvent
+  | SurveyClosedActivityEvent
+  | DocumentUploadedActivityEvent
+  | DeferredActivityEvent;

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -10,18 +10,13 @@ import type { CommitteeDocumentType } from './committee.interface';
  * no upstream source exists yet (no document-delete tombstone — hard delete, unindexed; no
  * committee-membership history tracking; no notes feature). The union stays complete now so the
  * wire contract doesn't grow a breaking change when a real event log starts emitting them.
+ *
+ * Derived from `ActivityEvent['type']` (declared below — TypeScript allows forward references
+ * between type aliases in the same module) rather than hand-restated, so adding, removing, or
+ * renaming a variant in the `ActivityEvent` union can't silently drift out of sync with this type —
+ * a hand-written duplicate would still compile even if the two fell out of step.
  */
-export type ActivityEventType =
-  | 'meeting_held'
-  | 'vote_opened'
-  | 'vote_closed'
-  | 'survey_published'
-  | 'survey_closed'
-  | 'document_uploaded'
-  | 'document_deleted'
-  | 'member_joined'
-  | 'member_left'
-  | 'notes_added';
+export type ActivityEventType = ActivityEvent['type'];
 
 interface BaseActivityEvent {
   /** ISO timestamp this event happened at — the feed's sort key. */

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -5,11 +5,11 @@ import type { CommitteeDocumentType } from './committee.interface';
 
 /**
  * Full target lifecycle-event vocabulary for a committee's activity feed (LFXV2-1707). Only the
- * first six are actually emitted in v1 — see `ACTIVITY_EVENT_TYPES_V1_EMITTED` /
- * `ACTIVITY_EVENT_TYPES_DEFERRED` in `../constants/activity-event.constants` for the split and why
- * each deferred type has no upstream source yet (no document-delete tombstone, no membership-history
- * tracking, no notes feature). The union stays complete now so the wire contract doesn't grow a
- * breaking change when a real event log starts emitting the deferred types.
+ * first six are actually emitted in v1 (aggregation-derived from existing sources: past meetings,
+ * votes, surveys, documents — see `committee-activity.service.ts`). The last four are deferred:
+ * no upstream source exists yet (no document-delete tombstone — hard delete, unindexed; no
+ * committee-membership history tracking; no notes feature). The union stays complete now so the
+ * wire contract doesn't grow a breaking change when a real event log starts emitting them.
  */
 export type ActivityEventType =
   | 'meeting_held'
@@ -31,10 +31,20 @@ interface BaseActivityEvent {
 
 export interface MeetingHeldActivityEvent extends BaseActivityEvent {
   type: 'meeting_held';
-  // No `password`: the client's click handler re-hydrates the full PastMeeting (including
-  // password) from its own already-fetched pastMeetings() signal via meeting_id, matching how
-  // ActivityFeedAction's `past-meeting` variant already carries only `meetingId`, not a password.
-  payload: { meeting_id: string; title: string };
+  payload: {
+    /** Navigation id — matches PastMeeting.id, same field the click action routes to `/meetings/:id` with. */
+    meeting_id: string;
+    /**
+     * `getPastMeetingResourceId(meeting)` (`meeting_and_occurrence_id ?? id`) — distinct from
+     * `meeting_id` because a recurring meeting's occurrences share one `meeting_id` but need
+     * distinct `@for` tracking keys client-side; using `meeting_id` alone would collide.
+     */
+    meeting_occurrence_id: string;
+    title: string;
+    // No `password`: the client's click handler re-hydrates the full PastMeeting (including
+    // password) from its own already-fetched pastMeetings() signal via meeting_id, matching how
+    // ActivityFeedAction's `past-meeting` variant already carries only `meetingId`, not a password.
+  };
 }
 
 /**

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -38,9 +38,14 @@ export interface MeetingHeldActivityEvent extends BaseActivityEvent {
      */
     meeting_occurrence_id: string;
     title: string;
-    // No `password`: the client's click handler re-hydrates the full PastMeeting (including
-    // password) from its own already-fetched pastMeetings() signal via meeting_id, matching how
-    // ActivityFeedAction's `past-meeting` variant already carries only `meetingId`, not a password.
+    /**
+     * Carried here (not re-hydrated client-side from a separate signal) because the activity feed
+     * is its own independent, differently-windowed fetch from the Overview page's own
+     * `pastMeetings()` signal — a password-protected meeting can appear in one without appearing in
+     * the other, which silently dropped the password on navigation (Copilot/Cursor Bugbot/dealako
+     * review on PR #1288).
+     */
+    password: string | null;
   };
 }
 

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -31,7 +31,13 @@ export interface CommitteeActivityQuery {
    * on for correctness. See the per-leg comments in `committee-activity.service.ts`.
    */
   since?: string;
-  /** Decoded from an incoming `page_token`. Undefined on page 1. */
+  /**
+   * Decoded from an incoming `page_token`. Undefined on page 1. `since` is NOT encoded into the
+   * cursor — a client that paginates through several pages without resending the same `since` on
+   * every request can silently widen the window mid-feed. Not exercised today (the client only
+   * ever fetches page 1), but a caller relying on `since` across multiple pages must resend it
+   * explicitly on every request.
+   */
   cursor?: ActivityPageCursor;
   limit: number;
 }

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -8,18 +8,26 @@
  * `committee-engagement.internal.interface.ts`'s precedent for the sibling LFXV2-1705 endpoint.
  */
 
+/**
+ * Keyset pagination position: the `occurred_at` of the last item on the previous page, plus a
+ * stable per-event tiebreaker key (see `eventKey` in `committee-activity.service.ts`) for when
+ * multiple events share that exact timestamp — e.g. a batch of documents uploaded in one request
+ * all sharing `created_at` to the second. A bare-timestamp cursor would either re-return or
+ * permanently drop the other tied events; comparing `(occurred_at, key)` as a compound position
+ * does neither.
+ */
+export interface ActivityPageCursor {
+  before: string;
+  key: string;
+}
+
 /** Parsed, validated query for `GET /api/committees/:uid/activity`, and the options threaded into the service. */
 export interface CommitteeActivityQuery {
   /** Inclusive lower bound on `occurred_at`, applied as `date_from` on every source that supports it. */
   since?: string;
-  /** Exclusive upper bound on `occurred_at`, decoded from an incoming `page_token`. Undefined on page 1. */
-  before?: string;
+  /** Decoded from an incoming `page_token`. Undefined on page 1. */
+  cursor?: ActivityPageCursor;
   limit: number;
-}
-
-/** Shape encoded into the opaque `page_token` string — see `encodeActivityPageToken` in `committee-activity-query.helper.ts`. */
-export interface ActivityPageTokenPayload {
-  before: string;
 }
 
 /** Upstream response shape for a committee folder (`GET /committees/:id/folders`). */

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -23,7 +23,12 @@ export interface ActivityPageCursor {
 
 /** Parsed, validated query for `GET /api/committees/:uid/activity`, and the options threaded into the service. */
 export interface CommitteeActivityQuery {
-  /** Inclusive lower bound on `occurred_at`, applied as `date_from` on every source that supports it. */
+  /**
+   * Inclusive lower bound on `occurred_at`. Applied in-memory to the merged pool on every source;
+   * additionally pushed upstream as `date_from` only on the surveys and documents legs, whose
+   * derivation field is unambiguous (the past-meetings and votes legs get no upstream date filter
+   * at all — see `committee-activity.service.ts`).
+   */
   since?: string;
   /** Decoded from an incoming `page_token`. Undefined on page 1. */
   cursor?: ActivityPageCursor;

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -1,0 +1,48 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Server-internal shapes for the committee activity aggregation endpoint (LFXV2-1707) — not part
+ * of the public `ActivityEvent` wire contract (`activity-event.interface.ts`). Kept in
+ * `@lfx-one/shared` per repo convention (no local interfaces inside `apps/lfx-one/`), mirroring
+ * `committee-engagement.internal.interface.ts`'s precedent for the sibling LFXV2-1705 endpoint.
+ */
+
+/** Parsed, validated query for `GET /api/committees/:uid/activity`, and the options threaded into the service. */
+export interface CommitteeActivityQuery {
+  /** Inclusive lower bound on `occurred_at`, applied as `date_from` on every source that supports it. */
+  since?: string;
+  /** Exclusive upper bound on `occurred_at`, decoded from an incoming `page_token`. Undefined on page 1. */
+  before?: string;
+  limit: number;
+}
+
+/** Shape encoded into the opaque `page_token` string — see `encodeActivityPageToken` in `committee-activity-query.helper.ts`. */
+export interface ActivityPageTokenPayload {
+  before: string;
+}
+
+/** Upstream response shape for a committee folder (`GET /committees/:id/folders`). */
+export interface CommitteeActivityFolder {
+  uid: string;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Upstream response shape for a committee link (`GET /committees/:id/links`). */
+export interface CommitteeActivityLink {
+  uid: string;
+  name: string;
+  url?: string;
+  created_at?: string;
+  updated_at?: string;
+}
+
+/** Query-service shape for an indexed `committee_document` (file) resource. */
+export interface CommitteeActivityDocumentFile {
+  uid: string;
+  name: string;
+  created_at?: string;
+  updated_at?: string;
+}

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -24,10 +24,11 @@ export interface ActivityPageCursor {
 /** Parsed, validated query for `GET /api/committees/:uid/activity`, and the options threaded into the service. */
 export interface CommitteeActivityQuery {
   /**
-   * Inclusive lower bound on `occurred_at`. Applied in-memory to the merged pool on every source;
-   * additionally pushed upstream as `date_from` only on the surveys and documents legs, whose
-   * derivation field is unambiguous (the past-meetings and votes legs get no upstream date filter
-   * at all — see `committee-activity.service.ts`).
+   * Inclusive lower bound on `occurred_at`. Enforced in-memory against the merged pool (the
+   * correctness guarantee); additionally pushed upstream as `date_from` on all four legs as
+   * best-effort narrowing only — each leg's upstream `date_field` approximates a multi-field
+   * fallback derivation it can't fully represent, so it narrows fetched volume but isn't relied
+   * on for correctness. See the per-leg comments in `committee-activity.service.ts`.
    */
   since?: string;
   /** Decoded from an incoming `page_token`. Undefined on page 1. */

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -42,7 +42,14 @@ export interface CommitteeActivityQuery {
   limit: number;
 }
 
-/** Upstream response shape for a committee folder (`GET /committees/:id/folders`). */
+/**
+ * Upstream response shape for a committee folder (`GET /committees/:id/folders`) — deliberately a
+ * narrower duplicate of `committee.service.ts`'s pre-existing local `CommitteeFolder` (this leg
+ * only needs `uid`/`name`/`created_at`/`updated_at` to build an activity row). Consolidating the
+ * two into one shared type, and fixing that file's own pre-existing local-interface convention
+ * violation, is out of scope for this endpoint — accepted as a known duplication risk rather than
+ * expanding this change into an unrelated refactor.
+ */
 export interface CommitteeActivityFolder {
   uid: string;
   name: string;

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -1,14 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { CommitteeDocument } from './committee.interface';
-import type { PastMeeting } from './meeting.interface';
-import type { Vote } from './poll.interface';
-import type { Survey } from './survey.interface';
-
 /**
  * Source kind backing an `ActivityFeedItem`.
- * @description Drives icon + tab-navigation choice in the group Overview activity feed stop-gap.
+ * @description Drives icon + tab-navigation choice in the committee Overview "Recent Activity" widget.
  */
 export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey' | 'document';
 
@@ -18,7 +13,7 @@ export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey
  * (navigate a route, open a drawer, open an external link) depending on `type`. Semantic variants
  * (`past-meeting`, not a baked `{ kind: 'route'; path: string }`) so `packages/shared` doesn't carry
  * app route strings — the component maps each kind to wherever that surface actually lives, which
- * survives route refactors and LFXV2-1707's server-fed activity items.
+ * survives route refactors independent of this contract.
  */
 export interface PastMeetingActivityFeedAction {
   kind: 'past-meeting';
@@ -53,11 +48,10 @@ export type ActivityFeedAction =
   | TabActivityFeedAction;
 
 /**
- * A single row in the group Overview activity feed stop-gap.
- * @description Normalized shape merged from past meetings, votes, surveys, and documents — sorted by
- * `timestamp` desc. Upcoming meetings ('meeting') are a reserved variant, not currently emitted: they're
- * future-dated and already covered by the "Next Meeting" card. Replaced by the real activity stream in
- * LFXV2-1707.
+ * A single row in the committee Overview "Recent Activity" widget — the UI view-model produced by
+ * `mapActivityEventsToFeedItems` (`../utils/activity-feed.utils`) from the server's `ActivityEvent[]`
+ * (`GET /api/committees/:uid/activity`, LFXV2-1707). Upcoming meetings ('meeting') are a reserved
+ * variant, not currently emitted: they're future-dated and already covered by the "Next Meeting" card.
  */
 export interface ActivityFeedItem {
   /** Source kind, drives the icon and default styling */
@@ -72,20 +66,4 @@ export interface ActivityFeedItem {
   icon: string;
   /** What clicking this row does — see `ActivityFeedAction` */
   action: ActivityFeedAction;
-}
-
-export interface BuildActivityFeedInput {
-  pastMeetings: PastMeeting[];
-  votes: Vote[];
-  surveys: Survey[];
-  documents: CommitteeDocument[];
-  /**
-   * Vote items are excluded entirely when false, so the feed doesn't surface vote activity for a
-   * committee that has voting disabled — matching the Votes tab itself being hidden in that state.
-   * (A clicked vote row opens VoteResultsDrawer in place, not the Votes tab, so this is a content
-   * decision rather than a dead-end-navigation guard.) This only affects the activity feed itself;
-   * the committee-overview "My Pending Actions" / "Active Votes" surfaces read `votes()` independently
-   * and are unaffected by this flag — see committee-overview.component.ts.
-   */
-  votingEnabled: boolean;
 }

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -18,6 +18,8 @@ export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey
 export interface PastMeetingActivityFeedAction {
   kind: 'past-meeting';
   meetingId: string;
+  /** From the source event's own payload — see `MeetingHeldActivityEvent.payload.password`'s doc comment for why this isn't re-hydrated client-side. */
+  password: string | null;
 }
 
 export interface VoteDrawerActivityFeedAction {

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -282,6 +282,9 @@ export * from './org-meetings-insights.internal.interface';
 // Group Overview activity feed stop-gap (LFXV2-1716)
 export * from './activity-feed.interface';
 
+// Committee activity feed aggregation (LFXV2-1707)
+export * from './activity-event.interface';
+
 // Committee member engagement/attendance rollup (LFXV2-1705)
 export * from './committee-engagement.interface';
 export * from './committee-engagement.internal.interface';

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -279,11 +279,12 @@ export * from './create-picker.interface';
 export * from './org-meetings-insights.interface';
 export * from './org-meetings-insights.internal.interface';
 
-// Group Overview activity feed stop-gap (LFXV2-1716)
+// Committee Overview "Recent Activity" widget view-model (LFXV2-1707, formerly the LFXV2-1716 stop-gap)
 export * from './activity-feed.interface';
 
-// Committee activity feed aggregation (LFXV2-1707)
+// Committee activity feed aggregation wire contract (LFXV2-1707)
 export * from './activity-event.interface';
+export * from './activity-event.internal.interface';
 
 // Committee member engagement/attendance rollup (LFXV2-1705)
 export * from './committee-engagement.interface';

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -17,7 +17,7 @@ function meetingHeld(overrides: Partial<Extract<ActivityEvent, { type: 'meeting_
     type: 'meeting_held',
     occurred_at: occurredAt,
     committee_uid: COMMITTEE_UID,
-    payload: { meeting_id: 'pm-1', meeting_occurrence_id: 'pm-1-occ-1', title: 'Weekly Sync', ...overrides },
+    payload: { meeting_id: 'pm-1', meeting_occurrence_id: 'pm-1-occ-1', title: 'Weekly Sync', password: null, ...overrides },
   };
 }
 
@@ -164,7 +164,14 @@ describe('mapActivityEventsToFeedItems', () => {
   describe('action', () => {
     it('routes a meeting_held item to its meeting_id', () => {
       const items = mapActivityEventsToFeedItems([meetingHeld({ meeting_id: 'pm-42', meeting_occurrence_id: 'pm-42-occ-1' })], { votingEnabled: true });
-      expect(items[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42' });
+      expect(items[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42', password: null });
+    });
+
+    it('carries the event payload password through to the action, not just meetingId', () => {
+      // Carried from the source event, not re-hydrated client-side from a separate signal — see
+      // MeetingHeldActivityEvent.payload.password's doc comment for why (PR #1288 review).
+      const items = mapActivityEventsToFeedItems([meetingHeld({ meeting_id: 'pm-42', password: 'sesame' })], { votingEnabled: true });
+      expect(items[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42', password: 'sesame' });
     });
 
     it('keys a meeting_held item on meeting_occurrence_id, not meeting_id — so two occurrences of the same recurring meeting get distinct @for tracking keys', () => {

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -96,10 +96,21 @@ describe('mapActivityEventsToFeedItems', () => {
       { votingEnabled: true }
     );
     const byKey = Object.fromEntries(items.map((i) => [i.key, i]));
-    expect(byKey['document-d-file'].label).toBe('Document: A');
-    expect(byKey['document-d-link'].label).toBe('Link: B');
-    expect(byKey['document-d-folder'].label).toBe('Folder: C');
-    expect(byKey['document-d-folder'].icon).toContain('folder');
+    expect(byKey['document-file-d-file'].label).toBe('Document: A');
+    expect(byKey['document-link-d-link'].label).toBe('Link: B');
+    expect(byKey['document-folder-d-folder'].label).toBe('Folder: C');
+    expect(byKey['document-folder-d-folder'].icon).toContain('folder');
+  });
+
+  it('keys a folder and a file that share a uid distinctly — document_type discriminates the @for tracking key', () => {
+    const items = mapActivityEventsToFeedItems(
+      [
+        documentUploaded({ document_uid: 'shared-uid', document_type: 'folder', name: 'Folder' }, '2026-01-02T00:00:00Z'),
+        documentUploaded({ document_uid: 'shared-uid', document_type: 'file', name: 'File' }, '2026-01-01T00:00:00Z'),
+      ],
+      { votingEnabled: true }
+    );
+    expect(new Set(items.map((i) => i.key)).size).toBe(2);
   });
 
   it('maps vote status through POLL_STATUS_LABELS instead of leaking the raw enum value', () => {

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -17,7 +17,7 @@ function meetingHeld(overrides: Partial<Extract<ActivityEvent, { type: 'meeting_
     type: 'meeting_held',
     occurred_at: occurredAt,
     committee_uid: COMMITTEE_UID,
-    payload: { meeting_id: 'pm-1', title: 'Weekly Sync', ...overrides },
+    payload: { meeting_id: 'pm-1', meeting_occurrence_id: 'pm-1-occ-1', title: 'Weekly Sync', ...overrides },
   };
 }
 
@@ -152,9 +152,15 @@ describe('mapActivityEventsToFeedItems', () => {
 
   describe('action', () => {
     it('routes a meeting_held item to its meeting_id', () => {
-      const items = mapActivityEventsToFeedItems([meetingHeld({ meeting_id: 'pm-42' })], { votingEnabled: true });
+      const items = mapActivityEventsToFeedItems([meetingHeld({ meeting_id: 'pm-42', meeting_occurrence_id: 'pm-42-occ-1' })], { votingEnabled: true });
       expect(items[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42' });
-      expect(items[0].key).toBe('past_meeting-pm-42');
+    });
+
+    it('keys a meeting_held item on meeting_occurrence_id, not meeting_id — so two occurrences of the same recurring meeting get distinct @for tracking keys', () => {
+      const items = mapActivityEventsToFeedItems([meetingHeld({ meeting_id: 'pm-42', meeting_occurrence_id: 'pm-42-occ-1' }, '2026-01-01T00:00:00Z')], {
+        votingEnabled: true,
+      });
+      expect(items[0].key).toBe('past_meeting-pm-42-occ-1');
     });
 
     it('opens the vote drawer for a vote event', () => {

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -7,296 +7,188 @@
 import { describe, expect, it } from 'vitest';
 
 import { PollStatus, SurveyStatus } from '../enums';
-import { BuildActivityFeedInput, CommitteeDocument, PastMeeting, Survey, Vote } from '../interfaces';
-import { buildActivityFeed } from './activity-feed.utils';
+import { ActivityEvent, CommitteeDocumentType } from '../interfaces';
+import { mapActivityEventsToFeedItems } from './activity-feed.utils';
 
-/** Minimal past-meeting builder — only the fields buildActivityFeed reads. */
-function pastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {
+const COMMITTEE_UID = 'committee-1';
+
+function meetingHeld(overrides: Partial<Extract<ActivityEvent, { type: 'meeting_held' }>['payload']> = {}, occurredAt = '2026-01-01T10:00:00Z'): ActivityEvent {
   return {
-    id: 'pm-1',
-    meeting_and_occurrence_id: 'pm-1-occ-1',
-    title: 'Weekly Sync',
-    start_time: '2026-01-01T10:00:00Z',
-    ...overrides,
-  } as PastMeeting;
+    type: 'meeting_held',
+    occurred_at: occurredAt,
+    committee_uid: COMMITTEE_UID,
+    payload: { meeting_id: 'pm-1', title: 'Weekly Sync', ...overrides },
+  };
 }
 
-/** Minimal vote builder — only the fields buildActivityFeed reads. */
-function vote(overrides: Partial<Vote> = {}): Vote {
+function voteEvent(
+  type: 'vote_opened' | 'vote_closed',
+  overrides: Partial<Extract<ActivityEvent, { type: 'vote_opened' }>['payload']> = {},
+  occurredAt = '2026-01-02T10:00:00Z'
+): ActivityEvent {
   return {
-    uid: 'vote-1',
-    name: 'Q1 Budget',
-    status: PollStatus.ACTIVE,
-    last_modified_time: '2026-01-02T10:00:00Z',
-    ...overrides,
-  } as Vote;
+    type,
+    occurred_at: occurredAt,
+    committee_uid: COMMITTEE_UID,
+    payload: { vote_uid: 'vote-1', name: 'Q1 Budget', status: PollStatus.ACTIVE, ...overrides },
+  };
 }
 
-/** Minimal survey builder — only the fields buildActivityFeed (via getSurveyDisplayStatus) reads. */
-function survey(overrides: Partial<Survey> = {}): Survey {
+function surveyEvent(
+  type: 'survey_published' | 'survey_closed',
+  overrides: Partial<Extract<ActivityEvent, { type: 'survey_published' }>['payload']> = {},
+  occurredAt = '2026-01-03T10:00:00Z'
+): ActivityEvent {
   return {
-    uid: 'survey-1',
-    survey_title: 'Community Feedback',
-    survey_status: SurveyStatus.OPEN,
-    survey_cutoff_date: null,
-    last_modified_at: '2026-01-03T10:00:00Z',
-    ...overrides,
-  } as Survey;
+    type,
+    occurred_at: occurredAt,
+    committee_uid: COMMITTEE_UID,
+    payload: { survey_uid: 'survey-1', title: 'Community Feedback', status: SurveyStatus.OPEN, ...overrides },
+  };
 }
 
-/** Minimal document builder — only the fields buildActivityFeed reads. */
-function document(overrides: Partial<CommitteeDocument> = {}): CommitteeDocument {
+function documentUploaded(
+  overrides: Partial<Extract<ActivityEvent, { type: 'document_uploaded' }>['payload']> = {},
+  occurredAt = '2026-01-04T10:00:00Z'
+): ActivityEvent {
   return {
-    uid: 'doc-1',
-    type: 'file',
-    name: 'Charter.pdf',
-    updated_at: '2026-01-04T10:00:00Z',
-    ...overrides,
-  } as CommitteeDocument;
+    type: 'document_uploaded',
+    occurred_at: occurredAt,
+    committee_uid: COMMITTEE_UID,
+    payload: { document_uid: 'doc-1', name: 'Charter.pdf', document_type: 'file', ...overrides },
+  };
 }
 
-function emptyInput(overrides: Partial<BuildActivityFeedInput> = {}): BuildActivityFeedInput {
-  return { pastMeetings: [], votes: [], surveys: [], documents: [], votingEnabled: true, ...overrides };
-}
-
-describe('buildActivityFeed', () => {
-  it('returns an empty array when every source is empty', () => {
-    expect(buildActivityFeed(emptyInput())).toEqual([]);
+describe('mapActivityEventsToFeedItems', () => {
+  it('returns an empty array when given no events', () => {
+    expect(mapActivityEventsToFeedItems([], { votingEnabled: true })).toEqual([]);
   });
 
-  it('merges all four sources and sorts the result by timestamp descending', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        pastMeetings: [pastMeeting({ start_time: '2026-01-01T00:00:00Z' })],
-        votes: [vote({ last_modified_time: '2026-01-03T00:00:00Z' })],
-        surveys: [survey({ last_modified_at: '2026-01-02T00:00:00Z' })],
-        documents: [document({ updated_at: '2026-01-04T00:00:00Z' })],
-      })
-    );
+  it('preserves the server-provided order — no re-sorting or capping client-side', () => {
+    const items = mapActivityEventsToFeedItems([documentUploaded(), voteEvent('vote_closed'), surveyEvent('survey_published'), meetingHeld()], {
+      votingEnabled: true,
+    });
     expect(items.map((i) => i.type)).toEqual(['document', 'vote', 'survey', 'past_meeting']);
   });
 
-  it('sorts correctly across sources when timestamps use different UTC offset formats', () => {
-    // 2026-01-01T09:00:00+05:30 == 2026-01-01T03:30:00Z, so it should sort between the survey and
-    // the vote below despite being lexicographically smaller than both (localeCompare would get
-    // this wrong — it'd sort by the raw string, putting the offset form last).
-    const items = buildActivityFeed(
-      emptyInput({
-        votes: [vote({ last_modified_time: '2026-01-01T04:00:00Z' })],
-        surveys: [survey({ last_modified_at: '2026-01-01T03:00:00Z' })],
-        documents: [document({ updated_at: '2026-01-01T09:00:00+05:30' })],
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['vote', 'document', 'survey']);
-  });
-
-  it('sorts an unparseable timestamp as the oldest item instead of throwing', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        votes: [vote({ last_modified_time: 'not-a-timestamp', creation_time: undefined })],
-        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['survey', 'vote']);
-  });
-
-  it('does not sort a past meeting as ancient when start_time is a Go zero-date', () => {
-    // Zoom/ITX past-meeting rows sometimes carry "0001-01-01T00:00:00Z" on start_time — a raw
-    // Date.parse would treat that as a real (~year 1) timestamp and sort it as the oldest item,
-    // even when scheduled_start_time has a real, recent value.
-    const items = buildActivityFeed(
-      emptyInput({
-        pastMeetings: [pastMeeting({ start_time: '0001-01-01T00:00:00Z', scheduled_start_time: '2026-01-05T00:00:00Z' })],
-        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['past_meeting', 'survey']);
-  });
-
-  it('sorts a past meeting as oldest when both start_time and scheduled_start_time are zero-dates', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        pastMeetings: [pastMeeting({ start_time: '0001-01-01T00:00:00Z', scheduled_start_time: '0001-01-01T00:00:00Z' })],
-        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['survey', 'past_meeting']);
-  });
-
-  it('does not sort a vote as ancient when last_modified_time is a Go zero-date', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        votes: [vote({ last_modified_time: '0001-01-01T00:00:00Z', creation_time: '2026-01-05T00:00:00Z' })],
-        surveys: [survey({ last_modified_at: '2026-01-01T00:00:00Z' })],
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['vote', 'survey']);
-  });
-
-  it('does not sort a survey as ancient when last_modified_at is a Go zero-date', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        surveys: [survey({ last_modified_at: '0001-01-01T00:00:00Z', created_at: '2026-01-05T00:00:00Z' })],
-        votes: [vote({ last_modified_time: '2026-01-01T00:00:00Z' })],
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['survey', 'vote']);
-  });
-
-  it('does not sort a document as ancient when updated_at is a Go zero-date', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        documents: [document({ updated_at: '0001-01-01T00:00:00Z', created_at: '2026-01-05T00:00:00Z' })],
-        votes: [vote({ last_modified_time: '2026-01-01T00:00:00Z' })],
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['document', 'vote']);
-  });
-
-  it('caps each source at 5 items before merging, keeping the most recent per source', () => {
-    const pastMeetings = Array.from({ length: 7 }, (_, i) =>
-      pastMeeting({ id: `pm-${i}`, meeting_and_occurrence_id: `pm-${i}-occ`, start_time: `2026-01-0${i + 1}T00:00:00Z` })
-    );
-    const items = buildActivityFeed(emptyInput({ pastMeetings }));
-    expect(items).toHaveLength(5);
-    // The 5 most recent (highest-dated) of the 7 survive the per-source cap.
-    expect(items.map((i) => i.key)).toEqual([
-      'past_meeting-pm-6-occ',
-      'past_meeting-pm-5-occ',
-      'past_meeting-pm-4-occ',
-      'past_meeting-pm-3-occ',
-      'past_meeting-pm-2-occ',
-    ]);
-  });
-
-  it('caps the final merged feed at 8 items even when every source is full', () => {
-    const many = (n: number) => Array.from({ length: n }, (_, i) => i);
-    const items = buildActivityFeed(
-      emptyInput({
-        pastMeetings: many(5).map((i) => pastMeeting({ id: `pm-${i}`, meeting_and_occurrence_id: `pm-${i}`, start_time: `2026-01-01T0${i}:00:00Z` })),
-        votes: many(5).map((i) => vote({ uid: `vote-${i}`, last_modified_time: `2026-01-02T0${i}:00:00Z` })),
-        surveys: many(5).map((i) => survey({ uid: `survey-${i}`, last_modified_at: `2026-01-03T0${i}:00:00Z` })),
-        documents: many(5).map((i) => document({ uid: `doc-${i}`, updated_at: `2026-01-04T0${i}:00:00Z` })),
-      })
-    );
-    expect(items).toHaveLength(8);
-  });
-
-  it('excludes vote items entirely when votingEnabled is false, but keeps the other sources', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        votes: [vote()],
-        surveys: [survey()],
-        votingEnabled: false,
-      })
-    );
-    expect(items.map((i) => i.type)).toEqual(['survey']);
-  });
-
-  it('falls back to created_at / creation_time when the modified/updated timestamp is absent', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        votes: [vote({ last_modified_time: undefined, creation_time: '2026-01-05T00:00:00Z' })],
-      })
-    );
+  it('carries occurred_at straight through as the item timestamp', () => {
+    const items = mapActivityEventsToFeedItems([meetingHeld({}, '2026-01-05T00:00:00Z')], { votingEnabled: true });
     expect(items[0].timestamp).toBe('2026-01-05T00:00:00Z');
   });
 
+  it('excludes vote events entirely when votingEnabled is false, but keeps the other sources', () => {
+    const items = mapActivityEventsToFeedItems([voteEvent('vote_opened'), surveyEvent('survey_published')], { votingEnabled: false });
+    expect(items.map((i) => i.type)).toEqual(['survey']);
+  });
+
+  it('keeps vote_closed events excluded too when votingEnabled is false', () => {
+    const items = mapActivityEventsToFeedItems([voteEvent('vote_closed')], { votingEnabled: false });
+    expect(items).toEqual([]);
+  });
+
   it('labels documents by type — file, link, and folder render distinct labels and icons', () => {
-    const items = buildActivityFeed(
-      emptyInput({
-        documents: [
-          document({ uid: 'd-file', type: 'file', name: 'A', updated_at: '2026-01-01T00:00:00Z' }),
-          document({ uid: 'd-link', type: 'link', name: 'B', updated_at: '2026-01-02T00:00:00Z' }),
-          document({ uid: 'd-folder', type: 'folder', name: 'C', updated_at: '2026-01-03T00:00:00Z' }),
-        ],
-      })
+    const items = mapActivityEventsToFeedItems(
+      [
+        documentUploaded({ document_uid: 'd-file', document_type: 'file', name: 'A' }),
+        documentUploaded({ document_uid: 'd-link', document_type: 'link', name: 'B' }),
+        documentUploaded({ document_uid: 'd-folder', document_type: 'folder', name: 'C' }),
+      ],
+      { votingEnabled: true }
     );
-    const byUid = Object.fromEntries(items.map((i) => [i.key, i]));
-    expect(byUid['document-d-file'].label).toBe('Document: A');
-    expect(byUid['document-d-link'].label).toBe('Link: B');
-    expect(byUid['document-d-folder'].label).toBe('Folder: C');
-    expect(byUid['document-d-folder'].icon).toContain('folder');
+    const byKey = Object.fromEntries(items.map((i) => [i.key, i]));
+    expect(byKey['document-d-file'].label).toBe('Document: A');
+    expect(byKey['document-d-link'].label).toBe('Link: B');
+    expect(byKey['document-d-folder'].label).toBe('Folder: C');
+    expect(byKey['document-d-folder'].icon).toContain('folder');
   });
 
   it('maps vote status through POLL_STATUS_LABELS instead of leaking the raw enum value', () => {
-    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: PollStatus.ENDED })] }));
+    const items = mapActivityEventsToFeedItems([voteEvent('vote_closed', { status: PollStatus.ENDED })], { votingEnabled: true });
     expect(items[0].label).toBe('Vote Ended: Q1 Budget');
   });
 
   it('normalizes an uppercase/mixed-case vote status before mapping through POLL_STATUS_LABELS', () => {
-    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: 'ACTIVE' as PollStatus })] }));
+    const items = mapActivityEventsToFeedItems([voteEvent('vote_opened', { status: 'ACTIVE' })], { votingEnabled: true });
     expect(items[0].label).toBe('Vote Active: Q1 Budget');
   });
 
   it('falls back to the raw vote status when it has no POLL_STATUS_LABELS entry', () => {
-    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: 'archived' as PollStatus })] }));
+    const items = mapActivityEventsToFeedItems([voteEvent('vote_opened', { status: 'archived' })], { votingEnabled: true });
     expect(items[0].label).toBe('Vote archived: Q1 Budget');
   });
 
   it('falls back to a generic label instead of "Vote undefined" when status is missing', () => {
-    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: undefined })] }));
+    const items = mapActivityEventsToFeedItems([voteEvent('vote_opened', { status: undefined as unknown as string })], { votingEnabled: true });
     expect(items[0].label).toBe('Vote Updated: Q1 Budget');
   });
 
   it('falls back to a generic label instead of "Vote :" when status is an empty string', () => {
-    const items = buildActivityFeed(emptyInput({ votes: [vote({ status: '' as PollStatus })] }));
+    const items = mapActivityEventsToFeedItems([voteEvent('vote_opened', { status: '' })], { votingEnabled: true });
     expect(items[0].label).toBe('Vote Updated: Q1 Budget');
   });
 
+  it('renders the survey status label for both published and closed events', () => {
+    const published = mapActivityEventsToFeedItems([surveyEvent('survey_published', { status: SurveyStatus.DRAFT })], { votingEnabled: true });
+    expect(published[0].label).toBe('Survey Draft: Community Feedback');
+
+    const closed = mapActivityEventsToFeedItems([surveyEvent('survey_closed', { status: SurveyStatus.CLOSED })], { votingEnabled: true });
+    expect(closed[0].label).toBe('Survey Closed: Community Feedback');
+  });
+
   it('falls back to a generic label instead of "undefined:" when a document type is unrecognized', () => {
-    const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'unexpected' as CommitteeDocument['type'] })] }));
+    const items = mapActivityEventsToFeedItems([documentUploaded({ document_type: 'unexpected' as CommitteeDocumentType })], {
+      votingEnabled: true,
+    });
     expect(items[0].label).toBe('Document: Charter.pdf');
     expect(items[0].icon).toContain('file');
   });
 
+  it('silently drops deferred event types instead of throwing', () => {
+    const deferred: ActivityEvent = { type: 'document_deleted', occurred_at: '2026-01-01T00:00:00Z', committee_uid: COMMITTEE_UID, payload: {} };
+    const items = mapActivityEventsToFeedItems([deferred, meetingHeld()], { votingEnabled: true });
+    expect(items).toHaveLength(1);
+    expect(items[0].type).toBe('past_meeting');
+  });
+
   describe('action', () => {
-    it("routes a past-meeting item to meeting.id — matching the Past Meeting card's own link — regardless of meeting_and_occurrence_id", () => {
-      const withComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
-      expect(withComposite[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42' });
-
-      const withoutComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: undefined })] }));
-      expect(withoutComposite[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42' });
+    it('routes a meeting_held item to its meeting_id', () => {
+      const items = mapActivityEventsToFeedItems([meetingHeld({ meeting_id: 'pm-42' })], { votingEnabled: true });
+      expect(items[0].action).toEqual({ kind: 'past-meeting', meetingId: 'pm-42' });
+      expect(items[0].key).toBe('past_meeting-pm-42');
     });
 
-    it('still prefers the composite occurrence id for the @for tracking key, independent of the navigation id', () => {
-      const withComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: 'pm-42-occ-9' })] }));
-      expect(withComposite[0].key).toBe('past_meeting-pm-42-occ-9');
-
-      const withoutComposite = buildActivityFeed(emptyInput({ pastMeetings: [pastMeeting({ id: 'pm-42', meeting_and_occurrence_id: undefined })] }));
-      expect(withoutComposite[0].key).toBe('past_meeting-pm-42');
-    });
-
-    it('opens the vote drawer for a vote item', () => {
-      const items = buildActivityFeed(emptyInput({ votes: [vote({ uid: 'vote-42' })] }));
+    it('opens the vote drawer for a vote event', () => {
+      const items = mapActivityEventsToFeedItems([voteEvent('vote_opened', { vote_uid: 'vote-42' })], { votingEnabled: true });
       expect(items[0].action).toEqual({ kind: 'vote-drawer', voteUid: 'vote-42' });
     });
 
-    it('opens the survey drawer for a survey item', () => {
-      const items = buildActivityFeed(emptyInput({ surveys: [survey({ uid: 'survey-42' })] }));
+    it('opens the survey drawer for a survey event', () => {
+      const items = mapActivityEventsToFeedItems([surveyEvent('survey_published', { survey_uid: 'survey-42' })], { votingEnabled: true });
       expect(items[0].action).toEqual({ kind: 'survey-drawer', surveyUid: 'survey-42' });
     });
 
     it('opens a link document directly when it has a valid http(s) url', () => {
-      const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'link', url: 'https://example.com/notes' })] }));
+      const items = mapActivityEventsToFeedItems([documentUploaded({ document_type: 'link', url: 'https://example.com/notes' })], { votingEnabled: true });
       expect(items[0].action).toEqual({ kind: 'external-url', url: 'https://example.com/notes' });
     });
 
     it('falls back to the documents tab for a link document with a missing or unsafe url', () => {
-      const missingUrl = buildActivityFeed(emptyInput({ documents: [document({ type: 'link', url: undefined })] }));
+      const missingUrl = mapActivityEventsToFeedItems([documentUploaded({ document_type: 'link', url: undefined })], { votingEnabled: true });
       expect(missingUrl[0].action).toEqual({ kind: 'tab', tab: 'documents' });
 
-      const unsafeUrl = buildActivityFeed(emptyInput({ documents: [document({ type: 'link', url: 'javascript:alert(1)' })] }));
+      const unsafeUrl = mapActivityEventsToFeedItems([documentUploaded({ document_type: 'link', url: 'javascript:alert(1)' })], { votingEnabled: true });
       expect(unsafeUrl[0].action).toEqual({ kind: 'tab', tab: 'documents' });
     });
 
     it('falls back to the documents tab for a file document even when a url is present', () => {
-      const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'file', url: 'https://example.com/storage/charter.pdf' })] }));
+      const items = mapActivityEventsToFeedItems([documentUploaded({ document_type: 'file', url: 'https://example.com/storage/charter.pdf' })], {
+        votingEnabled: true,
+      });
       expect(items[0].action).toEqual({ kind: 'tab', tab: 'documents' });
     });
 
     it('falls back to the documents tab for a folder document', () => {
-      const items = buildActivityFeed(emptyInput({ documents: [document({ type: 'folder' })] }));
+      const items = mapActivityEventsToFeedItems([documentUploaded({ document_type: 'folder' })], { votingEnabled: true });
       expect(items[0].action).toEqual({ kind: 'tab', tab: 'documents' });
     });
   });

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -36,7 +36,7 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
         label: `Meeting held: ${event.payload.title}`,
         timestamp: event.occurred_at,
         icon: 'fa-light fa-clock-rotate-left',
-        action: { kind: 'past-meeting', meetingId: event.payload.meeting_id },
+        action: { kind: 'past-meeting', meetingId: event.payload.meeting_id, password: event.payload.password },
       };
 
     case 'vote_opened':

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -72,7 +72,11 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
       const { document_uid, name, document_type, url } = event.payload;
       return {
         type: 'document',
-        key: `document-${document_uid}`,
+        // document_type in the key, not just document_uid — folders, links, and files are three
+        // distinct upstream uid namespaces (matches eventKey's identical reasoning server-side in
+        // committee-activity.service.ts); a folder and a file coincidentally sharing a uid would
+        // otherwise collide on this @for tracking key (NG0955).
+        key: `document-${document_type}-${document_uid}`,
         label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[document_type] ?? COMMITTEE_DOCUMENT_TYPE_LABELS.file}: ${name}`,
         timestamp: event.occurred_at,
         icon: COMMITTEE_DOCUMENT_TYPE_ICONS[document_type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file,
@@ -95,8 +99,10 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
  * Maps a committee's server-fed `ActivityEvent[]` to `ActivityFeedItem[]` for the Overview
  * "Recent Activity" widget. `votingEnabled` mirrors the old stop-gap's behavior: vote events are
  * excluded entirely (not just hidden) when the committee has voting disabled, matching the Votes
- * tab itself being hidden in that state — still a UI-only concern, so it's applied here rather
- * than by the server.
+ * tab itself being hidden in that state. Applied at BOTH layers, not just here: the server
+ * (`CommitteeActivityService.getCommitteeActivity`) already excludes vote events from the response
+ * when `committee.enable_voting` is false, so this filter is defense-in-depth against a client
+ * that has a stale/different view of `committee()` than what the server resolved — not the sole gate.
  */
 export function mapActivityEventsToFeedItems(events: ActivityEvent[], opts: { votingEnabled: boolean }): ActivityFeedItem[] {
   return events

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -12,121 +12,92 @@
 import { COMMITTEE_DOCUMENT_TYPE_ICONS, COMMITTEE_DOCUMENT_TYPE_LABELS } from '../constants/committee-documents.constants';
 import { POLL_STATUS_LABELS } from '../constants/poll.constants';
 import { SURVEY_STATUS_LABELS } from '../constants/survey.constants';
-import type { ActivityFeedItem, BuildActivityFeedInput } from '../interfaces';
-import { firstValidTimestamp } from './iso-timestamp.utils';
-import { getPastMeetingResourceId, getPastMeetingStartTimeMs } from './past-meeting.utils';
+import type { ActivityEvent, ActivityFeedItem } from '../interfaces';
 import { normalizePollStatus } from './poll.utils';
-import { getSurveyDisplayStatus } from './survey.utils';
 import { isValidUrl } from './url.utils';
 
-/** Per-source cap before merging, so one noisy source can't crowd out the rest. */
-const PER_SOURCE_LIMIT = 5;
-/** Final row count returned after the merge-sort. */
-const FEED_LIMIT = 8;
-
 /**
- * Parse an ISO timestamp to epoch ms for sorting, treating an absent/unparseable value as the
- * oldest possible. A plain `localeCompare` on the raw strings only sorts correctly when every
- * source emits the identical format/offset — this feed merges four sources across two upstream
- * services (query-service, committee-service), so a `+05:30`-offset or non-`Z` variant from any
- * one of them would otherwise sort into the wrong position relative to the others.
+ * Maps one committee-activity `ActivityEvent` (the server's source-agnostic wire contract,
+ * LFXV2-1707) to the Overview widget's `ActivityFeedItem` view-model (label/icon/click-action).
+ * The server already sorts, caps, and paginates — this is a pure per-event presentation mapping,
+ * not a merge. Ports the label/fallback/action logic the old client-side `buildActivityFeed` used
+ * to apply directly to raw `Vote`/`Survey`/`PastMeeting`/`CommitteeDocument` entities, now reading
+ * from `event.payload` instead so rendering stays identical across the data-source swap.
  */
-function timestampValue(timestamp: string): number {
-  const parsed = Date.parse(timestamp);
-  return Number.isNaN(parsed) ? -Infinity : parsed;
+function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | null {
+  switch (event.type) {
+    case 'meeting_held':
+      return {
+        type: 'past_meeting',
+        key: `past_meeting-${event.payload.meeting_id}`,
+        label: `Meeting held: ${event.payload.title}`,
+        timestamp: event.occurred_at,
+        icon: 'fa-light fa-clock-rotate-left',
+        action: { kind: 'past-meeting', meetingId: event.payload.meeting_id },
+      };
+
+    case 'vote_opened':
+    case 'vote_closed': {
+      const { vote_uid, name, status } = event.payload;
+      const statusKey = normalizePollStatus(status);
+      return {
+        type: 'vote',
+        key: `vote-${vote_uid}`,
+        label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : status || 'Updated'}: ${name}`,
+        timestamp: event.occurred_at,
+        icon: 'fa-light fa-check-to-slot',
+        action: { kind: 'vote-drawer', voteUid: vote_uid },
+      };
+    }
+
+    case 'survey_published':
+    case 'survey_closed': {
+      const { survey_uid, title, status } = event.payload;
+      return {
+        type: 'survey',
+        key: `survey-${survey_uid}`,
+        label: `Survey ${SURVEY_STATUS_LABELS[status as keyof typeof SURVEY_STATUS_LABELS] ?? status}: ${title}`,
+        timestamp: event.occurred_at,
+        icon: 'fa-light fa-chart-simple',
+        action: { kind: 'survey-drawer', surveyUid: survey_uid },
+      };
+    }
+
+    // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a folder
+    // or link doesn't misrepresent itself as a file in the feed.
+    case 'document_uploaded': {
+      const { document_uid, name, document_type, url } = event.payload;
+      return {
+        type: 'document',
+        key: `document-${document_uid}`,
+        label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[document_type] ?? COMMITTEE_DOCUMENT_TYPE_LABELS.file}: ${name}`,
+        timestamp: event.occurred_at,
+        icon: COMMITTEE_DOCUMENT_TYPE_ICONS[document_type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file,
+        // Only 'link' documents open directly — the Documents tab treats 'file' as a download
+        // (via a committee-scoped proxy URL, not doc.url) rather than an "open", and 'folder' has
+        // no standalone target outside the Documents tab's own drill-down state. isValidUrl is the
+        // same shared validator used across the app for untrusted-URL sinks.
+        action: document_type === 'link' && url && isValidUrl(url) ? { kind: 'external-url', url } : { kind: 'tab', tab: 'documents' },
+      };
+    }
+
+    // Deferred types (document_deleted, member_joined, member_left, notes_added) — never emitted
+    // by the server in v1; guarded defensively rather than assumed unreachable.
+    default:
+      return null;
+  }
 }
 
 /**
- * Group Overview "Recent Activity" stop-gap: merges the latest items across past meetings, votes,
- * surveys, and documents into one time-ordered list. Upcoming meetings are intentionally excluded
- * — they're future-dated, already covered by the "Next Meeting" card, and would otherwise dominate
- * a feed labelled "Recent Activity". Replaced by the real activity stream in LFXV2-1707.
+ * Maps a committee's server-fed `ActivityEvent[]` to `ActivityFeedItem[]` for the Overview
+ * "Recent Activity" widget. `votingEnabled` mirrors the old stop-gap's behavior: vote events are
+ * excluded entirely (not just hidden) when the committee has voting disabled, matching the Votes
+ * tab itself being hidden in that state — still a UI-only concern, so it's applied here rather
+ * than by the server.
  */
-export function buildActivityFeed(input: BuildActivityFeedInput): ActivityFeedItem[] {
-  const pastMeetingItems: ActivityFeedItem[] = [...input.pastMeetings]
-    .map((m) => {
-      // getPastMeetingStartTimeMs — the same helper meetings-dashboard.component.ts and
-      // meeting-organizer.component.ts already go through, so this feed can't quietly diverge if
-      // that helper's field-preference or zero-date handling ever changes. committee-overview's own
-      // lastMeeting computed does not go through it (pre-existing, raw start_time.localeCompare) —
-      // a Go zero-date start_time can therefore make the "Past Meeting" card and this feed's top
-      // row name different meetings, out of this fix's scope.
-      const startMs = getPastMeetingStartTimeMs(m);
-      return { meeting: m, timestamp: startMs !== null ? new Date(startMs).toISOString() : '' };
-    })
-    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
-    .slice(0, PER_SOURCE_LIMIT)
-    .map(({ meeting: m, timestamp }) => ({
-      type: 'past_meeting' as const,
-      // getPastMeetingResourceId (meeting_and_occurrence_id ?? id) for tracking — the same helper
-      // every other past-meeting surface uses (meeting-card, meeting-organizer, attachments) —
-      // deliberately independent of the navigation id below, which has a different job (matching
-      // an existing link) rather than uniquely identifying the occurrence.
-      key: `past_meeting-${getPastMeetingResourceId(m)}`,
-      label: `Meeting held: ${m.title}`,
-      timestamp,
-      icon: 'fa-light fa-clock-rotate-left',
-      // meeting.id, not getPastMeetingResourceId — matches the "Past Meeting" card's own link
-      // (committee-overview.component.html: `'/meetings/' + meeting.id`). The component maps this
-      // semantic action to that route (also carrying the meeting's password query param, matching
-      // the card); packages/shared doesn't carry the path string.
-      action: { kind: 'past-meeting' as const, meetingId: m.id },
-    }));
-
-  const voteItems: ActivityFeedItem[] = input.votingEnabled
-    ? [...input.votes]
-        .map((v) => ({ vote: v, timestamp: firstValidTimestamp(v.last_modified_time, v.creation_time) }))
-        .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
-        .slice(0, PER_SOURCE_LIMIT)
-        .map(({ vote: v, timestamp }) => {
-          const statusKey = normalizePollStatus(v.status);
-          return {
-            type: 'vote' as const,
-            key: `vote-${v.uid}`,
-            label: `Vote ${statusKey ? POLL_STATUS_LABELS[statusKey] : v.status || 'Updated'}: ${v.name}`,
-            timestamp,
-            icon: 'fa-light fa-check-to-slot',
-            action: { kind: 'vote-drawer' as const, voteUid: v.uid },
-          };
-        })
-    : [];
-
-  const surveyItems: ActivityFeedItem[] = [...input.surveys]
-    .map((s) => ({ survey: s, timestamp: firstValidTimestamp(s.last_modified_at, s.created_at) }))
-    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
-    .slice(0, PER_SOURCE_LIMIT)
-    .map(({ survey: s, timestamp }) => {
-      const displayStatus = getSurveyDisplayStatus(s);
-      return {
-        type: 'survey' as const,
-        key: `survey-${s.uid}`,
-        label: `Survey ${SURVEY_STATUS_LABELS[displayStatus] ?? displayStatus}: ${s.survey_title}`,
-        timestamp,
-        icon: 'fa-light fa-chart-simple',
-        action: { kind: 'survey-drawer' as const, surveyUid: s.uid },
-      };
-    });
-
-  // CommitteeDocument.type is 'file' | 'link' | 'folder' — differentiate icon/label so a folder
-  // or link doesn't misrepresent itself as a file in the feed.
-  const documentItems: ActivityFeedItem[] = [...input.documents]
-    .map((d) => ({ document: d, timestamp: firstValidTimestamp(d.updated_at, d.created_at) }))
-    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
-    .slice(0, PER_SOURCE_LIMIT)
-    .map(({ document: d, timestamp }) => ({
-      type: 'document' as const,
-      key: `document-${d.uid}`,
-      label: `${COMMITTEE_DOCUMENT_TYPE_LABELS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_LABELS.file}: ${d.name}`,
-      timestamp,
-      icon: COMMITTEE_DOCUMENT_TYPE_ICONS[d.type] ?? COMMITTEE_DOCUMENT_TYPE_ICONS.file,
-      // Only 'link' documents open directly — the Documents tab treats 'file' as a download
-      // (via a committee-scoped proxy URL, not doc.url) rather than an "open", and 'folder' has
-      // no standalone target outside the Documents tab's own drill-down state. isValidUrl is the
-      // same shared validator used across the app for untrusted-URL sinks.
-      action: d.type === 'link' && d.url && isValidUrl(d.url) ? { kind: 'external-url' as const, url: d.url } : { kind: 'tab' as const, tab: 'documents' },
-    }));
-
-  return [...pastMeetingItems, ...voteItems, ...surveyItems, ...documentItems]
-    .sort((a, b) => timestampValue(b.timestamp) - timestampValue(a.timestamp))
-    .slice(0, FEED_LIMIT);
+export function mapActivityEventsToFeedItems(events: ActivityEvent[], opts: { votingEnabled: boolean }): ActivityFeedItem[] {
+  return events
+    .filter((event) => opts.votingEnabled || (event.type !== 'vote_opened' && event.type !== 'vote_closed'))
+    .map(mapActivityEventToFeedItem)
+    .filter((item): item is ActivityFeedItem => item !== null);
 }

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -29,7 +29,10 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
     case 'meeting_held':
       return {
         type: 'past_meeting',
-        key: `past_meeting-${event.payload.meeting_id}`,
+        // meeting_occurrence_id, not meeting_id — a recurring meeting's occurrences share one
+        // meeting_id but need distinct @for tracking keys; meetingId (below) is still the
+        // navigation id, matching the "Past Meeting" card's own link.
+        key: `past_meeting-${event.payload.meeting_occurrence_id}`,
         label: `Meeting held: ${event.payload.title}`,
         timestamp: event.occurred_at,
         icon: 'fa-light fa-clock-rotate-left',

--- a/packages/shared/src/utils/past-meeting.utils.ts
+++ b/packages/shared/src/utils/past-meeting.utils.ts
@@ -4,7 +4,12 @@
 import { EnrichedPastMeetingParticipant, Meeting, PastMeeting, PastMeetingRecording, PastParticipantFilters } from '../interfaces';
 import { firstValidTimestampMs } from './iso-timestamp.utils';
 
-// Zoom/ITX rows sometimes carry a Go zero-date on scheduled_start_time; fall back to start_time.
+// scheduled_start_time can be absent or a Go zero-date depending on the row's source — fall back to
+// start_time. (For rows sourced from the v1_past_meeting query-service index specifically,
+// scheduled_start_time is verified always absent, never just zero-dated — see the "Meetings"
+// paragraph in apps/lfx-one/src/server/services/committee-activity.service.ts's fetchSize comment.
+// This function is shared across callers beyond that one leg, so it stays defensive here rather
+// than assuming every caller's data shares that same guarantee.)
 export function getPastMeetingStartTimeMs(meeting: Pick<PastMeeting, 'scheduled_start_time' | 'start_time'>): number | null {
   return firstValidTimestampMs(meeting.scheduled_start_time, meeting.start_time);
 }


### PR DESCRIPTION
## Summary

Replaces the committee overview's client-side "Recent Activity" stop-gap (`buildActivityFeed`, which independently fetched past meetings, votes, surveys, and — solely to seed this widget — documents, then merged/sorted/capped them in the browser) with a server-side BFF endpoint: `GET /api/committees/:uid/activity`.

v1 aggregates only *existing* upstream sources (past meetings, votes, surveys, documents) — no new microservice, no event log. The wire contract (`ActivityEvent` discriminated union) is shaped so a real event log can populate it later without changing the response shape or client rendering.

## What changed

- **Shared (`packages/shared`)**: new `ActivityEvent` discriminated union (`packages/shared/src/interfaces/activity-event.interface.ts`) and `activity-event.constants.ts`. `ActivityEventType` is derived (`ActivityEvent['type']`), not hand-duplicated. `activity-feed.utils.ts`'s `buildActivityFeed` is replaced by a pure `mapActivityEventsToFeedItems(events, opts)` mapper — same label/icon/action logic, now reading from `event.payload` instead of raw entities.
- **Server**: new `committee-activity.controller.ts` / `committee-activity.service.ts` / `committee-activity-query.helper.ts` (3-file pattern), wired into `committees.route.ts`. The service fans out to 4 upstream legs (past meetings, votes, surveys, documents — itself 3 calls: folders/links/files) plus a committee-service lookup for `enable_voting`, merges by a composite `(occurred_at, key)` cursor, and returns `{ data, page_token }`.
- **Client**: `committee-overview.component.ts` swaps its 4-source fetch-and-merge for one call to the new endpoint; rendering is unchanged (same `ActivityFeedItem` shape, same click-through drawer hydration from the existing `votes()`/`surveys()` signals).

## v1-emitted vs. deferred event types

`ActivityEventType` documents the full target vocabulary so the future event-log swap doesn't require a contract change:

- **v1-emitted** (constructed by this PR): `meeting_held`, `vote_opened`, `vote_closed`, `survey_published`, `survey_closed`, `document_uploaded`.
- **Deferred** (typed now, never constructed in v1 — no upstream source exists yet): `document_deleted` (no delete-tombstone upstream), `member_joined`/`member_left` (no membership-history tracking), `notes_added` (no notes feature).

## One-event-per-row design choice

Votes and surveys each emit **one** event per row, not two (open + close): if the row has ended, emit `vote_closed`/`survey_closed` at its end timestamp; otherwise `vote_opened`/`survey_opened` at creation time. This keeps the widget's rendering identical to today's single-row-per-vote/survey behavior — a data-source swap, not a redesign. A future real event log would naturally emit both events as they actually occur; the type enum already accommodates that.

## Sort-order / date-field limitations

- **Meetings**: `occurred_at` is built from `start_time` and is a **hard guarantee**, not an approximation — verified directly against `lfx-v2-meeting-service` source (`internal/domain/models/event_models.go`, `cmd/meeting-api/eventing/past_meeting_event_handler.go`, `docs/event-processing.md`): `v1_past_meeting` rows are sourced from exactly one NATS stream and the struct backing them has no `scheduled_start_time` field at all, so there's no alternate value it could diverge from. A runtime tripwire (aggregated per-request `logger.warning` in `fetchPastMeetingEvents`) still fires if this upstream contract ever changes, since "verified today" isn't "true forever."
- **Votes / files**: best-effort narrowing — query-service's documented `sort` enum (`name_asc/desc`, `updated_asc/desc`) doesn't support arbitrary date-field ordering, so these legs use `date_field`/`date_from`/`date_to` filtering plus a bounded per-leg page size, not a proven-complete sort. This is materially better than the old stop-gap's *unbounded* drain, but not a mathematical guarantee at high volume — acceptable at committee-activity scale, called out here as a known v1 limitation.
- **Surveys**: deliberately sends **no** upstream date narrowing at all (fixed after review — see below), relying entirely on the in-memory since/cursor pass, and a bounded per-leg page size (`sort: updated_desc` only) for correctness. Unlike votes/files, a survey's cutoff-driven `occurred_at` isn't bounded below by any field the row is ever written to, so date-field narrowing on this leg would systematically (not just approximately) exclude in-window rows.
- Folders/links (no upstream date filter at all) are filtered in-memory against the request window before capping, to avoid truncating the correct window with an arbitrary page boundary.

## Forward path

The real event log (this ticket's original, deferred scope) is expected to swap in behind this same `ActivityEvent` contract later, without a client-visible change.

## Test coverage

No `.component.spec.ts` for the swapped `committee-overview.component.ts` — this repo has no Angular component-test runner wired up at all (confirmed: zero such files exist anywhere in the repo). Server-side coverage (`committee-activity.service.spec.ts`, `.controller.spec.ts`, `committee-activity-query.helper.spec.ts`) covers: merge ordering across sources, `since`/`limit`/cursor validation and pagination round-trips (composite-cursor tie handling, 30-item pagination-walk and 30-tied-timestamp regressions), per-leg failure isolation (one leg failing doesn't blank the others), `enable_voting=false` vote exclusion, and the meetings-leg runtime tripwire (positive + negative cases, each verified by mutation testing to actually discriminate).

## Accepted trade-offs (explicit decision, not oversights)

A full-branch reviewer sweep raised 5 "Important" findings (no Criticals). All 5 are deliberately left as documented trade-offs rather than fixed in this PR:

1. **Pagination machinery has no current consumer.** `page_token`, saturation detection (`anyLegSaturated`), and the composite cursor are real and tested, but the client only ever fetches page 1 today. This matches an earlier explicit choice in this PR to implement real timestamp-cursor pagination now rather than a stub, so a future "load more" UI needs no server changes.
2. **High comment-to-code ratio in `committee-activity.service.ts`**, reflecting the multi-round upstream-contract verification described above (meetings' `occurred_at` guarantee in particular). Left inline rather than split into a separate doc, since the comments are directly load-bearing for why specific code paths exist.
3. **`ActivityEventType` has no current consumers of its deferred variants** — it documents the forward-looking wire contract (including types with no v1 source) per the ticket's explicit goal of a future event-log swap without a contract change.
4. **`fetchCommittee` (the FGA-enforced committee lookup) runs concurrently with, not gating, the 6 data-fetch calls inside the same `Promise.all`.** No data leak — `Promise.all` discards every result on any rejection — but an unauthorized caller triggers ~9 upstream calls before the 403 resolves, rather than failing fast on the first. Accepted as a request-amplification cost, not a security issue.
5. **Net upstream call volume for the Overview page increased**, not decreased, versus the old stop-gap. The real win is boundedness — replacing what was previously an unbounded `fetchAllQueryResources` drain (documents leg) with capped, windowed per-leg fetches — not a reduction in call count.
6. **Vote-drawer click miss shows a toast instead of hydrating the drawer by UID.** `this.votes()` and the activity feed are independent, differently-windowed fetches, so a vote recent enough to appear in the feed can miss `this.votes()`'s own 100-item window; the click handler toasts "Vote unavailable" rather than opening the drawer seeded with just `voteUid`. Considered, not an oversight: `VoteResultsDrawerComponent`'s own `@if (vote(); as voteData)` has no `@else`, so a null-seeded drawer would render empty with no loading/not-found state until (or unless) its own re-fetch resolves — worse than the toast for the genuinely-missing case. Flagged by dealako's review as worth listing here for visibility (not blocking); revisit if a low-effort loading/`@else` branch on the shared drawer ever closes this gap.
7. **A `hasMore: false` response can still be non-terminal when access-control filters an entire fetched page to zero visible rows.** Confirmed against `lfx-v2-query-service`'s own source and documented contract: FGA access-checking runs *after* OpenSearch paginates, so `page_token` reflects the raw pre-filter page — a leg's single bounded fetch can come back with zero visible resources while `page_token` is still set, meaning authorized rows could exist on a later upstream page this endpoint never requests. `anyLegSaturated` already reflects this correctly via each leg's real `page_token`, but if every leg's page filters down to zero visible rows in the same response, there's no `lastPageItem` to anchor a cursor on, so `hasMore` forces `false` regardless. Closing this for real means looping a leg's own upstream call until a visible candidate or exhaustion — ruled out for v1 by the "bounded calls, no per-event follow-ups" requirement (the same constraint behind trade-off #5's call-volume note above). Flagged by Copilot; independently verified against `lfx-v2-query-service`'s `internal/service/resource_search.go` and `docs/query-service-contract.md`.

## Review feedback addressed

A full-branch reviewer sweep (Copilot, CodeRabbit, Cursor Bugbot) plus a human review from @dealako independently confirmed 5 minor issues, cross-checked against current code:

- **Vote status casing bug** — `mapVoteToEvent` now goes through `normalizePollStatus` before comparing to `PollStatus.ENDED`, matching `isVoteCalendarEventPast`'s existing pattern; a non-canonical-case `"Ended"` no longer misclassifies as `vote_opened` at the wrong timestamp.
- **Survey `occurred_at` for cutoff-driven closures** — a `SENT` survey whose cutoff has passed (no corresponding `last_modified_at` write) now stamps `survey_closed` at `survey_cutoff_date`, not the stale publish/update time.
- **Saturation detection now uses each leg's real upstream `page_token`**, not a `length >= fetchSize` row-count comparison — a leg returning a genuine final page no longer triggers a false-positive `hasMore`/cursor to an empty next page.
- **Meeting password now travels in the activity event's own payload**, not a lookup against the separately-windowed `pastMeetings()` signal — closes a real regression where a password-protected meeting recent enough for the feed but outside that signal's window silently lost its password on navigation.
- **Repeated query params (`?since=a&since=b`) are now rejected with a 400**, not silently treated as absent — Express's `qs` parser turns them into arrays, which previously restarted pagination / ignored `since` / fell back `page_size` to its default with no error surfaced.
- **`console.error` now logs a safe field subset** (`{ status, message }` for the HTTP fetch failure, `{ message }` for the mapping-step failure), not the raw error object, in the two call sites this PR introduced.
- **Survey leg no longer sends any upstream date narrowing** — a follow-up finding from Copilot on the cutoff-driven-closure fix above: `date_field: 'last_modified_at'` silently excluded exactly the rows a `since`-scoped request needs, since a cutoff-driven closure's `occurred_at` has no corresponding write to `last_modified_at`. Now relies entirely on the in-memory since/cursor pass; see the updated "Sort-order / date-field limitations" section above.
- **An `ACTIVE` vote whose `end_time` has already passed is now treated as closed**, not left as `vote_opened` at `creation_time` indefinitely — `mapVoteToEvent` now checks the deadline via a locally-reimplemented `isVoteDeadlinePast` (mirrors `isVoteCalendarEventPast`'s existing "deadline passed" semantics; reimplemented rather than imported since that helper lives in `meeting.utils.ts`, which pulls in an Angular-only `@angular/common/http` import this server file already avoids). Flagged by Cursor Bugbot as a follow-up to the casing fix above.

## Test plan

- [x] `yarn lint && yarn format:check && yarn test && yarn build` all pass
- [x] All commits DCO-signed (`--signoff`) and GPG-signed (verified via `git log --format='%G? %h %s'`)
- [x] Rebased cleanly onto latest `origin/main` (962 tests passing, up from 909 pre-rebase)
- [x] Full-branch reviewer sweep (general + Self Serve conventions + learnings) run against `origin/main`, findings documented above as accepted trade-offs
- [x] Review round from @dealako/Copilot/CodeRabbit/Cursor Bugbot addressed in `7a023002c`/`7ffddb7e1`/`d3cf4e86f`/`59f678f27` (see "Review feedback addressed" above); 976 tests passing, up from 962
- [ ] Manual verification in a running dev server: `GET /api/committees/:uid/activity` with no params, `since` only, `limit` bounds, pagination via `page_token`, and a voting-disabled committee
- [ ] Committee overview page renders the activity widget identically to before (same labels/icons/click targets), now via one BFF call instead of four


