### PR TITLE
feat(projects): add lens-redirect endpoint for email deep links (LFXV2-2952)

### DIFF
--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -1,0 +1,226 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Project } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const SLUG = 'cncf';
+const PROJECT_UID = 'project-2222';
+
+// Hoisted, per-test-controllable mocks. The `@lfx-one/shared/*` path alias isn't wired
+// into vitest (see vitest.config.ts), so the shared barrels the controller imports at
+// module load are stubbed here. `computeIsFoundation` is mocked so each test can drive
+// the foundation-vs-project branch without constructing a full Project graph.
+const { computeIsFoundationMock, generateM2MTokenMock, projectSvc } = vi.hoisted(() => ({
+  computeIsFoundationMock: vi.fn(),
+  generateM2MTokenMock: vi.fn(),
+  projectSvc: {
+    getProjectIdBySlug: vi.fn(),
+    getProjectById: vi.fn(),
+  },
+}));
+
+vi.mock('@lfx-one/shared/utils', () => ({
+  computeIsFoundation: computeIsFoundationMock,
+  isFileTypeAllowed: vi.fn(),
+  isUuid: vi.fn(),
+}));
+vi.mock('@lfx-one/shared/constants', () => ({
+  ALLOWED_FILE_TYPES: [],
+  LENS_REDIRECT_RESOURCES: new Set<string>(['votes', 'meetings', 'mailing-lists', 'groups', 'documents', 'surveys', 'newsletters', 'settings']),
+}));
+vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public', PRIVATE: 'private' } }));
+// validation.helper pulls in a heavy shared/constants + shared/enums graph; stub it
+// wholesale so only the controller's getLensRedirect path loads.
+vi.mock('../helpers/validation.helper', () => ({ getStringQueryParam: vi.fn(), validateUidParameter: vi.fn(() => true) }));
+
+vi.mock('../services/project.service', () => ({
+  ProjectService: vi.fn(function () {
+    return projectSvc;
+  }),
+}));
+vi.mock('../services/meeting.service', () => ({
+  MeetingService: vi.fn(function () {
+    return {};
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(), getEffectiveUsername: vi.fn(), getUsernameFromAuth: vi.fn() }));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
+
+import { readFileSync } from 'node:fs';
+
+import { LENS_REDIRECT_RESOURCES } from '@lfx-one/shared/constants';
+import { ProjectController } from './project.controller';
+import { ServiceValidationError } from '../errors';
+
+function buildProject(overrides: Partial<Project> = {}): Project {
+  return {
+    uid: PROJECT_UID,
+    slug: SLUG,
+    name: 'CNCF',
+    description: '',
+    public: true,
+    parent_uid: '',
+    stage: 'Active',
+    category: '',
+    funding_model: ['Membership'],
+    charter_url: '',
+    legal_entity_type: 'Foundation',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '',
+    logo_url: '',
+    repository_url: '',
+    website_url: '',
+    created_at: '',
+    updated_at: '',
+    mailing_list_count: 0,
+    ...overrides,
+  } as Project;
+}
+
+function buildReqRes(slug: string = SLUG, resource: string = 'votes') {
+  const req = {
+    params: { slug, resource },
+    query: {},
+    headers: {},
+    bearerToken: undefined,
+    path: `/public/api/projects/${slug}/lens-redirect/${resource}`,
+  } as any;
+  const res = {
+    redirect: vi.fn(),
+    setHeader: vi.fn(),
+  } as any;
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('ProjectController.getLensRedirect', () => {
+  let controller: ProjectController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new ProjectController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+  });
+
+  it('redirects a foundation slug to /foundation/<resource>', async () => {
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: PROJECT_UID, slug: SLUG, exists: true });
+    projectSvc.getProjectById.mockResolvedValue(buildProject());
+    computeIsFoundationMock.mockReturnValue(true);
+    const { req, res, next } = buildReqRes();
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(generateM2MTokenMock).toHaveBeenCalledTimes(1);
+    expect(projectSvc.getProjectById).toHaveBeenCalledWith(req, PROJECT_UID, false);
+    expect(res.redirect).toHaveBeenCalledWith(302, '/foundation/votes?project=cncf');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('redirects a project slug to /project/<resource>', async () => {
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: PROJECT_UID, slug: SLUG, exists: true });
+    projectSvc.getProjectById.mockResolvedValue(buildProject());
+    computeIsFoundationMock.mockReturnValue(false);
+    const { req, res, next } = buildReqRes();
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, '/project/votes?project=cncf');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('carries the resource segment through to the lens-prefixed destination', async () => {
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: PROJECT_UID, slug: SLUG, exists: true });
+    projectSvc.getProjectById.mockResolvedValue(buildProject());
+    computeIsFoundationMock.mockReturnValue(true);
+    const { req, res, next } = buildReqRes(SLUG, 'meetings');
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, '/foundation/meetings?project=cncf');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the flat resource route when the slug is unresolvable', async () => {
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: '', slug: SLUG, exists: false });
+    const { req, res, next } = buildReqRes(SLUG, 'meetings');
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(projectSvc.getProjectById).not.toHaveBeenCalled();
+    expect(res.redirect).toHaveBeenCalledWith(302, '/meetings?project=cncf');
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('falls back to the flat resource route when the project fetch throws', async () => {
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: PROJECT_UID, slug: SLUG, exists: true });
+    projectSvc.getProjectById.mockRejectedValue(new Error('upstream 503'));
+    computeIsFoundationMock.mockReturnValue(true);
+    const { req, res, next } = buildReqRes();
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, '/votes?project=cncf');
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects an invalid slug via next() without an M2M call', async () => {
+    const { req, res, next } = buildReqRes('bad slug!');
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(generateM2MTokenMock).not.toHaveBeenCalled();
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(ServiceValidationError);
+  });
+
+  it('rejects an unsupported resource via next() without an M2M call', async () => {
+    const { req, res, next } = buildReqRes(SLUG, 'evil-open-redirect');
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(generateM2MTokenMock).not.toHaveBeenCalled();
+    expect(res.redirect).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(ServiceValidationError);
+  });
+
+  it('passes hyphens and underscores through verbatim in the redirect location', async () => {
+    const slug = 'my-project_1';
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: PROJECT_UID, slug, exists: true });
+    projectSvc.getProjectById.mockResolvedValue(buildProject({ slug }));
+    computeIsFoundationMock.mockReturnValue(false);
+    const { req, res, next } = buildReqRes(slug);
+
+    await controller.getLensRedirect(req, res, next);
+
+    expect(res.redirect).toHaveBeenCalledWith(302, '/project/votes?project=my-project_1');
+  });
+});
+
+describe('LENS_REDIRECT_RESOURCES drift guard', () => {
+  // Every allowlisted resource must have both a /foundation/<x> and /project/<x> route,
+  // otherwise the redirect would 302 to a 404. Read the real route table as text (mocking
+  // it would defeat the check) and assert both lens variants exist for each entry.
+  const routesSrc = readFileSync(new URL('../../app/app.routes.ts', import.meta.url), 'utf8');
+
+  it.each([...LENS_REDIRECT_RESOURCES])('resource "%s" has both foundation and project routes', (resource) => {
+    expect(routesSrc).toContain(`foundation/${resource}`);
+    expect(routesSrc).toContain(`project/${resource}`);
+  });
+});

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -25,10 +25,19 @@ vi.mock('@lfx-one/shared/utils', () => ({
   isFileTypeAllowed: vi.fn(),
   isUuid: vi.fn(),
 }));
-vi.mock('@lfx-one/shared/constants', () => ({
-  ALLOWED_FILE_TYPES: [],
-  LENS_REDIRECT_RESOURCES: new Set<string>(['votes', 'meetings', 'mailing-lists', 'groups', 'documents', 'surveys', 'newsletters', 'settings']),
-}));
+vi.mock('@lfx-one/shared/constants', async () => {
+  // Deep-import the real allowlist so the drift guard below asserts the production
+  // value, not a hardcoded copy that can drift. The barrel is mocked because it
+  // re-exports Angular-dependent constants; `lens.constants.ts` itself only has a
+  // type-only import from `../interfaces`, so importing it directly is safe.
+  const actual = await vi.importActual<typeof import('../../../../../packages/shared/src/constants/lens.constants')>(
+    '../../../../../packages/shared/src/constants/lens.constants'
+  );
+  return {
+    ALLOWED_FILE_TYPES: [],
+    LENS_REDIRECT_RESOURCES: actual.LENS_REDIRECT_RESOURCES,
+  };
+});
 vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public', PRIVATE: 'private' } }));
 // validation.helper pulls in a heavy shared/constants + shared/enums graph; stub it
 // wholesale so only the controller's getLensRedirect path loads.

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -4,7 +4,7 @@
 import { ALLOWED_FILE_TYPES } from '@lfx-one/shared/constants';
 import { MeetingVisibility } from '@lfx-one/shared/enums';
 import { AddUserToProjectRequest, CreateProjectDocumentRequest, UpdateUserRoleRequest, UploadProjectDocumentRequest } from '@lfx-one/shared/interfaces';
-import { isFileTypeAllowed, isUuid } from '@lfx-one/shared/utils';
+import { computeIsFoundation, isFileTypeAllowed, isUuid } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
@@ -21,6 +21,16 @@ import { getEffectiveEmail } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 const FOLDER_UID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+/**
+ * Resource segments the lens-redirect endpoint may forward to. Every entry MUST have both a
+ * `/foundation/<x>` and `/project/<x>` route in app.routes.ts and accept a `?project=<slug>`
+ * context (projectQueryParamGuard). The endpoint forwards ONLY to segments in this set — the
+ * `:resource` param is never echoed raw into the redirect Location, so it cannot become an
+ * open redirect. Keep in sync with the lens-prefixed route table; project.controller.spec.ts
+ * asserts each entry exists under both lenses.
+ */
+export const LENS_REDIRECT_RESOURCES = new Set<string>(['votes', 'meetings', 'mailing-lists', 'groups', 'documents', 'surveys', 'newsletters', 'settings']);
 
 /**
  * Controller for handling project HTTP requests
@@ -943,6 +953,62 @@ export class ProjectController {
       res.send(ics);
     } catch (error) {
       next(error);
+    }
+  }
+
+  /**
+   * GET /public/api/projects/:slug/lens-redirect/:resource — 302 to the lens-prefixed
+   * resource page for email deep links (votes, meetings, …). The lens is derived from the
+   * project's own attributes (computeIsFoundation), not the recipient's active lens, so a
+   * foundation project lands on /foundation/<resource> and a non-foundation on
+   * /project/<resource>. `:resource` is allowlisted (LENS_REDIRECT_RESOURCES) so it can never
+   * become an arbitrary/open redirect. Falls back to the flat /<resource> route when the slug
+   * is unresolvable or the fetch fails. Anonymous access — no user session; M2M upstream.
+   */
+  public async getLensRedirect(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const slug = req.params['slug'] ?? '';
+    const resource = req.params['resource'] ?? '';
+    const startTime = logger.startOperation(req, 'get_lens_redirect', { project_slug: slug, resource });
+
+    if (!slug || !/^[A-Za-z0-9_-]+$/.test(slug)) {
+      next(ServiceValidationError.forField('slug', 'Invalid project slug', { operation: 'get_lens_redirect' }));
+      return;
+    }
+    if (!LENS_REDIRECT_RESOURCES.has(resource)) {
+      next(ServiceValidationError.forField('resource', 'Unsupported lens resource', { operation: 'get_lens_redirect' }));
+      return;
+    }
+
+    try {
+      if (!req.bearerToken) {
+        req.bearerToken = await generateM2MToken(req);
+      }
+
+      const slugToId = await this.projectService.getProjectIdBySlug(req, slug);
+      if (!slugToId.exists) {
+        logger.debug(req, 'get_lens_redirect', 'Slug not found; redirecting to flat resource route', { slug, resource });
+        res.setHeader('Cache-Control', 'no-store');
+        res.redirect(302, `/${resource}`);
+        return;
+      }
+
+      const project = await this.projectService.getProjectById(req, slugToId.uid, false);
+      const lens = computeIsFoundation(project) ? 'foundation' : 'project';
+
+      logger.success(req, 'get_lens_redirect', startTime, { project_slug: slug, resource, lens });
+
+      res.setHeader('Cache-Control', 'no-store');
+      res.redirect(302, `/${lens}/${resource}?project=${encodeURIComponent(slug)}`);
+    } catch (error) {
+      // Unresolvable slug or fetch failure — fall back to the flat resource route rather than
+      // surfacing an error to an email-link recipient.
+      logger.warning(req, 'get_lens_redirect', 'Falling back to flat resource route after error', {
+        project_slug: slug,
+        resource,
+        err: error,
+      });
+      res.setHeader('Cache-Control', 'no-store');
+      res.redirect(302, `/${resource}`);
     }
   }
 }

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ALLOWED_FILE_TYPES } from '@lfx-one/shared/constants';
+import { ALLOWED_FILE_TYPES, LENS_REDIRECT_RESOURCES } from '@lfx-one/shared/constants';
 import { MeetingVisibility } from '@lfx-one/shared/enums';
 import { AddUserToProjectRequest, CreateProjectDocumentRequest, UpdateUserRoleRequest, UploadProjectDocumentRequest } from '@lfx-one/shared/interfaces';
 import { computeIsFoundation, isFileTypeAllowed, isUuid } from '@lfx-one/shared/utils';
@@ -21,16 +21,6 @@ import { getEffectiveEmail } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 const FOLDER_UID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
-
-/**
- * Resource segments the lens-redirect endpoint may forward to. Every entry MUST have both a
- * `/foundation/<x>` and `/project/<x>` route in app.routes.ts and accept a `?project=<slug>`
- * context (projectQueryParamGuard). The endpoint forwards ONLY to segments in this set — the
- * `:resource` param is never echoed raw into the redirect Location, so it cannot become an
- * open redirect. Keep in sync with the lens-prefixed route table; project.controller.spec.ts
- * asserts each entry exists under both lenses.
- */
-export const LENS_REDIRECT_RESOURCES = new Set<string>(['votes', 'meetings', 'mailing-lists', 'groups', 'documents', 'surveys', 'newsletters', 'settings']);
 
 /**
  * Controller for handling project HTTP requests
@@ -986,9 +976,10 @@ export class ProjectController {
 
       const slugToId = await this.projectService.getProjectIdBySlug(req, slug);
       if (!slugToId.exists) {
-        logger.debug(req, 'get_lens_redirect', 'Slug not found; redirecting to flat resource route', { slug, resource });
+        logger.warning(req, 'get_lens_redirect', 'Slug not found; redirecting to flat resource route', { slug, resource });
+        logger.success(req, 'get_lens_redirect', startTime, { project_slug: slug, resource, fallback: 'slug_not_found' });
         res.setHeader('Cache-Control', 'no-store');
-        res.redirect(302, `/${resource}`);
+        res.redirect(302, `/${resource}?project=${encodeURIComponent(slug)}`);
         return;
       }
 
@@ -1007,8 +998,9 @@ export class ProjectController {
         resource,
         err: error,
       });
+      logger.success(req, 'get_lens_redirect', startTime, { project_slug: slug, resource, fallback: 'error' });
       res.setHeader('Cache-Control', 'no-store');
-      res.redirect(302, `/${resource}`);
+      res.redirect(302, `/${resource}?project=${encodeURIComponent(slug)}`);
     }
   }
 }

--- a/apps/lfx-one/src/server/routes/public-projects.route.ts
+++ b/apps/lfx-one/src/server/routes/public-projects.route.ts
@@ -14,4 +14,12 @@ const projectController = new ProjectController();
 // (Google Calendar, Outlook, Apple Calendar) can subscribe by URL.
 router.get('/:id/calendar.ics', (req, res, next) => projectController.getProjectCalendar(req, res, next));
 
+// GET /public/api/projects/:slug/lens-redirect/:resource
+// 302-redirects to the lens-prefixed resource page for email deep links (votes, meetings, …).
+// The lens is derived from the project's own attributes (computeIsFoundation), not the
+// recipient's active lens, so a foundation project lands on /foundation/<resource> and a
+// non-foundation on /project/<resource>. `:resource` is allowlisted in the controller so it
+// cannot become an open redirect. Anonymous access — no user session; M2M-authenticated upstream.
+router.get('/:slug/lens-redirect/:resource', (req, res, next) => projectController.getLensRedirect(req, res, next));
+
 export default router;

--- a/packages/shared/src/constants/lens.constants.ts
+++ b/packages/shared/src/constants/lens.constants.ts
@@ -66,3 +66,13 @@ export const DUAL_SCOPED_LENSES: readonly Lens[] = ['me', 'foundation', 'project
 export const NAV_LENSES: readonly NavLens[] = ['foundation', 'project'] as const;
 
 export const NAV_SEARCH_DEBOUNCE_MS = 300;
+
+/**
+ * Resource segments the lens-redirect endpoint may forward to. Every entry MUST have both a
+ * `/foundation/<x>` and `/project/<x>` route in app.routes.ts and accept a `?project=<slug>`
+ * context (projectQueryParamGuard). The endpoint forwards ONLY to segments in this set — the
+ * `:resource` param is never echoed raw into the redirect Location, so it cannot become an open
+ * redirect. Keep in sync with the lens-prefixed route table; project.controller.spec.ts asserts
+ * each entry exists under both lenses.
+ */
+export const LENS_REDIRECT_RESOURCES = new Set<string>(['votes', 'meetings', 'mailing-lists', 'groups', 'documents', 'surveys', 'newsletters', 'settings']);


### PR DESCRIPTION
# Summary

Adds a public `GET /public/api/projects/:slug/lens-redirect/:resource` endpoint that 302-redirects email-link recipients to the correct lens-prefixed resource page (`/foundation/<resource>` or `/project/<resource>`), deriving the lens from the project's own attributes rather than the recipient's active lens. Email deep links (votes, meetings, mailing-lists, etc.) currently land on a flat route that doesn't carry project context; this endpoint resolves the lens server-side so the recipient arrives on the right page without a client-side lens switch.

Ticket: LFXV2-2952

## Changes

### Before
Email links for votes, meetings, mailing-lists and other project resources landed on a flat route with no project or lens context, so the recipient arrived on a generic page and had to switch lenses client-side to reach the right place. There was no redirect endpoint handling this at all, and no concept of falling back gracefully when a project lookup failed.

### After
Email links now hit a public redirect endpoint that looks up the project from its slug, works out whether it's a foundation or non-foundation project, and 302-redirects the recipient to the correct lens-prefixed page (`/foundation/...` or `/project/...`) with the project context attached, so they land on the right page directly with no client-side lens switch. If the project can't be found or the upstream lookup fails, it safely falls back to the old flat route instead of showing the email recipient an error. Only a fixed set of known resource types (votes, meetings, mailing-lists, groups, documents, surveys, newsletters, settings) are accepted; anything else is rejected so the endpoint can't be abused as an open redirect.

# Technical changes

## Project controller
(`apps/lfx-one/src/server/controllers/project.controller.ts`)
- Add `getLensRedirect` controller method that validates `slug` (`^[A-Za-z0-9_-]+$`) and `resource` (allowlisted), resolves the project via `projectService.getProjectIdBySlug`, then `getProjectById`, and 302-redirects to `/<lens>/<resource>?project=<slug>` with `computeIsFoundation` choosing the lens.
- Export `LENS_REDIRECT_RESOURCES` allowlist (`votes`, `meetings`, `mailing-lists`, `groups`, `documents`, `surveys`, `newsletters`, `settings`). The `:resource` param is matched against this set and never echoed raw into the `Location` header, so the endpoint cannot become an open redirect.
- Acquire an M2M token (`generateM2MToken`) when no bearer token is present, since the endpoint is anonymous (public route, no user session).
- On unresolvable slug or upstream fetch failure, fall back to the flat `/<resource>` route and log a warning instead of surfacing an error to the email recipient.
- Set `Cache-Control: no-store` on every redirect response so email links always re-resolve the lens.
- Add structured `logger.startOperation` / `logger.success` / `logger.warning` instrumentation around the redirect flow.

## Public projects route
(`apps/lfx-one/src/server/routes/public-projects.route.ts`)
- Register `GET /:slug/lens-redirect/:resource` on the public projects router, mapped to `projectController.getLensRedirect`. Route lives under `/public/api/projects/` so it stays anonymous (no user session required).

