### PR TITLE
feat(campaigns): shorten tab labels to verb form

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.html
@@ -601,11 +601,11 @@
       <!-- Edit Mode Actions -->
       <div class="flex items-center gap-3">
         <lfx-button
-          label="Save & Proceed to Implementation"
+          label="Save & Proceed to Implement"
           icon="fa-light fa-arrow-right"
           severity="primary"
           (onClick)="onProceedToImplementation()"
-          ariaLabel="Save edits and proceed to implementation"
+          ariaLabel="Save edits and proceed to implement"
           data-testid="planning-save-proceed-btn" />
         <lfx-button
           label="Save Edits"
@@ -902,11 +902,11 @@
       <!-- Read-Only Actions -->
       <div class="flex items-center gap-3">
         <lfx-button
-          label="Proceed to Implementation"
+          label="Proceed to Implement"
           icon="fa-light fa-arrow-right"
           severity="primary"
           (onClick)="onProceedToImplementation()"
-          ariaLabel="Proceed to implementation with this brief"
+          ariaLabel="Proceed to implement with this brief"
           data-testid="planning-proceed-btn" />
         <lfx-button
           label="Refine Brief"

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -21,10 +21,10 @@ import type {
 
 /** Tab definitions for the Campaigns page tab navigation. */
 export const CAMPAIGN_TABS: readonly CampaignTabOption[] = [
-  { id: 'planning', label: 'Planning', icon: 'fa-light fa-clipboard-list' },
-  { id: 'implementation', label: 'Implementation', icon: 'fa-light fa-rocket' },
-  { id: 'insights', label: 'Insights', icon: 'fa-light fa-chart-mixed' },
-  { id: 'optimization', label: 'Optimization', icon: 'fa-light fa-gauge-high' },
+  { id: 'planning', label: 'Plan', icon: 'fa-light fa-clipboard-list' },
+  { id: 'implementation', label: 'Implement', icon: 'fa-light fa-rocket' },
+  { id: 'insights', label: 'Monitor', icon: 'fa-light fa-chart-mixed' },
+  { id: 'optimization', label: 'Optimize', icon: 'fa-light fa-gauge-high' },
 ] as const;
 
 export const CAMPAIGN_PLATFORMS: readonly CampaignPlatformOption[] = [


### PR DESCRIPTION
## Summary

Renames the Campaigns page tabs to imperative verbs so the row reads as the workflow it represents.

| Before | After |
|---|---|
| Planning | **Plan** |
| Implementation | **Implement** |
| Insights | **Monitor** |
| Optimization | **Optimize** |

## Changes

- `campaign.constants.ts` — the four `CAMPAIGN_TABS` labels.
- `planning-tab.component.html` — the two buttons that navigate to the renamed tab ("Proceed to Implementation" → "Proceed to Implement"), plus their aria labels, so the CTA matches the tab it lands on.

## Notes

- **Tab `id` values are unchanged** (`planning`, `implementation`, `insights`, `optimization`), so routing, persisted tab state, and analytics keys are unaffected. This is a display-string change only.
- `Insights` → `Monitor` is the one rename that isn't a straight shortening; it was chosen to keep all four labels in the same imperative-verb voice.
- No E2E tests reference these labels (selectors use `data-testid`), so none needed updating.

## Testing

- `yarn build` — passes
- `yarn lint:check` — 0 errors (1 pre-existing warning, unrelated)
- `yarn format:check` — clean
- Not yet exercised in a browser: the change is a static label swap in a constants array with no conditional logic, and the build type-checks the template that consumes it. Happy to add a screenshot if a reviewer wants one.

LFXV2-2023