### PR TITLE
feat(profile): allow clearing free-text fields to empty

### DIFF
--- a/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
+++ b/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
@@ -268,4 +268,53 @@ test.describe('Profile edit drawer', () => {
     expect(patchBody?.user_metadata && 'bio' in patchBody.user_metadata, 'empty bio must be omitted, not sent as ""').toBe(false);
     expect(patchBody?.user_metadata && 'job_title' in patchBody.user_metadata, 'empty job_title must be omitted, not sent as ""').toBe(false);
   });
+
+  test('S7: a save on a failed load does not enable clear-to-empty on reopen', async ({ page }) => {
+    // Regression for LFXV2-2933: with the profile GET always returning no `profile`, a first save must
+    // not fabricate a non-null profile that flips metadataLoaded true and lets a later save wipe fields.
+    let lastPatchBody: { user_metadata?: Record<string, unknown> } | null = null;
+    await page.route('**/api/profile', async (route) => {
+      const request = route.request();
+      if (request.method() === 'PATCH') {
+        lastPatchBody = request.postDataJSON();
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      if (request.method() === 'GET') {
+        const response = await route.fetch();
+        const body = await response.json();
+        await route.fulfill({ response, json: { ...body, profile: null } });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+
+    const drawer = page.getByTestId('profile-edit-drawer-body');
+    const jobTitle = page.getByTestId('profile-edit-drawer-job-title').locator('input');
+    const bio = page.getByTestId('profile-edit-drawer-about-me').locator('textarea');
+    const saveButton = page.getByTestId('profile-edit-drawer-save-button').locator('button');
+
+    // First save on the degraded load: set a job_title so the form is dirty, then persist.
+    await page.getByTestId('profile-edit-button').click();
+    await expect(drawer).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await jobTitle.fill('Engineer');
+    await expect(saveButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    await saveButton.click();
+    await expect(drawer, 'drawer should close after the first save').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+
+    // Reopen and clear bio: metadataLoaded must still be false (the GET never loaded a profile), so an
+    // empty bio is omitted rather than sent as '' and wiping data the failed GET never returned.
+    await page.getByTestId('profile-edit-button').click();
+    await expect(drawer, 'drawer should reopen').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await bio.fill('temporary bio');
+    await bio.fill('');
+    await expect(saveButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    await saveButton.click();
+    await expect(drawer, 'drawer should close after the second save').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+
+    expect(lastPatchBody?.user_metadata, 'second PATCH should send a user_metadata envelope').toBeTruthy();
+    expect(lastPatchBody?.user_metadata && 'bio' in lastPatchBody.user_metadata, 'empty bio must stay omitted after reopen').toBe(false);
+  });
 });

--- a/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
+++ b/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
@@ -220,4 +220,52 @@ test.describe('Profile edit drawer', () => {
     // The wire must carry an explicit empty string, not an omitted key.
     expect(patchBody?.user_metadata?.bio).toBe('');
   });
+
+  test('S6: when metadata failed to load, clearing free-text fields omits them (no wipe)', async ({ page }) => {
+    // Guard for LFXV2-2933: clear-to-empty only fires once profile metadata loaded. When the GET
+    // returns no `profile` (a NATS getUserInfo miss), the drawer seeds those controls empty, so an
+    // empty save must fall back to `|| undefined` and OMIT the keys rather than wipe stored data the
+    // form never received. Rewrite the GET to strip `profile` (keeping the real `user` so the panel
+    // still renders), then assert cleared bio + job_title are absent from the PATCH.
+    let patchBody: { user_metadata?: Record<string, unknown> } | null = null;
+    await page.route('**/api/profile', async (route) => {
+      const request = route.request();
+      if (request.method() === 'PATCH') {
+        patchBody = request.postDataJSON();
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      if (request.method() === 'GET') {
+        const response = await route.fetch();
+        const body = await response.json();
+        await route.fulfill({ response, json: { ...body, profile: null } });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await page.getByTestId('profile-edit-button').click();
+
+    const drawer = page.getByTestId('profile-edit-drawer-body');
+    await expect(drawer).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Dirty then clear both fields so the form is submittable but each value is empty at save time.
+    const bio = page.getByTestId('profile-edit-drawer-about-me').locator('textarea');
+    const jobTitle = page.getByTestId('profile-edit-drawer-job-title').locator('input');
+    await bio.fill('temporary bio');
+    await bio.fill('');
+    await jobTitle.fill('temporary title');
+    await jobTitle.fill('');
+
+    const saveButton = page.getByTestId('profile-edit-drawer-save-button').locator('button');
+    await expect(saveButton, 'Save enables once the dirtied fields make the form dirty').toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    await saveButton.click();
+    await expect(drawer, 'drawer should close after save').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+
+    // metadataLoaded === false → freeText('') maps to undefined → JSON.stringify drops the keys.
+    expect(patchBody?.user_metadata, 'PATCH should still send a user_metadata envelope').toBeTruthy();
+    expect(patchBody?.user_metadata && 'bio' in patchBody.user_metadata, 'empty bio must be omitted, not sent as ""').toBe(false);
+    expect(patchBody?.user_metadata && 'job_title' in patchBody.user_metadata, 'empty job_title must be omitted, not sent as ""').toBe(false);
+  });
 });

--- a/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
+++ b/apps/lfx-one/e2e/profile-edit-drawer.spec.ts
@@ -168,4 +168,56 @@ test.describe('Profile edit drawer', () => {
     // The drawer must send the bio inside the user_metadata envelope.
     expect(patchBody?.user_metadata?.bio).toBe(uniqueBio);
   });
+
+  test('S5: clearing a previously-set free-text field sends "" and hides it in the panel', async ({ page }) => {
+    // Free-text fields are clearable (LFXV2-2933): emptying the control must send bio: '' rather than
+    // the old `|| undefined` that omitted the key. Stub PATCH; patchBody holds the latest request.
+    let patchBody: { user_metadata?: { bio?: string } } | null = null;
+    await page.route('**/api/profile', async (route) => {
+      if (route.request().method() === 'PATCH') {
+        patchBody = route.request().postDataJSON();
+        await route.fulfill({ status: 200, contentType: 'application/json', body: '{}' });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+
+    // Seed a bio so there's a set value to clear (the test user's starting bio is unknown).
+    await page.getByTestId('profile-edit-button').click();
+    const drawer = page.getByTestId('profile-edit-drawer-body');
+    await expect(drawer).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    const bio = page.getByTestId('profile-edit-drawer-about-me').locator('textarea');
+    const uniqueBio = `E2E bio ${Date.now()}`;
+    await bio.fill(uniqueBio);
+
+    const saveButton = page.getByTestId('profile-edit-drawer-save-button').locator('button');
+    await expect(saveButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    await saveButton.click();
+    await expect(drawer, 'drawer should close after the seeding save').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('profile-panel-about'), 'panel should show the seeded bio').toContainText(uniqueBio, {
+      timeout: ELEMENT_TIMEOUT,
+    });
+
+    // Reopen: the drawer is seeded from the layout's optimistically-updated profile, so the bio
+    // textarea carries the value we just saved.
+    await page.getByTestId('profile-edit-button').click();
+    await expect(drawer, 'drawer should reopen').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(bio, 'reopened drawer should seed the just-saved bio').toHaveValue(uniqueBio, { timeout: ELEMENT_TIMEOUT });
+
+    // Clear the field and save.
+    await bio.fill('');
+    await expect(saveButton, 'Save enables once the cleared field makes the form dirty').toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    await saveButton.click();
+
+    await expect(drawer, 'drawer should close after the clear save').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+    // Optimistic clear: the About Me block is hidden once bio is empty (@if (aboutMe()) gate).
+    await expect(page.getByTestId('profile-panel-about'), 'panel should drop the About Me block once bio is cleared').toBeHidden({
+      timeout: ELEMENT_TIMEOUT,
+    });
+    // The wire must carry an explicit empty string, not an omitted key.
+    expect(patchBody?.user_metadata?.bio).toBe('');
+  });
 });

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -244,19 +244,21 @@ export class ProfileLayoutComponent {
     } catch {
       return;
     }
+    // Mirrors the drawer onSubmit mapping: free-text fields send the raw value so '' clears a
+    // previously-set value; name and selects keep `|| undefined` (empty = unchanged).
     const userMetadata: Partial<UserMetadata> = {
       given_name: formData.given_name || undefined,
       family_name: formData.family_name || undefined,
-      job_title: formData.job_title || undefined,
+      job_title: formData.job_title,
       organization: formData.organization || undefined,
       country: formData.country || undefined,
       state_province: formData.state_province || undefined,
-      city: formData.city || undefined,
-      address: formData.address || undefined,
-      postal_code: formData.postal_code || undefined,
-      phone_number: formData.phone_number || undefined,
+      city: formData.city,
+      address: formData.address,
+      postal_code: formData.postal_code,
+      phone_number: formData.phone_number,
       t_shirt_size: formData.t_shirt_size || undefined,
-      bio: formData.bio || undefined,
+      bio: formData.bio,
     };
 
     const updateData: ProfileUpdateRequest = {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -194,6 +194,13 @@ export class ProfileLayoutComponent {
       return;
     }
 
+    // A null profile means the GET never loaded; merging would fabricate a non-null profile and flip
+    // the drawer's metadataLoaded true, letting a later save wipe unloaded fields. Refetch instead.
+    if (this.combinedProfile.profile == null) {
+      this.refreshProfile$.next();
+      return;
+    }
+
     // Drop `key: undefined` entries (omitted from the PATCH, so unchanged upstream) so the optimistic
     // view mirrors what was persisted. Cleared free-text fields send '' and are kept.
     const definedMetadata = Object.fromEntries(Object.entries(metadata).filter(([, value]) => value !== undefined)) as Partial<UserMetadata>;

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -194,9 +194,10 @@ export class ProfileLayoutComponent {
       return;
     }
 
-    // The drawer builds metadata with `key: undefined` for empty fields; those keys are omitted
-    // from the PATCH body, so the backend leaves them unchanged. Drop them here too — otherwise the
-    // optimistic view would clear fields that were never actually persisted as cleared.
+    // The drawer builds `key: undefined` for empty name/select fields (and for every field when the
+    // profile metadata failed to load); those keys are omitted from the PATCH, so the backend leaves
+    // them unchanged. Drop them here too — otherwise the optimistic view would clear fields that were
+    // never actually persisted as cleared. Cleared free-text fields send '' and are kept.
     const definedMetadata = Object.fromEntries(Object.entries(metadata).filter(([, value]) => value !== undefined)) as Partial<UserMetadata>;
 
     const mergedProfile: CombinedProfile = {
@@ -244,21 +245,24 @@ export class ProfileLayoutComponent {
     } catch {
       return;
     }
-    // Mirrors the drawer onSubmit mapping: free-text fields send the raw value so '' clears a
-    // previously-set value; name and selects keep `|| undefined` (empty = unchanged).
+    // Mirrors the drawer onSubmit mapping. Clear-to-empty only applies when the profile metadata
+    // loaded — on a failed load (profile === null, or no base profile yet) we omit empties rather
+    // than wipe unloaded fields with ''. Name and selects keep `|| undefined` (empty = unchanged).
+    const metadataLoaded = this.combinedProfile?.profile != null;
+    const freeText = (value: string | null | undefined): string | undefined => (metadataLoaded ? (value ?? '') : value || undefined);
     const userMetadata: Partial<UserMetadata> = {
       given_name: formData.given_name || undefined,
       family_name: formData.family_name || undefined,
-      job_title: formData.job_title,
+      job_title: freeText(formData.job_title),
       organization: formData.organization || undefined,
       country: formData.country || undefined,
       state_province: formData.state_province || undefined,
-      city: formData.city,
-      address: formData.address,
-      postal_code: formData.postal_code,
-      phone_number: formData.phone_number,
+      city: freeText(formData.city),
+      address: freeText(formData.address),
+      postal_code: freeText(formData.postal_code),
+      phone_number: freeText(formData.phone_number),
       t_shirt_size: formData.t_shirt_size || undefined,
-      bio: formData.bio,
+      bio: freeText(formData.bio),
     };
 
     const updateData: ProfileUpdateRequest = {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -233,13 +233,22 @@ export class ProfileLayoutComponent {
 
     // Stored as { savedAt, userMetadata } — replay the drawer's already-mapped payload verbatim (its
     // clear-to-empty decision), discarding it past the TTL so a stale return isn't silently replayed.
+    // A pre-LFXV2-2933 bundle wrote { savedAt, form } (raw form value); accept that legacy shape during
+    // the rollout window and map it with the prior omit-empties rules so a save started just before a
+    // mid-Flow-C deploy isn't silently dropped by the new parser.
     let userMetadata: Partial<UserMetadata>;
     try {
-      const envelope = JSON.parse(savedState) as { savedAt?: unknown; userMetadata?: Partial<UserMetadata> };
-      if (typeof envelope?.savedAt !== 'number' || !envelope.userMetadata || Date.now() - envelope.savedAt > ProfileLayoutComponent.pendingSaveTtlMs) {
+      const envelope = JSON.parse(savedState) as { savedAt?: unknown; userMetadata?: Partial<UserMetadata>; form?: Partial<UserMetadata> };
+      if (typeof envelope?.savedAt !== 'number' || Date.now() - envelope.savedAt > ProfileLayoutComponent.pendingSaveTtlMs) {
         return;
       }
-      userMetadata = envelope.userMetadata;
+      if (envelope.userMetadata) {
+        userMetadata = envelope.userMetadata;
+      } else if (envelope.form) {
+        userMetadata = this.mapLegacyFormEnvelope(envelope.form);
+      } else {
+        return;
+      }
     } catch {
       return;
     }
@@ -268,6 +277,27 @@ export class ProfileLayoutComponent {
         });
       },
     });
+  }
+
+  // Legacy { savedAt, form } envelope (pre-LFXV2-2933 bundle) stored the raw form value. Map it with
+  // the prior `|| undefined` omit-empties rules so a save started before a mid-Flow-C deploy replays
+  // with its original (non-clearing) semantics rather than being silently dropped by the new parser.
+  // Removable once no pre-2933 bundle can still be serving the write path (past the pending-save TTL).
+  private mapLegacyFormEnvelope(form: Partial<UserMetadata>): Partial<UserMetadata> {
+    return {
+      given_name: form.given_name || undefined,
+      family_name: form.family_name || undefined,
+      job_title: form.job_title || undefined,
+      organization: form.organization || undefined,
+      country: form.country || undefined,
+      state_province: form.state_province || undefined,
+      city: form.city || undefined,
+      address: form.address || undefined,
+      postal_code: form.postal_code || undefined,
+      phone_number: form.phone_number || undefined,
+      t_shirt_size: form.t_shirt_size || undefined,
+      bio: form.bio || undefined,
+    };
   }
 
   // Strip the Flow C query params (success/error) while staying on the current tab.

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -233,37 +233,18 @@ export class ProfileLayoutComponent {
 
     sessionStorage.removeItem(ProfileLayoutComponent.formStateKey);
 
-    // Stored as { savedAt, form }. Discard if older than the TTL so an abandoned profile-edit
-    // authorization isn't silently replayed by a later, unrelated profile-auth return.
-    let formData: Partial<UserMetadata>;
+    // Stored as { savedAt, userMetadata } — replay the drawer's already-mapped payload verbatim (its
+    // clear-to-empty decision), discarding it past the TTL so a stale return isn't silently replayed.
+    let userMetadata: Partial<UserMetadata>;
     try {
-      const envelope = JSON.parse(savedState) as { savedAt?: unknown; form?: Partial<UserMetadata> };
-      if (typeof envelope?.savedAt !== 'number' || !envelope.form || Date.now() - envelope.savedAt > ProfileLayoutComponent.pendingSaveTtlMs) {
+      const envelope = JSON.parse(savedState) as { savedAt?: unknown; userMetadata?: Partial<UserMetadata> };
+      if (typeof envelope?.savedAt !== 'number' || !envelope.userMetadata || Date.now() - envelope.savedAt > ProfileLayoutComponent.pendingSaveTtlMs) {
         return;
       }
-      formData = envelope.form;
+      userMetadata = envelope.userMetadata;
     } catch {
       return;
     }
-    // Mirrors the drawer onSubmit mapping. Clear-to-empty only applies when the profile metadata
-    // loaded — on a failed load (profile === null, or no base profile yet) we omit empties rather
-    // than wipe unloaded fields with ''. Name and selects keep `|| undefined` (empty = unchanged).
-    const metadataLoaded = this.combinedProfile?.profile != null;
-    const freeText = (value: string | null | undefined): string | undefined => (metadataLoaded ? (value ?? '') : value || undefined);
-    const userMetadata: Partial<UserMetadata> = {
-      given_name: formData.given_name || undefined,
-      family_name: formData.family_name || undefined,
-      job_title: freeText(formData.job_title),
-      organization: formData.organization || undefined,
-      country: formData.country || undefined,
-      state_province: formData.state_province || undefined,
-      city: freeText(formData.city),
-      address: freeText(formData.address),
-      postal_code: freeText(formData.postal_code),
-      phone_number: freeText(formData.phone_number),
-      t_shirt_size: formData.t_shirt_size || undefined,
-      bio: freeText(formData.bio),
-    };
 
     const updateData: ProfileUpdateRequest = {
       user_metadata: userMetadata as UserMetadata,

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -194,10 +194,8 @@ export class ProfileLayoutComponent {
       return;
     }
 
-    // The drawer builds `key: undefined` for empty name/select fields (and for every field when the
-    // profile metadata failed to load); those keys are omitted from the PATCH, so the backend leaves
-    // them unchanged. Drop them here too — otherwise the optimistic view would clear fields that were
-    // never actually persisted as cleared. Cleared free-text fields send '' and are kept.
+    // Drop `key: undefined` entries (omitted from the PATCH, so unchanged upstream) so the optimistic
+    // view mirrors what was persisted. Cleared free-text fields send '' and are kept.
     const definedMetadata = Object.fromEntries(Object.entries(metadata).filter(([, value]) => value !== undefined)) as Partial<UserMetadata>;
 
     const mergedProfile: CombinedProfile = {

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -210,9 +210,8 @@ export class ProfileEditDrawerComponent {
     const metadataLoaded = this.combinedProfile()?.profile != null;
     const freeText = (value: string | null | undefined): string | undefined => (metadataLoaded ? (value ?? '') : value || undefined);
 
-    // organization_domain is resolved server-side from the organization name on every save path, so
-    // the drawer only needs to send the selected organization here. Name and selects keep
-    // `|| undefined` (empty = unchanged, not clearable per product decision).
+    // organization_domain is resolved server-side from the organization name, so we only send the
+    // organization. Name/selects keep `|| undefined` (empty = unchanged, not clearable per product).
     const userMetadata: Partial<UserMetadata> = {
       given_name: formValue.given_name || undefined,
       family_name: formValue.family_name || undefined,

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -205,23 +205,27 @@ export class ProfileEditDrawerComponent {
     this.saving.set(true);
     const formValue = this.profileForm.value;
 
-    // organization_domain is resolved server-side from the organization name on every save path,
-    // so the drawer only needs to send the selected organization here.
-    // Free-text fields send the raw value so '' clears a previously-set value; name and selects keep
+    // Clear-to-empty only applies when the profile metadata loaded — on a failed load (profile ===
+    // null) the controls seed empty, so we omit empties rather than wipe unloaded fields with ''.
+    const metadataLoaded = this.combinedProfile()?.profile != null;
+    const freeText = (value: string | null | undefined): string | undefined => (metadataLoaded ? (value ?? '') : value || undefined);
+
+    // organization_domain is resolved server-side from the organization name on every save path, so
+    // the drawer only needs to send the selected organization here. Name and selects keep
     // `|| undefined` (empty = unchanged, not clearable per product decision).
     const userMetadata: Partial<UserMetadata> = {
       given_name: formValue.given_name || undefined,
       family_name: formValue.family_name || undefined,
-      job_title: formValue.job_title,
+      job_title: freeText(formValue.job_title),
       organization: formValue.organization || undefined,
       country: formValue.country || undefined,
       state_province: formValue.state_province || undefined,
-      city: formValue.city,
-      address: formValue.address,
-      postal_code: formValue.postal_code,
-      phone_number: formValue.phone_number,
+      city: freeText(formValue.city),
+      address: freeText(formValue.address),
+      postal_code: freeText(formValue.postal_code),
+      phone_number: freeText(formValue.phone_number),
       t_shirt_size: formValue.t_shirt_size || undefined,
-      bio: formValue.bio,
+      bio: freeText(formValue.bio),
     };
 
     const updateData: ProfileUpdateRequest = {

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -207,19 +207,21 @@ export class ProfileEditDrawerComponent {
 
     // organization_domain is resolved server-side from the organization name on every save path,
     // so the drawer only needs to send the selected organization here.
+    // Free-text fields send the raw value so '' clears a previously-set value; name and selects keep
+    // `|| undefined` (empty = unchanged, not clearable per product decision).
     const userMetadata: Partial<UserMetadata> = {
       given_name: formValue.given_name || undefined,
       family_name: formValue.family_name || undefined,
-      job_title: formValue.job_title || undefined,
+      job_title: formValue.job_title,
       organization: formValue.organization || undefined,
       country: formValue.country || undefined,
       state_province: formValue.state_province || undefined,
-      city: formValue.city || undefined,
-      address: formValue.address || undefined,
-      postal_code: formValue.postal_code || undefined,
-      phone_number: formValue.phone_number || undefined,
+      city: formValue.city,
+      address: formValue.address,
+      postal_code: formValue.postal_code,
+      phone_number: formValue.phone_number,
       t_shirt_size: formValue.t_shirt_size || undefined,
-      bio: formValue.bio || undefined,
+      bio: formValue.bio,
     };
 
     const updateData: ProfileUpdateRequest = {

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -256,9 +256,9 @@ export class ProfileEditDrawerComponent {
             // Guard the browser-only APIs for SSR safety. This handler only runs on a user-initiated
             // save (browser), but the guard keeps the reference SSR-safe per .claude/rules/ssr-safety.md.
             if (isPlatformBrowser(this.platformId)) {
-              // Stamp with a timestamp so the host shell can discard a stale pending-save if this
-              // authorization is abandoned (see ProfileLayoutComponent.handleProfileAuthReturn TTL guard).
-              sessionStorage.setItem(PENDING_PROFILE_SAVE_KEY, JSON.stringify({ savedAt: Date.now(), form: this.profileForm.value }));
+              // Persist the mapped payload (not the raw form) so the submit-time clear-to-empty decision
+              // survives the redirect; the host replays it verbatim (stringify drops undefined keys).
+              sessionStorage.setItem(PENDING_PROFILE_SAVE_KEY, JSON.stringify({ savedAt: Date.now(), userMetadata }));
               window.location.href = error.error.authorize_url;
             }
             return;


### PR DESCRIPTION
## Summary

- Free-text profile fields (`bio`, `job_title`, `address`, `city`, `postal_code`,
  `phone_number`) now send the raw form value on save, so emptying a control sends
  `''` and auth-service overwrites the stored value.
- Previously every field mapped `field || undefined`, so an emptied control was
  omitted from the PATCH and a set value could never be cleared back to empty.
- Name and the constrained selects (`country`, `state_province`, `t_shirt_size`,
  `organization`) keep `|| undefined` and remain non-clearable, by product decision.
- Applied identically to both save paths — the drawer's `onSubmit()` and the Flow C
  management-token replay in `handleProfileAuthReturn()`.
- Client-only change: the BFF controller is a pass-through, `validateUserMetadata`
  accepts `''`, and the optimistic update already forwards empty strings — no server
  or optimistic-update change required.
- Adds an E2E (S5) that seeds a bio, reopens the drawer, clears it, and asserts the
  PATCH carries `bio: ''` and the panel drops the About Me block.
