### PR TITLE
fix(cla): download My CLAs PDF without orphaned blank tab

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -106,7 +106,7 @@ SPDX-License-Identifier: MIT
                   size="small"
                   [text]="true"
                   [loading]="downloadingId() === agreement.id"
-                  (onClick)="onDownload(agreement.id)" />
+                  (onClick)="onDownload(agreement)" />
               } @else if (agreement.kind === 'ECLA') {
                 <span class="text-xs text-slate-400">Covered by Corporate CLA (CCLA)</span>
               } @else {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -74,16 +74,18 @@ export class ProfileClasComponent {
   /**
    * Resolves the ICLA's short-lived PDF URL and triggers a file download (no new tab).
    * Origin-tab spinner stays on while the presigned URL resolves; see #1228.
+   * Filename includes project/CLA-group name so multi-project downloads don't collide.
    */
-  protected onDownload(signatureId: string): void {
+  protected onDownload(agreement: MyClaAgreement): void {
     if (this.downloadingId()) return;
 
-    this.downloadingId.set(signatureId);
+    this.downloadingId.set(agreement.id);
 
-    this.myClasService.getPdfUrl(signatureId).subscribe({
+    this.myClasService.getPdfUrl(agreement.id).subscribe({
       next: ({ url }) => {
         this.downloadingId.set(null);
-        downloadFromUrl(url, 'signed-cla.pdf');
+        const label = agreement.projectName || agreement.claGroupName || 'cla';
+        downloadFromUrl(url, `${label}-signed.pdf`);
       },
       error: () => {
         this.downloadingId.set(null);

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -6,7 +6,7 @@ import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, sign
 import { toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import type { MyClaAgreement, MyClasState } from '@lfx-one/shared/interfaces';
-import { isMyClasEmpty } from '@lfx-one/shared/utils';
+import { downloadFromUrl, isMyClasEmpty } from '@lfx-one/shared/utils';
 import { MessageService } from 'primeng/api';
 import { ToastModule } from 'primeng/toast';
 import { BehaviorSubject, catchError, of, switchMap } from 'rxjs';
@@ -22,8 +22,8 @@ import { MyClasService } from '@services/my-clas.service';
  * Read-only "My CLAs" Profile tab (Me lens). Renders the user's currently-valid signed CLAs
  * (ICLA + ECLA) from `/v4/my-clas` in a single table (Project / Type / Signed / Document) per
  * the approved M1 mockup — no status column, because the BFF filters to valid-only so every row
- * is valid. Agreements are resolved server-side from the session identity; ICLA PDFs open via
- * short-lived URLs.
+ * is valid. Agreements are resolved server-side from the session identity; ICLA PDFs download via
+ * short-lived URLs (no new tab).
  */
 @Component({
   selector: 'lfx-profile-clas',
@@ -72,34 +72,26 @@ export class ProfileClasComponent {
   }
 
   /**
-   * Resolves the ICLA's short-lived PDF URL and opens it. A blank tab is opened
-   * synchronously on click (before the async request) so the browser attributes it to the
-   * user gesture and does not block the popup; its location is set once the URL resolves.
+   * Resolves the ICLA's short-lived PDF URL and triggers a file download (no new tab).
+   * Origin-tab spinner stays on while the presigned URL resolves; see #1228.
    */
   protected onDownload(signatureId: string): void {
     if (this.downloadingId()) return;
 
-    // Open the blank tab WITHOUT `noopener` so we retain the window handle to redirect once the
-    // URL resolves (`noopener` makes window.open return null). Sever the opener link manually for
-    // the same reverse-tabnabbing protection `noopener` would provide.
-    const tab = window.open('', '_blank');
-    if (tab) tab.opener = null;
     this.downloadingId.set(signatureId);
 
     this.myClasService.getPdfUrl(signatureId).subscribe({
       next: ({ url }) => {
         this.downloadingId.set(null);
-        if (tab) {
-          tab.location.href = url;
-        } else {
-          // Popup was blocked despite the synchronous open — fall back to a same-tab navigation.
-          window.location.href = url;
-        }
+        downloadFromUrl(url, 'signed-cla.pdf');
       },
       error: () => {
         this.downloadingId.set(null);
-        tab?.close();
-        this.messageService.add({ severity: 'error', summary: 'Download failed', detail: 'Could not open the signed document. Please try again.' });
+        this.messageService.add({
+          severity: 'error',
+          summary: 'Download failed',
+          detail: 'Could not download the signed document. Please try again.',
+        });
       },
     });
   }

--- a/packages/shared/src/utils/file.utils.ts
+++ b/packages/shared/src/utils/file.utils.ts
@@ -317,7 +317,6 @@ export function downloadFromUrl(url: string, filename?: string): void {
   if (filename) {
     anchor.download = sanitizeFilename(filename);
   }
-  anchor.rel = 'noopener';
   anchor.style.display = 'none';
   document.body.appendChild(anchor);
   anchor.click();

--- a/packages/shared/src/utils/file.utils.ts
+++ b/packages/shared/src/utils/file.utils.ts
@@ -306,6 +306,24 @@ export function rowsToCsv(rows: ReadonlyArray<ReadonlyArray<string | number>>): 
   return rows.map((row) => row.map(escapeCsvCell).join(',')).join('\r\n');
 }
 
+/** Trigger a browser file download from a URL via `<a download>` (no new tab). No-op during SSR. */
+export function downloadFromUrl(url: string, filename?: string): void {
+  if (typeof document === 'undefined') {
+    return;
+  }
+
+  const anchor = document.createElement('a');
+  anchor.href = url;
+  if (filename) {
+    anchor.download = sanitizeFilename(filename);
+  }
+  anchor.rel = 'noopener';
+  anchor.style.display = 'none';
+  document.body.appendChild(anchor);
+  anchor.click();
+  document.body.removeChild(anchor);
+}
+
 /**
  * Trigger a client-side CSV file download in the browser. No-op during SSR (no `document`).
  * Prepends a UTF-8 BOM so Excel detects the encoding.


### PR DESCRIPTION
## Summary

- **What changed**: `ProfileClasComponent.onDownload` no longer opens a blank tab; it waits for the presigned URL then calls new shared `downloadFromUrl` (`packages/shared/src/utils/file.utils.ts`). Origin-tab spinner + error toast kept.
- **Why**: [lfx-self-serve#1228](https://github.com/linuxfoundation/lfx-self-serve/issues/1228) — orphaned blank tab / no loading feedback on My CLAs PDF download.
- **Non-obvious**: Cross-origin S3 often ignores the `download` attribute; when the object is `Content-Disposition: attachment` the browser still downloads without navigating (the orphan-tab case this fixes). Upstream EasyCLA presign does not set `ResponseContentDisposition` — confirm on the preview deploy that the file downloads rather than navigating the SPA away.

## Test plan

- [ ] Open `/profile/clas`, click **Download PDF** on an ICLA — file should download with no new tab.
- [ ] Button spinner shown during the URL fetch.
- [ ] Error toast shown if the call fails.
- [ ] Verify on preview deploy once labeled.

Closes #1228