### PR TITLE
feat(profile): proxy public profile artifacts from s3

### DIFF
--- a/apps/lfx-one/src/server/constants/index.ts
+++ b/apps/lfx-one/src/server/constants/index.ts
@@ -3,5 +3,6 @@
 
 export * from './gateway.constants';
 export * from './meta.constants';
+export * from './public-profile.constants';
 export * from './reddit.constants';
 export * from './rewards.constants';

--- a/apps/lfx-one/src/server/constants/public-profile.constants.ts
+++ b/apps/lfx-one/src/server/constants/public-profile.constants.ts
@@ -5,15 +5,8 @@
 export const PUBLIC_PROFILE_SERVICE_NAME = 'public_profile_service';
 
 /**
- * Environment variable holding the base URL of the S3 bucket that hosts per-user public
- * profile artifacts (`${bucket}/${username}.json`), published by the upstream
- * `GenerateUserPublicProfile` flow (no trailing slash). The bucket differs per environment and
- * is supplied entirely through this variable — the value is never hard-coded here.
- *
- * There is intentionally NO hard-coded default: a baked-in dev bucket would make a missing
- * production value silently serve dev data. When this var is unset, the app still boots and
- * only the public profile endpoint is inert (responds 503), so the misconfiguration surfaces
- * loudly and in isolation instead of leaking the wrong environment's data.
+ * Env var holding the S3 bucket base URL for public profile artifacts (no trailing slash).
+ * No hard-coded default: when unset only this endpoint is inert (503), never serves wrong data.
  */
 export const PUBLIC_PROFILES_BUCKET_URL_ENV = 'PUBLIC_PROFILES_BUCKET_URL';
 
@@ -24,8 +17,7 @@ export const PUBLIC_PROFILES_BUCKET_URL_ENV = 'PUBLIC_PROFILES_BUCKET_URL';
 export const PUBLIC_PROFILE_FETCH_TIMEOUT_MS = 10_000;
 
 /**
- * Username format allowed in the public profile route. Anchored and restricted to the
- * characters legacy usernames use, so the value can be safely interpolated into the S3 object
- * key without enabling path traversal or probing of unrelated keys.
+ * Allowed username format in the public route. Anchored and restricted so it can be safely
+ * interpolated into the S3 key without path traversal or probing unrelated keys.
  */
 export const PUBLIC_PROFILE_USERNAME_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;

--- a/apps/lfx-one/src/server/constants/public-profile.constants.ts
+++ b/apps/lfx-one/src/server/constants/public-profile.constants.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/** Service name used in public profile logs and error contexts. */
+export const PUBLIC_PROFILE_SERVICE_NAME = 'public_profile_service';
+
+/**
+ * Environment variable holding the base URL of the S3 bucket that hosts per-user public
+ * profile artifacts (`${bucket}/${username}.json`), published by the upstream
+ * `GenerateUserPublicProfile` flow (no trailing slash). The bucket differs per environment and
+ * is supplied entirely through this variable — the value is never hard-coded here.
+ *
+ * There is intentionally NO hard-coded default: a baked-in dev bucket would make a missing
+ * production value silently serve dev data. When this var is unset, the app still boots and
+ * only the public profile endpoint is inert (responds 503), so the misconfiguration surfaces
+ * loudly and in isolation instead of leaking the wrong environment's data.
+ */
+export const PUBLIC_PROFILES_BUCKET_URL_ENV = 'PUBLIC_PROFILES_BUCKET_URL';
+
+/**
+ * Timeout in milliseconds for the S3 fetch. Shorter than the API-gateway timeout — S3 is a
+ * static object store, so a slow response indicates a problem rather than heavy compute.
+ */
+export const PUBLIC_PROFILE_FETCH_TIMEOUT_MS = 10_000;
+
+/**
+ * Username format allowed in the public profile route. Anchored and restricted to the
+ * characters legacy usernames use, so the value can be safely interpolated into the S3 object
+ * key without enabling path traversal or probing of unrelated keys.
+ */
+export const PUBLIC_PROFILE_USERNAME_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;

--- a/apps/lfx-one/src/server/controllers/public-profile.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-profile.controller.spec.ts
@@ -2,7 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import type { PublicProfile } from '@lfx-one/shared/interfaces';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, type Mock, vi } from 'vitest';
 
 // Per-test-controllable service mock. The controller constructs `new PublicProfileService()`
 // as a field, so the mocked constructor must hand back this same object every time.
@@ -21,12 +22,10 @@ vi.mock('../services/logger.service', () => ({
 import { ResourceNotFoundError } from '../errors';
 import { PublicProfileController } from './public-profile.controller';
 
-const USERNAME = 'jane';
-
-function buildReqRes() {
-  const req = { params: { username: USERNAME }, path: `/public/api/profile/${USERNAME}`, log: {} } as any;
-  const res = { json: vi.fn(), status: vi.fn().mockReturnThis() } as any;
-  const next = vi.fn();
+function buildReqRes(username = 'jane'): { req: Request; res: Response & { json: Mock; status: Mock }; next: NextFunction & Mock } {
+  const req = { params: { username }, path: `/public/api/profile/${username}`, log: {} } as unknown as Request;
+  const res = { json: vi.fn(), status: vi.fn().mockReturnThis() } as unknown as Response & { json: Mock; status: Mock };
+  const next = vi.fn() as unknown as NextFunction & Mock;
   return { req, res, next };
 }
 

--- a/apps/lfx-one/src/server/controllers/public-profile.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-profile.controller.spec.ts
@@ -1,0 +1,96 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { PublicProfile } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Per-test-controllable service mock. The controller constructs `new PublicProfileService()`
+// as a field, so the mocked constructor must hand back this same object every time.
+const { getPublicProfileMock } = vi.hoisted(() => ({ getPublicProfileMock: vi.fn() }));
+
+vi.mock('../services/public-profile.service', () => ({
+  PublicProfileService: vi.fn(function () {
+    return { getPublicProfile: getPublicProfileMock };
+  }),
+}));
+
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+import { ResourceNotFoundError } from '../errors';
+import { PublicProfileController } from './public-profile.controller';
+
+const USERNAME = 'jane';
+
+function buildReqRes() {
+  const req = { params: { username: USERNAME }, path: `/public/api/profile/${USERNAME}`, log: {} } as any;
+  const res = { json: vi.fn(), status: vi.fn().mockReturnThis() } as any;
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('PublicProfileController.getPublicProfile', () => {
+  let controller: PublicProfileController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicProfileController();
+  });
+
+  it('responds with exactly { isPublic: false } for a private profile and leaks no withheld data', async () => {
+    // The service resolved a real artifact but flagged it private — the controller is the
+    // exposure boundary and must never forward the underlying PII to an anonymous caller.
+    getPublicProfileMock.mockResolvedValue({
+      isPublic: false,
+      basic: { Name: 'Jane Private', About: 'secret bio' },
+      technical_contribution: { projects: [] },
+    } as PublicProfile);
+    const { req, res, next } = buildReqRes();
+
+    await controller.getPublicProfile(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({ isPublic: false });
+    // Defense in depth: no field of the withheld payload appears anywhere in the response.
+    const serialized = JSON.stringify(res.json.mock.calls[0][0]);
+    expect(serialized).not.toContain('Jane Private');
+    expect(serialized).not.toContain('secret bio');
+  });
+
+  it('responds with the full profile for a public profile', async () => {
+    const profile = { isPublic: true, basic: { Name: 'Jane Public' } } as PublicProfile;
+    getPublicProfileMock.mockResolvedValue(profile);
+    const { req, res, next } = buildReqRes();
+
+    await controller.getPublicProfile(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith(profile);
+  });
+
+  it('forwards a 404 ResourceNotFoundError when the profile is missing (service returns null)', async () => {
+    getPublicProfileMock.mockResolvedValue(null);
+    const { req, res, next } = buildReqRes();
+
+    await controller.getPublicProfile(req, res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    const err = next.mock.calls[0][0];
+    expect(err).toBeInstanceOf(ResourceNotFoundError);
+    expect(err.statusCode).toBe(404);
+  });
+
+  it('forwards service errors to next (e.g. upstream/config failures)', async () => {
+    const failure = new Error('bucket not configured');
+    getPublicProfileMock.mockRejectedValue(failure);
+    const { req, res, next } = buildReqRes();
+
+    await controller.getPublicProfile(req, res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(failure);
+  });
+});

--- a/apps/lfx-one/src/server/controllers/public-profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-profile.controller.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import { ResourceNotFoundError } from '../errors';
+import { logger } from '../services/logger.service';
+import { PublicProfileService } from '../services/public-profile.service';
+
+/**
+ * Controller for the public (unauthenticated) profile page data source.
+ */
+export class PublicProfileController {
+  private publicProfileService: PublicProfileService = new PublicProfileService();
+
+  /**
+   * GET /public/api/profile/:username
+   * Returns a user's public profile artifact. A missing or malformed profile is a 404. A
+   * profile whose owner has made it private responds 200 with only `{ isPublic: false }` so
+   * the page can render its private state without exposing any withheld data.
+   */
+  public async getPublicProfile(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { username } = req.params;
+    const startTime = logger.startOperation(req, 'get_public_profile', { username });
+
+    try {
+      const profile = await this.publicProfileService.getPublicProfile(req, username);
+
+      if (!profile) {
+        throw new ResourceNotFoundError('Profile', username, {
+          operation: 'get_public_profile',
+          service: 'public_profile_controller',
+          path: req.path,
+        });
+      }
+
+      logger.success(req, 'get_public_profile', startTime, { username, is_public: profile.isPublic });
+
+      if (!profile.isPublic) {
+        res.json({ isPublic: false });
+        return;
+      }
+
+      res.json(profile);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/public-profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-profile.controller.ts
@@ -7,17 +7,13 @@ import { ResourceNotFoundError } from '../errors';
 import { logger } from '../services/logger.service';
 import { PublicProfileService } from '../services/public-profile.service';
 
-/**
- * Controller for the public (unauthenticated) profile page data source.
- */
+/** Controller for the public (unauthenticated) profile page data source. */
 export class PublicProfileController {
   private publicProfileService: PublicProfileService = new PublicProfileService();
 
   /**
-   * GET /public/api/profile/:username
-   * Returns a user's public profile artifact. A missing or malformed profile is a 404. A
-   * profile whose owner has made it private responds 200 with only `{ isPublic: false }` so
-   * the page can render its private state without exposing any withheld data.
+   * GET /public/api/profile/:username — 404 when missing/malformed; a private profile
+   * responds 200 with only `{ isPublic: false }` so no withheld data is exposed.
    */
   public async getPublicProfile(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { username } = req.params;

--- a/apps/lfx-one/src/server/routes/public-profile.route.ts
+++ b/apps/lfx-one/src/server/routes/public-profile.route.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { PublicProfileController } from '../controllers/public-profile.controller';
+
+const router = Router();
+const publicProfileController = new PublicProfileController();
+
+// GET /public/api/profile/:username - get a user's public profile artifact (public access, no authentication required)
+router.get('/:username', (req, res, next) => publicProfileController.getPublicProfile(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -47,6 +47,7 @@ import projectsRouter from './routes/projects.route';
 import publicCommitteesRouter from './routes/public-committees.route';
 import publicGroupsRouter from './routes/public-groups.route';
 import publicMeetingsRouter from './routes/public-meetings.route';
+import publicProfileRouter from './routes/public-profile.route';
 import publicProjectsRouter from './routes/public-projects.route';
 import rewardsRouter from './routes/rewards.route';
 import searchRouter from './routes/search.route';
@@ -308,6 +309,7 @@ app.use('/login', authRateLimiter);
 app.use('/public/api/meetings', publicMeetingsRouter);
 app.use('/public/api/committees', publicCommitteesRouter);
 app.use('/public/api/groups', publicGroupsRouter);
+app.use('/public/api/profile', publicProfileRouter);
 app.use('/public/api/projects', publicProjectsRouter);
 
 app.use('/api/projects', projectsRouter);

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -74,6 +74,18 @@ describe('resolvePublicFlag', () => {
     expect(resolvePublicFlag({ IsPublic: false, isPublic: true })).toBe(false);
   });
 
+  it('fails closed on the reciprocal conflict (PascalCase true, camelCase false)', () => {
+    expect(resolvePublicFlag({ IsPublic: true, isPublic: false })).toBe(false);
+  });
+
+  it('fails closed when a present casing is null even if the other is true', () => {
+    expect(resolvePublicFlag({ IsPublic: null, isPublic: true })).toBe(false);
+  });
+
+  it('treats both casings explicitly true as public', () => {
+    expect(resolvePublicFlag({ IsPublic: true, isPublic: true })).toBe(true);
+  });
+
   it('treats a non-boolean flag as private (string "false")', () => {
     expect(resolvePublicFlag({ IsPublic: 'false' })).toBe(false);
   });
@@ -115,6 +127,14 @@ describe('PublicProfileService.getPublicProfile', () => {
 
   it('throws a 503 MicroserviceError when the bucket URL uses a non-http scheme, without fetching', async () => {
     process.env[BUCKET_ENV] = 'file:///etc';
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 503 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a 503 MicroserviceError when the bucket URL has no host, without fetching', async () => {
+    // `https://` trims to `https:`; a combined-URL parse would treat the username as the host, so
+    // the base itself must be rejected rather than producing an outbound fetch.
+    process.env[BUCKET_ENV] = 'https://';
     await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 503 });
     expect(fetchMock).not.toHaveBeenCalled();
   });

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -1,0 +1,155 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('./logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+import type { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { getPublicProfilesBucketUrl, PublicProfileService, resolvePublicFlag } from './public-profile.service';
+
+const req = {} as unknown as Request;
+const BUCKET_ENV = 'PUBLIC_PROFILES_BUCKET_URL';
+
+/** Builds a minimal fetch Response stand-in with the given status and text body. */
+function mockResponse(status: number, body: string): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: `status ${status}`,
+    text: async () => body,
+  } as unknown as Response;
+}
+
+let fetchMock: ReturnType<typeof vi.fn>;
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  delete process.env[BUCKET_ENV];
+  fetchMock = vi.fn();
+  vi.stubGlobal('fetch', fetchMock);
+});
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe('getPublicProfilesBucketUrl', () => {
+  it('returns an empty string when the env var is unset (no baked-in default)', () => {
+    expect(getPublicProfilesBucketUrl()).toBe('');
+  });
+
+  it('reads PUBLIC_PROFILES_BUCKET_URL and trims surrounding whitespace and trailing slashes', () => {
+    process.env[BUCKET_ENV] = '  https://profiles-bucket.example.com///  ';
+    expect(getPublicProfilesBucketUrl()).toBe('https://profiles-bucket.example.com');
+  });
+});
+
+describe('resolvePublicFlag', () => {
+  it('treats an absent flag as public (published implies public)', () => {
+    expect(resolvePublicFlag({})).toBe(true);
+  });
+
+  it('treats a truthy PascalCase IsPublic as public', () => {
+    expect(resolvePublicFlag({ IsPublic: true })).toBe(true);
+  });
+
+  it('treats an explicit false as private (PascalCase)', () => {
+    expect(resolvePublicFlag({ IsPublic: false })).toBe(false);
+  });
+
+  it('treats an explicit false as private (camelCase)', () => {
+    expect(resolvePublicFlag({ isPublic: false })).toBe(false);
+  });
+});
+
+describe('PublicProfileService.getPublicProfile', () => {
+  const service = new PublicProfileService();
+  const TEST_BUCKET = 'https://test-bucket.example.com';
+
+  beforeEach(() => {
+    process.env[BUCKET_ENV] = TEST_BUCKET;
+  });
+
+  it('rejects a malformed username without fetching', async () => {
+    const result = await service.getPublicProfile(req, '../secrets');
+    expect(result).toBeNull();
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a 503 MicroserviceError when the bucket is not configured, without fetching', async () => {
+    delete process.env[BUCKET_ENV];
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 503 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a 503 MicroserviceError when the configured bucket URL is malformed, without fetching', async () => {
+    process.env[BUCKET_ENV] = 'not a url';
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 503 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('throws a 503 MicroserviceError when the bucket URL uses a non-http scheme, without fetching', async () => {
+    process.env[BUCKET_ENV] = 'file:///etc';
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 503 });
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('URL-encodes the username into the bucket object key', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, JSON.stringify({ IsPublic: true, basic: { Name: 'Jane' } })));
+    await service.getPublicProfile(req, 'jane.doe');
+    expect(fetchMock).toHaveBeenCalledWith(`${TEST_BUCKET}/jane.doe.json`, expect.objectContaining({ signal: expect.anything() }));
+  });
+
+  it('returns null when the artifact does not exist (404)', async () => {
+    fetchMock.mockResolvedValue(mockResponse(404, 'Not Found'));
+    expect(await service.getPublicProfile(req, 'ghost')).toBeNull();
+  });
+
+  it('returns null when S3 forbids access (403)', async () => {
+    fetchMock.mockResolvedValue(mockResponse(403, 'Forbidden'));
+    expect(await service.getPublicProfile(req, 'ghost')).toBeNull();
+  });
+
+  it('returns the parsed profile with isPublic true for a public artifact', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, JSON.stringify({ IsPublic: true, basic: { Name: 'Jane Apple' } })));
+    const result = await service.getPublicProfile(req, 'jane');
+    expect(result).toEqual({ IsPublic: true, basic: { Name: 'Jane Apple' }, isPublic: true });
+  });
+
+  it('normalizes isPublic to false for a private artifact and preserves the payload', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, JSON.stringify({ IsPublic: false, basic: { Name: 'Jane' } })));
+    const result = await service.getPublicProfile(req, 'jane');
+    expect(result?.isPublic).toBe(false);
+  });
+
+  it('throws a MicroserviceError on a non-404 upstream failure', async () => {
+    fetchMock.mockResolvedValue(mockResponse(500, 'boom'));
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toBeInstanceOf(MicroserviceError);
+  });
+
+  it('throws a MicroserviceError when the body is empty', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, '   '));
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toBeInstanceOf(MicroserviceError);
+  });
+
+  it('throws a MicroserviceError when the body is invalid JSON', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, '{not json'));
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toBeInstanceOf(MicroserviceError);
+  });
+
+  it('maps a fetch timeout to a 504 MicroserviceError', async () => {
+    const timeout = Object.assign(new Error('timed out'), { name: 'TimeoutError' });
+    fetchMock.mockRejectedValue(timeout);
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 504 });
+  });
+
+  it('maps a network failure to a 502 MicroserviceError', async () => {
+    fetchMock.mockRejectedValue(new Error('connection refused'));
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 502 });
+  });
+});

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -50,12 +50,16 @@ describe('getPublicProfilesBucketUrl', () => {
 });
 
 describe('resolvePublicFlag', () => {
-  it('treats an absent flag as public (published implies public)', () => {
-    expect(resolvePublicFlag({})).toBe(true);
+  it('treats an absent flag as private (fail closed — requires an explicit opt-in)', () => {
+    expect(resolvePublicFlag({})).toBe(false);
   });
 
-  it('treats a truthy PascalCase IsPublic as public', () => {
+  it('treats an explicit boolean true as public (PascalCase)', () => {
     expect(resolvePublicFlag({ IsPublic: true })).toBe(true);
+  });
+
+  it('treats an explicit boolean true as public (camelCase)', () => {
+    expect(resolvePublicFlag({ isPublic: true })).toBe(true);
   });
 
   it('treats an explicit false as private (PascalCase)', () => {
@@ -64,6 +68,22 @@ describe('resolvePublicFlag', () => {
 
   it('treats an explicit false as private (camelCase)', () => {
     expect(resolvePublicFlag({ isPublic: false })).toBe(false);
+  });
+
+  it('lets an explicit PascalCase false win over a stray camelCase true (fail closed)', () => {
+    expect(resolvePublicFlag({ IsPublic: false, isPublic: true })).toBe(false);
+  });
+
+  it('treats a non-boolean flag as private (string "false")', () => {
+    expect(resolvePublicFlag({ IsPublic: 'false' })).toBe(false);
+  });
+
+  it('treats a non-boolean flag as private (numeric 0)', () => {
+    expect(resolvePublicFlag({ IsPublic: 0 })).toBe(false);
+  });
+
+  it('treats a non-boolean flag as private (object)', () => {
+    expect(resolvePublicFlag({ IsPublic: {} })).toBe(false);
   });
 });
 
@@ -140,6 +160,34 @@ describe('PublicProfileService.getPublicProfile', () => {
   it('throws a MicroserviceError when the body is invalid JSON', async () => {
     fetchMock.mockResolvedValue(mockResponse(200, '{not json'));
     await expect(service.getPublicProfile(req, 'jane')).rejects.toBeInstanceOf(MicroserviceError);
+  });
+
+  it('throws a MicroserviceError when the body parses to null (not a JSON object)', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, 'null'));
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 502 });
+  });
+
+  it('throws a MicroserviceError when the body parses to a JSON array (not an object)', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, '[1,2,3]'));
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 502 });
+  });
+
+  it('throws a MicroserviceError when the body parses to a JSON primitive (not an object)', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, '42'));
+    await expect(service.getPublicProfile(req, 'jane')).rejects.toMatchObject({ statusCode: 502 });
+  });
+
+  it('normalizes an absent flag to isPublic false (fail closed) and preserves the payload', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, JSON.stringify({ basic: { Name: 'Jane' } })));
+    const result = await service.getPublicProfile(req, 'jane');
+    expect(result?.isPublic).toBe(false);
+    expect(result?.basic).toEqual({ Name: 'Jane' });
+  });
+
+  it('normalizes a non-boolean flag to isPublic false (fail closed)', async () => {
+    fetchMock.mockResolvedValue(mockResponse(200, JSON.stringify({ IsPublic: 'false', basic: { Name: 'Jane' } })));
+    const result = await service.getPublicProfile(req, 'jane');
+    expect(result?.isPublic).toBe(false);
   });
 
   it('maps a fetch timeout to a 504 MicroserviceError', async () => {

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -1,0 +1,167 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PublicProfile } from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import {
+  PUBLIC_PROFILE_FETCH_TIMEOUT_MS,
+  PUBLIC_PROFILE_SERVICE_NAME,
+  PUBLIC_PROFILE_USERNAME_PATTERN,
+  PUBLIC_PROFILES_BUCKET_URL_ENV,
+  UPSTREAM_ERROR_BODY_LIMIT,
+} from '../constants';
+import { MicroserviceError } from '../errors';
+import { logger } from './logger.service';
+
+/**
+ * Resolves the configured S3 bucket base URL that hosts public profile artifacts from
+ * `PUBLIC_PROFILES_BUCKET_URL`, trimming any trailing slashes so the object key can be
+ * appended directly. Returns an empty string when the var is unset or blank — there is no
+ * baked-in default (see the env constant's doc comment); the caller treats an empty result as
+ * "not configured" and fails the request loudly rather than reading the wrong bucket.
+ */
+export function getPublicProfilesBucketUrl(): string {
+  return (process.env[PUBLIC_PROFILES_BUCKET_URL_ENV] || '').trim().replace(/\/+$/, '');
+}
+
+/**
+ * Normalizes the artifact's public flag into a single boolean. The upstream flow only
+ * publishes a file when the profile is public, so an absent flag is treated as public;
+ * only an explicit `false` (in either the PascalCase `IsPublic` or camelCase `isPublic`
+ * form some artifacts use) marks the profile private.
+ */
+export function resolvePublicFlag(parsed: Record<string, unknown>): boolean {
+  const raw = parsed['IsPublic'] ?? parsed['isPublic'];
+  return raw !== false;
+}
+
+/**
+ * Fetches a user's public profile artifact from S3 (no authentication). Returns `null` when
+ * the username is malformed or the artifact does not exist (S3 404) — both surface to the
+ * caller as "not found". Any other failure (network, timeout, non-404 upstream status,
+ * empty/invalid body) throws a MicroserviceError.
+ *
+ * The parsed payload is returned verbatim with a normalized `isPublic` flag attached; the
+ * controller is responsible for withholding the body when the profile is private.
+ */
+export class PublicProfileService {
+  public async getPublicProfile(req: Request, username: string): Promise<PublicProfile | null> {
+    const operation = 'get_public_profile';
+
+    if (!PUBLIC_PROFILE_USERNAME_PATTERN.test(username)) {
+      logger.warning(req, operation, 'Rejected malformed username', { username });
+      return null;
+    }
+
+    const bucketUrl = getPublicProfilesBucketUrl();
+    if (!bucketUrl) {
+      // No bucket configured for this environment — fail loudly and in isolation rather than
+      // reading a wrong/default bucket. The app keeps running; only this endpoint is inert.
+      logger.warning(req, operation, `Public profiles bucket not configured (${PUBLIC_PROFILES_BUCKET_URL_ENV} unset)`, { username });
+      throw new MicroserviceError(`Public profile fetch failed: ${PUBLIC_PROFILES_BUCKET_URL_ENV} is not configured`, 503, 'PUBLIC_PROFILES_NOT_CONFIGURED', {
+        operation,
+        service: PUBLIC_PROFILE_SERVICE_NAME,
+      });
+    }
+
+    const url = `${bucketUrl}/${encodeURIComponent(username)}.json`;
+
+    // Validate the operator-supplied bucket URL is well-formed and http(s) before fetching. The
+    // host is fixed by config (not user input), so this guards against a misconfigured bucket
+    // value (malformed URL, or a non-http scheme like file:) rather than user-driven SSRF — a
+    // clear 503 beats an opaque network 502 when the environment is set up wrong.
+    let parsedUrl: URL;
+    try {
+      parsedUrl = new URL(url);
+    } catch {
+      logger.warning(req, operation, `Public profiles bucket URL is malformed (${PUBLIC_PROFILES_BUCKET_URL_ENV})`, { bucket_url: bucketUrl, username });
+      throw new MicroserviceError(`Public profile fetch failed: ${PUBLIC_PROFILES_BUCKET_URL_ENV} is malformed`, 503, 'PUBLIC_PROFILES_BUCKET_URL_INVALID', {
+        operation,
+        service: PUBLIC_PROFILE_SERVICE_NAME,
+      });
+    }
+    if (parsedUrl.protocol !== 'https:' && parsedUrl.protocol !== 'http:') {
+      logger.warning(req, operation, `Public profiles bucket URL has an unsupported scheme (${PUBLIC_PROFILES_BUCKET_URL_ENV})`, {
+        protocol: parsedUrl.protocol,
+        username,
+      });
+      throw new MicroserviceError(
+        `Public profile fetch failed: ${PUBLIC_PROFILES_BUCKET_URL_ENV} must use http or https`,
+        503,
+        'PUBLIC_PROFILES_BUCKET_URL_INVALID',
+        {
+          operation,
+          service: PUBLIC_PROFILE_SERVICE_NAME,
+        }
+      );
+    }
+
+    logger.debug(req, operation, 'Fetching public profile artifact', { username });
+
+    let upstream: Response;
+    try {
+      upstream = await fetch(url, { signal: AbortSignal.timeout(PUBLIC_PROFILE_FETCH_TIMEOUT_MS) });
+    } catch (error: unknown) {
+      if (error instanceof Error && (error.name === 'AbortError' || error.name === 'TimeoutError')) {
+        logger.warning(req, operation, 'Public profile fetch timed out', { timeout_ms: PUBLIC_PROFILE_FETCH_TIMEOUT_MS, username });
+        throw new MicroserviceError(`Public profile fetch failed: request timed out after ${PUBLIC_PROFILE_FETCH_TIMEOUT_MS}ms`, 504, 'UPSTREAM_TIMEOUT', {
+          operation,
+          service: PUBLIC_PROFILE_SERVICE_NAME,
+        });
+      }
+
+      const cause = (error as (Error & { cause?: { code?: string } }) | undefined)?.cause;
+      const networkCode = cause?.code ?? 'UPSTREAM_UNREACHABLE';
+      const message = error instanceof Error ? error.message : String(error);
+
+      logger.warning(req, operation, 'Public profile fetch failed before response', { err: error, error_code: networkCode, username });
+      throw new MicroserviceError(`Public profile fetch failed: ${message}`, 502, networkCode, { operation, service: PUBLIC_PROFILE_SERVICE_NAME });
+    }
+
+    // A missing artifact is the normal "no public profile" case — surface as not-found, not an error.
+    if (upstream.status === 404 || upstream.status === 403) {
+      logger.debug(req, operation, 'Public profile artifact not found', { username, status: upstream.status });
+      return null;
+    }
+
+    if (!upstream.ok) {
+      const body = (await upstream.text().catch(() => '')).slice(0, UPSTREAM_ERROR_BODY_LIMIT);
+      logger.warning(req, operation, 'Public profile fetch returned non-OK response', {
+        status: upstream.status,
+        status_text: upstream.statusText,
+        body,
+        username,
+      });
+      throw new MicroserviceError(`Public profile fetch failed: ${upstream.status} ${upstream.statusText}`, upstream.status, 'PUBLIC_PROFILE_FETCH_FAILED', {
+        operation,
+        service: PUBLIC_PROFILE_SERVICE_NAME,
+        errorBody: body,
+      });
+    }
+
+    const rawBody = await upstream.text();
+    if (!rawBody.trim()) {
+      logger.warning(req, operation, 'Public profile artifact was empty', { username });
+      throw new MicroserviceError('Public profile fetch failed: empty response from upstream', 502, 'UPSTREAM_INVALID_RESPONSE', {
+        operation,
+        service: PUBLIC_PROFILE_SERVICE_NAME,
+      });
+    }
+
+    let parsed: Record<string, unknown>;
+    try {
+      parsed = JSON.parse(rawBody) as Record<string, unknown>;
+    } catch (error: unknown) {
+      const truncatedBody = rawBody.slice(0, UPSTREAM_ERROR_BODY_LIMIT);
+      logger.warning(req, operation, 'Public profile artifact was invalid JSON', { err: error, body: truncatedBody, username });
+      throw new MicroserviceError('Public profile fetch failed: invalid JSON response from upstream', 502, 'UPSTREAM_INVALID_RESPONSE', {
+        operation,
+        service: PUBLIC_PROFILE_SERVICE_NAME,
+        errorBody: truncatedBody,
+      });
+    }
+
+    return { ...parsed, isPublic: resolvePublicFlag(parsed) } as PublicProfile;
+  }
+}

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -4,13 +4,7 @@
 import { PublicProfile } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
-import {
-  PUBLIC_PROFILE_FETCH_TIMEOUT_MS,
-  PUBLIC_PROFILE_SERVICE_NAME,
-  PUBLIC_PROFILE_USERNAME_PATTERN,
-  PUBLIC_PROFILES_BUCKET_URL_ENV,
-  UPSTREAM_ERROR_BODY_LIMIT,
-} from '../constants';
+import { PUBLIC_PROFILE_FETCH_TIMEOUT_MS, PUBLIC_PROFILE_SERVICE_NAME, PUBLIC_PROFILE_USERNAME_PATTERN, PUBLIC_PROFILES_BUCKET_URL_ENV } from '../constants';
 import { MicroserviceError } from '../errors';
 import { logger } from './logger.service';
 
@@ -114,17 +108,17 @@ export class PublicProfileService {
     }
 
     if (!upstream.ok) {
-      const body = (await upstream.text().catch(() => '')).slice(0, UPSTREAM_ERROR_BODY_LIMIT);
+      // Log only the body length, never the raw body — this is a public PII-bearing artifact.
+      const bodyLength = (await upstream.text().catch(() => '')).length;
       logger.warning(req, operation, 'Public profile fetch returned non-OK response', {
         status: upstream.status,
         status_text: upstream.statusText,
-        body,
+        body_length: bodyLength,
         username,
       });
       throw new MicroserviceError(`Public profile fetch failed: ${upstream.status} ${upstream.statusText}`, upstream.status, 'PUBLIC_PROFILE_FETCH_FAILED', {
         operation,
         service: PUBLIC_PROFILE_SERVICE_NAME,
-        errorBody: body,
       });
     }
 
@@ -141,12 +135,11 @@ export class PublicProfileService {
     try {
       parsed = JSON.parse(rawBody) as Record<string, unknown>;
     } catch (error: unknown) {
-      const truncatedBody = rawBody.slice(0, UPSTREAM_ERROR_BODY_LIMIT);
-      logger.warning(req, operation, 'Public profile artifact was invalid JSON', { err: error, body: truncatedBody, username });
+      // Log only the body length, never the raw body — it may hold private profile data.
+      logger.warning(req, operation, 'Public profile artifact was invalid JSON', { err: error, body_length: rawBody.length, username });
       throw new MicroserviceError('Public profile fetch failed: invalid JSON response from upstream', 502, 'UPSTREAM_INVALID_RESPONSE', {
         operation,
         service: PUBLIC_PROFILE_SERVICE_NAME,
-        errorBody: truncatedBody,
       });
     }
 

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -17,12 +17,14 @@ export function getPublicProfilesBucketUrl(): string {
 }
 
 /**
- * Normalizes the artifact's public flag to a boolean: an absent flag means public
- * (published implies public); only an explicit `false` (IsPublic/isPublic) is private.
+ * Normalizes the artifact's public flag to a boolean. This is the sole privacy gate for an
+ * anonymous endpoint, so it fails closed: the payload is released only when the upstream flag
+ * (IsPublic/isPublic) is explicitly boolean `true`. A missing or non-boolean flag resolves to
+ * `false` — artifacts exist for private profiles too, so a dropped/malformed flag must not leak.
  */
 export function resolvePublicFlag(parsed: Record<string, unknown>): boolean {
   const raw = parsed['IsPublic'] ?? parsed['isPublic'];
-  return raw !== false;
+  return raw === true;
 }
 
 /**
@@ -131,9 +133,9 @@ export class PublicProfileService {
       });
     }
 
-    let parsed: Record<string, unknown>;
+    let parsed: unknown;
     try {
-      parsed = JSON.parse(rawBody) as Record<string, unknown>;
+      parsed = JSON.parse(rawBody);
     } catch (error: unknown) {
       // Log only the body length, never the raw body — it may hold private profile data.
       logger.warning(req, operation, 'Public profile artifact was invalid JSON', { err: error, body_length: rawBody.length, username });
@@ -143,6 +145,18 @@ export class PublicProfileService {
       });
     }
 
-    return { ...parsed, isPublic: resolvePublicFlag(parsed) } as PublicProfile;
+    // Valid JSON can still be the wrong shape (null / array / primitive). Reject anything that
+    // isn't a plain object rather than crashing on the flag lookup or spreading a non-object
+    // into a "public" payload. Log only the body length, never the raw body.
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      logger.warning(req, operation, 'Public profile artifact was not a JSON object', { body_length: rawBody.length, username });
+      throw new MicroserviceError('Public profile fetch failed: unexpected response shape from upstream', 502, 'UPSTREAM_INVALID_RESPONSE', {
+        operation,
+        service: PUBLIC_PROFILE_SERVICE_NAME,
+      });
+    }
+
+    const record = parsed as Record<string, unknown>;
+    return { ...record, isPublic: resolvePublicFlag(record) } as PublicProfile;
   }
 }

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -15,21 +15,16 @@ import { MicroserviceError } from '../errors';
 import { logger } from './logger.service';
 
 /**
- * Resolves the configured S3 bucket base URL that hosts public profile artifacts from
- * `PUBLIC_PROFILES_BUCKET_URL`, trimming any trailing slashes so the object key can be
- * appended directly. Returns an empty string when the var is unset or blank — there is no
- * baked-in default (see the env constant's doc comment); the caller treats an empty result as
- * "not configured" and fails the request loudly rather than reading the wrong bucket.
+ * Resolves the public profiles bucket base URL from env, trimming trailing slashes.
+ * Returns '' when unset/blank (no default); the caller treats '' as "not configured".
  */
 export function getPublicProfilesBucketUrl(): string {
   return (process.env[PUBLIC_PROFILES_BUCKET_URL_ENV] || '').trim().replace(/\/+$/, '');
 }
 
 /**
- * Normalizes the artifact's public flag into a single boolean. The upstream flow only
- * publishes a file when the profile is public, so an absent flag is treated as public;
- * only an explicit `false` (in either the PascalCase `IsPublic` or camelCase `isPublic`
- * form some artifacts use) marks the profile private.
+ * Normalizes the artifact's public flag to a boolean: an absent flag means public
+ * (published implies public); only an explicit `false` (IsPublic/isPublic) is private.
  */
 export function resolvePublicFlag(parsed: Record<string, unknown>): boolean {
   const raw = parsed['IsPublic'] ?? parsed['isPublic'];
@@ -37,13 +32,8 @@ export function resolvePublicFlag(parsed: Record<string, unknown>): boolean {
 }
 
 /**
- * Fetches a user's public profile artifact from S3 (no authentication). Returns `null` when
- * the username is malformed or the artifact does not exist (S3 404) — both surface to the
- * caller as "not found". Any other failure (network, timeout, non-404 upstream status,
- * empty/invalid body) throws a MicroserviceError.
- *
- * The parsed payload is returned verbatim with a normalized `isPublic` flag attached; the
- * controller is responsible for withholding the body when the profile is private.
+ * Fetches a user's public profile artifact from S3 (no auth). Returns null when the username
+ * is malformed or the artifact is missing (404); other failures throw a MicroserviceError.
  */
 export class PublicProfileService {
   public async getPublicProfile(req: Request, username: string): Promise<PublicProfile | null> {
@@ -67,10 +57,8 @@ export class PublicProfileService {
 
     const url = `${bucketUrl}/${encodeURIComponent(username)}.json`;
 
-    // Validate the operator-supplied bucket URL is well-formed and http(s) before fetching. The
-    // host is fixed by config (not user input), so this guards against a misconfigured bucket
-    // value (malformed URL, or a non-http scheme like file:) rather than user-driven SSRF — a
-    // clear 503 beats an opaque network 502 when the environment is set up wrong.
+    // Validate the operator-supplied bucket URL is well-formed and http(s) before fetching —
+    // guards a misconfigured bucket value (malformed URL / non-http scheme), not user SSRF.
     let parsedUrl: URL;
     try {
       parsedUrl = new URL(url);

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -18,13 +18,16 @@ export function getPublicProfilesBucketUrl(): string {
 
 /**
  * Normalizes the artifact's public flag to a boolean. This is the sole privacy gate for an
- * anonymous endpoint, so it fails closed: the payload is released only when the upstream flag
- * (IsPublic/isPublic) is explicitly boolean `true`. A missing or non-boolean flag resolves to
- * `false` — artifacts exist for private profiles too, so a dropped/malformed flag must not leak.
+ * anonymous endpoint, so it fails closed: the payload is released only when at least one flag
+ * casing (IsPublic/isPublic) is present and every present casing is explicitly boolean `true`.
+ * A missing, non-boolean, or conflicting flag (e.g. `{ IsPublic: true, isPublic: false }`)
+ * resolves to `false` — artifacts exist for private profiles too, so anything but an unambiguous
+ * opt-in must not leak.
  */
 export function resolvePublicFlag(parsed: Record<string, unknown>): boolean {
-  const raw = parsed['IsPublic'] ?? parsed['isPublic'];
-  return raw === true;
+  const keys = ['IsPublic', 'isPublic'] as const;
+  const present = keys.filter((key) => Object.prototype.hasOwnProperty.call(parsed, key));
+  return present.length > 0 && present.every((key) => parsed[key] === true);
 }
 
 /**
@@ -51,13 +54,14 @@ export class PublicProfileService {
       });
     }
 
-    const url = `${bucketUrl}/${encodeURIComponent(username)}.json`;
-
-    // Validate the operator-supplied bucket URL is well-formed and http(s) before fetching —
+    // Validate the operator-supplied bucket *base* (not the combined key URL) before fetching —
     // guards a misconfigured bucket value (malformed URL / non-http scheme), not user SSRF.
+    // Parsing the base rather than the combined URL is what closes the empty-authority hole:
+    // a bucket set to just `https://` collapses to `https:`, which `new URL()` rejects here,
+    // whereas `new URL('https:/jane.json')` is lenient and would treat the username as the host.
     let parsedUrl: URL;
     try {
-      parsedUrl = new URL(url);
+      parsedUrl = new URL(bucketUrl);
     } catch {
       logger.warning(req, operation, `Public profiles bucket URL is malformed (${PUBLIC_PROFILES_BUCKET_URL_ENV})`, { bucket_url: bucketUrl, username });
       throw new MicroserviceError(`Public profile fetch failed: ${PUBLIC_PROFILES_BUCKET_URL_ENV} is malformed`, 503, 'PUBLIC_PROFILES_BUCKET_URL_INVALID', {
@@ -81,6 +85,10 @@ export class PublicProfileService {
       );
     }
 
+    // Build the object-key URL from the validated base. encodeURIComponent guards the key even
+    // though the username pattern above already excludes path/traversal characters.
+    const url = `${bucketUrl}/${encodeURIComponent(username)}.json`;
+
     logger.debug(req, operation, 'Fetching public profile artifact', { username });
 
     let upstream: Response;
@@ -97,10 +105,16 @@ export class PublicProfileService {
 
       const cause = (error as (Error & { cause?: { code?: string } }) | undefined)?.cause;
       const networkCode = cause?.code ?? 'UPSTREAM_UNREACHABLE';
-      const message = error instanceof Error ? error.message : String(error);
+      const errorName = error instanceof Error ? error.name : 'UnknownError';
 
-      logger.warning(req, operation, 'Public profile fetch failed before response', { err: error, error_code: networkCode, username });
-      throw new MicroserviceError(`Public profile fetch failed: ${message}`, 502, networkCode, { operation, service: PUBLIC_PROFILE_SERVICE_NAME });
+      // Keep the network diagnostics (name + code) in the server log, but throw a stable public
+      // message/code: apiErrorHandler serializes MicroserviceError.message/.code into the response,
+      // so raw fetch diagnostics (ENOTFOUND, ECONNREFUSED, TLS errors) must not reach anonymous callers.
+      logger.warning(req, operation, 'Public profile fetch failed before response', { error_name: errorName, error_code: networkCode, username });
+      throw new MicroserviceError('Public profile fetch failed: upstream unreachable', 502, 'UPSTREAM_UNREACHABLE', {
+        operation,
+        service: PUBLIC_PROFILE_SERVICE_NAME,
+      });
     }
 
     // A missing artifact is the normal "no public profile" case — surface as not-found, not an error.
@@ -137,8 +151,10 @@ export class PublicProfileService {
     try {
       parsed = JSON.parse(rawBody);
     } catch (error: unknown) {
-      // Log only the body length, never the raw body — it may hold private profile data.
-      logger.warning(req, operation, 'Public profile artifact was invalid JSON', { err: error, body_length: rawBody.length, username });
+      // Log only the error name and body length, never the error object — Node's JSON.parse
+      // SyntaxError message embeds a snippet of the input, which may hold private profile data.
+      const errorName = error instanceof Error ? error.name : 'UnknownError';
+      logger.warning(req, operation, 'Public profile artifact was invalid JSON', { error_name: errorName, body_length: rawBody.length, username });
       throw new MicroserviceError('Public profile fetch failed: invalid JSON response from upstream', 502, 'UPSTREAM_INVALID_RESPONSE', {
         operation,
         service: PUBLIC_PROFILE_SERVICE_NAME,

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -59,6 +59,9 @@ export * from './access-check.interface';
 // User profile interfaces
 export * from './user-profile.interface';
 
+// Public profile interfaces (S3 artifact proxied by /public/api/profile/:username)
+export * from './public-profile.interface';
+
 // User statistics interfaces
 export * from './user-statistics.interface';
 

--- a/packages/shared/src/interfaces/public-profile.interface.ts
+++ b/packages/shared/src/interfaces/public-profile.interface.ts
@@ -1,0 +1,158 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Shape of the public profile artifact published to S3 by the upstream
+ * `GenerateUserPublicProfile` flow and proxied by `/public/api/profile/:username`.
+ *
+ * The LFX One server is a thin proxy — it fetches the JSON verbatim, gates on the
+ * public flag, and passes the payload through untransformed. These interfaces mirror
+ * the artifact's own (mixed-case) field names rather than renaming them.
+ *
+ * Field casing is taken from the reference artifact sample
+ * (`myprofile/frontend/public/profiles/example.json`): `basic`, `technical_contribution`,
+ * `community_roles`, and `event_activities` use PascalCase members, while
+ * `certification_activities` and `skills` use their own casing. Some optional sections
+ * (`presentations`, `training_activities`) are not present in that sample, so their member
+ * shapes are best-effort and should be reconfirmed against a live artifact when the public
+ * page UI consumes them.
+ */
+export interface PublicProfile {
+  /**
+   * Normalized public gate written by the proxy. `true` when the upstream artifact's
+   * public flag is truthy or absent; `false` only when it is explicitly disabled.
+   */
+  isPublic: boolean;
+  /** Raw upstream public flag, preserved as-is for reference. */
+  IsPublic?: boolean;
+  basic?: PublicProfileBasic;
+  /** Long-form bio / about section (HTML or markdown). */
+  About?: string;
+  technical_contribution?: PublicProfileTechnicalContribution;
+  community_roles?: PublicProfileCommunityRole[];
+  event_activities?: PublicProfileEvent[];
+  training_activities?: PublicProfileTraining[] | null;
+  certification_activities?: PublicProfileCertification[];
+  badges?: PublicProfileBadge[];
+  skills?: PublicProfileSkill[];
+  presentations?: PublicProfilePresentation[];
+}
+
+export interface PublicProfileBasic {
+  Name?: string;
+  LogoURL?: string;
+  TwitterID?: string;
+  LinkedInID?: string;
+  GithubID?: string;
+  Username?: string;
+  Title?: string;
+  Bio?: string;
+  AccountLogoURL?: string;
+  Identities?: PublicProfileIdentity[];
+}
+
+export interface PublicProfileIdentity {
+  Username?: string;
+  Avatar?: string;
+}
+
+export interface PublicProfileTechnicalContribution {
+  projects: PublicProfileProject[];
+}
+
+export interface PublicProfileProject {
+  ID: string;
+  LogoURL?: string;
+  Name: string;
+  Slug?: string;
+  affiliations?: PublicProfileAffiliation[];
+  commits: number;
+  deleted: number;
+  added: number;
+  prs: number;
+  issues: number;
+  docs: number;
+  contributions?: PublicProfileContribution[];
+}
+
+export interface PublicProfileAffiliation {
+  ID?: string;
+  Level?: string;
+  Organization?: PublicProfileAffiliationOrganization;
+  StartDate?: string;
+  EndDate?: string;
+}
+
+export interface PublicProfileAffiliationOrganization {
+  ID?: string;
+  LogoURL?: string;
+  Name?: string;
+}
+
+export interface PublicProfileContribution {
+  date: string;
+  commits: number;
+  added: number;
+  deleted: number;
+  prs: number;
+  issues: number;
+  docs: number;
+  count: number;
+}
+
+export interface PublicProfileCommunityRole {
+  ID: string;
+  LogoURL?: string;
+  roles: PublicProfileCommunityRoleEntry[];
+}
+
+export interface PublicProfileCommunityRoleEntry {
+  Name: string;
+  Role: string;
+  RoleStartDate?: string;
+  RoleEndDate?: string;
+}
+
+export interface PublicProfileEvent {
+  ID: string;
+  Name: string;
+  StartDate?: string;
+  EndDate?: string;
+  EventURL?: string;
+  LocationName?: string;
+}
+
+export interface PublicProfileCertification {
+  id: string;
+  name: string;
+  status: string;
+  startDate?: string;
+  endDate?: string;
+  type?: string;
+}
+
+export interface PublicProfileTraining {
+  Name?: string;
+  Status?: string;
+  Type?: string;
+  StartDate?: string;
+  EndDate?: string;
+}
+
+export interface PublicProfileBadge {
+  image: string;
+  url?: string;
+}
+
+export interface PublicProfileSkill {
+  ID: string;
+  Name: string;
+}
+
+export interface PublicProfilePresentation {
+  Name?: string;
+  EventURL?: string;
+  StartDate?: string;
+  EndDate?: string;
+  LocationName?: string;
+}

--- a/packages/shared/src/interfaces/public-profile.interface.ts
+++ b/packages/shared/src/interfaces/public-profile.interface.ts
@@ -2,20 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Shape of the public profile artifact published to S3 by the upstream
- * `GenerateUserPublicProfile` flow and proxied by `/public/api/profile/:username`.
- *
- * The LFX One server is a thin proxy — it fetches the JSON verbatim, gates on the
- * public flag, and passes the payload through untransformed. These interfaces mirror
- * the artifact's own (mixed-case) field names rather than renaming them.
- *
- * Field casing is taken from the reference artifact sample
- * (`myprofile/frontend/public/profiles/example.json`): `basic`, `technical_contribution`,
- * `community_roles`, and `event_activities` use PascalCase members, while
- * `certification_activities` and `skills` use their own casing. Some optional sections
- * (`presentations`, `training_activities`) are not present in that sample, so their member
- * shapes are best-effort and should be reconfirmed against a live artifact when the public
- * page UI consumes them.
+ * Shape of the S3 public profile artifact proxied by `/public/api/profile/:username`.
+ * Mirrors the artifact's own mixed-case field names; the server passes it through verbatim.
  */
 export interface PublicProfile {
   /**
@@ -31,10 +19,12 @@ export interface PublicProfile {
   technical_contribution?: PublicProfileTechnicalContribution;
   community_roles?: PublicProfileCommunityRole[];
   event_activities?: PublicProfileEvent[];
+  /** Best-effort shape — absent from the reference sample; reconfirm against a live artifact. */
   training_activities?: PublicProfileTraining[] | null;
   certification_activities?: PublicProfileCertification[];
   badges?: PublicProfileBadge[];
   skills?: PublicProfileSkill[];
+  /** Best-effort shape — absent from the reference sample; reconfirm against a live artifact. */
   presentations?: PublicProfilePresentation[];
 }
 

--- a/packages/shared/src/interfaces/public-profile.interface.ts
+++ b/packages/shared/src/interfaces/public-profile.interface.ts
@@ -7,8 +7,9 @@
  */
 export interface PublicProfile {
   /**
-   * Normalized public gate written by the proxy. `true` when the upstream artifact's
-   * public flag is truthy or absent; `false` only when it is explicitly disabled.
+   * Normalized public gate written by the proxy. `true` only when the upstream artifact's
+   * public flag is explicitly boolean `true`; a missing or non-boolean flag resolves to
+   * `false` (fail closed — the proxy withholds the payload for anything but an explicit opt-in).
    */
   isPublic: boolean;
   /** Raw upstream public flag, preserved as-is for reference. */


### PR DESCRIPTION
## Summary

Backend-only foundation for the public profile page (LFXV2-2631, part of the
myprofile → LFX Self-Serve cutover epic LFXV2-1948). Adds a server-side proxy
that reads the per-user public profile JSON artifact the upstream
`GenerateUserPublicProfile` flow publishes to S3, so the (later) public page can
render it SSR-safe without exposing S3 to the browser or dealing with CORS.

- **New public endpoint** `GET /public/api/profile/:username` — mounted under the
  `/public/api` stack (anonymous, `publicApiRateLimiter`, no auth). Confirmed out
  of scope of the impersonation service (mount order + identity-agnostic service).
- **`PublicProfileService`** — fetches `${bucket}/${username}.json`; maps 404/403 →
  not-found (null), non-OK/empty/invalid-JSON/timeout/network → `MicroserviceError`
  with appropriate status. Normalizes the artifact's public flag (`IsPublic` /
  `isPublic`) into a single `isPublic` boolean.
- **Controller** returns 404 for a missing profile, `{ isPublic: false }` (body
  withheld) for a private profile, and the full payload for a public one.
- **Username validation** — anchored pattern restricts the value before it's
  interpolated into the S3 object key (no path traversal / key probing).
- **Bucket URL is required config** — `PUBLIC_PROFILES_BUCKET_URL` env var, with no
  baked-in default. When unset/malformed/non-http, the app still boots and only this
  endpoint is inert (responds 503), so a misconfiguration surfaces loudly and in
  isolation rather than silently serving the wrong environment's data.
- Shared `PublicProfile` interface in `@lfx-one/shared`.
- 20 unit tests covering validation, config guards, status mapping, and flag
  normalization.

## Configuration

`PUBLIC_PROFILES_BUCKET_URL` must be set per environment to the base URL of the
bucket hosting the public profile artifacts. Handled entirely in code — no default
is baked in.

Part of LFXV2-2631
