### PR TITLE
docs(profile): add My CLAs user documentation

### DIFF
--- a/docs/user/profile/edit-profile/index.md
+++ b/docs/user/profile/edit-profile/index.md
@@ -18,7 +18,7 @@ The Profile page (`/profile`) includes these tabs:
 - **Work history & Affiliations** — your work history and project affiliations
 - **Identities** — connected accounts used to identify you and attribute contributions
 - **Individual Enrollment** — enroll in the Linux Foundation Individual Supporter plan
-- **My CLAs** — your signed Individual and Employee CLAs (`/profile/clas`); see [My CLAs](../my-clas/)
+- **My CLAs** — your signed ICLAs and Employee CLA (ECLA) coverage (`/profile/clas`); see [My CLAs](../my-clas/)
 - **Transactions** — your Linux Foundation purchase history (`/profile/transactions`)
 - **Settings** — email addresses, password, and developer API token (`/profile/settings`)
 
@@ -64,5 +64,5 @@ Developer settings are in the **Settings** tab of your Profile (`/profile/settin
 ## Related
 
 - [Profile overview](../) — an overview of the Profile section
-- [My CLAs](../my-clas/) — view your signed Individual and Employee CLAs
+- [My CLAs](../my-clas/) — view your signed ICLAs and Employee CLA coverage
 - [Settings](../../settings/) — email, password, and API token management

--- a/docs/user/profile/edit-profile/index.md
+++ b/docs/user/profile/edit-profile/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Profile
 tags: [profile, edit, affiliations, identities]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-04
 intercom_collection: Profile
 ---
 
@@ -13,11 +13,12 @@ Use the Profile section to keep your account information current. Your profile i
 
 ## Profile tabs
 
-The Profile page (`/profile`) has five tabs:
+The Profile page (`/profile`) includes these tabs:
 
 - **Work history & Affiliations** — your work history and project affiliations
 - **Identities** — connected accounts used to identify you and attribute contributions
 - **Individual Enrollment** — enroll in the Linux Foundation Individual Supporter plan
+- **My CLAs** — your signed Individual and Employee CLAs (`/profile/clas`); see [My CLAs](../my-clas/)
 - **Transactions** — your Linux Foundation purchase history (`/profile/transactions`)
 - **Settings** — email addresses, password, and developer API token (`/profile/settings`)
 
@@ -63,4 +64,5 @@ Developer settings are in the **Settings** tab of your Profile (`/profile/settin
 ## Related
 
 - [Profile overview](../) — an overview of the Profile section
+- [My CLAs](../my-clas/) — view your signed Individual and Employee CLAs
 - [Settings](../../settings/) — email, password, and API token management

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -3,9 +3,9 @@ title: Profile FAQ
 description: Frequently asked questions about your LFX Self Serve profile.
 audience: [all]
 product_area: Profile
-tags: [profile, faq, email, password, affiliations]
+tags: [profile, faq, email, password, affiliations, cla, easycla]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-04
 intercom_collection: Profile
 ---
 
@@ -32,6 +32,22 @@ Developer settings (API token) are in the **Settings** tab of your Profile (`/pr
 ## My name is displaying incorrectly. How do I fix it?
 
 Go to **Profile** (`/profile`) and update your first and last name fields and save your changes.
+
+## Where do I find My CLAs?
+
+Go to **Profile** → **My CLAs** (`/profile/clas`), or open [app.lfx.dev](https://app.lfx.dev) and select **Profile**, then the **My CLAs** tab. For full detail, see [My CLAs](../my-clas/).
+
+## What is the difference between an ICLA and an ECLA?
+
+An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from My CLAs when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; My CLAs lists it with the company name and no individual PDF. See [My CLAs](../my-clas/).
+
+## Why don't my signed CLAs show up on My CLAs?
+
+My CLAs matches agreements to your LF username, verified emails, and linked GitHub accounts. If you signed with an email or GitHub account that is not linked to this LFX profile, the CLA will not appear. Open [Identities](/profile/identities), link those accounts, then return to **My CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
+
+## Can I sign a CLA from the My CLAs tab?
+
+No. My CLAs is read-only and only shows agreements already on file. Signing happens in the EasyCLA contributor flow when you contribute to a project that requires a CLA. See [My CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
 ## Who do I contact if I cannot access my account?
 

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -43,11 +43,11 @@ An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can 
 
 ## Why don't my signed CLAs show up on My CLAs?
 
-My CLAs matches agreements to your LF username, verified emails, and linked GitHub accounts. If you signed with an email or GitHub account that is not linked to this LFX profile, the CLA will not appear. Open [Identities](/profile/identities), link those accounts, then return to **My CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
+My CLAs matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **My CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
 
 ## Can I sign a CLA from the My CLAs tab?
 
-No. My CLAs is read-only and only shows agreements already on file. Signing happens in the EasyCLA contributor flow when you contribute to a project that requires a CLA. See [My CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
+No. My CLAs is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [My CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## Who do I contact if I cannot access my account?
 

--- a/docs/user/profile/index.md
+++ b/docs/user/profile/index.md
@@ -19,7 +19,7 @@ The information below covers **your individual** LFX account — the profile tie
 
 - View and update your work history and project affiliations
 - Manage the identities used to attribute your contributions
-- View your signed Contributor License Agreements (CLAs)
+- View your Individual CLAs (ICLAs) and Employee CLA (ECLA) coverage
 - Enroll in the Linux Foundation Individual Supporter plan
 - View your Linux Foundation purchase history
 - Manage your email addresses, password, and developer API token
@@ -32,14 +32,14 @@ All authenticated users have a profile. Every user can view and edit their own p
 
 Go to **app.lfx.dev** and select **Profile** from the left navigation sidebar, or navigate directly to `/profile`. The profile section uses a tabbed layout with the following tabs:
 
-| Tab                         | Route                            | Description                                                 |
-| --------------------------- | -------------------------------- | ----------------------------------------------------------- |
-| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                  |
-| Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work |
-| Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan    |
-| My CLAs                     | `/profile/clas`                  | Your signed Individual and Employee CLAs (read-only)        |
-| Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                      |
-| Settings                    | `/profile/settings`              | Email addresses, password, and developer API token          |
+| Tab                         | Route                            | Description                                                    |
+| --------------------------- | -------------------------------- | -------------------------------------------------------------- |
+| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     |
+| Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work    |
+| Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan       |
+| My CLAs                     | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) |
+| Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                         |
+| Settings                    | `/profile/settings`              | Email addresses, password, and developer API token             |
 
 `/profile` opens the **Work history & Affiliations** tab by default.
 
@@ -65,7 +65,7 @@ Viewing your organization's profile in Org Lens requires **admin access** to you
 
 ## Related sections
 
-- [My CLAs](./my-clas/) — view your signed Individual and Employee CLAs
+- [My CLAs](./my-clas/) — view your signed ICLAs and Employee CLA coverage
 - [Settings](../settings/) — application-level preferences
 - [Badges](../badges/) — view your earned credentials
 - [Trainings](../trainings/) — view your enrolled training programs

--- a/docs/user/profile/index.md
+++ b/docs/user/profile/index.md
@@ -3,9 +3,9 @@ title: Profile
 description: Manage your LFX user profile, account settings, and personal information.
 audience: [all]
 product_area: Profile
-tags: [profile, account, email, password, affiliations, developer]
+tags: [profile, account, email, password, affiliations, developer, cla, easycla]
 last_generated: 2026-05-22
-last_updated: 2026-06-22
+last_updated: 2026-08-04
 intercom_collection: Profile
 ---
 
@@ -19,6 +19,7 @@ The information below covers **your individual** LFX account — the profile tie
 
 - View and update your work history and project affiliations
 - Manage the identities used to attribute your contributions
+- View your signed Contributor License Agreements (CLAs)
 - Enroll in the Linux Foundation Individual Supporter plan
 - View your Linux Foundation purchase history
 - Manage your email addresses, password, and developer API token
@@ -36,6 +37,7 @@ Go to **app.lfx.dev** and select **Profile** from the left navigation sidebar, o
 | Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                  |
 | Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work |
 | Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan    |
+| My CLAs                     | `/profile/clas`                  | Your signed Individual and Employee CLAs (read-only)        |
 | Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                      |
 | Settings                    | `/profile/settings`              | Email addresses, password, and developer API token          |
 
@@ -63,6 +65,7 @@ Viewing your organization's profile in Org Lens requires **admin access** to you
 
 ## Related sections
 
+- [My CLAs](./my-clas/) — view your signed Individual and Employee CLAs
 - [Settings](../settings/) — application-level preferences
 - [Badges](../badges/) — view your earned credentials
 - [Trainings](../trainings/) — view your enrolled training programs

--- a/docs/user/profile/my-clas/index.md
+++ b/docs/user/profile/my-clas/index.md
@@ -1,0 +1,74 @@
+---
+title: My CLAs
+description: View your signed Individual and Employee CLAs in LFX Self Serve, and understand why an agreement might not appear.
+audience: [all]
+product_area: Profile
+tags: [profile, cla, easycla, icla, ecla, identities]
+last_generated: 2026-08-04
+last_updated: 2026-08-04
+intercom_collection: Profile
+---
+
+**My CLAs** is a read-only Profile tab that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. It answers: _which agreements have I signed, and under which projects am I covered?_
+
+You do **not** sign a CLA from this page. Signing happens as part of the EasyCLA contributor flow when you contribute to a project that requires a CLA. The signing experience continues to evolve; this page only shows agreements already on file.
+
+For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
+
+## How to open My CLAs
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Profile** from the left navigation sidebar.
+3. Open the **My CLAs** tab, or go directly to `/profile/clas`.
+
+Agreements are matched automatically from your signed-in session and your [linked identities](/profile/identities) (Email, GitHub, GitLab). You never search or type a project name here.
+
+## ICLA vs ECLA
+
+| Type                      | What it means                                                                                                      | On My CLAs                                                               | Document                                                       |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------- |
+| **ICLA** (Individual CLA) | You signed as yourself for a project                                                                               | Listed                                                                   | **Download PDF** of your signed agreement                      |
+| **ECLA** (Employee CLA)   | You are covered because your employer holds a Corporate CLA (CCLA) and you are on that company's **Approved List** | Listed (shows the employer name)                                         | No individual PDF — shown as _Covered by Corporate CLA (CCLA)_ |
+| **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                              | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab         |
+
+In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered under your company's **CCLA**.
+
+## What the list shows
+
+When agreements are found, My CLAs shows a table with four columns:
+
+| Column       | Contents                                                                                                    |
+| ------------ | ----------------------------------------------------------------------------------------------------------- |
+| **Project**  | Project logo (or a placeholder), project name, and — when it differs — the CLA group name as secondary text |
+| **Type**     | `ICLA`, or `ECLA · <company name>`                                                                          |
+| **Signed**   | The date the agreement was signed                                                                           |
+| **Document** | **Download PDF** for an ICLA; _Covered by Corporate CLA (CCLA)_ for an ECLA                                 |
+
+Only currently valid agreements appear on this list.
+
+### Empty state
+
+If nothing matches your linked identities, you see:
+
+- **No CLAs on file yet**
+- _We haven't found any signed ICLAs or ECLAs for your linked identities._
+
+That does not always mean you never signed — see the next section.
+
+## Why a signed CLA might not show up
+
+My CLAs only finds agreements that match an identity linked to your LFX account. A CLA can be missing from the list when:
+
+- The **email**, **GitHub**, or **GitLab** account you used when signing is **not linked** to this LFX profile
+- You signed under a **work or secondary email** that is not among your verified / linked emails
+- You signed with a **GitHub or GitLab username** that is not connected under Identities
+
+**What to do:** open [Identities](/profile/identities) (`/profile/identities`) and link the Email, GitHub, or GitLab accounts you use for contributions. Then return to **My CLAs** — matching is automatic once the identity is linked.
+
+The info banner on the My CLAs tab also points to the same Identities flow: _Link your Email, GitHub, or GitLab accounts →_.
+
+## Related
+
+- [Profile overview](../) — Profile tabs and navigation
+- [Edit your profile](../edit-profile/) — personal details, affiliations, and account settings
+- [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) — CLA concepts, consoles, and troubleshooting outside Self Serve

--- a/docs/user/profile/my-clas/index.md
+++ b/docs/user/profile/my-clas/index.md
@@ -13,7 +13,7 @@ These steps apply to any signed-in user on LFX Self Serve.
 
 **My CLAs** is a read-only Profile tab that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. My CLAs answers: _which agreements have I signed, and under which projects am I covered?_
 
-You cannot sign a CLA from this page. Signing happens in the EasyCLA contributor flow when you contribute to a project that requires a CLA. The signing experience continues to evolve; this page only shows agreements already on file.
+You cannot sign a CLA from this page. Signing happens outside My CLAs, and the signing process may evolve; this page only shows agreements already on file.
 
 For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
@@ -83,7 +83,7 @@ No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCL
 
 ## Can I sign a CLA from My CLAs?
 
-No. My CLAs is read-only. To get covered, follow the EasyCLA contributor flow when you contribute to a project that requires a CLA. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for how signing works.
+No. My CLAs is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## Related
 

--- a/docs/user/profile/my-clas/index.md
+++ b/docs/user/profile/my-clas/index.md
@@ -21,7 +21,7 @@ For broader EasyCLA concepts (what a CLA is, project and corporate consoles, tro
 2. Select **Profile** from the left navigation sidebar.
 3. Open the **My CLAs** tab, or go directly to `/profile/clas`.
 
-Agreements are matched automatically from your signed-in session and your [linked identities](/profile/identities) (Email, GitHub, GitLab). You never search or type a project name here.
+Agreements are matched automatically from your signed-in session and your linked [Email and GitHub identities](/profile/identities). You never search or type a project name here.
 
 ## ICLA vs ECLA
 
@@ -57,15 +57,15 @@ That does not always mean you never signed — see the next section.
 
 ## Why a signed CLA might not show up
 
-My CLAs only finds agreements that match an identity linked to your LFX account. A CLA can be missing from the list when:
+My CLAs only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
 
-- The **email**, **GitHub**, or **GitLab** account you used when signing is **not linked** to this LFX profile
+- The **email** or **GitHub** account you used when signing is **not linked** to this LFX profile
 - You signed under a **work or secondary email** that is not among your verified / linked emails
-- You signed with a **GitHub or GitLab username** that is not connected under Identities
+- You signed with a **GitHub username** that is not connected under Identities
 
-**What to do:** open [Identities](/profile/identities) (`/profile/identities`) and link the Email, GitHub, or GitLab accounts you use for contributions. Then return to **My CLAs** — matching is automatic once the identity is linked.
+**What to do:** open [Identities](/profile/identities) and link the Email or GitHub accounts you used when signing. Then return to **My CLAs** — matching is automatic once the identity is linked.
 
-The info banner on the My CLAs tab also points to the same Identities flow: _Link your Email, GitHub, or GitLab accounts →_.
+The info banner on the My CLAs tab also points to the Identities flow (_Link your Email, GitHub, or GitLab accounts →_). Linking Email or GitHub is what recovers missing CLA matches today.
 
 ## Related
 

--- a/docs/user/profile/my-clas/index.md
+++ b/docs/user/profile/my-clas/index.md
@@ -25,11 +25,11 @@ Agreements are matched automatically from your signed-in session and your linked
 
 ## ICLA vs ECLA
 
-| Type                      | What it means                                                                                                      | On My CLAs                                                               | Document                                                       |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | -------------------------------------------------------------- |
-| **ICLA** (Individual CLA) | You signed as yourself for a project                                                                               | Listed                                                                   | **Download PDF** of your signed agreement                      |
-| **ECLA** (Employee CLA)   | You are covered because your employer holds a Corporate CLA (CCLA) and you are on that company's **Approved List** | Listed (shows the employer name)                                         | No individual PDF — shown as _Covered by Corporate CLA (CCLA)_ |
-| **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                              | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab         |
+| Type                      | What it means                                                                                                      | On My CLAs                                                               | Document                                                                        |
+| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
+| **ICLA** (Individual CLA) | You signed as yourself for a project                                                                               | Listed                                                                   | **Download PDF** when EasyCLA has the signed file (otherwise _PDF unavailable_) |
+| **ECLA** (Employee CLA)   | You are covered because your employer holds a Corporate CLA (CCLA) and you are on that company's **Approved List** | Listed (shows the employer name)                                         | No individual PDF — shown as _Covered by Corporate CLA (CCLA)_                  |
+| **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                              | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab                          |
 
 In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered under your company's **CCLA**.
 
@@ -37,12 +37,12 @@ In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered und
 
 When agreements are found, My CLAs shows a table with four columns:
 
-| Column       | Contents                                                                                                    |
-| ------------ | ----------------------------------------------------------------------------------------------------------- |
-| **Project**  | Project logo (or a placeholder), project name, and — when it differs — the CLA group name as secondary text |
-| **Type**     | `ICLA`, or `ECLA · <company name>`                                                                          |
-| **Signed**   | The date the agreement was signed                                                                           |
-| **Document** | **Download PDF** for an ICLA; _Covered by Corporate CLA (CCLA)_ for an ECLA                                 |
+| Column       | Contents                                                                                                            |
+| ------------ | ------------------------------------------------------------------------------------------------------------------- |
+| **Project**  | Project logo (or a placeholder), project name, and — when it differs — the CLA group name as secondary text         |
+| **Type**     | `ICLA`, or `ECLA · <company name>`                                                                                  |
+| **Signed**   | The date the agreement was signed                                                                                   |
+| **Document** | **Download PDF** for an ICLA when available (else _PDF unavailable_); _Covered by Corporate CLA (CCLA)_ for an ECLA |
 
 Only currently valid agreements appear on this list.
 

--- a/docs/user/profile/my-clas/index.md
+++ b/docs/user/profile/my-clas/index.md
@@ -9,21 +9,23 @@ last_updated: 2026-08-04
 intercom_collection: Profile
 ---
 
-**My CLAs** is a read-only Profile tab that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. It answers: _which agreements have I signed, and under which projects am I covered?_
+These steps apply to any signed-in user on LFX Self Serve.
 
-You do **not** sign a CLA from this page. Signing happens as part of the EasyCLA contributor flow when you contribute to a project that requires a CLA. The signing experience continues to evolve; this page only shows agreements already on file.
+**My CLAs** is a read-only Profile tab that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. My CLAs answers: _which agreements have I signed, and under which projects am I covered?_
+
+You cannot sign a CLA from this page. Signing happens in the EasyCLA contributor flow when you contribute to a project that requires a CLA. The signing experience continues to evolve; this page only shows agreements already on file.
 
 For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
-## How to open My CLAs
+## Where do I find My CLAs?
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Select **Profile** from the left navigation sidebar.
 3. Open the **My CLAs** tab, or go directly to `/profile/clas`.
 
-Agreements are matched automatically from your signed-in session and your linked [Email and GitHub identities](/profile/identities). You never search or type a project name here.
+Agreements are matched from your signed-in session and your linked [Email and GitHub identities](/profile/identities). You never search or type a project name here.
 
-## ICLA vs ECLA
+## What is the difference between ICLA and ECLA?
 
 | Type                      | What it means                                                                                                      | On My CLAs                                                               | Document                                                                        |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
@@ -33,7 +35,7 @@ Agreements are matched automatically from your signed-in session and your linked
 
 In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered under your company's **CCLA**.
 
-## What the list shows
+## What does the My CLAs list show?
 
 When agreements are found, My CLAs shows a table with four columns:
 
@@ -46,7 +48,7 @@ When agreements are found, My CLAs shows a table with four columns:
 
 Only currently valid agreements appear on this list.
 
-### Empty state
+### Why does My CLAs say I have no CLAs?
 
 If nothing matches your linked identities, you see:
 
@@ -55,7 +57,7 @@ If nothing matches your linked identities, you see:
 
 That does not always mean you never signed — see the next section.
 
-## Why a signed CLA might not show up
+## Why don't my signed CLAs show up?
 
 My CLAs only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
 
@@ -63,12 +65,29 @@ My CLAs only finds agreements that match an identity linked to your LFX account.
 - You signed under a **work or secondary email** that is not among your verified / linked emails
 - You signed with a **GitHub username** that is not connected under Identities
 
-**What to do:** open [Identities](/profile/identities) and link the Email or GitHub accounts you used when signing. Then return to **My CLAs** — newly linked Email/GitHub identities are included on the next load. If an agreement is still missing after that, see [EasyCLA troubleshooting](https://docs.linuxfoundation.org/lfx/easycla/v2-current/getting-started/easycla-troubleshooting).
+**What to do:**
+
+1. Open [Identities](/profile/identities).
+2. Link the Email or GitHub accounts you used when signing.
+3. Return to **My CLAs** — newly linked Email/GitHub identities are included on the next load.
+
+If an agreement is still missing after that, see [EasyCLA troubleshooting](https://docs.linuxfoundation.org/lfx/easycla/v2-current/getting-started/easycla-troubleshooting).
 
 The info banner on the My CLAs tab also points to the Identities flow (_Link your Email, GitHub, or GitLab accounts →_). Linking Email or GitHub is what recovers missing CLA matches today.
+
+## Can I download my signed CLA PDF?
+
+Yes for an **ICLA**, when EasyCLA has the signed file — use **Download PDF** in the Document column. If the file is missing, the row shows _PDF unavailable_.
+
+No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. The Document column shows _Covered by Corporate CLA (CCLA)_.
+
+## Can I sign a CLA from My CLAs?
+
+No. My CLAs is read-only. To get covered, follow the EasyCLA contributor flow when you contribute to a project that requires a CLA. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for how signing works.
 
 ## Related
 
 - [Profile overview](../) — Profile tabs and navigation
+- [Profile FAQ](../faq/) — short answers to common Profile questions, including My CLAs
 - [Edit your profile](../edit-profile/) — personal details, affiliations, and account settings
 - [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) — CLA concepts, consoles, and troubleshooting outside Self Serve

--- a/docs/user/profile/my-clas/index.md
+++ b/docs/user/profile/my-clas/index.md
@@ -63,7 +63,7 @@ My CLAs only finds agreements that match an identity linked to your LFX account.
 - You signed under a **work or secondary email** that is not among your verified / linked emails
 - You signed with a **GitHub username** that is not connected under Identities
 
-**What to do:** open [Identities](/profile/identities) and link the Email or GitHub accounts you used when signing. Then return to **My CLAs** — matching is automatic once the identity is linked.
+**What to do:** open [Identities](/profile/identities) and link the Email or GitHub accounts you used when signing. Then return to **My CLAs** — newly linked Email/GitHub identities are included on the next load. If an agreement is still missing after that, see [EasyCLA troubleshooting](https://docs.linuxfoundation.org/lfx/easycla/v2-current/getting-started/easycla-troubleshooting).
 
 The info banner on the My CLAs tab also points to the Identities flow (_Link your Email, GitHub, or GitLab accounts →_). Linking Email or GitHub is what recovers missing CLA matches today.
 


### PR DESCRIPTION
## Summary

- New Self Serve docs article at `/docs/profile/my-clas` covering ICLA vs ECLA, the My CLAs list, empty state, and why a CLA may be missing
- Profile overview + edit-profile updated to list the **My CLAs** tab (UI order: before Transactions) and link to the new article

Fixes #1280

Unblocks #1181 (empty-state docs link) after merge/deploy — do not close #1181.

## Deploy preview

Once the deploy-preview is up, open:

`https://ui-pr-<N>.dev.v2.cluster.linuxfound.info/docs/profile/my-clas`

(Replace `<N>` with this PR number.)

After merge/deploy to app: `https://app.lfx.dev/docs/profile/my-clas` — post that URL on #1181 and wire the empty-state link.

## Test plan

- [ ] `yarn docs:check`
- [ ] Open deploy-preview `/docs/profile/my-clas`
- [ ] Confirm Profile overview lists the My CLAs tab before Transactions
- [ ] Confirm edit-profile related links include My CLAs