### PR TITLE
test(enrollment): document and pin Purchased status derivation

### DIFF
--- a/packages/shared/src/utils/enrollment.utils.spec.ts
+++ b/packages/shared/src/utils/enrollment.utils.spec.ts
@@ -129,6 +129,25 @@ describe('deriveEnrollmentStatus', () => {
     const item = enrollment({ membership: membership({ endDate: daysFromNow(10) }) });
     expect(deriveEnrollmentStatus(item)).toBe('Expiring Soon');
   });
+
+  // 'Purchased' has no dedicated branch — it deliberately flows into the same date-based derivation
+  // as 'Active'. These pin that equivalence so the fall-through can't silently regress.
+  describe("treats 'Purchased' identically to 'Active'", () => {
+    it('returns Active when EndDate is more than 30 days out', () => {
+      const item = enrollment({ membership: membership({ status: 'Purchased', endDate: daysFromNow(60) }) });
+      expect(deriveEnrollmentStatus(item)).toBe('Active');
+    });
+
+    it('returns Expiring Soon when EndDate is within 30 days and not stripe-autoRenew', () => {
+      const item = enrollment({ membership: membership({ status: 'Purchased', endDate: daysFromNow(10) }) });
+      expect(deriveEnrollmentStatus(item)).toBe('Expiring Soon');
+    });
+
+    it('returns Expired when EndDate is in the past', () => {
+      const item = enrollment({ membership: membership({ status: 'Purchased', endDate: daysFromNow(-5) }) });
+      expect(deriveEnrollmentStatus(item)).toBe('Expired');
+    });
+  });
 });
 
 describe('enrollmentStatusSeverity', () => {

--- a/packages/shared/src/utils/enrollment.utils.ts
+++ b/packages/shared/src/utils/enrollment.utils.ts
@@ -10,6 +10,8 @@ import { EnrollmentDisplayStatus, IndividualEnrollment } from '../interfaces/enr
 export function deriveEnrollmentStatus(item: IndividualEnrollment): EnrollmentDisplayStatus {
   const { membership, price } = item;
   if (!membership) return 'Not Enrolled';
+  // Only 'Expired' short-circuits here. 'Active' and 'Purchased' are equivalent for display — a
+  // purchased membership is an active one, so both flow into the date-based derivation below.
   if (membership.status === 'Expired') return 'Expired';
   if (price === null || price === undefined) return 'Active';
   const endDateString = membership.endDate.length >= 10 ? membership.endDate.slice(0, 10) : membership.endDate;


### PR DESCRIPTION
## Summary

- Document that `deriveEnrollmentStatus` intentionally has no dedicated `'Purchased'` branch — only `'Expired'` short-circuits, while `'Active'` and `'Purchased'` are equivalent for display and both flow into the date-based derivation (EndDate + Stripe/auto-renew).
- Add tests pinning `'Purchased'` to the same outcomes as `'Active'` (active when >30 days out, expiring-soon within 30 days, expired when past) so the fall-through can't silently regress.

Follow-up to PR #732 review notes. No behavior change.

LFXV2-1664
