### PR TITLE
feat(groups): partial-coverage active members count with disclosure

### DIFF
--- a/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
+++ b/apps/lfx-one/e2e/groups-engagement-stats.spec.ts
@@ -147,7 +147,13 @@ async function stubEngagementStats(page: Page): Promise<void> {
     route.fulfill({
       status: 200,
       contentType: 'application/json',
-      body: JSON.stringify({ active_members: 7, meetings_this_month: 2, computed_at: new Date().toISOString(), source: 'live' }),
+      body: JSON.stringify({
+        active_members: 7,
+        meetings_this_month: 2,
+        computed_at: new Date().toISOString(),
+        source: 'live',
+        coverage: { covered: 1, total: 1 },
+      }),
     })
   );
 }

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -567,6 +567,9 @@ describe('GroupsEngagementStatsService', () => {
       const result = await service.getEngagementStats(buildReq());
 
       expect(result.active_members).toBeNull();
+      // total reflects the visible-committee count established before the chunk failure (not 0) —
+      // the caller's committee set was known even though the count itself couldn't be trusted.
+      expect(result.coverage).toEqual({ covered: 0, total: 150 });
     });
 
     it('degrades to active_members: null (not 0) when the Snowflake query hits a missing-object error', async () => {
@@ -578,6 +581,7 @@ describe('GroupsEngagementStatsService', () => {
       expect(result.active_members).toBeNull();
       expect(result.meetings_this_month).toBeNull();
       expect(result.source).toBe('live');
+      expect(result.coverage).toEqual({ covered: 0, total: 1 });
     });
 
     it('degrades to active_members: null without throwing when fetching the visible committee set fails', async () => {
@@ -588,6 +592,9 @@ describe('GroupsEngagementStatsService', () => {
       expect(result.active_members).toBeNull();
       expect(result.meetings_this_month).toBeNull();
       expect(execute).not.toHaveBeenCalled();
+      // total is 0 here (not just covered) — the failure happened before the visible-committee
+      // count was ever established, unlike the chunk-failure case above.
+      expect(result.coverage).toEqual({ covered: 0, total: 0 });
     });
 
     it('rethrows via degrade (not a thrown error) on an unexpected non-missing-object Snowflake error', async () => {
@@ -597,6 +604,7 @@ describe('GroupsEngagementStatsService', () => {
       const result = await service.getEngagementStats(buildReq());
 
       expect(result.active_members).toBeNull();
+      expect(result.coverage).toEqual({ covered: 0, total: 1 });
     });
   });
 

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -191,6 +191,12 @@ describe('GroupsEngagementStatsService', () => {
       expect(execute).not.toHaveBeenCalled();
       expect(getMyCommitteeUids).not.toHaveBeenCalled();
     });
+
+    it('fabricates full coverage (covered === total, both positive) so the mock path exercises the no-qualifier UI state', async () => {
+      const result = await service.getEngagementStats(buildReq());
+      expect(result.coverage.covered).toBe(result.coverage.total);
+      expect(result.coverage.total).toBeGreaterThan(0);
+    });
   });
 
   describe('caching', () => {
@@ -219,6 +225,23 @@ describe('GroupsEngagementStatsService', () => {
       // the real VALKEY_CACHE namespace (not a hardcoded duplicate) so a `:v1` → `:v2` bump can't
       // leave this assertion silently checking a key the service no longer writes to.
       cacheStore.set(`${VALKEY_CACHE.GROUPS_ENGAGEMENT_NAMESPACE}:alice`, { active_members: 'not-a-number' });
+
+      await service.getEngagementStats(buildReq());
+      expect(fetcherCalls.count).toBe(2);
+    });
+
+    it('treats a pre-LFXV2-2978 cached entry with no `coverage` field as a miss and recomputes, rather than serving it stale for the TTL', async () => {
+      await service.getEngagementStats(buildReq());
+      expect(fetcherCalls.count).toBe(1);
+
+      // Otherwise-valid shape from before `coverage` was added — simulates a cache entry written by
+      // a pre-upgrade instance still sharing the same key immediately after deploy.
+      cacheStore.set(`${VALKEY_CACHE.GROUPS_ENGAGEMENT_NAMESPACE}:alice`, {
+        active_members: 5,
+        meetings_this_month: 2,
+        computed_at: new Date().toISOString(),
+        source: 'mock',
+      });
 
       await service.getEngagementStats(buildReq());
       expect(fetcherCalls.count).toBe(2);
@@ -264,6 +287,7 @@ describe('GroupsEngagementStatsService', () => {
       const result = await service.getEngagementStats(buildReq());
 
       expect(result.active_members).toBe(0);
+      expect(result.coverage).toEqual({ covered: 0, total: 0 });
       expect(execute).not.toHaveBeenCalled();
     });
 
@@ -312,20 +336,25 @@ describe('GroupsEngagementStatsService', () => {
 
       expect(execute).not.toHaveBeenCalled();
       expect(result.active_members).toBeNull();
+      expect(result.coverage).toEqual({ covered: 0, total: 2 });
     });
 
-    it('treats an unresolved committee uid as uncovered — null overall, short-circuiting before any chunk query even runs', async () => {
-      // committee-1 resolves; committee-2 never resolves to a v1 id at all. A partial resolution
-      // already guarantees `fullyCovered` will be false (committee-2 can never gain a covered row),
-      // so this now short-circuits to null immediately rather than paying for a Snowflake round trip
-      // whose result is discarded regardless — see computeActiveMembers' early-return.
+    it('no longer short-circuits on an unresolved committee uid — counts over the resolved/covered subset instead (LFXV2-2978)', async () => {
+      // committee-1 resolves and is covered by a model row; committee-2 never resolves to a v1 id at
+      // all. Under the old all-or-nothing rule this returned null without ever querying Snowflake.
+      // Under partial coverage, the covered subset (committee-1) is still queried and counted, and
+      // the unresolved committee-2 is reported as uncovered via `coverage`, not swallowed into null.
       getMyCommitteeUids.mockResolvedValue(new Set(['committee-1', 'committee-2']));
       resolveCommitteeV2UidsToV1Ids.mockResolvedValueOnce(new Map([['committee-1', 'v1-sfid-1']]));
+      execute.mockResolvedValueOnce({ rows: [activeMemberRow({ COMMITTEE_ID: 'v1-sfid-1', MEMBER_USER_ID: 'm1', ATTENDED_COUNT_30D: 1 })] });
 
       const result = await service.getEngagementStats(buildReq());
 
-      expect(execute).not.toHaveBeenCalled();
-      expect(result.active_members).toBeNull();
+      expect(execute).toHaveBeenCalledTimes(1);
+      const [, binds] = execute.mock.calls[0] as [string, string[]];
+      expect(binds).toEqual(['v1-sfid-1']);
+      expect(result.active_members).toBe(1);
+      expect(result.coverage).toEqual({ covered: 1, total: 2 });
     });
 
     it('handles two visible v2 committees resolving to the SAME v1 id without under-counting coverage (duplicate-safe, not an inverted-map lookup)', async () => {
@@ -435,20 +464,21 @@ describe('GroupsEngagementStatsService', () => {
       expect(result.active_members).toBe(0);
     });
 
-    it("returns null (not 0) when the caller has visible committees but every chunk returns zero rows — mirrors the sibling endpoint's zero-row semantics", async () => {
+    it("returns null (not 0) with zero coverage when the caller has visible committees but every chunk returns zero rows — mirrors the sibling endpoint's zero-row semantics", async () => {
       getMyCommitteeUids.mockResolvedValue(new Set(['committee-1', 'committee-2']));
       execute.mockResolvedValueOnce({ rows: [] });
 
       const result = await service.getEngagementStats(buildReq());
 
       expect(result.active_members).toBeNull();
+      expect(result.coverage).toEqual({ covered: 0, total: 2 });
     });
 
-    it('returns null when SOME visible committees are covered but at least one is not (partial coverage), rather than an undercount', async () => {
-      // Regression test: rowCount > 0 alone used to be treated as "complete", so a caller with 3
-      // visible committees where only 1 was synced would silently report a plausible-looking count
-      // for that 1 committee while the other 2's absence went unnoticed. Coverage must now be
-      // checked per-committee.
+    it('counts over the covered subset when SOME visible committees are covered but at least one is not (partial coverage), rather than degrading to null (LFXV2-2978)', async () => {
+      // Regression test for the OLD behavior this replaces: a caller with 3 visible committees where
+      // only 2 were synced used to degrade the whole request to null, discarding an otherwise-good
+      // count over the 2 covered committees. The product decision is now to count over the covered
+      // subset and disclose coverage, not discard it.
       getMyCommitteeUids.mockResolvedValue(new Set(['committee-1', 'committee-2', 'committee-3']));
       execute.mockResolvedValueOnce({
         rows: [
@@ -460,7 +490,8 @@ describe('GroupsEngagementStatsService', () => {
 
       const result = await service.getEngagementStats(buildReq());
 
-      expect(result.active_members).toBeNull();
+      expect(result.active_members).toBe(2);
+      expect(result.coverage).toEqual({ covered: 2, total: 3 });
     });
 
     it('returns a real 0 (not null) when rows are present for every visible committee but nobody in them is active', async () => {

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -170,7 +170,7 @@ export class GroupsEngagementStatsService {
    * id — see the coverage-loop comment below). `activeMembers` is computed over the covered subset
    * only (LFXV2-2978 — a caller with 10 visible committees where 9 are covered gets a real count
    * over those 9, plus `coverage: { covered: 9, total: 10 }`, rather than a blanket `null` for the
-   * whole caller). Three distinct "nothing to report" cases stay distinguishable:
+   * whole caller). Four distinct result shapes stay distinguishable:
    * - `{ activeMembers: 0, coverage: { covered: 0, total: 0 } }`: the caller genuinely has no
    *   visible committees — a real answer, no query even runs.
    * - `{ activeMembers: null, coverage: { covered: 0, total } }`: every visible committee is
@@ -179,10 +179,14 @@ export class GroupsEngagementStatsService {
    * - `{ activeMembers: N, coverage: { covered, total } }` (`covered` possibly `< total`): a real,
    *   computed count over whichever committees are covered — `covered === total` means it's
    *   complete; `covered < total` means it's a real but partial count the client should disclose.
-   * - `{ activeMembers: null, coverage: { covered: 0, total: 0 } }` (error): the count couldn't be
-   *   computed at all (missing committee-set lookup, a Snowflake missing-object/not-authorized
-   *   error, or any chunk failing) — never thrown, so a stats failure never blocks the rest of the
-   *   groups dashboard.
+   *   `N` can itself be `0` (a real, fully- or partially-covered zero — nobody active in the covered
+   *   subset), which is why this shape is distinguished from the null cases by `active_members`
+   *   being non-null, not by it being nonzero.
+   * - `{ activeMembers: null, coverage: { covered: 0, total } }` (error, `total` possibly `0`): the
+   *   count couldn't be computed at all (missing committee-set lookup, a Snowflake missing-object/
+   *   not-authorized error, or any chunk failing) — never thrown, so a stats failure never blocks the
+   *   rest of the groups dashboard. `total` reports the visible-committee count if it was already
+   *   known before the failure, `0` if the failure happened before that — see the catch block below.
    */
   private async computeActiveMembers(req: Request): Promise<{ activeMembers: number | null; coverage: { covered: number; total: number } }> {
     // Tracked outside the try block (not just a `const` inside it) so the catch block can still
@@ -261,28 +265,20 @@ export class GroupsEngagementStatsService {
       // not a filter applied after the fact.
       const activeMembers = coveredCount > 0 ? activeUids.size : null;
 
-      if (coveredCount < committeeUids.length) {
-        // The most likely-to-occur partial-coverage case in a partially-rolled-out model — warrants
-        // visibility at WARNING, same as the error paths below, even though (unlike those) it still
-        // produces a usable (if partial) count rather than degrading the whole request.
-        logger.warning(
-          req,
-          'get_groups_engagement_stats',
-          'Some visible committees are not covered by the engagement model; counting over the covered subset',
-          {
-            covered: coveredCount,
-            total: committeeUids.length,
-            uncovered_committee_count: uncoveredCount,
-          }
-        );
-      } else {
-        logger.debug(req, 'get_groups_engagement_stats', 'Computed active members', {
-          committee_count: committeeUids.length,
-          chunk_count: chunks.length,
-          row_count: rowCount,
-          active_members: activeMembers,
-        });
-      }
+      // DEBUG, not WARNING: live validation showed nearly every real caller has at least one
+      // uncovered visible committee (see the class doc comment above), so `coveredCount <
+      // committeeUids.length` is now the expected steady state on most cache misses, not a
+      // degraded/recoverable-error condition per `.claude/rules/logging-patterns.md`'s WARN
+      // criteria — a WARN here would fire on nearly every request and bury the genuine WARNs the
+      // catch block below emits on actual failures.
+      logger.debug(req, 'get_groups_engagement_stats', 'Computed active members', {
+        committee_count: committeeUids.length,
+        chunk_count: chunks.length,
+        row_count: rowCount,
+        active_members: activeMembers,
+        covered: coveredCount,
+        uncovered_committee_count: uncoveredCount,
+      });
 
       return { activeMembers, coverage };
     } catch (error) {

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -271,9 +271,14 @@ export class GroupsEngagementStatsService {
         // `.claude/rules/logging-patterns.md` reserves WARN for, and the only thing that
         // distinguishes this from the catch block's post-fetch-failure WARNs in production logs
         // (both produce the identical `{ activeMembers: null, coverage: { covered: 0, total } }`
-        // wire shape — see the doc comment above).
+        // wire shape — see the doc comment above). `resolved_v1_count`/`chunk_count` distinguish
+        // the two sub-causes on-call would otherwise have to guess between: 0 resolved ids means no
+        // visible uid mapped at all (an `lfx.lookup_v1_mapping` problem), while resolved ids > 0
+        // means uids mapped but the model has no rows for them yet (a dbt/sync problem).
         logger.warning(req, 'get_groups_engagement_stats', 'No visible committee is covered by the engagement model; returning null active_members', {
           committee_count: committeeUids.length,
+          resolved_v1_count: v1Ids.length,
+          chunk_count: chunks.length,
         });
       } else {
         // DEBUG, not WARNING: live validation showed nearly every real caller has at least one

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -33,6 +33,12 @@ type ActiveMemberRow = Pick<
  * hit for up to `GROUPS_ENGAGEMENT_TTL_SECONDS`. Without this, a stray `mock` entry cached
  * before a switch to `live`/production would keep answering "Sample data" for up to 60s after
  * the switch, undermining the production hard-block's guarantee.
+ *
+ * The same reasoning generalizes beyond `source`: this validator is also this response shape's
+ * version check. A field a newer service version always sets (like `coverage`, added in
+ * LFXV2-2978) must be checked here too, so a cache entry written by a pre-upgrade instance —
+ * which never had that field — reads as a miss and recomputes immediately instead of being served
+ * to a client expecting the newer shape for up to `GROUPS_ENGAGEMENT_TTL_SECONDS` after deploy.
  */
 function isGroupsEngagementStats(value: unknown, expectedSource: 'mock' | 'live'): boolean {
   const v = value as Partial<GroupsEngagementStats>;
@@ -42,7 +48,11 @@ function isGroupsEngagementStats(value: unknown, expectedSource: 'mock' | 'live'
     (v.active_members === null || typeof v.active_members === 'number') &&
     (v.meetings_this_month === null || typeof v.meetings_this_month === 'number') &&
     typeof v.computed_at === 'string' &&
-    v.source === expectedSource
+    v.source === expectedSource &&
+    typeof v.coverage === 'object' &&
+    v.coverage !== null &&
+    typeof v.coverage.covered === 'number' &&
+    typeof v.coverage.total === 'number'
   );
 }
 
@@ -84,12 +94,15 @@ function resolveBackend(): 'mock' | 'live' {
  * live-validation confirmation, not a settled fact.) Visible committee uids are v2 committee-service
  * UUIDs; the model is keyed on the v1 committee SFID, so every uid is resolved via
  * `resolveCommitteeV2UidsToV1Ids` before querying (confirmed with Jordan Evans, data owner,
- * LFXV2-2968 — see `computeActiveMembers`'s doc comment for the coverage-checking details).
- * `meetings_this_month` stays `null` in live mode — the model exposes only rolling 30d/90d/YTD
- * meeting counts, not a calendar-month grain, so there's no honest source for it yet (LFXV2-2961
- * tracks adding one). Defaults to `live` (never fabricated numbers) unless `ENGAGEMENT_BACKEND=mock`
- * is explicitly set, and `mock` is additionally
- * hard-blocked when `NODE_ENV=production`.
+ * LFXV2-2968). Live validation showed nearly every real caller has at least one visible committee
+ * that's unresolved or not yet synced, so as of LFXV2-2978 `active_members` counts over the
+ * *covered* subset only and reports `coverage: { covered, total }` alongside it, rather than
+ * degrading to `null` on any single gap — see `computeActiveMembers`'s doc comment for exactly what
+ * "covered" means. `meetings_this_month` stays `null` in live mode — the model exposes only rolling
+ * 30d/90d/YTD meeting counts, not a calendar-month grain, so there's no honest source for it yet
+ * (LFXV2-2961 tracks adding one). Defaults to `live` (never fabricated numbers) unless
+ * `ENGAGEMENT_BACKEND=mock` is explicitly set, and `mock` is additionally hard-blocked when
+ * `NODE_ENV=production`.
  */
 export class GroupsEngagementStatsService {
   private readonly snowflakeService = SnowflakeService.getInstance();
@@ -120,11 +133,11 @@ export class GroupsEngagementStatsService {
     const computedAt = new Date().toISOString();
 
     if (backend === 'live') {
-      const activeMembers = await this.computeActiveMembers(req);
+      const { activeMembers, coverage } = await this.computeActiveMembers(req);
       // meetings_this_month: no calendar-month grain exists in the model (only rolling
       // 30d/90d/YTD) — left null rather than mislabeling a rolling window as "this month".
       // LFXV2-2961 tracks adding a calendar-month data source.
-      return { active_members: activeMembers, meetings_this_month: null, computed_at: computedAt, source: 'live' };
+      return { active_members: activeMembers, meetings_this_month: null, computed_at: computedAt, source: 'live', coverage };
     }
 
     // WARN, not DEBUG, on every call: unlike the live branch above, mock should essentially never
@@ -137,60 +150,58 @@ export class GroupsEngagementStatsService {
   /**
    * Counts distinct active members (attended >=1 meeting in the trailing 30 days, or joined within
    * it, excluding Emeritus — `isCommitteeMemberActive`, the same function LFXV2-1705 uses) across
-   * every committee the caller can see (`getMyCommitteeUids` — "mine" semantics, no scope param, per
-   * LFXV2-1711). A member is counted once even if active on multiple visible committees — the model's
-   * grain is one row per `(committee_id, member_user_id)`, so a member on N committees produces N
-   * rows; deduping by `MEMBER_USER_ID` is what makes this a *member* count rather than a row count.
-   * `getMyCommitteeUids` returns v2 committee-service UUIDs; the model is keyed on the v1 committee
-   * SFID (confirmed with Jordan Evans, data owner, LFXV2-2968), so every visible uid is resolved
-   * via `resolveCommitteeV2UidsToV1Ids` (the platform's `lfx.lookup_v1_mapping` NATS bridge) before
-   * querying — see that helper's doc comment for the v1/v2 split. The committee-uid list (now v1
-   * ids) is chunked (`COMMITTEE_UID_CHUNK_SIZE`) so a caller who belongs to many committees (e.g.
-   * LF staff) doesn't produce an unbounded bind list or row volume in one query, and chunks run at
-   * most `GROUPS_ENGAGEMENT_CHUNK_CONCURRENCY` at a time so that same caller can't monopolize a
-   * large fraction of the shared Snowflake connection pool in one request.
+   * the *covered* subset of committees the caller can see (`getMyCommitteeUids` — "mine" semantics,
+   * no scope param, per LFXV2-1711). A member is counted once even if active on multiple covered
+   * committees — the model's grain is one row per `(committee_id, member_user_id)`, so a member on
+   * N committees produces N rows; deduping by `MEMBER_USER_ID` is what makes this a *member* count
+   * rather than a row count. `getMyCommitteeUids` returns v2 committee-service UUIDs; the model is
+   * keyed on the v1 committee SFID (confirmed with Jordan Evans, data owner, LFXV2-2968), so every
+   * visible uid is resolved via `resolveCommitteeV2UidsToV1Ids` (the platform's
+   * `lfx.lookup_v1_mapping` NATS bridge) before querying — see that helper's doc comment for the
+   * v1/v2 split. The (resolved) committee-uid list is chunked (`COMMITTEE_UID_CHUNK_SIZE`) so a
+   * caller who belongs to many committees (e.g. LF staff) doesn't produce an unbounded bind list or
+   * row volume in one query, and chunks run at most `GROUPS_ENGAGEMENT_CHUNK_CONCURRENCY` at a time
+   * so that same caller can't monopolize a large fraction of the shared Snowflake connection pool in
+   * one request.
    *
-   * Four distinct "nothing to report" cases stay distinguishable:
-   * - `0`: the caller genuinely has no visible committees — a real answer, no query even runs.
-   * - `null` (incomplete coverage): at least one visible committee has no covered row in the model —
-   *   either its v2 uid didn't resolve to a v1 id at all, or it resolved but the model has zero rows
-   *   for that v1 id. Both read the same way: mirrors `committee-engagement.service.ts`'s zero-row
-   *   `dataAvailable: false` reading (the model is roster-anchored with zero-activity members
-   *   retained, so a synced committee should yield >=1 row). This is checked per-committee, not
-   *   just "did any row come back at all" — a caller with 3 visible committees where only 1 is
-   *   covered would otherwise report a plausible but incomplete count for the other 2's silent
-   *   absence, rather than degrading honestly. The first case (an unresolved v2 uid) is caught
-   *   immediately after the committee-id bridge runs, before any chunk query — a partial resolution
-   *   already guarantees this method's result, so there's no reason to pay for the Snowflake
-   *   round trips first.
-   * - `0` (full coverage, none active): a real, computed zero — every visible committee resolved
-   *   and is represented in the model, and nobody in them happens to be active this window.
-   * - `null` (error): the count couldn't be computed at all (missing committee-set lookup, a
-   *   Snowflake missing-object/not-authorized error, or any chunk failing) — never thrown, so a
-   *   stats failure never blocks the rest of the groups dashboard.
+   * A committee is "covered" when its v2 uid resolved to a v1 id AND the model has at least one row
+   * for that v1 id — checked per originally-requested v2 committee, forward through `v2ToV1Map` (not
+   * via a v1->v2 inversion, which would be lossy if two v2 committees ever resolved to the same v1
+   * id — see the coverage-loop comment below). `activeMembers` is computed over the covered subset
+   * only (LFXV2-2978 — a caller with 10 visible committees where 9 are covered gets a real count
+   * over those 9, plus `coverage: { covered: 9, total: 10 }`, rather than a blanket `null` for the
+   * whole caller). Three distinct "nothing to report" cases stay distinguishable:
+   * - `{ activeMembers: 0, coverage: { covered: 0, total: 0 } }`: the caller genuinely has no
+   *   visible committees — a real answer, no query even runs.
+   * - `{ activeMembers: null, coverage: { covered: 0, total } }`: every visible committee is
+   *   uncovered (none resolved to a v1 id, or none have model rows yet) — nothing to count, still
+   *   distinguishable from the zero-visible-committees case above via `coverage.total`.
+   * - `{ activeMembers: N, coverage: { covered, total } }` (`covered` possibly `< total`): a real,
+   *   computed count over whichever committees are covered — `covered === total` means it's
+   *   complete; `covered < total` means it's a real but partial count the client should disclose.
+   * - `{ activeMembers: null, coverage: { covered: 0, total: 0 } }` (error): the count couldn't be
+   *   computed at all (missing committee-set lookup, a Snowflake missing-object/not-authorized
+   *   error, or any chunk failing) — never thrown, so a stats failure never blocks the rest of the
+   *   groups dashboard.
    */
-  private async computeActiveMembers(req: Request): Promise<number | null> {
+  private async computeActiveMembers(req: Request): Promise<{ activeMembers: number | null; coverage: { covered: number; total: number } }> {
+    // Tracked outside the try block (not just a `const` inside it) so the catch block can still
+    // report an accurate `total` in its `coverage` if the failure happens after the committee set
+    // was fetched but before the count could be computed (e.g. a chunk query failure).
+    let visibleCount = 0;
     try {
       const committeeUids = [...(await this.committeeService.getMyCommitteeUids(req))];
-      if (committeeUids.length === 0) return 0;
+      visibleCount = committeeUids.length;
+      if (committeeUids.length === 0) return { activeMembers: 0, coverage: { covered: 0, total: 0 } };
 
       const v2ToV1Map = await resolveCommitteeV2UidsToV1Ids(req, this.natsService, committeeUids);
-      // Any unresolved committee already guarantees `fullyCovered` is `false` below (an unresolved
-      // v2 uid has no v1 id to check coverage against, so `uncoveredCount` can never reach 0) — the
-      // Snowflake chunk-query pipeline's result would be discarded regardless, so a partial
-      // resolution short-circuits here rather than paying for chunked queries whose only possible
-      // outcome is the same `null` this returns immediately.
-      if (v2ToV1Map.size < committeeUids.length) {
-        logger.warning(req, 'get_groups_engagement_stats', 'One or more visible committee v2 uids did not resolve to a v1 id; returning null', {
-          committee_count: committeeUids.length,
-          resolved_v2_uid_count: v2ToV1Map.size,
-        });
-        return null;
-      }
       // Deduped (not just [...values()]): two visible v2 committees could in principle resolve to
       // the same v1 id, and an inverted v1->v2 map would then silently drop one of them — checking
       // coverage forward (per v2 uid, via v2ToV1Map.get) below instead of through an inversion means
-      // that never needs to be a 1:1 assumption.
+      // that never needs to be a 1:1 assumption. Only resolved uids appear in this map at all
+      // (`resolveCommitteeV2UidsToV1Ids`'s contract), so this already queries the covered subset
+      // only — an unresolved v2 uid simply contributes nothing to `v1Ids` rather than blocking the
+      // rest of the caller's covered committees from being counted.
       const v1Ids = [...new Set(v2ToV1Map.values())];
 
       const chunks: string[][] = [];
@@ -242,20 +253,28 @@ export class GroupsEngagementStatsService {
         const v1Id = v2ToV1Map.get(uid);
         return !v1Id || !coveredV1Ids.has(v1Id);
       }).length;
-      const fullyCovered = uncoveredCount === 0;
-      // Computed before logging so the logged active_members always matches what's actually returned.
-      const activeMembers = fullyCovered ? activeUids.size : null;
+      const coveredCount = committeeUids.length - uncoveredCount;
+      const coverage = { covered: coveredCount, total: committeeUids.length };
+      // Computed before logging so the logged active_members always matches what's actually
+      // returned. `activeUids` is already scoped to covered committees (rows only exist for
+      // committees present in the query result), so this is a true "count over the covered subset,"
+      // not a filter applied after the fact.
+      const activeMembers = coveredCount > 0 ? activeUids.size : null;
 
-      if (!fullyCovered) {
-        // The most likely-to-occur null case in a partially-rolled-out model — warrants the same
-        // visibility as the other two degrade paths below, not silent DEBUG.
-        logger.warning(req, 'get_groups_engagement_stats', 'One or more visible committees have no engagement rows; returning null (not yet synced?)', {
-          committee_count: committeeUids.length,
-          resolved_v2_uid_count: v2ToV1Map.size,
-          distinct_v1_id_count: v1Ids.length,
-          chunk_count: chunks.length,
-          uncovered_committee_count: uncoveredCount,
-        });
+      if (coveredCount < committeeUids.length) {
+        // The most likely-to-occur partial-coverage case in a partially-rolled-out model — warrants
+        // visibility at WARNING, same as the error paths below, even though (unlike those) it still
+        // produces a usable (if partial) count rather than degrading the whole request.
+        logger.warning(
+          req,
+          'get_groups_engagement_stats',
+          'Some visible committees are not covered by the engagement model; counting over the covered subset',
+          {
+            covered: coveredCount,
+            total: committeeUids.length,
+            uncovered_committee_count: uncoveredCount,
+          }
+        );
       } else {
         logger.debug(req, 'get_groups_engagement_stats', 'Computed active members', {
           committee_count: committeeUids.length,
@@ -265,18 +284,23 @@ export class GroupsEngagementStatsService {
         });
       }
 
-      return activeMembers;
+      return { activeMembers, coverage };
     } catch (error) {
+      // `total: visibleCount` rather than a hardcoded 0 — if `getMyCommitteeUids` succeeded and the
+      // failure happened later (e.g. a chunk query), the visible-committee count is still known and
+      // more honest than reporting 0. It stays 0 only when the failure happened before that count
+      // was ever established.
+      const coverage = { covered: 0, total: visibleCount };
       if (!SnowflakeService.isMissingObjectError(error)) {
         // A non-Snowflake failure (e.g. the visible-committee-set lookup, or a chunk query error
         // other than missing-object) is unexpected — surface it distinctly from the expected
         // pre-sync/missing-GRANT case below, but still degrade to null rather than failing the
         // whole dashboard stats request.
         logger.warning(req, 'get_groups_engagement_stats', 'Failed to compute active members; returning null', { err: error });
-        return null;
+        return { activeMembers: null, coverage };
       }
       logger.warning(req, 'get_groups_engagement_stats', 'Active-members query hit a missing-object/not-authorized error; returning null', { err: error });
-      return null;
+      return { activeMembers: null, coverage };
     }
   }
 
@@ -294,13 +318,18 @@ export class GroupsEngagementStatsService {
 /**
  * Deterministic fixture keyed off the caller's identity — same user always sees the same numbers
  * across requests/instances (no randomness), so the mock behaves predictably in manual testing and
- * screenshots without needing a backing store.
+ * screenshots without needing a backing store. `coverage` is always full (`covered === total`) —
+ * mock never fabricates a partial-coverage state, since the whole point of mock mode is exercising
+ * the UI with plausible-looking values, not a degraded one the live path already covers via its own
+ * partial/zero-coverage tests.
  */
-function deterministicMockStats(username: string): Pick<GroupsEngagementStats, 'active_members' | 'meetings_this_month'> {
+function deterministicMockStats(username: string): Pick<GroupsEngagementStats, 'active_members' | 'meetings_this_month' | 'coverage'> {
   const hash = hashString(username || 'anonymous');
+  const visibleGroups = 1 + (hash % 6);
   return {
     active_members: 1 + (hash % 50),
     meetings_this_month: hash % 8,
+    coverage: { covered: visibleGroups, total: visibleGroups },
   };
 }
 

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -170,23 +170,23 @@ export class GroupsEngagementStatsService {
    * id — see the coverage-loop comment below). `activeMembers` is computed over the covered subset
    * only (LFXV2-2978 — a caller with 10 visible committees where 9 are covered gets a real count
    * over those 9, plus `coverage: { covered: 9, total: 10 }`, rather than a blanket `null` for the
-   * whole caller). Four distinct result shapes stay distinguishable:
+   * whole caller). Result shapes:
    * - `{ activeMembers: 0, coverage: { covered: 0, total: 0 } }`: the caller genuinely has no
    *   visible committees — a real answer, no query even runs.
-   * - `{ activeMembers: null, coverage: { covered: 0, total } }`: every visible committee is
-   *   uncovered (none resolved to a v1 id, or none have model rows yet) — nothing to count, still
-   *   distinguishable from the zero-visible-committees case above via `coverage.total`.
    * - `{ activeMembers: N, coverage: { covered, total } }` (`covered` possibly `< total`): a real,
    *   computed count over whichever committees are covered — `covered === total` means it's
    *   complete; `covered < total` means it's a real but partial count the client should disclose.
    *   `N` can itself be `0` (a real, fully- or partially-covered zero — nobody active in the covered
    *   subset), which is why this shape is distinguished from the null cases by `active_members`
    *   being non-null, not by it being nonzero.
-   * - `{ activeMembers: null, coverage: { covered: 0, total } }` (error, `total` possibly `0`): the
-   *   count couldn't be computed at all (missing committee-set lookup, a Snowflake missing-object/
-   *   not-authorized error, or any chunk failing) — never thrown, so a stats failure never blocks the
-   *   rest of the groups dashboard. `total` reports the visible-committee count if it was already
-   *   known before the failure, `0` if the failure happened before that — see the catch block below.
+   * - `{ activeMembers: null, coverage: { covered: 0, total } }`: nothing could be counted, for
+   *   either of two reasons that deliberately alias to the same wire shape — every visible committee
+   *   is uncovered (none resolved to a v1 id, or none have model rows yet), or the computation
+   *   failed after the committee set was already known (a Snowflake missing-object/not-authorized
+   *   error, or any chunk failing). Both degrade the client identically ("Unavailable"), so the two
+   *   aren't distinguished in the payload — the WARN log below is what tells them apart operationally.
+   *   `total` is `0` only when the failure happened before the committee count was ever established
+   *   (e.g. the committee-set lookup itself failing) — see the catch block.
    */
   private async computeActiveMembers(req: Request): Promise<{ activeMembers: number | null; coverage: { covered: number; total: number } }> {
     // Tracked outside the try block (not just a `const` inside it) so the catch block can still
@@ -265,20 +265,32 @@ export class GroupsEngagementStatsService {
       // not a filter applied after the fact.
       const activeMembers = coveredCount > 0 ? activeUids.size : null;
 
-      // DEBUG, not WARNING: live validation showed nearly every real caller has at least one
-      // uncovered visible committee (see the class doc comment above), so `coveredCount <
-      // committeeUids.length` is now the expected steady state on most cache misses, not a
-      // degraded/recoverable-error condition per `.claude/rules/logging-patterns.md`'s WARN
-      // criteria — a WARN here would fire on nearly every request and bury the genuine WARNs the
-      // catch block below emits on actual failures.
-      logger.debug(req, 'get_groups_engagement_stats', 'Computed active members', {
-        committee_count: committeeUids.length,
-        chunk_count: chunks.length,
-        row_count: rowCount,
-        active_members: activeMembers,
-        covered: coveredCount,
-        uncovered_committee_count: uncoveredCount,
-      });
+      if (coveredCount === 0) {
+        // WARN, not DEBUG: this is the one in-band path that fully degrades `active_members` to
+        // `null` without throwing — the same "recoverable error, returning null" case
+        // `.claude/rules/logging-patterns.md` reserves WARN for, and the only thing that
+        // distinguishes this from the catch block's post-fetch-failure WARNs in production logs
+        // (both produce the identical `{ activeMembers: null, coverage: { covered: 0, total } }`
+        // wire shape — see the doc comment above).
+        logger.warning(req, 'get_groups_engagement_stats', 'No visible committee is covered by the engagement model; returning null active_members', {
+          committee_count: committeeUids.length,
+        });
+      } else {
+        // DEBUG, not WARNING: live validation showed nearly every real caller has at least one
+        // uncovered visible committee (see the class doc comment above), so partial coverage
+        // (`0 < coveredCount < committeeUids.length`) is now the expected steady state on most
+        // cache misses, not a degraded/recoverable-error condition — a WARN here would fire on
+        // nearly every request and bury the genuine WARN above. Full coverage logs at the same
+        // level since it's the same "trace what got computed" concern, not a degrade at all.
+        logger.debug(req, 'get_groups_engagement_stats', 'Computed active members', {
+          committee_count: committeeUids.length,
+          chunk_count: chunks.length,
+          row_count: rowCount,
+          active_members: activeMembers,
+          covered: coveredCount,
+          uncovered_committee_count: uncoveredCount,
+        });
+      }
 
       return { activeMembers, coverage };
     } catch (error) {

--- a/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
+++ b/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
@@ -12,8 +12,9 @@
  * covered (nothing to count) or the computation itself failed (missing committee-set lookup, a
  * Snowflake missing-object error, or any other unexpected failure) — see `computeActiveMembers` in
  * `groups-engagement-stats.service.ts`. A `0` is always a real, computed answer (no visible
- * committees at all, or full coverage with nobody active) — never a stand-in for "unavailable", and
- * `null` is never a disguised real zero. `meetings_this_month` stays `null` in live mode — the model
+ * committees at all, or nobody active across the covered subset — whether that subset is full or
+ * partial, check `coverage` to tell which) — never a stand-in for "unavailable", and `null` is never
+ * a disguised real zero. `meetings_this_month` stays `null` in live mode — the model
  * has no calendar-month grain yet (LFXV2-2961).
  */
 export interface GroupsEngagementStats {

--- a/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
+++ b/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
@@ -3,24 +3,27 @@
 
 /**
  * Engagement rollup for the caller's visible set of groups (mine semantics, no scope param).
- * Backed by the same dbt engagement model as LFXV2-1705. `active_members` reads live; `null` means
- * the count couldn't be computed — a missing committee-set lookup, a Snowflake missing-object error,
- * or incomplete warehouse coverage across the caller's visible committees. That last case isn't
- * "zero rows across the board" — it's checked per-committee, so a caller with 10 visible committees
- * where even 1 lacks a covered row (not yet synced into the model, or its v2 uid never resolved to a
- * v1 id) gets `null`, not a plausible-but-incomplete count for the other 9 (see `computeActiveMembers`
- * in `groups-engagement-stats.service.ts`). A `0` is always a real, computed answer (no visible
+ * Backed by the same dbt engagement model as LFXV2-1705. `active_members` reads live, counted over
+ * the *covered* subset of the caller's visible committees only (LFXV2-2978) — a committee is
+ * covered when its v2 uid resolved to a v1 id via `resolveCommitteeV2UidsToV1Ids` AND the model has
+ * at least one row for that v1 id. `coverage` discloses how much of the caller's visible set that
+ * subset represents, so the client can render "across N of M groups" instead of silently reporting
+ * a number that's quietly incomplete. `active_members` is `null` only when *zero* committees are
+ * covered (nothing to count) or the computation itself failed (missing committee-set lookup, a
+ * Snowflake missing-object error, or any other unexpected failure) — see `computeActiveMembers` in
+ * `groups-engagement-stats.service.ts`. A `0` is always a real, computed answer (no visible
  * committees at all, or full coverage with nobody active) — never a stand-in for "unavailable", and
  * `null` is never a disguised real zero. `meetings_this_month` stays `null` in live mode — the model
  * has no calendar-month grain yet (LFXV2-2961).
  */
 export interface GroupsEngagementStats {
   /**
-   * Distinct members active on any visible committee — attended >=1 meeting in the trailing 30
-   * days, or joined within it (tenure grace), excluding Emeritus (`isCommitteeMemberActive`, the
-   * same rule LFXV2-1705 uses). A member active on multiple visible committees is counted once, not
-   * once per committee. `null` when not computable — see this interface's doc comment for exactly
-   * which cases that covers.
+   * Distinct members active on any *covered* visible committee — attended >=1 meeting in the
+   * trailing 30 days, or joined within it (tenure grace), excluding Emeritus
+   * (`isCommitteeMemberActive`, the same rule LFXV2-1705 uses). A member active on multiple visible
+   * committees is counted once, not once per committee. `null` only when `coverage.covered` is `0`
+   * or the computation failed — see this interface's doc comment for exactly which cases that
+   * covers.
    */
   active_members: number | null;
   /** Meeting occurrences within the current calendar month. `null` when not computable. */
@@ -33,4 +36,13 @@ export interface GroupsEngagementStats {
    * numbers can never be mistaken for live ones during local/synced-prod-data validation.
    */
   source: 'mock' | 'live';
+  /**
+   * How many of the caller's visible committees (`total`) contributed to `active_members`
+   * (`covered`) — see this interface's doc comment for what "covered" means. `covered === total`
+   * means the count is complete; `covered < total` means it's a real but partial count, and the
+   * client should disclose that (e.g. "across 2 of 3 groups"). Mock responses always report full
+   * coverage (`covered === total`) so the mock path stays exercisable without fabricating a
+   * misleading partial state.
+   */
+  coverage: { covered: number; total: number };
 }

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -510,4 +510,16 @@ describe('buildEngagementStatCards', () => {
     const cards = buildEngagementStatCards(nullWithCoverage, false);
     expect(cards[0]).toMatchObject({ value: '—', subLine: 'Unavailable' });
   });
+
+  it('does not throw and degrades to the plain sub-line when `coverage` is absent from the response (pre-upgrade server during a rolling deploy)', () => {
+    // Simulates a client bundle ahead of the server: a response shaped like the pre-LFXV2-2978
+    // contract, with no `coverage` field at all. `stats` is deliberately typed loosely here (not
+    // `GroupsEngagementStats`) since the whole point is that runtime shape can drift from the type.
+    const staleShape = { active_members: 12, meetings_this_month: 3, computed_at: new Date().toISOString(), source: 'live' };
+    expect(() => buildEngagementStatCards(staleShape as GroupsEngagementStats, false)).not.toThrow();
+    const cards = buildEngagementStatCards(staleShape as GroupsEngagementStats, false);
+    expect(cards[0]).toMatchObject({ label: 'Active Members', value: 12 });
+    expect(cards[0].subLine).toMatch(/^Updated /);
+    expect(cards[0].subLine).not.toContain('across');
+  });
 });

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -410,7 +410,13 @@ describe('countVotingReps', () => {
 });
 
 describe('buildEngagementStatCards', () => {
-  const stats: GroupsEngagementStats = { active_members: 12, meetings_this_month: 3, computed_at: new Date().toISOString(), source: 'live' };
+  const stats: GroupsEngagementStats = {
+    active_members: 12,
+    meetings_this_month: 3,
+    computed_at: new Date().toISOString(),
+    source: 'live',
+    coverage: { covered: 3, total: 3 },
+  };
 
   it('renders em-dash placeholders with no sub-line while loading, regardless of stats', () => {
     const cards = buildEngagementStatCards(stats, true);
@@ -445,7 +451,13 @@ describe('buildEngagementStatCards', () => {
   });
 
   it('degrades to "Unavailable" em-dash cards when the live backend returns null engagement fields', () => {
-    const liveStub: GroupsEngagementStats = { active_members: null, meetings_this_month: null, computed_at: new Date().toISOString(), source: 'live' };
+    const liveStub: GroupsEngagementStats = {
+      active_members: null,
+      meetings_this_month: null,
+      computed_at: new Date().toISOString(),
+      source: 'live',
+      coverage: { covered: 0, total: 0 },
+    };
     const cards = buildEngagementStatCards(liveStub, false);
     cards.forEach((card) => {
       expect(card.value).toBe('—');
@@ -454,10 +466,48 @@ describe('buildEngagementStatCards', () => {
   });
 
   it('degrades each card independently — one null field does not blank the other', () => {
-    const partial: GroupsEngagementStats = { active_members: 9, meetings_this_month: null, computed_at: new Date().toISOString(), source: 'live' };
+    const partial: GroupsEngagementStats = {
+      active_members: 9,
+      meetings_this_month: null,
+      computed_at: new Date().toISOString(),
+      source: 'live',
+      coverage: { covered: 3, total: 3 },
+    };
     const cards = buildEngagementStatCards(partial, false);
     expect(cards[0]).toMatchObject({ label: 'Active Members', value: 9 });
     expect(cards[0].subLine).toMatch(/^Updated /);
     expect(cards[1]).toMatchObject({ label: 'Meetings This Month', value: '—', subLine: 'Unavailable' });
+  });
+
+  it('appends a coverage qualifier to the Active Members sub-line only, when coverage is partial', () => {
+    const partialCoverage: GroupsEngagementStats = { ...stats, coverage: { covered: 2, total: 3 } };
+    const cards = buildEngagementStatCards(partialCoverage, false);
+    expect(cards[0]).toMatchObject({ label: 'Active Members', value: 12 });
+    expect(cards[0].subLine).toMatch(/^Updated .* · across 2 of 3 groups$/);
+    expect(cards[1]).toMatchObject({ label: 'Meetings This Month', value: 3 });
+    expect(cards[1].subLine).toMatch(/^Updated /);
+    expect(cards[1].subLine).not.toContain('across');
+  });
+
+  it('renders no coverage qualifier when coverage is full', () => {
+    const fullCoverage: GroupsEngagementStats = { ...stats, coverage: { covered: 3, total: 3 } };
+    const cards = buildEngagementStatCards(fullCoverage, false);
+    expect(cards[0].subLine).toMatch(/^Updated /);
+    expect(cards[0].subLine).not.toContain('across');
+  });
+
+  it('keeps mock-sourced "Sample data" free of a coverage qualifier even with a (fabricated) full-coverage shape', () => {
+    const mockStats: GroupsEngagementStats = { ...stats, source: 'mock', coverage: { covered: 3, total: 3 } };
+    const cards = buildEngagementStatCards(mockStats, false);
+    expect(cards[0]).toMatchObject({ subLine: 'Sample data' });
+  });
+
+  it('keeps the existing "Unavailable" state for a null active_members even when coverage reports partial totals', () => {
+    // coverage.covered is always 0 whenever active_members is null (LFXV2-2978 contract), but this
+    // proves the qualifier logic doesn't independently override the null-value branch even if that
+    // invariant were ever violated upstream.
+    const nullWithCoverage: GroupsEngagementStats = { ...stats, active_members: null, coverage: { covered: 0, total: 3 } };
+    const cards = buildEngagementStatCards(nullWithCoverage, false);
+    expect(cards[0]).toMatchObject({ value: '—', subLine: 'Unavailable' });
   });
 });

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -351,11 +351,14 @@ function compareCodeUnits(a: string, b: string): number {
 /**
  * Builds the Active Members / Meetings This Month stat cards from the engagement-stats rollup.
  * Extracted as a pure function (no Angular component-test runner exists in this repo — see
- * `resolveGroupsCardRoleSeverity` above) so all four render states are unit-tested directly:
- * loading (em-dash, no sub-line), populated (value + relative-time freshness label), mock-sourced
- * (value + a "Sample data" marker instead of a freshness label, so fabricated fixture numbers can
- * never be mistaken for live ones), and degraded (fetch failed, or the `live` backend hasn't got a
- * dbt read path yet — em-dash + "Unavailable", never throws, never blocks the rest of the dashboard).
+ * `resolveGroupsCardRoleSeverity` above) so all render states are unit-tested directly: loading
+ * (em-dash, no sub-line), populated (value + relative-time freshness label), mock-sourced (value +
+ * a "Sample data" marker instead of a freshness label, so fabricated fixture numbers can never be
+ * mistaken for live ones), degraded (fetch failed, or the count is null — em-dash + "Unavailable",
+ * never throws, never blocks the rest of the dashboard), and partial-coverage (LFXV2-2978 — Active
+ * Members only, since `active_members` is the only field whose count can be real-but-incomplete:
+ * its sub-line gains "· across N of M groups" alongside the freshness/mock label; Meetings This
+ * Month never carries this qualifier).
  */
 export function buildEngagementStatCards(stats: GroupsEngagementStats | null, loading: boolean): StatCardItem[] {
   const activeMembersCard: StatCardItem = {
@@ -385,10 +388,13 @@ export function buildEngagementStatCards(stats: GroupsEngagementStats | null, lo
   // aggregates (trailing-30-day attendance vs. current-month occurrences), so a partially-deployed
   // dbt model could plausibly resolve one without the other — neither field's availability implies
   // the other's.
-  const resolveCard = (base: StatCardItem, value: number | null): StatCardItem =>
-    value === null ? { ...base, subLine: 'Unavailable' } : { ...base, value, subLine: subLineForValue };
+  const resolveCard = (base: StatCardItem, value: number | null, subLine: string | undefined): StatCardItem =>
+    value === null ? { ...base, subLine: 'Unavailable' } : { ...base, value, subLine };
 
-  return [resolveCard(activeMembersCard, stats?.active_members ?? null), resolveCard(meetingsThisMonthCard, stats?.meetings_this_month ?? null)];
+  return [
+    resolveCard(activeMembersCard, stats?.active_members ?? null, resolveActiveMembersSubLine(stats, subLineForValue)),
+    resolveCard(meetingsThisMonthCard, stats?.meetings_this_month ?? null, subLineForValue),
+  ];
 }
 
 /** Extracted to avoid nesting a ternary inside another ternary's branch (`stats && source === 'mock' ? … : stats ? … : …`). */
@@ -396,4 +402,17 @@ function resolveEngagementSubLine(stats: GroupsEngagementStats | null): string |
   if (!stats) return undefined;
   if (stats.source === 'mock') return 'Sample data';
   return `Updated ${formatRelativeTime(new Date(stats.computed_at))}`;
+}
+
+/**
+ * Active Members is the only card whose count can be a real-but-partial one (LFXV2-2978) — coverage
+ * is a property of *which committees* fed the count, not of meetings-this-month, so this qualifier
+ * is deliberately not shared with the sibling card via `resolveEngagementSubLine`. Appends to the
+ * base sub-line (rather than replacing it) so the freshness/mock provenance stays visible alongside
+ * the disclosure. Full coverage (`covered === total`, always true for mock) renders no qualifier —
+ * identical to the sibling card's plain sub-line.
+ */
+function resolveActiveMembersSubLine(stats: GroupsEngagementStats | null, baseSubLine: string | undefined): string | undefined {
+  if (!stats || stats.coverage.covered >= stats.coverage.total) return baseSubLine;
+  return `${baseSubLine} · across ${stats.coverage.covered} of ${stats.coverage.total} groups`;
 }

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -410,9 +410,12 @@ function resolveEngagementSubLine(stats: GroupsEngagementStats | null): string |
  * is deliberately not shared with the sibling card via `resolveEngagementSubLine`. Appends to the
  * base sub-line (rather than replacing it) so the freshness/mock provenance stays visible alongside
  * the disclosure. Full coverage (`covered === total`, always true for mock) renders no qualifier —
- * identical to the sibling card's plain sub-line.
+ * identical to the sibling card's plain sub-line. `stats.coverage` is optional-chained (not just a
+ * `stats` null check) — a rolling deploy can put this client bundle in front of a pre-upgrade server
+ * instance whose response predates `coverage`, and that shape drift must degrade to the plain
+ * sub-line, not throw inside the `computed()` this feeds (which would blank the whole stat-card row).
  */
 function resolveActiveMembersSubLine(stats: GroupsEngagementStats | null, baseSubLine: string | undefined): string | undefined {
-  if (!stats || stats.coverage.covered >= stats.coverage.total) return baseSubLine;
+  if (!stats?.coverage || stats.coverage.covered >= stats.coverage.total) return baseSubLine;
   return `${baseSubLine} · across ${stats.coverage.covered} of ${stats.coverage.total} groups`;
 }


### PR DESCRIPTION
## Summary

- `active_members` on the groups dashboard now counts distinct active members over the *covered* subset of the caller's visible committees only, instead of degrading to `null` whenever any single visible committee is unresolved or not-yet-synced. Live validation against prod showed the old all-or-nothing rule returned `null` for essentially every real caller.
- The response gains `coverage: { covered, total }` (visible committees covered vs. total visible). `active_members` is `null` only when zero committees are covered, or the computation itself failed.
- UI: the Active Members card's sub-line gains "· across N of M groups" when coverage is partial, appended to the existing freshness/mock label; full coverage renders no qualifier. The existing "Unavailable" state for a null count is unchanged.
- Mock mode fabricates full coverage (`covered === total`) so the mock path stays exercisable.

## Cache-validator shape-versioning note

`isGroupsEngagementStats` (the Valkey read-through cache's `accept` validator) now also checks for the `coverage` field, so a cache entry written by a pre-upgrade instance during a rolling deploy reads as a miss and recomputes, rather than being served to a client expecting the new shape for up to `GROUPS_ENGAGEMENT_TTL_SECONDS`. The validator's doc comment generalizes this: it's not just a cross-backend (`mock`/`live`) check anymore, it's this response shape's version check — any field a newer service version always sets belongs here.

The same rolling-deploy shape drift is guarded client-side too: `resolveActiveMembersSubLine` optional-chains `stats?.coverage` rather than dereferencing it directly, so a response from a pre-upgrade server (missing `coverage` entirely) degrades to the plain sub-line instead of throwing inside the `computed()` that feeds the whole My Groups stat-card row.

## Branch history note

This branch was originally stacked on `feat/LFXV2-1705-live-read-path` (#1293). That PR merged (squash) while this one was in review, so the branch was rebased/cherry-picked onto current `main` and force-pushed to retarget this PR directly at `main` — the diff below is only this PR's own 4 commits (+293/-109 across 6 files), not the merged parent's.

## Trade-offs (documented per PR-readiness SHOULD_FIX)

- Branch name (`feat/LFXV2-2978-stats-partial-coverage`) carries a descriptive suffix beyond `type/LFXV2-NNN`.
- The `feat(groups): ...(LFXV2-2978)` commit header is 80 chars — over the 72-char team style but within commitlint's 100-char hard limit.

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass on the rebased branch
- [x] New/updated unit tests: partial resolution (2 of 3 committees covered → count over 2 + `coverage: {2,3}`), unresolved uid no longer short-circuits, zero coverage → null + `{0,N}`, full coverage → no UI qualifier, cache validator rejects entries missing `coverage`, mock mode fabricates full coverage, client-side guard against a `coverage`-less response
- [x] e2e fixture (`groups-engagement-stats.spec.ts`) updated with the new `coverage` field
- [x] Post-commit reviewer trio (general + Self Serve conventions + learnings) run and addressed after every commit; full-branch sweep run and clean with respect to this branch's own diff