### PR TITLE
feat(dashboards): split web sessions into a dedicated overview card

### DIFF
--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -150,20 +150,12 @@ test.describe('Marketing Metric Cards', () => {
     await switchToExecutiveDirector(page);
   });
 
-  test('renders Website Visits card', async ({ page }) => {
-    const card = page.locator('[data-testid="marketing-card-website-visits"]');
+  test('renders Email card', async ({ page }) => {
+    const card = page.locator('[data-testid="ed-evo-campaign-performance"]');
     await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
     await card.scrollIntoViewIfNeeded();
     await expect(card).toBeVisible();
-    await expect(card).toContainText('Website Visits');
-  });
-
-  test('renders Email CTR card', async ({ page }) => {
-    const card = page.locator('[data-testid="marketing-card-email-ctr"]');
-    await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
-    await card.scrollIntoViewIfNeeded();
-    await expect(card).toBeVisible();
-    await expect(card).toContainText('Email CTR');
+    await expect(card).toContainText('Email');
   });
 
   test('renders Paid Media card', async ({ page }) => {
@@ -174,12 +166,12 @@ test.describe('Marketing Metric Cards', () => {
     await expect(card).toContainText('Paid Media');
   });
 
-  test('renders Social Media card', async ({ page }) => {
-    const card = page.locator('[data-testid="marketing-card-social-media"]');
+  test('renders Social card', async ({ page }) => {
+    const card = page.locator('[data-testid="ed-evo-brand-reach"]');
     await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
     await card.scrollIntoViewIfNeeded();
     await expect(card).toBeVisible();
-    await expect(card).toContainText('Social Media');
+    await expect(card).toContainText('Social');
   });
 
   test('renders Web card', async ({ page }) => {
@@ -208,7 +200,7 @@ test.describe('Website Visits Drawer', () => {
   });
 
   test('shows stats section with data', async ({ page }) => {
-    await openDrawerAndWaitForData(page, 'marketing-card-website-visits', 'website-visits-drawer-content', 'website-visits-drawer-stats');
+    await openDrawerAndWaitForData(page, 'ed-evo-web-sessions', 'website-visits-drawer-content', 'website-visits-drawer-stats');
     const statCards = page.locator('[data-testid="website-visits-drawer-stats"]').locator('lfx-card');
     await expect(statCards).toHaveCount(2);
   });
@@ -232,17 +224,17 @@ test.describe('Email CTR Drawer', () => {
   });
 
   test('opens and shows title when card is clicked', async ({ page }) => {
-    await openDrawer(page, 'marketing-card-email-ctr', 'email-ctr-drawer-content');
+    await openDrawer(page, 'ed-evo-campaign-performance', 'email-ctr-drawer-content');
     await expect(page.locator('[data-testid="email-ctr-drawer-title"]')).toContainText('Email');
   });
 
   test('shows stats and email sections', async ({ page }) => {
-    await openDrawerAndWaitForData(page, 'marketing-card-email-ctr', 'email-ctr-drawer-content', 'email-ctr-drawer-stats');
+    await openDrawerAndWaitForData(page, 'ed-evo-campaign-performance', 'email-ctr-drawer-content', 'email-ctr-drawer-stats');
     await expect(page.locator('[data-testid="email-ctr-drawer-email-section"]')).toBeVisible();
   });
 
   test('closes when close button is clicked', async ({ page }) => {
-    await openDrawer(page, 'marketing-card-email-ctr', 'email-ctr-drawer-content');
+    await openDrawer(page, 'ed-evo-campaign-performance', 'email-ctr-drawer-content');
     await page.locator('[data-testid="email-ctr-drawer-close"]').click();
     await expect(page.locator('[data-testid="email-ctr-drawer-content"]')).not.toBeVisible();
   });
@@ -272,7 +264,12 @@ test.describe('Paid Social Reach Drawer', () => {
   });
 });
 
-test.describe('Social Media Drawer', () => {
+// The social-media drawer is still rendered by marketing-overview, but no card sets
+// drawerType: MarketingSocialMedia, so there is no way to open it from the UI. These
+// tests targeted 'marketing-card-social-media', a card that no longer exists. Skipped
+// rather than repointed: the Social card opens BrandReach, not this drawer, so no
+// rename makes them pass. Re-enable once a card routes to MarketingSocialMedia.
+test.describe.skip('Social Media Drawer', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(DASHBOARD_URL);
     await switchToExecutiveDirector(page);

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -180,6 +180,11 @@ test.describe('Marketing Metric Cards', () => {
     await card.scrollIntoViewIfNeeded();
     await expect(card).toBeVisible();
     await expect(card).toContainText('Web');
+    // Assert the split itself, not just the card's presence: sessions must live on
+    // Web and no longer on Social. A title-only check would still pass if sessions
+    // had stayed on the Social card and Web were an empty duplicate.
+    await expect(card).toContainText('Sessions (30d)');
+    await expect(page.locator('[data-testid="ed-evo-brand-reach"]')).not.toContainText('Sessions (30d)');
   });
 
   test('renders filter pills', async ({ page }) => {

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -182,6 +182,14 @@ test.describe('Marketing Metric Cards', () => {
     await expect(card).toContainText('Social Media');
   });
 
+  test('renders Web card', async ({ page }) => {
+    const card = page.locator('[data-testid="ed-evo-web-sessions"]');
+    await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
+    await card.scrollIntoViewIfNeeded();
+    await expect(card).toBeVisible();
+    await expect(card).toContainText('Web');
+  });
+
   test('renders filter pills', async ({ page }) => {
     const filters = page.locator('[data-testid="ed-evolution-filters"]');
     await expect(filters).toBeVisible();
@@ -195,7 +203,7 @@ test.describe('Website Visits Drawer', () => {
   });
 
   test('opens and shows title when card is clicked', async ({ page }) => {
-    await openDrawer(page, 'marketing-card-website-visits', 'website-visits-drawer-content');
+    await openDrawer(page, 'ed-evo-web-sessions', 'website-visits-drawer-content');
     await expect(page.locator('[data-testid="website-visits-drawer-title"]')).toContainText('Website Visits');
   });
 
@@ -206,12 +214,12 @@ test.describe('Website Visits Drawer', () => {
   });
 
   test('shows trend chart section', async ({ page }) => {
-    await openDrawer(page, 'marketing-card-website-visits', 'website-visits-drawer-content');
+    await openDrawer(page, 'ed-evo-web-sessions', 'website-visits-drawer-content');
     await expect(page.locator('[data-testid="website-visits-drawer-trend-section"]')).toBeVisible();
   });
 
   test('closes when close button is clicked', async ({ page }) => {
-    await openDrawer(page, 'marketing-card-website-visits', 'website-visits-drawer-content');
+    await openDrawer(page, 'ed-evo-web-sessions', 'website-visits-drawer-content');
     await page.locator('[data-testid="website-visits-drawer-close"]').click();
     await expect(page.locator('[data-testid="website-visits-drawer-content"]')).not.toBeVisible();
   });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -154,7 +154,11 @@ export class WebsiteVisitsDrawerComponent {
     };
 
     const visible$ = toObservable(this.visible);
-    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || ''));
+    // Falls back to `tlf` to match how the overview loads the Web card
+    // (marketing-overview.component.ts) — the ED "all foundations" default. Mapping a
+    // missing selection to '' here instead would filter the request out entirely, so a
+    // populated card would open a permanently empty drawer.
+    const foundation$ = toObservable(this.projectContextService.selectedFoundation).pipe(map((f) => f?.slug || 'tlf'));
 
     return toSignal(
       combineLatest([visible$, foundation$]).pipe(

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -768,7 +768,7 @@ function seriesTrendDirection(series: number[], activity: number[] = series): 'u
 /**
  * Build ED Evolution dashboard cards from live API data.
  * 6 North Star (Events, Members, Adoption, Email, Paid Media, Attribution)
- * + 2 Brand (Social, Sentiment) + Flywheel.
+ * + 3 Brand (Social, Web, Sentiment) + Flywheel.
  * Member Retention is merged into the Members drawer.
  *
  * Sparkline color semantics:
@@ -799,9 +799,11 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   return [
     // Card order is the display order in the Marketing Overview carousel, and the
     // filter pills preserve it within each category — so this array is the single
-    // source of truth for sequence. North Star cards lead (Events → Members →
-    // Adoption), then Social, then Campaign Performance, then the remaining Brand
-    // and Flywheel cards.
+    // source of truth for sequence: Events → Members → Adoption → Social → Web →
+    // Email → Paid Media → Attribution → Sentiment → Flywheel. Note the display
+    // order interleaves categories — Social and Web (Brand) sit between the North
+    // Star cards and Email/Paid Media/Attribution, and Sentiment (Brand) trails
+    // them — so this is not a category-grouped list.
     // === North Star ===
     {
       title: 'Events',

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -880,8 +880,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       changePercentage: formatMomChange(brandReach.changePercentage),
       trend: normalizeTrend(brandReach.changePercentage, brandReach.trend),
       subtitle: `${brandReach.activePlatforms} platform${brandReach.activePlatforms === 1 ? '' : 's'}`,
-      // No historical follower series available — render a flat line at the current
-      // total rather than reusing website-session data (they are different metrics).
+      // No historical follower series available. flatSparklineData renders a nearly
+      // flat line at the current total (a constant array collapses Chart.js's Y range
+      // and hides the line entirely) — it is a placeholder, not a trend. Website
+      // sessions are deliberately not reused here: different metric, different card.
       chartData: protoSparkline(flatSparklineData(brandReach.totalSocialFollowers), lfxColors.blue[500]),
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Social followers across all platforms, with month-over-month change.',
@@ -902,10 +904,11 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       value: formatNumber(brandReach.totalMonthlySessions),
       changePercentage: formatMomChange(brandReach.sessionMomChangePct),
       trend: normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down'),
-      // weeklyTrend only holds weeks WITH rows, so its length is not the reporting
-      // window — the endpoint covers a fixed six-month range, so the window is
-      // labeled directly rather than estimated from row count.
-      subtitle: brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Last 6 months' : 'Sessions (30d)',
+      // The value is a rolling 30-day total; the sparkline is a separate weekly series
+      // over a fixed six-month range. Label them separately so the 30-day figure is not
+      // read as a six-month number. weeklyTrend only holds weeks WITH rows, so its
+      // length is not the reporting window and the window is labeled directly.
+      subtitle: brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Trend: last 6 months' : 'Sessions (30d)',
       chartData: protoSparkline(
         brandReach.weeklyTrend.length > 0 ? brandReach.weeklyTrend.map((d) => d.sessions) : flatSparklineData(brandReach.totalMonthlySessions),
         lfxColors.violet[500]

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -875,35 +875,44 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       chartType: 'line',
       category: 'brand',
       testId: 'ed-evo-brand-reach',
-      description: 'Social followers across all platforms and rolling 30-day website sessions.',
-      customContentType: 'dual-signal',
-      dualSignals: [
-        protoDualSignal(
-          'Social Followers',
-          formatNumber(brandReach.totalSocialFollowers),
-          // No historical follower series available — leave the sparkline empty rather than reuse
-          // website-session data (they are different metrics).
-          [],
-          lfxColors.blue[500],
-          formatMomChange(brandReach.changePercentage),
-          normalizeTrend(brandReach.changePercentage, brandReach.trend)
-        ),
-        protoDualSignal(
-          'Sessions (30d)',
-          formatNumber(brandReach.totalMonthlySessions),
-          brandReach.weeklyTrend.length > 0 ? brandReach.weeklyTrend.map((d) => d.sessions) : [],
-          lfxColors.violet[500],
-          formatMomChange(brandReach.sessionMomChangePct),
-          normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down')
-        ),
-      ],
-      // weeklyTrend only holds weeks WITH rows, so its length is not the
-      // reporting window — the endpoint covers a fixed six-month range, so
-      // the window is labeled directly rather than estimated from row count.
-      caption: brandReach.weeklyTrend.length > 0 ? `${brandReach.activePlatforms} platforms · Last 6 months` : `${brandReach.activePlatforms} platforms`,
-      tooltipText:
-        'Social followers across all platforms (stock) and rolling 30-day website sessions (flow). Shown separately — these are different metric types.',
+      description: 'Social followers across all platforms.',
+      value: formatNumber(brandReach.totalSocialFollowers),
+      changePercentage: formatMomChange(brandReach.changePercentage),
+      trend: normalizeTrend(brandReach.changePercentage, brandReach.trend),
+      subtitle: `${brandReach.activePlatforms} platform${brandReach.activePlatforms === 1 ? '' : 's'}`,
+      // No historical follower series available — render a flat line at the current
+      // total rather than reusing website-session data (they are different metrics).
+      chartData: protoSparkline(flatSparklineData(brandReach.totalSocialFollowers), lfxColors.blue[500]),
+      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
+      tooltipText: 'Social followers across all platforms, with month-over-month change.',
       drawerType: DashboardDrawerType.BrandReach,
+    } as DashboardMetricCard,
+
+    // === Web ===
+    // Website sessions were previously the second dual-signal on the Social card.
+    // Split out so followers (a stock) and sessions (a flow) each get their own card
+    // rather than sharing one, and so web activity gets a dedicated drill-down.
+    {
+      title: 'Web',
+      icon: 'fa-light fa-globe',
+      chartType: 'line',
+      category: 'brand',
+      testId: 'ed-evo-web-sessions',
+      description: 'Rolling 30-day sessions across foundation web properties.',
+      value: formatNumber(brandReach.totalMonthlySessions),
+      changePercentage: formatMomChange(brandReach.sessionMomChangePct),
+      trend: normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down'),
+      // weeklyTrend only holds weeks WITH rows, so its length is not the reporting
+      // window — the endpoint covers a fixed six-month range, so the window is
+      // labeled directly rather than estimated from row count.
+      subtitle: brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Last 6 months' : 'Sessions (30d)',
+      chartData: protoSparkline(
+        brandReach.weeklyTrend.length > 0 ? brandReach.weeklyTrend.map((d) => d.sessions) : flatSparklineData(brandReach.totalMonthlySessions),
+        lfxColors.violet[500]
+      ),
+      chartOptions: NO_TOOLTIP_CHART_OPTIONS,
+      tooltipText: 'Rolling 30-day website sessions across foundation web properties, with month-over-month change.',
+      drawerType: DashboardDrawerType.MarketingWebsiteVisits,
     } as DashboardMetricCard,
 
     // === Email ===

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -908,6 +908,8 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       // over a fixed six-month range. Label them separately so the 30-day figure is not
       // read as a six-month number. weeklyTrend only holds weeks WITH rows, so its
       // length is not the reporting window and the window is labeled directly.
+      // When weeklyTrend is empty, flatSparklineData renders a placeholder at the
+      // current total (see the Social card above), not a trend.
       subtitle: brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Trend: last 6 months' : 'Sessions (30d)',
       chartData: protoSparkline(
         brandReach.weeklyTrend.length > 0 ? brandReach.weeklyTrend.map((d) => d.sessions) : flatSparklineData(brandReach.totalMonthlySessions),


### PR DESCRIPTION
## Summary

Splits website sessions out of the ED marketing overview's **Social** card into a dedicated **Web** card.

Social previously carried two dual-signals — social followers and website sessions (30d). Those measure different things: followers are a stock, sessions are a flow. Separating them gives each its own card and, for web, its own drill-down.

This also reconnects an orphaned drawer. `website-visits-drawer` and `DashboardDrawerType.MarketingWebsiteVisits` already existed and were already bound in `marketing-overview.component.html`, but no card routed to them after #1300. The Web card sets `drawerType: MarketingWebsiteVisits`, so the existing drawer becomes reachable again — no new component required.

Card order is now: Events · Members · Adoption · **Social** · **Web** · Email · Paid Media · Attribution · Sentiment · Flywheel.

## Changes

- `dashboard-metrics.constants.ts` — Social reduced to a single-value followers card; new Web card for rolling 30-day sessions.
- `marketing-dashboard.spec.ts` — added a Web card render test and repaired stale testIds (below).

## E2E repairs

Three `marketing-card-*` testIds referenced by the spec have been absent from source since the #1300 restructure, so those suites could not pass:

| Reference | Action |
|---|---|
| `marketing-card-website-visits` (4×) | Repointed to `ed-evo-web-sessions`; duplicate render test dropped since the new Web card test covers it |
| `marketing-card-email-ctr` (4×) | Repointed to `ed-evo-campaign-performance` |
| `marketing-card-social-media` (render) | Repointed to `ed-evo-brand-reach` |
| `marketing-card-social-media` (drawer, 3×) | **Suite skipped** — see below |

The **Social Media Drawer** suite is skipped rather than repointed. No card sets `drawerType: MarketingSocialMedia`, so that drawer is rendered by the template but unreachable from the UI; the Social card opens `BrandReach`, not the social-media drawer. No rename makes those tests pass. The skip carries a comment naming the precondition to re-enable. **This is pre-existing from #1300, not introduced here** — worth a follow-up ticket to either wire it up or remove the drawer.

## Known trade-offs

- **Sparkline window differs from the value.** The Web value is a rolling 30-day total from `WEB_ACTIVITIES_SUMMARY`; the sparkline is a weekly series over six months from `WEB_ACTIVITIES_BY_PROJECT`. The subtitle labels both windows explicitly (`Sessions (30d) · Trend: last 6 months`) so the 30-day figure isn't read as a six-month number. Per an existing code comment, `WEB_ACTIVITIES_BY_PROJECT` lacks `LF_SUB_DOMAIN_CLASSIFICATION`, so the trend is all-program totals.
- **Social sparkline is a placeholder.** No historical follower series is available, so it renders `flatSparklineData` at the current total — deliberately not reusing website sessions, which is a different metric.
- **Brand Reach drawer still shows "Website Sessions by Domain."** Left in place intentionally: `brand-reach-drawer.component.ts` uses `websiteDomains.length` in its empty-state guard and derives a top-domain recommendation from it, and the website-visits drawer uses a different response type. Moving it is a separate change.

Card and drawer totals agree — both sum `TOTAL_SESSIONS_LAST_30_DAYS` from the same `WEB_ACTIVITIES_SUMMARY` table.

## Testing

- `yarn lint:check` clean (one pre-existing warning in `campaigns.component.ts`, untouched here)
- `yarn check-types` passes
- `yarn build` passes
- Verified in browser at `/foundation/marketing-overview?project=tlf`
- Every active testId in the spec cross-checked against source

Ref: LFXV2-2023
