### PR TITLE
feat(dashboards): add education card and drawer to marketing overview

### DIFF
--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -221,6 +221,47 @@ test.describe('Education Drawer', () => {
     await expect(page.locator('[data-testid="education-drawer-formats"]')).toBeVisible();
   });
 
+  // Guards the null-vs-zero distinction: edX revenue is hardcoded null (COURSE_PURCHASES
+  // carries no revenue column) and must render "not tracked", while every other format
+  // has measured revenue and renders a currency figure — $0 included. A refactor that
+  // coalesced null to 0 would silently report edX as having earned nothing.
+  test('distinguishes untracked revenue from a measured zero', async ({ page }) => {
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-formats');
+
+    const edxRow = page.locator('[data-testid="education-drawer-format-row"]', { hasText: 'edX' });
+    await expect(edxRow).toContainText('not tracked');
+    await expect(edxRow).not.toContainText('$');
+
+    // Instructor Led revenue is measured, so it must show a currency value rather than
+    // the untracked placeholder — $0 is a legitimate reading here.
+    const instructorLedRow = page.locator('[data-testid="education-drawer-format-row"]', { hasText: 'Instructor Led' });
+    await expect(instructorLedRow).toContainText('$');
+    await expect(instructorLedRow).not.toContainText('not tracked');
+  });
+
+  // The attention/performing sections are driven by computed thresholds (concentration
+  // risk >70%, cert attach rate, balanced-portfolio) and routed by splitByPriority.
+  // TLF's live mix decides which of the two renders, so assert the invariant that holds
+  // either way: at least one section renders, and whichever renders carries content.
+  test('renders a priority-routed insight section', async ({ page }) => {
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-formats');
+
+    const attention = page.locator('[data-testid="education-drawer-attention"]');
+    const performing = page.locator('[data-testid="education-drawer-performing"]');
+    const facts = page.locator('[data-testid="education-drawer-facts"]');
+
+    const sectionCount = (await attention.count()) + (await performing.count()) + (await facts.count());
+    expect(sectionCount).toBeGreaterThan(0);
+
+    // Whichever sections rendered must be non-empty — an empty shell means the
+    // computed logic produced a section with nothing routed into it.
+    for (const section of [attention, performing, facts]) {
+      if ((await section.count()) > 0) {
+        await expect(section.first()).not.toBeEmpty();
+      }
+    }
+  });
+
   test('closes when close button is clicked', async ({ page }) => {
     await openDrawer(page, 'ed-evo-education', 'education-drawer-content');
     await page.locator('[data-testid="education-drawer-close"]').click();

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -3,6 +3,8 @@
 
 import { test, expect, Page } from '@playwright/test';
 
+import type { TrainingCertificationSummaryResponse } from '@lfx-one/shared/interfaces';
+
 /**
  * Marketing Dashboard E2E Tests
  *
@@ -199,6 +201,62 @@ test.describe('Marketing Metric Cards', () => {
   });
 });
 
+/**
+ * Stub the training-certification endpoint so a test can exercise a specific data
+ * shape instead of whatever TLF currently returns. Must be called before `page.goto`:
+ * the Education card is built during SSR, so a route registered after navigation
+ * would only affect subsequent client-side fetches and leave the card on live data.
+ */
+async function stubEducationSummary(page: Page, summary: TrainingCertificationSummaryResponse): Promise<void> {
+  await page.route('**/api/analytics/training-certification-summary*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(summary) })
+  );
+}
+
+/** Baseline fixture: every format active, revenue measured, no single format dominant. */
+const EDUCATION_BALANCED: TrainingCertificationSummaryResponse = {
+  projectId: 'tlf-test-project',
+  range: 'YTD',
+  enrollment: { instructorLed: 300, eLearning: 300, certExams: 250, edx: 150 },
+  revenue: { instructorLed: 120_000, eLearning: 60_000, certExams: 45_000 },
+};
+
+/**
+ * All-edX fixture: enrollments exist (so the card renders) but every revenue-bearing
+ * format is empty, making net revenue genuinely untracked rather than zero. This is
+ * the branch the card/drawer contradiction lived in and that live TLF data never hits.
+ */
+const EDUCATION_ALL_EDX: TrainingCertificationSummaryResponse = {
+  projectId: 'tlf-test-project',
+  range: 'YTD',
+  enrollment: { instructorLed: 0, eLearning: 0, certExams: 0, edx: 900 },
+  revenue: { instructorLed: 0, eLearning: 0, certExams: 0 },
+};
+
+/**
+ * Measured-zero fixture: instructor-led enrollments exist but earned $0. Distinct from
+ * the all-edX case above — here revenue IS tracked and happens to be zero, so both card
+ * and drawer must render `$0` rather than the untracked em dash.
+ */
+const EDUCATION_MEASURED_ZERO: TrainingCertificationSummaryResponse = {
+  projectId: 'tlf-test-project',
+  range: 'YTD',
+  enrollment: { instructorLed: 120, eLearning: 40, certExams: 20, edx: 60 },
+  revenue: { instructorLed: 0, eLearning: 0, certExams: 0 },
+};
+
+/**
+ * Concentration-risk fixture: one format above the 70% threshold with zero cert exams,
+ * which drives both the "Diversify education formats" and "No certification exam
+ * activity" actions into Needs Your Attention deterministically.
+ */
+const EDUCATION_CONCENTRATED: TrainingCertificationSummaryResponse = {
+  projectId: 'tlf-test-project',
+  range: 'YTD',
+  enrollment: { instructorLed: 900, eLearning: 50, certExams: 0, edx: 50 },
+  revenue: { instructorLed: 250_000, eLearning: 5_000, certExams: 0 },
+};
+
 test.describe('Education Drawer', () => {
   test.beforeEach(async ({ page }) => {
     await page.goto(DASHBOARD_URL);
@@ -319,6 +377,116 @@ test.describe('Education Drawer', () => {
     await openDrawer(page, 'ed-evo-education', 'education-drawer-content');
     await page.locator('[data-testid="education-drawer-close"]').click();
     await expect(page.locator('[data-testid="education-drawer-content"]')).not.toBeVisible();
+  });
+});
+
+/**
+ * Education branches that live TLF data does not reach.
+ *
+ * The suite above asserts invariants against whatever the API currently returns, which
+ * catches real integration breakage but leaves the interesting branches unexercised:
+ * TLF has revenue-bearing enrollments, so the untracked-revenue path never runs, and its
+ * format mix decides on its own whether the concentration-risk action fires. A rendering
+ * regression in either branch would pass unnoticed. These tests pin the response instead,
+ * so each branch fails deterministically when it breaks.
+ */
+test.describe('Education Drawer — fixture-driven branches', () => {
+  test('renders a measured $0 as $0 on both card and drawer', async ({ page }) => {
+    await stubEducationSummary(page, EDUCATION_MEASURED_ZERO);
+    await page.goto(DASHBOARD_URL);
+    await switchToExecutiveDirector(page);
+
+    // Revenue is tracked (instructor-led enrollments exist) and happens to be zero, so
+    // the card must state the figure rather than fall back to the untracked wording.
+    const card = page.locator('[data-testid="ed-evo-education"]');
+    await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
+    await card.scrollIntoViewIfNeeded();
+    await expect(card).toContainText('$0');
+    await expect(card).not.toContainText('net revenue not tracked');
+
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-stats');
+    const netRevenueStat = page.locator('[data-testid="education-drawer-stats"] > *', { hasText: 'Net Revenue' });
+    await expect(netRevenueStat).toContainText('$0');
+    await expect(netRevenueStat).not.toContainText('—');
+  });
+
+  test('renders untracked revenue as a dash on both card and drawer', async ({ page }) => {
+    await stubEducationSummary(page, EDUCATION_ALL_EDX);
+    await page.goto(DASHBOARD_URL);
+    await switchToExecutiveDirector(page);
+
+    // edX carries enrollments but no revenue column, so net revenue is untracked rather
+    // than zero. This is the case where the card previously read "$0.00 net revenue"
+    // while the drawer showed an em dash for the same figure.
+    const card = page.locator('[data-testid="ed-evo-education"]');
+    await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
+    await card.scrollIntoViewIfNeeded();
+    await expect(card).toContainText('net revenue not tracked');
+    await expect(card).not.toContainText('$0');
+
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-stats');
+    const netRevenueStat = page.locator('[data-testid="education-drawer-stats"] > *', { hasText: 'Net Revenue' });
+    await expect(netRevenueStat).toContainText('—');
+    await expect(netRevenueStat).not.toContainText('$');
+  });
+
+  test('routes a dominant format into Needs Your Attention only', async ({ page }) => {
+    await stubEducationSummary(page, EDUCATION_CONCENTRATED);
+    await page.goto(DASHBOARD_URL);
+    await switchToExecutiveDirector(page);
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-formats');
+
+    // 900 of 1000 enrollments clears the >70% concentration threshold, and zero cert
+    // exams triggers the credential-gap action — both are high priority.
+    const attention = page.locator('[data-testid="education-drawer-attention"]');
+    await expect(attention).toBeVisible();
+    await expect(attention).toContainText('Diversify education formats');
+    await expect(attention).toContainText('No certification exam activity');
+
+    // The same dominant format must not also be praised. It is reported as a neutral
+    // fact instead, which is the fix for the earlier flag-and-praise contradiction.
+    await expect(page.locator('[data-testid="education-drawer-facts"]')).toContainText('Instructor Led leads');
+    const performing = page.locator('[data-testid="education-drawer-performing"]');
+    if ((await performing.count()) > 0) {
+      await expect(performing).not.toContainText('Instructor Led');
+    }
+  });
+
+  test('routes a balanced mix into Performing Well without a concentration flag', async ({ page }) => {
+    await stubEducationSummary(page, EDUCATION_BALANCED);
+    await page.goto(DASHBOARD_URL);
+    await switchToExecutiveDirector(page);
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-formats');
+
+    // Four active formats, none above 50%, so the balanced-portfolio insight fires and
+    // the concentration-risk action must not.
+    const performing = page.locator('[data-testid="education-drawer-performing"]');
+    await expect(performing).toBeVisible();
+    await expect(performing).toContainText('Balanced format mix');
+
+    const attention = page.locator('[data-testid="education-drawer-attention"]');
+    if ((await attention.count()) > 0) {
+      await expect(attention).not.toContainText('Diversify education formats');
+    }
+  });
+
+  test('keeps edX untracked while other formats show measured revenue', async ({ page }) => {
+    await stubEducationSummary(page, EDUCATION_BALANCED);
+    await page.goto(DASHBOARD_URL);
+    await switchToExecutiveDirector(page);
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-formats');
+
+    // Four rows, one per format — a regression that dropped or merged rows would pass
+    // a mere visibility assertion on the container.
+    await expect(page.locator('[data-testid="education-drawer-format-row"]')).toHaveCount(4);
+
+    const edxRow = page.locator('[data-testid="education-drawer-format-row"]', { hasText: 'edX' });
+    await expect(edxRow).toContainText('not tracked');
+    await expect(edxRow).not.toContainText('$');
+
+    const instructorLedRow = page.locator('[data-testid="education-drawer-format-row"]', { hasText: 'Instructor Led' });
+    await expect(instructorLedRow).toContainText('$120,000');
+    await expect(instructorLedRow).not.toContainText('not tracked');
   });
 });
 

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -182,9 +182,48 @@ test.describe('Marketing Metric Cards', () => {
     await expect(card).toContainText('Web');
   });
 
+  // The Education card is suppressed when the foundation reports zero enrollments, so
+  // assert on attachment rather than a hard failure if TLF ever drops to no training.
+  test('renders Education card', async ({ page }) => {
+    const card = page.locator('[data-testid="ed-evo-education"]');
+    await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
+    await card.scrollIntoViewIfNeeded();
+    await expect(card).toBeVisible();
+    await expect(card).toContainText('Education');
+  });
+
   test('renders filter pills', async ({ page }) => {
     const filters = page.locator('[data-testid="ed-evolution-filters"]');
     await expect(filters).toBeVisible();
+  });
+});
+
+test.describe('Education Drawer', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(DASHBOARD_URL);
+    await switchToExecutiveDirector(page);
+  });
+
+  test('opens and shows title when card is clicked', async ({ page }) => {
+    await openDrawer(page, 'ed-evo-education', 'education-drawer-content');
+    await expect(page.locator('[data-testid="education-drawer-title"]')).toContainText('Education');
+  });
+
+  test('shows stats section with data', async ({ page }) => {
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-stats');
+    const statCards = page.locator('[data-testid="education-drawer-stats"]').locator('lfx-card');
+    await expect(statCards).toHaveCount(3);
+  });
+
+  test('shows format breakdown section', async ({ page }) => {
+    await openDrawer(page, 'ed-evo-education', 'education-drawer-content');
+    await expect(page.locator('[data-testid="education-drawer-formats"]')).toBeVisible();
+  });
+
+  test('closes when close button is clicked', async ({ page }) => {
+    await openDrawer(page, 'ed-evo-education', 'education-drawer-content');
+    await page.locator('[data-testid="education-drawer-close"]').click();
+    await expect(page.locator('[data-testid="education-drawer-content"]')).not.toBeVisible();
   });
 });
 

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -182,8 +182,9 @@ test.describe('Marketing Metric Cards', () => {
     await expect(card).toContainText('Web');
   });
 
-  // The Education card is suppressed when the foundation reports zero enrollments, so
-  // assert on attachment rather than a hard failure if TLF ever drops to no training.
+  // The card is conditional on non-zero enrollments upstream, so it is asserted on
+  // attachment first — it renders off-screen in the carousel until scrolled to. TLF
+  // always reports training activity, so an absent card is a real regression here.
   test('renders Education card', async ({ page }) => {
     const card = page.locator('[data-testid="ed-evo-education"]');
     await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -239,6 +239,34 @@ test.describe('Education Drawer', () => {
     await expect(instructorLedRow).not.toContainText('not tracked');
   });
 
+  // The Net Revenue stat card is gated by `hasTrackedRevenue`, a separate signal from
+  // the per-row null check above, and the card subtitle is gated by an equivalent
+  // boolean in buildEdEvolutionMetrics. Live TLF data is not all-edX, so rather than
+  // asserting one branch this asserts the invariant that must hold under either data
+  // shape: the card and the drawer it opens never disagree about whether revenue is
+  // tracked. That is the contradiction that regressed — the card read "$0.00 net
+  // revenue" while the drawer showed an em dash for the same figure.
+  test('card and drawer agree on whether revenue is tracked', async ({ page }) => {
+    const card = page.locator('[data-testid="ed-evo-education"]');
+    await expect(card).toBeAttached({ timeout: DATA_LOAD_TIMEOUT });
+    await card.scrollIntoViewIfNeeded();
+    const cardSaysUntracked = (await card.textContent())?.includes('net revenue not tracked') ?? false;
+
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-stats');
+    const netRevenueStat = page.locator('[data-testid="education-drawer-stats"] > *', { hasText: 'Net Revenue' });
+    const drawerSaysUntracked = (await netRevenueStat.textContent())?.includes('—') ?? false;
+
+    expect(drawerSaysUntracked).toBe(cardSaysUntracked);
+
+    // And whichever way they agree, the rendering is the expected one on both sides.
+    if (cardSaysUntracked) {
+      await expect(netRevenueStat).not.toContainText('$');
+    } else {
+      await expect(card).toContainText('net revenue');
+      await expect(netRevenueStat).toContainText('$');
+    }
+  });
+
   // The attention/performing sections are driven by computed thresholds (concentration
   // risk >70%, cert attach rate, balanced-portfolio) and routed by splitByPriority.
   // TLF's live mix decides which of the two renders, so assert the invariant that holds
@@ -259,6 +287,31 @@ test.describe('Education Drawer', () => {
       if ((await section.count()) > 0) {
         await expect(section.first()).not.toBeEmpty();
       }
+    }
+  });
+
+  // Guards the specific regression Copilot caught in an earlier round: the leading and
+  // highest-earning formats were `info` insights, and splitByPriority routes every
+  // non-warning insight into "Performing Well" — so the same format was praised there
+  // while being flagged as a concentration risk under "Needs Your Attention". They now
+  // render as neutral facts carrying no verdict. Asserting the contradiction is absent
+  // works against any data shape, where asserting a specific threshold outcome would
+  // need an all-edX or concentration-risk fixture that live TLF data does not provide.
+  test('never flags and praises the same education format', async ({ page }) => {
+    await openDrawerAndWaitForData(page, 'ed-evo-education', 'education-drawer-content', 'education-drawer-formats');
+
+    const attention = page.locator('[data-testid="education-drawer-attention"]');
+    const performing = page.locator('[data-testid="education-drawer-performing"]');
+    if ((await attention.count()) === 0 || (await performing.count()) === 0) {
+      test.skip(true, 'Needs both sections rendered; TLF live mix produced only one.');
+    }
+
+    const attentionText = (await attention.first().textContent()) ?? '';
+    const performingText = (await performing.first().textContent()) ?? '';
+    for (const format of ['Instructor Led', 'eLearning', 'Cert Exams', 'edX']) {
+      const flagged = attentionText.includes(format);
+      const praised = performingText.includes(format);
+      expect(flagged && praised, `"${format}" appears in both Needs Your Attention and Performing Well`).toBe(false);
     }
   });
 

--- a/apps/lfx-one/e2e/marketing-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/marketing-dashboard.spec.ts
@@ -9,10 +9,17 @@ import type { TrainingCertificationSummaryResponse } from '@lfx-one/shared/inter
  * Marketing Dashboard E2E Tests
  *
  * Tests the Executive Director marketing overview section including:
- * - Marketing metric cards (Website Visits, Email CTR, Paid Social Reach)
- * - North Star metric cards (Flywheel Conversion, Member Growth, Engaged Community)
+ * - North Star metric cards (Events, Members, Adoption, Email, Paid Media, Attribution)
+ * - Brand metric cards (Social, Web, Sentiment) and the Education card
  * - Drill-down drawers for each metric
- * - Carousel navigation
+ * - Carousel navigation and filter pills
+ *
+ * Two layers of coverage, deliberately kept separate:
+ * - Live-data suites hit the real API and assert invariants that hold under any data
+ *   shape. They catch integration breakage — contract changes, serialization bugs.
+ * - Fixture-driven suites stub the endpoint to force a specific branch. They catch
+ *   rendering regressions in cases live data does not reach (see the Education
+ *   fixture-driven block for the untracked-revenue and concentration-risk branches).
  *
  * Prerequisites:
  * - Dev server running on localhost:4200

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.html
@@ -43,7 +43,8 @@
       <lfx-card styleClass="flex-1">
         <div class="flex flex-col gap-1">
           <span class="text-sm text-gray-500">Net Revenue</span>
-          @if (totalRevenue() > 0) {
+          <!-- A measured $0 is data; the dash is only for the all-edX case where revenue is untracked. -->
+          @if (hasTrackedRevenue()) {
             <span class="text-2xl font-semibold text-gray-900">{{ totalRevenueLabel() }}</span>
           } @else {
             <span class="text-2xl font-semibold text-gray-400">—</span>
@@ -114,6 +115,19 @@
           <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
             <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
             <span>{{ insight.text }}</span>
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Neutral facts: reported without a performing/attention verdict, since the leading
+         format may be the same one flagged as a concentration risk above. -->
+    @if (neutralFacts().length > 0) {
+      <div class="flex flex-col rounded-lg border border-gray-200 bg-white overflow-hidden" data-testid="education-drawer-facts">
+        @for (fact of neutralFacts(); track fact) {
+          <div class="flex items-center gap-2 px-4 py-3 border-b border-gray-100 last:border-b-0 text-sm text-gray-700">
+            <i class="fa-light fa-circle-info text-gray-400 flex-shrink-0"></i>
+            <span>{{ fact }}</span>
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.html
@@ -1,0 +1,168 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="education-drawer">
+  <!-- Header -->
+  <ng-template #header>
+    <div class="flex items-start justify-between gap-4 w-full" data-testid="education-drawer-header">
+      <div class="flex flex-col gap-1 flex-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="education-drawer-title">Education</h2>
+        <p class="text-sm text-gray-500">Executive Director · Training &amp; Certification</p>
+      </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="education-drawer-close" />
+    </div>
+  </ng-template>
+
+  <!-- Content -->
+  <div class="flex flex-col gap-6 pb-2" data-testid="education-drawer-content">
+    <!-- Summary Stats -->
+    <div class="flex gap-4" data-testid="education-drawer-stats">
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Enrollments</span>
+          @if (totalEnrollments() > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ totalEnrollmentsLabel() }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Net Revenue</span>
+          @if (totalRevenue() > 0) {
+            <span class="text-2xl font-semibold text-gray-900">{{ totalRevenueLabel() }}</span>
+          } @else {
+            <span class="text-2xl font-semibold text-gray-400">—</span>
+          }
+        </div>
+      </lfx-card>
+      <lfx-card styleClass="flex-1">
+        <div class="flex flex-col gap-1">
+          <span class="text-sm text-gray-500">Revenue / Enrollment</span>
+          <span class="text-2xl font-semibold text-gray-900">{{ revenuePerEnrollmentLabel() }}</span>
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- FIRST FOLD: Needs Your Attention -->
+    @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+        data-testid="education-drawer-attention">
+        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+          <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+          <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+        </div>
+
+        @for (action of attentionActions(); track action.title) {
+          <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+              <p class="text-sm text-gray-500">{{ action.description }}</p>
+            </div>
+            @if (action.priority === 'high') {
+              <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+            } @else {
+              <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+            }
+          </div>
+        }
+
+        @for (insight of attentionInsights(); track insight.text) {
+          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+            <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+            <span>{{ insight.text }}</span>
+          </div>
+        }
+      </div>
+    }
+
+    <!-- SECOND FOLD: Performing Well -->
+    @if (performingActions().length > 0 || performingInsights().length > 0) {
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+        data-testid="education-drawer-performing">
+        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+          <i class="fa-light fa-check text-green-600"></i>
+          <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+        </div>
+
+        @for (action of performingActions(); track action.title) {
+          <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+              <p class="text-sm text-gray-500">{{ action.description }}</p>
+            </div>
+          </div>
+        }
+
+        @for (insight of performingInsights(); track insight.text) {
+          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+            <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+            <span>{{ insight.text }}</span>
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Enrollments by Format -->
+    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="education-drawer-formats">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Enrollments by Format</h3>
+        <p class="text-sm text-gray-600">Enrollments and net revenue across each education format</p>
+      </div>
+      @if (totalEnrollments() > 0) {
+        <div class="flex flex-col gap-0">
+          @for (row of categoryRows(); track row.label) {
+            <div class="flex flex-col gap-2 py-3 px-1 border-b border-gray-100" data-testid="education-drawer-format-row">
+              <div class="flex items-center justify-between gap-4">
+                <span class="text-sm font-medium text-gray-900">{{ row.label }}</span>
+                <div class="flex items-center gap-4 flex-shrink-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ row.enrollments | number }}</span>
+                  <!-- Fixed width keeps the revenue column aligned across rows -->
+                  <span class="text-sm text-gray-500 w-20 text-right">
+                    @if (row.revenue !== null) {
+                      {{ row.revenue | currency: 'USD' : 'symbol' : '1.0-0' }}
+                    } @else {
+                      <span class="text-gray-400" title="edX revenue is not tracked upstream">not tracked</span>
+                    }
+                  </span>
+                </div>
+              </div>
+              <!-- Share bar: enrollment share of total, not revenue share -->
+              <div class="flex items-center gap-2">
+                <div class="flex-1 h-1.5 bg-gray-100 rounded-full overflow-hidden">
+                  <div class="h-full bg-blue-500 rounded-full" [style.width.%]="row.enrollmentSharePct"></div>
+                </div>
+                <span class="text-xs text-gray-400 w-10 text-right">{{ row.enrollmentShareLabel }}</span>
+              </div>
+            </div>
+          }
+        </div>
+      } @else {
+        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="education-drawer-formats-empty">
+          Training and certification data not yet available
+        </div>
+      }
+    </div>
+
+    <!-- Source note: explains why there is no trend chart here -->
+    <p class="text-xs text-gray-400" data-testid="education-drawer-source-note">
+      Source reports pre-aggregated totals per reporting window with no monthly grain, so no trend is shown. edX contributes enrollments but carries no revenue.
+    </p>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
@@ -44,6 +44,22 @@ export class EducationDrawerComponent {
   protected readonly totalEnrollmentsLabel: Signal<string> = computed(() => formatNumber(this.totalEnrollments()));
   protected readonly totalRevenueLabel: Signal<string> = computed(() => formatCurrency(this.totalRevenue()));
 
+  /**
+   * Whether net revenue is a measured figure at all, as opposed to untracked.
+   *
+   * Gates the revenue stats on the presence of revenue-bearing enrollments rather than
+   * on a non-zero total. A foundation with instructor-led/eLearning/cert enrollments has
+   * its revenue measured, so a $0 result is real data and must render as $0 — showing a
+   * dash there would report a measured zero as "no data". The dash is reserved for the
+   * all-edX case, where COURSE_PURCHASES carries no revenue column and the figure is
+   * genuinely untracked. This also keeps the stat cards consistent with the format rows,
+   * which already distinguish null (untracked) from 0.
+   */
+  protected readonly hasTrackedRevenue: Signal<boolean> = computed(() => {
+    const e = this.data().enrollment;
+    return e.instructorLed + e.eLearning + e.certExams > 0;
+  });
+
   /** Revenue per enrollment across revenue-bearing categories only (edX excluded from both sides). */
   protected readonly revenuePerEnrollmentLabel: Signal<string> = computed(() => {
     const e = this.data().enrollment;
@@ -51,6 +67,14 @@ export class EducationDrawerComponent {
     if (revenueBearingEnrollments === 0) return '—';
     return formatCurrency(this.totalRevenue() / revenueBearingEnrollments);
   });
+
+  /**
+   * The leading format is a neutral fact, not an achievement — it is reported as a plain
+   * statement rather than an insight so it cannot be routed into "Performing Well" while
+   * the same format is simultaneously flagged as a concentration risk. Same for the
+   * highest-earning format below.
+   */
+  protected readonly neutralFacts: Signal<string[]> = this.initNeutralFacts();
 
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
   protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
@@ -159,16 +183,10 @@ export class EducationDrawerComponent {
 
       const rows = this.categoryRows();
 
-      // Leading format
-      const top = [...rows].sort((a, b) => b.enrollments - a.enrollments)[0];
-      if (top.enrollments > 0) {
-        insights.push({
-          text: `${top.label} leads with ${formatNumber(top.enrollments)} enrollments (${top.enrollmentSharePct.toFixed(0)}% of total)`,
-          type: 'info',
-        });
-      }
-
-      // Balanced portfolio — the genuine performing-well signal
+      // Balanced portfolio — the only genuine performing-well signal here. The leading
+      // and highest-earning formats are reported as neutral facts instead: splitByPriority
+      // routes every non-warning insight into "Performing Well", so emitting them here
+      // would praise the same format the concentration-risk action is flagging.
       const activeFormats = rows.filter((row) => row.enrollments > 0);
       if (activeFormats.length >= 3 && activeFormats.every((row) => row.enrollmentSharePct < 50)) {
         insights.push({
@@ -177,17 +195,33 @@ export class EducationDrawerComponent {
         });
       }
 
+      return insights;
+    });
+  }
+
+  private initNeutralFacts(): Signal<string[]> {
+    return computed(() => {
+      if (this.totalEnrollments() === 0) {
+        return [];
+      }
+
+      const rows = this.categoryRows();
+      const facts: string[] = [];
+
+      // Leading format
+      const top = [...rows].sort((a, b) => b.enrollments - a.enrollments)[0];
+      if (top.enrollments > 0) {
+        facts.push(`${top.label} leads with ${formatNumber(top.enrollments)} enrollments (${top.enrollmentSharePct.toFixed(0)}% of total)`);
+      }
+
       // Highest-earning format, which is often not the highest-enrolling one
       const revenueRows = rows.filter((row) => (row.revenue ?? 0) > 0);
       if (revenueRows.length > 0) {
         const topRevenue = [...revenueRows].sort((a, b) => (b.revenue ?? 0) - (a.revenue ?? 0))[0];
-        insights.push({
-          text: `${topRevenue.label} generates the most net revenue at ${formatCurrency(topRevenue.revenue ?? 0)}`,
-          type: 'info',
-        });
+        facts.push(`${topRevenue.label} generates the most net revenue at ${formatCurrency(topRevenue.revenue ?? 0)}`);
       }
 
-      return insights;
+      return facts;
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
@@ -230,8 +230,21 @@ export class EducationDrawerComponent {
    * Returns the row with the highest `score`. A single pass states the intent —
    * find one maximum — where a full sort implies an ordering nothing consumes.
    * Callers must pass a non-empty array; every call site is already length-guarded.
+   *
+   * Scores each row exactly once by carrying the running best score, rather than
+   * re-deriving it from the incumbent on every comparison. Ties keep the earlier
+   * row, preserving the declaration order of `categoryRows`.
    */
   private maxBy(rows: EducationCategoryRow[], score: (row: EducationCategoryRow) => number): EducationCategoryRow {
-    return rows.reduce((top, row) => (score(row) > score(top) ? row : top), rows[0]);
+    let top = rows[0];
+    let topScore = score(top);
+    for (let i = 1; i < rows.length; i++) {
+      const rowScore = score(rows[i]);
+      if (rowScore > topScore) {
+        top = rows[i];
+        topScore = rowScore;
+      }
+    }
+    return top;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
@@ -1,0 +1,193 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CurrencyPipe, DecimalPipe } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, input, model, Signal } from '@angular/core';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { HEALTH_METRICS_TRAINING_CERTIFICATION_DEFAULT_SUMMARY } from '@lfx-one/shared/constants';
+import { formatCurrency, formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { DrawerModule } from 'primeng/drawer';
+
+import type { EducationCategoryRow, MarketingKeyInsight, MarketingRecommendedAction, TrainingCertificationSummaryResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-education-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [ButtonComponent, CardComponent, CurrencyPipe, DecimalPipe, DrawerModule, TagComponent],
+  templateUrl: './education-drawer.component.html',
+})
+export class EducationDrawerComponent {
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  public readonly data = input<TrainingCertificationSummaryResponse>(HEALTH_METRICS_TRAINING_CERTIFICATION_DEFAULT_SUMMARY);
+
+  // === Computed Signals ===
+  protected readonly totalEnrollments: Signal<number> = computed(() => {
+    const e = this.data().enrollment;
+    return e.instructorLed + e.eLearning + e.certExams + e.edx;
+  });
+
+  // edX is excluded: COURSE_PURCHASES has no edX revenue column, so it contributes
+  // enrollments without revenue. Summing a 0 for it would understate revenue per
+  // enrollment without signalling why.
+  protected readonly totalRevenue: Signal<number> = computed(() => {
+    const r = this.data().revenue;
+    return r.instructorLed + r.eLearning + r.certExams;
+  });
+
+  protected readonly categoryRows: Signal<EducationCategoryRow[]> = this.initCategoryRows();
+
+  protected readonly totalEnrollmentsLabel: Signal<string> = computed(() => formatNumber(this.totalEnrollments()));
+  protected readonly totalRevenueLabel: Signal<string> = computed(() => formatCurrency(this.totalRevenue()));
+
+  /** Revenue per enrollment across revenue-bearing categories only (edX excluded from both sides). */
+  protected readonly revenuePerEnrollmentLabel: Signal<string> = computed(() => {
+    const e = this.data().enrollment;
+    const revenueBearingEnrollments = e.instructorLed + e.eLearning + e.certExams;
+    if (revenueBearingEnrollments === 0) return '—';
+    return formatCurrency(this.totalRevenue() / revenueBearingEnrollments);
+  });
+
+  protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
+  protected readonly keyInsights: Signal<MarketingKeyInsight[]> = this.initKeyInsights();
+  private readonly split: Signal<MarketingSplitByPriority> = computed(() => splitByPriority(this.recommendedActions(), this.keyInsights()));
+
+  protected readonly attentionActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().attentionActions);
+  protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
+  protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
+  protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  private initCategoryRows(): Signal<EducationCategoryRow[]> {
+    return computed(() => {
+      const { enrollment, revenue } = this.data();
+      const total = this.totalEnrollments();
+      const row = (label: string, enrollments: number, categoryRevenue: number | null): EducationCategoryRow => {
+        const enrollmentSharePct = total > 0 ? (enrollments / total) * 100 : 0;
+        return {
+          label,
+          enrollments,
+          revenue: categoryRevenue,
+          enrollmentSharePct,
+          enrollmentShareLabel: `${enrollmentSharePct.toFixed(0)}%`,
+        };
+      };
+
+      return [
+        row('Instructor Led', enrollment.instructorLed, revenue.instructorLed),
+        row('eLearning', enrollment.eLearning, revenue.eLearning),
+        row('Cert Exams', enrollment.certExams, revenue.certExams),
+        // null, not 0 — edX revenue is not tracked upstream rather than being zero.
+        row('edX', enrollment.edx, null),
+      ];
+    });
+  }
+
+  private initRecommendedActions(): Signal<MarketingRecommendedAction[]> {
+    return computed(() => {
+      const total = this.totalEnrollments();
+      const actions: MarketingRecommendedAction[] = [];
+
+      if (total === 0) {
+        return actions;
+      }
+
+      const rows = this.categoryRows();
+      const { enrollment } = this.data();
+
+      // Concentration risk — one format carrying the programme
+      const top = [...rows].sort((a, b) => b.enrollments - a.enrollments)[0];
+      if (top.enrollments > 0 && top.enrollmentSharePct > 70) {
+        actions.push({
+          title: 'Diversify education formats',
+          description: `${top.label} is ${top.enrollmentSharePct.toFixed(0)}% of ${formatNumber(total)} enrollments — a single format carrying the programme is fragile. Build depth in the next 2 formats`,
+          priority: 'high',
+          actionType: 'diversify',
+        });
+      }
+
+      // Certification is the credential that converts learners into members
+      const certShare = total > 0 ? (enrollment.certExams / total) * 100 : 0;
+      if (enrollment.certExams === 0) {
+        actions.push({
+          title: 'No certification exam activity',
+          description:
+            'Certification is the credential learners carry back to employers — zero exam enrollments means the programme is not converting training into credentials',
+          priority: 'high',
+          actionType: 'conversion',
+        });
+      } else if (certShare < 10) {
+        actions.push({
+          title: 'Grow certification attach rate',
+          description: `Cert exams are only ${certShare.toFixed(0)}% of enrollments — promote exam pathways from instructor-led and eLearning completions`,
+          priority: 'medium',
+          actionType: 'conversion',
+        });
+      }
+
+      // A format with enrollments but no revenue is either free or mispriced.
+      // edX is excluded — it has no revenue column at all, so it can never qualify.
+      const unmonetized = rows.filter((row) => row.label !== 'edX' && row.enrollments > 0 && (row.revenue ?? 0) === 0);
+      if (unmonetized.length > 0) {
+        actions.push({
+          title: 'Formats running without revenue',
+          description: `${unmonetized.map((row) => row.label).join(', ')} ${unmonetized.length === 1 ? 'has' : 'have'} enrollments but no recorded net revenue — confirm whether these are intentionally free or a pricing gap`,
+          priority: 'medium',
+          actionType: 'revenue',
+        });
+      }
+
+      return actions;
+    });
+  }
+
+  private initKeyInsights(): Signal<MarketingKeyInsight[]> {
+    return computed(() => {
+      const total = this.totalEnrollments();
+      const insights: MarketingKeyInsight[] = [];
+
+      if (total === 0) {
+        return insights;
+      }
+
+      const rows = this.categoryRows();
+
+      // Leading format
+      const top = [...rows].sort((a, b) => b.enrollments - a.enrollments)[0];
+      if (top.enrollments > 0) {
+        insights.push({
+          text: `${top.label} leads with ${formatNumber(top.enrollments)} enrollments (${top.enrollmentSharePct.toFixed(0)}% of total)`,
+          type: 'info',
+        });
+      }
+
+      // Balanced portfolio — the genuine performing-well signal
+      const activeFormats = rows.filter((row) => row.enrollments > 0);
+      if (activeFormats.length >= 3 && activeFormats.every((row) => row.enrollmentSharePct < 50)) {
+        insights.push({
+          text: `Balanced format mix across ${activeFormats.length} education formats — no single format above 50%`,
+          type: 'driver',
+        });
+      }
+
+      // Highest-earning format, which is often not the highest-enrolling one
+      const revenueRows = rows.filter((row) => (row.revenue ?? 0) > 0);
+      if (revenueRows.length > 0) {
+        const topRevenue = [...revenueRows].sort((a, b) => (b.revenue ?? 0) - (a.revenue ?? 0))[0];
+        insights.push({
+          text: `${topRevenue.label} generates the most net revenue at ${formatCurrency(topRevenue.revenue ?? 0)}`,
+          type: 'info',
+        });
+      }
+
+      return insights;
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/education-drawer/education-drawer.component.ts
@@ -127,7 +127,7 @@ export class EducationDrawerComponent {
       const { enrollment } = this.data();
 
       // Concentration risk — one format carrying the programme
-      const top = [...rows].sort((a, b) => b.enrollments - a.enrollments)[0];
+      const top = this.maxBy(rows, (row) => row.enrollments);
       if (top.enrollments > 0 && top.enrollmentSharePct > 70) {
         actions.push({
           title: 'Diversify education formats',
@@ -209,7 +209,7 @@ export class EducationDrawerComponent {
       const facts: string[] = [];
 
       // Leading format
-      const top = [...rows].sort((a, b) => b.enrollments - a.enrollments)[0];
+      const top = this.maxBy(rows, (row) => row.enrollments);
       if (top.enrollments > 0) {
         facts.push(`${top.label} leads with ${formatNumber(top.enrollments)} enrollments (${top.enrollmentSharePct.toFixed(0)}% of total)`);
       }
@@ -217,11 +217,21 @@ export class EducationDrawerComponent {
       // Highest-earning format, which is often not the highest-enrolling one
       const revenueRows = rows.filter((row) => (row.revenue ?? 0) > 0);
       if (revenueRows.length > 0) {
-        const topRevenue = [...revenueRows].sort((a, b) => (b.revenue ?? 0) - (a.revenue ?? 0))[0];
+        const topRevenue = this.maxBy(revenueRows, (row) => row.revenue ?? 0);
         facts.push(`${topRevenue.label} generates the most net revenue at ${formatCurrency(topRevenue.revenue ?? 0)}`);
       }
 
       return facts;
     });
+  }
+
+  // === Private Helpers ===
+  /**
+   * Returns the row with the highest `score`. A single pass states the intent —
+   * find one maximum — where a full sort implies an ordering nothing consumes.
+   * Callers must pass a non-empty array; every call site is already length-guarded.
+   */
+  private maxBy(rows: EducationCategoryRow[], score: (row: EducationCategoryRow) => number): EducationCategoryRow {
+    return rows.reduce((top, row) => (score(row) > score(top) ? row : top), rows[0]);
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -241,6 +241,12 @@
   [data]="revenueImpactData()"
   (visibleChange)="handleDrawerClose()"></lfx-revenue-impact-drawer>
 
+<!-- Education Drawer -->
+<lfx-education-drawer
+  [visible]="activeDrawer() === DashboardDrawerType.Education"
+  [data]="educationData()"
+  (visibleChange)="handleDrawerClose()"></lfx-education-drawer>
+
 <!-- Existing Marketing Drawers (accessible from Brand Reach / Engaged Community drawers in future) -->
 <lfx-website-visits-drawer
   [visible]="activeDrawer() === DashboardDrawerType.MarketingWebsiteVisits"

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -8,7 +8,12 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MetricCardComponent } from '@components/metric-card/metric-card.component';
 
-import { buildEdEvolutionMetrics, ED_EVOLUTION_FILTER_OPTIONS, NO_TOOLTIP_CHART_OPTIONS } from '@lfx-one/shared/constants';
+import {
+  buildEdEvolutionMetrics,
+  ED_EVOLUTION_FILTER_OPTIONS,
+  HEALTH_METRICS_TRAINING_CERTIFICATION_DEFAULT_SUMMARY,
+  NO_TOOLTIP_CHART_OPTIONS,
+} from '@lfx-one/shared/constants';
 import {
   BrandHealthResponse,
   BrandReachResponse,
@@ -22,6 +27,7 @@ import {
   MemberRetentionResponse,
   MetricCategory,
   RevenueImpactResponse,
+  TrainingCertificationSummaryResponse,
 } from '@lfx-one/shared/interfaces';
 
 import { AnalyticsService } from '@services/analytics.service';
@@ -32,6 +38,7 @@ import { catchError, forkJoin, map, Observable, of, skip, Subject, switchMap, ta
 
 import { BrandHealthDrawerComponent } from '../brand-health-drawer/brand-health-drawer.component';
 import { BrandReachDrawerComponent } from '../brand-reach-drawer/brand-reach-drawer.component';
+import { EducationDrawerComponent } from '../education-drawer/education-drawer.component';
 import { EmailCtrDrawerComponent } from '../email-ctr-drawer/email-ctr-drawer.component';
 import { EngagedCommunityDrawerComponent } from '../engaged-community-drawer/engaged-community-drawer.component';
 import { EventGrowthDrawerComponent } from '../event-growth-drawer/event-growth-drawer.component';
@@ -172,6 +179,10 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     monthlyRoas: [],
     channelGroups: [],
   },
+  // Explicitly undefined rather than omitted: safe() reads EMPTY_ED_EVOLUTION_DATA[key]
+  // as the per-call error fallback, and the Education card is suppressed on undefined.
+  // A zero-filled summary here would render the card at 0 on a failed request instead.
+  education: undefined,
 };
 
 @Component({
@@ -198,6 +209,7 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     BrandReachDrawerComponent,
     BrandHealthDrawerComponent,
     RevenueImpactDrawerComponent,
+    EducationDrawerComponent,
   ],
   templateUrl: './marketing-overview.component.html',
   styleUrl: './marketing-overview.component.scss',
@@ -238,6 +250,11 @@ export class MarketingOverviewComponent {
     return mentions ? { ...base, ...mentions } : base;
   });
   protected readonly revenueImpactData = computed<RevenueImpactResponse>(() => this.edEvolutionData().revenueImpact);
+  // Falls back to the shared zero summary so the drawer input stays non-optional. The card
+  // is suppressed when there is no education data, so the fallback is not normally reachable.
+  protected readonly educationData = computed<TrainingCertificationSummaryResponse>(
+    () => this.edEvolutionData().education ?? HEALTH_METRICS_TRAINING_CERTIFICATION_DEFAULT_SUMMARY
+  );
 
   // Rendered directly by the carousel, in array order — the category split that used
   // to sit here regrouped the cards and overrode the intended sequence.
@@ -330,6 +347,20 @@ export class MarketingOverviewComponent {
             revenueImpact: safe('revenueImpact', this.analyticsService.getRevenueImpact(slug, undefined, 'last-6')),
             emailCtr: safe('emailCtr', this.analyticsService.getEmailCtr(slug, undefined, 'last-6')),
             paidCampaign: safe('paidCampaign', this.analyticsService.getSocialReach(slug, undefined, 'last-6')),
+            // Reuses the Health Metrics training-certification endpoint so the Education
+            // card cannot disagree with that card. 'YTD' matches the default range there.
+            //
+            // getTrainingCertificationSummary() converts HTTP errors into an all-zeros
+            // response (its contract, relied on by the Health Metrics card — not changed
+            // here). That makes a failed request indistinguishable from a foundation with
+            // no training, and both would silently hide this card. Map the all-zeros shape
+            // back to undefined so "request failed" and "genuinely zero enrollments" stay
+            // distinguishable: undefined suppresses the card, real zeros are impossible to
+            // reach here because the card is only built when total enrollments are > 0.
+            education: safe<TrainingCertificationSummaryResponse | undefined>(
+              'education',
+              this.analyticsService.getTrainingCertificationSummary(slug, 'YTD').pipe(map((res) => (res && res.projectId !== '' ? res : undefined)))
+            ),
           })
         )
       ),

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -777,7 +777,27 @@ function seriesTrendDirection(series: number[], activity: number[] = series): 'u
  * Emerald/red are reserved for delta indicators (up/down), never sparkline stroke.
  */
 export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricCard[] {
-  const { flywheel, memberAcquisition, memberRetention, engagedCommunity, eventGrowth, brandReach, brandHealth, emailCtr, paidCampaign, revenueImpact } = data;
+  const {
+    flywheel,
+    memberAcquisition,
+    memberRetention,
+    engagedCommunity,
+    eventGrowth,
+    brandReach,
+    brandHealth,
+    emailCtr,
+    paidCampaign,
+    revenueImpact,
+    education,
+  } = data;
+
+  // Education totals. edX is counted in enrollments but has no revenue column in
+  // COURSE_PURCHASES, so it is intentionally absent from the revenue sum — adding a 0
+  // would be harmless here but the omission is deliberate and mirrored in the drawer.
+  const educationTotalEnrollments = education
+    ? education.enrollment.instructorLed + education.enrollment.eLearning + education.enrollment.certExams + education.enrollment.edx
+    : 0;
+  const educationTotalRevenue = education ? education.revenue.instructorLed + education.revenue.eLearning + education.revenue.certExams : 0;
 
   // Pre-compute email open rate for the Campaign Performance card
   const emailTotalSends = emailCtr.monthlySends.reduce((sum, v) => sum + v, 0);
@@ -799,9 +819,11 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   return [
     // Card order is the display order in the Marketing Overview carousel, and the
     // filter pills preserve it within each category — so this array is the single
-    // source of truth for sequence. North Star cards lead (Events → Members →
-    // Adoption), then Social, then Campaign Performance, then the remaining Brand
-    // and Flywheel cards.
+    // source of truth for sequence. Agreed sequence:
+    // Events → Education → Members → Adoption → Social → Email → Paid Media →
+    // Attribution → Sentiment → Flywheel.
+    // Note: Education is grouped with the North Star cards by position only; it keeps
+    // its own section marker below because it is not a North Star metric.
     // === North Star ===
     {
       title: 'Events',
@@ -825,6 +847,34 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       tooltipText: 'Year-to-date event registrants and YoY change.',
       drawerType: DashboardDrawerType.NorthStarEventGrowth,
     } as DashboardMetricCard,
+
+    // === Education ===
+    // Sits second, directly after Events, per the agreed carousel sequence.
+    // Reuses the Health Metrics training-certification endpoint, so the values match
+    // that card by construction. ENROLLMENTS is a pre-aggregated wide table with the
+    // range baked into column names and no date column, so no historical series is
+    // available — the sparkline is flat and the subtitle says so rather than implying
+    // a trend. Suppressed entirely when the foundation has no enrollment data.
+    ...(educationTotalEnrollments > 0
+      ? [
+          {
+            title: 'Education',
+            icon: 'fa-light fa-graduation-cap',
+            chartType: 'line',
+            category: 'memberships',
+            testId: 'ed-evo-education',
+            description: 'Training and certification enrollments across instructor-led, eLearning, cert exams, and edX.',
+            value: formatNumber(educationTotalEnrollments),
+            subtitle: `${formatCurrency(educationTotalRevenue)} net revenue · ${education?.range === 'YTD' ? 'YTD' : 'selected year'}`,
+            chartData: protoSparkline(flatSparklineData(educationTotalEnrollments), lfxColors.blue[500]),
+            chartOptions: NO_TOOLTIP_CHART_OPTIONS,
+            tooltipText:
+              'Total training and certification enrollments with net revenue. Source has no monthly grain, so no trend is shown. edX contributes enrollments but carries no revenue.',
+            drawerType: DashboardDrawerType.Education,
+          } as DashboardMetricCard,
+        ]
+      : []),
+
     {
       title: 'Members',
       icon: 'fa-light fa-user-group',

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -820,10 +820,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
     // Card order is the display order in the Marketing Overview carousel, and the
     // filter pills preserve it within each category — so this array is the single
     // source of truth for sequence. Agreed sequence:
-    // Events → Education → Members → Adoption → Social → Email → Paid Media →
+    // Events → Education → Members → Adoption → Social → Web → Email → Paid Media →
     // Attribution → Sentiment → Flywheel.
-    // Note: Education is grouped with the North Star cards by position only; it keeps
-    // its own section marker below because it is not a North Star metric.
+    // Note: Education sits second by position only. Its category is 'education', not
+    // 'memberships' — the 'memberships' pill is labelled "North Star", and the filter
+    // matches on exact category equality, so reusing it here would list Education as a
+    // North Star metric.
     // === North Star ===
     {
       title: 'Events',
@@ -861,7 +863,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
             title: 'Education',
             icon: 'fa-light fa-graduation-cap',
             chartType: 'line',
-            category: 'memberships',
+            category: 'education',
             testId: 'ed-evo-education',
             description: 'Training and certification enrollments across instructor-led, eLearning, cert exams, and edX.',
             value: formatNumber(educationTotalEnrollments),

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -798,6 +798,15 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
     ? education.enrollment.instructorLed + education.enrollment.eLearning + education.enrollment.certExams + education.enrollment.edx
     : 0;
   const educationTotalRevenue = education ? education.revenue.instructorLed + education.revenue.eLearning + education.revenue.certExams : 0;
+  // Whether net revenue is measured at all, as opposed to untracked. Gated on
+  // revenue-bearing enrollments rather than a non-zero total, mirroring the drawer's
+  // `hasTrackedRevenue`: a foundation with instructor-led/eLearning/cert enrollments
+  // has its revenue measured, so $0 is real data and must render as $0. Only the
+  // all-edX case is genuinely untracked. Without this the card would read
+  // "$0.00 net revenue" while the drawer it opens shows an em dash for the same figure.
+  const educationHasTrackedRevenue = education
+    ? education.enrollment.instructorLed + education.enrollment.eLearning + education.enrollment.certExams > 0
+    : false;
 
   // Pre-compute email open rate for the Campaign Performance card
   const emailTotalSends = emailCtr.monthlySends.reduce((sum, v) => sum + v, 0);
@@ -867,7 +876,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
             testId: 'ed-evo-education',
             description: 'Training and certification enrollments across instructor-led, eLearning, cert exams, and edX.',
             value: formatNumber(educationTotalEnrollments),
-            subtitle: `${formatCurrency(educationTotalRevenue)} net revenue · ${education?.range === 'YTD' ? 'YTD' : 'selected year'}`,
+            subtitle: `${educationHasTrackedRevenue ? `${formatCurrency(educationTotalRevenue)} net revenue` : 'net revenue not tracked'} · ${education?.range === 'YTD' ? 'YTD' : 'selected year'}`,
             chartData: protoSparkline(flatSparklineData(educationTotalEnrollments), lfxColors.blue[500]),
             chartOptions: NO_TOOLTIP_CHART_OPTIONS,
             tooltipText:

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { ProjectTableRow } from './dashboard-metric.interface';
+import type { ProjectTableRow, TrainingCertificationSummaryResponse } from './dashboard-metric.interface';
 
 /** Performance rating for paid project campaigns. */
 export type PaidProjectPerformance = 'EXCELLENT' | 'GOOD' | 'AVERAGE' | 'EMERGING';
@@ -2645,6 +2645,25 @@ export interface MarketingSplitByPriority {
 }
 
 // ============================================
+// Education (ED Marketing Overview)
+// ============================================
+
+/**
+ * One education category row in the Education drawer breakdown.
+ * Revenue is nullable rather than 0 because edX carries no revenue column in
+ * COURSE_PURCHASES — a 0 would read as "earned nothing" instead of "not tracked".
+ */
+export interface EducationCategoryRow {
+  label: string;
+  enrollments: number;
+  revenue: number | null;
+  /** Share of total enrollments, 0-100; 0 when there are no enrollments at all */
+  enrollmentSharePct: number;
+  /** Pre-rounded share label (e.g. "60%") so the template does not call toFixed() per render */
+  enrollmentShareLabel: string;
+}
+
+// ============================================
 // Social Reach (Marketing Dashboard)
 // ============================================
 
@@ -3474,6 +3493,17 @@ export interface EdEvolutionData {
   emailCtr: EmailCtrResponse;
   paidCampaign: SocialReachResponse;
   attribution?: MarketingAttributionResponse;
+  /**
+   * Training & certification summary reused from the Health Metrics endpoint.
+   * Declared required-but-undefinable (not `education?:`) so forkJoin's result type,
+   * which always supplies the key, stays assignable to this interface.
+   *
+   * undefined means "request failed" and suppresses the Education card. The caller maps
+   * the analytics service's all-zeros error fallback (identified by an empty projectId)
+   * to undefined, so a failed request cannot be mistaken for a foundation that genuinely
+   * has no enrollments.
+   */
+  education: TrainingCertificationSummaryResponse | undefined;
 }
 
 // ============================================

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -236,6 +236,7 @@ export enum DashboardDrawerType {
   BrandReach = 'brand-reach',
   BrandHealth = 'brand-health',
   RevenueImpact = 'revenue-impact',
+  Education = 'education',
 }
 
 /** Lifecycle stage of a foundation project */


### PR DESCRIPTION
## Summary

Adds an **Education** card to the ED Marketing Overview carousel in the second slot, directly after Events, plus the drawer behind it.

With this stacked on #1308 and #1309, the carousel sequence matches the agreed design:

> Events · **Education** · Members · Adoption · Social · Web · Email · Paid · Attribution · Sentiment · Flywheel

## Stacking

This PR is stacked. Its base branch `feat/LFXV2-2023-web-and-social-base` contains #1308 and #1309, which are sibling PRs off #1300 — neither one contains the other, so no existing branch could serve as a base that includes both.

**Merge order:** #1308 → #1309 → this PR. Once both land in `main`, I'll retarget this PR at `main`; the base branch is scaffolding and should not be merged on its own.

The one non-trivial integration point: #1308 *skipped* the social-media drawer e2e tests (the drawer was unreachable from the UI), while #1309 *deletes* that drawer outright. Resolved in favour of deletion — the skipped tests target a component that no longer exists.

## Data source

Reuses the existing Health Metrics training-certification endpoint rather than adding a new one, so the Education card and the Health Metrics card cannot disagree on enrollment or revenue figures.

`ANALYTICS.PLATINUM.ENROLLMENTS` is a pre-aggregated wide table with the reporting range baked into column names and **no date column**, so no monthly grain exists. The sparkline is deliberately flat and the subtitle names the range instead of implying a trend.

**Net revenue excludes edX**, which contributes enrollments but carries no revenue column upstream. In the drawer's format breakdown, edX revenue renders as "not tracked" (`null`) rather than `$0`, so "not measured" is never displayed as "earned nothing".

## Failure vs. zero

`getTrainingCertificationSummary()` converts HTTP errors into an all-zeros response — a contract the Health Metrics card depends on, so it is deliberately left unchanged. That would otherwise make a failed request indistinguishable from a foundation with no training, and both would silently hide the card.

Instead the call site maps that error shape (identified by an empty `projectId`, which the fallback hardcodes and a real row always populates) back to `undefined`. A failed request and a genuinely-zero foundation both suppress the card, but only real data can render it.

## Testing

- `yarn build` passes
- Verified in the browser at `/foundation/overview?project=tlf` against TLF: 100,430 enrollments, $361,936.90 net revenue
- E2E coverage added for the `ed-evo-education` card and the `education-drawer` open / stats / formats / close paths

LFXV2-2023