### PR TITLE
fix(profile): always show cla group name under my clas

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -76,7 +76,7 @@ SPDX-License-Identifier: MIT
                   <span class="truncate text-sm font-semibold text-slate-900" [attr.data-testid]="'agreement-project-' + agreement.id">
                     {{ agreement.projectName || agreement.claGroupName }}
                   </span>
-                  @if (agreement.projectName && agreement.claGroupName && agreement.claGroupName !== agreement.projectName) {
+                  @if (agreement.projectName && agreement.claGroupName) {
                     <span class="truncate text-xs text-slate-500" [attr.data-testid]="'agreement-cla-group-' + agreement.id">{{ agreement.claGroupName }}</span>
                   }
                 </div>


### PR DESCRIPTION
## Summary
- In `profile-clas.component.html`, show the CLA group subtitle whenever both `projectName` and `claGroupName` are present — removed the `claGroupName !== projectName` equality guard.
- Fixes [#1311](https://github.com/linuxfoundation/lfx-self-serve/issues/1311) — always show both names under My CLAs even when identical (CNCF/ONAP collide; O-RAN already showed both).

## Out of scope (intentionally)
- Primary line still uses `projectName || claGroupName`; only subtitle visibility changed.

## Test plan
- [ ] Open My CLAs for an account with a CLA where project name equals CLA group name (e.g. CNCF)
- [ ] Confirm the Project cell shows project name + CLA group subtitle