### PR TITLE
feat(profile): link My CLAs empty state to docs

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -33,7 +33,10 @@ SPDX-License-Identifier: MIT
       <lfx-empty-state
         icon="fa-light fa-file-signature"
         title="No CLAs on file yet"
-        subtitle="We haven't found any signed ICLAs or ECLAs for your linked identities." />
+        subtitle="We haven't found any signed ICLAs or ECLAs for your linked identities."
+        ctaLabel="Learn about My CLAs"
+        [ctaRoute]="['/docs', 'profile', 'my-clas']"
+        data-testid="my-clas-empty-state" />
     } @else {
       <lfx-table
         [value]="agreements()"


### PR DESCRIPTION
## Summary

- Wire the My CLAs empty-state CTA to the published docs article at `/docs/profile/my-clas`
- CTA label: **Learn about My CLAs** (uses existing `lfx-empty-state` `ctaRoute`)

Fixes #1181

Unblocked by #1304 (docs live at https://app.lfx.dev/docs/profile/my-clas).

## Test plan

- [ ] With a user that has zero matched CLAs, open Profile → My CLAs
- [ ] Confirm empty state shows **Learn about My CLAs**
- [ ] Click CTA → lands on `/docs/profile/my-clas` (not `/docs/not-found`)
- [ ] Deploy-preview: `https://ui-pr-<N>.dev.v2.cluster.linuxfound.info/profile/clas` (empty user) and `/docs/profile/my-clas`