### PR TITLE
feat(mktg-os): brand kit session-consumer persistence endpoint

### DIFF
--- a/apps/lfx-one/package.json
+++ b/apps/lfx-one/package.json
@@ -41,6 +41,7 @@
     "@angular/platform-server": "^20.3.15",
     "@angular/router": "^20.3.15",
     "@angular/ssr": "^20.3.13",
+    "@aws-sdk/client-s3": "^3.726.0",
     "@datadog/browser-rum": "6.25.4",
     "@fullcalendar/angular": "6.1.20",
     "@fullcalendar/core": "6.1.20",

--- a/apps/lfx-one/src/server/controllers/mktg-agents.controller.ts
+++ b/apps/lfx-one/src/server/controllers/mktg-agents.controller.ts
@@ -2,11 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import { MKTG_AGENTS } from '@lfx-one/shared/constants';
-import { MktgChatRequest, MktgChatResponse, MktgHistoryResponse } from '@lfx-one/shared/interfaces';
+import { BrandKitPersistReceipt, BrandKitPersistRequest, MktgChatRequest, MktgChatResponse, MktgHistoryResponse } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError, AuthorizationError, ServiceValidationError } from '../errors';
 import { getStringQueryParam } from '../helpers/validation.helper';
+import { BrandKitService } from '../services/brand-kit.service';
 import { GuildService } from '../services/guild.service';
 import { logger } from '../services/logger.service';
 import { getEffectiveSub } from '../utils/auth-helper';
@@ -14,6 +15,7 @@ import { createSessionOwnerToken, verifySessionOwnerToken } from '../utils/mktg-
 
 export class MktgAgentsController {
   private readonly guildService = new GuildService();
+  private readonly brandKitService = new BrandKitService();
 
   /**
    * POST /api/mktg-agents/chat
@@ -136,6 +138,58 @@ export class MktgAgentsController {
       logger.success(req, 'mktg_agents_history', startTime, { message_count: messages.length });
       const response: MktgHistoryResponse = { messages };
       res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * POST /api/mktg-agents/brand-kit/persist
+   * Validates the session's final Brand Kit envelope (contract
+   * brand-kit-output/v1) and persists the document to object storage.
+   * Only the session's creator may persist — same owner-token proof as
+   * posting a follow-up.
+   */
+  public async persistBrandKit(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { sessionId, ownerToken } = req.body as BrandKitPersistRequest;
+
+    const validSessionId = typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : undefined;
+    if (!validSessionId) {
+      next(
+        ServiceValidationError.forField('sessionId', 'sessionId is required and must be a non-empty string', {
+          operation: 'brand_kit_persist',
+          service: 'mktg_agents_controller',
+          path: req.path,
+        })
+      );
+      return;
+    }
+
+    const userId = getEffectiveSub(req);
+    if (!userId) {
+      next(
+        new AuthenticationError('Could not identify the requesting user.', {
+          operation: 'brand_kit_persist',
+          service: 'mktg_agents_controller',
+          path: req.path,
+        })
+      );
+      return;
+    }
+
+    if (!verifySessionOwnerToken(ownerToken, userId, validSessionId)) {
+      next(
+        new AuthorizationError('You do not have permission to persist this session.', { operation: 'brand_kit_persist', service: 'mktg_agents_controller' })
+      );
+      return;
+    }
+
+    const startTime = logger.startOperation(req, 'brand_kit_persist', {});
+
+    try {
+      const receipt: BrandKitPersistReceipt = await this.brandKitService.persistFromSession(req, validSessionId);
+      logger.success(req, 'brand_kit_persist', startTime, { s3_key: receipt.s3_key, version: receipt.version });
+      res.json(receipt);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/mktg-agents.controller.ts
+++ b/apps/lfx-one/src/server/controllers/mktg-agents.controller.ts
@@ -153,6 +153,9 @@ export class MktgAgentsController {
   public async persistBrandKit(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { sessionId, ownerToken } = req.body as BrandKitPersistRequest;
 
+    // Type-gate body fields — never rely on downstream defensive coercion.
+    const validOwnerToken = typeof ownerToken === 'string' && ownerToken ? ownerToken : undefined;
+
     const validSessionId = typeof sessionId === 'string' && sessionId.trim() ? sessionId.trim() : undefined;
     if (!validSessionId) {
       next(
@@ -177,7 +180,7 @@ export class MktgAgentsController {
       return;
     }
 
-    if (!verifySessionOwnerToken(ownerToken, userId, validSessionId)) {
+    if (!verifySessionOwnerToken(validOwnerToken, userId, validSessionId)) {
       next(
         new AuthorizationError('You do not have permission to persist this session.', { operation: 'brand_kit_persist', service: 'mktg_agents_controller' })
       );

--- a/apps/lfx-one/src/server/routes/mktg-agents.route.ts
+++ b/apps/lfx-one/src/server/routes/mktg-agents.route.ts
@@ -14,4 +14,7 @@ router.post('/chat', (req, res, next) => mktgAgentsController.chat(req, res, nex
 // GET /api/mktg-agents/history - fetch mapped session history
 router.get('/history', (req, res, next) => mktgAgentsController.history(req, res, next));
 
+// POST /api/mktg-agents/brand-kit/persist - validate + persist a session's final Brand Kit document
+router.post('/brand-kit/persist', (req, res, next) => mktgAgentsController.persistBrandKit(req, res, next));
+
 export default router;

--- a/apps/lfx-one/src/server/services/brand-kit.service.ts
+++ b/apps/lfx-one/src/server/services/brand-kit.service.ts
@@ -4,7 +4,7 @@
 import { BRAND_KIT_MAX_DOCUMENT_BYTES } from '@lfx-one/shared/constants';
 import { BrandKitEnvelope, BrandKitPersistReceipt } from '@lfx-one/shared/interfaces';
 import { buildBrandKitObjectKey, extractBrandKitEnvelopeCandidates, validateBrandKitEnvelope } from '@lfx-one/shared/utils';
-import { createHash } from 'crypto';
+import { createHash } from 'node:crypto';
 import { Request } from 'express';
 
 import { ServiceValidationError } from '../errors';
@@ -57,8 +57,8 @@ export class BrandKitService {
       });
     }
 
-    // Contract §3 step 4: size gate (defense in depth — also checked pre-hash
-    // by the shared validator on string length).
+    // Contract §3 step 4: size gate (defense in depth — also checked byte-accurately
+    // by the shared validator via TextEncoder).
     if (documentBytes.length > BRAND_KIT_MAX_DOCUMENT_BYTES) {
       throw ServiceValidationError.forField('document_markdown', 'Document exceeds the 20 MB object size cap.', {
         operation: 'brand_kit_persist',
@@ -90,9 +90,10 @@ export class BrandKitService {
   }
 
   /**
-   * Scan raw event payloads for envelope candidates and return the LAST one
-   * that passes the shared contract validation (later events supersede earlier
-   * drafts within a session).
+   * Scan raw event payloads (chronologically ordered by the Guild service)
+   * for envelope candidates and return the authoritative one: the highest
+   * `version` among valid candidates, with the latest occurrence winning ties
+   * (later events supersede earlier drafts within a session).
    */
   private findAuthoritativeEnvelope(req: Request, payloads: string[]): BrandKitEnvelope | null {
     let best: BrandKitEnvelope | null = null;
@@ -104,7 +105,9 @@ export class BrandKitService {
         candidateCount++;
         const result = validateBrandKitEnvelope(candidate);
         if (result.valid) {
-          best = candidate;
+          if (!best || candidate.version >= best.version) {
+            best = candidate;
+          }
         } else {
           invalidCount++;
           logger.debug(req, 'brand_kit_persist', 'Rejected envelope candidate', { errors: result.errors });

--- a/apps/lfx-one/src/server/services/brand-kit.service.ts
+++ b/apps/lfx-one/src/server/services/brand-kit.service.ts
@@ -1,0 +1,124 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { BRAND_KIT_MAX_DOCUMENT_BYTES } from '@lfx-one/shared/constants';
+import { BrandKitEnvelope, BrandKitPersistReceipt } from '@lfx-one/shared/interfaces';
+import { buildBrandKitObjectKey, extractBrandKitEnvelopeCandidates, validateBrandKitEnvelope } from '@lfx-one/shared/utils';
+import { createHash } from 'crypto';
+import { Request } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { logger } from './logger.service';
+import { GuildService } from './guild.service';
+import { ObjectStoreService } from './object-store.service';
+
+/**
+ * Brand Kit session-consumer — the BFF write path of dec-brand-kit-storage-v1.
+ *
+ * Scans a finished Guild session for the `finalize_brand_kit` tool-result
+ * envelope (the authoritative typed output per the live-smoke A3 verdict — the
+ * `__submit__`-ed text may be prose or abridged and is never trusted),
+ * validates it per contract §3, and persists the raw `document_markdown`
+ * bytes to versioned object storage under the content-addressed key
+ * `brand-kit/{project}/{content_sha256}.md`.
+ *
+ * v1 defers all graph writes: the returned receipt carries exactly the fields
+ * needed for later Artifact minting (wi-lfx-one-service-actor).
+ */
+export class BrandKitService {
+  private readonly guildService = new GuildService();
+  private readonly objectStore = new ObjectStoreService();
+
+  /**
+   * Validate + persist the final Brand Kit document of a Guild session.
+   * Throws ServiceValidationError when no valid envelope is found.
+   */
+  public async persistFromSession(req: Request, sessionId: string): Promise<BrandKitPersistReceipt> {
+    const payloads = await this.guildService.getRawEventPayloads(req, sessionId);
+
+    const envelope = this.findAuthoritativeEnvelope(req, payloads);
+    if (!envelope) {
+      throw ServiceValidationError.forField('sessionId', 'No valid Brand Kit output envelope was found in this session.', {
+        operation: 'brand_kit_persist',
+        service: 'brand_kit_service',
+        path: req.path,
+      });
+    }
+
+    // Contract §3 step 2: recompute the sha over the UTF-8 bytes and require
+    // equality — envelope integrity rests wholly on the BFF (A2/A3 verdicts).
+    const documentBytes = Buffer.from(envelope.document_markdown, 'utf8');
+    const recomputedSha = createHash('sha256').update(documentBytes).digest('hex');
+    if (recomputedSha !== envelope.content_sha256) {
+      throw ServiceValidationError.forField('content_sha256', 'Envelope content_sha256 does not match the document bytes.', {
+        operation: 'brand_kit_persist',
+        service: 'brand_kit_service',
+        path: req.path,
+      });
+    }
+
+    // Contract §3 step 4: size gate (defense in depth — also checked pre-hash
+    // by the shared validator on string length).
+    if (documentBytes.length > BRAND_KIT_MAX_DOCUMENT_BYTES) {
+      throw ServiceValidationError.forField('document_markdown', 'Document exceeds the 20 MB object size cap.', {
+        operation: 'brand_kit_persist',
+        service: 'brand_kit_service',
+        path: req.path,
+      });
+    }
+
+    // Contract §3 step 5: key derived from validated fields only.
+    const key = buildBrandKitObjectKey(envelope.project, recomputedSha);
+
+    const written = await this.objectStore.putObjectIfAbsent(req, key, documentBytes, 'text/markdown; charset=utf-8');
+
+    logger.info(req, 'brand_kit_persist', 'Brand Kit document persisted', {
+      key,
+      written,
+      project: envelope.project,
+      version: envelope.version,
+      intake_mode: envelope.intake.mode,
+    });
+
+    return {
+      s3_key: key,
+      content_sha256: recomputedSha,
+      project: envelope.project,
+      version: envelope.version,
+      intake_mode: envelope.intake.mode,
+    };
+  }
+
+  /**
+   * Scan raw event payloads for envelope candidates and return the LAST one
+   * that passes the shared contract validation (later events supersede earlier
+   * drafts within a session).
+   */
+  private findAuthoritativeEnvelope(req: Request, payloads: string[]): BrandKitEnvelope | null {
+    let best: BrandKitEnvelope | null = null;
+    let candidateCount = 0;
+    let invalidCount = 0;
+
+    for (const payload of payloads) {
+      for (const candidate of extractBrandKitEnvelopeCandidates(payload)) {
+        candidateCount++;
+        const result = validateBrandKitEnvelope(candidate);
+        if (result.valid) {
+          best = candidate;
+        } else {
+          invalidCount++;
+          logger.debug(req, 'brand_kit_persist', 'Rejected envelope candidate', { errors: result.errors });
+        }
+      }
+    }
+
+    logger.debug(req, 'brand_kit_persist', 'Envelope scan complete', {
+      events: payloads.length,
+      candidates: candidateCount,
+      invalid: invalidCount,
+      found: !!best,
+    });
+
+    return best;
+  }
+}

--- a/apps/lfx-one/src/server/services/guild.service.ts
+++ b/apps/lfx-one/src/server/services/guild.service.ts
@@ -154,8 +154,21 @@ export class GuildService {
     const response = await this.fetchGuild(path, { method: 'GET' }, 'guild_get_raw_events');
     await this.assertOk(response, 'guild_get_raw_events', path);
 
-    const data = (await response.json()) as { items?: unknown[] };
-    return (data.items || []).map((item) => JSON.stringify(item));
+    const data = (await response.json()) as { items?: { created_at?: string }[] };
+    const items = data.items || [];
+
+    // Last-valid-wins selection downstream depends on chronological order —
+    // normalize it here instead of trusting the API's ordering.
+    const sorted = [...items].sort((a, b) => toEpoch(a?.created_at || '') - toEpoch(b?.created_at || ''));
+
+    // Truncation guard: a full page means the session may have more events than
+    // the cap, so the terminal envelope could be missing (or a stale draft could
+    // win). Surface it loudly; pagination is a follow-up if real sessions hit it.
+    if (items.length >= GUILD_RAW_EVENTS_LIMIT) {
+      logger.warning(req, 'guild_get_raw_events', 'Raw event page is full — session may be truncated', { count: items.length, limit: GUILD_RAW_EVENTS_LIMIT });
+    }
+
+    return sorted.map((item) => JSON.stringify(item));
   }
 
   /**

--- a/apps/lfx-one/src/server/services/guild.service.ts
+++ b/apps/lfx-one/src/server/services/guild.service.ts
@@ -22,6 +22,11 @@ const GUILD_EVENT_TYPES = 'trigger_message,agent_notification_message,user_messa
 // per-viewer timestamp localization deferred to LFXAI-99.
 const GUILD_HISTORY_LIMIT = 100;
 
+// Max raw events fetched when scanning a session for the Brand Kit output
+// envelope. Raw mode includes system events (llm_start/llm_done, task events),
+// which are far chattier than chat history — hence the higher cap.
+const GUILD_RAW_EVENTS_LIMIT = 500;
+
 // Leading `@mention` prefix — matches an @handle followed by whitespace OR the
 // end of the string, so a mention-only message (e.g. `@foo`) is stripped too.
 const MENTION_PREFIX_RE = /^@[a-zA-Z0-9_-]+(?:\s+|$)/;
@@ -127,6 +132,30 @@ export class GuildService {
       .filter((entry): entry is { message: MktgChatMessage; createdAt: string } => entry !== null)
       .sort((a, b) => toEpoch(a.createdAt) - toEpoch(b.createdAt))
       .map((entry) => entry.message);
+  }
+
+  /**
+   * Fetch a session's raw events with NO type filter, as opaque JSON payloads.
+   *
+   * Used by the Brand Kit session-consumer: per the live-smoke A3 verdict the
+   * authoritative typed output is the `finalize_brand_kit` tool RESULT, which
+   * rides system events (`llm_start`/`llm_done` stream bodies, task events)
+   * that the filtered history path drops. Callers scan the serialized payloads
+   * for the contract envelope; this method makes no shape assumptions beyond
+   * `{ items: [...] }`.
+   */
+  public async getRawEventPayloads(req: Request, sessionId: string): Promise<string[]> {
+    this.assertConfigured('guild_get_raw_events');
+
+    const path = `/api/sessions/${encodeURIComponent(sessionId)}/events?limit=${GUILD_RAW_EVENTS_LIMIT}`;
+
+    logger.debug(req, 'guild_get_raw_events', 'Fetching raw Guild session events', {});
+
+    const response = await this.fetchGuild(path, { method: 'GET' }, 'guild_get_raw_events');
+    await this.assertOk(response, 'guild_get_raw_events', path);
+
+    const data = (await response.json()) as { items?: unknown[] };
+    return (data.items || []).map((item) => JSON.stringify(item));
   }
 
   /**

--- a/apps/lfx-one/src/server/services/object-store.service.ts
+++ b/apps/lfx-one/src/server/services/object-store.service.ts
@@ -25,6 +25,10 @@ export class ObjectStoreService {
    * sha-addressed content by construction), the write is skipped and reported
    * as a no-op success per the content-addressing contract.
    *
+   * Note: HEAD-then-PUT is racy under concurrency, but the race is benign by
+   * construction — the key is content-addressed, so concurrent writers PUT
+   * identical bytes and the last write is indistinguishable from the first.
+   *
    * @returns true when a new object was written, false when it already existed.
    */
   public async putObjectIfAbsent(req: Request, key: string, body: Buffer, contentType: string): Promise<boolean> {
@@ -82,11 +86,13 @@ export class ObjectStoreService {
   }
 
   private wrap(error: unknown, operation: string, key: string): MicroserviceError {
+    // Preserve non-Error throws (theoretical with AWS SDK v3, but never drop diagnostics).
+    const original = error instanceof Error ? error : new Error(`Non-Error thrown by object store client: ${JSON.stringify(error)}`);
     return new MicroserviceError('Object storage request failed.', 502, 'object_store_error', {
       service: 'object_store',
       path: key,
       operation,
-      originalError: error instanceof Error ? error : undefined,
+      originalError: original,
     });
   }
 }

--- a/apps/lfx-one/src/server/services/object-store.service.ts
+++ b/apps/lfx-one/src/server/services/object-store.service.ts
@@ -1,0 +1,92 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HeadObjectCommand, NotFound, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
+import { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { logger } from './logger.service';
+
+/**
+ * Thin S3-compatible object-store client following the LFX object-store
+ * design contract (`S3_BUCKET`/`AWS_REGION`/`S3_ENDPOINT_URL` env vars):
+ *
+ * - AWS SDK default credential chain — static env creds locally (MinIO),
+ *   IRSA in deployed environments; no credential-mode branching in code.
+ * - `S3_ENDPOINT_URL` set → endpoint override + path-style addressing
+ *   (required by MinIO/nats-s3); empty → real AWS S3.
+ * - No bucket creation: buckets are provisioned ahead of time.
+ */
+export class ObjectStoreService {
+  private client: S3Client | null = null;
+
+  /**
+   * Idempotent, content-addressed write. When the key already exists (same
+   * sha-addressed content by construction), the write is skipped and reported
+   * as a no-op success per the content-addressing contract.
+   *
+   * @returns true when a new object was written, false when it already existed.
+   */
+  public async putObjectIfAbsent(req: Request, key: string, body: Buffer, contentType: string): Promise<boolean> {
+    const bucket = this.getBucket();
+    const client = this.getClient();
+
+    try {
+      await client.send(new HeadObjectCommand({ Bucket: bucket, Key: key }));
+      logger.info(req, 'object_store_put', 'Object already exists — content-addressed no-op', { key });
+      return false;
+    } catch (error) {
+      if (!this.isNotFound(error)) {
+        throw this.wrap(error, 'object_store_head', key);
+      }
+    }
+
+    try {
+      await client.send(new PutObjectCommand({ Bucket: bucket, Key: key, Body: body, ContentType: contentType }));
+      logger.info(req, 'object_store_put', 'Object written', { key, bytes: body.length });
+      return true;
+    } catch (error) {
+      throw this.wrap(error, 'object_store_put', key);
+    }
+  }
+
+  /** Lazily construct the S3 client so env is read at first use, not import time. */
+  private getClient(): S3Client {
+    if (!this.client) {
+      const endpoint = process.env['S3_ENDPOINT_URL'] || '';
+      this.client = new S3Client({
+        region: process.env['AWS_REGION'] || 'us-east-1',
+        ...(endpoint ? { endpoint, forcePathStyle: true } : {}),
+      });
+    }
+    return this.client;
+  }
+
+  private getBucket(): string {
+    const bucket = process.env['S3_BUCKET'] || '';
+    if (!bucket) {
+      throw new MicroserviceError('Object storage is not configured. Missing environment variable: S3_BUCKET.', 500, 'object_store_not_configured', {
+        service: 'object_store',
+        operation: 'object_store_config',
+      });
+    }
+    return bucket;
+  }
+
+  private isNotFound(error: unknown): boolean {
+    if (error instanceof NotFound) {
+      return true;
+    }
+    const status = (error as { $metadata?: { httpStatusCode?: number } })?.$metadata?.httpStatusCode;
+    return status === 404;
+  }
+
+  private wrap(error: unknown, operation: string, key: string): MicroserviceError {
+    return new MicroserviceError('Object storage request failed.', 502, 'object_store_error', {
+      service: 'object_store',
+      path: key,
+      operation,
+      originalError: error instanceof Error ? error : undefined,
+    });
+  }
+}

--- a/apps/lfx-one/src/server/services/object-store.service.ts
+++ b/apps/lfx-one/src/server/services/object-store.service.ts
@@ -87,12 +87,21 @@ export class ObjectStoreService {
 
   private wrap(error: unknown, operation: string, key: string): MicroserviceError {
     // Preserve non-Error throws (theoretical with AWS SDK v3, but never drop diagnostics).
-    const original = error instanceof Error ? error : new Error(`Non-Error thrown by object store client: ${JSON.stringify(error)}`);
+    const original = error instanceof Error ? error : new Error(`Non-Error thrown by object store client: ${safeStringify(error)}`);
     return new MicroserviceError('Object storage request failed.', 502, 'object_store_error', {
       service: 'object_store',
       path: key,
       operation,
       originalError: original,
     });
+  }
+}
+
+/** Stringify defensively — JSON.stringify throws on circular values and yields undefined for symbols/functions. */
+function safeStringify(value: unknown): string {
+  try {
+    return JSON.stringify(value) ?? String(value);
+  } catch {
+    return String(value);
   }
 }

--- a/packages/shared/src/constants/brand-kit.constants.ts
+++ b/packages/shared/src/constants/brand-kit.constants.ts
@@ -50,7 +50,7 @@ export const BRAND_KIT_INTAKE_ANSWER_COUNT = 7;
 /** Minimum document length (chars) per the contract schema. */
 export const BRAND_KIT_MIN_DOCUMENT_LENGTH = 1000;
 
-/** ISO-8601 timestamp shape gate (date-time with time part; offset or Z). */
+/** ISO-8601 timestamp shape gate: date + time part required; offset/Z optional (shape gate, not a UTC enforcer). */
 export const BRAND_KIT_ISO_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/;
 
 /** Max recursion depth when scanning event payloads for envelope candidates. */

--- a/packages/shared/src/constants/brand-kit.constants.ts
+++ b/packages/shared/src/constants/brand-kit.constants.ts
@@ -1,0 +1,51 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Brand Kit persistence constants (brand-kit-output/v1) — shared between the
+// BFF session-consumer validation gates and tests. Mirrors the normative
+// contract in marketing-os-agents docs/contracts/brand-kit-output.md §1/§3.
+
+/** Contract discriminator the BFF accepts; unknown majors are rejected. */
+export const BRAND_KIT_CONTRACT_ID = 'brand-kit-output/v1';
+
+/** Document kind within the contract. */
+export const BRAND_KIT_KIND = 'brand-kit';
+
+/** Object key prefix — full key is `brand-kit/{project}/{content_sha256}.md`. */
+export const BRAND_KIT_KEY_PREFIX = 'brand-kit';
+
+/** Hard per-object size cap (bytes) per the LFX object-store design (20 MB). */
+export const BRAND_KIT_MAX_DOCUMENT_BYTES = 20 * 1024 * 1024;
+
+/** Project slug pattern (lowercase kebab-case, ≤64 chars) from the contract schema. */
+export const BRAND_KIT_PROJECT_SLUG_REGEX = /^[a-z0-9](?:[a-z0-9-]{0,62}[a-z0-9])?$/;
+
+/** Lowercase hex SHA-256 pattern. */
+export const BRAND_KIT_SHA256_REGEX = /^[0-9a-f]{64}$/;
+
+/**
+ * The 12-heading structural presence gate (contract §1): document_markdown
+ * must contain each of these level-2 headings, in order. Matching is
+ * "starts with" per heading line, so trailing qualifiers the template allows
+ * do not fail the gate.
+ */
+export const BRAND_KIT_REQUIRED_HEADINGS = [
+  '## How to Use This Document',
+  '## 1. Project Definition',
+  '## 2. Positioning',
+  '## 3. Brand Personality & Voice',
+  '## 4. Primary Audiences & Messaging',
+  '## 5. Key Brand Strengths',
+  '## 6. Competitive Differentiation & Guardrails',
+  '## 7. Visual Identity',
+  '## 8. Tagline Options',
+  '## 9. Channel Quick Reference',
+  '## Appendix A: Document Architecture',
+  '## Appendix B: Source Intake',
+] as const;
+
+/** Exact number of intake answers the contract requires. */
+export const BRAND_KIT_INTAKE_ANSWER_COUNT = 7;
+
+/** Minimum document length (chars) per the contract schema. */
+export const BRAND_KIT_MIN_DOCUMENT_LENGTH = 1000;

--- a/packages/shared/src/constants/brand-kit.constants.ts
+++ b/packages/shared/src/constants/brand-kit.constants.ts
@@ -49,3 +49,9 @@ export const BRAND_KIT_INTAKE_ANSWER_COUNT = 7;
 
 /** Minimum document length (chars) per the contract schema. */
 export const BRAND_KIT_MIN_DOCUMENT_LENGTH = 1000;
+
+/** ISO-8601 timestamp shape gate (date-time with time part; offset or Z). */
+export const BRAND_KIT_ISO_TIMESTAMP_REGEX = /^\d{4}-\d{2}-\d{2}[Tt ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?(?:[Zz]|[+-]\d{2}:?\d{2})?$/;
+
+/** Max recursion depth when scanning event payloads for envelope candidates. */
+export const BRAND_KIT_EXTRACTION_MAX_DEPTH = 16;

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -92,3 +92,4 @@ export * from './writer-grants.constants';
 export * from './http-retry.constants';
 export * from './committee-engagement.constants';
 export * from './weekly-brief.constants';
+export * from './brand-kit.constants';

--- a/packages/shared/src/interfaces/brand-kit.interface.ts
+++ b/packages/shared/src/interfaces/brand-kit.interface.ts
@@ -1,0 +1,102 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Brand Kit output envelope contract (brand-kit-output/v1) shared between the
+// Express BFF session-consumer and any future Angular surfaces. Transcribed
+// from marketing-os-agents docs/contracts/brand-kit-output.schema.json — the
+// JSON Schema file is normative; this must stay in sync (reviewed at PR).
+
+/** One verbatim intake Q/A pair (Paul's fixed 7-question order). */
+export interface BrandKitIntakeAnswer {
+  /** Question position, 1–7. */
+  question_number: number;
+  /** The intake question text as asked (verbatim). */
+  question: string;
+  /** The user's answer, verbatim and untranslated. */
+  answer: string;
+}
+
+/** Machine-readable log of the 7-question intake. */
+export interface BrandKitIntake {
+  /** How the 7 answers were collected. */
+  mode: 'form' | 'conversational';
+  /** ISO-8601 UTC timestamp when intake completed. */
+  completed_at: string;
+  /** Exactly 7 entries, in Paul's fixed question order. */
+  answers: BrandKitIntakeAnswer[];
+}
+
+/** Producer provenance, filled by the agent wrapper. */
+export interface BrandKitAgentProvenance {
+  /** Guild agent identifier (owner~name). */
+  identifier?: string;
+  /** Published Guild agent version that produced the document (semver). */
+  agent_version?: string;
+  /** SHA-256 of the FIDELITY-MANIFEST.sha256 the prompt substance verified against. */
+  prompt_manifest_sha256?: string;
+}
+
+/**
+ * The Brand Kit output envelope — the typed output of the
+ * linux-foundation~brand-kit agent and the exact payload the BFF validates
+ * before persisting (dec-brand-kit-storage-v1).
+ */
+export interface BrandKitEnvelope {
+  /** Contract discriminator + version; consumers reject unknown majors. */
+  contract: string;
+  /** Document kind — always 'brand-kit' for this contract. */
+  kind: string;
+  /** Project slug — storage partition (lowercase kebab-case). */
+  project: string;
+  /** The project's display name exactly as given in intake Q1. */
+  project_name?: string;
+  /** Document draft version within a session lifecycle, starting at 1. */
+  version: number;
+  /** The complete Brand Kit document in Markdown (Paul's template verbatim-structured). */
+  document_markdown: string;
+  /** Lowercase hex SHA-256 of the UTF-8 bytes of document_markdown. */
+  content_sha256: string;
+  /** Verbatim intake log. */
+  intake: BrandKitIntake;
+  /** ISO-8601 UTC timestamp when this draft was emitted. */
+  generated_at?: string;
+  /** Producer provenance. */
+  agent?: BrandKitAgentProvenance;
+}
+
+/**
+ * Persistence receipt returned by `POST /api/mktg-agents/brand-kit/persist`.
+ * Carries exactly the fields needed for later Artifact minting in ai-brain
+ * (deferred to wi-lfx-one-service-actor — the BFF writes no graph rows in v1).
+ */
+export interface BrandKitPersistReceipt {
+  /** Content-addressed object key: brand-kit/{project}/{content_sha256}.md. */
+  s3_key: string;
+  /** Validated + recomputed document SHA-256. */
+  content_sha256: string;
+  /** Project slug (storage partition). */
+  project: string;
+  /** Document draft version from the envelope. */
+  version: number;
+  /** How the intake answers were collected. */
+  intake_mode: 'form' | 'conversational';
+}
+
+/** Request body for `POST /api/mktg-agents/brand-kit/persist`. */
+export interface BrandKitPersistRequest {
+  /** Guild session id whose terminal output should be persisted. */
+  sessionId: string;
+  /**
+   * Opaque owner token from the session-create response — the same
+   * creator-binding proof required for follow-up posts.
+   */
+  ownerToken: string;
+}
+
+/** Structured result of validating a candidate envelope. */
+export interface BrandKitValidationResult {
+  /** True when every gate passed. */
+  valid: boolean;
+  /** Machine-readable failure reasons (empty when valid). */
+  errors: string[];
+}

--- a/packages/shared/src/interfaces/brand-kit.interface.ts
+++ b/packages/shared/src/interfaces/brand-kit.interface.ts
@@ -16,10 +16,13 @@ export interface BrandKitIntakeAnswer {
   answer: string;
 }
 
+/** How the intake answers were collected. */
+export type BrandKitIntakeMode = 'form' | 'conversational';
+
 /** Machine-readable log of the 7-question intake. */
 export interface BrandKitIntake {
   /** How the 7 answers were collected. */
-  mode: 'form' | 'conversational';
+  mode: BrandKitIntakeMode;
   /** ISO-8601 UTC timestamp when intake completed. */
   completed_at: string;
   /** Exactly 7 entries, in Paul's fixed question order. */
@@ -79,7 +82,7 @@ export interface BrandKitPersistReceipt {
   /** Document draft version from the envelope. */
   version: number;
   /** How the intake answers were collected. */
-  intake_mode: 'form' | 'conversational';
+  intake_mode: BrandKitIntakeMode;
 }
 
 /** Request body for `POST /api/mktg-agents/brand-kit/persist`. */

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -301,3 +301,6 @@ export * from './committee-engagement.internal.interface';
 
 // Weekly Brief interfaces
 export * from './weekly-brief.interface';
+
+// Brand Kit persistence contract interfaces
+export * from './brand-kit.interface';

--- a/packages/shared/src/utils/brand-kit.utils.spec.ts
+++ b/packages/shared/src/utils/brand-kit.utils.spec.ts
@@ -113,6 +113,21 @@ describe('validateBrandKitEnvelope', () => {
     (badMode.intake as { mode: string }).mode = 'batch';
     expect(validateBrandKitEnvelope(badMode).valid).toBe(false);
   });
+
+  it('rejects out-of-order or duplicated intake question numbers', () => {
+    const dupes = buildEnvelope();
+    dupes.intake.answers = dupes.intake.answers.map((a) => ({ ...a, question_number: 1 }));
+    expect(validateBrandKitEnvelope(dupes).valid).toBe(false);
+  });
+
+  it('rejects non-ISO completed_at strings that Date() would accept', () => {
+    const loose = buildEnvelope();
+    loose.intake.completed_at = 'Aug 5 2026';
+    expect(validateBrandKitEnvelope(loose).valid).toBe(false);
+    const slash = buildEnvelope();
+    slash.intake.completed_at = '08/05/2026';
+    expect(validateBrandKitEnvelope(slash).valid).toBe(false);
+  });
 });
 
 describe('findMissingBrandKitHeadings', () => {

--- a/packages/shared/src/utils/brand-kit.utils.spec.ts
+++ b/packages/shared/src/utils/brand-kit.utils.spec.ts
@@ -1,0 +1,170 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Unit tests for the Brand Kit envelope validation + extraction helpers
+// (brand-kit-output/v1, wi-brand-kit-bff-persist).
+//
+// The fixture is fully synthetic: a schema-valid envelope with all 12 required
+// headings and a correct content_sha256 computed at test time. Never real data.
+
+import { createHash } from 'node:crypto';
+import { describe, expect, it } from 'vitest';
+
+import { BRAND_KIT_CONTRACT_ID, BRAND_KIT_REQUIRED_HEADINGS } from '../constants/brand-kit.constants';
+import { BrandKitEnvelope } from '../interfaces/brand-kit.interface';
+import { buildBrandKitObjectKey, extractBrandKitEnvelopeCandidates, findMissingBrandKitHeadings, validateBrandKitEnvelope } from './brand-kit.utils';
+
+/** Build a structurally valid document containing every required heading, padded past the 1000-char floor. */
+function buildDocument(): string {
+  const filler = 'Synthetic fixture prose for the Brand Kit structural gate. '.repeat(4);
+  const sections = ['# TestOrbit Brand Kit', '', '| Field | Value |', '| --- | --- |', '| Project | TestOrbit |', ''];
+  for (const heading of BRAND_KIT_REQUIRED_HEADINGS) {
+    sections.push(heading, '', filler, '');
+  }
+  return sections.join('\n');
+}
+
+function sha256(value: string): string {
+  return createHash('sha256').update(value, 'utf8').digest('hex');
+}
+
+function buildEnvelope(overrides: Partial<BrandKitEnvelope> = {}): BrandKitEnvelope {
+  const document = buildDocument();
+  return {
+    contract: BRAND_KIT_CONTRACT_ID,
+    kind: 'brand-kit',
+    project: 'testorbit',
+    project_name: 'TestOrbit',
+    version: 1,
+    document_markdown: document,
+    content_sha256: sha256(document),
+    intake: {
+      mode: 'form',
+      completed_at: '2026-08-05T00:00:00Z',
+      answers: Array.from({ length: 7 }, (_, i) => ({
+        question_number: i + 1,
+        question: `Synthetic question ${i + 1}?`,
+        answer: `Synthetic answer ${i + 1}.`,
+      })),
+    },
+    generated_at: '2026-08-05T00:00:01Z',
+    agent: {
+      identifier: 'linux-foundation~brand-kit',
+      agent_version: '1.0.14',
+      prompt_manifest_sha256: 'a'.repeat(64),
+    },
+    ...overrides,
+  };
+}
+
+describe('validateBrandKitEnvelope', () => {
+  it('accepts a fully valid envelope', () => {
+    const result = validateBrandKitEnvelope(buildEnvelope());
+    expect(result.errors).toEqual([]);
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects an unknown contract major', () => {
+    const result = validateBrandKitEnvelope(buildEnvelope({ contract: 'brand-kit-output/v2' }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('contract');
+  });
+
+  it('rejects a non-object payload', () => {
+    expect(validateBrandKitEnvelope('nope').valid).toBe(false);
+    expect(validateBrandKitEnvelope(null).valid).toBe(false);
+    expect(validateBrandKitEnvelope([buildEnvelope()]).valid).toBe(false);
+  });
+
+  it('rejects a document missing a required heading', () => {
+    const doc = buildDocument().replace('## 5. Key Brand Strengths', '## 5. Renamed Section');
+    const result = validateBrandKitEnvelope(buildEnvelope({ document_markdown: doc, content_sha256: sha256(doc) }));
+    expect(result.valid).toBe(false);
+    expect(result.errors.join(' ')).toContain('## 5. Key Brand Strengths');
+  });
+
+  it('rejects out-of-order headings', () => {
+    const doc = buildDocument();
+    const reordered = doc
+      .replace('## 2. Positioning', '## TMP')
+      .replace('## 9. Channel Quick Reference', '## 2. Positioning')
+      .replace('## TMP', '## 9. Channel Quick Reference');
+    const result = validateBrandKitEnvelope(buildEnvelope({ document_markdown: reordered, content_sha256: sha256(reordered) }));
+    expect(result.valid).toBe(false);
+  });
+
+  it('accepts headings with trailing qualifiers', () => {
+    const doc = buildDocument().replace('## 8. Tagline Options', '## 8. Tagline Options (Starter Set)');
+    const result = validateBrandKitEnvelope(buildEnvelope({ document_markdown: doc, content_sha256: sha256(doc) }));
+    expect(result.valid).toBe(true);
+  });
+
+  it('rejects a malformed sha and a bad slug', () => {
+    expect(validateBrandKitEnvelope(buildEnvelope({ content_sha256: 'XYZ' })).valid).toBe(false);
+    expect(validateBrandKitEnvelope(buildEnvelope({ project: 'Bad_Slug' })).valid).toBe(false);
+  });
+
+  it('rejects a short document and wrong intake shapes', () => {
+    expect(validateBrandKitEnvelope(buildEnvelope({ document_markdown: '## short' })).valid).toBe(false);
+    const badIntake = buildEnvelope();
+    badIntake.intake.answers = badIntake.intake.answers.slice(0, 6);
+    expect(validateBrandKitEnvelope(badIntake).valid).toBe(false);
+    const badMode = buildEnvelope();
+    (badMode.intake as { mode: string }).mode = 'batch';
+    expect(validateBrandKitEnvelope(badMode).valid).toBe(false);
+  });
+});
+
+describe('findMissingBrandKitHeadings', () => {
+  it('returns empty for a complete document and lists gaps otherwise', () => {
+    expect(findMissingBrandKitHeadings(buildDocument())).toEqual([]);
+    expect(findMissingBrandKitHeadings('# nothing here')).toHaveLength(BRAND_KIT_REQUIRED_HEADINGS.length);
+  });
+});
+
+describe('buildBrandKitObjectKey', () => {
+  it('derives the content-addressed key from validated fields', () => {
+    const sha = sha256('doc');
+    expect(buildBrandKitObjectKey('testorbit', sha)).toBe(`brand-kit/testorbit/${sha}.md`);
+  });
+
+  it('throws on unvalidated inputs (never client-supplied paths)', () => {
+    expect(() => buildBrandKitObjectKey('../escape', 'a'.repeat(64))).toThrow();
+    expect(() => buildBrandKitObjectKey('ok-slug', 'not-a-sha')).toThrow();
+  });
+});
+
+describe('extractBrandKitEnvelopeCandidates', () => {
+  it('extracts a direct JSON envelope', () => {
+    const envelope = buildEnvelope();
+    const found = extractBrandKitEnvelopeCandidates(JSON.stringify(envelope));
+    expect(found).toHaveLength(1);
+    expect(found[0].content_sha256).toBe(envelope.content_sha256);
+  });
+
+  it('extracts a tool-result envelope_json double-encoding (the A3 authoritative path)', () => {
+    const envelope = buildEnvelope();
+    const toolResult = JSON.stringify({ envelope_json: JSON.stringify(envelope) });
+    const found = extractBrandKitEnvelopeCandidates(toolResult);
+    expect(found).toHaveLength(1);
+    expect(found[0].project).toBe('testorbit');
+  });
+
+  it('extracts an envelope embedded in a non-JSON stream body', () => {
+    const envelope = buildEnvelope();
+    const payload = `llm stream noise... tool_result: ${JSON.stringify(envelope)} ...trailing`;
+    const found = extractBrandKitEnvelopeCandidates(payload);
+    expect(found).toHaveLength(1);
+  });
+
+  it('extracts from nested wrapper shapes', () => {
+    const envelope = buildEnvelope();
+    const wrapped = JSON.stringify({ content: { type: 'text', data: JSON.stringify({ envelope_json: JSON.stringify(envelope) }) } });
+    expect(extractBrandKitEnvelopeCandidates(wrapped)).toHaveLength(1);
+  });
+
+  it('returns empty when the discriminator is absent or malformed', () => {
+    expect(extractBrandKitEnvelopeCandidates('no envelopes here')).toEqual([]);
+    expect(extractBrandKitEnvelopeCandidates(`prose mentioning ${BRAND_KIT_CONTRACT_ID} without JSON`)).toEqual([]);
+  });
+});

--- a/packages/shared/src/utils/brand-kit.utils.ts
+++ b/packages/shared/src/utils/brand-kit.utils.ts
@@ -8,7 +8,9 @@
 
 import {
   BRAND_KIT_CONTRACT_ID,
+  BRAND_KIT_EXTRACTION_MAX_DEPTH,
   BRAND_KIT_INTAKE_ANSWER_COUNT,
+  BRAND_KIT_ISO_TIMESTAMP_REGEX,
   BRAND_KIT_KEY_PREFIX,
   BRAND_KIT_KIND,
   BRAND_KIT_MAX_DOCUMENT_BYTES,
@@ -69,15 +71,16 @@ export function validateBrandKitEnvelope(candidate: unknown): BrandKitValidation
     if (intake.mode !== 'form' && intake.mode !== 'conversational') {
       errors.push('intake.mode must be "form" or "conversational"');
     }
-    if (typeof intake.completed_at !== 'string' || Number.isNaN(new Date(intake.completed_at).getTime())) {
+    if (typeof intake.completed_at !== 'string' || !BRAND_KIT_ISO_TIMESTAMP_REGEX.test(intake.completed_at) || Number.isNaN(new Date(intake.completed_at).getTime())) {
       errors.push('intake.completed_at must be an ISO-8601 timestamp');
     }
     if (!Array.isArray(intake.answers) || intake.answers.length !== BRAND_KIT_INTAKE_ANSWER_COUNT) {
       errors.push(`intake.answers must contain exactly ${BRAND_KIT_INTAKE_ANSWER_COUNT} entries`);
     } else {
       intake.answers.forEach((entry, index) => {
-        const positionOk =
-          typeof entry?.question_number === 'number' && Number.isInteger(entry.question_number) && entry.question_number >= 1 && entry.question_number <= 7;
+        // Contract: exactly 7 entries in Paul's fixed question order — the
+        // position field must match its index, closing duplicate/reordered logs.
+        const positionOk = entry?.question_number === index + 1;
         const textOk = typeof entry?.question === 'string' && entry.question.length > 0 && typeof entry?.answer === 'string' && entry.answer.length > 0;
         if (!positionOk || !textOk) {
           errors.push(`intake.answers[${index}] is malformed`);
@@ -143,12 +146,17 @@ export function extractBrandKitEnvelopeCandidates(payload: string): BrandKitEnve
 
   const candidates: BrandKitEnvelope[] = [];
 
-  const consider = (value: unknown): void => {
+  const consider = (value: unknown, depth: number): void => {
+    if (depth > BRAND_KIT_EXTRACTION_MAX_DEPTH) {
+      // Guard against pathological deeply-nested payloads; real Guild event
+      // wrappers are only a few levels deep.
+      return;
+    }
     if (typeof value === 'string') {
       // envelope_json double-encoding: a string that itself parses to an envelope.
       if (value.includes(BRAND_KIT_CONTRACT_ID)) {
         try {
-          consider(JSON.parse(value));
+          consider(JSON.parse(value), depth + 1);
         } catch {
           // Not valid JSON — scan it for embedded objects instead.
           candidates.push(...scanForEnvelopeObjects(value));
@@ -165,19 +173,21 @@ export function extractBrandKitEnvelopeCandidates(payload: string): BrandKitEnve
       return;
     }
     if (typeof record['envelope_json'] === 'string') {
-      consider(record['envelope_json']);
+      consider(record['envelope_json'], depth + 1);
       return;
     }
-    // Recurse one level into common wrapper shapes ({content: ...}, {data: ...}, arrays).
+    // Recurse into wrapper shapes ({content: ...}, {data: ...}, arrays) — full
+    // depth up to the cap; only branches that can contain the contract id are
+    // followed (string branches are pre-filtered by the includes() check).
     for (const child of Object.values(record)) {
       if (child && (typeof child === 'object' || (typeof child === 'string' && child.includes(BRAND_KIT_CONTRACT_ID)))) {
-        consider(child);
+        consider(child, depth + 1);
       }
     }
   };
 
   try {
-    consider(JSON.parse(payload));
+    consider(JSON.parse(payload), 0);
   } catch {
     candidates.push(...scanForEnvelopeObjects(payload));
   }

--- a/packages/shared/src/utils/brand-kit.utils.ts
+++ b/packages/shared/src/utils/brand-kit.utils.ts
@@ -1,0 +1,261 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Pure Brand Kit envelope validation + extraction helpers (brand-kit-output/v1).
+// The SHA-256 recompute is deliberately NOT here: hashing is environment-specific
+// (node:crypto on the server) and the shared package stays platform-neutral.
+// Callers recompute the hash and compare against `envelope.content_sha256`.
+
+import {
+  BRAND_KIT_CONTRACT_ID,
+  BRAND_KIT_INTAKE_ANSWER_COUNT,
+  BRAND_KIT_KEY_PREFIX,
+  BRAND_KIT_KIND,
+  BRAND_KIT_MAX_DOCUMENT_BYTES,
+  BRAND_KIT_MIN_DOCUMENT_LENGTH,
+  BRAND_KIT_PROJECT_SLUG_REGEX,
+  BRAND_KIT_REQUIRED_HEADINGS,
+  BRAND_KIT_SHA256_REGEX,
+} from '../constants/brand-kit.constants';
+import { BrandKitEnvelope, BrandKitValidationResult } from '../interfaces/brand-kit.interface';
+
+/**
+ * Validate a candidate Brand Kit envelope against the v1 contract's schema
+ * gates and the 12-heading structural presence gate (contract §1 + §3 steps
+ * 1, 3, 4). Hash equality (step 2) is the caller's job — see module note.
+ */
+export function validateBrandKitEnvelope(candidate: unknown): BrandKitValidationResult {
+  const errors: string[] = [];
+
+  if (typeof candidate !== 'object' || candidate === null || Array.isArray(candidate)) {
+    return { valid: false, errors: ['envelope must be a JSON object'] };
+  }
+
+  const envelope = candidate as Partial<BrandKitEnvelope>;
+
+  if (envelope.contract !== BRAND_KIT_CONTRACT_ID) {
+    // Reject unknown contract majors outright — do not attempt to interpret them.
+    errors.push(`contract must be "${BRAND_KIT_CONTRACT_ID}" (got ${JSON.stringify(envelope.contract ?? null)})`);
+  }
+  if (envelope.kind !== BRAND_KIT_KIND) {
+    errors.push(`kind must be "${BRAND_KIT_KIND}"`);
+  }
+  if (typeof envelope.project !== 'string' || !BRAND_KIT_PROJECT_SLUG_REGEX.test(envelope.project)) {
+    errors.push('project must be a lowercase kebab-case slug');
+  }
+  if (typeof envelope.version !== 'number' || !Number.isInteger(envelope.version) || envelope.version < 1) {
+    errors.push('version must be an integer >= 1');
+  }
+  if (typeof envelope.content_sha256 !== 'string' || !BRAND_KIT_SHA256_REGEX.test(envelope.content_sha256)) {
+    errors.push('content_sha256 must be 64 lowercase hex characters');
+  }
+
+  if (typeof envelope.document_markdown !== 'string' || envelope.document_markdown.length < BRAND_KIT_MIN_DOCUMENT_LENGTH) {
+    errors.push(`document_markdown must be a string of at least ${BRAND_KIT_MIN_DOCUMENT_LENGTH} characters`);
+  } else {
+    const missing = findMissingBrandKitHeadings(envelope.document_markdown);
+    if (missing.length > 0) {
+      errors.push(`document_markdown is missing required headings (in order): ${missing.join(' | ')}`);
+    }
+    if (getUtf8ByteLength(envelope.document_markdown) > BRAND_KIT_MAX_DOCUMENT_BYTES) {
+      errors.push(`document_markdown exceeds the ${BRAND_KIT_MAX_DOCUMENT_BYTES}-byte object size cap`);
+    }
+  }
+
+  const intake = envelope.intake;
+  if (typeof intake !== 'object' || intake === null) {
+    errors.push('intake must be an object');
+  } else {
+    if (intake.mode !== 'form' && intake.mode !== 'conversational') {
+      errors.push('intake.mode must be "form" or "conversational"');
+    }
+    if (typeof intake.completed_at !== 'string' || Number.isNaN(new Date(intake.completed_at).getTime())) {
+      errors.push('intake.completed_at must be an ISO-8601 timestamp');
+    }
+    if (!Array.isArray(intake.answers) || intake.answers.length !== BRAND_KIT_INTAKE_ANSWER_COUNT) {
+      errors.push(`intake.answers must contain exactly ${BRAND_KIT_INTAKE_ANSWER_COUNT} entries`);
+    } else {
+      intake.answers.forEach((entry, index) => {
+        const positionOk =
+          typeof entry?.question_number === 'number' && Number.isInteger(entry.question_number) && entry.question_number >= 1 && entry.question_number <= 7;
+        const textOk = typeof entry?.question === 'string' && entry.question.length > 0 && typeof entry?.answer === 'string' && entry.answer.length > 0;
+        if (!positionOk || !textOk) {
+          errors.push(`intake.answers[${index}] is malformed`);
+        }
+      });
+    }
+  }
+
+  return { valid: errors.length === 0, errors };
+}
+
+/**
+ * Return the required headings missing from the document, enforcing order:
+ * each heading must appear (at the start of a line, prefix match) after the
+ * previous one. A heading found out of order counts as missing.
+ */
+export function findMissingBrandKitHeadings(documentMarkdown: string): string[] {
+  const lines = documentMarkdown.split('\n').map((line) => line.trimEnd());
+  const missing: string[] = [];
+  let cursor = 0;
+
+  for (const heading of BRAND_KIT_REQUIRED_HEADINGS) {
+    let found = -1;
+    for (let i = cursor; i < lines.length; i++) {
+      if (lines[i].startsWith(heading)) {
+        found = i;
+        break;
+      }
+    }
+    if (found === -1) {
+      missing.push(heading);
+    } else {
+      cursor = found + 1;
+    }
+  }
+
+  return missing;
+}
+
+/** Derive the content-addressed object key from validated fields only (contract §3.5). */
+export function buildBrandKitObjectKey(project: string, contentSha256: string): string {
+  if (!BRAND_KIT_PROJECT_SLUG_REGEX.test(project) || !BRAND_KIT_SHA256_REGEX.test(contentSha256)) {
+    throw new Error('buildBrandKitObjectKey requires already-validated project and content_sha256 values');
+  }
+  return `${BRAND_KIT_KEY_PREFIX}/${project}/${contentSha256}.md`;
+}
+
+/**
+ * Extract candidate Brand Kit envelopes from an arbitrary text payload.
+ *
+ * Per the live-smoke A3 verdict, the authoritative envelope is the
+ * `finalize_brand_kit` TOOL RESULT (`{ envelope_json: "..." }`) riding inside
+ * session event bodies — the `__submit__`-ed text may be prose or abridged.
+ * This helper therefore scans the payload for JSON objects that carry the
+ * contract discriminator, handling both direct envelopes and the
+ * `envelope_json` double-encoding, and returns every parse that succeeds.
+ * The caller validates each candidate and picks the last valid one.
+ */
+export function extractBrandKitEnvelopeCandidates(payload: string): BrandKitEnvelope[] {
+  if (!payload || !payload.includes(BRAND_KIT_CONTRACT_ID)) {
+    return [];
+  }
+
+  const candidates: BrandKitEnvelope[] = [];
+
+  const consider = (value: unknown): void => {
+    if (typeof value === 'string') {
+      // envelope_json double-encoding: a string that itself parses to an envelope.
+      if (value.includes(BRAND_KIT_CONTRACT_ID)) {
+        try {
+          consider(JSON.parse(value));
+        } catch {
+          // Not valid JSON — scan it for embedded objects instead.
+          candidates.push(...scanForEnvelopeObjects(value));
+        }
+      }
+      return;
+    }
+    if (typeof value !== 'object' || value === null) {
+      return;
+    }
+    const record = value as Record<string, unknown>;
+    if (record['contract'] === BRAND_KIT_CONTRACT_ID) {
+      candidates.push(record as unknown as BrandKitEnvelope);
+      return;
+    }
+    if (typeof record['envelope_json'] === 'string') {
+      consider(record['envelope_json']);
+      return;
+    }
+    // Recurse one level into common wrapper shapes ({content: ...}, {data: ...}, arrays).
+    for (const child of Object.values(record)) {
+      if (child && (typeof child === 'object' || (typeof child === 'string' && child.includes(BRAND_KIT_CONTRACT_ID)))) {
+        consider(child);
+      }
+    }
+  };
+
+  try {
+    consider(JSON.parse(payload));
+  } catch {
+    candidates.push(...scanForEnvelopeObjects(payload));
+  }
+
+  return candidates;
+}
+
+/**
+ * Scan free text for balanced `{...}` JSON objects containing the contract id
+ * and parse each. Used when the payload is not itself valid JSON (e.g. an LLM
+ * stream body with an embedded tool result).
+ */
+function scanForEnvelopeObjects(text: string): BrandKitEnvelope[] {
+  const found: BrandKitEnvelope[] = [];
+  let searchFrom = 0;
+
+  for (;;) {
+    const marker = text.indexOf(BRAND_KIT_CONTRACT_ID, searchFrom);
+    if (marker === -1) {
+      break;
+    }
+    // Walk back to the opening brace of the object containing the marker.
+    const start = text.lastIndexOf('{', marker);
+    if (start === -1) {
+      searchFrom = marker + 1;
+      continue;
+    }
+    const objectText = readBalancedObject(text, start);
+    if (objectText) {
+      try {
+        const parsed = JSON.parse(objectText) as Record<string, unknown>;
+        if (parsed['contract'] === BRAND_KIT_CONTRACT_ID) {
+          found.push(parsed as unknown as BrandKitEnvelope);
+        }
+      } catch {
+        // Malformed fragment — keep scanning.
+      }
+    }
+    searchFrom = marker + BRAND_KIT_CONTRACT_ID.length;
+  }
+
+  return found;
+}
+
+/** Read a balanced JSON object starting at `start` (must be `{`), string-aware. */
+function readBalancedObject(text: string, start: number): string | null {
+  let depth = 0;
+  let inString = false;
+  let escaped = false;
+
+  for (let i = start; i < text.length; i++) {
+    const ch = text[i];
+    if (inString) {
+      if (escaped) {
+        escaped = false;
+      } else if (ch === '\\') {
+        escaped = true;
+      } else if (ch === '"') {
+        inString = false;
+      }
+      continue;
+    }
+    if (ch === '"') {
+      inString = true;
+    } else if (ch === '{') {
+      depth++;
+    } else if (ch === '}') {
+      depth--;
+      if (depth === 0) {
+        return text.slice(start, i + 1);
+      }
+    }
+  }
+
+  return null;
+}
+
+/** UTF-8 byte length without assuming Buffer (browser-safe). */
+function getUtf8ByteLength(value: string): number {
+  return new TextEncoder().encode(value).length;
+}

--- a/packages/shared/src/utils/brand-kit.utils.ts
+++ b/packages/shared/src/utils/brand-kit.utils.ts
@@ -71,7 +71,11 @@ export function validateBrandKitEnvelope(candidate: unknown): BrandKitValidation
     if (intake.mode !== 'form' && intake.mode !== 'conversational') {
       errors.push('intake.mode must be "form" or "conversational"');
     }
-    if (typeof intake.completed_at !== 'string' || !BRAND_KIT_ISO_TIMESTAMP_REGEX.test(intake.completed_at) || Number.isNaN(new Date(intake.completed_at).getTime())) {
+    if (
+      typeof intake.completed_at !== 'string' ||
+      !BRAND_KIT_ISO_TIMESTAMP_REGEX.test(intake.completed_at) ||
+      Number.isNaN(new Date(intake.completed_at).getTime())
+    ) {
       errors.push('intake.completed_at must be an ISO-8601 timestamp');
     }
     if (!Array.isArray(intake.answers) || intake.answers.length !== BRAND_KIT_INTAKE_ANSWER_COUNT) {

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -52,3 +52,4 @@ export * from './cla-view.utils';
 export * from './committee-engagement-classifier.utils';
 export * from './committee-engagement-display.utils';
 export * from './committee-engagement-freshness.utils';
+export * from './brand-kit.utils';

--- a/yarn.lock
+++ b/yarn.lock
@@ -13502,6 +13502,7 @@ __metadata:
     "@angular/platform-server": "npm:^20.3.15"
     "@angular/router": "npm:^20.3.15"
     "@angular/ssr": "npm:^20.3.13"
+    "@aws-sdk/client-s3": "npm:^3.726.0"
     "@datadog/browser-rum": "npm:6.25.4"
     "@eslint/js": "npm:^9.39.1"
     "@fullcalendar/angular": "npm:6.1.20"


### PR DESCRIPTION
## Summary

Implements the BFF write path of **dec-brand-kit-storage-v1** (LFXV2-2059, WorkItem `wi-brand-kit-bff-persist`): `POST /api/mktg-agents/brand-kit/persist` validates a Guild session's final Brand Kit document against the `brand-kit-output/v1` contract and persists it to versioned object storage — the agent holds no credentials.

### What it does

1. **Fetches raw session events** (new `GuildService.getRawEventPayloads`, unfiltered, chronologically sorted). Per the live-smoke A3 verdict, the authoritative envelope is the `finalize_brand_kit` **tool result** riding system events — the `__submit__`-ed text may be prose or abridged and is never trusted.
2. **Extracts envelope candidates** (shared, fully unit-tested): direct JSON, `envelope_json` double-encoding, and balanced-object scanning of non-JSON stream bodies; recursion depth-capped; highest `version` wins, latest occurrence breaks ties.
3. **Validates per contract §3**: schema gates, 12-heading structural presence gate (in order), server-side SHA-256 recompute over the UTF-8 bytes (reject on mismatch), 20 MB size cap.
4. **Persists** raw `document_markdown` bytes (`text/markdown; charset=utf-8`) to the content-addressed key `brand-kit/{project}/{content_sha256}.md` — key derived from validated fields only. Content addressing makes the write idempotent (HEAD-then-PUT; race benign by construction).
5. **Returns a receipt** `{s3_key, content_sha256, project, version, intake_mode}`. Graph Artifact writes are deferred per the A5 ruling (`wi-lfx-one-service-actor`); the receipt carries exactly the fields needed for later Artifact minting.

**Auth**: endpoint sits behind the global auth middleware; only the session's creator may persist (same HMAC owner-token proof as posting a follow-up, constant-time compare).

**Storage env contract**: standard `S3_BUCKET` / `AWS_REGION` / `S3_ENDPOINT_URL` (MinIO local via endpoint override + path-style; AWS+IRSA deployed via default credential chain — no credential-mode branching in code). New direct dependency: `@aws-sdk/client-s3`.

## Testing

- 18-test vitest spec for the shared validation/extraction utils (fixtures: valid envelope, contract-major rejection, missing/reordered headings, sha/slug/intake failures, all three extraction encodings, path-traversal key rejection).
- **Live e2e** against the real form-mode smoke session `019fcd89-ecd8-f268-0000-8e14e8b4b22b`: envelope recovered from the finalize tool result (2 abridged candidates correctly rejected), persisted to local MinIO (19,045 bytes), idempotent re-run returned `written: false`, GetObject readback sha verified.
- `yarn build`, `yarn check-types`, `yarn lint:check`, `yarn format:check`, `./check-headers.sh` all pass.

## Documented trade-offs

- **Raw-event page cap (500) is warn-only**: a full page logs a loud warning but proceeds; pagination is a follow-up if real sessions approach the cap (current sessions emit <10 events).
- **No unit specs for the two new server services** — repo convention (no existing `server/services/*.spec.ts`); all non-trivial pure logic lives in the fully-tested shared utils, and the service was exercised end-to-end live.
- Pre-existing failing suite `meeting-privacy.utils.spec.ts` (missing vitest imports, from #1093) is unrelated to this branch.

## Protected files

- `apps/lfx-one/package.json` / `yarn.lock` — single dependency addition (`@aws-sdk/client-s3`), no script or tooling changes.

## External references

- Contract: `marketing-os-agents/docs/contracts/brand-kit-output.{md,schema.json}` (normative; the shared interface is its transcription)
- Producer agent: `linux-foundation~brand-kit` (Guild), deployed under `wi-brand-kit-guild-deploy`