### PR TITLE
feat(groups): add public foundation and project group directories

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -453,6 +453,16 @@ export const routes: Routes = [
     path: 'u/:username',
     loadComponent: () => import('./modules/public-profile/public-profile-page/public-profile-page.component').then((m) => m.PublicProfilePageComponent),
   },
+  // Public foundation groups directory — lists all public groups for a foundation (no auth required).
+  {
+    path: 'foundations/:foundationSlug/groups',
+    loadComponent: () => import('./modules/groups/public-foundation-groups/public-foundation-groups.component').then((m) => m.PublicFoundationGroupsComponent),
+  },
+  // Public project groups directory — lists all public groups for a project (no auth required).
+  {
+    path: 'projects/:projectSlug/groups',
+    loadComponent: () => import('./modules/groups/public-project-groups/public-project-groups.component').then((m) => m.PublicProjectGroupsComponent),
+  },
   // Invite acceptance — authGuard preserves ?token= through the Auth0 login redirect.
   {
     path: 'invite',

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
@@ -29,7 +29,7 @@
       <lfx-empty-state
         icon="fa-light fa-circle-exclamation"
         title="Unable to load groups"
-        description="Something went wrong while fetching group data. Please try refreshing the page."
+        subtitle="Something went wrong while fetching group data. Please try refreshing the page."
         data-testid="public-foundation-groups-error" />
     } @else if (loading()) {
       <!-- Loading skeleton -->
@@ -51,7 +51,7 @@
       <lfx-empty-state
         icon="fa-light fa-users-rectangle"
         title="No public groups found"
-        description="This foundation has no publicly visible working groups or committees yet."
+        subtitle="This foundation has no publicly visible working groups or committees yet."
         data-testid="public-foundation-groups-empty" />
     } @else {
       <!-- Group count -->

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
@@ -1,0 +1,108 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="min-h-screen bg-gray-50">
+  <lfx-header />
+
+  <main class="container mx-auto flex flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8" data-testid="public-foundation-groups-page">
+    <!-- Page header -->
+    <header class="flex flex-col gap-1" data-testid="public-foundation-groups-header">
+      @if (loading()) {
+        <p-skeleton width="12rem" height="2rem" />
+        <p-skeleton width="20rem" height="1rem" class="mt-1" />
+      } @else {
+        <h1 class="font-display font-light text-2xl text-gray-900" data-testid="public-foundation-groups-title">
+          @if (foundationName()) {
+            {{ foundationName() }} — Working Groups &amp; Committees
+          } @else {
+            Working Groups &amp; Committees
+          }
+        </h1>
+        <p class="text-sm text-gray-500" data-testid="public-foundation-groups-subtitle">
+          Discover official working groups, special interest groups, and committees for this foundation.
+        </p>
+      }
+    </header>
+
+    <!-- Error state -->
+    @if (fetchError()) {
+      <lfx-empty-state
+        icon="fa-light fa-circle-exclamation"
+        title="Unable to load groups"
+        description="Something went wrong while fetching group data. Please try refreshing the page."
+        data-testid="public-foundation-groups-error" />
+    } @else if (loading()) {
+      <!-- Loading skeleton -->
+      <div class="flex flex-col gap-3" data-testid="public-foundation-groups-skeleton">
+        @for (i of [1, 2, 3, 4, 5, 6]; track i) {
+          <div class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4">
+            <p-skeleton width="2.25rem" height="2.25rem" borderRadius="9999px" />
+            <div class="flex flex-col gap-1.5 flex-1">
+              <p-skeleton width="45%" height="1rem" />
+              <p-skeleton width="28%" height="0.75rem" />
+            </div>
+            <p-skeleton width="5rem" height="1.375rem" borderRadius="9999px" />
+            <p-skeleton width="4rem" height="1.375rem" borderRadius="9999px" />
+          </div>
+        }
+      </div>
+    } @else if (groupsVm().length === 0) {
+      <!-- Empty state -->
+      <lfx-empty-state
+        icon="fa-light fa-users-rectangle"
+        title="No public groups found"
+        description="This foundation has no publicly visible working groups or committees yet."
+        data-testid="public-foundation-groups-empty" />
+    } @else {
+      <!-- Group count -->
+      <p class="text-sm text-gray-500" data-testid="public-foundation-groups-count">{{ total() }} {{ total() === 1 ? 'group' : 'groups' }}</p>
+
+      <!-- Group list -->
+      <div class="flex flex-col gap-2" role="list" data-testid="public-foundation-groups-list">
+        @for (group of groupsVm(); track group.uid) {
+          @let config = group.classConfig;
+          <a
+            [routerLink]="['/groups', group.uid]"
+            role="listitem"
+            class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+            [attr.data-testid]="'public-foundation-groups-item-' + group.uid"
+            [attr.aria-label]="group.name + ', ' + config.label">
+            <!-- Icon -->
+            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full" [class]="config.bgColor">
+              <i [class]="config.icon + ' ' + config.color + ' text-base'" aria-hidden="true"></i>
+            </div>
+
+            <!-- Name + meta -->
+            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+              <p class="truncate text-sm font-medium text-gray-900" data-testid="public-foundation-groups-item-name">{{ group.name }}</p>
+              @if (group.context.project_name) {
+                <p class="truncate text-xs text-gray-400" data-testid="public-foundation-groups-item-project">{{ group.context.project_name }}</p>
+              }
+              @if (group.description) {
+                <p class="truncate text-xs text-gray-500 mt-0.5 hidden sm:block" data-testid="public-foundation-groups-item-desc">{{ group.description }}</p>
+              }
+            </div>
+
+            <!-- Behavioral class chip -->
+            <lfx-tag [value]="config.label" [severity]="'secondary'" class="shrink-0 hidden sm:flex" />
+
+            <!-- Join mode badge -->
+            @if (group.joinLabel) {
+              <lfx-tag [value]="group.joinLabel" [severity]="group.join_mode === 'open' ? 'success' : 'secondary'" class="shrink-0 hidden md:flex" />
+            }
+
+            <!-- Member count -->
+            @if (group.total_members) {
+              <div class="flex items-center gap-1 shrink-0 text-sm text-gray-500 hidden lg:flex" data-testid="public-foundation-groups-item-members">
+                <i class="fa-light fa-users text-gray-400 text-xs" aria-hidden="true"></i>
+                <span>{{ group.total_members }}</span>
+              </div>
+            }
+
+            <i class="fa-light fa-chevron-right text-gray-300 text-xs shrink-0" aria-hidden="true"></i>
+          </a>
+        }
+      </div>
+    }
+  </main>
+</div>

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.ts
@@ -57,5 +57,4 @@ export class PublicFoundationGroupsComponent {
 
   protected readonly total: Signal<number> = computed(() => this.directoryData()?.total ?? 0);
   protected readonly foundationName: Signal<string> = computed(() => this.directoryData()?.groups[0]?.context?.foundation_name ?? '');
-  protected readonly foundationLogoUrl: Signal<string | undefined> = computed(() => this.directoryData()?.groups[0]?.context?.foundation_logo_url);
 }

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.ts
@@ -1,0 +1,61 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { BEHAVIORAL_CLASS_CONFIG, JOIN_MODE_LABELS } from '@lfx-one/shared/constants';
+import type { GroupBehavioralClass, PublicGroupDirectoryVm } from '@lfx-one/shared/interfaces';
+import { TagComponent } from '@components/tag/tag.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { HeaderComponent } from '@components/header/header.component';
+import { GroupService } from '@services/group.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, map, of, switchMap } from 'rxjs';
+
+@Component({
+  selector: 'lfx-public-foundation-groups',
+  imports: [RouterLink, TagComponent, EmptyStateComponent, HeaderComponent, SkeletonModule],
+  templateUrl: './public-foundation-groups.component.html',
+})
+export class PublicFoundationGroupsComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly groupService = inject(GroupService);
+
+  protected readonly loading = signal(true);
+  protected readonly fetchError = signal(false);
+
+  private readonly directoryData = toSignal(
+    this.route.paramMap.pipe(
+      map((params) => params.get('foundationSlug') ?? ''),
+      switchMap((slug) => {
+        this.loading.set(true);
+        this.fetchError.set(false);
+        return this.groupService.getPublicFoundationGroups(slug).pipe(
+          map((response) => {
+            this.loading.set(false);
+            return response;
+          }),
+          catchError(() => {
+            this.loading.set(false);
+            this.fetchError.set(true);
+            return of(null);
+          })
+        );
+      })
+    )
+  );
+
+  protected readonly groupsVm: Signal<PublicGroupDirectoryVm[]> = computed(() =>
+    (this.directoryData()?.groups ?? []).map((g) => ({
+      ...g,
+      classConfig: BEHAVIORAL_CLASS_CONFIG[g.behavioral_class as GroupBehavioralClass] ?? BEHAVIORAL_CLASS_CONFIG['other'],
+      joinLabel: g.join_mode ? JOIN_MODE_LABELS[g.join_mode] : undefined,
+    }))
+  );
+
+  protected readonly total: Signal<number> = computed(() => this.directoryData()?.total ?? 0);
+  protected readonly foundationName: Signal<string> = computed(() => this.directoryData()?.groups[0]?.context?.foundation_name ?? '');
+  protected readonly foundationLogoUrl: Signal<string | undefined> = computed(() => this.directoryData()?.groups[0]?.context?.foundation_logo_url);
+}

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
@@ -32,7 +32,7 @@
       <lfx-empty-state
         icon="fa-light fa-circle-exclamation"
         title="Unable to load groups"
-        description="Something went wrong while fetching group data. Please try refreshing the page."
+        subtitle="Something went wrong while fetching group data. Please try refreshing the page."
         data-testid="public-project-groups-error" />
     } @else if (loading()) {
       <!-- Loading skeleton -->
@@ -54,7 +54,7 @@
       <lfx-empty-state
         icon="fa-light fa-users-rectangle"
         title="No public groups found"
-        description="This project has no publicly visible working groups or committees yet."
+        subtitle="This project has no publicly visible working groups or committees yet."
         data-testid="public-project-groups-empty" />
     } @else {
       <!-- Group count -->

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
@@ -1,0 +1,108 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="min-h-screen bg-gray-50">
+  <lfx-header />
+
+  <main class="container mx-auto flex flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8" data-testid="public-project-groups-page">
+    <!-- Page header -->
+    <header class="flex flex-col gap-1" data-testid="public-project-groups-header">
+      @if (loading()) {
+        <p-skeleton width="12rem" height="2rem" />
+        <p-skeleton width="20rem" height="1rem" class="mt-1" />
+      } @else {
+        <h1 class="font-display font-light text-2xl text-gray-900" data-testid="public-project-groups-title">
+          @if (projectName()) {
+            {{ projectName() }} — Working Groups &amp; Committees
+          } @else {
+            Working Groups &amp; Committees
+          }
+        </h1>
+        @if (foundationName()) {
+          <p class="text-sm text-gray-400" data-testid="public-project-groups-foundation">{{ foundationName() }}</p>
+        }
+        <p class="text-sm text-gray-500" data-testid="public-project-groups-subtitle">
+          Discover official working groups, special interest groups, and committees for this project.
+        </p>
+      }
+    </header>
+
+    <!-- Error state -->
+    @if (fetchError()) {
+      <lfx-empty-state
+        icon="fa-light fa-circle-exclamation"
+        title="Unable to load groups"
+        description="Something went wrong while fetching group data. Please try refreshing the page."
+        data-testid="public-project-groups-error" />
+    } @else if (loading()) {
+      <!-- Loading skeleton -->
+      <div class="flex flex-col gap-3" data-testid="public-project-groups-skeleton">
+        @for (i of [1, 2, 3, 4, 5]; track i) {
+          <div class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4">
+            <p-skeleton width="2.25rem" height="2.25rem" borderRadius="9999px" />
+            <div class="flex flex-col gap-1.5 flex-1">
+              <p-skeleton width="45%" height="1rem" />
+              <p-skeleton width="28%" height="0.75rem" />
+            </div>
+            <p-skeleton width="5rem" height="1.375rem" borderRadius="9999px" />
+            <p-skeleton width="4rem" height="1.375rem" borderRadius="9999px" />
+          </div>
+        }
+      </div>
+    } @else if (groupsVm().length === 0) {
+      <!-- Empty state -->
+      <lfx-empty-state
+        icon="fa-light fa-users-rectangle"
+        title="No public groups found"
+        description="This project has no publicly visible working groups or committees yet."
+        data-testid="public-project-groups-empty" />
+    } @else {
+      <!-- Group count -->
+      <p class="text-sm text-gray-500" data-testid="public-project-groups-count">{{ total() }} {{ total() === 1 ? 'group' : 'groups' }}</p>
+
+      <!-- Group list -->
+      <div class="flex flex-col gap-2" role="list" data-testid="public-project-groups-list">
+        @for (group of groupsVm(); track group.uid) {
+          @let config = group.classConfig;
+          <a
+            [routerLink]="['/groups', group.uid]"
+            role="listitem"
+            class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+            [attr.data-testid]="'public-project-groups-item-' + group.uid"
+            [attr.aria-label]="group.name + ', ' + config.label">
+            <!-- Icon -->
+            <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full" [class]="config.bgColor">
+              <i [class]="config.icon + ' ' + config.color + ' text-base'" aria-hidden="true"></i>
+            </div>
+
+            <!-- Name + meta -->
+            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
+              <p class="truncate text-sm font-medium text-gray-900" data-testid="public-project-groups-item-name">{{ group.name }}</p>
+              @if (group.description) {
+                <p class="truncate text-xs text-gray-500 mt-0.5 hidden sm:block" data-testid="public-project-groups-item-desc">{{ group.description }}</p>
+              }
+            </div>
+
+            <!-- Behavioral class chip -->
+            <lfx-tag [value]="config.label" [severity]="'secondary'" class="shrink-0 hidden sm:flex" />
+
+            <!-- Join mode badge -->
+            @if (group.joinLabel) {
+              <lfx-tag [value]="group.joinLabel" [severity]="group.join_mode === 'open' ? 'success' : 'secondary'" class="shrink-0 hidden md:flex" />
+            }
+
+            <!-- Member count -->
+            @if (group.total_members) {
+              <div class="flex items-center gap-1 shrink-0 text-sm text-gray-500 hidden lg:flex" data-testid="public-project-groups-item-members">
+                <i class="fa-light fa-users text-gray-400 text-xs" aria-hidden="true"></i>
+                <span>{{ group.total_members }}</span>
+              </div>
+            }
+
+            <i class="fa-light fa-chevron-right text-gray-300 text-xs shrink-0" aria-hidden="true"></i>
+          </a>
+        }
+      </div>
+    }
+  </main>
+</div>

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.ts
@@ -1,0 +1,61 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { BEHAVIORAL_CLASS_CONFIG, JOIN_MODE_LABELS } from '@lfx-one/shared/constants';
+import type { GroupBehavioralClass, PublicGroupDirectoryVm } from '@lfx-one/shared/interfaces';
+import { TagComponent } from '@components/tag/tag.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { HeaderComponent } from '@components/header/header.component';
+import { GroupService } from '@services/group.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, map, of, switchMap } from 'rxjs';
+
+@Component({
+  selector: 'lfx-public-project-groups',
+  imports: [RouterLink, TagComponent, EmptyStateComponent, HeaderComponent, SkeletonModule],
+  templateUrl: './public-project-groups.component.html',
+})
+export class PublicProjectGroupsComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly groupService = inject(GroupService);
+
+  protected readonly loading = signal(true);
+  protected readonly fetchError = signal(false);
+
+  private readonly directoryData = toSignal(
+    this.route.paramMap.pipe(
+      map((params) => params.get('projectSlug') ?? ''),
+      switchMap((slug) => {
+        this.loading.set(true);
+        this.fetchError.set(false);
+        return this.groupService.getPublicProjectGroups(slug).pipe(
+          map((response) => {
+            this.loading.set(false);
+            return response;
+          }),
+          catchError(() => {
+            this.loading.set(false);
+            this.fetchError.set(true);
+            return of(null);
+          })
+        );
+      })
+    )
+  );
+
+  protected readonly groupsVm: Signal<PublicGroupDirectoryVm[]> = computed(() =>
+    (this.directoryData()?.groups ?? []).map((g) => ({
+      ...g,
+      classConfig: BEHAVIORAL_CLASS_CONFIG[g.behavioral_class as GroupBehavioralClass] ?? BEHAVIORAL_CLASS_CONFIG['other'],
+      joinLabel: g.join_mode ? JOIN_MODE_LABELS[g.join_mode] : undefined,
+    }))
+  );
+
+  protected readonly total: Signal<number> = computed(() => this.directoryData()?.total ?? 0);
+  protected readonly projectName: Signal<string> = computed(() => this.directoryData()?.groups[0]?.context?.project_name ?? '');
+  protected readonly foundationName: Signal<string> = computed(() => this.directoryData()?.groups[0]?.context?.foundation_name ?? '');
+}

--- a/apps/lfx-one/src/app/shared/services/group.service.ts
+++ b/apps/lfx-one/src/app/shared/services/group.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { PublicGroupDetail } from '@lfx-one/shared/interfaces';
+import { PublicGroupDetail, PublicGroupDirectoryResponse } from '@lfx-one/shared/interfaces';
 import { Observable } from 'rxjs';
 
 @Injectable({ providedIn: 'root' })
@@ -12,5 +12,13 @@ export class GroupService {
 
   public getPublicGroup(groupUid: string): Observable<PublicGroupDetail> {
     return this.http.get<PublicGroupDetail>(`/public/api/groups/${groupUid}`);
+  }
+
+  public getPublicFoundationGroups(identifier: string): Observable<PublicGroupDirectoryResponse> {
+    return this.http.get<PublicGroupDirectoryResponse>(`/public/api/foundations/${encodeURIComponent(identifier)}/groups`);
+  }
+
+  public getPublicProjectGroups(identifier: string): Observable<PublicGroupDirectoryResponse> {
+    return this.http.get<PublicGroupDirectoryResponse>(`/public/api/projects/${encodeURIComponent(identifier)}/groups`);
   }
 }

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -191,6 +191,7 @@ export class PublicGroupsController {
     const startTime = logger.startOperation(req, 'get_public_groups_by_foundation', { identifier });
 
     try {
+      // M2M token required: public endpoint with no user session; app credentials needed for upstream calls
       const m2mToken = await generateM2MToken(req);
       req.bearerToken = m2mToken;
 
@@ -223,6 +224,7 @@ export class PublicGroupsController {
     const startTime = logger.startOperation(req, 'get_public_groups_by_project', { identifier });
 
     try {
+      // M2M token required: public endpoint with no user session; app credentials needed for upstream calls
       const m2mToken = await generateM2MToken(req);
       req.bearerToken = m2mToken;
 
@@ -271,7 +273,7 @@ export class PublicGroupsController {
   }
 
   private async fetchPublicCommitteesForProjects(req: Request, projectUids: string[]): Promise<Committee[]> {
-    const BATCH_LIMIT = 20;
+    const BATCH_LIMIT = 10;
     const uids = projectUids.slice(0, BATCH_LIMIT);
     const batches = await Promise.all(
       uids.map((uid) => this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }).catch(() => []))
@@ -291,11 +293,15 @@ export class PublicGroupsController {
 
   private async resolveContextProjects(req: Request, committees: Committee[]): Promise<Map<string, any>> {
     const uids = [...new Set(committees.map((c) => c.project_uid).filter(Boolean))];
-    const projects = await Promise.all(uids.map((uid) => this.projectService.getProjectById(req, uid, false).catch(() => null)));
+    const BATCH_SIZE = 10;
     const map = new Map<string, any>();
-    for (let i = 0; i < uids.length; i++) {
-      const p = projects[i];
-      if (p) map.set(uids[i], p);
+    for (let i = 0; i < uids.length; i += BATCH_SIZE) {
+      const batch = uids.slice(i, i + BATCH_SIZE);
+      const projects = await Promise.all(batch.map((uid) => this.projectService.getProjectById(req, uid, false).catch(() => null)));
+      for (let j = 0; j < batch.length; j++) {
+        const p = projects[j];
+        if (p) map.set(batch[j], p);
+      }
     }
     return map;
   }

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -4,19 +4,22 @@
 import { CHAIR_ROLES } from '@lfx-one/shared/constants';
 import { CommitteeMemberVisibility, MeetingVisibility } from '@lfx-one/shared/enums';
 import {
+  Committee,
   CommitteeMember,
   GroupsIOMailingList,
   PublicGroupContext,
   PublicGroupDetail,
+  PublicGroupDirectoryResponse,
   PublicGroupLinks,
   PublicGroupMeeting,
   PublicGroupMember,
+  PublicGroupSummary,
   QueryServiceResponse,
 } from '@lfx-one/shared/interfaces';
-import { buildCommitteeCadenceSummary } from '@lfx-one/shared/utils';
+import { buildCommitteeCadenceSummary, getGroupBehavioralClass } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
-import { AuthorizationError } from '../errors';
+import { AuthorizationError, ResourceNotFoundError } from '../errors';
 import { validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { CommitteeService } from '../services/committee.service';
@@ -181,5 +184,155 @@ export class PublicGroupsController {
     } catch (error) {
       return next(error);
     }
+  }
+
+  public async getPublicGroupsByFoundation(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { identifier } = req.params;
+    const startTime = logger.startOperation(req, 'get_public_groups_by_foundation', { identifier });
+
+    try {
+      const m2mToken = await generateM2MToken(req);
+      req.bearerToken = m2mToken;
+
+      const foundationUid = await this.resolveProjectIdentifier(req, identifier);
+      const [foundation, childUids] = await Promise.all([
+        this.projectService.getProjectById(req, foundationUid, false),
+        this.projectService.getFoundationProjectUids(req, foundationUid),
+      ]);
+
+      const allCommittees = await this.fetchPublicCommitteesForProjects(req, childUids);
+      const projects = await this.resolveContextProjects(req, allCommittees);
+
+      const groups = allCommittees.map((c) => this.buildGroupSummary(c, projects, foundation, null));
+
+      const response: PublicGroupDirectoryResponse = { groups, total: groups.length };
+
+      logger.success(req, 'get_public_groups_by_foundation', startTime, {
+        foundation_uid: foundationUid,
+        groups_count: groups.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getPublicGroupsByProject(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { identifier } = req.params;
+    const startTime = logger.startOperation(req, 'get_public_groups_by_project', { identifier });
+
+    try {
+      const m2mToken = await generateM2MToken(req);
+      req.bearerToken = m2mToken;
+
+      const projectUid = await this.resolveProjectIdentifier(req, identifier);
+      const project = await this.projectService.getProjectById(req, projectUid, false);
+
+      let parentFoundation = null;
+      if (project.parent_uid) {
+        parentFoundation = await this.projectService.getProjectById(req, project.parent_uid, false).catch(() => null);
+      }
+
+      const committees = await this.committeeService.getCommittees(req, { tags: `project_uid:${projectUid}` }, { skipMailingListEnrichment: true });
+      const publicCommittees = committees.filter((c) => c.public);
+
+      const groups = publicCommittees.map((c) =>
+        this.buildGroupSummary(c, new Map([[projectUid, project]]), parentFoundation ?? project, project.parent_uid ? project : null)
+      );
+
+      const response: PublicGroupDirectoryResponse = { groups, total: groups.length };
+
+      logger.success(req, 'get_public_groups_by_project', startTime, {
+        project_uid: projectUid,
+        groups_count: groups.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  private async resolveProjectIdentifier(req: Request, identifier: string): Promise<string> {
+    // UUID v4 pattern — treat as UID directly
+    if (/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(identifier)) {
+      return identifier;
+    }
+    const result = await this.projectService.getProjectIdBySlug(req, identifier);
+    if (!result.exists || !result.uid) {
+      throw new ResourceNotFoundError('Project', identifier, {
+        operation: 'resolve_project_identifier',
+        service: 'public_groups_controller',
+        path: `/projects/${identifier}`,
+      });
+    }
+    return result.uid;
+  }
+
+  private async fetchPublicCommitteesForProjects(req: Request, projectUids: string[]): Promise<Committee[]> {
+    const BATCH_LIMIT = 20;
+    const uids = projectUids.slice(0, BATCH_LIMIT);
+    const batches = await Promise.all(
+      uids.map((uid) => this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }).catch(() => []))
+    );
+    const seen = new Set<string>();
+    const result: Committee[] = [];
+    for (const batch of batches) {
+      for (const c of batch) {
+        if (c.public && !seen.has(c.uid)) {
+          seen.add(c.uid);
+          result.push(c);
+        }
+      }
+    }
+    return result.sort((a, b) => a.name.localeCompare(b.name));
+  }
+
+  private async resolveContextProjects(req: Request, committees: Committee[]): Promise<Map<string, any>> {
+    const uids = [...new Set(committees.map((c) => c.project_uid).filter(Boolean))];
+    const projects = await Promise.all(uids.map((uid) => this.projectService.getProjectById(req, uid, false).catch(() => null)));
+    const map = new Map<string, any>();
+    for (let i = 0; i < uids.length; i++) {
+      const p = projects[i];
+      if (p) map.set(uids[i], p);
+    }
+    return map;
+  }
+
+  private buildGroupSummary(committee: Committee, projectMap: Map<string, any>, foundation: any, project: any): PublicGroupSummary {
+    const proj = project ?? projectMap.get(committee.project_uid) ?? null;
+    const isFoundationScope = !proj || proj.uid === foundation?.uid;
+
+    const context: PublicGroupContext = {
+      scope: isFoundationScope ? 'foundation' : 'project',
+      foundation_uid: foundation?.uid ?? committee.project_uid,
+      foundation_name: foundation?.name ?? '',
+      foundation_slug: foundation?.slug ?? '',
+      foundation_logo_url: foundation?.logo_url ?? undefined,
+      ...(!isFoundationScope &&
+        proj && {
+          project_uid: proj.uid,
+          project_name: proj.name,
+          project_slug: proj.slug,
+          project_logo_url: proj.logo_url ?? undefined,
+        }),
+    };
+
+    return {
+      uid: committee.uid,
+      name: committee.name,
+      display_name: committee.display_name,
+      description: committee.description ?? undefined,
+      category: committee.category,
+      behavioral_class: getGroupBehavioralClass(committee.category),
+      context,
+      join_mode: committee.join_mode,
+      total_members: committee.total_members,
+      website: committee.website,
+      mailing_list: committee.mailing_list,
+      chat_channel: committee.chat_channel,
+      has_public_calendar: committee.calendar?.public ?? false,
+    };
   }
 }

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -274,6 +274,12 @@ export class PublicGroupsController {
 
   private async fetchPublicCommitteesForProjects(req: Request, projectUids: string[]): Promise<Committee[]> {
     const BATCH_LIMIT = 10;
+    if (projectUids.length > BATCH_LIMIT) {
+      logger.warning(req, 'fetch_public_committees_for_projects', 'Foundation has more child projects than batch limit; results may be incomplete', {
+        total_projects: projectUids.length,
+        batch_limit: BATCH_LIMIT,
+      });
+    }
     const uids = projectUids.slice(0, BATCH_LIMIT);
     const batches = await Promise.all(
       uids.map((uid) => this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }).catch(() => []))

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -233,7 +233,19 @@ export class PublicGroupsController {
 
       let parentFoundation = null;
       if (project.parent_uid) {
-        parentFoundation = await this.projectService.getProjectById(req, project.parent_uid, false);
+        try {
+          const candidate = await this.projectService.getProjectById(req, project.parent_uid, false);
+          // ROOT is an administrative pseudo-project — treat its children as top-level foundations
+          if (candidate?.slug !== 'ROOT') {
+            parentFoundation = candidate;
+          }
+        } catch (error) {
+          logger.warning(req, 'get_public_groups_by_project', 'Parent foundation lookup failed, treating project as top-level', {
+            project_uid: projectUid,
+            parent_uid: project.parent_uid,
+            error: error instanceof Error ? error.message : String(error),
+          });
+        }
       }
 
       const committees = await this.committeeService.getCommittees(req, { tags: `project_uid:${projectUid}` }, { skipMailingListEnrichment: true });
@@ -279,7 +291,15 @@ export class PublicGroupsController {
     for (let i = 0; i < projectUids.length; i += BATCH_SIZE) {
       const batch = projectUids.slice(i, i + BATCH_SIZE);
       const batchResults = await Promise.all(
-        batch.map((uid) => this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }))
+        batch.map((uid) =>
+          this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }).catch((error) => {
+            logger.warning(req, 'fetch_public_committees_for_projects', 'getCommittees failed for project, skipping', {
+              project_uid: uid,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return [] as Committee[];
+          })
+        )
       );
       for (const committees of batchResults) {
         for (const c of committees) {
@@ -299,7 +319,17 @@ export class PublicGroupsController {
     const map = new Map<string, any>();
     for (let i = 0; i < uids.length; i += BATCH_SIZE) {
       const batch = uids.slice(i, i + BATCH_SIZE);
-      const projects = await Promise.all(batch.map((uid) => this.projectService.getProjectById(req, uid, false)));
+      const projects = await Promise.all(
+        batch.map((uid) =>
+          this.projectService.getProjectById(req, uid, false).catch((error) => {
+            logger.warning(req, 'resolve_context_projects', 'getProjectById failed for project, context will be incomplete', {
+              project_uid: uid,
+              error: error instanceof Error ? error.message : String(error),
+            });
+            return null;
+          })
+        )
+      );
       for (let j = 0; j < batch.length; j++) {
         map.set(batch[j], projects[j]);
       }
@@ -337,7 +367,6 @@ export class PublicGroupsController {
       join_mode: committee.join_mode,
       total_members: committee.total_members,
       website: committee.website,
-      chat_channel: committee.chat_channel,
       has_public_calendar: committee.calendar?.public ?? false,
     };
   }

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -233,15 +233,15 @@ export class PublicGroupsController {
 
       let parentFoundation = null;
       if (project.parent_uid) {
-        parentFoundation = await this.projectService.getProjectById(req, project.parent_uid, false).catch(() => null);
+        parentFoundation = await this.projectService.getProjectById(req, project.parent_uid, false);
       }
 
       const committees = await this.committeeService.getCommittees(req, { tags: `project_uid:${projectUid}` }, { skipMailingListEnrichment: true });
       const publicCommittees = committees.filter((c) => c.public);
 
-      const groups = publicCommittees.map((c) =>
-        this.buildGroupSummary(c, new Map([[projectUid, project]]), parentFoundation ?? project, project.parent_uid ? project : null)
-      );
+      const groups = publicCommittees
+        .map((c) => this.buildGroupSummary(c, new Map([[projectUid, project]]), parentFoundation ?? project, project.parent_uid ? project : null))
+        .sort((a, b) => a.name.localeCompare(b.name, 'en'));
 
       const response: PublicGroupDirectoryResponse = { groups, total: groups.length };
 
@@ -273,28 +273,24 @@ export class PublicGroupsController {
   }
 
   private async fetchPublicCommitteesForProjects(req: Request, projectUids: string[]): Promise<Committee[]> {
-    const BATCH_LIMIT = 10;
-    if (projectUids.length > BATCH_LIMIT) {
-      logger.warning(req, 'fetch_public_committees_for_projects', 'Foundation has more child projects than batch limit; results may be incomplete', {
-        total_projects: projectUids.length,
-        batch_limit: BATCH_LIMIT,
-      });
-    }
-    const uids = projectUids.slice(0, BATCH_LIMIT);
-    const batches = await Promise.all(
-      uids.map((uid) => this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }).catch(() => []))
-    );
+    const BATCH_SIZE = 10;
     const seen = new Set<string>();
     const result: Committee[] = [];
-    for (const batch of batches) {
-      for (const c of batch) {
-        if (c.public && !seen.has(c.uid)) {
-          seen.add(c.uid);
-          result.push(c);
+    for (let i = 0; i < projectUids.length; i += BATCH_SIZE) {
+      const batch = projectUids.slice(i, i + BATCH_SIZE);
+      const batchResults = await Promise.all(
+        batch.map((uid) => this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }))
+      );
+      for (const committees of batchResults) {
+        for (const c of committees) {
+          if (c.public && !seen.has(c.uid)) {
+            seen.add(c.uid);
+            result.push(c);
+          }
         }
       }
     }
-    return result.sort((a, b) => a.name.localeCompare(b.name));
+    return result.sort((a, b) => a.name.localeCompare(b.name, 'en'));
   }
 
   private async resolveContextProjects(req: Request, committees: Committee[]): Promise<Map<string, any>> {
@@ -303,10 +299,9 @@ export class PublicGroupsController {
     const map = new Map<string, any>();
     for (let i = 0; i < uids.length; i += BATCH_SIZE) {
       const batch = uids.slice(i, i + BATCH_SIZE);
-      const projects = await Promise.all(batch.map((uid) => this.projectService.getProjectById(req, uid, false).catch(() => null)));
+      const projects = await Promise.all(batch.map((uid) => this.projectService.getProjectById(req, uid, false)));
       for (let j = 0; j < batch.length; j++) {
-        const p = projects[j];
-        if (p) map.set(batch[j], p);
+        map.set(batch[j], projects[j]);
       }
     }
     return map;
@@ -342,7 +337,6 @@ export class PublicGroupsController {
       join_mode: committee.join_mode,
       total_members: committee.total_members,
       website: committee.website,
-      mailing_list: committee.mailing_list,
       chat_channel: committee.chat_channel,
       has_public_calendar: committee.calendar?.public ?? false,
     };

--- a/apps/lfx-one/src/server/controllers/public-groups.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-groups.controller.ts
@@ -288,17 +288,26 @@ export class PublicGroupsController {
     const BATCH_SIZE = 10;
     const seen = new Set<string>();
     const result: Committee[] = [];
+    let successCount = 0;
+    let lastError: unknown;
     for (let i = 0; i < projectUids.length; i += BATCH_SIZE) {
       const batch = projectUids.slice(i, i + BATCH_SIZE);
       const batchResults = await Promise.all(
         batch.map((uid) =>
-          this.committeeService.getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true }).catch((error) => {
-            logger.warning(req, 'fetch_public_committees_for_projects', 'getCommittees failed for project, skipping', {
-              project_uid: uid,
-              error: error instanceof Error ? error.message : String(error),
-            });
-            return [] as Committee[];
-          })
+          this.committeeService
+            .getCommittees(req, { tags: `project_uid:${uid}` }, { skipMailingListEnrichment: true })
+            .then((committees) => {
+              successCount++;
+              return committees;
+            })
+            .catch((error) => {
+              lastError = error;
+              logger.warning(req, 'fetch_public_committees_for_projects', 'getCommittees failed for project, skipping', {
+                project_uid: uid,
+                error: error instanceof Error ? error.message : String(error),
+              });
+              return [] as Committee[];
+            })
         )
       );
       for (const committees of batchResults) {
@@ -309,6 +318,10 @@ export class PublicGroupsController {
           }
         }
       }
+    }
+    // If every call failed, the upstream is down — propagate rather than returning an empty directory
+    if (successCount === 0 && projectUids.length > 0) {
+      throw lastError;
     }
     return result.sort((a, b) => a.name.localeCompare(b.name, 'en'));
   }

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -36,6 +36,11 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // impersonation session never leaks here; anchored regex prevents `startsWith` fail-open onto `/u/...`.
   { pattern: /^\/u\/[^/]+\/?$/, type: 'ssr', auth: 'public' },
 
+  // Public foundation and project group directories — unauthenticated discovery (LFXV2-2010)
+  // Regex-anchored to /:identifier/groups so the prefix cannot fail-open on unrelated paths
+  { pattern: /^\/foundations\/[^/]+\/groups(?:\/.*)?$/, type: 'ssr', auth: 'optional' },
+  { pattern: /^\/projects\/[^/]+\/groups(?:\/.*)?$/, type: 'ssr', auth: 'optional' },
+
   // Flow C callback via /passwordless/callback — needs session auth but no bearer token
   { pattern: '/passwordless/callback', type: 'ssr', auth: 'required', tokenRequired: false },
 

--- a/apps/lfx-one/src/server/routes/public-foundations.route.ts
+++ b/apps/lfx-one/src/server/routes/public-foundations.route.ts
@@ -1,0 +1,17 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { PublicGroupsController } from '../controllers/public-groups.controller';
+
+const router = Router();
+const publicGroupsController = new PublicGroupsController();
+
+// GET /public/api/foundations/:identifier/groups
+// Returns public group summaries for a foundation (by UID or slug).
+// Includes groups from all child projects under the foundation.
+// Public access — no authentication required; M2M token used for upstream calls.
+router.get('/:identifier/groups', (req, res, next) => publicGroupsController.getPublicGroupsByFoundation(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/routes/public-projects.route.ts
+++ b/apps/lfx-one/src/server/routes/public-projects.route.ts
@@ -3,10 +3,12 @@
 
 import { Router } from 'express';
 
+import { PublicGroupsController } from '../controllers/public-groups.controller';
 import { ProjectController } from '../controllers/project.controller';
 
 const router = Router();
 const projectController = new ProjectController();
+const publicGroupsController = new PublicGroupsController();
 
 // GET /public/api/projects/:id/calendar.ics
 // Returns the iCalendar (.ics) feed for a project's (or foundation's) meetings.
@@ -21,5 +23,10 @@ router.get('/:id/calendar.ics', (req, res, next) => projectController.getProject
 // non-foundation on /project/<resource>. `:resource` is allowlisted in the controller so it
 // cannot become an open redirect. Anonymous access — no user session; M2M-authenticated upstream.
 router.get('/:slug/lens-redirect/:resource', (req, res, next) => projectController.getLensRedirect(req, res, next));
+
+// GET /public/api/projects/:identifier/groups
+// Returns public group summaries for a project (by UID or slug).
+// Public access — no authentication required; M2M token used for upstream calls.
+router.get('/:identifier/groups', (req, res, next) => publicGroupsController.getPublicGroupsByProject(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -45,6 +45,7 @@ import personaRouter from './routes/persona.route';
 import profileRouter from './routes/profile.route';
 import projectsRouter from './routes/projects.route';
 import publicCommitteesRouter from './routes/public-committees.route';
+import publicFoundationsRouter from './routes/public-foundations.route';
 import publicGroupsRouter from './routes/public-groups.route';
 import publicMeetingsRouter from './routes/public-meetings.route';
 import publicProfileRouter from './routes/public-profile.route';
@@ -308,6 +309,7 @@ app.use('/login', authRateLimiter);
 
 app.use('/public/api/meetings', publicMeetingsRouter);
 app.use('/public/api/committees', publicCommitteesRouter);
+app.use('/public/api/foundations', publicFoundationsRouter);
 app.use('/public/api/groups', publicGroupsRouter);
 app.use('/public/api/profile', publicProfileRouter);
 app.use('/public/api/projects', publicProjectsRouter);

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -6268,20 +6268,17 @@ export class ProjectService {
     logger.debug(req, 'get_foundation_project_uids', 'Resolving child projects for foundation', { foundation_uid: foundationUid });
     const uids = [foundationUid];
     try {
-      const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<{ uid: string; slug?: string }>>(
-        req,
-        'LFX_V2_SERVICE',
-        '/query/resources',
-        'GET',
-        {
+      const resources = await fetchAllQueryResources<{ uid: string; slug?: string }>(req, (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<{ uid: string; slug?: string }>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
           type: 'project',
           parent: `project:${foundationUid}`,
-        }
+          ...(pageToken && { page_token: pageToken }),
+        })
       );
       for (const r of resources) {
         // Skip ROOT — administrative pseudo-project, never a real foundation child.
-        if (r.data?.uid && r.data.slug !== ROOT_PROJECT_SLUG) {
-          uids.push(r.data.uid);
+        if (r.uid && r.slug !== ROOT_PROJECT_SLUG) {
+          uids.push(r.uid);
         }
       }
     } catch (error) {

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -68,7 +68,6 @@ export interface PublicGroupSummary {
   total_members?: number;
   website?: string | null;
   mailing_list?: string | null;
-  chat_channel?: string | null;
   has_public_calendar?: boolean;
   external_sources?: PublicGroupExternalSource[];
 }

--- a/packages/shared/src/interfaces/public-group.interface.ts
+++ b/packages/shared/src/interfaces/public-group.interface.ts
@@ -3,7 +3,7 @@
 
 import { CommitteeMemberVisibility } from '../enums/committee.enum';
 
-import { JoinMode } from './committee.interface';
+import { BehavioralClassDisplayConfig, JoinMode } from './committee.interface';
 
 export interface PublicGroupMember {
   name: string;
@@ -38,6 +38,51 @@ export interface PublicGroupContext {
   project_name?: string;
   project_slug?: string;
   project_logo_url?: string;
+}
+
+/** OCG or other external source linked to this group. */
+export interface PublicGroupExternalSource {
+  provider: 'ocg';
+  entity_type: 'community' | 'group' | 'event';
+  label: string;
+  url: string;
+  external_id?: string;
+  external_category?: string;
+  external_region?: string;
+}
+
+/** Public-safe group summary returned by the directory endpoints. */
+export interface PublicGroupSummary {
+  uid: string;
+  /** URL-safe slug for the group (may be absent if upstream does not return one). */
+  slug?: string;
+  name: string;
+  display_name?: string;
+  description?: string;
+  /** Raw category string from the committee service (e.g. "Working Group"). */
+  category: string;
+  /** Pre-computed behavioral class derived from `category`. */
+  behavioral_class: string;
+  context: PublicGroupContext;
+  join_mode?: JoinMode;
+  total_members?: number;
+  website?: string | null;
+  mailing_list?: string | null;
+  chat_channel?: string | null;
+  has_public_calendar?: boolean;
+  external_sources?: PublicGroupExternalSource[];
+}
+
+/** Response envelope returned by `GET /public/api/foundations/:uid/groups` and `GET /public/api/projects/:uid/groups`. */
+export interface PublicGroupDirectoryResponse {
+  groups: PublicGroupSummary[];
+  total: number;
+}
+
+/** Frontend view model — extends PublicGroupSummary with pre-computed display metadata. */
+export interface PublicGroupDirectoryVm extends PublicGroupSummary {
+  classConfig: BehavioralClassDisplayConfig;
+  joinLabel: string | undefined;
 }
 
 export interface PublicGroupDetail {


### PR DESCRIPTION
## Summary

- **Backend:** Two new public REST endpoints — `GET /public/api/foundations/:identifier/groups` and `GET /public/api/projects/:identifier/groups` — allow unauthenticated visitors to discover official WG/SIG/committee groups for a foundation or project. Both accept a slug or UID as the identifier.
- **Shared interfaces:** `PublicGroupSummary`, `PublicGroupDirectoryResponse`, `PublicGroupDirectoryVm`, `PublicGroupExternalSource` added to `@lfx-one/shared/interfaces`.
- **Frontend:** Two new lazy-loaded public components — `/foundations/:foundationSlug/groups` and `/projects/:projectSlug/groups` — with skeleton loading, empty/error states, and responsive group cards using pre-computed `groupsVm` computed signals (no function calls in templates).

Closes LFXV2-2010.

## What changed

### Backend

- `public-groups.controller.ts` — `getPublicGroupsByFoundation` resolves the identifier (slug→UID via NATS, or UID directly), calls `getFoundationProjectUids`, fans out `getCommittees` in parallel (capped at 20 project UIDs), deduplicates by committee UID, and returns sorted public groups. `getPublicGroupsByProject` does the same for a single project with optional parent-foundation context.
- `public-foundations.route.ts` (new) — `GET /:identifier/groups` mounted in `server.ts` at `/public/api/foundations`.
- `public-projects.route.ts` — extended with `GET /:identifier/groups` for `getPublicGroupsByProject`.
- All directory endpoints use M2M tokens (no user session on public surfaces). `skipMailingListEnrichment: true` used for performance.

### Shared

- `PublicGroupSummary` — directory base type: `uid`, `name`, `category`, `behavioral_class`, `context`, `join_mode?`, `total_members?`, etc.
- `PublicGroupDirectoryResponse` — `{ groups: PublicGroupSummary[]; total: number }`.
- `PublicGroupDirectoryVm` — extends `PublicGroupSummary` with `classConfig: BehavioralClassDisplayConfig` and `joinLabel: string | undefined` pre-computed from constants.
- `PublicGroupExternalSource` — external source links for future OCG provider integration.

### Frontend

- `group.service.ts` — `getPublicFoundationGroups(identifier)` and `getPublicProjectGroups(identifier)`.
- `PublicFoundationGroupsComponent` (`/foundations/:foundationSlug/groups`) — skeleton → error/empty/list states; `groupsVm` computed signal pre-builds `classConfig` + `joinLabel`; cards link to `/groups/:uid`.
- `PublicProjectGroupsComponent` (`/projects/:projectSlug/groups`) — same structure; shows project name and foundation breadcrumb from context.
- `app.routes.ts` — two new lazy-loaded top-level unauthenticated routes added.

## Protected files

This PR modifies **`apps/lfx-one/src/server/server.ts`** (server bootstrap) to mount the new `publicFoundationsRouter` at `/public/api/foundations`. No changes to core server initialization logic — one additional `app.use(...)` line only.

## Test plan

- [ ] `GET /public/api/foundations/<slug>/groups` returns `{ groups: [...], total: N }` for a known foundation slug (e.g. `cncf`)
- [ ] `GET /public/api/foundations/<uid>/groups` returns same result when UID passed directly
- [ ] `GET /public/api/projects/<slug>/groups` returns groups scoped to that project
- [ ] Unauthenticated request succeeds (no 401/403)
- [ ] Unknown slug returns 404
- [ ] `/foundations/cncf/groups` renders groups list with skeleton → content transition
- [ ] `/projects/kubernetes/groups` renders groups with project/foundation headers
- [ ] Empty project shows empty state; network error shows error state
- [ ] Cards link correctly to `/groups/:uid`

🤖 Generated with [Claude Code](https://claude.com/claude-code)