### PR TITLE
[LFXV2-2389] End-to-end newsletter send + analytics wiring + Playwright E2E

### DIFF
--- a/apps/lfx-one/e2e/helpers/live-env.helper.ts
+++ b/apps/lfx-one/e2e/helpers/live-env.helper.ts
@@ -1,0 +1,63 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { test } from '@playwright/test';
+
+/**
+ * Env-var-driven fixture for the newsletter live-service specs
+ * (`newsletter-live-send*.spec.ts`). Those specs are the deliberate exception
+ * to this suite's `page.route()`-mocked convention — they exercise the real
+ * newsletter-service / committee-service / project-service stack, so they
+ * need a seeded project + committee to target instead of fixture data.
+ *
+ * Required env vars (set in `apps/lfx-one/.env`, alongside `TEST_USERNAME` /
+ * `TEST_PASSWORD` — see `docs/architecture/testing/e2e-testing.md`):
+ *
+ * - `LIVE_PROJECT_SLUG` — slug of a seeded project the test user can manage
+ *   (ED / project-writer) newsletters for.
+ * - `LIVE_PROJECT_UID` — that same project's UID (newsletter edit/analytics
+ *   routes are UID-keyed, not slug-keyed).
+ * - `LIVE_COMMITTEE_UID` — UID of a committee under that project with at
+ *   least one member, so a send has a real recipient.
+ * - `LIVE_COMMITTEE_NAME` — that committee's display name, needed to select
+ *   it from the audience picker's rendered option list (PrimeNG `p-select`
+ *   options are chosen by visible label, not by value).
+ *
+ * All four are required together — a partially-configured environment skips
+ * cleanly via `skipWhenLiveEnvMissing()` rather than failing on a missing
+ * fixture.
+ */
+export interface LiveNewsletterEnv {
+  projectSlug: string;
+  projectUid: string;
+  committeeUid: string;
+  committeeName: string;
+}
+
+const LIVE_ENV_PRESENT =
+  !!process.env.LIVE_PROJECT_SLUG && !!process.env.LIVE_PROJECT_UID && !!process.env.LIVE_COMMITTEE_UID && !!process.env.LIVE_COMMITTEE_NAME;
+
+export function liveEnvPresent(): boolean {
+  return LIVE_ENV_PRESENT;
+}
+
+/**
+ * Skips the current test when the live-service env vars aren't configured.
+ * Mirrors the `skipWhenAuthMissing()` pattern used by the mocked specs —
+ * gated on explicit env vars rather than URL sniffing, so a genuinely broken
+ * live stack still fails loudly rather than silently skipping.
+ */
+export function skipWhenLiveEnvMissing(): void {
+  if (!LIVE_ENV_PRESENT) {
+    test.skip(true, 'LIVE_PROJECT_SLUG / LIVE_PROJECT_UID / LIVE_COMMITTEE_UID / LIVE_COMMITTEE_NAME not configured — see live-env.helper.ts');
+  }
+}
+
+export function getLiveEnv(): LiveNewsletterEnv {
+  return {
+    projectSlug: process.env.LIVE_PROJECT_SLUG || '',
+    projectUid: process.env.LIVE_PROJECT_UID || '',
+    committeeUid: process.env.LIVE_COMMITTEE_UID || '',
+    committeeName: process.env.LIVE_COMMITTEE_NAME || '',
+  };
+}

--- a/apps/lfx-one/e2e/newsletter-live-send-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-live-send-robust.spec.ts
@@ -1,0 +1,115 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Structural companion to `newsletter-live-send.spec.ts` — see that file's
+ * header for the rationale behind the live-service exception to this suite's
+ * `page.route()`-mocked convention.
+ *
+ * This spec asserts the `data-testid` contract holds up through a real
+ * compose → send → analytics run: presence, nesting, and stable identifiers
+ * across the step transitions — not copy or business-rule outcomes (that's
+ * the content-based spec's job).
+ */
+
+import { expect, Page, test } from '@playwright/test';
+import { getLiveEnv, skipWhenLiveEnvMissing } from './helpers/live-env.helper';
+
+test.setTimeout(120_000);
+
+const ELEMENT_TIMEOUT = 10_000;
+const SEND_SETTLE_TIMEOUT = 30_000;
+
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+async function gotoAuthed(page: Page, path: string): Promise<void> {
+  skipWhenAuthMissing();
+  skipWhenLiveEnvMissing();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+}
+
+test.describe('Newsletter live send — structural contract', () => {
+  test('stepper, step panels, and send controls keep their testid contract through a live run', async ({ page }) => {
+    const env = getLiveEnv();
+    const subject = `Live E2E Structural ${Date.now()}`;
+
+    await gotoAuthed(page, `/foundation/newsletters/create?project=${env.projectSlug}`);
+
+    const stepper = page.getByTestId('newsletter-manage-stepper');
+    await expect(stepper).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+
+    // Audience step.
+    const audienceStep = page.getByTestId('newsletter-audience-step');
+    await expect(audienceStep).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+    const committeePicker = page.getByTestId('newsletter-audience-committees');
+    await expect(committeePicker).toBeAttached();
+
+    await committeePicker.click();
+    await page.getByRole('option', { name: env.committeeName, exact: true }).click();
+    await page.getByTestId('newsletter-manage-next-btn').click();
+
+    // Content step — the rich editor's wrapper and its nested tiptap content
+    // node both carry the same testid by design (see rich-editor.component.ts);
+    // assert both halves of that contract explicitly so a future refactor that
+    // accidentally de-dupes it is caught either way.
+    const contentStep = page.getByTestId('newsletter-content-step');
+    await expect(contentStep).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+
+    const subjectField = page.getByTestId('newsletter-content-subject');
+    await expect(subjectField).toBeAttached();
+    await expect(subjectField.locator('input')).toBeAttached();
+
+    const bodyField = page.getByTestId('newsletter-content-body');
+    await expect(bodyField.first()).toBeAttached();
+    const editorContent = page.locator('.lfx-rich-editor__content');
+    await expect(editorContent).toBeAttached();
+
+    await subjectField.locator('input').fill(subject);
+    await editorContent.click();
+    await page.keyboard.type('Structural spec body content.');
+
+    await expect(page.getByTestId('newsletter-content-saved-indicator')).toBeVisible({ timeout: SEND_SETTLE_TIMEOUT });
+    await page.getByTestId('newsletter-manage-next-btn').click();
+
+    // Send step.
+    const sendStep = page.getByTestId('newsletter-send-step');
+    await expect(sendStep).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-send-test-button')).toBeAttached();
+    const sendNowButton = page.getByTestId('newsletter-send-now-button');
+    await expect(sendNowButton).toBeAttached();
+    await expect(sendNowButton).toBeEnabled();
+
+    const sendResponsePromise = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && /\/newsletters\/[^/]+\/send$/.test(new URL(response.url()).pathname),
+      { timeout: SEND_SETTLE_TIMEOUT }
+    );
+    await sendNowButton.click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await dialog.getByRole('button', { name: /send now/i }).click();
+
+    const sendResponse = await sendResponsePromise;
+    const sendResult = await sendResponse.json();
+    const projectUid: string = sendResult.newsletter.project_uid;
+    const newsletterId: string = sendResult.newsletter.id;
+
+    await expect(page).toHaveURL(/tab=sent/, { timeout: SEND_SETTLE_TIMEOUT });
+
+    // Analytics screen — nested testid structure.
+    await page.goto(`/foundation/newsletters/${projectUid}/${newsletterId}/analytics?project=${env.projectSlug}`, { waitUntil: 'domcontentloaded' });
+    const analyticsRoot = page.getByTestId('newsletter-analytics');
+    await expect(analyticsRoot).toBeAttached({ timeout: SEND_SETTLE_TIMEOUT });
+    await expect(analyticsRoot.getByTestId('newsletter-analytics-subject')).toBeAttached();
+    await expect(analyticsRoot.getByTestId('newsletter-analytics-recipients')).toBeAttached();
+  });
+});

--- a/apps/lfx-one/e2e/newsletter-live-send.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-live-send.spec.ts
@@ -1,0 +1,215 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Newsletter live-send pipeline — LFXV2-2389.
+ *
+ * Every other newsletter spec in this suite stubs the newsletter / committee /
+ * project APIs with `page.route()`. This spec is a deliberate, narrowly-scoped
+ * exception: it drives the compose → send → analytics flow against the real
+ * lfx-v2-newsletter-service / committee-service / project-service stack, so a
+ * wiring gap between the frontend contract and the live backend response shape
+ * can't hide behind a mock that encodes the same (possibly wrong) assumption.
+ *
+ * Not covered here: nonzero "opens" in analytics. Email opens are triggered by
+ * an external mail client loading a tracking pixel — there is no deterministic
+ * way to fire one from a Playwright run. The happy path only asserts that
+ * Analytics loads and correlates to the send's `group_id`.
+ *
+ * Prerequisites:
+ *   - Full local platform stack up (see lfx-v2-helm) with lfx-v2-newsletter-service,
+ *     lfx-v2-committee-service, and lfx-v2-email-service reachable.
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see
+ *     e2e/helpers/auth.helper.ts) AND the four LIVE_* vars documented in
+ *     e2e/helpers/live-env.helper.ts, pointing at a seeded project + committee
+ *     with at least one member.
+ *   - Run in isolation via `yarn e2e:live` — NOT part of the default `yarn e2e`
+ *     gate, since CI has no job that stands up the full local stack yet.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+import { getLiveEnv, skipWhenLiveEnvMissing } from './helpers/live-env.helper';
+
+test.setTimeout(120_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+const SEND_SETTLE_TIMEOUT = 30_000;
+
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+async function gotoAuthed(page: Page, path: string): Promise<void> {
+  skipWhenAuthMissing();
+  skipWhenLiveEnvMissing();
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto(path, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+}
+
+async function selectAudienceCommittee(page: Page, committeeName: string): Promise<void> {
+  await page.getByTestId('newsletter-audience-committees').click();
+  await page.getByRole('option', { name: committeeName, exact: true }).click();
+}
+
+async function fillSubject(page: Page, subject: string): Promise<void> {
+  await page.getByTestId('newsletter-content-subject').locator('input').fill(subject);
+}
+
+async function fillBody(page: Page, body: string): Promise<void> {
+  // The tiptap content div shares the `newsletter-content-body` testid with its
+  // wrapper (see rich-editor.component.html/.ts), so target it by class instead
+  // of getByTestId to avoid a strict-mode multi-match error.
+  const editorContent = page.locator('.lfx-rich-editor__content');
+  await editorContent.click();
+  await page.keyboard.type(body);
+}
+
+test.describe('Newsletter live send — happy path', () => {
+  test('compose, send to a real committee, and load analytics for the sent newsletter', async ({ page }) => {
+    const env = getLiveEnv();
+    const subject = `Live E2E Newsletter ${Date.now()}`;
+
+    await gotoAuthed(page, `/foundation/newsletters/create?project=${env.projectSlug}`);
+    await expect(page.getByTestId('newsletter-manage-stepper'), 'create should land on the stepper').toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    // Step 1 — Audience.
+    await expect(page.getByTestId('newsletter-audience-step')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await selectAudienceCommittee(page, env.committeeName);
+    await expect(page.getByTestId('newsletter-audience-committees'), 'picker should reflect the selected committee').toContainText(env.committeeName);
+    await page.getByTestId('newsletter-manage-next-btn').click();
+
+    // Step 2 — Content. Filling triggers the debounced autosave, which creates
+    // the draft (POST .../newsletters) the first time subject+body+audience are
+    // all present — capture that response to get the newsletter id / project_uid.
+    await expect(page.getByTestId('newsletter-content-step')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    const createResponsePromise = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && /\/api\/projects\/[^/]+\/newsletters$/.test(new URL(response.url()).pathname),
+      { timeout: SEND_SETTLE_TIMEOUT }
+    );
+    await fillSubject(page, subject);
+    await fillBody(page, 'Live E2E send body content — verifying the compose-to-analytics pipeline against the real backend.');
+
+    const createResponse = await createResponsePromise;
+    expect(createResponse.ok(), 'draft autosave-create should succeed').toBeTruthy();
+    const draft = await createResponse.json();
+    const newsletterId: string = draft.id;
+    const projectUid: string = draft.project_uid;
+    expect(newsletterId).toBeTruthy();
+    expect(projectUid).toBeTruthy();
+
+    await expect(page.getByTestId('newsletter-content-saved-indicator'), 'saved indicator should confirm the autosave landed').toBeVisible({
+      timeout: SEND_SETTLE_TIMEOUT,
+    });
+    await page.getByTestId('newsletter-manage-next-btn').click();
+
+    // Step 3 — Send.
+    await expect(page.getByTestId('newsletter-send-step')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-send-now-button')).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+
+    const sendResponsePromise = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && response.url().includes(`/newsletters/${newsletterId}/send`),
+      { timeout: SEND_SETTLE_TIMEOUT }
+    );
+    await page.getByTestId('newsletter-send-now-button').click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog, 'send confirmation dialog should appear').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await dialog.getByRole('button', { name: /send now/i }).click();
+
+    const sendResponse = await sendResponsePromise;
+    expect(sendResponse.ok(), 'send request should be accepted').toBeTruthy();
+    const sendResult = await sendResponse.json();
+    const groupId: string = sendResult.group_id;
+    expect(groupId, 'send result should carry a group_id for analytics correlation').toBeTruthy();
+    expect(['sending', 'sent']).toContain(sendResult.newsletter.status);
+
+    // Both the synchronous (`sent`, zero-recipient edge case) and asynchronous
+    // (`sending`) accept paths land on the Sent tab.
+    await expect(page).toHaveURL(/tab=sent/, { timeout: SEND_SETTLE_TIMEOUT });
+
+    // Navigate directly to Analytics via the captured id/project_uid rather than
+    // depending on list-row ordering.
+    await page.goto(`/foundation/newsletters/${projectUid}/${newsletterId}/analytics?project=${env.projectSlug}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('newsletter-analytics'), 'analytics screen should load for the sent newsletter').toBeVisible({
+      timeout: SEND_SETTLE_TIMEOUT,
+    });
+    await expect(page.getByTestId('newsletter-analytics-subject')).toContainText(subject);
+    await expect(page.getByTestId('newsletter-analytics-recipients')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    // Deliberately not asserting a nonzero open count — see file header.
+  });
+});
+
+test.describe('Newsletter live send — re-send an already-sent newsletter', () => {
+  test('re-sending a sent newsletter is treated as a no-op, not an error', async ({ page }) => {
+    const env = getLiveEnv();
+    const subject = `Live E2E Resend Guard ${Date.now()}`;
+
+    // Compose + send once (mirrors the happy path) to get a genuinely `sent`
+    // newsletter to re-target.
+    await gotoAuthed(page, `/foundation/newsletters/create?project=${env.projectSlug}`);
+    await selectAudienceCommittee(page, env.committeeName);
+    await page.getByTestId('newsletter-manage-next-btn').click();
+
+    const createResponsePromise = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && /\/api\/projects\/[^/]+\/newsletters$/.test(new URL(response.url()).pathname),
+      { timeout: SEND_SETTLE_TIMEOUT }
+    );
+    await fillSubject(page, subject);
+    await fillBody(page, 'Body content for the resend-guard regression check.');
+    const createResponse = await createResponsePromise;
+    const draft = await createResponse.json();
+    const newsletterId: string = draft.id;
+    const projectUid: string = draft.project_uid;
+
+    await expect(page.getByTestId('newsletter-content-saved-indicator')).toBeVisible({ timeout: SEND_SETTLE_TIMEOUT });
+    await page.getByTestId('newsletter-manage-next-btn').click();
+
+    await expect(page.getByTestId('newsletter-send-now-button')).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    const firstSendPromise = page.waitForResponse(
+      (response) => response.request().method() === 'POST' && response.url().includes(`/newsletters/${newsletterId}/send`),
+      { timeout: SEND_SETTLE_TIMEOUT }
+    );
+    await page.getByTestId('newsletter-send-now-button').click();
+    await page.locator('[role="dialog"]').getByRole('button', { name: /send now/i }).click();
+    await firstSendPromise;
+    await expect(page).toHaveURL(/tab=sent/, { timeout: SEND_SETTLE_TIMEOUT });
+
+    // Give the async fan-out a moment to settle to `sent` before re-targeting it.
+    await expect
+      .poll(
+        async () => {
+          const res = await page.request.get(`/api/projects/${projectUid}/newsletters/${newsletterId}`);
+          const body = await res.json();
+          return body.status;
+        },
+        { timeout: SEND_SETTLE_TIMEOUT, intervals: [1_000, 2_000, 3_000] }
+      )
+      .toBe('sent');
+
+    // Reopen the now-sent newsletter and attempt to send it again. The upstream
+    // rejects with 409 already_sent, but the UI's handleSendError() refetches and
+    // finds status='sent' — it surfaces an INFO "Newsletter sent" toast and
+    // returns to the Sent tab instead of a generic error, guarding against a
+    // duplicate-send regression (LFXV2-2604). Assert on that real behavior.
+    await page.goto(`/foundation/newsletters/${projectUid}/${newsletterId}/edit?project=${env.projectSlug}`, { waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('newsletter-review'), 'reopening a sent newsletter lands on the review screen').toBeVisible({
+      timeout: PAGE_LOAD_TIMEOUT,
+    });
+
+    await page.getByTestId('newsletter-review-send-now-btn').click();
+    await page.locator('[role="dialog"]').getByRole('button', { name: /send now/i }).click();
+
+    await expect(page.locator('.p-toast'), 'a resend attempt should surface the no-op info toast, not a generic error').toContainText(
+      'Newsletter sent',
+      { timeout: SEND_SETTLE_TIMEOUT }
+    );
+    await expect(page).toHaveURL(/tab=sent/, { timeout: SEND_SETTLE_TIMEOUT });
+  });
+});

--- a/apps/lfx-one/package.json
+++ b/apps/lfx-one/package.json
@@ -21,6 +21,7 @@
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
     "e2e:headed": "playwright test --headed",
+    "e2e:live": "playwright test newsletter-live-send",
     "docs:build": "node scripts/build-docs.mjs",
     "docs:validate": "node scripts/validate-manifest.mjs",
     "docs:check-coverage": "node scripts/check-coverage.mjs",

--- a/docs/architecture/testing/e2e-testing.md
+++ b/docs/architecture/testing/e2e-testing.md
@@ -270,6 +270,40 @@ For a new feature, write both specs together:
 4. If the feature has an error path, mock the relevant API with `page.route()` and cover the error-state component.
 5. Verify locally with `yarn e2e` before opening a PR.
 
+## Live-Service Exception
+
+Every spec above stubs the newsletter/committee/project APIs with `page.route()`. `newsletter-live-send.spec.ts` and `newsletter-live-send-robust.spec.ts` are a deliberate, narrowly-scoped exception: they drive the newsletter compose → send → analytics flow against the real `lfx-v2-newsletter-service`, `lfx-v2-committee-service`, and `lfx-v2-email-service` stack, with zero `page.route()` mocking of those APIs. A mock encodes the same assumption the frontend contract makes about the backend response shape — it can't catch a genuine wiring gap between the two. These specs can.
+
+This exception is scoped narrowly on purpose:
+
+- Only these two files skip mocking. Every other spec keeps the standard `page.route()` convention.
+- They run via a separate script, `yarn e2e:live`, and are **not** part of the default `yarn e2e` gate — CI has no job yet that stands up the full local platform stack, so they're opt-in and local-only for now.
+- The happy path asserts that Analytics loads and correlates to the send's `group_id` — it does **not** assert a nonzero open count. Email opens are triggered by a mail client loading a tracking pixel; there's no deterministic way to fire one from a Playwright run.
+- The error-path spec re-sends an already-`sent` newsletter and asserts the real no-op behavior (an info toast + navigation back to the Sent tab), not a generic error — see `handleSendError()` in `newsletter-manage.component.ts`.
+
+### Required environment
+
+Beyond `TEST_USERNAME` / `TEST_PASSWORD`, these specs need a seeded project and committee to target. Set these in `apps/lfx-one/.env` (documented in full, with rationale, in `e2e/helpers/live-env.helper.ts`):
+
+| Var                   | Purpose                                                                             |
+| ---------------------- | ------------------------------------------------------------------------------------ |
+| `LIVE_PROJECT_SLUG`    | Slug of a seeded project the test user can manage newsletters for.                   |
+| `LIVE_PROJECT_UID`     | That project's UID (newsletter edit/analytics routes are UID-keyed, not slug-keyed). |
+| `LIVE_COMMITTEE_UID`   | UID of a committee under that project with at least one member.                      |
+| `LIVE_COMMITTEE_NAME`  | That committee's display name, used to select it from the audience picker's options. |
+
+All four are required together. `skipWhenLiveEnvMissing()` mirrors the existing `skipWhenAuthMissing()` pattern — gated on explicit env-var presence rather than URL sniffing, so a genuinely broken live stack still fails loudly instead of silently skipping. A partially-configured environment skips cleanly rather than failing on a missing fixture.
+
+### Running locally
+
+```bash
+# bring up the full local platform stack first (see lfx-v2-helm), with
+# lfx-v2-newsletter-service, lfx-v2-committee-service, and lfx-v2-email-service
+# reachable, and the four LIVE_* vars + TEST_USERNAME/TEST_PASSWORD set
+
+yarn e2e:live
+```
+
 ## Related
 
 - [Testing Best Practices](testing-best-practices.md) — deeper treatment of dual architecture and `data-testid` conventions.


### PR DESCRIPTION
Resolves danthebaker/lfx-roadmap#5

### Gates
- adversarial review: pass
- security: pass
- blast radius: needs_human

### Spec
Now let me check the e2e testing architecture doc and playwright config to understand the "dual architecture" convention and how "no mock data" live-service tests would fit (or diverge from) the existing all-mocked pattern.I now have enough to write the complete spec. Two more facts worth locking in: the newsletter-service's email chrome renderer (`internal/service/render/email_chrome.go`) is a plain Go string-templating package — no MJML anywhere — and it explicitly documents that `BodyHTML` is interpolated "verbatim" with no sanitizer. There's no template-engine exception path; the only validation-style failure in the send path is things like `ErrInvalidRequest` for a bad `to_email` on test-send. That settles the "MJML" and "render-error" ambiguities in the issue text. Writing the spec now.No wiki-write tool is available in this environment — only `wiki_search`/`wiki_read` — so the spec below is the deliverable of record; it isn't persisted to project memory automatically.

---

# SPEC: End-to-end newsletter send + analytics wiring + Playwright E2E

**JIRA:** LFXV2-2389 · **Epic:** LFXV2-2682 · **GitHub Issue:** #5
**Branch:** `feat/LFXV2-2389`
**Depends on:** LFXV2-2388 (separate ticket, separate repo scope — see §5 Architecture Classification)
**Status:** Draft spec — not implemented. No code has been changed while producing this document.

## 0. Resolution of prior blocking review

This document replaces an earlier submission that was rejected for five reasons. Each is addressed directly:

| # | Prior objection | Resolution in this spec |
|---|---|---|
| 1 | Submission was a raw exploration transcript, not a spec | This is a structured spec: goal, scope, architecture classification, file list, test plan, risks. |
| 2 | Ended mid-sentence, no concrete spec produced | Complete document below, no unfinished sections. |
| 3 | No stated target deliverable; ambiguous which repo(s) | §1/§2 state the deliverable precisely: **Playwright E2E coverage in `lfx-self-serve` only**, plus a narrow verification/wiring task, not a SendGrid rebuild. |
| 4 | SendGrid work is architectural and wasn't classified | §5 explicitly classifies: the SendGrid provider swap (LFXV2-2388) is architectural and **out of scope here**; the work in this spec is not. |
| 5 | No JIRA/branch/PR scope/test plan/file list | Provided in §2, §6, §7 below. |

## 1. Prior-art check (wiki_search)

Searched project memory for overlapping specs (`newsletter e2e`, `LFXV2-2389`, `SendGrid newsletter`, `newsletter send analytics`). No existing `specs/` page covers this ticket or LFXV2-2388. The only newsletter-related spec hits (`specs/spec-newsletters-module`, `imported/gatewaze-newsletters-integration`) belong to the unrelated Gatewaze project and are not in conflict.

One directly relevant non-spec memory page exists and is load-bearing for this spec: `imported/lfx-local-dev-model`. It documents that the **full-local OrbStack/`lfx-v2-helm` stack (NATS + Mailpit + Authelia + all backend services) already exercises the entire send path end-to-end today with no SendGrid/SES involved** ("newsletter-service → NATS → email-service → Mailpit"), and that the default remote-dev `yarn start` target cannot reach NATS, which breaks persona/project resolution and hides the Newsletters nav entirely. This is treated as an existing decision, not contradicted — it directly shapes §6's environment requirement.

## 2. Goal and scope (target deliverable)

**Goal:** Prove, with automated tests, that the already-implemented backend pipeline — committee recipient resolution → email chrome rendering → send fan-out → engagement/analytics overlay — works end-to-end from the LFX One UI, using dual-architecture Playwright specs against live backend services (no `page.route()` mocking of the newsletter APIs under test).

**In scope (this ticket, this spec):**
- New Playwright E2E specs in `lfx-self-serve` covering: compose → preview → send to a committee → engagement appears in analytics (happy path), and a render/send-error path.
- A short verification pass confirming the already-built backend pipeline (documented in `lfx-v2-newsletter-service/docs/newsletter-service-contract.md` and `docs/recipient-resolution.md`) has no gaps against what the UI actually calls. If a genuine wiring gap is found (e.g., a field the UI needs that the API doesn't return), a minimal, non-architectural fix in `lfx-v2-newsletter-service` and/or the `lfx-self-serve` BFF proxy layer.

**Explicitly out of scope (this ticket):**
- Building or swapping any email-sending provider (SendGrid or otherwise). See §5.
- Any MJML templating work. There is no MJML anywhere in this pipeline today (see §4) — the issue text's reference to "MJML `body_html`" does not match the current implementation and is called out as a factual correction, not implemented against.
- Any new NATS subject, new table, new service, or new third-party integration.

**Two important corrections to the issue text**, surfaced explicitly rather than silently assumed:

1. **"SendGrid send"**: no SendGrid code, config, or references exist anywhere in the workspace. The current, fully-implemented, documented email dispatch path is SMTP/Amazon SES via `lfx-v2-email-service` (`lfx-v2-email-service/CLAUDE.md`, `lfx-v2-newsletter-service/docs/recipient-resolution.md` §"Email-Service Fan-Out"). LFXV2-2388 ("SendGrid provider, on branch `feat/LFXV2-2388`") does not exist in this checkout. This spec's E2E tests exercise whatever provider is actually deployed in the target test environment — for the full-local stack, that's SMTP→Mailpit; nothing here depends on SendGrid landing.
2. **"MJML `body_html`"**: `internal/service/render/email_chrome.go` in `lfx-v2-newsletter-service` is a plain Go string-builder (per-tag inline CSS injected into an HTML envelope), not MJML. The package's own doc comment states `BodyHTML` is "interpolated verbatim" with **no HTML sanitizer** — authored content comes from the writer's WYSIWYG editor in `lfx-self-serve`. No MJML dependency needs to be added for this ticket.

## 3. Current state (what already works — verified by reading, not assumed)

Confirmed already implemented and documented, requiring no new backend design:
- Recipient resolution: `SendOrchestrator.resolveRecipients` → `lfx.committee-api.list_members` per committee, dedup/normalize/unsubscribe-filter (`docs/recipient-resolution.md`).
- Chrome rendering: `render.Chrome` / `render.EmailHTML` / `render.EmailText`.
- Fan-out: `SendOrchestrator.SendNewsletter` → `lfx.email-service.send_email`, bounded concurrency, `group_id` minted for correlation, async `202`-accept state machine (`draft`→`sending`→`sent`, crash-recovery sweep via `STUCK_SEND_TTL`).
- Analytics overlay: `GET /projects/{project_uid}/newsletters/{newsletter_uid}/analytics`, aggregating local opens with `lfx.email-service.get_email_engagement_analytics` by `group_id`.
- Frontend: full compose stepper (audience/content/send), review screen, preview drawer, send-step component (`newsletter-send-step.component.ts`: `send`/`sendTest` outputs, `canSend`/`sending`/`recipientCount` inputs), analytics component (`newsletter-analytics.component.ts`) with chart, empty state, and a "failed recipients" drawer for partial-failure visibility.

This confirms the real gap this ticket needs to close is **test coverage**, not backend construction.

## 4. Architecture classification

Per the root LFX process rules and `lfx-v2-newsletter-service`'s own CLAUDE.md, classify honestly:

- **This ticket's actual scope (E2E tests + verification, no new contract/service/datastore/dependency) is NOT an architecture change.** It adds no new service, no new table, no new or changed cross-service contract, and no new third-party dependency. It proceeds directly to implementation without an `lfx-architecture-scratch` proposal.
- **LFXV2-2388 (a SendGrid provider), if and when it is real, IS architectural** under `lfx-v2-newsletter-service`'s/`lfx-v2-email-service`'s own CLAUDE.md rule ("a new external dependency or third-party integration (a new SaaS, a new provider SDK, a new outbound egress)"). That work must go through its own architecture proposal in `linuxfoundation/lfx-architecture-scratch` in whichever repo ends up owning it, independently of this spec. This spec takes no position on whether that proposal exists yet — it is out of scope here and is called out as a dependency risk in §8, not absorbed into this ticket.

## 5. Approach

### 5.1 Test environment (blocking precondition)

Per `imported/lfx-local-dev-model`, the default `yarn start` target used by `playwright.config.ts`'s `webServer` cannot reach NATS, so the Newsletters nav/persona gating won't even render. The new specs require the **full-local stack** (`lfx-v2-helm` → `charts/lfx-platform` on OrbStack, with Mailpit as the local SMTP catcher and Authelia for auth) to be running, with `SES_FANOUT_ENABLED`/`SEND_FANOUT_ENABLED=true` and mock data seeded (a project with a writer/ED persona and at least one committee with members). This is documented as a named precondition, not silently assumed:

- Local dev: engineer brings up the full-local stack per `lfx-v2-helm`'s local-stack skill, then runs `yarn e2e` against it (may require pointing `playwright.config.ts`'s `webServer`/`baseURL` at the full-local app instance, or running the Angular dev server against the local backend's API base URL — an env-var change, not a code architecture change).
- CI: **flagged as an open risk (§8)** — there is currently no CI job that stands up the full-local Helm stack for E2E. This PR does not attempt to build that CI infrastructure; it delivers specs designed to run against it, and documents the requirement so a follow-up CI ticket can provision it. Until that exists, these specs are **not** part of the default `yarn e2e` gate — they get their own npm script and `describe` tag so they can be skipped in normal CI (see §6).

### 5.2 Reconciling "no mock data" with the house dual-architecture convention

`docs/architecture/testing/e2e-testing.md` explicitly recommends `page.route()` mocking for error-path coverage, and every existing newsletter spec is fully mocked. LFXV2-2389's acceptance criteria explicitly require the opposite for this feature. This spec resolves the tension as a deliberate, scoped exception rather than a silent violation:

- The new specs (`newsletter-live-send.spec.ts` / `-robust.spec.ts`) make **zero** `page.route()` calls against newsletter, committee, or project APIs. They drive the real BFF (`newsletter.controller.ts`) against the real newsletter-service/committee-service/email-service.
- **Happy path**: compose a newsletter targeting a seeded test committee → preview → send → poll the Sent list until status flips to `sent` → open Analytics → assert the page renders (open count may legitimately be 0 immediately after send; the assertion is "analytics view loads and shows the newsletter's real `group_id`-correlated record," not "opens > 0," since driving a real email client open isn't feasible in CI).
- **Render-error path**: rather than stubbing a 500 (which would violate "no mock data"), this is triggered with a **real, live validation failure** — e.g., attempting `send` with zero resolved recipients (a committee seeded with no members), which the backend already rejects/handles as a documented zero-recipient edge case per `newsletter-service-contract.md`, or a real 4xx from `test-send` with a malformed email. This exercises an authentic backend error response, satisfying "no mock data" while still covering the UI's error-rendering path (toast/error state assertions).
- This exception is scoped to these two new spec files only. Existing mocked newsletter specs are left as-is (they cover different, complementary concerns — reopen/review, opt-out — and are out of this ticket's scope to rewrite).

## 6. Files to change

**Repo: `lfx-self-serve`** (primary deliverable)

- `apps/lfx-one/e2e/newsletter-live-send.spec.ts` — new, content-based, live-service happy-path + error-path spec.
- `apps/lfx-one/e2e/newsletter-live-send-robust.spec.ts` — new, structural spec asserting `data-testid` contract on send-step/analytics components during a live run.
- `apps/lfx-one/e2e/helpers/live-env.helper.ts` — new, small helper: reads env vars for a seeded test committee UID / project slug, and a `skipWhenLiveEnvMissing()` guard (mirrors the existing `skipWhenAuthMissing()` pattern) so these specs no-op cleanly outside the full-local stack.
- `apps/lfx-one/package.json` — add a separate script, e.g. `"e2e:live"`, that runs only `*-live-send*.spec.ts`, so these are opt-in and don't join the default `yarn e2e` gate until CI infra exists (§8).
- `docs/architecture/testing/e2e-testing.md` — add a short "Live-service exception" subsection documenting this pattern (per repo convention: docs updated in the same PR as behavior change).
- Any `data-testid` additions needed on `newsletter-send-step`, `newsletter-review`, or `newsletter-analytics` components if the existing surface is insufficient (to be confirmed during implementation; current surface documented in the earlier investigation already looks adequate — `newsletter-review-send-now-btn`, `newsletter-status-sent-${id}`-style testids if they don't already exist for the Sent tab, etc.).

**Repo: `lfx-v2-newsletter-service`** (only if verification finds a real gap — not assumed)

- Possible minor fix inside `internal/service/send_orchestrator.go` or `internal/handler/` if the E2E work surfaces a real contract mismatch (e.g., a missing field in the analytics or send response the UI needs). No file is pre-committed here; if no gap is found, this repo has **zero** diff for this ticket.
- If a fix is needed: update `docs/newsletter-service-contract.md` and/or `docs/recipient-resolution.md` in the same PR per that repo's own change checklist, and add/adjust a Go table-driven test.

**Not touched:** `lfx-v2-email-service`, `lfx-v2-committee-service`, `lfx-v2-helm` (stack usage only, no chart changes), `lfx-v2-mockdata` (seed data reused/extended via its existing playbooks if the test committee doesn't already exist — see Test Plan).

## 7. Test plan

1. **Precondition check**: full-local stack up (`lfx-v2-helm`), mock data seeded via `lfx-v2-mockdata`'s `/load-mock-data` skill including at least one committee with ≥1 member and one with 0 members (for the error path).
2. `newsletter-live-send.spec.ts` (content):
   - Compose a draft targeting the populated committee, verify preview renders real recipient count.
   - Send; poll until list shows `sent` status.
   - Open Analytics; assert the page loads with the correct `group_id`-correlated record (no reliance on a nonzero open count).
   - Error path: attempt send against the zero-member committee; assert the real backend-driven error/empty-state UI renders (toast or inline message, whichever the current UI emits for this case — confirmed during implementation, not assumed here).
3. `newsletter-live-send-robust.spec.ts` (structural): assert `data-testid` presence/nesting on the send-step, review, and analytics components through the same live flow (no route mocking).
4. If a backend fix lands in `lfx-v2-newsletter-service`: `go test ./...` plus `make check` per that repo's own gates.
5. `yarn e2e:live` run locally against the full-local stack before PR open; standard `yarn e2e` (mocked suite) also still run and must stay green, confirming no regression to existing mocked specs.
6. Both repos' post-commit review cycles (per their own CLAUDE.md) run as normal before PR open.

## 8. Risks

- **CI feasibility gap**: no existing CI job stands up the full-local Helm stack; these specs cannot run in the default CI pipeline yet. Mitigated by keeping them under a separate opt-in script (`yarn e2e:live`), not blocking the default gate; flagged as a follow-up infra ticket, not solved here.
- **LFXV2-2388 dependency is unconfirmed**: the referenced SendGrid branch does not exist in this checkout. This spec does not depend on it (tests run against whatever provider is actually deployed), but if the epic intends these tests to specifically validate a SendGrid path, that's a scope decision for the epic owner to make explicitly — flagged, not assumed.
- **Non-deterministic "open" analytics**: real email engagement (an actual open pixel hit) can't be reliably triggered in an automated test; the happy-path assertion is scoped to "analytics view loads correctly post-send," not "shows a nonzero open," to avoid a flaky/undeliverable acceptance criterion.
- **Seeded data drift**: live tests depend on stable seeded committees/members via `lfx-v2-mockdata`; if that data changes shape, tests break for reasons unrelated to newsletter code. Mitigated by using a small helper (`live-env.helper.ts`) that reads committee UID from env rather than hardcoding, and skips cleanly when absent.
- **Backend gap discovery risk**: if verification finds a real contract mismatch, that fix must stay minimal and non-architectural; if it turns out to require a new contract/field exposed cross-service, that portion must be split into its own architecture-classified follow-up rather than smuggled into this PR.