### PR TITLE
feat(committees): add pending invitations tab to group members list

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -26,9 +26,12 @@ import {
   TagSeverity,
 } from '@lfx-one/shared';
 import {
+  AcceptInviteOrganizationDialogData,
+  AcceptInviteOrganizationDialogResult,
   CommitteeEngagementResponse,
   CommitteeEngagementWindow,
   CommitteeJoinApplication,
+  CommitteeOrganizationReference,
   GroupsIOMailingList,
   Meeting,
   PendingInvitation,
@@ -36,7 +39,7 @@ import {
   TabConfigEntry,
 } from '@lfx-one/shared/interfaces';
 import { COMMITTEE_ENGAGEMENT_DEFAULT_WINDOW, COMMITTEE_VALID_TABS, WG_ENGAGEMENT_METRICS_FLAG } from '@lfx-one/shared/constants';
-import { canManageCommitteeMembers, findPendingInvitationForCommittee, invitationRequiresOrganization } from '@lfx-one/shared/utils';
+import { canManageCommitteeMembers, committeeRequiresOrganization, findPendingInvitationForCommittee, invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { CommitteeJoinApplicationSessionService } from '@services/committee-join-application-session.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
@@ -58,6 +61,7 @@ import { catchError, combineLatest, distinctUntilChanged, EMPTY, exhaustMap, fil
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
+import { AcceptInviteOrganizationDialogComponent } from '@components/accept-invite-organization-dialog/accept-invite-organization-dialog.component';
 import { JoinApplicationDialogComponent } from '../components/join-application-dialog/join-application-dialog.component';
 
 import { CommitteeAboutComponent } from '../components/committee-about/committee-about.component';
@@ -471,18 +475,27 @@ export class CommitteeViewComponent {
     });
   }
 
-  public handleJoinRequest(): void {
+  public async handleJoinRequest(): Promise<void> {
     const committee = this.committee();
     if (!committee || this.joiningOrLeaving()) {
       return;
     }
 
     const joinMode = committee.join_mode;
+    const requiresOrg = committeeRequiresOrganization(committee);
 
     if (joinMode === 'open') {
+      let organization: CommitteeOrganizationReference | undefined;
+      if (requiresOrg) {
+        const result = await this.openOrganizationDialog(committee.name);
+        if (!result?.organization) {
+          return;
+        }
+        organization = result.organization;
+      }
       this.joiningOrLeaving.set(true);
       this.committeeService
-        .joinCommittee(committee.uid)
+        .joinCommittee(committee.uid, organization)
         .pipe(finalize(() => this.joiningOrLeaving.set(false)))
         .subscribe({
           next: () => {
@@ -498,7 +511,15 @@ export class CommitteeViewComponent {
       if (this.hasPendingApplication()) {
         return;
       }
-      this.openApplicationDialog(committee.uid, committee.name);
+      let organization: CommitteeOrganizationReference | undefined;
+      if (requiresOrg) {
+        const result = await this.openOrganizationDialog(committee.name);
+        if (!result?.organization) {
+          return;
+        }
+        organization = result.organization;
+      }
+      this.openApplicationDialog(committee.uid, committee.name, organization);
     } else {
       // closed — no self-service action available
       this.messageService.add({ severity: 'info', summary: 'Contact Admin', detail: 'Contact a group admin to request membership.' });
@@ -704,7 +725,7 @@ export class CommitteeViewComponent {
       });
   }
 
-  private openApplicationDialog(committeeUid: string, committeeName: string): void {
+  private openApplicationDialog(committeeUid: string, committeeName: string, organization?: CommitteeOrganizationReference): void {
     if (this.joiningOrLeaving()) {
       return;
     }
@@ -727,7 +748,7 @@ export class CommitteeViewComponent {
       }
 
       this.committeeService
-        .submitApplication(committeeUid, result.message)
+        .submitApplication(committeeUid, result.message, organization)
         .pipe(finalize(() => this.joiningOrLeaving.set(false)))
         .subscribe({
           next: () => {
@@ -751,6 +772,22 @@ export class CommitteeViewComponent {
             this.messageService.add({ severity: 'error', summary: 'Unable to Submit', detail, life: 6000 });
           },
         });
+    });
+  }
+
+  private openOrganizationDialog(committeeName: string): Promise<AcceptInviteOrganizationDialogResult | null> {
+    const ref = this.dialogService.open(AcceptInviteOrganizationDialogComponent, {
+      header: 'Confirm Organization',
+      width: '32rem',
+      modal: true,
+      closable: true,
+      data: { committeeName, organization: null } satisfies AcceptInviteOrganizationDialogData,
+    });
+    if (!ref) {
+      return Promise.resolve(null);
+    }
+    return new Promise((resolve) => {
+      ref.onClose.pipe(take(1)).subscribe((result: AcceptInviteOrganizationDialogResult | null) => resolve(result ?? null));
     });
   }
 

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -39,7 +39,12 @@ import {
   TabConfigEntry,
 } from '@lfx-one/shared/interfaces';
 import { COMMITTEE_ENGAGEMENT_DEFAULT_WINDOW, COMMITTEE_VALID_TABS, WG_ENGAGEMENT_METRICS_FLAG } from '@lfx-one/shared/constants';
-import { canManageCommitteeMembers, committeeRequiresOrganization, findPendingInvitationForCommittee, invitationRequiresOrganization } from '@lfx-one/shared/utils';
+import {
+  canManageCommitteeMembers,
+  committeeRequiresOrganization,
+  findPendingInvitationForCommittee,
+  invitationRequiresOrganization,
+} from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { CommitteeJoinApplicationSessionService } from '@services/committee-join-application-session.service';
 import { FeatureFlagService } from '@services/feature-flag.service';

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -6,7 +6,7 @@
   <p-confirmDialog></p-confirmDialog>
 
   <!-- Committee Members Section -->
-  <lfx-card [styleClass]="showPendingTab() ? '[&_.p-card-body]:p-0 [&_.p-card-content]:p-0' : ''">
+  <lfx-card [styleClass]="showPendingInvites() ? '[&_.p-card-body]:p-0 [&_.p-card-content]:p-0' : ''">
     @if (!showMembersSection()) {
       <div class="text-sm text-gray-500 text-center py-6" data-testid="members-hidden-placeholder">Member list is not publicly visible for this group.</div>
     } @else if (!showMemberRoster() && canSendMemberInvites()) {
@@ -22,12 +22,12 @@
         </lfx-button>
       </div>
     } @else {
-      @if (showPendingTab()) {
+      @if (showPendingInvites()) {
         <lfx-card-tabs-bar [options]="tabOptions()" [selectedFilter]="activeTab()" (filterChange)="onTabChange($event)" data-testid="members-tab-bar">
         </lfx-card-tabs-bar>
       }
 
-      <div [class]="showPendingTab() ? 'p-4 md:p-6' : ''">
+      <div [class]="showPendingInvites() ? 'p-4 md:p-6' : ''">
         @if (activeTab() === 'all') {
           <!-- Quick Filter Chips + engagement window controls -->
           <div class="flex flex-wrap items-center justify-between gap-2 mb-4">
@@ -185,7 +185,6 @@
                   </span>
                 } @else {
                   <div class="flex flex-wrap items-center gap-2">
-                    <span class="text-sm font-inter text-gray-900 font-medium">{{ row.data.invitee_email }}</span>
                     <lfx-tag value="Pending invitation" severity="warn" />
                   </div>
                 }
@@ -347,7 +346,7 @@
                 <td [attr.colspan]="emptyStateColspan()" class="text-center py-8">
                   <div class="text-center">
                     <i class="fa-light fa-users text-3xl text-gray-300 mb-2"></i>
-                    <p class="text-sm font-medium text-gray-600">No members found</p>
+                    <p class="text-sm font-medium text-gray-600">{{ activeTab() === 'pending' ? 'No pending invitations' : 'No members found' }}</p>
                     @if (canManageMembers() && activeTab() !== 'pending') {
                       <div class="mt-3">
                         <button class="text-xs text-blue-600 hover:text-blue-700 font-medium" (click)="openAddMemberDialog()">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -311,6 +311,7 @@
                   [rounded]="true"
                   size="small"
                   severity="secondary"
+                  ariaLabel="Invite actions"
                   [attr.data-testid]="'invite-actions-btn-' + row.data.uid"
                   (onClick)="toggleInviteActionMenu($event, row.data, inviteActionMenu)">
                 </lfx-button>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -23,11 +23,7 @@
       </div>
     } @else {
       @if (showPendingTab()) {
-        <lfx-card-tabs-bar
-          [options]="tabOptions()"
-          [selectedFilter]="activeTab()"
-          (filterChange)="onTabChange($event)"
-          data-testid="members-tab-bar">
+        <lfx-card-tabs-bar [options]="tabOptions()" [selectedFilter]="activeTab()" (filterChange)="onTabChange($event)" data-testid="members-tab-bar">
         </lfx-card-tabs-bar>
       }
 
@@ -73,7 +69,14 @@
 
             <!-- Role Filter -->
             <div class="w-full sm:w-auto sm:shrink-0">
-              <lfx-select [form]="filterForm" control="role" size="small" [options]="roleOptions()" placeholder="All Roles" [showClear]="true" styleClass="w-full">
+              <lfx-select
+                [form]="filterForm"
+                control="role"
+                size="small"
+                [options]="roleOptions()"
+                placeholder="All Roles"
+                [showClear]="true"
+                styleClass="w-full">
               </lfx-select>
             </div>
 
@@ -104,258 +107,260 @@
             </div>
           }
 
-        @if (canManageMembers()) {
-          <lfx-button
-            icon="fa-light fa-user-plus"
-            label="Add Member"
-            size="small"
-            severity="info"
-            (onClick)="openAddMemberDialog()"
-            data-testid="add-member-btn">
-          </lfx-button>
-        } @else if (canSendMemberInvites()) {
-          <lfx-button
-            icon="fa-light fa-paper-plane"
-            label="Invite Someone"
-            size="small"
-            severity="info"
-            (onClick)="openInviteMemberDialog()"
-            data-testid="invite-member-btn">
-          </lfx-button>
-        }
-      </div>
+          @if (canManageMembers()) {
+            <lfx-button
+              icon="fa-light fa-user-plus"
+              label="Add Member"
+              size="small"
+              severity="info"
+              (onClick)="openAddMemberDialog()"
+              data-testid="add-member-btn">
+            </lfx-button>
+          } @else if (canSendMemberInvites()) {
+            <lfx-button
+              icon="fa-light fa-paper-plane"
+              label="Invite Someone"
+              size="small"
+              severity="info"
+              (onClick)="openInviteMemberDialog()"
+              data-testid="invite-member-btn">
+            </lfx-button>
+          }
+        </div>
 
-      <!-- Table View -->
-      <lfx-table
-        [value]="tableRows()"
-        [paginator]="true"
-        [rows]="10"
-        [rowsPerPageOptions]="[10, 25, 50]"
-        [showCurrentPageReport]="true"
-        currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
-        styleClass="p-datatable-sm">
-        <ng-template #header>
-          <tr>
-            <th>
-              <span class="text-sm font-inter text-gray-500">Name</span>
-            </th>
-            <th>
-              <span class="text-sm font-inter text-gray-500">Email</span>
-            </th>
-            <th>
-              <span class="text-sm font-inter text-gray-500">Organization</span>
-            </th>
-            @if (committee()?.enable_voting) {
+        <!-- Table View -->
+        <lfx-table
+          [value]="tableRows()"
+          [paginator]="true"
+          [rows]="10"
+          [rowsPerPageOptions]="[10, 25, 50]"
+          [showCurrentPageReport]="true"
+          currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
+          styleClass="p-datatable-sm">
+          <ng-template #header>
+            <tr>
               <th>
-                <span class="text-sm font-inter text-gray-500">Role</span>
+                <span class="text-sm font-inter text-gray-500">Name</span>
               </th>
               <th>
-                <span class="text-sm font-inter text-gray-500">Voting Status</span>
-              </th>
-            }
-            @if (engagementEnabled() && engagementAccessible()) {
-              <th>
-                <span class="text-sm font-inter text-gray-500">Meetings</span>
+                <span class="text-sm font-inter text-gray-500">Email</span>
               </th>
               <th>
-                <span class="text-sm font-inter text-gray-500">Engagement</span>
+                <span class="text-sm font-inter text-gray-500">Organization</span>
               </th>
-            }
-            <th>
-              <span class="text-sm font-inter text-gray-500">Permission</span>
-            </th>
-            <th style="width: 80px">
-              <div class="flex justify-center">
-                <span class="text-sm font-inter text-gray-500">Actions</span>
-              </div>
-            </th>
-          </tr>
-        </ng-template>
-
-        <ng-template #body let-row>
-          <tr [attr.data-testid]="row.rowType === 'member' ? 'member-row-' + row.data.uid : 'invite-row-' + row.data.uid">
-            <!-- Name -->
-            <td>
-              @if (row.rowType === 'member') {
-                <span class="text-sm font-inter text-gray-900 font-medium">
-                  {{ row.data | fullName | titlecase }}
-                </span>
-              } @else {
-                <div class="flex flex-wrap items-center gap-2">
-                  <span class="text-sm font-inter text-gray-900 font-medium">{{ row.data.invitee_email }}</span>
-                  <lfx-tag value="Pending invitation" severity="warn" />
+              @if (committee()?.enable_voting) {
+                <th>
+                  <span class="text-sm font-inter text-gray-500">Role</span>
+                </th>
+                <th>
+                  <span class="text-sm font-inter text-gray-500">Voting Status</span>
+                </th>
+              }
+              @if (engagementEnabled() && engagementAccessible()) {
+                <th>
+                  <span class="text-sm font-inter text-gray-500">Meetings</span>
+                </th>
+                <th>
+                  <span class="text-sm font-inter text-gray-500">Engagement</span>
+                </th>
+              }
+              <th>
+                <span class="text-sm font-inter text-gray-500">Permission</span>
+              </th>
+              <th style="width: 80px">
+                <div class="flex justify-center">
+                  <span class="text-sm font-inter text-gray-500">Actions</span>
                 </div>
-              }
-            </td>
-            <!-- Email -->
-            <td>
-              @if (row.rowType === 'member') {
-                <span class="text-sm font-inter text-gray-500">{{ row.data.email || '-' }}</span>
-              } @else {
-                <span class="text-sm font-inter text-gray-500">{{ row.data.invitee_email }}</span>
-              }
-            </td>
-            <!-- Organization -->
-            <td>
-              @if (row.rowType === 'member') {
-                @if (row.data.organization?.website) {
-                  <a
-                    [href]="row.data.organization.website"
-                    target="_blank"
-                    rel="noopener noreferrer"
-                    class="text-primary hover:text-primary-600 text-sm font-inter">
-                    {{ row.data.organization.name }}
-                  </a>
-                } @else {
-                  <span class="text-sm font-inter text-gray-500">{{ row.data.organization?.name || '-' }}</span>
-                }
-              } @else {
-                <span class="text-sm font-inter text-gray-500">{{ row.data.organization || '—' }}</span>
-              }
-            </td>
-            @if (committee()?.enable_voting) {
-              <!-- Role -->
+              </th>
+            </tr>
+          </ng-template>
+
+          <ng-template #body let-row>
+            <tr [attr.data-testid]="row.rowType === 'member' ? 'member-row-' + row.data.uid : 'invite-row-' + row.data.uid">
+              <!-- Name -->
               <td>
                 @if (row.rowType === 'member') {
-                  <span class="text-sm font-inter text-gray-500">{{ row.data.role?.name || 'None' }}</span>
+                  <span class="text-sm font-inter text-gray-900 font-medium">
+                    {{ row.data | fullName | titlecase }}
+                  </span>
                 } @else {
-                  <span class="text-sm font-inter text-gray-400">{{ (row.data.role && row.data.role !== noRoleSentinel) ? row.data.role : '—' }}</span>
+                  <div class="flex flex-wrap items-center gap-2">
+                    <span class="text-sm font-inter text-gray-900 font-medium">{{ row.data.invitee_email }}</span>
+                    <lfx-tag value="Pending invitation" severity="warn" />
+                  </div>
                 }
               </td>
-              <!-- Voting Status -->
+              <!-- Email -->
               <td>
                 @if (row.rowType === 'member') {
-                  <span class="text-sm font-inter text-gray-500">{{ row.data.voting?.status || 'None' }}</span>
+                  <span class="text-sm font-inter text-gray-500">{{ row.data.email || '-' }}</span>
                 } @else {
-                  <span class="text-sm font-inter text-gray-400">—</span>
+                  <span class="text-sm font-inter text-gray-500">{{ row.data.invitee_email }}</span>
                 }
               </td>
-            }
-            @if (engagementEnabled() && engagementAccessible()) {
-              <!-- Meetings -->
+              <!-- Organization -->
               <td>
                 @if (row.rowType === 'member') {
-                  @if (engagementLoading()) {
-                    <p-skeleton width="2.5rem" height="0.875rem" />
+                  @if (row.data.organization?.website) {
+                    <a
+                      [href]="row.data.organization.website"
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      class="text-primary hover:text-primary-600 text-sm font-inter">
+                      {{ row.data.organization.name }}
+                    </a>
                   } @else {
-                    @let engagementView = memberEngagementRows().get(row.data.uid);
-                    <span class="text-sm font-inter text-gray-900" [attr.data-testid]="'members-engagement-meetings-' + row.data.uid">
-                      {{ engagementView?.meetingsLabel }}
-                    </span>
+                    <span class="text-sm font-inter text-gray-500">{{ row.data.organization?.name || '-' }}</span>
                   }
                 } @else {
-                  <span class="text-sm font-inter text-gray-400">—</span>
+                  <span class="text-sm font-inter text-gray-500">{{ row.data.organization || '—' }}</span>
                 }
               </td>
-              <!-- Engagement -->
-              <td>
-                @if (row.rowType === 'member') {
-                  @if (engagementLoading()) {
-                    <p-skeleton width="4rem" height="1.25rem" borderRadius="1rem" />
+              @if (committee()?.enable_voting) {
+                <!-- Role -->
+                <td>
+                  @if (row.rowType === 'member') {
+                    <span class="text-sm font-inter text-gray-500">{{ row.data.role?.name || 'None' }}</span>
                   } @else {
-                    @let engagementView = memberEngagementRows().get(row.data.uid);
-                    @if (engagementView && engagementView.row && engagementDataAvailable()) {
-                      <lfx-tag
-                        [value]="engagementView.row.classification"
-                        [severity]="engagementView.severity"
-                        [tooltip]="engagementView.context"
-                        [attr.data-testid]="'members-engagement-chip-' + row.data.uid" />
+                    <span class="text-sm font-inter text-gray-400">{{ row.data.role && row.data.role !== noRoleSentinel ? row.data.role : '—' }}</span>
+                  }
+                </td>
+                <!-- Voting Status -->
+                <td>
+                  @if (row.rowType === 'member') {
+                    <span class="text-sm font-inter text-gray-500">{{ row.data.voting?.status || 'None' }}</span>
+                  } @else {
+                    <span class="text-sm font-inter text-gray-400">—</span>
+                  }
+                </td>
+              }
+              @if (engagementEnabled() && engagementAccessible()) {
+                <!-- Meetings -->
+                <td>
+                  @if (row.rowType === 'member') {
+                    @if (engagementLoading()) {
+                      <p-skeleton width="2.5rem" height="0.875rem" />
                     } @else {
-                      <span class="text-sm font-inter text-gray-400" [attr.data-testid]="'members-engagement-chip-' + row.data.uid">—</span>
+                      @let engagementView = memberEngagementRows().get(row.data.uid);
+                      <span class="text-sm font-inter text-gray-900" [attr.data-testid]="'members-engagement-meetings-' + row.data.uid">
+                        {{ engagementView?.meetingsLabel }}
+                      </span>
                     }
+                  } @else {
+                    <span class="text-sm font-inter text-gray-400">—</span>
                   }
+                </td>
+                <!-- Engagement -->
+                <td>
+                  @if (row.rowType === 'member') {
+                    @if (engagementLoading()) {
+                      <p-skeleton width="4rem" height="1.25rem" borderRadius="1rem" />
+                    } @else {
+                      @let engagementView = memberEngagementRows().get(row.data.uid);
+                      @if (engagementView && engagementView.row && engagementDataAvailable()) {
+                        <lfx-tag
+                          [value]="engagementView.row.classification"
+                          [severity]="engagementView.severity"
+                          [tooltip]="engagementView.context"
+                          [attr.data-testid]="'members-engagement-chip-' + row.data.uid" />
+                      } @else {
+                        <span class="text-sm font-inter text-gray-400" [attr.data-testid]="'members-engagement-chip-' + row.data.uid">—</span>
+                      }
+                    }
+                  } @else {
+                    <span class="text-sm font-inter text-gray-400">—</span>
+                  }
+                </td>
+              }
+              <!-- Permission -->
+              <td>
+                @if (row.rowType === 'member') {
+                  @let permission = getMemberPermissionInfo(row.data);
+                  <lfx-tag
+                    [value]="getMemberPermissionLabel(permission.level, permission.inherited)"
+                    [severity]="getMemberPermissionSeverity(permission.level)">
+                  </lfx-tag>
                 } @else {
                   <span class="text-sm font-inter text-gray-400">—</span>
                 }
               </td>
-            }
-            <!-- Permission -->
-            <td>
-              @if (row.rowType === 'member') {
-                @let permission = getMemberPermissionInfo(row.data);
-                <lfx-tag [value]="getMemberPermissionLabel(permission.level, permission.inherited)" [severity]="getMemberPermissionSeverity(permission.level)">
-                </lfx-tag>
-              } @else {
-                <span class="text-sm font-inter text-gray-400">—</span>
-              }
-            </td>
-            <!-- Actions -->
-            <td class="text-right relative">
-              @if (row.rowType === 'member') {
-                <lfx-menu #memberActionMenu [model]="memberActionMenuItems" [popup]="true" appendTo="body"></lfx-menu>
-                @if (canManageMembers()) {
+              <!-- Actions -->
+              <td class="text-right relative">
+                @if (row.rowType === 'member') {
+                  <lfx-menu #memberActionMenu [model]="memberActionMenuItems" [popup]="true" appendTo="body"></lfx-menu>
+                  @if (canManageMembers()) {
+                    <lfx-button
+                      icon="fa-light fa-ellipsis-vertical"
+                      [text]="true"
+                      [rounded]="true"
+                      size="small"
+                      severity="secondary"
+                      (onClick)="toggleMemberActionMenu($event, row.data, memberActionMenu)">
+                    </lfx-button>
+                  } @else {
+                    <lfx-button
+                      icon="fa-light fa-envelope"
+                      [text]="true"
+                      [rounded]="true"
+                      size="small"
+                      severity="secondary"
+                      [href]="'mailto:' + row.data.email"
+                      pTooltip="Send Message">
+                    </lfx-button>
+                  }
+                } @else if (canManageMembers()) {
+                  <lfx-menu #inviteActionMenu [model]="inviteActionMenuItems" [popup]="true" appendTo="body"></lfx-menu>
                   <lfx-button
                     icon="fa-light fa-ellipsis-vertical"
                     [text]="true"
                     [rounded]="true"
                     size="small"
                     severity="secondary"
-                    (onClick)="toggleMemberActionMenu($event, row.data, memberActionMenu)">
-                  </lfx-button>
-                } @else {
-                  <lfx-button
-                    icon="fa-light fa-envelope"
-                    [text]="true"
-                    [rounded]="true"
-                    size="small"
-                    severity="secondary"
-                    [href]="'mailto:' + row.data.email"
-                    pTooltip="Send Message">
+                    ariaLabel="Invite actions"
+                    [attr.data-testid]="'invite-actions-btn-' + row.data.uid"
+                    (onClick)="toggleInviteActionMenu($event, row.data, inviteActionMenu)">
                   </lfx-button>
                 }
-              } @else if (canManageMembers()) {
-                <lfx-menu #inviteActionMenu [model]="inviteActionMenuItems" [popup]="true" appendTo="body"></lfx-menu>
-                <lfx-button
-                  icon="fa-light fa-ellipsis-vertical"
-                  [text]="true"
-                  [rounded]="true"
-                  size="small"
-                  severity="secondary"
-                  ariaLabel="Invite actions"
-                  [attr.data-testid]="'invite-actions-btn-' + row.data.uid"
-                  (onClick)="toggleInviteActionMenu($event, row.data, inviteActionMenu)">
-                </lfx-button>
-              }
-            </td>
-          </tr>
-        </ng-template>
+              </td>
+            </tr>
+          </ng-template>
 
-        <!-- Empty Message Template -->
-        <ng-template #emptymessage>
-          @if (membersLoading()) {
-            <tr>
-              <td [attr.colspan]="emptyStateColspan()" class="text-center py-8">
-                <div class="flex flex-col gap-4 px-4">
-                  @for (_ of [1, 2, 3]; track _) {
-                    <div class="flex items-center gap-4">
-                      <p-skeleton shape="circle" size="2rem" />
-                      <p-skeleton width="8rem" height="0.875rem" />
-                      <p-skeleton width="10rem" height="0.875rem" />
-                      <p-skeleton width="6rem" height="0.875rem" />
-                    </div>
-                  }
-                </div>
-              </td>
-            </tr>
-          } @else {
-            <tr>
-              <td [attr.colspan]="emptyStateColspan()" class="text-center py-8">
-                <div class="text-center">
-                  <i class="fa-light fa-users text-3xl text-gray-300 mb-2"></i>
-                  <p class="text-sm font-medium text-gray-600">No members found</p>
-                  @if (canManageMembers()) {
-                    <div class="mt-3">
-                      <button class="text-xs text-blue-600 hover:text-blue-700 font-medium" (click)="openAddMemberDialog()">
-                        <i class="fa-light fa-user-plus mr-1"></i>Add the first member
-                      </button>
-                    </div>
-                  }
-                </div>
-              </td>
-            </tr>
-          }
-        </ng-template>
-      </lfx-table>
+          <!-- Empty Message Template -->
+          <ng-template #emptymessage>
+            @if (membersLoading()) {
+              <tr>
+                <td [attr.colspan]="emptyStateColspan()" class="text-center py-8">
+                  <div class="flex flex-col gap-4 px-4">
+                    @for (_ of [1, 2, 3]; track _) {
+                      <div class="flex items-center gap-4">
+                        <p-skeleton shape="circle" size="2rem" />
+                        <p-skeleton width="8rem" height="0.875rem" />
+                        <p-skeleton width="10rem" height="0.875rem" />
+                        <p-skeleton width="6rem" height="0.875rem" />
+                      </div>
+                    }
+                  </div>
+                </td>
+              </tr>
+            } @else {
+              <tr>
+                <td [attr.colspan]="emptyStateColspan()" class="text-center py-8">
+                  <div class="text-center">
+                    <i class="fa-light fa-users text-3xl text-gray-300 mb-2"></i>
+                    <p class="text-sm font-medium text-gray-600">No members found</p>
+                    @if (canManageMembers()) {
+                      <div class="mt-3">
+                        <button class="text-xs text-blue-600 hover:text-blue-700 font-medium" (click)="openAddMemberDialog()">
+                          <i class="fa-light fa-user-plus mr-1"></i>Add the first member
+                        </button>
+                      </div>
+                    }
+                  </div>
+                </td>
+              </tr>
+            }
+          </ng-template>
+        </lfx-table>
       </div>
     }
   </lfx-card>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -213,7 +213,7 @@
                     <span class="text-sm font-inter text-gray-500">{{ row.data.organization?.name || '-' }}</span>
                   }
                 } @else {
-                  <span class="text-sm font-inter text-gray-500">{{ row.data.organization || '—' }}</span>
+                  <span class="text-sm font-inter text-gray-500">{{ row.data.organization?.name || '—' }}</span>
                 }
               </td>
               @if (committee()?.enable_voting) {
@@ -327,7 +327,7 @@
 
           <!-- Empty Message Template -->
           <ng-template #emptymessage>
-            @if (membersLoading()) {
+            @if (membersLoading() || (activeTab() === 'pending' && invitesLoading())) {
               <tr>
                 <td [attr.colspan]="emptyStateColspan()" class="text-center py-8">
                   <div class="flex flex-col gap-4 px-4">
@@ -348,7 +348,7 @@
                   <div class="text-center">
                     <i class="fa-light fa-users text-3xl text-gray-300 mb-2"></i>
                     <p class="text-sm font-medium text-gray-600">No members found</p>
-                    @if (canManageMembers()) {
+                    @if (canManageMembers() && activeTab() !== 'pending') {
                       <div class="mt-3">
                         <button class="text-xs text-blue-600 hover:text-blue-700 font-medium" (click)="openAddMemberDialog()">
                           <i class="fa-light fa-user-plus mr-1"></i>Add the first member

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.html
@@ -6,7 +6,7 @@
   <p-confirmDialog></p-confirmDialog>
 
   <!-- Committee Members Section -->
-  <lfx-card>
+  <lfx-card [styleClass]="showPendingTab() ? '[&_.p-card-body]:p-0 [&_.p-card-content]:p-0' : ''">
     @if (!showMembersSection()) {
       <div class="text-sm text-gray-500 text-center py-6" data-testid="members-hidden-placeholder">Member list is not publicly visible for this group.</div>
     } @else if (!showMemberRoster() && canSendMemberInvites()) {
@@ -22,73 +22,87 @@
         </lfx-button>
       </div>
     } @else {
-      <!-- Quick Filter Chips + engagement window controls -->
-      <div class="flex flex-wrap items-center justify-between gap-2 mb-4">
-        <div class="flex flex-wrap items-center gap-2" data-testid="members-filter-chips">
-          @for (chip of chipConfig(); track chip.key) {
-            <button
-              type="button"
-              class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
-              [attr.aria-pressed]="memberFilterChip() === chip.key"
-              [class]="memberFilterChip() === chip.key ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'"
-              (click)="selectChip(chip.key)"
-              [attr.data-testid]="'members-chip-' + chip.key">
-              {{ chip.label }} ({{ chip.count }})
-            </button>
-          }
-        </div>
-        @if (engagementEnabled() && engagementAccessible()) {
-          <div class="flex flex-wrap items-center gap-3" data-testid="members-engagement-controls">
-            @if (isMockEngagement()) {
-              <lfx-tag value="Sample data" severity="warn" data-testid="members-engagement-mock-tag" />
+      @if (showPendingTab()) {
+        <lfx-card-tabs-bar
+          [options]="tabOptions()"
+          [selectedFilter]="activeTab()"
+          (filterChange)="onTabChange($event)"
+          data-testid="members-tab-bar">
+        </lfx-card-tabs-bar>
+      }
+
+      <div [class]="showPendingTab() ? 'p-4 md:p-6' : ''">
+        @if (activeTab() === 'all') {
+          <!-- Quick Filter Chips + engagement window controls -->
+          <div class="flex flex-wrap items-center justify-between gap-2 mb-4">
+            <div class="flex flex-wrap items-center gap-2" data-testid="members-filter-chips">
+              @for (chip of chipConfig(); track chip.key) {
+                <button
+                  type="button"
+                  class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+                  [attr.aria-pressed]="memberFilterChip() === chip.key"
+                  [class]="memberFilterChip() === chip.key ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'"
+                  (click)="selectChip(chip.key)"
+                  [attr.data-testid]="'members-chip-' + chip.key">
+                  {{ chip.label }} ({{ chip.count }})
+                </button>
+              }
+            </div>
+            @if (engagementEnabled() && engagementAccessible()) {
+              <div class="flex flex-wrap items-center gap-3" data-testid="members-engagement-controls">
+                @if (isMockEngagement()) {
+                  <lfx-tag value="Sample data" severity="warn" data-testid="members-engagement-mock-tag" />
+                }
+                @if (engagementDataAvailable()) {
+                  <span class="text-xs text-gray-400" data-testid="members-engagement-freshness">{{ engagementFreshnessLabel() }}</span>
+                }
+                <lfx-filter-pills [options]="engagementWindowOptions" [selectedFilter]="engagementWindow()" (filterChange)="onEngagementWindowChange($event)" />
+              </div>
             }
-            @if (engagementDataAvailable()) {
-              <span class="text-xs text-gray-400" data-testid="members-engagement-freshness">{{ engagementFreshnessLabel() }}</span>
-            }
-            <lfx-filter-pills [options]="engagementWindowOptions" [selectedFilter]="engagementWindow()" (filterChange)="onEngagementWindowChange($event)" />
           </div>
         }
-      </div>
 
-      <!-- Search, Filter Controls, and Add Member -->
-      <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4 mb-6">
-        <!-- Search Input -->
-        <div class="flex-1">
-          <lfx-input-text [form]="filterForm" control="search" placeholder="Search members..." icon="fa-light fa-search" styleClass="w-full" size="small">
-          </lfx-input-text>
-        </div>
+        <!-- Search, Filter Controls, and Add Member -->
+        <div class="flex flex-col md:flex-row md:items-center gap-3 md:gap-4 mb-6">
+          @if (activeTab() === 'all') {
+            <!-- Search Input -->
+            <div class="flex-1">
+              <lfx-input-text [form]="filterForm" control="search" placeholder="Search members..." icon="fa-light fa-search" styleClass="w-full" size="small">
+              </lfx-input-text>
+            </div>
 
-        <!-- Role Filter -->
-        <div class="w-full sm:w-auto sm:shrink-0">
-          <lfx-select [form]="filterForm" control="role" size="small" [options]="roleOptions()" placeholder="All Roles" [showClear]="true" styleClass="w-full">
-          </lfx-select>
-        </div>
+            <!-- Role Filter -->
+            <div class="w-full sm:w-auto sm:shrink-0">
+              <lfx-select [form]="filterForm" control="role" size="small" [options]="roleOptions()" placeholder="All Roles" [showClear]="true" styleClass="w-full">
+              </lfx-select>
+            </div>
 
-        <!-- Voting Status Filter -->
-        <div class="w-full sm:w-auto sm:shrink-0">
-          <lfx-select
-            [form]="filterForm"
-            control="votingStatus"
-            size="small"
-            [options]="votingStatusOptions()"
-            placeholder="All Voting Status"
-            [showClear]="true"
-            styleClass="w-full">
-          </lfx-select>
-        </div>
+            <!-- Voting Status Filter -->
+            <div class="w-full sm:w-auto sm:shrink-0">
+              <lfx-select
+                [form]="filterForm"
+                control="votingStatus"
+                size="small"
+                [options]="votingStatusOptions()"
+                placeholder="All Voting Status"
+                [showClear]="true"
+                styleClass="w-full">
+              </lfx-select>
+            </div>
 
-        <!-- Organization Filter -->
-        <div class="w-full sm:w-auto sm:shrink-0">
-          <lfx-select
-            [form]="filterForm"
-            control="organization"
-            size="small"
-            [options]="organizationOptions()"
-            placeholder="All Organizations"
-            [showClear]="true"
-            styleClass="w-full">
-          </lfx-select>
-        </div>
+            <!-- Organization Filter -->
+            <div class="w-full sm:w-auto sm:shrink-0">
+              <lfx-select
+                [form]="filterForm"
+                control="organization"
+                size="small"
+                [options]="organizationOptions()"
+                placeholder="All Organizations"
+                [showClear]="true"
+                styleClass="w-full">
+              </lfx-select>
+            </div>
+          }
 
         @if (canManageMembers()) {
           <lfx-button
@@ -113,15 +127,13 @@
 
       <!-- Table View -->
       <lfx-table
-        [value]="filteredMembers()"
+        [value]="tableRows()"
         [paginator]="true"
         [rows]="10"
         [rowsPerPageOptions]="[10, 25, 50]"
         [showCurrentPageReport]="true"
-        currentPageReportTemplate="Showing {first} to {last} of {totalRecords} members"
-        styleClass="p-datatable-sm"
-        sortField="first_name"
-        [sortOrder]="1">
+        currentPageReportTemplate="Showing {first} to {last} of {totalRecords} entries"
+        styleClass="p-datatable-sm">
         <ng-template #header>
           <tr>
             <th>
@@ -160,89 +172,147 @@
           </tr>
         </ng-template>
 
-        <ng-template #body let-member>
-          <tr>
+        <ng-template #body let-row>
+          <tr [attr.data-testid]="row.rowType === 'member' ? 'member-row-' + row.data.uid : 'invite-row-' + row.data.uid">
+            <!-- Name -->
             <td>
-              <span class="text-sm font-inter text-gray-900 font-medium">
-                {{ member | fullName | titlecase }}
-              </span>
-            </td>
-            <td>
-              <span class="text-sm font-inter text-gray-500">{{ member.email || '-' }}</span>
-            </td>
-            <td>
-              @if (member.organization?.website) {
-                <a
-                  [href]="member.organization.website"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  class="text-primary hover:text-primary-600 text-sm font-inter">
-                  {{ member.organization.name }}
-                </a>
+              @if (row.rowType === 'member') {
+                <span class="text-sm font-inter text-gray-900 font-medium">
+                  {{ row.data | fullName | titlecase }}
+                </span>
               } @else {
-                <span class="text-sm font-inter text-gray-500">{{ member.organization?.name || '-' }}</span>
+                <div class="flex flex-wrap items-center gap-2">
+                  <span class="text-sm font-inter text-gray-900 font-medium">{{ row.data.invitee_email }}</span>
+                  <lfx-tag value="Pending invitation" severity="warn" />
+                </div>
+              }
+            </td>
+            <!-- Email -->
+            <td>
+              @if (row.rowType === 'member') {
+                <span class="text-sm font-inter text-gray-500">{{ row.data.email || '-' }}</span>
+              } @else {
+                <span class="text-sm font-inter text-gray-500">{{ row.data.invitee_email }}</span>
+              }
+            </td>
+            <!-- Organization -->
+            <td>
+              @if (row.rowType === 'member') {
+                @if (row.data.organization?.website) {
+                  <a
+                    [href]="row.data.organization.website"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    class="text-primary hover:text-primary-600 text-sm font-inter">
+                    {{ row.data.organization.name }}
+                  </a>
+                } @else {
+                  <span class="text-sm font-inter text-gray-500">{{ row.data.organization?.name || '-' }}</span>
+                }
+              } @else {
+                <span class="text-sm font-inter text-gray-500">{{ row.data.organization || '—' }}</span>
               }
             </td>
             @if (committee()?.enable_voting) {
+              <!-- Role -->
               <td>
-                <span class="text-sm font-inter text-gray-500">{{ member.role?.name || 'None' }}</span>
+                @if (row.rowType === 'member') {
+                  <span class="text-sm font-inter text-gray-500">{{ row.data.role?.name || 'None' }}</span>
+                } @else {
+                  <span class="text-sm font-inter text-gray-400">{{ (row.data.role && row.data.role !== noRoleSentinel) ? row.data.role : '—' }}</span>
+                }
               </td>
+              <!-- Voting Status -->
               <td>
-                <span class="text-sm font-inter text-gray-500">{{ member.voting?.status || 'None' }}</span>
+                @if (row.rowType === 'member') {
+                  <span class="text-sm font-inter text-gray-500">{{ row.data.voting?.status || 'None' }}</span>
+                } @else {
+                  <span class="text-sm font-inter text-gray-400">—</span>
+                }
               </td>
             }
             @if (engagementEnabled() && engagementAccessible()) {
-              @let engagementView = memberEngagementRows().get(member.uid);
+              <!-- Meetings -->
               <td>
-                @if (engagementLoading()) {
-                  <p-skeleton width="2.5rem" height="0.875rem" />
+                @if (row.rowType === 'member') {
+                  @if (engagementLoading()) {
+                    <p-skeleton width="2.5rem" height="0.875rem" />
+                  } @else {
+                    @let engagementView = memberEngagementRows().get(row.data.uid);
+                    <span class="text-sm font-inter text-gray-900" [attr.data-testid]="'members-engagement-meetings-' + row.data.uid">
+                      {{ engagementView?.meetingsLabel }}
+                    </span>
+                  }
                 } @else {
-                  <span class="text-sm font-inter text-gray-900" [attr.data-testid]="'members-engagement-meetings-' + member.uid">
-                    {{ engagementView?.meetingsLabel }}
-                  </span>
+                  <span class="text-sm font-inter text-gray-400">—</span>
                 }
               </td>
+              <!-- Engagement -->
               <td>
-                @if (engagementLoading()) {
-                  <p-skeleton width="4rem" height="1.25rem" borderRadius="1rem" />
-                } @else {
-                  @if (engagementView && engagementView.row && engagementDataAvailable()) {
-                    <lfx-tag
-                      [value]="engagementView.row.classification"
-                      [severity]="engagementView.severity"
-                      [tooltip]="engagementView.context"
-                      [attr.data-testid]="'members-engagement-chip-' + member.uid" />
+                @if (row.rowType === 'member') {
+                  @if (engagementLoading()) {
+                    <p-skeleton width="4rem" height="1.25rem" borderRadius="1rem" />
                   } @else {
-                    <span class="text-sm font-inter text-gray-400" [attr.data-testid]="'members-engagement-chip-' + member.uid">—</span>
+                    @let engagementView = memberEngagementRows().get(row.data.uid);
+                    @if (engagementView && engagementView.row && engagementDataAvailable()) {
+                      <lfx-tag
+                        [value]="engagementView.row.classification"
+                        [severity]="engagementView.severity"
+                        [tooltip]="engagementView.context"
+                        [attr.data-testid]="'members-engagement-chip-' + row.data.uid" />
+                    } @else {
+                      <span class="text-sm font-inter text-gray-400" [attr.data-testid]="'members-engagement-chip-' + row.data.uid">—</span>
+                    }
                   }
+                } @else {
+                  <span class="text-sm font-inter text-gray-400">—</span>
                 }
               </td>
             }
+            <!-- Permission -->
             <td>
-              @let permission = getMemberPermissionInfo(member);
-              <lfx-tag [value]="getMemberPermissionLabel(permission.level, permission.inherited)" [severity]="getMemberPermissionSeverity(permission.level)">
-              </lfx-tag>
+              @if (row.rowType === 'member') {
+                @let permission = getMemberPermissionInfo(row.data);
+                <lfx-tag [value]="getMemberPermissionLabel(permission.level, permission.inherited)" [severity]="getMemberPermissionSeverity(permission.level)">
+                </lfx-tag>
+              } @else {
+                <span class="text-sm font-inter text-gray-400">—</span>
+              }
             </td>
+            <!-- Actions -->
             <td class="text-right relative">
-              <lfx-menu #memberActionMenu [model]="memberActionMenuItems" [popup]="true" appendTo="body"> </lfx-menu>
-              @if (canManageMembers()) {
+              @if (row.rowType === 'member') {
+                <lfx-menu #memberActionMenu [model]="memberActionMenuItems" [popup]="true" appendTo="body"></lfx-menu>
+                @if (canManageMembers()) {
+                  <lfx-button
+                    icon="fa-light fa-ellipsis-vertical"
+                    [text]="true"
+                    [rounded]="true"
+                    size="small"
+                    severity="secondary"
+                    (onClick)="toggleMemberActionMenu($event, row.data, memberActionMenu)">
+                  </lfx-button>
+                } @else {
+                  <lfx-button
+                    icon="fa-light fa-envelope"
+                    [text]="true"
+                    [rounded]="true"
+                    size="small"
+                    severity="secondary"
+                    [href]="'mailto:' + row.data.email"
+                    pTooltip="Send Message">
+                  </lfx-button>
+                }
+              } @else if (canManageMembers()) {
+                <lfx-menu #inviteActionMenu [model]="inviteActionMenuItems" [popup]="true" appendTo="body"></lfx-menu>
                 <lfx-button
                   icon="fa-light fa-ellipsis-vertical"
                   [text]="true"
                   [rounded]="true"
                   size="small"
                   severity="secondary"
-                  (onClick)="toggleMemberActionMenu($event, member, memberActionMenu)">
-                </lfx-button>
-              } @else {
-                <lfx-button
-                  icon="fa-light fa-envelope"
-                  [text]="true"
-                  [rounded]="true"
-                  size="small"
-                  severity="secondary"
-                  [href]="'mailto:' + member.email"
-                  pTooltip="Send Message">
+                  [attr.data-testid]="'invite-actions-btn-' + row.data.uid"
+                  (onClick)="toggleInviteActionMenu($event, row.data, inviteActionMenu)">
                 </lfx-button>
               }
             </td>
@@ -285,66 +355,9 @@
           }
         </ng-template>
       </lfx-table>
+      </div>
     }
   </lfx-card>
-
-  <!-- Pending Invitations Section (managers only; hidden in closed mode) -->
-  @if (showPendingInvites()) {
-    <lfx-card>
-      <div class="flex flex-col gap-3" data-testid="pending-invites">
-        <div class="flex items-center gap-2">
-          <i class="fa-light fa-envelope-open-text text-gray-500" aria-hidden="true"></i>
-          <h3 class="text-sm font-semibold text-gray-900">Pending Invitations</h3>
-          @if (!invitesLoading()) {
-            <span class="text-xs text-gray-400">({{ invites().length }})</span>
-          }
-        </div>
-
-        <p class="text-xs text-gray-400">Invited people appear here until they accept. They become members automatically on acceptance.</p>
-
-        @if (invitesLoading()) {
-          <div class="flex flex-col gap-2">
-            @for (_ of [1, 2]; track _) {
-              <div class="flex items-center gap-3">
-                <p-skeleton width="14rem" height="0.875rem" />
-                <p-skeleton width="6rem" height="0.875rem" />
-              </div>
-            }
-          </div>
-        } @else {
-          <ul class="flex flex-col gap-2" role="list">
-            @for (invite of invites(); track invite.uid) {
-              <li
-                class="flex items-center gap-3 px-3 py-2.5 rounded-lg border border-gray-200 bg-white"
-                [attr.data-testid]="'pending-invite-' + invite.invitee_email">
-                <i class="fa-light fa-clock text-amber-500" aria-hidden="true"></i>
-                <div class="flex flex-col gap-0.5 flex-1 min-w-0">
-                  <span class="text-sm font-medium text-gray-900 truncate">{{ invite.invitee_email }}</span>
-                  @if (invite.role && invite.role !== noRoleSentinel) {
-                    <span class="text-xs text-gray-400">Invited as {{ invite.role }}</span>
-                  }
-                </div>
-                <lfx-tag value="Pending" severity="warn"></lfx-tag>
-                <lfx-button
-                  icon="fa-light fa-xmark"
-                  [text]="true"
-                  [rounded]="true"
-                  size="small"
-                  severity="secondary"
-                  tooltip="Revoke invitation"
-                  ariaLabel="Revoke invitation"
-                  [loading]="revokingInviteUid() === invite.uid"
-                  [disabled]="!!revokingInviteUid()"
-                  (onClick)="revokeInvite(invite)"
-                  [attr.data-testid]="'revoke-invite-' + invite.invitee_email">
-                </lfx-button>
-              </li>
-            }
-          </ul>
-        }
-      </div>
-    </lfx-card>
-  }
 
   <!-- Pending Applications Section (managers only, application join mode) -->
   @if (showPendingApplications()) {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -135,7 +135,7 @@ export class CommitteeMembersComponent implements OnInit {
   // linkedSignal: resets to 'all' when the Pending tab becomes invisible (all invites revoked /
   // none loaded) so the user is never left looking at an empty Pending table.
   public activeTab = linkedSignal<boolean, CommitteeMemberTab>({
-    source: () => this.showPendingTab(),
+    source: () => this.showPendingInvites(),
     computation: (pendingVisible, previous) => {
       if (previous && previous.value === 'pending' && !pendingVisible) {
         return 'all';
@@ -174,11 +174,9 @@ export class CommitteeMembersComponent implements OnInit {
   public readonly showPendingInvites = computed(
     () => this.canManageMembers() && this.joinMode() !== 'closed' && (this.invitesLoading() || this.invites().length > 0)
   );
-  /** Show the Pending tab only when there are (or are loading) pending invites a manager can see. */
-  public readonly showPendingTab = computed(() => this.showPendingInvites());
   public readonly tabOptions = computed<FilterPillOption[]>(() => {
     const opts: FilterPillOption[] = [{ id: 'all', label: 'All' }];
-    if (this.showPendingTab()) {
+    if (this.showPendingInvites()) {
       const count = this.invitesLoading() ? '' : ` (${this.invites().length})`;
       opts.push({ id: 'pending', label: `Pending${count}` });
     }
@@ -957,13 +955,13 @@ export class CommitteeMembersComponent implements OnInit {
 
   private initTableRows(): Signal<CommitteeTableRow[]> {
     return computed(() => {
-      const inviteRows: CommitteeTableRow[] = this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));
-      if (this.activeTab() === 'pending') {
-        return inviteRows;
-      }
       const memberRows: CommitteeTableRow[] = this.filteredMembers().map((m) => ({ rowType: 'member' as const, data: m }));
       if (!this.canManageMembers() || this.joinMode() === 'closed') {
         return memberRows;
+      }
+      const inviteRows: CommitteeTableRow[] = this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));
+      if (this.activeTab() === 'pending' && this.showPendingInvites()) {
+        return inviteRows;
       }
       return [...memberRows, ...inviteRows];
     });

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -9,6 +9,7 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
+import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MenuComponent } from '@components/menu/menu.component';
@@ -34,8 +35,11 @@ import {
   CommitteeMemberFilterChip,
   CommitteeMemberFilterChipConfig,
   CommitteeMemberPermissionInfo,
+  CommitteeMemberTab,
   CommitteePermissionLevel,
+  CommitteeTableRow,
   CommitteeUser,
+  FilterPillOption,
   JoinMode,
   TagSeverity,
 } from '@lfx-one/shared/interfaces';
@@ -69,6 +73,7 @@ import { RejectApplicationDialogComponent } from '../reject-application-dialog/r
     TitleCasePipe,
     ReactiveFormsModule,
     CardComponent,
+    CardTabsBarComponent,
     FilterPillsComponent,
     FullNamePipe,
     MenuComponent,
@@ -123,9 +128,11 @@ export class CommitteeMembersComponent implements OnInit {
 
   // Simple writable signals
   public selectedMember = signal<CommitteeMember | null>(null);
+  public selectedInvite = signal<CommitteeInvite | null>(null);
   public isDeleting = signal<boolean>(false);
   public revokingInviteUid = signal<string | null>(null);
   public processingApplicationUid = signal<string | null>(null);
+  public activeTab = signal<CommitteeMemberTab>('all');
   // linkedSignal, not signal: the At Risk chip is only offered while a real engagement response is
   // present, so if it's selected when the data degrades (window switch, fetch failure) the
   // selection resets to 'all' — otherwise no chip would render as pressed and the at-risk filter
@@ -140,6 +147,7 @@ export class CommitteeMembersComponent implements OnInit {
     },
   });
   public memberActionMenuItems: MenuItem[] = [];
+  public inviteActionMenuItems: MenuItem[] = [];
   public committeeLabel = COMMITTEE_LABEL;
   // Upstream "no role" sentinel for committee invites — kept in one place rather than inline in the template.
   public readonly noRoleSentinel = CommitteeMemberRole.NONE;
@@ -156,6 +164,16 @@ export class CommitteeMembersComponent implements OnInit {
   public readonly showPendingInvites = computed(
     () => this.canManageMembers() && this.joinMode() !== 'closed' && (this.invitesLoading() || this.invites().length > 0)
   );
+  /** Show the Pending tab only when there are (or are loading) pending invites a manager can see. */
+  public readonly showPendingTab = computed(() => this.showPendingInvites());
+  public readonly tabOptions = computed<FilterPillOption[]>(() => {
+    const opts: FilterPillOption[] = [{ id: 'all', label: 'All' }];
+    if (this.showPendingTab()) {
+      const count = this.invitesLoading() ? '' : ` (${this.invites().length})`;
+      opts.push({ id: 'pending', label: `Pending${count}` });
+    }
+    return opts;
+  });
   public readonly showPendingApplications = computed(
     () => this.canManageMembers() && this.joinMode() === 'application' && (this.applicationsLoading() || this.pendingApplications().length > 0)
   );
@@ -205,6 +223,7 @@ export class CommitteeMembersComponent implements OnInit {
   // Complex computed signals — use private init functions
   public readonly chipConfig: Signal<CommitteeMemberFilterChipConfig[]> = this.initChipConfig();
   private readonly chipFilteredMembers: Signal<CommitteeMember[]> = this.initChipFilteredMembers();
+  public readonly tableRows: Signal<CommitteeTableRow[]> = this.initTableRows();
   // Both empty-state rows must span every rendered column: 5 base, +2 when the voting columns
   // render, +2 when the flag-gated engagement columns render.
   public readonly emptyStateColspan: Signal<number> = computed(() => {
@@ -255,6 +274,13 @@ export class CommitteeMembersComponent implements OnInit {
 
   public ngOnInit(): void {
     this.memberActionMenuItems = this.initializeMemberActionMenuItems();
+    this.inviteActionMenuItems = this.initializeInviteActionMenuItems();
+  }
+
+  public onTabChange(tab: string): void {
+    if (tab === 'all' || tab === 'pending') {
+      this.activeTab.set(tab);
+    }
   }
 
   public toggleMemberActionMenu(event: Event, member: CommitteeMember, menuComponent: MenuComponent): void {
@@ -262,6 +288,13 @@ export class CommitteeMembersComponent implements OnInit {
     this.selectedMember.set(member);
     // Rebuild menu items so MenuItem.url reflects the selected member's email
     this.memberActionMenuItems = this.initializeMemberActionMenuItems(member);
+    menuComponent.toggle(event);
+  }
+
+  public toggleInviteActionMenu(event: Event, invite: CommitteeInvite, menuComponent: MenuComponent): void {
+    event.stopPropagation();
+    this.selectedInvite.set(invite);
+    this.inviteActionMenuItems = this.initializeInviteActionMenuItems(invite);
     menuComponent.toggle(event);
   }
 
@@ -910,5 +943,36 @@ export class CommitteeMembersComponent implements OnInit {
       return `${row.role} — attended ${row.attended} of ${row.invited} invited meetings`;
     }
     return '';
+  }
+
+  private initTableRows(): Signal<CommitteeTableRow[]> {
+    return computed(() => {
+      if (this.activeTab() === 'pending') {
+        return this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));
+      }
+      const memberRows: CommitteeTableRow[] = this.filteredMembers().map((m) => ({ rowType: 'member' as const, data: m }));
+      if (!this.canManageMembers() || this.joinMode() === 'closed') {
+        return memberRows;
+      }
+      const inviteRows: CommitteeTableRow[] = this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));
+      return [...memberRows, ...inviteRows];
+    });
+  }
+
+  private initializeInviteActionMenuItems(invite?: CommitteeInvite): MenuItem[] {
+    return [
+      {
+        label: 'Revoke invitation',
+        icon: 'fa-light fa-ban',
+        styleClass: 'text-red-500',
+        disabled: !!this.revokingInviteUid(),
+        command: () => {
+          const target = invite ?? this.selectedInvite();
+          if (target) {
+            this.revokeInvite(target);
+          }
+        },
+      },
+    ];
   }
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -132,7 +132,17 @@ export class CommitteeMembersComponent implements OnInit {
   public isDeleting = signal<boolean>(false);
   public revokingInviteUid = signal<string | null>(null);
   public processingApplicationUid = signal<string | null>(null);
-  public activeTab = signal<CommitteeMemberTab>('all');
+  // linkedSignal: resets to 'all' when the Pending tab becomes invisible (all invites revoked /
+  // none loaded) so the user is never left looking at an empty Pending table.
+  public activeTab = linkedSignal<boolean, CommitteeMemberTab>({
+    source: () => this.showPendingTab(),
+    computation: (pendingVisible, previous) => {
+      if (previous && previous.value === 'pending' && !pendingVisible) {
+        return 'all';
+      }
+      return previous?.value ?? 'all';
+    },
+  });
   // linkedSignal, not signal: the At Risk chip is only offered while a real engagement response is
   // present, so if it's selected when the data degrades (window switch, fetch failure) the
   // selection resets to 'all' — otherwise no chip would render as pressed and the at-risk filter

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -957,14 +957,14 @@ export class CommitteeMembersComponent implements OnInit {
 
   private initTableRows(): Signal<CommitteeTableRow[]> {
     return computed(() => {
+      const inviteRows: CommitteeTableRow[] = this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));
       if (this.activeTab() === 'pending') {
-        return this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));
+        return inviteRows;
       }
       const memberRows: CommitteeTableRow[] = this.filteredMembers().map((m) => ({ rowType: 'member' as const, data: m }));
       if (!this.canManageMembers() || this.joinMode() === 'closed') {
         return memberRows;
       }
-      const inviteRows: CommitteeTableRow[] = this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));
       return [...memberRows, ...inviteRows];
     });
   }

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -13,6 +13,7 @@ import {
   CommitteeInvite,
   CommitteeJoinApplication,
   CommitteeMember,
+  CommitteeOrganizationReference,
   CommitteeUser,
   CreateCommitteeDocumentRequest,
   CreateCommitteeInviteRequest,
@@ -199,8 +200,9 @@ export class CommitteeService {
   // ── Join / Leave Methods ──────────────────────────────────────────────────
 
   /** Self-join an open group */
-  public joinCommittee(committeeId: string): Observable<CommitteeMember> {
-    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/join`, {}).pipe(take(1));
+  public joinCommittee(committeeId: string, organization?: CommitteeOrganizationReference): Observable<CommitteeMember> {
+    const body = organization ? { organization } : {};
+    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/join`, body).pipe(take(1));
   }
 
   /** Leave a group */
@@ -209,8 +211,8 @@ export class CommitteeService {
   }
 
   /** Submit a join application for a group with join_mode 'application' */
-  public submitApplication(committeeId: string, message?: string): Observable<CommitteeJoinApplication> {
-    const body: CreateCommitteeJoinApplicationRequest = { message: message || '' };
+  public submitApplication(committeeId: string, message?: string, organization?: CommitteeOrganizationReference): Observable<CommitteeJoinApplication> {
+    const body: CreateCommitteeJoinApplicationRequest = { message: message || '', ...(organization ? { organization } : {}) };
     return this.http.post<CommitteeJoinApplication>(`/api/committees/${committeeId}/applications`, body).pipe(take(1));
   }
 

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -6,6 +6,7 @@ import { MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   AcceptCommitteeInviteRequest,
   CommitteeCreateData,
+  CommitteeOrganizationReference,
   CommitteeUpdateData,
   CreateCommitteeDocumentRequest,
   CreateCommitteeInviteRequest,
@@ -1328,10 +1329,11 @@ export class CommitteeController {
    */
   public async joinCommittee(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { id } = req.params;
+    const { organization } = req.body as { organization?: CommitteeOrganizationReference };
     const startTime = logger.startOperation(req, 'join_committee', { committee_id: id });
 
     try {
-      const member = await this.committeeService.joinCommittee(req, id);
+      const member = await this.committeeService.joinCommittee(req, id, organization);
 
       logger.success(req, 'join_committee', startTime, { committee_id: id });
       res.status(201).json(member);

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -10,6 +10,7 @@ import {
   CommitteeInvite,
   CommitteeJoinApplication,
   CommitteeMember,
+  CommitteeOrganizationReference,
   CommitteeSettingsData,
   CommitteeUpdateData,
   CommitteeUser,
@@ -1103,8 +1104,9 @@ export class CommitteeService {
 
   // ── Join / Leave Methods ────────────────────────────────────────────────────
 
-  public async joinCommittee(req: Request, committeeId: string): Promise<CommitteeMember> {
-    return this.microserviceProxy.proxyRequest<CommitteeMember>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/join`, 'POST');
+  public async joinCommittee(req: Request, committeeId: string, organization?: CommitteeOrganizationReference): Promise<CommitteeMember> {
+    const body = organization ? { organization } : undefined;
+    return this.microserviceProxy.proxyRequest<CommitteeMember>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/join`, 'POST', {}, body);
   }
 
   public async leaveCommittee(req: Request, committeeId: string): Promise<void> {

--- a/packages/shared/src/interfaces/committee-application.interface.ts
+++ b/packages/shared/src/interfaces/committee-application.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { CommitteeOrganizationReference } from './committee.interface';
+
 /**
  * Status of a committee join application
  */
@@ -45,4 +47,5 @@ export interface RejectCommitteeJoinApplicationRequest {
 export interface CreateCommitteeJoinApplicationRequest {
   /** Message from the applicant (max 2000 chars) */
   message: string;
+  organization?: CommitteeOrganizationReference;
 }

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -596,6 +596,9 @@ export type CommitteeVoteStatus = 'open' | 'closed' | 'cancelled';
  */
 export type CommitteeMemberFilterChip = 'all' | 'voting' | 'observers' | 'chairs' | 'atRisk';
 
+/** Tab selector for the committee Members card: 'all' shows members + pending invites; 'pending' shows invites only. */
+export type CommitteeMemberTab = 'all' | 'pending';
+
 /** A single chip entry in the committee Members quick-filter row. */
 export interface CommitteeMemberFilterChipConfig {
   key: CommitteeMemberFilterChip;

--- a/packages/shared/src/interfaces/member.interface.ts
+++ b/packages/shared/src/interfaces/member.interface.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { CommitteeMemberAppointedBy, CommitteeMemberRole, CommitteeMemberStatus, CommitteeMemberVotingStatus } from '../enums';
-import { CommitteePermissionLevel } from './committee.interface';
+import { CommitteeInvite, CommitteePermissionLevel } from './committee.interface';
 
 /**
  * Committee member entity with complete profile and role information
@@ -185,3 +185,11 @@ export interface MemberPendingChanges {
   /** Member UIDs to be deleted via API */
   toDelete: string[];
 }
+
+/**
+ * Unified table row for the committee Members list.
+ * Member rows carry a `CommitteeMember`; invite rows carry a `CommitteeInvite`.
+ * The `rowType` discriminant drives conditional template rendering without nested ternaries.
+ */
+export type CommitteeTableRow = { rowType: 'member'; data: CommitteeMember } | { rowType: 'invite'; data: CommitteeInvite };
+

--- a/packages/shared/src/interfaces/member.interface.ts
+++ b/packages/shared/src/interfaces/member.interface.ts
@@ -192,4 +192,3 @@ export interface MemberPendingChanges {
  * The `rowType` discriminant drives conditional template rendering without nested ternaries.
  */
 export type CommitteeTableRow = { rowType: 'member'; data: CommitteeMember } | { rowType: 'invite'; data: CommitteeInvite };
-


### PR DESCRIPTION
## Ticket

[LFXV2-2841](https://linuxfoundation.atlassian.net/browse/LFXV2-2841)

## Summary

- Replaces the below-fold "Pending Invitations" card with a **"Pending" tab** inside the committee members card, making pending invites immediately discoverable without scrolling
- Invite rows now use the **same table column layout** as regular member rows (Name, Email, Organization, Role, Voting Status, Meetings, Engagement, Permission, Actions)
- A **"Pending invitation" tag** appears inline after the invitee email in the Name column
- The **row actions dropdown** for invite rows contains only "Revoke invitation"
- Pending invite rows appear in **both the "All" and "Pending" tabs**; the Pending tab is hidden when there are no pending invites
- `activeTab` uses `linkedSignal` to auto-reset to "All" when all invites are revoked (matching the existing `memberFilterChip` pattern)
- Filter chips and search/filter controls are hidden on the Pending tab (they apply to member rows only)

## Known pre-existing issues (out of scope)

Two patterns flagged by the learnings reviewer were pre-existing in the unchanged code paths that this PR restructured (not introduced):

- `[href]="organization.website"` — external URL bound without scheme validation (pre-dates this PR; in the original member org link)
- `[class]` + static `class=` co-existence on the filter chip buttons — pre-existing Tailwind class clobber; separate fix needed

## Trade-offs

- **Removed table-level `sortField`** — PrimeNG table sorting on `first_name` was dropped because invite rows have no `first_name` field, and mixing the two in the same `[value]` array would produce undefined sort behavior. Members arrive pre-sorted from the API; invites are appended at the end of the "All" tab naturally.

[LFXV2-2841]: https://linuxfoundation.atlassian.net/browse/LFXV2-2841?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ