### PR TITLE
feat(meetings): add send reminder email to participants toggle

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -141,7 +141,7 @@
                 id="email-reminder-hours"
                 styleClass="w-16"
                 data-testid="email-reminder-hours-input"></lfx-input-number>
-              <span class="text-sm text-neutral-950">hours</span>
+              <label for="email-reminder-hours" class="text-sm text-neutral-950">hours</label>
               <lfx-input-number
                 [form]="form()"
                 control="reminderMinutes"
@@ -149,7 +149,7 @@
                 id="email-reminder-minutes"
                 styleClass="w-16"
                 data-testid="email-reminder-minutes-input"></lfx-input-number>
-              <span class="text-sm text-neutral-950">minutes before the meeting starts</span>
+              <label for="email-reminder-minutes" class="text-sm text-neutral-950">minutes before the meeting starts</label>
               <i
                 class="fa-light fa-info-circle text-gray-400 cursor-help"
                 tabindex="0"

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -128,6 +128,46 @@
           </div>
         </div>
       }
+
+      <!-- Send Reminder Email (with nested timing inputs) -->
+      <lfx-feature-toggle [feature]="emailReminderFeature" [form]="form()">
+        @if (form().get('auto_email_reminder_enabled')?.value) {
+          <div class="mt-4 pt-4 border-t border-gray-200 flex flex-col gap-2">
+            <div class="flex items-center gap-2 flex-wrap">
+              <lfx-input-number
+                [form]="form()"
+                control="reminderHours"
+                size="small"
+                id="email-reminder-hours"
+                styleClass="w-16"
+                data-testid="email-reminder-hours-input"></lfx-input-number>
+              <span class="text-sm text-neutral-950">hours</span>
+              <lfx-input-number
+                [form]="form()"
+                control="reminderMinutes"
+                size="small"
+                id="email-reminder-minutes"
+                styleClass="w-16"
+                data-testid="email-reminder-minutes-input"></lfx-input-number>
+              <span class="text-sm text-neutral-950">minutes before the meeting starts</span>
+              <i
+                class="fa-light fa-info-circle text-gray-400 cursor-help"
+                [pTooltip]="emailReminderTooltip"
+                tooltipPosition="right"
+                tooltipStyleClass="text-xs max-w-xs"></i>
+            </div>
+            @if (form().get('reminderHours')?.errors?.['min'] && form().get('reminderHours')?.touched) {
+              <p class="text-sm text-red-600" data-testid="email-reminder-hours-min-error">Reminder must be at least 2 hours before the meeting starts</p>
+            }
+            @if (form().get('reminderHours')?.errors?.['max'] && form().get('reminderHours')?.touched) {
+              <p class="text-sm text-red-600" data-testid="email-reminder-hours-max-error">Reminder cannot be more than 24 hours before the meeting starts</p>
+            }
+            @if (form().get('reminderMinutes')?.errors?.['min'] || form().get('reminderMinutes')?.errors?.['max']) {
+              <p class="text-sm text-red-600" data-testid="email-reminder-minutes-error">Minutes must be between 0 and 59</p>
+            }
+          </div>
+        }
+      </lfx-feature-toggle>
     </div>
   </div>
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -152,17 +152,29 @@
               <span class="text-sm text-neutral-950">minutes before the meeting starts</span>
               <i
                 class="fa-light fa-info-circle text-gray-400 cursor-help"
+                tabindex="0"
+                role="img"
+                [attr.aria-label]="emailReminderTooltip"
                 [pTooltip]="emailReminderTooltip"
                 tooltipPosition="right"
-                tooltipStyleClass="text-xs max-w-xs"></i>
+                tooltipStyleClass="text-xs max-w-xs"
+                data-testid="email-reminder-tooltip"></i>
             </div>
+            @if (form().get('reminderHours')?.errors?.['required'] && form().get('reminderHours')?.touched) {
+              <p class="text-sm text-red-600" data-testid="email-reminder-hours-required-error">Reminder hours is required</p>
+            }
             @if (form().get('reminderHours')?.errors?.['min'] && form().get('reminderHours')?.touched) {
               <p class="text-sm text-red-600" data-testid="email-reminder-hours-min-error">Reminder must be at least 2 hours before the meeting starts</p>
             }
             @if (form().get('reminderHours')?.errors?.['max'] && form().get('reminderHours')?.touched) {
               <p class="text-sm text-red-600" data-testid="email-reminder-hours-max-error">Reminder cannot be more than 24 hours before the meeting starts</p>
             }
-            @if (form().get('reminderMinutes')?.errors?.['min'] || form().get('reminderMinutes')?.errors?.['max']) {
+            @if (
+              (form().get('reminderMinutes')?.errors?.['required'] ||
+                form().get('reminderMinutes')?.errors?.['min'] ||
+                form().get('reminderMinutes')?.errors?.['max']) &&
+              form().get('reminderMinutes')?.touched
+            ) {
               <p class="text-sm text-red-600" data-testid="email-reminder-minutes-error">Minutes must be between 0 and 59</p>
             }
           </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -163,6 +163,9 @@
             @if (form().get('reminderHours')?.errors?.['required'] && form().get('reminderHours')?.touched) {
               <p class="text-sm text-red-600" data-testid="email-reminder-hours-required-error">Reminder hours is required</p>
             }
+            @if (form().get('reminderHours')?.errors?.['pattern'] && form().get('reminderHours')?.touched) {
+              <p class="text-sm text-red-600" data-testid="email-reminder-hours-pattern-error">Reminder hours must be a whole number</p>
+            }
             @if (form().get('reminderHours')?.errors?.['min'] && form().get('reminderHours')?.touched) {
               <p class="text-sm text-red-600" data-testid="email-reminder-hours-min-error">Reminder must be at least 2 hours before the meeting starts</p>
             }
@@ -171,11 +174,12 @@
             }
             @if (
               (form().get('reminderMinutes')?.errors?.['required'] ||
+                form().get('reminderMinutes')?.errors?.['pattern'] ||
                 form().get('reminderMinutes')?.errors?.['min'] ||
                 form().get('reminderMinutes')?.errors?.['max']) &&
               form().get('reminderMinutes')?.touched
             ) {
-              <p class="text-sm text-red-600" data-testid="email-reminder-minutes-error">Minutes must be between 0 and 59</p>
+              <p class="text-sm text-red-600" data-testid="email-reminder-minutes-error">Minutes must be a whole number between 0 and 59</p>
             }
           </div>
         }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.ts
@@ -5,10 +5,16 @@ import { Component, DestroyRef, inject, input, OnInit, output } from '@angular/c
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggle.component';
+import { InputNumberComponent } from '@components/input-number/input-number.component';
 import { SelectComponent } from '@components/select/select.component';
 import { ToggleComponent } from '@components/toggle/toggle.component';
 import {
   ARTIFACT_VISIBILITY_OPTIONS,
+  DEFAULT_EMAIL_REMINDER_HOURS,
+  DEFAULT_EMAIL_REMINDER_MINUTES,
+  EMAIL_REMINDER_FEATURE,
+  EMAIL_REMINDER_TOOLTIP,
+  MAX_EMAIL_REMINDER_HOURS,
   MEETING_DETAILS_STEP,
   MEETING_FEATURES,
   MEETING_PLATFORMS,
@@ -19,7 +25,7 @@ import { map, of, startWith, switchMap } from 'rxjs';
 
 @Component({
   selector: 'lfx-meeting-platform-features',
-  imports: [ReactiveFormsModule, FeatureToggleComponent, SelectComponent, ToggleComponent, TooltipModule],
+  imports: [ReactiveFormsModule, FeatureToggleComponent, InputNumberComponent, SelectComponent, ToggleComponent, TooltipModule],
   templateUrl: './meeting-platform-features.component.html',
 })
 export class MeetingPlatformFeaturesComponent implements OnInit {
@@ -51,6 +57,8 @@ export class MeetingPlatformFeaturesComponent implements OnInit {
   public readonly transcriptFeature = MEETING_FEATURES.find((f) => f.key === 'transcript_enabled')!;
   public readonly youtubeFeature = MEETING_FEATURES.find((f) => f.key === 'youtube_upload_enabled')!;
   public readonly aiSummaryFeature = MEETING_FEATURES.find((f) => f.key === 'zoom_ai_enabled')!;
+  public readonly emailReminderFeature = EMAIL_REMINDER_FEATURE;
+  public readonly emailReminderTooltip = EMAIL_REMINDER_TOOLTIP;
 
   // Transform platforms into dropdown options (only available platforms)
   public readonly platformDropdownOptions = MEETING_PLATFORMS.map((platform) => ({
@@ -84,6 +92,52 @@ export class MeetingPlatformFeaturesComponent implements OnInit {
             control.updateValueAndValidity();
           }
         });
+      });
+
+    // Watch the reminder toggle to enable/disable the hours and minutes inputs
+    this.form()
+      .get('auto_email_reminder_enabled')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((reminderEnabled: boolean) => {
+        const hoursControl = this.form().get('reminderHours');
+        const minutesControl = this.form().get('reminderMinutes');
+        if (!hoursControl || !minutesControl) {
+          return;
+        }
+
+        if (reminderEnabled) {
+          hoursControl.enable({ emitEvent: false });
+          // Minutes stay locked at 0 while hours is at the 24-hour maximum
+          if (Number(hoursControl.value) === MAX_EMAIL_REMINDER_HOURS) {
+            minutesControl.setValue(DEFAULT_EMAIL_REMINDER_MINUTES, { emitEvent: false });
+            minutesControl.disable({ emitEvent: false });
+          } else {
+            minutesControl.enable({ emitEvent: false });
+          }
+        } else {
+          hoursControl.setValue(DEFAULT_EMAIL_REMINDER_HOURS, { emitEvent: false });
+          hoursControl.disable({ emitEvent: false });
+          minutesControl.setValue(DEFAULT_EMAIL_REMINDER_MINUTES, { emitEvent: false });
+          minutesControl.disable({ emitEvent: false });
+        }
+      });
+
+    // When set to 24 hours, minutes are automatically set to 0
+    this.form()
+      .get('reminderHours')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((hours) => {
+        const minutesControl = this.form().get('reminderMinutes');
+        if (!minutesControl || !this.form().get('auto_email_reminder_enabled')?.value) {
+          return;
+        }
+
+        if (Number(hours) === MAX_EMAIL_REMINDER_HOURS) {
+          minutesControl.setValue(DEFAULT_EMAIL_REMINDER_MINUTES, { emitEvent: false });
+          minutesControl.disable({ emitEvent: false });
+        } else {
+          minutesControl.enable({ emitEvent: false });
+        }
       });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -558,11 +558,12 @@ export class MeetingManageComponent {
       require_ai_summary_approval: formValue.zoom_ai_enabled ? formValue.require_ai_summary_approval || false : false,
       artifact_visibility: formValue.recording_enabled || formValue.zoom_ai_enabled ? formValue.artifact_visibility || DEFAULT_ARTIFACT_VISIBILITY : null,
       auto_email_reminder_enabled: formValue.auto_email_reminder_enabled || false,
-      // Total minutes before start, clamped to the upstream 120-1440 range; omitted when disabled so upstream resets the stored value
+      // Total whole minutes before start, clamped to the upstream 120-1440 range. Omitted when disabled:
+      // ITX resets the stored time to 0 whenever enabled is explicitly false, so no time value is needed.
       auto_email_reminder_time: formValue.auto_email_reminder_enabled
         ? Math.min(
             Math.max(
-              Number(formValue.reminderHours || DEFAULT_EMAIL_REMINDER_HOURS) * 60 + Number(formValue.reminderMinutes || 0),
+              Math.round(Number(formValue.reminderHours || DEFAULT_EMAIL_REMINDER_HOURS) * 60 + Number(formValue.reminderMinutes || 0)),
               MIN_EMAIL_REMINDER_HOURS * 60
             ),
             MAX_EMAIL_REMINDER_TIME
@@ -1026,10 +1027,15 @@ export class MeetingManageComponent {
         artifact_visibility: new FormControl(DEFAULT_ARTIFACT_VISIBILITY),
         auto_email_reminder_enabled: new FormControl(false),
         reminderHours: new FormControl({ value: DEFAULT_EMAIL_REMINDER_HOURS, disabled: true }, [
+          Validators.required,
           Validators.min(MIN_EMAIL_REMINDER_HOURS),
           Validators.max(MAX_EMAIL_REMINDER_HOURS),
         ]),
-        reminderMinutes: new FormControl({ value: DEFAULT_EMAIL_REMINDER_MINUTES, disabled: true }, [Validators.min(0), Validators.max(59)]),
+        reminderMinutes: new FormControl({ value: DEFAULT_EMAIL_REMINDER_MINUTES, disabled: true }, [
+          Validators.required,
+          Validators.min(0),
+          Validators.max(59),
+        ]),
 
         // Step 4: Resources & Summary
         attachments: new FormControl<PendingAttachment[]>([]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -11,11 +11,16 @@ import {
   DEFAULT_ARTIFACT_VISIBILITY,
   DEFAULT_DURATION,
   DEFAULT_EARLY_JOIN_TIME,
+  DEFAULT_EMAIL_REMINDER_HOURS,
+  DEFAULT_EMAIL_REMINDER_MINUTES,
   DEFAULT_MEETING_TOOL,
   DEFAULT_MEETING_TYPE,
   MAX_EARLY_JOIN_TIME,
+  MAX_EMAIL_REMINDER_HOURS,
+  MAX_EMAIL_REMINDER_TIME,
   MEETING_STEP_TITLES,
   MIN_EARLY_JOIN_TIME,
+  MIN_EMAIL_REMINDER_HOURS,
   STEPPER_SCROLL_OFFSET,
   TOTAL_STEPS,
   YOUTUBE_MAX_MEETING_TITLE_LENGTH,
@@ -552,6 +557,17 @@ export class MeetingManageComponent {
       ai_summary_enabled: formValue.zoom_ai_enabled || false,
       require_ai_summary_approval: formValue.zoom_ai_enabled ? formValue.require_ai_summary_approval || false : false,
       artifact_visibility: formValue.recording_enabled || formValue.zoom_ai_enabled ? formValue.artifact_visibility || DEFAULT_ARTIFACT_VISIBILITY : null,
+      auto_email_reminder_enabled: formValue.auto_email_reminder_enabled || false,
+      // Total minutes before start, clamped to the upstream 120-1440 range; omitted when disabled so upstream resets the stored value
+      auto_email_reminder_time: formValue.auto_email_reminder_enabled
+        ? Math.min(
+            Math.max(
+              Number(formValue.reminderHours || DEFAULT_EMAIL_REMINDER_HOURS) * 60 + Number(formValue.reminderMinutes || 0),
+              MIN_EMAIL_REMINDER_HOURS * 60
+            ),
+            MAX_EMAIL_REMINDER_TIME
+          )
+        : undefined,
       recurrence: recurrenceObject,
       platform: formValue.platform || DEFAULT_MEETING_TOOL,
       committees: formValue.committees || [],
@@ -795,6 +811,19 @@ export class MeetingManageComponent {
       this.form().get('youtube_upload_enabled')?.enable();
     }
 
+    // Map the stored reminder time (total minutes) back to the hours/minutes helper controls
+    let reminderTotalMinutes = DEFAULT_EMAIL_REMINDER_HOURS * 60;
+    if (meeting.auto_email_reminder_enabled && meeting.auto_email_reminder_time) {
+      reminderTotalMinutes = meeting.auto_email_reminder_time;
+    }
+    const reminderHours = Math.floor(reminderTotalMinutes / 60);
+    if (meeting.auto_email_reminder_enabled) {
+      this.form().get('reminderHours')?.enable();
+      if (reminderHours !== MAX_EMAIL_REMINDER_HOURS) {
+        this.form().get('reminderMinutes')?.enable();
+      }
+    }
+
     this.form().patchValue({
       title: meeting.title,
       description: meeting.description,
@@ -814,6 +843,9 @@ export class MeetingManageComponent {
       zoom_ai_enabled: meeting.ai_summary_enabled || false,
       require_ai_summary_approval: meeting.require_ai_summary_approval ?? false,
       artifact_visibility: meeting.artifact_visibility ?? DEFAULT_ARTIFACT_VISIBILITY,
+      auto_email_reminder_enabled: meeting.auto_email_reminder_enabled ?? false,
+      reminderHours: reminderHours,
+      reminderMinutes: reminderTotalMinutes % 60,
       recurrenceType: finalRecurrenceValue,
       committees: meeting.committees || [],
     });
@@ -934,7 +966,8 @@ export class MeetingManageComponent {
         );
 
       case 3: // Platform & Features
-        return form.get('platform')?.valid ?? false;
+        // Reminder controls are checked via !invalid so their disabled state (toggle off) doesn't block the step
+        return (form.get('platform')?.valid ?? false) && !form.get('reminderHours')?.invalid && !form.get('reminderMinutes')?.invalid;
 
       case 4: // Resources & Summary (optional)
       case 5: // Manage Guests (optional)
@@ -991,6 +1024,12 @@ export class MeetingManageComponent {
         zoom_ai_enabled: new FormControl(false),
         require_ai_summary_approval: new FormControl(false),
         artifact_visibility: new FormControl(DEFAULT_ARTIFACT_VISIBILITY),
+        auto_email_reminder_enabled: new FormControl(false),
+        reminderHours: new FormControl({ value: DEFAULT_EMAIL_REMINDER_HOURS, disabled: true }, [
+          Validators.min(MIN_EMAIL_REMINDER_HOURS),
+          Validators.max(MAX_EMAIL_REMINDER_HOURS),
+        ]),
+        reminderMinutes: new FormControl({ value: DEFAULT_EMAIL_REMINDER_MINUTES, disabled: true }, [Validators.min(0), Validators.max(59)]),
 
         // Step 4: Resources & Summary
         attachments: new FormControl<PendingAttachment[]>([]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -1028,11 +1028,13 @@ export class MeetingManageComponent {
         auto_email_reminder_enabled: new FormControl(false),
         reminderHours: new FormControl({ value: DEFAULT_EMAIL_REMINDER_HOURS, disabled: true }, [
           Validators.required,
+          Validators.pattern(/^\d+$/),
           Validators.min(MIN_EMAIL_REMINDER_HOURS),
           Validators.max(MAX_EMAIL_REMINDER_HOURS),
         ]),
         reminderMinutes: new FormControl({ value: DEFAULT_EMAIL_REMINDER_MINUTES, disabled: true }, [
           Validators.required,
+          Validators.pattern(/^\d+$/),
           Validators.min(0),
           Validators.max(59),
         ]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -967,8 +967,10 @@ export class MeetingManageComponent {
         );
 
       case 3: // Platform & Features
-        // Reminder controls are checked via !invalid so their disabled state (toggle off) doesn't block the step
-        return (form.get('platform')?.valid ?? false) && !form.get('reminderHours')?.invalid && !form.get('reminderMinutes')?.invalid;
+        // Reminder controls use `invalid ?? true` (not `.valid`) because a disabled control (toggle off,
+        // or minutes locked at the 24h max) reports valid === false and would wrongly block the step;
+        // the ?? true fallback still fails closed if the controls are ever missing from the form.
+        return (form.get('platform')?.valid ?? false) && !(form.get('reminderHours')?.invalid ?? true) && !(form.get('reminderMinutes')?.invalid ?? true);
 
       case 4: // Resources & Summary (optional)
       case 5: // Manage Guests (optional)

--- a/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.html
+++ b/apps/lfx-one/src/app/shared/components/feature-toggle/feature-toggle.component.html
@@ -36,6 +36,7 @@
         [id]="feature().key"
         [trueValue]="feature().trueValue || true"
         [falseValue]="feature().falseValue || false"
+        [ariaLabel]="feature().title"
         [attr.data-testid]="'toggle-' + feature().key">
       </lfx-toggle>
     }

--- a/apps/lfx-one/src/app/shared/components/toggle/toggle.component.html
+++ b/apps/lfx-one/src/app/shared/components/toggle/toggle.component.html
@@ -10,6 +10,7 @@
       [styleClass]="styleClass()"
       [trueValue]="trueValue()"
       [falseValue]="falseValue()"
+      [ariaLabel]="ariaLabel()"
       [attr.data-test]="dataTest()"></p-toggleSwitch>
     @if (label()) {
       <label [for]="id()" class="text-sm font-medium text-gray-700 cursor-pointer">

--- a/apps/lfx-one/src/app/shared/components/toggle/toggle.component.ts
+++ b/apps/lfx-one/src/app/shared/components/toggle/toggle.component.ts
@@ -16,6 +16,7 @@ export class ToggleComponent {
   public form = input.required<FormGroup>();
   public control = input.required<string>();
   public label = input<string>();
+  public ariaLabel = input<string>();
   public id = input<string>();
   public readonly = input<boolean>(false);
   public styleClass = input<string>();

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -304,6 +304,44 @@ export const YOUTUBE_MAX_MEETING_TITLE_LENGTH = YOUTUBE_MAX_TITLE_LENGTH - YOUTU
 export const DEFAULT_EARLY_JOIN_TIME = 10;
 
 /**
+ * Minimum reminder email lead time in hours
+ * @description Earliest the automatic reminder email can be sent before the meeting starts
+ */
+export const MIN_EMAIL_REMINDER_HOURS = 2;
+
+/**
+ * Maximum reminder email lead time in hours
+ * @description Latest the automatic reminder email can be sent before the meeting starts
+ */
+export const MAX_EMAIL_REMINDER_HOURS = 24;
+
+/**
+ * Default reminder email lead time in hours
+ * @description Standard reminder window for meetings when the reminder is first enabled
+ */
+export const DEFAULT_EMAIL_REMINDER_HOURS = 24;
+
+/**
+ * Default reminder email lead time minutes component
+ * @description Minutes component of the reminder window; forced to 0 when hours is 24
+ */
+export const DEFAULT_EMAIL_REMINDER_MINUTES = 0;
+
+/**
+ * Maximum reminder email lead time in total minutes
+ * @description Upstream ITX limit for auto_email_reminder_time (24 hours)
+ */
+export const MAX_EMAIL_REMINDER_TIME = 1440;
+
+/**
+ * Tooltip text for the send reminder email feature
+ * @description Explains the automatic reminder email behavior and its 2-24 hour window
+ */
+export const EMAIL_REMINDER_TOOLTIP =
+  'Automatically send a reminder email to all participants before the meeting starts. ' +
+  'You can set the reminder time between 2 and 24 hours before the meeting. When set to 24 hours, minutes are automatically set to 0.';
+
+/**
  * Zoom API codes for weekdays (Monday through Friday)
  * @description String format used by Zoom API: '2,3,4,5,6' where 1=Sunday, 2=Monday, etc.
  */
@@ -503,6 +541,19 @@ export const RECURRING_MEETING_FEATURE = {
   description: 'This meeting repeats on a schedule',
   recommended: false,
   color: lfxColors.blue[500],
+};
+
+/**
+ * Send reminder email feature configuration
+ * @description Feature toggle config for the automatic participant reminder email
+ */
+export const EMAIL_REMINDER_FEATURE = {
+  key: 'auto_email_reminder_enabled',
+  icon: 'fa-light fa-bell',
+  title: 'Send reminder email to participants',
+  description: 'Automatically send a reminder email to all participants before the meeting starts',
+  recommended: false,
+  color: lfxColors.amber[500],
 };
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -267,6 +267,10 @@ export interface Meeting {
   ai_summary_enabled?: boolean | null;
   /** Whether AI summary requires approval before being shared */
   require_ai_summary_approval?: boolean | null;
+  /** Whether an automatic reminder email is sent to participants before the meeting starts */
+  auto_email_reminder_enabled?: boolean | null;
+  /** Minutes before the meeting start time to send the reminder email (120-1440) */
+  auto_email_reminder_time?: number | null;
   /** Nested Zoom config from the indexed query-service projection (source for ai_summary_enabled on list views) */
   zoom_config?: MeetingZoomConfig | null;
 
@@ -401,6 +405,8 @@ export interface CreateMeetingRequest {
   organizers?: string[]; // Array of organizer email addresses
   ai_summary_enabled?: boolean; // Whether Zoom AI Companion summary is enabled
   require_ai_summary_approval?: boolean; // Whether AI summary requires approval before sharing
+  auto_email_reminder_enabled?: boolean; // Whether an automatic reminder email is sent to participants
+  auto_email_reminder_time?: number; // Minutes before the meeting start time to send the reminder email (120-1440)
 }
 
 export interface UpdateMeetingRequest {
@@ -428,6 +434,8 @@ export interface UpdateMeetingRequest {
   organizers?: string[]; // Array of organizer email addresses
   ai_summary_enabled?: boolean | null; // Whether Zoom AI Companion summary is enabled
   require_ai_summary_approval?: boolean | null; // Whether AI summary requires approval before sharing
+  auto_email_reminder_enabled?: boolean | null; // Whether an automatic reminder email is sent to participants
+  auto_email_reminder_time?: number | null; // Minutes before the meeting start time to send the reminder email (120-1440)
 }
 
 export interface DeleteMeetingRequest {


### PR DESCRIPTION
## Summary

Adds the legacy app's **Send reminder email to participants** option to the meeting create/edit wizard (Step 3 — Platform & Features), backed by the existing ITX reminder capability:

- New feature toggle card with hours/minutes inputs: reminder window of 2–24 hours before start; when hours is 24, minutes lock to 0 (matching legacy behavior and copy verbatim, including the info tooltip).
- Maps to the upstream contract `auto_email_reminder_enabled` (bool) + `auto_email_reminder_time` (total minutes, 120–1440, default 1440) on create and update; values round-trip on edit.
- Payload hardening: totals are rounded and clamped to the upstream range; when disabled, the time field is omitted (ITX resets the stored pair on explicit disable — verified in itx-service-zoom `validateAndSetAutoEmailReminderTime`).
- Validation: `required` + min/max on the enabled inputs, gated into step-3 validity so a cleared input blocks submission with a visible error; disabled controls never block.
- Accessibility: the tooltip icon is keyboard-focusable (`tabindex="0"`) with an `aria-label`; `data-testid`s on all new interactive elements and error messages.
- Shared package: interface fields on `Meeting` / `CreateMeetingRequest` / `UpdateMeetingRequest`, reminder constants, and an `EMAIL_REMINDER_FEATURE` config. BFF unchanged (verbatim passthrough).

## External references

- **Depends on** linuxfoundation/lfx-v2-meeting-service#236 — exposes the reminder fields on the ITX create/update payloads. Until that deploys, the toggle is a harmless no-op (fields dropped upstream); deploy #236 first.
- JIRA: [LFXV2-3007](https://linuxfoundation.atlassian.net/browse/LFXV2-3007)

## Testing

- `yarn check-types`, `yarn lint`, `yarn build` (SSR) all green; pre-commit hooks (headers, format, lint, type-check) pass.
- Reminder field mapping is covered end-to-end by unit tests in the meeting-service PR (payload→domain→ITX request, create + update + explicit-false disable wire format).
- Post-commit reviewer trio + full-branch sweep run clean; remaining nits (minutes required-message copy, toggle-off resetting hours to the 24h default) are documented as accepted.

[LFXV2-3007]: https://linuxfoundation.atlassian.net/browse/LFXV2-3007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable email reminders for meetings.
  * Enable reminders and set lead time from 2–24 hours, with minute-level options.
  * Reminder settings are preserved when editing meetings and included when saving changes.

* **Bug Fixes**
  * Added validation for required reminder values and valid hour/minute ranges.

* **Accessibility**
  * Improved toggle labeling for screen readers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->