### PR TITLE
fix(meetings): keep reminder timing inputs on one line

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-platform-features/meeting-platform-features.component.html
@@ -133,29 +133,35 @@
       <lfx-feature-toggle [feature]="emailReminderFeature" [form]="form()">
         @if (form().get('auto_email_reminder_enabled')?.value) {
           <div class="mt-4 pt-4 border-t border-gray-200 flex flex-col gap-2">
-            <div class="flex items-center gap-2 flex-wrap">
-              <lfx-input-number
-                [form]="form()"
-                control="reminderHours"
-                size="small"
-                id="email-reminder-hours"
-                styleClass="w-16"
-                data-testid="email-reminder-hours-input"></lfx-input-number>
-              <label for="email-reminder-hours" class="text-sm text-neutral-950">hours</label>
-              <lfx-input-number
-                [form]="form()"
-                control="reminderMinutes"
-                size="small"
-                id="email-reminder-minutes"
-                styleClass="w-16"
-                data-testid="email-reminder-minutes-input"></lfx-input-number>
-              <label for="email-reminder-minutes" class="text-sm text-neutral-950">minutes before the meeting starts</label>
+            <div class="flex items-center gap-x-2 gap-y-1 flex-wrap" role="group" aria-label="Send reminder before the meeting starts">
+              <div class="flex items-center gap-2">
+                <lfx-input-number
+                  class="w-20 flex-none"
+                  [form]="form()"
+                  control="reminderHours"
+                  size="small"
+                  id="email-reminder-hours"
+                  data-testid="email-reminder-hours-input"></lfx-input-number>
+                <label for="email-reminder-hours" class="text-sm text-neutral-950">hours</label>
+              </div>
+              <div class="flex items-center gap-2">
+                <lfx-input-number
+                  class="w-20 flex-none"
+                  [form]="form()"
+                  control="reminderMinutes"
+                  size="small"
+                  id="email-reminder-minutes"
+                  data-testid="email-reminder-minutes-input"></lfx-input-number>
+                <label for="email-reminder-minutes" class="text-sm text-neutral-950">minutes</label>
+              </div>
+              <span class="text-sm text-neutral-950">before the meeting starts</span>
               <i
                 class="fa-light fa-info-circle text-gray-400 cursor-help"
                 tabindex="0"
                 role="img"
                 [attr.aria-label]="emailReminderTooltip"
                 [pTooltip]="emailReminderTooltip"
+                tooltipEvent="both"
                 tooltipPosition="right"
                 tooltipStyleClass="text-xs max-w-xs"
                 data-testid="email-reminder-tooltip"></i>


### PR DESCRIPTION
## Summary

The "Send reminder email to participants" timing row (added in #1329) rendered confusingly: the hours/minutes inputs stretched to full width, pushing the trailing label "minutes before the meeting starts" onto its own line.

**Root cause:** the `lfx-input-number` wrapper puts both `[class]="styleClass()"` and a static `class="w-full"` on its inner `<input>`; `w-full` wins in Tailwind's emission order, so the `styleClass="w-16"` passed by the template never applied.

**Fix (template-only):**
- Constrain the width on the `<lfx-input-number>` host (`w-20 flex-none`) — the wrapper's inner `w-full` input fills the 5rem host, so each input is compact and the row reads as one sentence: `[24] hours [0] minutes before the meeting starts (i)`
- Pair each input with its unit label in a sub-group so any wrapping on narrow screens breaks at input+unit boundaries instead of orphaning the label
- `role="group"` + aria-label preserves the full sentence for screen readers now that the visible minutes label is shortened
- Add `tooltipEvent="both"` to the info icon so keyboard focus shows the tooltip (pTooltip defaults to hover-only, leaving the existing `tabindex="0"` stop with no visible payoff)

## Screenshots context

Before: inputs full-width, label wrapped to its own line. After: single-line sentence layout with compact inputs.

## Non-blocking follow-ups surfaced during review (out of scope here)

- The `input-number` wrapper's `styleClass` + static `w-full` conflict silently breaks any `w-*` caller — same broken pattern exists in `meeting-recurrence-pattern.component.html` (`w-16`/`w-20` usages)
- The wrapper renders the same `id` on host and inner input (app-wide pattern)
- Reminder validation copy hardcodes the 2–24h window that `MIN/MAX_EMAIL_REMINDER_HOURS` constants own

## JIRA

[LFXV2-3007](https://linuxfoundation.atlassian.net/browse/LFXV2-3007)

[LFXV2-3007]: https://linuxfoundation.atlassian.net/browse/LFXV2-3007?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ