### PR TITLE
feat(committees): prefill org from profile on join and apply flows

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.html
@@ -193,7 +193,7 @@
                     icon="fa-light fa-user-plus"
                     severity="info"
                     size="small"
-                    [loading]="joiningOrLeaving()"
+                    [loading]="joiningOrLeaving() || resolvingOrg()"
                     (onClick)="handleJoinRequest()"
                     data-testid="committee-view-join-btn" />
                 } @else if (committee()?.join_mode === 'application' && !hasPendingApplication()) {
@@ -202,7 +202,7 @@
                     icon="fa-light fa-file-signature"
                     severity="info"
                     size="small"
-                    [loading]="joiningOrLeaving()"
+                    [loading]="joiningOrLeaving() || resolvingOrg()"
                     (onClick)="handleJoinRequest()"
                     data-testid="committee-view-apply-btn" />
                 } @else if (committee()?.join_mode === 'closed') {

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -200,7 +200,7 @@ export class CommitteeViewComponent {
   public joiningOrLeaving = signal(false);
   // Blocks the join/apply CTA during the async org-prefetch window so a second tap
   // doesn't fire a parallel resolveCurrentEmployer() + dialog pair.
-  private readonly resolvingOrg = signal(false);
+  protected readonly resolvingOrg = signal(false);
   // Engagement rollup (LFXV2-1705): shared window state so the Members table and the Overview
   // summary stay in sync across tab switches (tab panels unmount in the @switch below).
   // linkedSignal, not signal: resets to the default window whenever committeeId() changes, the same

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -156,6 +156,9 @@ export class CommitteeViewComponent {
   public invitesLoading = signal<boolean>(true);
   public applicationsLoading = signal<boolean>(true);
   public joiningOrLeaving = signal(false);
+  // Blocks the join/apply CTA during the async org-prefetch window so a second tap
+  // doesn't fire a parallel resolveCurrentEmployer() + dialog pair.
+  private readonly resolvingOrg = signal(false);
   // Engagement rollup (LFXV2-1705): shared window state so the Members table and the Overview
   // summary stay in sync across tab switches (tab panels unmount in the @switch below).
   // linkedSignal, not signal: resets to the default window whenever committeeId() changes, the same
@@ -482,7 +485,7 @@ export class CommitteeViewComponent {
 
   public async handleJoinRequest(): Promise<void> {
     const committee = this.committee();
-    if (!committee || this.joiningOrLeaving()) {
+    if (!committee || this.joiningOrLeaving() || this.resolvingOrg()) {
       return;
     }
 
@@ -492,7 +495,8 @@ export class CommitteeViewComponent {
     if (joinMode === 'open') {
       let organization: CommitteeOrganizationReference | undefined;
       if (requiresOrg) {
-        const result = await this.openOrganizationDialog(committee.name);
+        this.resolvingOrg.set(true);
+        const result = await this.openOrganizationDialog(committee.name).finally(() => this.resolvingOrg.set(false));
         if (!result?.organization) {
           return;
         }
@@ -518,7 +522,8 @@ export class CommitteeViewComponent {
       }
       let organization: CommitteeOrganizationReference | undefined;
       if (requiresOrg) {
-        const result = await this.openOrganizationDialog(committee.name);
+        this.resolvingOrg.set(true);
+        const result = await this.openOrganizationDialog(committee.name).finally(() => this.resolvingOrg.set(false));
         if (!result?.organization) {
           return;
         }

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -198,8 +198,9 @@ export class CommitteeViewComponent {
   public invitesLoading = signal<boolean>(true);
   public applicationsLoading = signal<boolean>(true);
   public joiningOrLeaving = signal(false);
-  // Blocks the join/apply CTA during the async org-prefetch window so a second tap
-  // doesn't fire a parallel resolveCurrentEmployer() + dialog pair.
+  // Blocks the join/apply CTA while the org-prefetch is running and while the dialog
+  // is open (signal stays true until .finally() resolves when the dialog closes) so a
+  // second tap can't open a parallel resolveCurrentEmployer() + dialog pair.
   protected readonly resolvingOrg = signal(false);
   // Engagement rollup (LFXV2-1705): shared window state so the Members table and the Overview
   // summary stay in sync across tab switches (tab panels unmount in the @switch below).
@@ -837,7 +838,8 @@ export class CommitteeViewComponent {
     // Pre-fill from the user's profile work experiences — same pre-resolution the invite
     // accept flow uses so the user doesn't have to re-enter an org they've already set.
     // takeUntilDestroyed cancels the observable if the component is destroyed while the
-    // profile/domain lookup (≤2 s) is still in flight, preventing dangling subscriptions.
+    // profile/domain lookup (≤4 s worst case — 2 s for the work-experiences GET + 2 s for
+    // the CDP domain resolve) is still in flight, preventing dangling subscriptions.
     // We track destruction explicitly because firstValueFrom's defaultValue: null causes
     // the await to resolve successfully even when takeUntilDestroyed completed early due
     // to component teardown — without this guard the dialog would open over a new route.

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -62,7 +62,7 @@ import { InvitationSubtextPipe } from '@pipes/invitation-subtext.pipe';
 import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
 import { DescriptionDialogComponent } from '../components/description-dialog/description-dialog.component';
 import { MessageService } from 'primeng/api';
-import { catchError, combineLatest, distinctUntilChanged, EMPTY, exhaustMap, filter, finalize, map, of, startWith, switchMap, take, tap, timer } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, EMPTY, exhaustMap, filter, finalize, firstValueFrom, map, of, startWith, switchMap, take, tap, timer } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
@@ -780,13 +780,17 @@ export class CommitteeViewComponent {
     });
   }
 
-  private openOrganizationDialog(committeeName: string): Promise<AcceptInviteOrganizationDialogResult | null> {
+  private async openOrganizationDialog(committeeName: string): Promise<AcceptInviteOrganizationDialogResult | null> {
+    // Pre-fill from the user's profile work experiences — same pre-resolution the invite
+    // accept flow uses so the user doesn't have to re-enter an org they've already set.
+    const prefillOrg = await firstValueFrom(this.invitationAcceptFlow.resolveCurrentEmployer());
+
     const ref = this.dialogService.open(AcceptInviteOrganizationDialogComponent, {
       header: 'Confirm Organization',
       width: '32rem',
       modal: true,
       closable: true,
-      data: { committeeName, organization: null } satisfies AcceptInviteOrganizationDialogData,
+      data: { committeeName, organization: prefillOrg } satisfies AcceptInviteOrganizationDialogData,
     });
     if (!ref) {
       return Promise.resolve(null);

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -62,7 +62,23 @@ import { InvitationSubtextPipe } from '@pipes/invitation-subtext.pipe';
 import { JoinModeLabelPipe } from '@pipes/join-mode-label.pipe';
 import { DescriptionDialogComponent } from '../components/description-dialog/description-dialog.component';
 import { MessageService } from 'primeng/api';
-import { catchError, combineLatest, distinctUntilChanged, EMPTY, exhaustMap, filter, finalize, firstValueFrom, map, of, startWith, switchMap, take, tap, timer } from 'rxjs';
+import {
+  catchError,
+  combineLatest,
+  distinctUntilChanged,
+  EMPTY,
+  exhaustMap,
+  filter,
+  finalize,
+  firstValueFrom,
+  map,
+  of,
+  startWith,
+  switchMap,
+  take,
+  tap,
+  timer,
+} from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { JoinApplicationDialogResult } from '@lfx-one/shared/interfaces';
@@ -788,7 +804,11 @@ export class CommitteeViewComponent {
   private async openOrganizationDialog(committeeName: string): Promise<AcceptInviteOrganizationDialogResult | null> {
     // Pre-fill from the user's profile work experiences — same pre-resolution the invite
     // accept flow uses so the user doesn't have to re-enter an org they've already set.
-    const prefillOrg = await firstValueFrom(this.invitationAcceptFlow.resolveCurrentEmployer());
+    // takeUntilDestroyed cancels the observable if the component is destroyed while the
+    // profile/domain lookup (≤2 s) is still in flight, preventing dangling subscriptions.
+    const prefillOrg = await firstValueFrom(this.invitationAcceptFlow.resolveCurrentEmployer().pipe(takeUntilDestroyed(this.destroyRef)), {
+      defaultValue: null,
+    });
 
     const ref = this.dialogService.open(AcceptInviteOrganizationDialogComponent, {
       header: 'Confirm Organization',

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -542,6 +542,9 @@ export class CommitteeViewComponent {
         if (!result?.organization) {
           return;
         }
+        if (this.committeeId() !== committee.uid) {
+          return;
+        }
         organization = result.organization;
       }
       this.joiningOrLeaving.set(true);
@@ -567,6 +570,9 @@ export class CommitteeViewComponent {
         this.resolvingOrg.set(true);
         const result = await this.openOrganizationDialog(committee.name).finally(() => this.resolvingOrg.set(false));
         if (!result?.organization) {
+          return;
+        }
+        if (this.committeeId() !== committee.uid) {
           return;
         }
         organization = result.organization;

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -806,9 +806,22 @@ export class CommitteeViewComponent {
     // accept flow uses so the user doesn't have to re-enter an org they've already set.
     // takeUntilDestroyed cancels the observable if the component is destroyed while the
     // profile/domain lookup (≤2 s) is still in flight, preventing dangling subscriptions.
+    // We track destruction explicitly because firstValueFrom's defaultValue: null causes
+    // the await to resolve successfully even when takeUntilDestroyed completed early due
+    // to component teardown — without this guard the dialog would open over a new route.
+    let destroyed = false;
+    const cleanupDestroyListener = this.destroyRef.onDestroy(() => {
+      destroyed = true;
+    });
+
     const prefillOrg = await firstValueFrom(this.invitationAcceptFlow.resolveCurrentEmployer().pipe(takeUntilDestroyed(this.destroyRef)), {
       defaultValue: null,
     });
+
+    cleanupDestroyListener();
+    if (destroyed) {
+      return null;
+    }
 
     const ref = this.dialogService.open(AcceptInviteOrganizationDialogComponent, {
       header: 'Confirm Organization',

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.html
@@ -14,7 +14,7 @@
       nameControl="organization"
       domainControl="organization_url"
       idControl="organization_id"
-      [domainRequired]="isNewOrg()"
+      [domainRequired]="hasOrgName()"
       placeholder="Search for organization..."
       styleClass="w-full"
       inputStyleClass="text-sm w-full"

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -43,13 +43,12 @@ export class AcceptInviteOrganizationDialogComponent {
   private readonly formValue = this.initFormValue();
   private readonly urlStatus = signal<FormControlStatus>(this.urlControl.status);
 
+  // URL validators must stay active whenever an org name is present — not just while the
+  // URL field is empty — because clearing them on the first URL keystroke allowed any
+  // non-empty string (e.g. "not-a-url") to pass urlStatus as VALID and enable Confirm.
   protected readonly isNewOrg = computed(() => {
     const value = this.formValue();
-    // URL is always required because organization_id is stripped before the payload reaches
-    // committee-service — the server must receive either an SFID (which we don't have) or
-    // name + domain. Treat any org without a confirmed website as requiring URL input.
-    const hasUrl = !!(value?.organization_url ?? '').trim();
-    return !hasUrl && !!value?.organization?.trim();
+    return !!value?.organization?.trim();
   });
 
   private readonly orgInvalid = computed(() => {

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, effect, inject, signal, viewChild } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, inject, signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormControlStatus, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
@@ -101,17 +101,19 @@ export class AcceptInviteOrganizationDialogComponent {
       this.urlStatus.set(status);
     });
 
-    effect(() => {
-      if (this.isNewOrg()) {
-        this.urlControl.setValidators([trimmedRequired(), httpsUrlValidator()]);
-      } else {
-        this.urlControl.clearValidators();
-      }
-      this.urlControl.updateValueAndValidity({ emitEvent: false });
-      // Manually sync after updateValueAndValidity({ emitEvent: false }) since
-      // suppressing the event means statusChanges won't fire for validator changes.
-      this.urlStatus.set(this.urlControl.status);
-    });
+    toObservable(this.isNewOrg)
+      .pipe(takeUntilDestroyed())
+      .subscribe((isNew) => {
+        if (isNew) {
+          this.urlControl.setValidators([trimmedRequired(), httpsUrlValidator()]);
+        } else {
+          this.urlControl.clearValidators();
+        }
+        this.urlControl.updateValueAndValidity({ emitEvent: false });
+        // Manually sync after updateValueAndValidity({ emitEvent: false }) since
+        // suppressing the event means statusChanges won't fire for validator changes.
+        this.urlStatus.set(this.urlControl.status);
+      });
   }
 
   public onOrgResolved(result: OrganizationResolveResult): void {

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -46,7 +46,10 @@ export class AcceptInviteOrganizationDialogComponent {
   // URL validators must stay active whenever an org name is present — not just while the
   // URL field is empty — because clearing them on the first URL keystroke allowed any
   // non-empty string (e.g. "not-a-url") to pass urlStatus as VALID and enable Confirm.
-  protected readonly isNewOrg = computed(() => {
+  // Named hasOrgName (not isNewOrg) because it is true for CDP-resolved orgs too —
+  // organization_id is stripped before forwarding to committee-service, so the URL
+  // is required regardless of whether the org already exists in CDP.
+  protected readonly hasOrgName = computed(() => {
     const value = this.formValue();
     return !!value?.organization?.trim();
   });
@@ -100,10 +103,12 @@ export class AcceptInviteOrganizationDialogComponent {
       this.urlStatus.set(status);
     });
 
-    toObservable(this.isNewOrg)
+    // toObservable (not effect) so we can write urlStatus inside the callback —
+    // effect() forbids signal writes without allowSignalWrites: true.
+    toObservable(this.hasOrgName)
       .pipe(takeUntilDestroyed())
-      .subscribe((isNew) => {
-        if (isNew) {
+      .subscribe((hasName) => {
+        if (hasName) {
           this.urlControl.setValidators([trimmedRequired(), httpsUrlValidator()]);
         } else {
           this.urlControl.clearValidators();
@@ -126,7 +131,7 @@ export class AcceptInviteOrganizationDialogComponent {
 
   public onConfirm(): void {
     this.organizationControl.markAsTouched();
-    if (this.isNewOrg()) {
+    if (this.hasOrgName()) {
       this.urlControl.markAsTouched();
     }
     if (!this.form.valid) {

--- a/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
+++ b/apps/lfx-one/src/app/shared/components/accept-invite-organization-dialog/accept-invite-organization-dialog.component.ts
@@ -45,7 +45,11 @@ export class AcceptInviteOrganizationDialogComponent {
 
   protected readonly isNewOrg = computed(() => {
     const value = this.formValue();
-    return !value?.organization_id && !!value?.organization?.trim();
+    // URL is always required because organization_id is stripped before the payload reaches
+    // committee-service — the server must receive either an SFID (which we don't have) or
+    // name + domain. Treat any org without a confirmed website as requiring URL input.
+    const hasUrl = !!(value?.organization_url ?? '').trim();
+    return !hasUrl && !!value?.organization?.trim();
   });
 
   private readonly orgInvalid = computed(() => {
@@ -59,11 +63,11 @@ export class AcceptInviteOrganizationDialogComponent {
     }
     const hasName = !!(vals?.organization ?? '').trim();
     if (!hasName) return true;
-    if (!vals?.organization_id) {
-      const urlValue = (vals?.organization_url ?? '').trim();
-      if (!urlValue) return true;
-      return this.urlStatus() !== 'VALID';
-    }
+    // URL is always required — organization_id is stripped before forwarding to committee-service,
+    // so committee-service must receive name + domain regardless of whether CDP resolved the org.
+    const urlValue = (vals?.organization_url ?? '').trim();
+    if (!urlValue) return true;
+    if (this.urlStatus() !== 'VALID') return true;
     // Block if visible search term was edited without a new selection — confirmed name/id may be stale.
     const searchTerm = search?.searchTerm() ?? '';
     const orgName = (vals?.organization ?? '').trim();

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -45,11 +45,7 @@ export class InvitationAcceptFlowService {
     // the user's current employer from their profile (fails silently — dialog opens blank).
     const contextReady$: Observable<InvitationAcceptContext> = context.organization
       ? of(context)
-      : this.http.get<WorkExperienceEntry[]>('/api/profile/work-experiences').pipe(
-          take(1),
-          map((experiences) => ({ ...context, organization: currentEmployerFromWorkExperiences(experiences) })),
-          catchError(() => of(context))
-        );
+      : this.resolveCurrentEmployer().pipe(map((org) => ({ ...context, organization: org ?? undefined })));
 
     return contextReady$.pipe(
       switchMap((ctx) => this.preResolveOrganization(ctx)),
@@ -83,7 +79,10 @@ export class InvitationAcceptFlowService {
       take(1),
       map((experiences) => currentEmployerFromWorkExperiences(experiences)),
       switchMap((org) => (org ? this.resolveOrgDomain(org) : of(null))),
-      catchError(() => of(null))
+      catchError((error) => {
+        console.warn('[InvitationAcceptFlowService] resolveCurrentEmployer failed; opening dialog blank', error);
+        return of(null);
+      })
     );
   }
 

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -7,6 +7,7 @@ import { AcceptInviteOrganizationDialogComponent } from '@components/accept-invi
 import {
   AcceptInviteOrganizationDialogData,
   AcceptInviteOrganizationDialogResult,
+  CommitteeOrganizationReference,
   InvitationAcceptContext,
   WorkExperienceEntry,
 } from '@lfx-one/shared/interfaces';
@@ -69,48 +70,67 @@ export class InvitationAcceptFlowService {
   }
 
   /**
-   * Attempts to resolve an org name to a CDP id before the dialog opens so a pre-filled
-   * name with no id is not treated as a brand-new org requiring a manual website entry.
+   * Resolves the current user's employer from their profile work experiences, including
+   * a best-effort domain lookup via CDP so the website field is populated.
    *
-   * Uses a two-step read-only approach to avoid the find-or-create side effect of calling
-   * resolveOrganization directly with an empty or unverified domain:
-   *  1. Search by name (read-only GET) to find the CDP-canonical domain.
-   *  2. Resolve only on an exact name match, using the canonical domain so the CDP call
-   *     is almost certainly a find (not a create).
+   * Used by open-group and application join flows to pre-fill the "Confirm Organization"
+   * dialog the same way the invite accept flow does.
    *
-   * Times out after 2 s and silently falls through — the dialog handles the unresolved case.
+   * Emits null and never throws — callers open the dialog with a blank org on any failure.
    */
-  private preResolveOrganization(ctx: InvitationAcceptContext): Observable<InvitationAcceptContext> {
-    const org = ctx.organization;
-    if (!org?.name?.trim() || org.id) {
-      return of(ctx);
+  public resolveCurrentEmployer(): Observable<CommitteeOrganizationReference | null> {
+    return this.http.get<WorkExperienceEntry[]>('/api/profile/work-experiences').pipe(
+      take(1),
+      map((experiences) => currentEmployerFromWorkExperiences(experiences)),
+      switchMap((org) => (org ? this.resolveOrgDomain(org) : of(null))),
+      catchError(() => of(null))
+    );
+  }
+
+  /**
+   * Attempts to resolve the website/domain for an org reference via CDP so the dialog can
+   * pre-fill the URL field and prevent the "name and domain required" rejection from
+   * committee-service (which always needs the domain since organization_id is stripped from
+   * the payload before forwarding).
+   *
+   * Skips the search only when both id AND website are already present.
+   * Times out after 2 s and silently returns the unmodified org on any failure.
+   */
+  private resolveOrgDomain(org: CommitteeOrganizationReference): Observable<CommitteeOrganizationReference> {
+    if (!org?.name?.trim() || (org.id && org.website?.trim())) {
+      return of(org);
     }
-    return this.organizationService.searchOrganizations(org.name).pipe(
+    return this.organizationService.searchOrganizations(org.name!).pipe(
       take(1),
       switchMap((suggestions) => {
         const match = suggestions.find((s) => s.name.toLowerCase() === org.name!.toLowerCase().trim());
         if (!match) {
-          return of(ctx);
+          return of(org);
         }
         return this.organizationService.resolveOrganization(match.name, match.domain).pipe(
           take(1),
           map((resolved) => ({
-            ...ctx,
-            organization: {
-              ...org,
-              id: resolved.id || null,
-              name: resolved.name || org.name,
-              website: normalizeToUrl(match.domain) ?? org.website,
-            },
+            ...org,
+            id: resolved.id || null,
+            name: resolved.name || org.name,
+            website: normalizeToUrl(match.domain) ?? org.website,
           }))
         );
       }),
       timeout(2000),
       catchError((error) => {
-        console.warn('[InvitationAcceptFlowService] Org pre-resolution failed; opening dialog with unresolved context', error);
-        return of(ctx);
+        console.warn('[InvitationAcceptFlowService] Org domain resolution failed; proceeding with unresolved org', error);
+        return of(org);
       })
     );
+  }
+
+  private preResolveOrganization(ctx: InvitationAcceptContext): Observable<InvitationAcceptContext> {
+    const org = ctx.organization;
+    if (!org) {
+      return of(ctx);
+    }
+    return this.resolveOrgDomain(org).pipe(map((resolvedOrg) => ({ ...ctx, organization: resolvedOrg })));
   }
 
   private openOrganizationDialog(context: InvitationAcceptContext): Promise<AcceptInviteOrganizationDialogResult | null> {

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -82,6 +82,10 @@ export class InvitationAcceptFlowService {
       timeout(2000),
       map((experiences) => currentEmployerFromWorkExperiences(experiences)),
       switchMap((org) => (org ? this.resolveOrgDomain(org) : of(null))),
+      // Only prefill when a domain was actually resolved — an org with name but no website
+      // would cause the dialog to open with the URL field empty yet show a red validation
+      // warning immediately (orgInvalid=true + hasName=true → showOrgWarning=true).
+      map((org) => (org?.website?.trim() ? org : null)),
       catchError((error) => {
         console.warn('[InvitationAcceptFlowService] resolveCurrentEmployer failed; opening dialog blank', error);
         return of(null);
@@ -97,27 +101,30 @@ export class InvitationAcceptFlowService {
    *
    * Skips the search only when both id AND website are already present.
    * Times out after 2 s and silently returns the unmodified org on any failure.
+   * (resolveCurrentEmployer's preceding 2 s GET timeout means the total worst-case
+   * prefill window is ~4 s, not 2 s.)
    */
   private resolveOrgDomain(org: CommitteeOrganizationReference): Observable<CommitteeOrganizationReference> {
-    if (!org?.name?.trim() || (org.id && org.website?.trim())) {
+    const name = (org?.name ?? '').trim();
+    if (!name || (org.id && org.website?.trim())) {
       return of(org);
     }
-    return this.organizationService.searchOrganizations(org.name!).pipe(
+    return this.organizationService.searchOrganizations(name).pipe(
       take(1),
-      switchMap((suggestions) => {
-        const match = suggestions.find((s) => s.name.toLowerCase() === org.name!.toLowerCase().trim());
+      map((suggestions) => {
+        const match = suggestions.find((s) => s.name.toLowerCase() === name.toLowerCase());
         if (!match) {
-          return of(org);
+          return org;
         }
-        return this.organizationService.resolveOrganization(match.name, match.domain).pipe(
-          take(1),
-          map((resolved) => ({
-            ...org,
-            id: resolved.id || null,
-            name: resolved.name || org.name,
-            website: normalizeToUrl(match.domain) ?? org.website,
-          }))
-        );
+        // Build the prefill directly from the search result — the canonical name and
+        // normalised domain are all committee-service needs (organization_id is stripped
+        // before forwarding). Avoids an unnecessary find-or-create POST.
+        return {
+          ...org,
+          id: null,
+          name: match.name,
+          website: normalizeToUrl(match.domain) ?? org.website,
+        };
       }),
       timeout(2000),
       catchError((error) => {
@@ -127,6 +134,7 @@ export class InvitationAcceptFlowService {
     );
   }
 
+  /** Adapts resolveOrgDomain to the invite-accept-context shape, threading the resolved org back into ctx. */
   private preResolveOrganization(ctx: InvitationAcceptContext): Observable<InvitationAcceptContext> {
     const org = ctx.organization;
     if (!org) {

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -79,6 +79,7 @@ export class InvitationAcceptFlowService {
   public resolveCurrentEmployer(): Observable<CommitteeOrganizationReference | null> {
     return this.http.get<WorkExperienceEntry[]>('/api/profile/work-experiences').pipe(
       take(1),
+      timeout(2000),
       map((experiences) => currentEmployerFromWorkExperiences(experiences)),
       switchMap((org) => (org ? this.resolveOrgDomain(org) : of(null))),
       catchError((error) => {

--- a/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
+++ b/apps/lfx-one/src/app/shared/services/invitation-accept-flow.service.ts
@@ -41,14 +41,16 @@ export class InvitationAcceptFlowService {
       return this.invitationService.acceptInvitation(context.committeeUid, context.inviteUid, { fromLfidInvite: context.fromLfidInvite });
     }
 
-    // Resolve the pre-fill org: use the invite's org when present, otherwise fall back to
-    // the user's current employer from their profile (fails silently — dialog opens blank).
+    // Resolve the pre-fill org:
+    // - Invite supplied an org → pre-resolve its domain (may be missing id/website).
+    // - No invite org → employer fallback via resolveCurrentEmployer(), which already calls
+    //   resolveOrgDomain() internally; skip preResolveOrganization to avoid a duplicate
+    //   CDP lookup that doubles latency and can repeat a find-or-create POST.
     const contextReady$: Observable<InvitationAcceptContext> = context.organization
-      ? of(context)
+      ? of(context).pipe(switchMap((ctx) => this.preResolveOrganization(ctx)))
       : this.resolveCurrentEmployer().pipe(map((org) => ({ ...context, organization: org ?? undefined })));
 
     return contextReady$.pipe(
-      switchMap((ctx) => this.preResolveOrganization(ctx)),
       switchMap((ctx) =>
         from(this.openOrganizationDialog(ctx)).pipe(
           switchMap((result) => {


### PR DESCRIPTION
## Summary

- Extracts a public `resolveCurrentEmployer()` method on `InvitationAcceptFlowService` that fetches the user's work experiences, picks the current employer, and resolves its domain — mirroring `preResolveOrganization` for invite payloads
- Calls it from `committee-view` before opening the Confirm Organization dialog on both the open-join and apply-to-join paths so the dialog is pre-filled from the user's profile
- Tightens `isNewOrg` and `orgInvalid` in `AcceptInviteOrganizationDialogComponent`: `organization_url` is now always required because `organization_id` (CDP UUID) is stripped before the payload reaches committee-service, which requires name + domain

## Background

When joining an open committee or applying to a committee that requires an organization (voting enabled or business email required), the Confirm Organization dialog was blank. The invite flow already pre-filled from the invite record, but open-join and apply paths had no equivalent source. This caused a confusing UX and, for apply flows, meant the submitted org was missing — leading to `organization id or organization name and domain are required` errors when an admin approved the application.

The back-end counterpart (storing org on the application record and using it at approve time) is in [lfx-v2-committee-service#174](https://github.com/linuxfoundation/lfx-v2-committee-service/pull/174).

## Test plan

- [ ] Open committee: click Join — Confirm Organization dialog pre-fills with profile employer
- [ ] Apply-to-join committee with `enable_voting: true` — dialog pre-fills with profile employer
- [ ] Submit application — org is included in the payload
- [ ] User with no work experience — dialog opens empty (no pre-fill, no error)
- [ ] Invite flow — still works as before (no regression)

Resolves: [LFXV2-2690](https://linuxfoundation.atlassian.net/browse/LFXV2-2690)

Made with [Cursor](https://cursor.com)

[LFXV2-2690]: https://linuxfoundation.atlassian.net/browse/LFXV2-2690?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ