### PR TITLE
fix(cla): pad single-valued identity query params to survive gateway multi-value strip

### DIFF
--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -303,6 +303,104 @@ describe('ClaService.getMyClas', () => {
     expect(calledUrl).toContain('githubUsername=octocat');
   });
 
+  it('duplicates single-valued github keys when email is multi-valued, to survive the gateway multi-value strip (lfx-gateway#114)', async () => {
+    getEffectiveUsername.mockReturnValue('alice');
+    getEffectiveEmail.mockReturnValue('alice@x.org');
+    getEffectiveSub.mockReturnValue('auth0|abc');
+    getUserEmails.mockResolvedValueOnce({
+      primary_email: 'alice@x.org',
+      alternate_emails: [
+        { email: 'alice@work.com', verified: true },
+        { email: 'alice@personal.com', verified: true },
+      ],
+    });
+    getUserIdentities.mockResolvedValueOnce([{ provider: 'github', user_id: 'github|13434323', connection: 'github', profileData: { nickname: 'octocat' } }]);
+    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1'], clas: [] });
+
+    await new ClaService().getMyClas(req);
+
+    const calledUrl = gatewayFetch.mock.calls[0][1] as string;
+    const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
+    // 3 verified emails -> email is multi-valued, so the lone github keys are padded to 2 so the
+    // gateway keeps them (it forwards only multi-valued params once any param repeats); the backend de-dupes.
+    expect(params.getAll('email').length).toBeGreaterThan(1);
+    expect(params.getAll('githubId')).toEqual(['13434323', '13434323']);
+    expect(params.getAll('githubUsername')).toEqual(['octocat', 'octocat']);
+    // lfUsername stays single-valued (harmless: the backend derives the principal from the X-USERNAME header).
+    expect(params.getAll('lfUsername')).toEqual(['alice']);
+    // The padded values are byte-identical (a repeated single value, not two distinct ids), so the
+    // backend collapses them via pre-authorization de-dupe — no double-count (FR-003, BFF half).
+    expect(new Set(params.getAll('githubId')).size).toBe(1);
+    expect(new Set(params.getAll('githubUsername')).size).toBe(1);
+  });
+
+  it('FR-011 guard: a multi-email caller reaches the gateway with its GitHub keys present (survives the strip)', async () => {
+    getEffectiveUsername.mockReturnValue('alice');
+    getEffectiveEmail.mockReturnValue('alice@x.org');
+    getEffectiveSub.mockReturnValue('auth0|abc');
+    getUserEmails.mockResolvedValueOnce({
+      primary_email: 'alice@x.org',
+      alternate_emails: [
+        { email: 'alice@work.com', verified: true },
+        { email: 'alice@personal.com', verified: true },
+      ],
+    });
+    getUserIdentities.mockResolvedValueOnce([{ provider: 'github', user_id: 'github|13434323', connection: 'github', profileData: { nickname: 'octocat' } }]);
+    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1'], clas: [] });
+
+    await new ClaService().getMyClas(req);
+
+    const calledUrl = gatewayFetch.mock.calls[0][1] as string;
+    const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
+    // Invariant, NOT the padding mechanism: a multi-email caller's github keys must reach the backend.
+    // Stays true after the #114 padding is removed and the gateway stops stripping single-value params.
+    expect(params.getAll('githubId')).toContain('13434323');
+    expect(params.getAll('githubUsername')).toContain('octocat');
+  });
+
+  it('does not duplicate github keys on the single-email path (no-regression, FR-002)', async () => {
+    getEffectiveUsername.mockReturnValue('alice');
+    getEffectiveEmail.mockReturnValue('alice@x.org');
+    getEffectiveSub.mockReturnValue('auth0|abc');
+    getUserIdentities.mockResolvedValueOnce([{ provider: 'github', user_id: 'github|13434323', connection: 'github', profileData: { nickname: 'octocat' } }]);
+    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1'], clas: [] });
+
+    await new ClaService().getMyClas(req);
+
+    const calledUrl = gatewayFetch.mock.calls[0][1] as string;
+    const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
+    // One email -> nothing is multi-valued -> no padding: byte-for-byte the pre-#114 query.
+    expect(params.getAll('email')).toEqual(['alice@x.org']);
+    expect(params.getAll('githubId')).toEqual(['13434323']);
+    expect(params.getAll('githubUsername')).toEqual(['octocat']);
+  });
+
+  it('under impersonation, pads and forwards the TARGET user github keys with the target token (FR-009)', async () => {
+    isImpersonating.mockReturnValue(true);
+    // getEffective* return the *target* identity during impersonation.
+    getEffectiveUsername.mockReturnValue('alice');
+    getEffectiveEmail.mockReturnValue('alice@x.org');
+    getEffectiveSub.mockReturnValue('auth0|abc');
+    getUserEmails.mockResolvedValueOnce({
+      primary_email: 'alice@x.org',
+      alternate_emails: [
+        { email: 'alice@work.com', verified: true },
+        { email: 'alice@personal.com', verified: true },
+      ],
+    });
+    getUserIdentities.mockResolvedValueOnce([{ provider: 'github', user_id: 'github|13434323', connection: 'github', profileData: { nickname: 'octocat' } }]);
+    const imperReq = { bearerToken: 'target-token' } as unknown as Request;
+    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1'], clas: [] });
+
+    await new ClaService().getMyClas(imperReq);
+
+    const [, calledUrl, opts] = gatewayFetch.mock.calls[0] as [unknown, string, { bearerToken?: string }];
+    const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
+    expect(params.getAll('githubId')).toContain('13434323'); // target's key, padded, present
+    expect(params.getAll('githubUsername')).toContain('octocat');
+    expect(opts.bearerToken).toBe('target-token'); // runs under the target's token, not the impersonator's
+  });
+
   it('maps the upstream clas list and reports matched user ids', async () => {
     getEffectiveUsername.mockReturnValue('alice');
     gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1', 'u-2'], clas: [icla({ signatureID: 's1' }), ecla({ signatureID: 's2' })] });

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -301,13 +301,40 @@ export class ClaService {
    * `lfUsername` defaults to the authenticated principal upstream when omitted,
    * but is sent explicitly for clarity. GitHub id and username are both sent (see
    * resolveIdentity).
+   *
+   * STOPGAP (lfx-gateway#114): the platform API gateway's awslambda middleware
+   * forwards ONLY multi-valued query params when ANY param is repeated, silently
+   * dropping every single-valued one. With 2+ verified emails that strips the
+   * single `githubId`/`githubUsername`, so GitHub-only CLAs disappear. Pad each
+   * array key to length >= 2 (duplicate the lone value) whenever any key is
+   * already multi-valued, so it survives the gateway; EasyCLA de-dupes each
+   * identity list before authorizing, so the duplicate is a no-op server-side.
+   * `lfUsername` is intentionally NOT padded - the backend derives the principal
+   * from the X-USERNAME header, so its loss is harmless. Remove once #114 ships.
    */
   private identityQuery(identity: ResolvedClaIdentity): URLSearchParams {
     const params = new URLSearchParams();
+
+    const anyMulti = identity.emails.length > 1 || identity.githubIds.length > 1 || identity.githubUsernames.length > 1;
+
+    const appendKeepAlive = (key: string, values: string[]): void => {
+      if (values.length === 0) {
+        return;
+      }
+      if (anyMulti && values.length === 1) {
+        params.append(key, values[0]);
+        params.append(key, values[0]);
+        return;
+      }
+      for (const value of values) {
+        params.append(key, value);
+      }
+    };
+
     if (identity.lfUsername) params.set('lfUsername', identity.lfUsername);
-    for (const email of identity.emails) params.append('email', email);
-    for (const githubId of identity.githubIds) params.append('githubId', githubId);
-    for (const githubUsername of identity.githubUsernames) params.append('githubUsername', githubUsername);
+    appendKeepAlive('email', identity.emails);
+    appendKeepAlive('githubId', identity.githubIds);
+    appendKeepAlive('githubUsername', identity.githubUsernames);
     return params;
   }
 }


### PR DESCRIPTION
Fixes #1314. Upstream root cause: linuxfoundation/lfx-gateway#114.

> **Interim / stopgap fix.** This is the BFF half of a two-part fix. It must be removed once the durable gateway fix (lfx-gateway#114, in the `linuxfoundation/traefik` fork) deploys.

## Summary
- BFF `identityQuery` in `cla.service.ts` now pads single-valued `githubId` / `githubUsername` (and `email`) to length >= 2 (duplicating the lone value) whenever any identity key is multi-valued, so they survive the gateway.
- Adds 3 tests + 1 assertion in `cla.service.spec.ts` (38 passing).

## Why
A multi-email contributor's GitHub-only CLAs vanished from My CLAs (#1314) because the LFX API gateway's `awslambda` middleware (lfx-gateway#114) drops single-valued query params whenever any param repeats. This is the interim BFF recovery until the durable gateway fix ships.

## Non-obvious details
- Padded values are byte-identical, and the backend de-dupes, so there is no double-count.
- `lfUsername` is intentionally **not** padded — the backend derives the principal from `X-USERNAME`.
- The FR-011 guard test asserts the invariant (github keys reach the backend), not the padding mechanism, so it outlives workaround removal.

## Follow-ups
- Durable gateway fix in the `linuxfoundation/traefik` fork (separate repo).
- Remove this padding once lfx-gateway#114 deploys.

## Test plan
- [x] `cd apps/lfx-one && npx vitest run src/server/services/cla.service.spec.ts` -> 38 passing.