### PR TITLE
feat(ui): add generic not-found page for unrecognized urls

### DIFF
--- a/apps/lfx-one/src/app/app.routes.server.ts
+++ b/apps/lfx-one/src/app/app.routes.server.ts
@@ -13,6 +13,13 @@ export const serverRoutes: ServerRoute[] = [
     renderMode: RenderMode.Server,
     status: 404,
   },
+  // Branded 404 page — responds with HTTP 404 so crawlers, caches, and monitoring tools
+  // treat unrecognized URLs correctly instead of indexing/caching a soft 404 (HTTP 200).
+  {
+    path: 'not-found',
+    renderMode: RenderMode.Server,
+    status: 404,
+  },
   {
     path: '**',
     renderMode: RenderMode.Server,

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -484,10 +484,18 @@ export const routes: Routes = [
     path: 'auth-error',
     loadComponent: () => import('./modules/auth-error/auth-error.component').then((m) => m.AuthErrorComponent),
   },
-  // Generic 404 — catches all unrecognized URLs and renders a branded not-found page. Must be
-  // last so it never shadows real routes. Outside the auth guard so anonymous users see it too.
+  // Branded 404 page — public named route so unauthenticated users can reach it directly
+  // (e.g. after login redirect returns them to an unrecognized URL). Anchored to /not-found
+  // following the same pattern as auth-error and invite/error.
+  {
+    path: 'not-found',
+    loadComponent: () => import('./modules/not-found/not-found.component').then((m) => m.NotFoundComponent),
+  },
+  // Generic catch-all — redirects unrecognized URLs to /not-found so they get a proper HTTP 404
+  // status and a branded page regardless of whether the user arrived authenticated or not.
+  // Must be last so it never shadows real routes.
   {
     path: '**',
-    loadComponent: () => import('./modules/not-found/not-found.component').then((m) => m.NotFoundComponent),
+    redirectTo: '/not-found',
   },
 ];

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -484,4 +484,10 @@ export const routes: Routes = [
     path: 'auth-error',
     loadComponent: () => import('./modules/auth-error/auth-error.component').then((m) => m.AuthErrorComponent),
   },
+  // Generic 404 — catches all unrecognized URLs and renders a branded not-found page. Must be
+  // last so it never shadows real routes. Outside the auth guard so anonymous users see it too.
+  {
+    path: '**',
+    loadComponent: () => import('./modules/not-found/not-found.component').then((m) => m.NotFoundComponent),
+  },
 ];

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -484,15 +484,21 @@ export const routes: Routes = [
     path: 'auth-error',
     loadComponent: () => import('./modules/auth-error/auth-error.component').then((m) => m.AuthErrorComponent),
   },
-  // Branded 404 page — public named route so unauthenticated users can reach it directly
-  // (e.g. after login redirect returns them to an unrecognized URL). Anchored to /not-found
-  // following the same pattern as auth-error and invite/error.
+  // Branded 404 page — public named route so the /not-found destination is reachable without a
+  // session (auth.middleware.ts classifies it as 'public'). Following the same pattern as
+  // auth-error and invite/error.
+  // Note: for authenticated users this page is reached directly via the ** wildcard below.
+  // For anonymous users the Express auth middleware classifies unrecognized paths as required-auth
+  // and redirects to login first; after login the returnTo URL is honoured and the ** wildcard
+  // then redirects here — so the branded 404 is always shown, just after authentication for
+  // anonymous deep-links rather than before.
   {
     path: 'not-found',
     loadComponent: () => import('./modules/not-found/not-found.component').then((m) => m.NotFoundComponent),
   },
-  // Generic catch-all — redirects unrecognized URLs to /not-found so they get a proper HTTP 404
-  // status and a branded page regardless of whether the user arrived authenticated or not.
+  // Generic catch-all — redirects unrecognized URLs to /not-found so authenticated users get a
+  // proper HTTP 404 status and a branded page. Also handles post-login returnTo redirects for
+  // anonymous users who followed a stale or mistyped URL (see /not-found comment above).
   // Must be last so it never shadows real routes.
   {
     path: '**',

--- a/apps/lfx-one/src/app/modules/not-found/not-found.component.html
+++ b/apps/lfx-one/src/app/modules/not-found/not-found.component.html
@@ -1,0 +1,31 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+<lfx-header></lfx-header>
+
+<div class="bg-gray-50 min-h-screen">
+  <div class="container mx-auto py-6 px-8">
+    <div class="max-w-4xl mx-auto">
+      <lfx-card data-testid="not-found-card">
+        <div class="text-center py-12">
+          <div class="flex justify-center mb-6">
+            <div class="w-24 h-24 bg-blue-50 rounded-full flex items-center justify-center">
+              <i class="fa-light fa-map-location-dot text-4xl text-blue-400"></i>
+            </div>
+          </div>
+
+          <h1 class="mb-3" data-testid="not-found-title">Page not found</h1>
+
+          <p class="text-gray-600 mb-8 max-w-lg mx-auto" data-testid="not-found-description">
+            The link you followed doesn't exist in LFX. This can happen from a mistyped URL or a stale bookmark.
+          </p>
+
+          <div class="flex flex-col sm:flex-row items-center justify-center gap-4">
+            <lfx-button routerLink="/" icon="fa-light fa-house" label="Go to Dashboard" size="small" data-testid="not-found-dashboard-button"></lfx-button>
+            <lfx-button (click)="goBack()" label="Go Back" size="small" severity="secondary" icon="fa-light fa-arrow-left" data-testid="not-found-back-button">
+            </lfx-button>
+          </div>
+        </div>
+      </lfx-card>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/not-found/not-found.component.html
+++ b/apps/lfx-one/src/app/modules/not-found/not-found.component.html
@@ -8,8 +8,8 @@
       <lfx-card data-testid="not-found-card">
         <div class="text-center py-12">
           <div class="flex justify-center mb-6">
-            <div class="w-24 h-24 bg-blue-50 rounded-full flex items-center justify-center">
-              <i class="fa-light fa-map-location-dot text-4xl text-blue-400"></i>
+            <div class="w-24 h-24 bg-amber-50 rounded-full flex items-center justify-center">
+              <i class="fa-light fa-triangle-exclamation text-4xl text-amber-400"></i>
             </div>
           </div>
 

--- a/apps/lfx-one/src/app/modules/not-found/not-found.component.html
+++ b/apps/lfx-one/src/app/modules/not-found/not-found.component.html
@@ -1,6 +1,6 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
-<lfx-header></lfx-header>
+<lfx-header [showMyMeetings]="false"></lfx-header>
 
 <div class="bg-gray-50 min-h-screen">
   <div class="container mx-auto py-6 px-8">

--- a/apps/lfx-one/src/app/modules/not-found/not-found.component.html
+++ b/apps/lfx-one/src/app/modules/not-found/not-found.component.html
@@ -9,7 +9,7 @@
         <div class="text-center py-12">
           <div class="flex justify-center mb-6">
             <div class="w-24 h-24 bg-amber-50 rounded-full flex items-center justify-center">
-              <i class="fa-light fa-triangle-exclamation text-4xl text-amber-400"></i>
+              <i class="fa-light fa-triangle-exclamation text-4xl text-amber-400" aria-hidden="true"></i>
             </div>
           </div>
 

--- a/apps/lfx-one/src/app/modules/not-found/not-found.component.html
+++ b/apps/lfx-one/src/app/modules/not-found/not-found.component.html
@@ -8,8 +8,8 @@
       <lfx-card data-testid="not-found-card">
         <div class="text-center py-12">
           <div class="flex justify-center mb-6">
-            <div class="w-24 h-24 bg-amber-50 rounded-full flex items-center justify-center">
-              <i class="fa-light fa-triangle-exclamation text-4xl text-amber-400" aria-hidden="true"></i>
+            <div class="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center">
+              <i class="fa-light fa-face-thinking text-4xl text-gray-400" aria-hidden="true"></i>
             </div>
           </div>
 

--- a/apps/lfx-one/src/app/modules/not-found/not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/not-found/not-found.component.ts
@@ -1,0 +1,22 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Location } from '@angular/common';
+import { Component, inject } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { HeaderComponent } from '@components/header/header.component';
+
+@Component({
+  selector: 'lfx-not-found',
+  imports: [HeaderComponent, CardComponent, ButtonComponent, RouterLink],
+  templateUrl: './not-found.component.html',
+})
+export class NotFoundComponent {
+  private readonly location = inject(Location);
+
+  protected goBack(): void {
+    this.location.back();
+  }
+}

--- a/apps/lfx-one/src/app/modules/not-found/not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/not-found/not-found.component.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Location } from '@angular/common';
-import { Component, inject } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { isPlatformBrowser, Location } from '@angular/common';
+import { Component, inject, PLATFORM_ID } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { HeaderComponent } from '@components/header/header.component';
@@ -15,8 +15,14 @@ import { HeaderComponent } from '@components/header/header.component';
 })
 export class NotFoundComponent {
   private readonly location = inject(Location);
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly router = inject(Router);
 
   protected goBack(): void {
-    this.location.back();
+    if (isPlatformBrowser(this.platformId) && window.history.length > 1) {
+      this.location.back();
+    } else {
+      void this.router.navigate(['/']);
+    }
   }
 }

--- a/apps/lfx-one/src/app/shared/components/header/header.component.html
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.html
@@ -45,6 +45,16 @@
               <div class="relative flex items-center gap-4">
                 @if (userService.authenticated()) {
                   <div class="flex items-center gap-4">
+                    @if (showMyMeetings()) {
+                      <a
+                        routerLink="/meetings"
+                        class="flex items-center gap-2 text-sm font-medium text-gray-600 border border-gray-200 hover:border-gray-300 hover:text-gray-800 hover:bg-gray-50 transition-colors px-3 py-1.5 rounded-md whitespace-nowrap"
+                        data-testid="my-meetings-header-button">
+                        <i class="fa-light fa-calendar text-xs"></i>
+                        My Meetings
+                        <i class="fa-light fa-arrow-up-right text-xs"></i>
+                      </a>
+                    }
                     <lfx-avatar
                       [image]="userService.user()?.picture"
                       [icon]="'fa-light fa-user'"

--- a/apps/lfx-one/src/app/shared/components/header/header.component.html
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.html
@@ -45,14 +45,6 @@
               <div class="relative flex items-center gap-4">
                 @if (userService.authenticated()) {
                   <div class="flex items-center gap-4">
-                    <a
-                      routerLink="/meetings"
-                      class="flex items-center gap-2 text-sm font-medium text-gray-600 border border-gray-200 hover:border-gray-300 hover:text-gray-800 hover:bg-gray-50 transition-colors px-3 py-1.5 rounded-md whitespace-nowrap"
-                      data-testid="my-meetings-header-button">
-                      <i class="fa-light fa-calendar text-xs"></i>
-                      My Meetings
-                      <i class="fa-light fa-arrow-up-right text-xs"></i>
-                    </a>
                     <lfx-avatar
                       [image]="userService.user()?.picture"
                       [icon]="'fa-light fa-user'"

--- a/apps/lfx-one/src/app/shared/components/header/header.component.ts
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, ElementRef, inject, Signal, signal, viewChild, WritableSignal } from '@angular/core';
+import { Component, computed, ElementRef, inject, input, Signal, signal, viewChild, WritableSignal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { Router, RouterModule } from '@angular/router';
@@ -29,6 +29,8 @@ export class HeaderComponent {
   private readonly projectService = inject(ProjectService);
   private readonly appService = inject(AppService);
   public readonly userService = inject(UserService);
+
+  public readonly showMyMeetings = input(true);
 
   // Mobile search state
   public showMobileSearch: WritableSignal<boolean> = signal(false);

--- a/apps/lfx-one/src/app/shared/components/header/header.component.ts
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.ts
@@ -30,7 +30,7 @@ export class HeaderComponent {
   private readonly appService = inject(AppService);
   public readonly userService = inject(UserService);
 
-  public readonly showMyMeetings = input(true);
+  public readonly showMyMeetings = input<boolean>(true);
 
   // Mobile search state
   public showMobileSearch: WritableSignal<boolean> = signal(false);

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -86,6 +86,11 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   { pattern: /^\/sitemap\.xml$/, type: 'ssr', auth: 'public' },
   { pattern: /^\/robots\.txt$/, type: 'ssr', auth: 'public' },
 
+  // Generic not-found page — public so anonymous users land on a branded 404 instead of a login
+  // prompt when redirected here from an unrecognized URL. Anchored regex prevents startsWith
+  // semantics from matching /not-found-admin or similar future paths.
+  { pattern: /^\/not-found$/, type: 'ssr', auth: 'public' },
+
   // All other routes - Angular SSR routes requiring authentication
   { pattern: '/', type: 'ssr', auth: 'required' },
 ];

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -89,7 +89,7 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // Generic not-found page — public so anonymous users land on a branded 404 instead of a login
   // prompt when redirected here from an unrecognized URL. Anchored regex prevents startsWith
   // semantics from matching /not-found-admin or similar future paths.
-  { pattern: /^\/not-found$/, type: 'ssr', auth: 'public' },
+  { pattern: /^\/not-found\/?$/, type: 'ssr', auth: 'public' },
 
   // All other routes - Angular SSR routes requiring authentication
   { pattern: '/', type: 'ssr', auth: 'required' },


### PR DESCRIPTION
## Summary

- Adds `NotFoundComponent` with a branded 404 card (amber warning-triangle icon, "Page not found" heading, generic copy about mistyped URLs or stale bookmarks)
- `/not-found` is a named public route classified as `auth: 'public'` in the Express middleware (same pattern as `auth-error` and `invite/error`) — accessible without login
- The Angular `**` wildcard does `redirectTo: '/not-found'` so authenticated users who mistype a URL land on the branded page with a clean URL
- `app.routes.server.ts` sets `status: 404` on the `not-found` server route so SSR emits the correct HTTP status (not a soft 200)
- "Go Back" guards against empty history with `isPlatformBrowser + window.history.length > 1`; falls back to `router.navigate(['/'])` for direct links and stale bookmarks

Refs: LFXV2-2010

**Scope note:** The primary use case is **authenticated users** who mistype a URL — they see the branded 404 immediately. Anonymous users with a wrong URL go through login first (consistent with every other protected route in this auth-first app) and land on `/not-found` after authenticating. This is a deliberate architectural constraint: Angular's `authGuard` returns `true` on the server (trusting Express middleware), so making the catch-all `optional` would render protected SSR components without auth context.

## Test plan

- [ ] Visit any invalid URL (e.g. `/foundation/tlf/groups`, `/foo/bar`) while **logged in** — should show the not-found card at `/not-found` with HTTP 404
- [ ] Visit `/not-found` directly while **not logged in** — should show the branded card without a login redirect
- [ ] Click "Go Back" from a page you navigated to — should return to the previous page
- [ ] Click "Go Back" from a direct link (no prior history) — should navigate to `/` (dashboard fallback)
- [ ] Click "Go to Dashboard" — should navigate to `/`
- [ ] Verify existing routes (`/`, `/foundation/overview`, `/foundations/tlf/groups`) still work as expected