### PR TITLE
docs: fill ticket-reference gaps missed by #1335 (preflight skill + two top-level docs)

### DIFF
--- a/.claude/skills/preflight/SKILL.md
+++ b/.claude/skills/preflight/SKILL.md
@@ -30,7 +30,7 @@ git log --format="%h %s%n%b" origin/main...HEAD
 
 - **Uncommitted changes?** — Ask the contributor: commit now or stash?
 - **No commits ahead of main?** — The branch has nothing to validate. Ask if they're on the right branch.
-- **Commit messages missing a ticket reference?** — Flag commits that don't include `LFXV2-` (JIRA) or `GH-` (GitHub Issue) references in subject or body.
+- **Commit messages missing a ticket reference?** — Flag commits that don't include `LFXV2-XXX` (JIRA), `GH-XXX` (GitHub Issue), or the fully-qualified `org/repo#XXX` form (e.g. `linuxfoundation/lfx-self-serve#1331`) in subject or body. See `.claude/rules/commit-workflow.md` § Ticket Tracking.
 - **Commits missing `--signoff`?** — Flag any commits without `Signed-off-by:` lines (visible in the full commit body above).
 
 Resolve any issues before proceeding to the checks below.
@@ -123,7 +123,7 @@ git log --format="%h %s%n%b" origin/main...HEAD
 - **All changes committed?** — If not, remind the contributor to commit remaining changes.
 - **Commit messages follow conventions?** — `type(scope): description` format per `commit-workflow.md`.
 - **`--signoff` on all commits?** — Every commit must have `Signed-off-by:` (check in the full body output above).
-- **Ticket referenced?** — Commit messages should include `LFXV2-` (JIRA) or `GH-` (GitHub Issue) references.
+- **Ticket referenced?** — Commit messages should include `LFXV2-XXX` (JIRA), `GH-XXX` (GitHub Issue), or the fully-qualified `org/repo#XXX` form (e.g. `linuxfoundation/lfx-self-serve#1331`).
 
 ## Check 7: Change Summary
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -123,4 +123,4 @@ LFX One is a modern Angular 20 SSR application built with stable zoneless change
 
 ---
 
-_This documentation reflects the current state of the LFX v2 UI application architecture. For questions or updates, please refer to the project's JIRA board using project key LFXV2._
+_This documentation reflects the current state of the LFX v2 UI application architecture. For questions or updates, file a JIRA ticket in the `LFXV2` project or a GitHub Issue on [`linuxfoundation/lfx-self-serve`](https://github.com/linuxfoundation/lfx-self-serve/issues)._

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -435,10 +435,10 @@ ping your-microservice-host
 
 ### Support Channels
 
-- **JIRA Project**: LFXV2 - Create tickets for bugs and issues
+- **Ticket Tracking**: JIRA project `LFXV2` or GitHub Issues on [`linuxfoundation/lfx-self-serve`](https://github.com/linuxfoundation/lfx-self-serve/issues) — file bugs and issues in whichever tracker fits the work (see `.claude/rules/commit-workflow.md` § Ticket Tracking)
 - **Architecture Questions**: Refer to architecture documentation
 - **Environment Issues**: Check environment configuration guide
 
 ---
 
-_This troubleshooting guide is specific to LFX One. For questions or additional issues, create a JIRA ticket using project key LFXV2._
+_This troubleshooting guide is specific to LFX One. For questions or additional issues, file a JIRA ticket in the `LFXV2` project or a GitHub Issue on [`linuxfoundation/lfx-self-serve`](https://github.com/linuxfoundation/lfx-self-serve/issues)._


### PR DESCRIPTION
Fills gaps missed by #1335 (docs(rules): support GitHub Issue refs alongside JIRA tickets).

David's PR covered the `.claude/` policy surface and `CLAUDE.md` thoroughly, but did not touch two top-level docs and left the preflight skill slightly out of sync with `commit-workflow.md` and `pr-shape.md` on the fully-qualified `org/repo#XXX` form.

## Changes

- **`docs/architecture/README.md`** — closing footer now points to both JIRA (`LFXV2`) and GitHub Issues on `linuxfoundation/lfx-self-serve` instead of JIRA-only.
- **`docs/troubleshooting.md`** — Support Channels row and closing footer both list both trackers.
- **`.claude/skills/preflight/SKILL.md`** — Check 0 and Check 6 now mention the fully-qualified `org/repo#XXX` ticket-reference form alongside `LFXV2-XXX` and `GH-XXX`, matching the vocabulary in `commit-workflow.md` and `pr-shape.md`.

## Diff size

3 files, +5 / −5 lines. Documentation-only.

Closes GH-1341
