### PR TITLE
fix(enrollment): build enrollment hrefs via URL api

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -7,7 +7,7 @@ import { DatePipe, formatDate } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { DisplayEnrollment, EnrollmentsState } from '@lfx-one/shared/interfaces';
-import { deriveEnrollmentStatus, enrollmentStatusSeverity } from '@lfx-one/shared/utils';
+import { buildEnrollmentHref, deriveEnrollmentStatus, enrollmentStatusSeverity } from '@lfx-one/shared/utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { ToastModule } from 'primeng/toast';
@@ -69,8 +69,8 @@ export class ProfileIndividualEnrollmentComponent {
                 ...item,
                 displayStatus,
                 severity: enrollmentStatusSeverity(displayStatus),
-                enrollHref: `${base}${item.ctaPath}`,
-                renewHref: `${base}${item.ctaPath}&renew=true`,
+                enrollHref: buildEnrollmentHref(base, item.ctaPath),
+                renewHref: buildEnrollmentHref(base, item.ctaPath, true),
                 pending: false,
               };
             })

--- a/packages/shared/src/utils/enrollment.utils.spec.ts
+++ b/packages/shared/src/utils/enrollment.utils.spec.ts
@@ -8,7 +8,7 @@
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 
 import { EnrollmentMembership, IndividualEnrollment } from '../interfaces';
-import { deriveEnrollmentStatus, enrollmentStatusSeverity } from './enrollment.utils';
+import { buildEnrollmentHref, deriveEnrollmentStatus, enrollmentStatusSeverity } from './enrollment.utils';
 
 /** Formats a Date as YYYY-MM-DD, matching the EndDate shape the member-service returns. */
 function isoDate(date: Date): string {
@@ -146,5 +146,29 @@ describe('enrollmentStatusSeverity', () => {
 
   it('maps Not Enrolled to secondary', () => {
     expect(enrollmentStatusSeverity('Not Enrolled')).toBe('secondary');
+  });
+});
+
+describe('buildEnrollmentHref', () => {
+  const CTA = '?product=prod-1&project=tlf';
+
+  it('composes the base and query-only ctaPath into an absolute URL', () => {
+    expect(buildEnrollmentHref('https://enroll.example.org/', CTA)).toBe('https://enroll.example.org/?product=prod-1&project=tlf');
+  });
+
+  it('appends renew=true when renew is set', () => {
+    expect(buildEnrollmentHref('https://enroll.example.org/', CTA, true)).toBe('https://enroll.example.org/?product=prod-1&project=tlf&renew=true');
+  });
+
+  it('tolerates a base without a trailing slash', () => {
+    expect(buildEnrollmentHref('https://enroll.example.org', CTA)).toBe('https://enroll.example.org/?product=prod-1&project=tlf');
+  });
+
+  it('tolerates a base that carries a path segment (no trailing slash)', () => {
+    expect(buildEnrollmentHref('https://enroll.example.org/join', CTA)).toBe('https://enroll.example.org/join?product=prod-1&project=tlf');
+  });
+
+  it('tolerates a ctaPath without a leading question mark', () => {
+    expect(buildEnrollmentHref('https://enroll.example.org/', 'product=prod-1&project=tlf')).toBe('https://enroll.example.org/?product=prod-1&project=tlf');
   });
 });

--- a/packages/shared/src/utils/enrollment.utils.ts
+++ b/packages/shared/src/utils/enrollment.utils.ts
@@ -33,6 +33,15 @@ export function deriveEnrollmentStatus(item: IndividualEnrollment): EnrollmentDi
   return 'Active';
 }
 
+// Composes an enrollment CTA URL via URL + URLSearchParams (not string concat), so it is robust to
+// a `base` with/without a trailing slash and a `ctaPath` with/without a leading `?`. `renew` adds renew=true.
+export function buildEnrollmentHref(base: string, ctaPath: string, renew = false): string {
+  const url = new URL(base);
+  new URLSearchParams(ctaPath).forEach((value, key) => url.searchParams.set(key, value));
+  if (renew) url.searchParams.set('renew', 'true');
+  return url.toString();
+}
+
 export function enrollmentStatusSeverity(status: EnrollmentDisplayStatus): 'success' | 'warn' | 'danger' | 'secondary' {
   switch (status) {
     case 'Active':


### PR DESCRIPTION
## Summary

- Replace the `${base}${ctaPath}` string concatenation in the individual enrollment component with a `buildEnrollmentHref` util that composes the URL via `new URL` + `URLSearchParams`.
- Removes the silent dependency on the base ending in `/` and `ctaPath` starting with `?` — a future env URL or `ctaPath` format change can no longer break the CTA link.
- Added unit coverage in `enrollment.utils.spec.ts` for the trailing-slash, path-segment, and leading-`?` cases (plus the `renew=true` param).

LFXV2-1664
