### PR TITLE
feat(profile): add public profile visibility drawer

### DIFF
--- a/apps/lfx-one/e2e/profile-visibility-drawer.spec.ts
+++ b/apps/lfx-one/e2e/profile-visibility-drawer.spec.ts
@@ -277,4 +277,69 @@ test.describe('Profile visibility drawer', () => {
     });
     await expect(page.getByTestId('profile-visibility-drawer-tab-sections'), 'the tablist should render after retry').toBeVisible({ timeout: ELEMENT_TIMEOUT });
   });
+
+  test('S6: a flush queued behind an in-flight save keeps the close-time edit after reopen', async ({ page }) => {
+    const patchSections: Sections[] = [];
+    let releaseFirstPatch: (() => void) | null = null;
+    const firstPatchGate = new Promise<void>((resolve) => {
+      releaseFirstPatch = resolve;
+    });
+    let patchCount = 0;
+    // The GET returns the current stored map; it only advances once a PATCH is fulfilled.
+    let storedSections = sectionsMap({ basic: true, aboutMe: true, personalInfo: true });
+
+    await page.route('**/api/profile/visibility', async (route) => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: true, sections: storedSections, preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      if (request.method() === 'PATCH') {
+        const body = request.postDataJSON();
+        patchCount += 1;
+        patchSections.push(body.sections);
+        // Hold the first save in flight so the close-time flush must queue behind it (concatMap).
+        if (patchCount === 1) {
+          await firstPatchGate;
+        }
+        storedSections = body.sections;
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: body.isPublic, sections: body.sections, preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await openDrawer(page);
+
+    // Save A: toggle badges → the debounced PATCH fires and is held open by the gate above.
+    const firstPatch = page.waitForRequest((r) => r.url().includes('/api/profile/visibility') && r.method() === 'PATCH');
+    await page.locator('[data-test="profile-visibility-drawer-toggle-badges"]').click();
+    await firstPatch;
+
+    // Edit B + close while save A is still in flight → the flush is queued behind A.
+    await page.locator('[data-test="profile-visibility-drawer-toggle-skills"]').click();
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('profile-visibility-drawer-body'), 'drawer should close').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+
+    // Reopen while A is still held → the GET re-seeds the form from the (pre-A) stored map, dropping
+    // skills back to false in the live form. The queued flush must still carry the close-time edit.
+    await openDrawer(page);
+
+    // Release A; the queued flush now drains and issues the second PATCH.
+    releaseFirstPatch?.();
+    await expect.poll(() => patchSections.length, { timeout: ELEMENT_TIMEOUT }).toBeGreaterThanOrEqual(2);
+
+    // The flushed (second) PATCH must serialize the state at close (skills on), not the reloaded map.
+    expect(patchSections[1]?.skills, 'the queued flush should serialize the close-time edit').toBe(true);
+    expect(patchSections[1]?.badges, 'the queued flush should also retain the earlier toggle').toBe(true);
+  });
 });

--- a/apps/lfx-one/e2e/profile-visibility-drawer.spec.ts
+++ b/apps/lfx-one/e2e/profile-visibility-drawer.spec.ts
@@ -11,6 +11,10 @@
  *      Information children in the persisted map.
  *   4. Closing the drawer flushes a pending (debounced) change so nothing is lost.
  *   5. A failed load shows the error + retry affordance, and retry recovers into the form.
+ *   6. Dismissing the drawer while a save is in flight keeps it open (busy-close guard) and closes
+ *      only once the queued flush drains, still carrying the close-time edit.
+ *   7. A superseded failed save (an older write that fails while a newer one is already queued) does
+ *      not pin the inline indicator on "Saving".
  *
  * Every test stubs GET and PATCH /api/profile/visibility so the real account is never mutated — the
  * assertions are on the seeded state, the drawer behaviour, and the PATCH payloads.
@@ -278,14 +282,13 @@ test.describe('Profile visibility drawer', () => {
     await expect(page.getByTestId('profile-visibility-drawer-tab-sections'), 'the tablist should render after retry').toBeVisible({ timeout: ELEMENT_TIMEOUT });
   });
 
-  test('S6: a flush queued behind an in-flight save keeps the close-time edit after reopen', async ({ page }) => {
+  test('S6: a dismissal during an in-flight save keeps the drawer open, then closes once it drains', async ({ page }) => {
     const patchSections: Sections[] = [];
     let releaseFirstPatch: (() => void) | null = null;
     const firstPatchGate = new Promise<void>((resolve) => {
       releaseFirstPatch = resolve;
     });
     let patchCount = 0;
-    // The GET returns the current stored map; it only advances once a PATCH is fulfilled.
     let storedSections = sectionsMap({ basic: true, aboutMe: true, personalInfo: true });
 
     await page.route('**/api/profile/visibility', async (route) => {
@@ -325,21 +328,88 @@ test.describe('Profile visibility drawer', () => {
     await page.locator('[data-test="profile-visibility-drawer-toggle-badges"]').click();
     await firstPatch;
 
-    // Edit B + close while save A is still in flight → the flush is queued behind A.
+    // Edit B + dismiss while save A is still in flight → the flush queues B behind A, and the busy-close
+    // guard keeps the drawer open (the dismissal can't cancel the write) rather than closing immediately.
     await page.locator('[data-test="profile-visibility-drawer-toggle-skills"]').click();
     await page.keyboard.press('Escape');
-    await expect(page.getByTestId('profile-visibility-drawer-body'), 'drawer should close').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('profile-visibility-drawer-body'), 'drawer stays open while a save is pending').toBeVisible();
+    await expect(page.getByTestId('profile-visibility-drawer-status'), 'the indicator reflects the pending save').toContainText('Saving', {
+      timeout: ELEMENT_TIMEOUT,
+    });
 
-    // Reopen while A is still held → the GET re-seeds the form from the (pre-A) stored map, dropping
-    // skills back to false in the live form. The queued flush must still carry the close-time edit.
+    // Release A → it drains, the queued flush issues the second PATCH, and the deferred close fires.
+    releaseFirstPatch?.();
+    await expect.poll(() => patchSections.length, { timeout: ELEMENT_TIMEOUT }).toBeGreaterThanOrEqual(2);
+    await expect(page.getByTestId('profile-visibility-drawer-body'), 'drawer closes once the deferred save drains').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+
+    // The queued flush serializes the state at dismissal (skills on), retaining both edits.
+    expect(patchSections[1]?.skills, 'the queued flush should carry the close-time edit').toBe(true);
+    expect(patchSections[1]?.badges, 'the queued flush should also retain the earlier toggle').toBe(true);
+  });
+
+  test('S7: a superseded failed save does not pin the indicator on "Saving"', async ({ page }) => {
+    const patchSections: Sections[] = [];
+    let releaseFirstPatch: (() => void) | null = null;
+    const firstPatchGate = new Promise<void>((resolve) => {
+      releaseFirstPatch = resolve;
+    });
+    let patchCount = 0;
+    const storedSections = sectionsMap({ basic: true, aboutMe: true, personalInfo: true });
+
+    await page.route('**/api/profile/visibility', async (route) => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: true, sections: storedSections, preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      if (request.method() === 'PATCH') {
+        const body = request.postDataJSON();
+        patchCount += 1;
+        patchSections.push(body.sections);
+        if (patchCount === 1) {
+          // Hold the older save in flight so the newer one queues behind it, then fail it.
+          await firstPatchGate;
+          await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'boom' }) });
+          return;
+        }
+        // The newer (superseding) save succeeds.
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: body.isPublic, sections: body.sections, preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
     await openDrawer(page);
 
-    // Release A; the queued flush now drains and issues the second PATCH.
+    // Save A: toggle badges → the debounced PATCH fires and is held (it will 500).
+    const firstPatch = page.waitForRequest((r) => r.url().includes('/api/profile/visibility') && r.method() === 'PATCH');
+    await page.locator('[data-test="profile-visibility-drawer-toggle-badges"]').click();
+    await firstPatch;
+
+    // Save B: toggle skills → let the debounce elapse so B is accepted and queued behind A (concatMap
+    // won't fire B's request until A settles, so waiting on the debounce is the only observable signal).
+    await page.locator('[data-test="profile-visibility-drawer-toggle-skills"]').click();
+    await page.waitForTimeout(1_000);
+
+    // Release A → it fails, but a newer save (B) is already queued, so the failure is superseded: no
+    // error toast, no sticky dirty. B drains successfully and the indicator settles on "saved".
     releaseFirstPatch?.();
     await expect.poll(() => patchSections.length, { timeout: ELEMENT_TIMEOUT }).toBeGreaterThanOrEqual(2);
 
-    // The flushed (second) PATCH must serialize the state at close (skills on), not the reloaded map.
-    expect(patchSections[1]?.skills, 'the queued flush should serialize the close-time edit').toBe(true);
-    expect(patchSections[1]?.badges, 'the queued flush should also retain the earlier toggle').toBe(true);
+    await expect(page.getByTestId('profile-visibility-drawer-status'), 'a superseded failure must not pin the indicator on Saving').toContainText(
+      'All changes saved',
+      { timeout: ELEMENT_TIMEOUT }
+    );
+    expect(patchSections[1]?.skills, 'the superseding save carries the newer edit').toBe(true);
+    expect(patchSections[1]?.badges, 'the superseding save retains the earlier toggle').toBe(true);
   });
 });

--- a/apps/lfx-one/e2e/profile-visibility-drawer.spec.ts
+++ b/apps/lfx-one/e2e/profile-visibility-drawer.spec.ts
@@ -1,0 +1,280 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Public-profile visibility drawer E2E — LFXV2-2629.
+ *
+ * Covers the visibility drawer opened from the profile panel:
+ *   1. Opening it fetches the current visibility (GET /api/profile/visibility) and seeds the toggles.
+ *   2. Toggling a section auto-saves (debounced PATCH) and the inline status reflects "saved".
+ *   3. The client-side cascade: turning the `basic` parent off zeroes its About Me / Personal
+ *      Information children in the persisted map.
+ *   4. Closing the drawer flushes a pending (debounced) change so nothing is lost.
+ *   5. A failed load shows the error + retry affordance, and retry recovers into the form.
+ *
+ * Every test stubs GET and PATCH /api/profile/visibility so the real account is never mutated — the
+ * assertions are on the seeded state, the drawer behaviour, and the PATCH payloads.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+
+type Sections = Record<string, boolean>;
+
+/** All-false section map with optional overrides (mirrors PROFILE_VISIBILITY_DEFAULTS ordering). */
+function sectionsMap(overrides: Sections = {}): Sections {
+  return {
+    basic: false,
+    aboutMe: false,
+    personalInfo: false,
+    technical_contribution: false,
+    community_roles: false,
+    event_activities: false,
+    training_activities: false,
+    certification_activities: false,
+    badges: false,
+    skills: false,
+    ...overrides,
+  };
+}
+
+// Hard skip when the auth-bootstrap failed — hostname-exact match so a crafted URL can't fool the gate.
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — keep running; a failure here is useful signal, not noise.
+  }
+}
+
+// Neutralize the Osano consent overlay, which otherwise intercepts pointer events.
+async function suppressCookieBanner(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const hide = (): void => {
+      if (document.getElementById('e2e-hide-osano')) {
+        return;
+      }
+      const style = document.createElement('style');
+      style.id = 'e2e-hide-osano';
+      style.textContent = '.osano-cm-window { display: none !important; pointer-events: none !important; }';
+      (document.head ?? document.documentElement).appendChild(style);
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', hide);
+    } else {
+      hide();
+    }
+  });
+}
+
+/** Navigate to the profile hub and wait for the panel to render with real data. */
+async function gotoProfile(page: Page): Promise<void> {
+  await page.goto('/profile', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page.getByTestId('profile-panel'), 'profile panel should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+  await expect(page.getByTestId('profile-display-name'), 'profile display name should resolve').toBeVisible({ timeout: LOAD_TIMEOUT });
+}
+
+/** Open the visibility drawer from the panel affordance and wait for its body. */
+async function openDrawer(page: Page): Promise<void> {
+  await page.getByTestId('profile-visibility-button').click();
+  await expect(page.getByTestId('profile-visibility-drawer-body'), 'visibility drawer should open').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+}
+
+/** The interactive input inside an lfx-toggle wrapper for a given visibility key. */
+function toggleInput(page: Page, key: string) {
+  return page.locator(`[data-test="profile-visibility-drawer-toggle-${key}"] input`);
+}
+
+test.describe('Profile visibility drawer', () => {
+  test.beforeEach(async ({ page }) => {
+    await suppressCookieBanner(page);
+  });
+
+  test('S1: opening the drawer seeds the toggles from the fetched visibility', async ({ page }) => {
+    await page.route('**/api/profile/visibility', async (route) => {
+      if (route.request().method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({
+            isPublic: true,
+            sections: sectionsMap({ basic: true, aboutMe: true, personalInfo: true, badges: true }),
+            preferenceId: 'pref-1',
+          }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await openDrawer(page);
+
+    // Sections tab is active first; the badges toggle should reflect the seeded `true`.
+    await expect(toggleInput(page, 'badges'), 'seeded badges toggle should be on').toBeChecked({ timeout: ELEMENT_TIMEOUT });
+    // A section left false in the fetched map should be off.
+    await expect(toggleInput(page, 'skills'), 'seeded skills toggle should be off').not.toBeChecked();
+  });
+
+  test('S2: toggling a section auto-saves and the status reflects "saved"', async ({ page }) => {
+    let lastPatch: { isPublic?: boolean; sections?: Sections } | null = null;
+    await page.route('**/api/profile/visibility', async (route) => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: true, sections: sectionsMap({ basic: true, aboutMe: true, personalInfo: true }), preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      if (request.method() === 'PATCH') {
+        lastPatch = request.postDataJSON();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: lastPatch?.isPublic, sections: lastPatch?.sections, preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await openDrawer(page);
+
+    // Turn the badges section on; the debounced auto-save fires a PATCH carrying badges: true.
+    const patchPromise = page.waitForRequest((r) => r.url().includes('/api/profile/visibility') && r.method() === 'PATCH');
+    await page.locator('[data-test="profile-visibility-drawer-toggle-badges"]').click();
+    await patchPromise;
+
+    await expect(page.getByTestId('profile-visibility-drawer-status'), 'status should confirm the save').toContainText('All changes saved', {
+      timeout: ELEMENT_TIMEOUT,
+    });
+    expect(lastPatch?.sections?.badges, 'PATCH should carry the toggled-on section').toBe(true);
+  });
+
+  test('S3: turning the basic parent off zeroes its children in the saved map', async ({ page }) => {
+    let lastPatch: { sections?: Sections } | null = null;
+    await page.route('**/api/profile/visibility', async (route) => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: true, sections: sectionsMap({ basic: true, aboutMe: true, personalInfo: true }), preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      if (request.method() === 'PATCH') {
+        lastPatch = request.postDataJSON();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: true, sections: lastPatch?.sections, preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await openDrawer(page);
+
+    // The basic group lives on the Personal Data tab.
+    await page.getByTestId('profile-visibility-drawer-tab-personal').click();
+    await expect(page.getByTestId('profile-visibility-drawer-personal'), 'personal tab panel should render').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    const patchPromise = page.waitForRequest((r) => r.url().includes('/api/profile/visibility') && r.method() === 'PATCH');
+    await page.locator('[data-test="profile-visibility-drawer-toggle-basic"]').click();
+    await patchPromise;
+
+    // Cascade: the parent and both children are off in the persisted map.
+    expect(lastPatch?.sections?.basic, 'basic should be off').toBe(false);
+    expect(lastPatch?.sections?.aboutMe, 'aboutMe should cascade off').toBe(false);
+    expect(lastPatch?.sections?.personalInfo, 'personalInfo should cascade off').toBe(false);
+  });
+
+  test('S4: closing the drawer flushes a pending change', async ({ page }) => {
+    let lastPatch: { sections?: Sections } | null = null;
+    await page.route('**/api/profile/visibility', async (route) => {
+      const request = route.request();
+      if (request.method() === 'GET') {
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: true, sections: sectionsMap({ basic: true, aboutMe: true, personalInfo: true }), preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      if (request.method() === 'PATCH') {
+        lastPatch = request.postDataJSON();
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: true, sections: lastPatch?.sections, preferenceId: 'pref-1' }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await openDrawer(page);
+
+    // Toggle then immediately close — the close-time flush must persist the change without waiting for
+    // the debounce window.
+    const patchPromise = page.waitForRequest((r) => r.url().includes('/api/profile/visibility') && r.method() === 'PATCH');
+    await page.locator('[data-test="profile-visibility-drawer-toggle-badges"]').click();
+    await page.keyboard.press('Escape');
+    await patchPromise;
+
+    await expect(page.getByTestId('profile-visibility-drawer-body'), 'drawer should close').toBeHidden({ timeout: ELEMENT_TIMEOUT });
+    expect(lastPatch?.sections?.badges, 'the flushed PATCH should carry the change').toBe(true);
+  });
+
+  test('S5: a failed load shows the retry affordance and recovers on retry', async ({ page }) => {
+    let failNext = true;
+    await page.route('**/api/profile/visibility', async (route) => {
+      if (route.request().method() === 'GET') {
+        if (failNext) {
+          failNext = false;
+          await route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'boom' }) });
+          return;
+        }
+        await route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify({ isPublic: false, sections: sectionsMap(), preferenceId: null }),
+        });
+        return;
+      }
+      await route.fallback();
+    });
+
+    await gotoProfile(page);
+    await openDrawer(page);
+
+    // First load failed → the error + retry block renders instead of the form.
+    await expect(page.getByTestId('profile-visibility-drawer-error'), 'error block should render on load failure').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Retry re-fetches (now succeeding) and the form replaces the error block.
+    await page.getByTestId('profile-visibility-drawer-retry-button').click();
+    await expect(page.getByTestId('profile-visibility-drawer-error'), 'error block should clear after a successful retry').toBeHidden({
+      timeout: ELEMENT_TIMEOUT,
+    });
+    await expect(page.getByTestId('profile-visibility-drawer-tab-sections'), 'the tablist should render after retry').toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  });
+});

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -26,7 +26,8 @@
       [tshirtSize]="tshirtSizeLabel()"
       [aboutMe]="aboutMe()"
       [githubHandle]="githubHandle()"
-      (editRequested)="openEditDrawer()" />
+      (editRequested)="openEditDrawer()"
+      (visibilityRequested)="openVisibilityDrawer()" />
   </div>
 
   <!-- Left column -->
@@ -76,3 +77,6 @@
 
 <!-- Profile edit drawer — opened via ProfileEditDrawerService when the panel emits editRequested -->
 <lfx-profile-edit-drawer (saved)="onProfileSaved($event)" />
+
+<!-- Public-profile visibility drawer — opened via ProfileVisibilityDrawerService (panel visibilityRequested) -->
+<lfx-profile-visibility-drawer />

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -16,6 +16,8 @@ import { BehaviorSubject, catchError, EMPTY, filter, map, of, startWith, switchM
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
 import { ProfileEditDrawerComponent } from '../../modules/profile/components/profile-edit-drawer/profile-edit-drawer.component';
 import { ProfileEditDrawerService } from '../../modules/profile/components/profile-edit-drawer/profile-edit-drawer.service';
+import { ProfileVisibilityDrawerComponent } from '../../modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component';
+import { ProfileVisibilityDrawerService } from '../../modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.service';
 import { ProfilePanelComponent } from './profile-panel/profile-panel.component';
 
 // Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
@@ -41,10 +43,10 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
  */
 @Component({
   selector: 'lfx-profile-layout',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, ProfilePanelComponent, ProfileEditDrawerComponent],
-  // ProfileEditDrawerService is layout-scoped (not root) so its retained profile context is torn
-  // down when the hub is left; the drawer child shares this injector and resolves the same instance.
-  providers: [MessageService, ProfileEditDrawerService],
+  imports: [RouterOutlet, RouterLink, RouterLinkActive, ProfilePanelComponent, ProfileEditDrawerComponent, ProfileVisibilityDrawerComponent],
+  // The drawer services are layout-scoped (not root) so their retained context is torn down when the
+  // hub is left; each drawer child shares this injector and resolves the same instance.
+  providers: [MessageService, ProfileEditDrawerService, ProfileVisibilityDrawerService],
   templateUrl: './profile-layout.component.html',
   styleUrl: './profile-layout.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -61,6 +63,7 @@ export class ProfileLayoutComponent {
   private readonly router = inject(Router);
   private readonly userService = inject(UserService);
   private readonly editDrawer = inject(ProfileEditDrawerService);
+  private readonly visibilityDrawer = inject(ProfileVisibilityDrawerService);
   private readonly messageService = inject(MessageService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly featureFlagService = inject(FeatureFlagService);
@@ -173,6 +176,11 @@ export class ProfileLayoutComponent {
   public openEditDrawer(): void {
     if (!this.combinedProfile) return;
     this.editDrawer.open(this.combinedProfile);
+  }
+
+  public openVisibilityDrawer(): void {
+    // The drawer fetches its own state; it only needs the username to build the public-profile URL.
+    this.visibilityDrawer.open(this.displayUsername() ?? '');
   }
 
   /** Apply the optimistic update emitted by the edit drawer's `saved` output. */

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -44,8 +44,8 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
 @Component({
   selector: 'lfx-profile-layout',
   imports: [RouterOutlet, RouterLink, RouterLinkActive, ProfilePanelComponent, ProfileEditDrawerComponent, ProfileVisibilityDrawerComponent],
-  // The drawer services are layout-scoped (not root) so their retained context is torn down when the
-  // hub is left; each drawer child shares this injector and resolves the same instance.
+  // Drawer services are layout-scoped (not root) so their retained context is torn down when the hub
+  // is left; each drawer child shares this injector instance via the providers below.
   providers: [MessageService, ProfileEditDrawerService, ProfileVisibilityDrawerService],
   templateUrl: './profile-layout.component.html',
   styleUrl: './profile-layout.component.scss',

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -58,6 +58,18 @@
       Edit profile
     </button>
 
+    <!-- Public profile visibility (LFXV2-2629) -->
+    <button
+      type="button"
+      (click)="onVisibility()"
+      [disabled]="impersonating()"
+      [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : null"
+      class="flex w-full items-center justify-center gap-1.5 rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-800 transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+      data-testid="profile-visibility-button">
+      <i class="fa-light fa-eye text-xs"></i>
+      Public profile settings
+    </button>
+
     <div class="my-5 h-px bg-slate-200"></div>
 
     <!-- Fields — each renders only when its value is present -->

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -47,6 +47,7 @@ export class ProfilePanelComponent {
 
   // Outputs
   public readonly editRequested = output<void>();
+  public readonly visibilityRequested = output<void>();
 
   // The avatar URL that failed to load, if any. Tracking the URL (rather than a plain boolean)
   // lets a newly-set/refreshed picture re-attempt to load without an effect(): once avatarUrl
@@ -68,6 +69,17 @@ export class ProfilePanelComponent {
       return;
     }
     this.editRequested.emit();
+  }
+
+  /**
+   * Request the public-profile visibility flow from the parent. No-op while impersonating, since
+   * visibility changes act on the real account and are blocked server-side.
+   */
+  public onVisibility(): void {
+    if (this.impersonating()) {
+      return;
+    }
+    this.visibilityRequested.emit();
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -1,0 +1,132 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- Public-profile visibility drawer (LFXV2-2629) — master IsPublic flag + section visibility. -->
+<p-drawer
+  [visible]="drawer.isOpen()"
+  (visibleChange)="onVisibleChange($event)"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="!saving()"
+  [dismissible]="!saving()"
+  [closeOnEscape]="!saving()"
+  styleClass="lg:w-[560px] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="profile-visibility-drawer">
+  <ng-template #header>
+    <h2 class="text-lg font-semibold text-slate-900" data-testid="profile-visibility-drawer-header">Public Profile settings</h2>
+  </ng-template>
+
+  <div class="flex flex-col gap-8" data-testid="profile-visibility-drawer-body">
+    <p class="text-sm text-slate-500" data-testid="profile-visibility-drawer-description">
+      Control whether your contributor profile is publicly visible and which sections it exposes. Changes take effect the next time your public profile is
+      regenerated.
+    </p>
+
+    @if (loadingVisibility()) {
+      <div class="flex items-center gap-2 text-sm text-slate-500" data-testid="profile-visibility-drawer-loading">
+        <i class="pi pi-spinner pi-spin"></i>
+        <span>Loading visibility settings...</span>
+      </div>
+    } @else {
+      <form [formGroup]="visibilityForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-8">
+        <!-- Master flag -->
+        <div class="flex items-start justify-between gap-4 rounded-md border border-slate-200 p-4" data-testid="profile-visibility-drawer-master">
+          <div class="flex flex-col gap-0.5">
+            <span class="text-sm font-medium text-slate-900">Public profile</span>
+            <span class="text-xs text-slate-500">When off, your profile is hidden and no sections are exposed.</span>
+          </div>
+          <lfx-toggle [form]="visibilityForm" control="isPublic" ariaLabel="Public profile" dataTest="profile-visibility-drawer-master-toggle" />
+        </div>
+
+        <!-- Public URL row — only when the profile is public and the username is known -->
+        @if (isPublic() && publicProfileUrl()) {
+          <div class="flex flex-col gap-2" data-testid="profile-visibility-drawer-url">
+            <span class="text-xs font-medium text-slate-500">Public profile link</span>
+            <div class="flex items-center gap-2">
+              <span class="min-w-0 flex-1 truncate rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
+                {{ publicProfileUrl() }}
+              </span>
+              <lfx-button
+                type="button"
+                variant="outlined"
+                size="small"
+                icon="fa-light fa-copy"
+                ariaLabel="Copy public profile link"
+                (onClick)="onCopyUrl()"
+                data-testid="profile-visibility-drawer-copy-button" />
+              <a
+                [href]="publicProfileUrl()"
+                target="_blank"
+                rel="noopener noreferrer"
+                class="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+                data-testid="profile-visibility-drawer-open-link">
+                <i class="fa-light fa-arrow-up-right-from-square"></i>
+                Open
+              </a>
+            </div>
+          </div>
+        }
+
+        <!-- Sections -->
+        <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
+          <h3 class="text-base font-semibold text-slate-900">Visible sections</h3>
+
+          <!-- Basic group: parent + indented children -->
+          @for (section of basicGroup; track section.key) {
+            <div
+              class="flex items-start justify-between gap-4"
+              [class.pl-6]="section.parent"
+              [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-sm text-slate-900">{{ section.name }}</span>
+                <span class="text-xs text-slate-500">{{ section.description }}</span>
+              </div>
+              <lfx-toggle
+                [form]="visibilityForm"
+                [control]="section.key"
+                [ariaLabel]="section.name"
+                [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
+            </div>
+          }
+
+          <div class="h-px bg-slate-200"></div>
+
+          <!-- Standalone activity sections -->
+          @for (section of activitySections; track section.key) {
+            <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-sm text-slate-900">{{ section.name }}</span>
+                <span class="text-xs text-slate-500">{{ section.description }}</span>
+              </div>
+              <lfx-toggle
+                [form]="visibilityForm"
+                [control]="section.key"
+                [ariaLabel]="section.name"
+                [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
+            </div>
+          }
+        </div>
+
+        <!-- Actions -->
+        <div class="flex justify-end gap-3 border-t border-slate-200 pt-6 mt-2" data-testid="profile-visibility-drawer-actions">
+          <lfx-button
+            type="button"
+            variant="outlined"
+            label="Cancel"
+            (onClick)="onCancel()"
+            [disabled]="saving()"
+            size="small"
+            data-testid="profile-visibility-drawer-cancel-button" />
+          <lfx-button
+            type="submit"
+            severity="info"
+            [label]="saving() ? 'Saving...' : 'Save Changes'"
+            [loading]="saving()"
+            [disabled]="!hasChanges() || saving()"
+            size="small"
+            data-testid="profile-visibility-drawer-save-button" />
+        </div>
+      </form>
+    }
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -103,7 +103,6 @@
               data-testid="profile-visibility-drawer-tab-contact">
               <i class="fa-light fa-address-card" aria-hidden="true"></i>
               Contact &amp; Social links
-              <span class="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">Soon</span>
             </button>
           </div>
 

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -76,19 +76,85 @@
           }
         </div>
 
-        <!-- Public-profile section map -->
-        <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
-          @for (section of activitySections; track section.key) {
-            <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
-              <div class="flex flex-col gap-0.5">
-                <span class="text-sm text-slate-900">{{ section.name }}</span>
-                <span class="text-xs text-slate-500">{{ section.description }}</span>
-              </div>
-              <lfx-toggle
-                [form]="visibilityForm"
-                [control]="section.key"
-                [ariaLabel]="section.name"
-                [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
+        <!-- Tab bar: Sections (activity toggles) + Personal Data (basic group) -->
+        <div class="flex flex-col gap-6">
+          <div role="tablist" aria-label="Visibility settings" class="flex gap-1 border-b border-slate-200">
+            <button
+              type="button"
+              role="tab"
+              [attr.aria-selected]="activeTab() === 'sections'"
+              (click)="activeTab.set('sections')"
+              class="-mb-px flex items-center gap-1.5 border-b-2 px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors"
+              [class.border-blue-600]="activeTab() === 'sections'"
+              [class.text-blue-600]="activeTab() === 'sections'"
+              [class.border-transparent]="activeTab() !== 'sections'"
+              [class.text-slate-500]="activeTab() !== 'sections'"
+              data-testid="profile-visibility-drawer-tab-sections">
+              <i class="fa-light fa-grid-2" aria-hidden="true"></i>
+              Sections
+            </button>
+            <button
+              type="button"
+              role="tab"
+              [attr.aria-selected]="activeTab() === 'personal'"
+              (click)="activeTab.set('personal')"
+              class="-mb-px flex items-center gap-1.5 border-b-2 px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors"
+              [class.border-blue-600]="activeTab() === 'personal'"
+              [class.text-blue-600]="activeTab() === 'personal'"
+              [class.border-transparent]="activeTab() !== 'personal'"
+              [class.text-slate-500]="activeTab() !== 'personal'"
+              data-testid="profile-visibility-drawer-tab-personal">
+              <i class="fa-light fa-address-card" aria-hidden="true"></i>
+              Personal Data
+            </button>
+          </div>
+
+          @if (activeTab() === 'sections') {
+            <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
+              @for (section of activitySections; track section.key) {
+                <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
+                  <div class="flex flex-col gap-0.5">
+                    <span class="text-sm text-slate-900">{{ section.name }}</span>
+                    <span class="text-xs text-slate-500">{{ section.description }}</span>
+                  </div>
+                  <lfx-toggle
+                    [form]="visibilityForm"
+                    [control]="section.key"
+                    [ariaLabel]="section.name"
+                    [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
+                </div>
+              }
+            </div>
+          }
+
+          @if (activeTab() === 'personal') {
+            <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-personal">
+              @if (basicSection; as basic) {
+                <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + basic.key">
+                  <div class="flex flex-col gap-0.5">
+                    <span class="text-sm text-slate-900">{{ basic.name }}</span>
+                    <span class="text-xs text-slate-500">{{ basic.description }}</span>
+                  </div>
+                  <lfx-toggle
+                    [form]="visibilityForm"
+                    [control]="basic.key"
+                    [ariaLabel]="basic.name"
+                    [dataTest]="'profile-visibility-drawer-toggle-' + basic.key" />
+                </div>
+              }
+              @for (child of basicChildSections; track child.key) {
+                <div class="flex items-start justify-between gap-4 pl-4" [attr.data-testid]="'profile-visibility-drawer-section-' + child.key">
+                  <div class="flex flex-col gap-0.5">
+                    <span class="text-sm text-slate-900">{{ child.name }}</span>
+                    <span class="text-xs text-slate-500">{{ child.description }}</span>
+                  </div>
+                  <lfx-toggle
+                    [form]="visibilityForm"
+                    [control]="child.key"
+                    [ariaLabel]="child.name"
+                    [dataTest]="'profile-visibility-drawer-toggle-' + child.key" />
+                </div>
+              }
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -109,27 +109,6 @@
 
           @if (activeTab() === 'sections') {
             <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
-              <!-- Basic group: parent + indented children -->
-              @for (section of basicGroup; track section.key) {
-                <div
-                  class="flex items-start justify-between gap-4"
-                  [class.pl-6]="section.parent"
-                  [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
-                  <div class="flex flex-col gap-0.5">
-                    <span class="text-sm text-slate-900">{{ section.name }}</span>
-                    <span class="text-xs text-slate-500">{{ section.description }}</span>
-                  </div>
-                  <lfx-toggle
-                    [form]="visibilityForm"
-                    [control]="section.key"
-                    [ariaLabel]="section.name"
-                    [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
-                </div>
-              }
-
-              <div class="h-px bg-slate-200"></div>
-
-              <!-- Standalone activity sections -->
               @for (section of activitySections; track section.key) {
                 <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
                   <div class="flex flex-col gap-0.5">

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -76,51 +76,19 @@
           }
         </div>
 
-        <!-- Tab bar: Sections (interactive) + Contact & Social links (disabled, no backing store yet) -->
-        <div class="flex flex-col gap-6">
-          <div role="tablist" aria-label="Visibility settings" class="flex gap-1 border-b border-slate-200">
-            <button
-              type="button"
-              role="tab"
-              [attr.aria-selected]="activeTab() === 'sections'"
-              (click)="activeTab.set('sections')"
-              class="-mb-px flex items-center gap-1.5 border-b-2 px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors"
-              [class.border-blue-600]="activeTab() === 'sections'"
-              [class.text-blue-600]="activeTab() === 'sections'"
-              [class.border-transparent]="activeTab() !== 'sections'"
-              [class.text-slate-500]="activeTab() !== 'sections'"
-              data-testid="profile-visibility-drawer-tab-sections">
-              <i class="fa-light fa-grid-2" aria-hidden="true"></i>
-              Sections
-            </button>
-            <button
-              type="button"
-              role="tab"
-              disabled
-              aria-disabled="true"
-              title="Coming soon"
-              class="-mb-px flex cursor-not-allowed items-center gap-1.5 border-b-2 border-transparent px-3 pb-2.5 pt-1 text-[13px] font-medium text-slate-400"
-              data-testid="profile-visibility-drawer-tab-contact">
-              <i class="fa-light fa-address-card" aria-hidden="true"></i>
-              Contact &amp; Social links
-            </button>
-          </div>
-
-          @if (activeTab() === 'sections') {
-            <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
-              @for (section of activitySections; track section.key) {
-                <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
-                  <div class="flex flex-col gap-0.5">
-                    <span class="text-sm text-slate-900">{{ section.name }}</span>
-                    <span class="text-xs text-slate-500">{{ section.description }}</span>
-                  </div>
-                  <lfx-toggle
-                    [form]="visibilityForm"
-                    [control]="section.key"
-                    [ariaLabel]="section.name"
-                    [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
-                </div>
-              }
+        <!-- Public-profile section map -->
+        <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
+          @for (section of activitySections; track section.key) {
+            <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
+              <div class="flex flex-col gap-0.5">
+                <span class="text-sm text-slate-900">{{ section.name }}</span>
+                <span class="text-xs text-slate-500">{{ section.description }}</span>
+              </div>
+              <lfx-toggle
+                [form]="visibilityForm"
+                [control]="section.key"
+                [ariaLabel]="section.name"
+                [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -27,6 +27,21 @@
         <i class="pi pi-spinner pi-spin"></i>
         <span>Loading visibility settings...</span>
       </div>
+    } @else if (loadError()) {
+      <div class="flex flex-col items-start gap-3 text-sm" data-testid="profile-visibility-drawer-error">
+        <div class="flex items-center gap-2 text-slate-600">
+          <i class="fa-light fa-triangle-exclamation text-red-500" aria-hidden="true"></i>
+          <span>Couldn't load your visibility settings.</span>
+        </div>
+        <button
+          type="button"
+          (click)="onRetry()"
+          class="inline-flex items-center gap-1.5 rounded-md border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+          data-testid="profile-visibility-drawer-retry-button">
+          <i class="fa-light fa-rotate-right text-sm" aria-hidden="true"></i>
+          Try again
+        </button>
+      </div>
     } @else {
       <form [formGroup]="visibilityForm" class="flex flex-col gap-8">
         <!-- Profile visibility card: master control on top, public-profile link as a connected bottom section -->
@@ -82,8 +97,12 @@
             <button
               type="button"
               role="tab"
+              id="profile-visibility-drawer-tab-sections"
+              aria-controls="profile-visibility-drawer-panel-sections"
               [attr.aria-selected]="activeTab() === 'sections'"
+              [attr.tabindex]="activeTab() === 'sections' ? 0 : -1"
               (click)="activeTab.set('sections')"
+              (keydown)="onTabKeydown($event, 'sections')"
               class="-mb-px flex items-center gap-1.5 border-b-2 px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors"
               [class.border-blue-600]="activeTab() === 'sections'"
               [class.text-blue-600]="activeTab() === 'sections'"
@@ -96,8 +115,12 @@
             <button
               type="button"
               role="tab"
+              id="profile-visibility-drawer-tab-personal"
+              aria-controls="profile-visibility-drawer-panel-personal"
               [attr.aria-selected]="activeTab() === 'personal'"
+              [attr.tabindex]="activeTab() === 'personal' ? 0 : -1"
               (click)="activeTab.set('personal')"
+              (keydown)="onTabKeydown($event, 'personal')"
               class="-mb-px flex items-center gap-1.5 border-b-2 px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors"
               [class.border-blue-600]="activeTab() === 'personal'"
               [class.text-blue-600]="activeTab() === 'personal'"
@@ -110,7 +133,13 @@
           </div>
 
           @if (activeTab() === 'sections') {
-            <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
+            <div
+              role="tabpanel"
+              id="profile-visibility-drawer-panel-sections"
+              aria-labelledby="profile-visibility-drawer-tab-sections"
+              tabindex="0"
+              class="flex flex-col gap-4"
+              data-testid="profile-visibility-drawer-sections">
               @for (section of activitySections; track section.key) {
                 <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
                   <div class="flex flex-col gap-0.5">
@@ -128,7 +157,13 @@
           }
 
           @if (activeTab() === 'personal') {
-            <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-personal">
+            <div
+              role="tabpanel"
+              id="profile-visibility-drawer-panel-personal"
+              aria-labelledby="profile-visibility-drawer-tab-personal"
+              tabindex="0"
+              class="flex flex-col gap-4"
+              data-testid="profile-visibility-drawer-personal">
               @if (basicSection; as basic) {
                 <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + basic.key">
                   <div class="flex flex-col gap-0.5">

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -29,80 +29,117 @@
       </div>
     } @else {
       <form [formGroup]="visibilityForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-8">
-        <!-- Master flag -->
-        <div class="flex items-start justify-between gap-4 rounded-md border border-slate-200 p-4" data-testid="profile-visibility-drawer-master">
-          <div class="flex flex-col gap-0.5">
-            <span class="text-sm font-medium text-slate-900">Public profile</span>
-            <span class="text-xs text-slate-500">When off, your profile is hidden and no sections are exposed.</span>
+        <!-- Profile visibility card: master Private/Public control + the public-profile link inline -->
+        <div class="flex flex-col gap-4 rounded-lg border border-slate-200 p-4" data-testid="profile-visibility-drawer-master">
+          <div class="flex items-start justify-between gap-4">
+            <div class="flex flex-col gap-0.5">
+              <span class="text-sm font-medium text-slate-900">Profile visibility</span>
+              <span class="text-xs text-slate-500">When private, your profile is hidden and no sections are exposed.</span>
+            </div>
+            <lfx-select-button
+              [form]="visibilityForm"
+              control="isPublic"
+              [options]="modeOptions"
+              optionLabel="label"
+              optionValue="value"
+              data-testid="profile-visibility-drawer-mode" />
           </div>
-          <lfx-toggle [form]="visibilityForm" control="isPublic" ariaLabel="Public profile" dataTest="profile-visibility-drawer-master-toggle" />
-        </div>
 
-        <!-- Public URL row — only when the profile is public and the username is known -->
-        @if (isPublic() && publicProfileUrl()) {
-          <div class="flex flex-col gap-2" data-testid="profile-visibility-drawer-url">
-            <span class="text-xs font-medium text-slate-500">Public profile link</span>
-            <div class="flex items-center gap-2">
-              <span class="min-w-0 flex-1 truncate rounded-md border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-700">
-                {{ publicProfileUrl() }}
-              </span>
-              <lfx-button
-                type="button"
-                variant="outlined"
-                size="small"
-                icon="fa-light fa-copy"
-                ariaLabel="Copy public profile link"
-                (onClick)="onCopyUrl()"
-                data-testid="profile-visibility-drawer-copy-button" />
+          <!-- Public link row — only when the profile is public and the username is known -->
+          @if (isPublic() && publicProfileUrl()) {
+            <div class="flex items-center gap-2" data-testid="profile-visibility-drawer-url">
+              <div class="flex min-w-0 flex-1 items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
+                <i class="fa-light fa-link text-sm text-slate-400" aria-hidden="true"></i>
+                <span class="min-w-0 flex-1 truncate text-sm text-slate-700">{{ publicProfileUrl() }}</span>
+                <button
+                  type="button"
+                  (click)="onCopyUrl()"
+                  aria-label="Copy public profile link"
+                  class="text-slate-400 transition-colors hover:text-slate-600"
+                  data-testid="profile-visibility-drawer-copy-button">
+                  <i class="fa-light fa-copy text-sm"></i>
+                </button>
+              </div>
               <a
                 [href]="publicProfileUrl()"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-slate-700 transition-colors hover:bg-slate-50"
+                class="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-blue-600 transition-colors hover:bg-slate-50"
                 data-testid="profile-visibility-drawer-open-link">
-                <i class="fa-light fa-arrow-up-right-from-square"></i>
+                <i class="fa-light fa-arrow-up-right-from-square text-sm" aria-hidden="true"></i>
                 Open
               </a>
             </div>
-          </div>
-        }
-
-        <!-- Sections -->
-        <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
-          <h3 class="text-base font-semibold text-slate-900">Visible sections</h3>
-
-          <!-- Basic group: parent + indented children -->
-          @for (section of basicGroup; track section.key) {
-            <div
-              class="flex items-start justify-between gap-4"
-              [class.pl-6]="section.parent"
-              [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
-              <div class="flex flex-col gap-0.5">
-                <span class="text-sm text-slate-900">{{ section.name }}</span>
-                <span class="text-xs text-slate-500">{{ section.description }}</span>
-              </div>
-              <lfx-toggle
-                [form]="visibilityForm"
-                [control]="section.key"
-                [ariaLabel]="section.name"
-                [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
-            </div>
           }
+        </div>
 
-          <div class="h-px bg-slate-200"></div>
+        <!-- Tab bar: Sections (interactive) + Contact & Social links (disabled, no backing store yet) -->
+        <div class="flex flex-col gap-6">
+          <div role="tablist" aria-label="Visibility settings" class="flex gap-1 border-b border-slate-200">
+            <button
+              type="button"
+              role="tab"
+              [attr.aria-selected]="activeTab() === 'sections'"
+              (click)="activeTab.set('sections')"
+              class="-mb-px flex items-center gap-1.5 border-b-2 px-3 pb-2.5 pt-1 text-[13px] font-medium transition-colors"
+              [class.border-blue-600]="activeTab() === 'sections'"
+              [class.text-blue-600]="activeTab() === 'sections'"
+              [class.border-transparent]="activeTab() !== 'sections'"
+              [class.text-slate-500]="activeTab() !== 'sections'"
+              data-testid="profile-visibility-drawer-tab-sections">
+              <i class="fa-light fa-grid-2" aria-hidden="true"></i>
+              Sections
+            </button>
+            <button
+              type="button"
+              role="tab"
+              disabled
+              aria-disabled="true"
+              title="Coming soon"
+              class="-mb-px flex cursor-not-allowed items-center gap-1.5 border-b-2 border-transparent px-3 pb-2.5 pt-1 text-[13px] font-medium text-slate-400"
+              data-testid="profile-visibility-drawer-tab-contact">
+              <i class="fa-light fa-address-card" aria-hidden="true"></i>
+              Contact &amp; Social links
+              <span class="rounded-full bg-slate-100 px-1.5 py-0.5 text-[10px] font-medium text-slate-500">Soon</span>
+            </button>
+          </div>
 
-          <!-- Standalone activity sections -->
-          @for (section of activitySections; track section.key) {
-            <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
-              <div class="flex flex-col gap-0.5">
-                <span class="text-sm text-slate-900">{{ section.name }}</span>
-                <span class="text-xs text-slate-500">{{ section.description }}</span>
-              </div>
-              <lfx-toggle
-                [form]="visibilityForm"
-                [control]="section.key"
-                [ariaLabel]="section.name"
-                [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
+          @if (activeTab() === 'sections') {
+            <div class="flex flex-col gap-4" data-testid="profile-visibility-drawer-sections">
+              <!-- Basic group: parent + indented children -->
+              @for (section of basicGroup; track section.key) {
+                <div
+                  class="flex items-start justify-between gap-4"
+                  [class.pl-6]="section.parent"
+                  [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
+                  <div class="flex flex-col gap-0.5">
+                    <span class="text-sm text-slate-900">{{ section.name }}</span>
+                    <span class="text-xs text-slate-500">{{ section.description }}</span>
+                  </div>
+                  <lfx-toggle
+                    [form]="visibilityForm"
+                    [control]="section.key"
+                    [ariaLabel]="section.name"
+                    [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
+                </div>
+              }
+
+              <div class="h-px bg-slate-200"></div>
+
+              <!-- Standalone activity sections -->
+              @for (section of activitySections; track section.key) {
+                <div class="flex items-start justify-between gap-4" [attr.data-testid]="'profile-visibility-drawer-section-' + section.key">
+                  <div class="flex flex-col gap-0.5">
+                    <span class="text-sm text-slate-900">{{ section.name }}</span>
+                    <span class="text-xs text-slate-500">{{ section.description }}</span>
+                  </div>
+                  <lfx-toggle
+                    [form]="visibilityForm"
+                    [control]="section.key"
+                    [ariaLabel]="section.name"
+                    [dataTest]="'profile-visibility-drawer-toggle-' + section.key" />
+                </div>
+              }
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -7,9 +7,9 @@
   (visibleChange)="onVisibleChange($event)"
   position="right"
   [modal]="true"
-  [showCloseIcon]="!saving()"
-  [dismissible]="!saving()"
-  [closeOnEscape]="!saving()"
+  [showCloseIcon]="true"
+  [dismissible]="true"
+  [closeOnEscape]="true"
   styleClass="lg:w-[560px] md:w-[70%] sm:w-[90%] w-full"
   data-testid="profile-visibility-drawer">
   <ng-template #header>
@@ -28,7 +28,7 @@
         <span>Loading visibility settings...</span>
       </div>
     } @else {
-      <form [formGroup]="visibilityForm" (ngSubmit)="onSubmit()" class="flex flex-col gap-8">
+      <form [formGroup]="visibilityForm" class="flex flex-col gap-8">
         <!-- Profile visibility card: master Private/Public control + the public-profile link inline -->
         <div class="flex flex-col gap-4 rounded-lg border border-slate-200 p-4" data-testid="profile-visibility-drawer-master">
           <div class="flex items-start justify-between gap-4">
@@ -144,25 +144,25 @@
           }
         </div>
 
-        <!-- Actions -->
-        <div class="flex justify-end gap-3 border-t border-slate-200 pt-6 mt-2" data-testid="profile-visibility-drawer-actions">
-          <lfx-button
-            type="button"
-            variant="outlined"
-            label="Cancel"
-            (onClick)="onCancel()"
-            [disabled]="saving()"
-            size="small"
-            data-testid="profile-visibility-drawer-cancel-button" />
-          <lfx-button
-            type="submit"
-            severity="info"
-            [label]="saving() ? 'Saving...' : 'Save Changes'"
-            [loading]="saving()"
-            [disabled]="!hasChanges() || saving()"
-            size="small"
-            data-testid="profile-visibility-drawer-save-button" />
-        </div>
+        <!-- Auto-save status (changes persist on change; there is no explicit Save button) -->
+        @if (saveState() !== 'idle') {
+          <div class="flex items-center gap-2 text-xs" data-testid="profile-visibility-drawer-status">
+            @switch (saveState()) {
+              @case ('saving') {
+                <i class="pi pi-spinner pi-spin text-slate-400"></i>
+                <span class="text-slate-500">Saving changes…</span>
+              }
+              @case ('saved') {
+                <i class="fa-light fa-circle-check text-emerald-500" aria-hidden="true"></i>
+                <span class="text-slate-500">All changes saved</span>
+              }
+              @case ('error') {
+                <i class="fa-light fa-triangle-exclamation text-red-500" aria-hidden="true"></i>
+                <span class="text-red-600">Couldn't save changes</span>
+              }
+            }
+          </div>
+        }
       </form>
     }
   </div>

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -29,9 +29,13 @@
       </div>
     } @else {
       <form [formGroup]="visibilityForm" class="flex flex-col gap-8">
-        <!-- Profile visibility card: master Private/Public control + the public-profile link inline -->
-        <div class="flex flex-col gap-4 rounded-lg border border-slate-200 p-4" data-testid="profile-visibility-drawer-master">
-          <div class="flex items-start justify-between gap-4">
+        <!-- Profile visibility card: master control on top, public-profile link as a connected bottom section -->
+        <!-- (banner+table "connected card" pattern: shared seam via rounded-t/rounded-b + -mb-px) -->
+        <div class="flex flex-col" data-testid="profile-visibility-drawer-master">
+          <div
+            class="flex items-start justify-between gap-4 rounded-t-lg border border-slate-200 p-4"
+            [class.rounded-b-lg]="!showPublicUrl()"
+            [class.-mb-px]="showPublicUrl()">
             <div class="flex flex-col gap-0.5">
               <span class="text-sm font-medium text-slate-900">Profile visibility</span>
               <span class="text-xs text-slate-500">When private, your profile is hidden and no sections are exposed.</span>
@@ -45,26 +49,25 @@
               data-testid="profile-visibility-drawer-mode" />
           </div>
 
-          <!-- Public link row — only when the profile is public and the username is known -->
-          @if (isPublic() && publicProfileUrl()) {
-            <div class="flex items-center gap-2" data-testid="profile-visibility-drawer-url">
-              <div class="flex min-w-0 flex-1 items-center gap-2 rounded-md border border-slate-200 bg-slate-50 px-3 py-2">
-                <i class="fa-light fa-link text-sm text-slate-400" aria-hidden="true"></i>
-                <span class="min-w-0 flex-1 truncate text-sm text-slate-700">{{ publicProfileUrl() }}</span>
-                <button
-                  type="button"
-                  (click)="onCopyUrl()"
-                  aria-label="Copy public profile link"
-                  class="text-slate-400 transition-colors hover:text-slate-600"
-                  data-testid="profile-visibility-drawer-copy-button">
-                  <i class="fa-light fa-copy text-sm"></i>
-                </button>
-              </div>
+          <!-- Public link — connected bottom section, only when the profile is public and the username is known -->
+          @if (showPublicUrl()) {
+            <div class="flex items-center gap-2 rounded-b-lg border border-slate-200 bg-slate-50 px-3 py-2.5" data-testid="profile-visibility-drawer-url">
+              <i class="fa-light fa-link text-sm text-slate-400" aria-hidden="true"></i>
+              <span class="min-w-0 flex-1 truncate text-sm text-slate-700">{{ publicProfileUrl() }}</span>
+              <button
+                type="button"
+                (click)="onCopyUrl()"
+                aria-label="Copy public profile link"
+                class="text-slate-400 transition-colors hover:text-slate-600"
+                data-testid="profile-visibility-drawer-copy-button">
+                <i class="fa-light fa-copy text-sm"></i>
+              </button>
+              <span class="h-4 w-px bg-slate-200" aria-hidden="true"></span>
               <a
                 [href]="publicProfileUrl()"
                 target="_blank"
                 rel="noopener noreferrer"
-                class="inline-flex items-center gap-1.5 rounded-md border border-slate-300 bg-white px-3 py-2 text-sm font-medium text-blue-600 transition-colors hover:bg-slate-50"
+                class="inline-flex items-center gap-1.5 text-sm font-medium text-blue-600 transition-colors hover:text-blue-700"
                 data-testid="profile-visibility-drawer-open-link">
                 <i class="fa-light fa-arrow-up-right-from-square text-sm" aria-hidden="true"></i>
                 Open

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.html
@@ -53,7 +53,7 @@
           @if (showPublicUrl()) {
             <div class="flex items-center gap-2 rounded-b-lg border border-slate-200 bg-slate-50 px-3 py-2.5" data-testid="profile-visibility-drawer-url">
               <i class="fa-light fa-link text-sm text-slate-400" aria-hidden="true"></i>
-              <span class="min-w-0 flex-1 truncate text-sm text-slate-700">{{ publicProfileUrl() }}</span>
+              <span class="min-w-0 flex-1 truncate text-sm text-slate-700" [title]="publicProfileUrl()">{{ publicProfileUrl() }}</span>
               <button
                 type="button"
                 (click)="onCopyUrl()"

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.scss
@@ -1,0 +1,2 @@
+/* Copyright The Linux Foundation and each contributor to LFX. */
+/* SPDX-License-Identifier: MIT */

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -42,10 +42,17 @@ export class ProfileVisibilityDrawerComponent {
   private readonly platformId = inject(PLATFORM_ID);
   protected readonly drawer = inject(ProfileVisibilityDrawerService);
 
-  // Section toggles shown in the drawer: the standalone activity sections only. The `basic` group
-  // (general info / about / personal) is not user-toggleable per the redesign — its keys are still
-  // persisted and driven by the master flag cascade (a public profile always exposes them).
+  // Sections tab: the standalone activity sections (everything outside the basic group).
   protected readonly activitySections = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key !== 'basic' && !section.parent);
+
+  // Personal Data tab: the `basic` parent (General Profile Information) and its indented children
+  // (About Me / Personal Information). Toggling the parent mirrors to the children; toggling any
+  // child ORs back into the parent (see wireCascade), matching myprofile.
+  protected readonly basicSection = PROFILE_VISIBILITY_SECTIONS.find((section) => section.key === 'basic');
+  protected readonly basicChildSections = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.parent === 'basic');
+
+  // Active drawer tab. Sections first, then Personal Data.
+  public readonly activeTab = signal<'sections' | 'personal'>('sections');
 
   // Segmented Private/Public options for the master-flag control (mutable copy for the p-selectbutton input).
   protected readonly modeOptions = [...PROFILE_VISIBILITY_MODE_OPTIONS];
@@ -210,11 +217,12 @@ export class ProfileVisibilityDrawerComponent {
   }
 
   /**
-   * Master-flag cascade: turning the profile public enables every section control and forces the
-   * basic group (general info / about / personal) on; turning it private zeroes and disables all of
-   * them. The basic group has no UI toggle — it is driven entirely from here and re-enforced
-   * server-side in `enforcePublicDefaults`. emitEvent:false writes avoid feedback loops (and extra
-   * saves).
+   * Client-side cascade (matches myprofile). Master flag: going public enables every section control
+   * and defaults the basic group (general info / about / personal) on; going private zeroes and
+   * disables all of them. Basic group: the `basic` parent mirrors its value to both children, and
+   * either child ORs back into the parent — so the parent is on iff any child is on. Defaulting the
+   * basic group on is only a starting point; the user can then toggle any of the three off. Server
+   * trusts whatever map results. emitEvent:false writes avoid feedback loops (and extra saves).
    */
   private wireCascade(): void {
     const control = (key: string) => this.visibilityForm.get(key);
@@ -235,6 +243,22 @@ export class ProfileVisibilityDrawerComponent {
           this.setSectionsEnabled(false);
         }
       });
+
+    control('basic')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: boolean) => {
+        control('aboutMe')?.setValue(value, { emitEvent: false });
+        control('personalInfo')?.setValue(value, { emitEvent: false });
+      });
+
+    for (const childKey of ['aboutMe', 'personalInfo']) {
+      control(childKey)
+        ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => {
+          const anyChildOn = Boolean(control('aboutMe')?.value) || Boolean(control('personalInfo')?.value);
+          control('basic')?.setValue(anyChildOn, { emitEvent: false });
+        });
+    }
   }
 
   /** Enable or disable every section control (the master flag gates them), without emitting events. */

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -261,13 +261,21 @@ export class ProfileVisibilityDrawerComponent {
     merge(this.visibilityForm.valueChanges.pipe(debounceTime(this.autosaveDebounceMs)), this.flush$)
       .pipe(
         filter(() => this.dirty && !this.loadingVisibility() && !this.loadError()),
-        // Serialize saves: each PATCH to /me + the preference completes before the next starts, so a
-        // slower earlier write can't land after (and overwrite) a newer one.
-        concatMap(() => {
+        // Snapshot the payload the moment the save is accepted — NOT inside concatMap. concatMap
+        // defers a queued inner's projection until the prior save completes, and by then a reopen's
+        // seedForm() could have replaced the form: building the payload late would serialize the
+        // reloaded state and drop the close-time edit. Counting the queued save here (pendingSaves)
+        // also gates the post-save re-seed against still-queued work.
+        map(() => {
           this.dirty = false;
           this.pendingSaves++;
           this.saveState.set('saving');
-          return this.userService.updateProfileVisibility(this.buildPayload()).pipe(
+          return this.buildPayload();
+        }),
+        // Serialize saves: each PATCH to /me + the preference completes before the next starts, so a
+        // slower earlier write can't land after (and overwrite) a newer one.
+        concatMap((payload) =>
+          this.userService.updateProfileVisibility(payload).pipe(
             map((visibility) => ({ ok: true, visibility: visibility as ProfileVisibility | null })),
             catchError(() => {
               // Re-arm dirty so the next change (or a close flush) retries the failed save.
@@ -276,8 +284,8 @@ export class ProfileVisibilityDrawerComponent {
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to save visibility settings. Please try again.' });
               return of({ ok: false, visibility: null as ProfileVisibility | null });
             })
-          );
-        }),
+          )
+        ),
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((result) => {

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -71,13 +71,7 @@ export class ProfileVisibilityDrawerComponent {
 
   // The public-profile URL for the copy/open row. Empty on the server or when the username is
   // unknown, which hides the row.
-  public readonly publicProfileUrl: Signal<string> = computed(() => {
-    const username = this.drawer.context();
-    if (!username || !isPlatformBrowser(this.platformId)) {
-      return '';
-    }
-    return `${window.location.origin}/u/${encodeURIComponent(username)}`;
-  });
+  public readonly publicProfileUrl: Signal<string> = this.initPublicProfileUrl();
 
   // Mirrors the master `isPublic` form control as a signal so the template can react (section
   // toggles are only meaningful for a public profile). Updated from seedForm and the cascade.
@@ -269,5 +263,21 @@ export class ProfileVisibilityDrawerComponent {
         control.disable({ emitEvent: false });
       }
     }
+  }
+
+  // Private initializer functions
+
+  /**
+   * Derive the public-profile URL from the drawer's username context. Empty on the server or when the
+   * username is unknown, which hides the copy/open row (and gates {@link showPublicUrl}).
+   */
+  private initPublicProfileUrl(): Signal<string> {
+    return computed(() => {
+      const username = this.drawer.context();
+      if (!username || !isPlatformBrowser(this.platformId)) {
+        return '';
+      }
+      return `${window.location.origin}/u/${encodeURIComponent(username)}`;
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -86,6 +86,11 @@ export class ProfileVisibilityDrawerComponent {
   // settle re-seeds the form, so an intermediate response can't revert edits a queued save still holds.
   private pendingSaves = 0;
 
+  // Set when a dismissal (Esc/backdrop/close icon) arrives while a save is still pending: the drawer
+  // stays open and closes once the save machine drains (busy-close guard, mirrors profile-edit-drawer).
+  // A fresh user edit cancels it so a later auto-save can't yank the drawer shut mid-edit.
+  private closeRequested = false;
+
   // Emits to force an immediate save (bypassing the debounce) when the drawer is dismissed.
   private readonly flush$ = new Subject<void>();
 
@@ -136,11 +141,20 @@ export class ProfileVisibilityDrawerComponent {
   }
 
   public onVisibleChange(visible: boolean): void {
-    if (!visible) {
-      // Flush any pending (debounced) change before closing so nothing is lost.
-      this.flush$.next();
-      this.drawer.close();
+    if (visible) {
+      return;
     }
+    // Flush any pending (debounced) change so the dismissal persists it immediately.
+    this.flush$.next();
+    // Busy-close guard (mirrors profile-edit-drawer): if that flush left a save in flight/queued, keep
+    // the drawer open and defer the close until the machine drains (see wireAutoSave's subscribe), so a
+    // dismissal can't cancel the write or hide a save failure. Leaving the layout before the debounce
+    // tick fires (sub-600ms navigate-away) remains inherently best-effort.
+    if (this.pendingSaves > 0) {
+      this.closeRequested = true;
+      return;
+    }
+    this.drawer.close();
   }
 
   public async onCopyUrl(): Promise<void> {
@@ -256,6 +270,8 @@ export class ProfileVisibilityDrawerComponent {
   private wireAutoSave(): void {
     this.visibilityForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       this.dirty = true;
+      // A fresh edit cancels a deferred close so a later auto-save can't yank the drawer shut mid-edit.
+      this.closeRequested = false;
     });
 
     merge(this.visibilityForm.valueChanges.pipe(debounceTime(this.autosaveDebounceMs)), this.flush$)
@@ -278,10 +294,17 @@ export class ProfileVisibilityDrawerComponent {
           this.userService.updateProfileVisibility(payload).pipe(
             map((visibility) => ({ ok: true, visibility: visibility as ProfileVisibility | null })),
             catchError(() => {
-              // Re-arm dirty so the next change (or a close flush) retries the failed save.
-              this.dirty = true;
-              this.saveState.set('error');
-              this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to save visibility settings. Please try again.' });
+              // Only the last queued save owns the terminal state. If a newer save is already queued
+              // behind this one (pendingSaves > 1), this failure is superseded — re-arming dirty or
+              // flipping the indicator to 'error' here would pin the UI on a stale result while the
+              // newer save (carrying fresher data) still settles. Let that newer save set the final
+              // state instead. pendingSaves is only decremented downstream, so it still counts this save.
+              if (this.pendingSaves <= 1) {
+                // Last save failed: re-arm dirty so the next change (or a close flush) retries, and surface it.
+                this.dirty = true;
+                this.saveState.set('error');
+                this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to save visibility settings. Please try again.' });
+              }
               return of({ ok: false, visibility: null as ProfileVisibility | null });
             })
           )
@@ -291,7 +314,8 @@ export class ProfileVisibilityDrawerComponent {
       .subscribe((result) => {
         this.pendingSaves--;
         if (!result.ok) {
-          // Error already surfaced and dirty re-armed for retry; leave the indicator on 'error'.
+          // Error already surfaced (or superseded by a newer queued save); leave any deferred close
+          // pending so a failed save keeps the drawer open instead of closing and losing the edit.
           return;
         }
         // Re-seed from the persisted response only when this is the last settled save (nothing dirty,
@@ -301,6 +325,12 @@ export class ProfileVisibilityDrawerComponent {
           this.seedForm(result.visibility);
         }
         this.saveState.set(busy ? 'saving' : 'saved');
+        // Busy-close guard: a dismissal deferred while this save was in flight closes now that the
+        // machine has fully drained.
+        if (!busy && this.closeRequested) {
+          this.closeRequested = false;
+          this.drawer.close();
+        }
       });
   }
 

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -210,8 +210,11 @@ export class ProfileVisibilityDrawerComponent {
   }
 
   /**
-   * Client-side cascade: master off zeroes+disables all sections, on enables them + the basic group;
-   * `basic`↔children mirror via OR. emitEvent:false writes avoid feedback loops (and extra saves).
+   * Master-flag cascade: turning the profile public enables every section control and forces the
+   * basic group (general info / about / personal) on; turning it private zeroes and disables all of
+   * them. The basic group has no UI toggle — it is driven entirely from here and re-enforced
+   * server-side in `enforcePublicDefaults`. emitEvent:false writes avoid feedback loops (and extra
+   * saves).
    */
   private wireCascade(): void {
     const control = (key: string) => this.visibilityForm.get(key);
@@ -232,22 +235,6 @@ export class ProfileVisibilityDrawerComponent {
           this.setSectionsEnabled(false);
         }
       });
-
-    control('basic')
-      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe((value: boolean) => {
-        control('aboutMe')?.setValue(value, { emitEvent: false });
-        control('personalInfo')?.setValue(value, { emitEvent: false });
-      });
-
-    for (const childKey of ['aboutMe', 'personalInfo']) {
-      control(childKey)
-        ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe(() => {
-          const anyChildOn = Boolean(control('aboutMe')?.value) || Boolean(control('personalInfo')?.value);
-          control('basic')?.setValue(anyChildOn, { emitEvent: false });
-        });
-    }
   }
 
   /** Enable or disable every section control (the master flag gates them), without emitting events. */

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -1,0 +1,258 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
+import { ToggleComponent } from '@components/toggle/toggle.component';
+import {
+  PROFILE_VISIBILITY_DEFAULTS,
+  PROFILE_VISIBILITY_KEYS,
+  PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS,
+  PROFILE_VISIBILITY_SECTIONS,
+} from '@lfx-one/shared/constants';
+import { ProfileVisibility, ProfileVisibilitySections, ProfileVisibilityUpdateRequest } from '@lfx-one/shared/interfaces';
+import { UserService } from '@services/user.service';
+import { MessageService } from 'primeng/api';
+import { DrawerModule } from 'primeng/drawer';
+import { catchError, filter, finalize, of, switchMap } from 'rxjs';
+
+import { ProfileVisibilityDrawerService } from './profile-visibility-drawer.service';
+
+/**
+ * Right-side public-profile visibility drawer (LFXV2-2629): reads/writes the master `IsPublic` flag
+ * plus the section `visibility` preference via `/api/profile/visibility`. Cascade is client-side.
+ */
+@Component({
+  selector: 'lfx-profile-visibility-drawer',
+  imports: [DrawerModule, ReactiveFormsModule, ToggleComponent, ButtonComponent],
+  templateUrl: './profile-visibility-drawer.component.html',
+  styleUrl: './profile-visibility-drawer.component.scss',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class ProfileVisibilityDrawerComponent {
+  // Private injections
+  private readonly fb = inject(FormBuilder);
+  private readonly userService = inject(UserService);
+  private readonly messageService = inject(MessageService);
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
+  protected readonly drawer = inject(ProfileVisibilityDrawerService);
+
+  // Section metadata split for the template: the `basic` group (parent + indented children) renders
+  // first, then the standalone activity sections.
+  protected readonly basicGroup = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key === 'basic' || section.parent === 'basic');
+  protected readonly activitySections = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key !== 'basic' && !section.parent);
+
+  // One boolean control per visibility key, plus the master `isPublic` flag.
+  public readonly visibilityForm: FormGroup = this.buildForm();
+
+  // Form/loading state
+  public readonly loadingVisibility = signal<boolean>(true);
+  public readonly saving = signal<boolean>(false);
+  public readonly hasChanges = signal<boolean>(false);
+
+  // The public-profile URL for the copy/open row. Empty on the server or when the username is
+  // unknown, which hides the row.
+  public readonly publicProfileUrl: Signal<string> = computed(() => {
+    const username = this.drawer.context();
+    if (!username || !isPlatformBrowser(this.platformId)) {
+      return '';
+    }
+    return `${window.location.origin}/u/${encodeURIComponent(username)}`;
+  });
+
+  // Mirrors the master `isPublic` form control as a signal so the template can react (section
+  // toggles are only meaningful for a public profile). Updated from seedForm and the cascade.
+  public readonly isPublic = signal<boolean>(false);
+
+  public constructor() {
+    // Fires once per drawer open (context is the username, or '' when unknown — both non-null).
+    const open$ = toObservable(this.drawer.context).pipe(filter((context): context is string => context !== null));
+
+    // Load the current visibility on each open. switchMap cancels a prior open's in-flight request so
+    // a slow earlier response can't overwrite a later one; the reset clears stale state on failure.
+    open$
+      .pipe(
+        switchMap(() => {
+          this.loadingVisibility.set(true);
+          return this.userService.getProfileVisibility().pipe(
+            catchError(() => {
+              this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load visibility settings.' });
+              return of(null);
+            }),
+            finalize(() => this.loadingVisibility.set(false))
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((visibility) => this.seedForm(visibility));
+
+    this.wireCascade();
+  }
+
+  public onVisibleChange(visible: boolean): void {
+    // Don't let a dismissal (close icon, backdrop, Esc) close the drawer mid-save.
+    if (!visible && !this.saving()) {
+      this.drawer.close();
+    }
+  }
+
+  public onCancel(): void {
+    this.drawer.close();
+  }
+
+  public onSubmit(): void {
+    if (this.saving()) {
+      return;
+    }
+
+    const raw = this.visibilityForm.getRawValue();
+    const sections = PROFILE_VISIBILITY_KEYS.reduce((acc, key) => {
+      acc[key] = Boolean(raw[key]);
+      return acc;
+    }, {} as ProfileVisibilitySections);
+
+    const payload: ProfileVisibilityUpdateRequest = {
+      isPublic: Boolean(raw.isPublic),
+      sections,
+    };
+
+    this.saving.set(true);
+    this.userService
+      .updateProfileVisibility(payload)
+      .pipe(
+        takeUntilDestroyed(this.destroyRef),
+        finalize(() => this.saving.set(false))
+      )
+      .subscribe({
+        next: (visibility) => {
+          this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Visibility settings updated successfully!' });
+          // Re-seed from the persisted response, resetting the pristine/changed baseline, then close.
+          this.seedForm(visibility);
+          this.drawer.close();
+        },
+        error: () => {
+          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to update visibility settings. Please try again.' });
+        },
+      });
+  }
+
+  public async onCopyUrl(): Promise<void> {
+    const url = this.publicProfileUrl();
+    if (!url || !isPlatformBrowser(this.platformId)) {
+      return;
+    }
+
+    try {
+      await navigator.clipboard.writeText(url);
+      this.messageService.add({ severity: 'success', summary: 'Copied', detail: 'Public profile link copied to clipboard.' });
+    } catch {
+      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to copy the link.' });
+    }
+  }
+
+  // Private helpers
+
+  /** Build the reactive form: one boolean control per visibility key plus the master `isPublic`. */
+  private buildForm(): FormGroup {
+    const controls = PROFILE_VISIBILITY_KEYS.reduce(
+      (acc, key) => {
+        acc[key] = this.fb.control<boolean>(PROFILE_VISIBILITY_DEFAULTS[key]);
+        return acc;
+      },
+      { isPublic: this.fb.control<boolean>(false) } as Record<string, unknown>
+    );
+    return this.fb.group(controls);
+  }
+
+  /**
+   * Seed the form from the fetched (or saved) visibility, or all-private defaults on load failure.
+   * Resets the pristine/changed baseline and aligns section-control enabled state to the flag.
+   */
+  private seedForm(visibility: ProfileVisibility | null): void {
+    const isPublic = visibility?.isPublic ?? false;
+    const sections = visibility?.sections ?? PROFILE_VISIBILITY_DEFAULTS;
+
+    const patch: Record<string, boolean> = { isPublic };
+    for (const key of PROFILE_VISIBILITY_KEYS) {
+      patch[key] = Boolean(sections[key]);
+    }
+
+    // emitEvent: false — the cascade subscriptions are already wired; a plain patch would fight the
+    // just-seeded values.
+    this.visibilityForm.patchValue(patch, { emitEvent: false });
+    this.setSectionsEnabled(isPublic);
+    this.isPublic.set(isPublic);
+    this.visibilityForm.markAsPristine();
+    this.hasChanges.set(false);
+  }
+
+  /**
+   * Client-side cascade: master off zeroes+disables all sections, on enables them + the basic group;
+   * `basic`↔children mirror via OR. emitEvent:false writes avoid feedback loops.
+   */
+  private wireCascade(): void {
+    const control = (key: string) => this.visibilityForm.get(key);
+
+    control('isPublic')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((isPublic: boolean) => {
+        this.isPublic.set(isPublic);
+        if (isPublic) {
+          this.setSectionsEnabled(true);
+          for (const key of PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS) {
+            control(key)?.setValue(true, { emitEvent: false });
+          }
+        } else {
+          for (const key of PROFILE_VISIBILITY_KEYS) {
+            control(key)?.setValue(false, { emitEvent: false });
+          }
+          this.setSectionsEnabled(false);
+        }
+        this.hasChanges.set(true);
+      });
+
+    control('basic')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((value: boolean) => {
+        control('aboutMe')?.setValue(value, { emitEvent: false });
+        control('personalInfo')?.setValue(value, { emitEvent: false });
+        this.hasChanges.set(true);
+      });
+
+    for (const childKey of ['aboutMe', 'personalInfo']) {
+      control(childKey)
+        ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => {
+          const anyChildOn = Boolean(control('aboutMe')?.value) || Boolean(control('personalInfo')?.value);
+          control('basic')?.setValue(anyChildOn, { emitEvent: false });
+          this.hasChanges.set(true);
+        });
+    }
+
+    // Any remaining (standalone) section toggle just marks the form as changed.
+    for (const section of this.activitySections) {
+      control(section.key)
+        ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+        .subscribe(() => this.hasChanges.set(true));
+    }
+  }
+
+  /** Enable or disable every section control (the master flag gates them), without emitting events. */
+  private setSectionsEnabled(enabled: boolean): void {
+    for (const key of PROFILE_VISIBILITY_KEYS) {
+      const control = this.visibilityForm.get(key);
+      if (!control) {
+        continue;
+      }
+      if (enabled) {
+        control.enable({ emitEvent: false });
+      } else {
+        control.disable({ emitEvent: false });
+      }
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -6,10 +6,12 @@ import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATF
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
+import { SelectButtonComponent } from '@components/select-button/select-button.component';
 import { ToggleComponent } from '@components/toggle/toggle.component';
 import {
   PROFILE_VISIBILITY_DEFAULTS,
   PROFILE_VISIBILITY_KEYS,
+  PROFILE_VISIBILITY_MODE_OPTIONS,
   PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS,
   PROFILE_VISIBILITY_SECTIONS,
 } from '@lfx-one/shared/constants';
@@ -27,7 +29,7 @@ import { ProfileVisibilityDrawerService } from './profile-visibility-drawer.serv
  */
 @Component({
   selector: 'lfx-profile-visibility-drawer',
-  imports: [DrawerModule, ReactiveFormsModule, ToggleComponent, ButtonComponent],
+  imports: [DrawerModule, ReactiveFormsModule, ToggleComponent, ButtonComponent, SelectButtonComponent],
   templateUrl: './profile-visibility-drawer.component.html',
   styleUrl: './profile-visibility-drawer.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -45,6 +47,13 @@ export class ProfileVisibilityDrawerComponent {
   // first, then the standalone activity sections.
   protected readonly basicGroup = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key === 'basic' || section.parent === 'basic');
   protected readonly activitySections = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key !== 'basic' && !section.parent);
+
+  // Segmented Private/Public options for the master-flag control (mutable copy for the p-selectbutton input).
+  protected readonly modeOptions = [...PROFILE_VISIBILITY_MODE_OPTIONS];
+
+  // Which drawer tab is active. `contact` (Contact & Social links) has no backing store yet and
+  // renders disabled ("Coming soon"); only `sections` is interactive.
+  public readonly activeTab = signal<'sections' | 'contact'>('sections');
 
   // One boolean control per visibility key, plus the master `isPublic` flag.
   public readonly visibilityForm: FormGroup = this.buildForm();

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -87,6 +87,10 @@ export class ProfileVisibilityDrawerComponent {
   // toggles are only meaningful for a public profile). Updated from seedForm and the cascade.
   public readonly isPublic = signal<boolean>(false);
 
+  // True when the public-profile link section should render (profile public + username known). Drives
+  // the connected top/bottom corner + seam styling on the visibility card.
+  public readonly showPublicUrl: Signal<boolean> = computed(() => this.isPublic() && Boolean(this.publicProfileUrl()));
+
   public constructor() {
     // Fires once per drawer open (context is the username, or '' when unknown — both non-null).
     const open$ = toObservable(this.drawer.context).pipe(filter((context): context is string => context !== null));

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -18,7 +18,7 @@ import { ProfileVisibility, ProfileVisibilitySaveState, ProfileVisibilitySection
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
-import { catchError, debounceTime, EMPTY, filter, finalize, merge, of, Subject, switchMap } from 'rxjs';
+import { catchError, concatMap, debounceTime, filter, finalize, map, merge, of, Subject, switchMap } from 'rxjs';
 
 import { ProfileVisibilityDrawerService } from './profile-visibility-drawer.service';
 
@@ -81,6 +81,10 @@ export class ProfileVisibilityDrawerComponent {
 
   // True when the form has unpersisted changes. Gates auto-save and the close-time flush.
   private dirty = false;
+
+  // Count of saves currently in flight or queued (concatMap serializes them). Only the last one to
+  // settle re-seeds the form, so an intermediate response can't revert edits a queued save still holds.
+  private pendingSaves = 0;
 
   // Emits to force an immediate save (bypassing the debounce) when the drawer is dismissed.
   private readonly flush$ = new Subject<void>();
@@ -245,7 +249,9 @@ export class ProfileVisibilityDrawerComponent {
 
   /**
    * Debounced auto-save: any user change marks the form dirty; a debounced tick (or the close-time
-   * flush) persists the resolved map. switchMap cancels an in-flight save when a newer change lands.
+   * flush) persists the resolved map. concatMap serializes the writes — switchMap would only cancel
+   * the client subscription while the upstream PATCH keeps writing, letting overlapping saves persist
+   * out of order.
    */
   private wireAutoSave(): void {
     this.visibilityForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
@@ -255,30 +261,38 @@ export class ProfileVisibilityDrawerComponent {
     merge(this.visibilityForm.valueChanges.pipe(debounceTime(this.autosaveDebounceMs)), this.flush$)
       .pipe(
         filter(() => this.dirty && !this.loadingVisibility() && !this.loadError()),
-        switchMap(() => {
+        // Serialize saves: each PATCH to /me + the preference completes before the next starts, so a
+        // slower earlier write can't land after (and overwrite) a newer one.
+        concatMap(() => {
           this.dirty = false;
+          this.pendingSaves++;
           this.saveState.set('saving');
           return this.userService.updateProfileVisibility(this.buildPayload()).pipe(
+            map((visibility) => ({ ok: true, visibility: visibility as ProfileVisibility | null })),
             catchError(() => {
               // Re-arm dirty so the next change (or a close flush) retries the failed save.
               this.dirty = true;
               this.saveState.set('error');
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to save visibility settings. Please try again.' });
-              return EMPTY;
+              return of({ ok: false, visibility: null as ProfileVisibility | null });
             })
           );
         }),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((visibility) => {
-        // Re-seed from the persisted response, but only when no newer edit landed mid-flight (dirty is
-        // true again) — otherwise re-seeding reverts those edits and drops the pending debounced save.
-        if (!this.dirty) {
-          this.seedForm(visibility);
+      .subscribe((result) => {
+        this.pendingSaves--;
+        if (!result.ok) {
+          // Error already surfaced and dirty re-armed for retry; leave the indicator on 'error'.
+          return;
         }
-        // If a newer edit landed mid-flight, a follow-up save is already queued — keep the indicator
-        // on 'saving' so it doesn't flash "saved" between the two writes.
-        this.saveState.set(this.dirty ? 'saving' : 'saved');
+        // Re-seed from the persisted response only when this is the last settled save (nothing dirty,
+        // nothing still queued) — otherwise re-seeding would revert edits a queued save still holds.
+        const busy = this.dirty || this.pendingSaves > 0;
+        if (!busy) {
+          this.seedForm(result.visibility);
+        }
+        this.saveState.set(busy ? 'saving' : 'saved');
       });
   }
 

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -45,9 +45,8 @@ export class ProfileVisibilityDrawerComponent {
   // Sections tab: the standalone activity sections (everything outside the basic group).
   protected readonly activitySections = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key !== 'basic' && !section.parent);
 
-  // Personal Data tab: the `basic` parent (General Profile Information) and its indented children
-  // (About Me / Personal Information). Toggling the parent mirrors to the children; toggling any
-  // child ORs back into the parent (see wireCascade), matching myprofile.
+  // Personal Data tab: the `basic` parent (General Profile Information) and its children (About Me /
+  // Personal Information). Parent↔child cascade lives in wireCascade, matching myprofile.
   protected readonly basicSection = PROFILE_VISIBILITY_SECTIONS.find((section) => section.key === 'basic');
   protected readonly basicChildSections = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.parent === 'basic');
 
@@ -210,9 +209,8 @@ export class ProfileVisibilityDrawerComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((visibility) => {
-        // Re-seed from the persisted response without re-triggering a save — but only when no newer
-        // edit landed while this save was in flight. If it did (dirty is true again), re-seeding would
-        // revert those edits and clear dirty, dropping the pending debounced save. Leave them to persist.
+        // Re-seed from the persisted response, but only when no newer edit landed mid-flight (dirty is
+        // true again) — otherwise re-seeding reverts those edits and drops the pending debounced save.
         if (!this.dirty) {
           this.seedForm(visibility);
         }
@@ -221,12 +219,8 @@ export class ProfileVisibilityDrawerComponent {
   }
 
   /**
-   * Client-side cascade (matches myprofile). Master flag: going public enables every section control
-   * and defaults the basic group (general info / about / personal) on; going private zeroes and
-   * disables all of them. Basic group: the `basic` parent mirrors its value to both children, and
-   * either child ORs back into the parent — so the parent is on iff any child is on. Defaulting the
-   * basic group on is only a starting point; the user can then toggle any of the three off. Server
-   * trusts whatever map results. emitEvent:false writes avoid feedback loops (and extra saves).
+   * Client-side cascade (matches myprofile): going public enables all sections and defaults the basic
+   * group on, going private zeroes all; the basic parent mirrors to its children and ORs back from them.
    */
   private wireCascade(): void {
     const control = (key: string) => this.visibilityForm.get(key);

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -42,9 +42,9 @@ export class ProfileVisibilityDrawerComponent {
   private readonly platformId = inject(PLATFORM_ID);
   protected readonly drawer = inject(ProfileVisibilityDrawerService);
 
-  // Section metadata split for the template: the `basic` group (parent + indented children) renders
-  // first, then the standalone activity sections.
-  protected readonly basicGroup = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key === 'basic' || section.parent === 'basic');
+  // Section toggles shown in the drawer: the standalone activity sections only. The `basic` group
+  // (general info / about / personal) is not user-toggleable per the redesign — its keys are still
+  // persisted and driven by the master flag cascade (a public profile always exposes them).
   protected readonly activitySections = PROFILE_VISIBILITY_SECTIONS.filter((section) => section.key !== 'basic' && !section.parent);
 
   // Segmented Private/Public options for the master-flag control (mutable copy for the p-selectbutton input).

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -53,6 +53,9 @@ export class ProfileVisibilityDrawerComponent {
   // Active drawer tab. Sections first, then Personal Data.
   public readonly activeTab = signal<'sections' | 'personal'>('sections');
 
+  // Tab order for roving-focus keyboard nav (matches the rendered tablist order).
+  private readonly tabOrder = ['sections', 'personal'] as const;
+
   // Segmented Private/Public options for the master-flag control (mutable copy for the p-selectbutton input).
   protected readonly modeOptions = [...PROFILE_VISIBILITY_MODE_OPTIONS];
 
@@ -61,6 +64,13 @@ export class ProfileVisibilityDrawerComponent {
 
   // Form/loading state
   public readonly loadingVisibility = signal<boolean>(true);
+
+  // True when the last load failed; the template shows an error + retry block instead of the form,
+  // and auto-save stays gated off so an unseeded form can't overwrite the stored map.
+  public readonly loadError = signal<boolean>(false);
+
+  // Emits to re-run the load after a failure (the "Try again" action).
+  private readonly retry$ = new Subject<void>();
 
   // Auto-save status for the inline indicator (there is no explicit Save button — changes persist on
   // change, debounced, and are flushed when the drawer closes).
@@ -91,15 +101,18 @@ export class ProfileVisibilityDrawerComponent {
     // Fires once per drawer open (context is the username, or '' when unknown — both non-null).
     const open$ = toObservable(this.drawer.context).pipe(filter((context): context is string => context !== null));
 
-    // Load the current visibility on each open. switchMap cancels a prior open's in-flight request so
-    // a slow earlier response can't overwrite a later one; the reset clears stale state on failure.
-    open$
+    // Load the current visibility on each open (or on an explicit retry). switchMap cancels a prior
+    // in-flight request so a slow earlier response can't overwrite a later one. On failure loadError
+    // gates the form off; only a successful (non-null) response seeds the form.
+    merge(open$, this.retry$)
       .pipe(
         switchMap(() => {
           this.loadingVisibility.set(true);
+          this.loadError.set(false);
           this.saveState.set('idle');
           return this.userService.getProfileVisibility().pipe(
             catchError(() => {
+              this.loadError.set(true);
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load visibility settings.' });
               return of(null);
             }),
@@ -108,7 +121,11 @@ export class ProfileVisibilityDrawerComponent {
         }),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((visibility) => this.seedForm(visibility));
+      .subscribe((visibility) => {
+        if (visibility) {
+          this.seedForm(visibility);
+        }
+      });
 
     this.wireCascade();
     this.wireAutoSave();
@@ -136,7 +153,52 @@ export class ProfileVisibilityDrawerComponent {
     }
   }
 
+  /** Re-run the visibility load after a failure (the "Try again" action). */
+  public onRetry(): void {
+    this.retry$.next();
+  }
+
+  /**
+   * Roving-focus keyboard nav for the tablist: arrows/Home/End move between tabs (with wraparound),
+   * activating and focusing the target. Other keys fall through untouched.
+   */
+  public onTabKeydown(event: KeyboardEvent, current: 'sections' | 'personal'): void {
+    const order = this.tabOrder;
+    const index = order.indexOf(current);
+    let nextIndex: number;
+    switch (event.key) {
+      case 'ArrowRight':
+      case 'ArrowDown':
+        nextIndex = (index + 1) % order.length;
+        break;
+      case 'ArrowLeft':
+      case 'ArrowUp':
+        nextIndex = (index - 1 + order.length) % order.length;
+        break;
+      case 'Home':
+        nextIndex = 0;
+        break;
+      case 'End':
+        nextIndex = order.length - 1;
+        break;
+      default:
+        return;
+    }
+    event.preventDefault();
+    const next = order[nextIndex];
+    this.activeTab.set(next);
+    this.focusTab(next);
+  }
+
   // Private helpers
+
+  /** Move DOM focus to a tab button by id (the drawer is appended to <body>, so query the document). */
+  private focusTab(tab: 'sections' | 'personal'): void {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    document.getElementById(`profile-visibility-drawer-tab-${tab}`)?.focus();
+  }
 
   /** Build the reactive form: one boolean control per visibility key plus the master `isPublic`. */
   private buildForm(): FormGroup {
@@ -192,7 +254,7 @@ export class ProfileVisibilityDrawerComponent {
 
     merge(this.visibilityForm.valueChanges.pipe(debounceTime(this.autosaveDebounceMs)), this.flush$)
       .pipe(
-        filter(() => this.dirty && !this.loadingVisibility()),
+        filter(() => this.dirty && !this.loadingVisibility() && !this.loadError()),
         switchMap(() => {
           this.dirty = false;
           this.saveState.set('saving');
@@ -214,7 +276,9 @@ export class ProfileVisibilityDrawerComponent {
         if (!this.dirty) {
           this.seedForm(visibility);
         }
-        this.saveState.set('saved');
+        // If a newer edit landed mid-flight, a follow-up save is already queued — keep the indicator
+        // on 'saving' so it doesn't flash "saved" between the two writes.
+        this.saveState.set(this.dirty ? 'saving' : 'saved');
       });
   }
 

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -50,10 +50,6 @@ export class ProfileVisibilityDrawerComponent {
   // Segmented Private/Public options for the master-flag control (mutable copy for the p-selectbutton input).
   protected readonly modeOptions = [...PROFILE_VISIBILITY_MODE_OPTIONS];
 
-  // Which drawer tab is active. `contact` (Contact & Social links) has no backing store yet and
-  // renders disabled ("Coming soon"); only `sections` is interactive.
-  public readonly activeTab = signal<'sections' | 'contact'>('sections');
-
   // One boolean control per visibility key, plus the master `isPublic` flag.
   public readonly visibilityForm: FormGroup = this.buildForm();
 

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -5,7 +5,6 @@ import { isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { ButtonComponent } from '@components/button/button.component';
 import { SelectButtonComponent } from '@components/select-button/select-button.component';
 import { ToggleComponent } from '@components/toggle/toggle.component';
 import {
@@ -15,11 +14,11 @@ import {
   PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS,
   PROFILE_VISIBILITY_SECTIONS,
 } from '@lfx-one/shared/constants';
-import { ProfileVisibility, ProfileVisibilitySections, ProfileVisibilityUpdateRequest } from '@lfx-one/shared/interfaces';
+import { ProfileVisibility, ProfileVisibilitySaveState, ProfileVisibilitySections, ProfileVisibilityUpdateRequest } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
-import { catchError, filter, finalize, of, switchMap } from 'rxjs';
+import { catchError, debounceTime, EMPTY, filter, finalize, merge, of, Subject, switchMap } from 'rxjs';
 
 import { ProfileVisibilityDrawerService } from './profile-visibility-drawer.service';
 
@@ -29,7 +28,7 @@ import { ProfileVisibilityDrawerService } from './profile-visibility-drawer.serv
  */
 @Component({
   selector: 'lfx-profile-visibility-drawer',
-  imports: [DrawerModule, ReactiveFormsModule, ToggleComponent, ButtonComponent, SelectButtonComponent],
+  imports: [DrawerModule, ReactiveFormsModule, ToggleComponent, SelectButtonComponent],
   templateUrl: './profile-visibility-drawer.component.html',
   styleUrl: './profile-visibility-drawer.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -60,8 +59,19 @@ export class ProfileVisibilityDrawerComponent {
 
   // Form/loading state
   public readonly loadingVisibility = signal<boolean>(true);
-  public readonly saving = signal<boolean>(false);
-  public readonly hasChanges = signal<boolean>(false);
+
+  // Auto-save status for the inline indicator (there is no explicit Save button — changes persist on
+  // change, debounced, and are flushed when the drawer closes).
+  public readonly saveState = signal<ProfileVisibilitySaveState>('idle');
+
+  // Debounce window before an auto-save fires; coalesces rapid toggles (and the master cascade burst).
+  private readonly autosaveDebounceMs = 600;
+
+  // True when the form has unpersisted changes. Gates auto-save and the close-time flush.
+  private dirty = false;
+
+  // Emits to force an immediate save (bypassing the debounce) when the drawer is dismissed.
+  private readonly flush$ = new Subject<void>();
 
   // The public-profile URL for the copy/open row. Empty on the server or when the username is
   // unknown, which hides the row.
@@ -87,6 +97,7 @@ export class ProfileVisibilityDrawerComponent {
       .pipe(
         switchMap(() => {
           this.loadingVisibility.set(true);
+          this.saveState.set('idle');
           return this.userService.getProfileVisibility().pipe(
             catchError(() => {
               this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to load visibility settings.' });
@@ -100,53 +111,15 @@ export class ProfileVisibilityDrawerComponent {
       .subscribe((visibility) => this.seedForm(visibility));
 
     this.wireCascade();
+    this.wireAutoSave();
   }
 
   public onVisibleChange(visible: boolean): void {
-    // Don't let a dismissal (close icon, backdrop, Esc) close the drawer mid-save.
-    if (!visible && !this.saving()) {
+    if (!visible) {
+      // Flush any pending (debounced) change before closing so nothing is lost.
+      this.flush$.next();
       this.drawer.close();
     }
-  }
-
-  public onCancel(): void {
-    this.drawer.close();
-  }
-
-  public onSubmit(): void {
-    if (this.saving()) {
-      return;
-    }
-
-    const raw = this.visibilityForm.getRawValue();
-    const sections = PROFILE_VISIBILITY_KEYS.reduce((acc, key) => {
-      acc[key] = Boolean(raw[key]);
-      return acc;
-    }, {} as ProfileVisibilitySections);
-
-    const payload: ProfileVisibilityUpdateRequest = {
-      isPublic: Boolean(raw.isPublic),
-      sections,
-    };
-
-    this.saving.set(true);
-    this.userService
-      .updateProfileVisibility(payload)
-      .pipe(
-        takeUntilDestroyed(this.destroyRef),
-        finalize(() => this.saving.set(false))
-      )
-      .subscribe({
-        next: (visibility) => {
-          this.messageService.add({ severity: 'success', summary: 'Success', detail: 'Visibility settings updated successfully!' });
-          // Re-seed from the persisted response, resetting the pristine/changed baseline, then close.
-          this.seedForm(visibility);
-          this.drawer.close();
-        },
-        error: () => {
-          this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to update visibility settings. Please try again.' });
-        },
-      });
   }
 
   public async onCopyUrl(): Promise<void> {
@@ -177,9 +150,19 @@ export class ProfileVisibilityDrawerComponent {
     return this.fb.group(controls);
   }
 
+  /** Resolve the current form into the update payload the BFF persists (raw includes disabled keys). */
+  private buildPayload(): ProfileVisibilityUpdateRequest {
+    const raw = this.visibilityForm.getRawValue();
+    const sections = PROFILE_VISIBILITY_KEYS.reduce((acc, key) => {
+      acc[key] = Boolean(raw[key]);
+      return acc;
+    }, {} as ProfileVisibilitySections);
+    return { isPublic: Boolean(raw.isPublic), sections };
+  }
+
   /**
    * Seed the form from the fetched (or saved) visibility, or all-private defaults on load failure.
-   * Resets the pristine/changed baseline and aligns section-control enabled state to the flag.
+   * Clears the dirty flag (emitEvent:false, so it never re-triggers a save) and aligns enabled state.
    */
   private seedForm(visibility: ProfileVisibility | null): void {
     const isPublic = visibility?.isPublic ?? false;
@@ -195,13 +178,46 @@ export class ProfileVisibilityDrawerComponent {
     this.visibilityForm.patchValue(patch, { emitEvent: false });
     this.setSectionsEnabled(isPublic);
     this.isPublic.set(isPublic);
-    this.visibilityForm.markAsPristine();
-    this.hasChanges.set(false);
+    this.dirty = false;
+  }
+
+  /**
+   * Debounced auto-save: any user change marks the form dirty; a debounced tick (or the close-time
+   * flush) persists the resolved map. switchMap cancels an in-flight save when a newer change lands.
+   */
+  private wireAutoSave(): void {
+    this.visibilityForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      this.dirty = true;
+    });
+
+    merge(this.visibilityForm.valueChanges.pipe(debounceTime(this.autosaveDebounceMs)), this.flush$)
+      .pipe(
+        filter(() => this.dirty && !this.loadingVisibility()),
+        switchMap(() => {
+          this.dirty = false;
+          this.saveState.set('saving');
+          return this.userService.updateProfileVisibility(this.buildPayload()).pipe(
+            catchError(() => {
+              // Re-arm dirty so the next change (or a close flush) retries the failed save.
+              this.dirty = true;
+              this.saveState.set('error');
+              this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Failed to save visibility settings. Please try again.' });
+              return EMPTY;
+            })
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((visibility) => {
+        // Re-seed from the persisted response (syncs preferenceId) without re-triggering a save.
+        this.seedForm(visibility);
+        this.saveState.set('saved');
+      });
   }
 
   /**
    * Client-side cascade: master off zeroes+disables all sections, on enables them + the basic group;
-   * `basic`↔children mirror via OR. emitEvent:false writes avoid feedback loops.
+   * `basic`↔children mirror via OR. emitEvent:false writes avoid feedback loops (and extra saves).
    */
   private wireCascade(): void {
     const control = (key: string) => this.visibilityForm.get(key);
@@ -221,7 +237,6 @@ export class ProfileVisibilityDrawerComponent {
           }
           this.setSectionsEnabled(false);
         }
-        this.hasChanges.set(true);
       });
 
     control('basic')
@@ -229,7 +244,6 @@ export class ProfileVisibilityDrawerComponent {
       .subscribe((value: boolean) => {
         control('aboutMe')?.setValue(value, { emitEvent: false });
         control('personalInfo')?.setValue(value, { emitEvent: false });
-        this.hasChanges.set(true);
       });
 
     for (const childKey of ['aboutMe', 'personalInfo']) {
@@ -238,15 +252,7 @@ export class ProfileVisibilityDrawerComponent {
         .subscribe(() => {
           const anyChildOn = Boolean(control('aboutMe')?.value) || Boolean(control('personalInfo')?.value);
           control('basic')?.setValue(anyChildOn, { emitEvent: false });
-          this.hasChanges.set(true);
         });
-    }
-
-    // Any remaining (standalone) section toggle just marks the form as changed.
-    for (const section of this.activitySections) {
-      control(section.key)
-        ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
-        .subscribe(() => this.hasChanges.set(true));
     }
   }
 

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component.ts
@@ -210,8 +210,12 @@ export class ProfileVisibilityDrawerComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((visibility) => {
-        // Re-seed from the persisted response (syncs preferenceId) without re-triggering a save.
-        this.seedForm(visibility);
+        // Re-seed from the persisted response without re-triggering a save — but only when no newer
+        // edit landed while this save was in flight. If it did (dirty is true again), re-seeding would
+        // revert those edits and clear dirty, dropping the pending debounced save. Leave them to persist.
+        if (!this.dirty) {
+          this.seedForm(visibility);
+        }
         this.saveState.set('saved');
       });
   }

--- a/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.service.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.service.ts
@@ -1,0 +1,29 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { computed, Injectable, Signal, signal } from '@angular/core';
+
+/**
+ * Coordinates the public-profile visibility drawer (LFXV2-2629): callers pass the username via
+ * {@link open} for the public-URL row; the drawer fetches its own state lazily on open. Layout-scoped.
+ */
+@Injectable()
+export class ProfileVisibilityDrawerService {
+  private readonly _context = signal<string | null>(null);
+
+  /** The username the drawer opened for (drives the public-profile URL), or null when closed. */
+  public readonly context: Signal<string | null> = this._context.asReadonly();
+
+  /** True while the drawer is open. */
+  public readonly isOpen: Signal<boolean> = computed(() => this._context() !== null);
+
+  /** Open the drawer for the given username (may be empty when the username is unknown). */
+  public open(username: string): void {
+    this._context.set(username);
+  }
+
+  /** Close the drawer. */
+  public close(): void {
+    this._context.set(null);
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -22,6 +22,8 @@ import {
   PastMeeting,
   ProfileAuthStatus,
   ProfileUpdateRequest,
+  ProfileVisibility,
+  ProfileVisibilityUpdateRequest,
   SalesforceIdResponse,
   SendEmailVerificationResponse,
   User,
@@ -118,6 +120,23 @@ export class UserService {
    */
   public updateUserProfile(data: ProfileUpdateRequest): Observable<any> {
     return this.http.patch('/api/profile', data).pipe(take(1));
+  }
+
+  // Public-profile visibility methods (LFXV2-2629)
+
+  /**
+   * Resolve the current user's public-profile visibility: the master IsPublic flag and the
+   * section-level `visibility` preference map.
+   */
+  public getProfileVisibility(): Observable<ProfileVisibility> {
+    return this.http.get<ProfileVisibility>('/api/profile/visibility');
+  }
+
+  /**
+   * Update the current user's public-profile visibility (master flag + section map).
+   */
+  public updateProfileVisibility(data: ProfileVisibilityUpdateRequest): Observable<ProfileVisibility> {
+    return this.http.patch<ProfileVisibility>('/api/profile/visibility', data).pipe(take(1));
   }
 
   // Email management methods

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -25,6 +25,7 @@ import {
   LinuxAliasData,
   ProfileAuthStatus,
   ProfileUpdateRequest,
+  ProfileVisibilityUpdateRequest,
   UpdateForwardRequest,
   UserEmail,
   UserMetadata,
@@ -2035,6 +2036,52 @@ export class ProfileController {
 
       logger.success(req, 'verify_and_link_email', startTime, { email });
       res.json({ success: true, message: 'Email identity verified and linked successfully' });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/profile/visibility — resolve the current user's public-profile visibility (master
+   * IsPublic flag + section-level `visibility` preference).
+   */
+  public async getVisibility(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_profile_visibility');
+
+    try {
+      const visibility = await this.userService.getProfileVisibility(req);
+
+      logger.success(req, 'get_profile_visibility', startTime, { is_public: visibility.isPublic });
+      res.json(visibility);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * PATCH /api/profile/visibility — update the current user's public-profile visibility. Blocked
+   * during impersonation by route middleware.
+   */
+  public async updateVisibility(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'update_profile_visibility');
+
+    try {
+      const { isPublic, sections }: ProfileVisibilityUpdateRequest = req.body ?? {};
+
+      if (typeof isPublic !== 'boolean' || !sections || typeof sections !== 'object') {
+        return next(
+          ServiceValidationError.forField('body', 'isPublic (boolean) and sections (object) are required', {
+            operation: 'update_profile_visibility',
+            service: 'profile_controller',
+            path: req.path,
+          })
+        );
+      }
+
+      const visibility = await this.userService.updateProfileVisibility(req, { isPublic, sections });
+
+      logger.success(req, 'update_profile_visibility', startTime, { is_public: visibility.isPublic });
+      res.json(visibility);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -9,6 +9,7 @@ import {
   CDP_TO_AUTH0_PROVIDER_MAP,
   EMAIL_ALREADY_LINKED_MESSAGE,
   EMAIL_REGEX,
+  PROFILE_VISIBILITY_KEYS,
   PURCHASE_LINUX_URL,
 } from '@lfx-one/shared/constants';
 import {
@@ -2068,9 +2069,18 @@ export class ProfileController {
     try {
       const { isPublic, sections }: ProfileVisibilityUpdateRequest = req.body ?? {};
 
-      if (typeof isPublic !== 'boolean' || !sections || typeof sections !== 'object' || Array.isArray(sections)) {
+      // Require a fully-resolved map (the client always sends every key). A partial/empty map is
+      // malformed: silently zero-filling missing keys would erase settings the caller didn't intend
+      // to touch, so reject it here rather than fail closed to all-private downstream.
+      const sectionsResolved =
+        Boolean(sections) &&
+        typeof sections === 'object' &&
+        !Array.isArray(sections) &&
+        PROFILE_VISIBILITY_KEYS.every((key) => typeof (sections as Record<string, unknown>)[key] === 'boolean');
+
+      if (typeof isPublic !== 'boolean' || !sectionsResolved) {
         return next(
-          ServiceValidationError.forField('body', 'isPublic (boolean) and sections (object) are required', {
+          ServiceValidationError.forField('body', 'isPublic (boolean) and a fully-resolved sections map (every visibility key a boolean) are required', {
             operation: 'update_profile_visibility',
             service: 'profile_controller',
             path: req.path,

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -2068,7 +2068,7 @@ export class ProfileController {
     try {
       const { isPublic, sections }: ProfileVisibilityUpdateRequest = req.body ?? {};
 
-      if (typeof isPublic !== 'boolean' || !sections || typeof sections !== 'object') {
+      if (typeof isPublic !== 'boolean' || !sections || typeof sections !== 'object' || Array.isArray(sections)) {
         return next(
           ServiceValidationError.forField('body', 'isPublic (boolean) and sections (object) are required', {
             operation: 'update_profile_visibility',

--- a/apps/lfx-one/src/server/routes/profile.route.ts
+++ b/apps/lfx-one/src/server/routes/profile.route.ts
@@ -36,6 +36,14 @@ router.get('/', (req, res, next) => profileController.getCurrentUserProfile(req,
 // PATCH /api/profile - Update user metadata via NATS (replaces separate user and details endpoints)
 router.patch('/', blockDuringImpersonation, (req, res, next) => profileController.updateUserMetadata(req, res, next));
 
+// Public-profile visibility (LFXV2-2629) — master IsPublic flag + section-level `visibility` preference
+
+// GET /api/profile/visibility - Resolve the current user's public-profile visibility
+router.get('/visibility', (req, res, next) => profileController.getVisibility(req, res, next));
+
+// PATCH /api/profile/visibility - Update the current user's public-profile visibility
+router.patch('/visibility', blockDuringImpersonation, (req, res, next) => profileController.updateVisibility(req, res, next));
+
 // Email management routes (backed by auth-service via NATS)
 
 // GET /api/profile/emails - Get current user's email management data

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1082,10 +1082,8 @@ export class UserService {
 
     const baseUrl = getUserServiceBaseUrl('update_profile_visibility', 'user_service');
     const nextIsPublic = Boolean(body?.isPublic);
-    // Trust the client's resolved section map (sanitized to known keys). The basic group defaults on
-    // when a profile is made public, but that is a client-side cascade — users can then toggle
-    // General Profile Information / About Me / Personal Information off individually, mirroring
-    // myprofile, so the server persists exactly what it is sent.
+    // Trust the client's resolved section map (sanitized to known keys) — the basic-group cascade is
+    // client-side (myprofile-style), so the server persists exactly what it is sent.
     const sections = this.sanitizeVisibilitySections(body?.sections);
 
     if (nextIsPublic !== Boolean(profile.IsPublic)) {
@@ -1109,9 +1107,8 @@ export class UserService {
   }
 
   /**
-   * Writes the section `visibility` preference: PATCH when it already exists, else POST. A POST that
-   * races into a 409 (already created, or missed by the read) falls back to a fetch + PATCH so the
-   * auto-saving client stays idempotent.
+   * Writes the section `visibility` preference: PATCH when it exists, else POST; a POST that races into
+   * a 409 falls back to fetch + PATCH so the auto-saving client stays idempotent.
    */
   private async upsertVisibilityPreference(req: Request, sfid: string, existing: UserServicePreference | null, value: string): Promise<string | null> {
     if (existing) {
@@ -1161,9 +1158,8 @@ export class UserService {
    */
   private async fetchVisibilityPreference(req: Request, sfid: string, operation: string): Promise<UserServicePreference | null> {
     const baseUrl = getUserServiceBaseUrl(operation, 'user_service');
-    // Upstream $filter values are unquoted (`Name eq visibility`); quoting compares against the
-    // literal `'visibility'` and matches nothing. A failed filter returns everything, so the find below
-    // is the real guard — it also disambiguates by AppName (the upstream uniqueness key is AppName+Name).
+    // Upstream $filter values are unquoted (`Name eq visibility`) — quoting matches nothing. A failed
+    // filter returns everything, so the find below (by AppName+Name, the uniqueness key) is the real guard.
     const filter = encodeURIComponent(`Name eq ${VISIBILITY_PREFERENCE_NAME}`);
     const url = `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences?$filter=${filter}`;
 

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1214,7 +1214,9 @@ export class UserService {
 
     if (raw && typeof raw === 'object') {
       for (const key of PROFILE_VISIBILITY_KEYS) {
-        sections[key] = Boolean(raw[key]);
+        // Accept only strict booleans; any other value (a stringified "false", {}, …) falls back to
+        // the all-false default so a malformed payload fails closed rather than flipping a section on.
+        sections[key] = typeof raw[key] === 'boolean' ? (raw[key] as boolean) : sections[key];
       }
     }
 

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -7,8 +7,12 @@ import {
   NATS_CONFIG,
   PENDING_ACTION_SEVERITY,
   PROFILE_BIO_MAX_LENGTH,
+  PROFILE_VISIBILITY_DEFAULTS,
+  PROFILE_VISIBILITY_KEYS,
   QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
   TSHIRT_SIZES,
+  VISIBILITY_PREFERENCE_APP_NAME,
+  VISIBILITY_PREFERENCE_NAME,
 } from '@lfx-one/shared/constants';
 import { IndexedVoteResponseStatus, NatsSubjects, PollStatus } from '@lfx-one/shared/enums';
 import {
@@ -25,6 +29,9 @@ import {
   PastMeetingParticipant,
   PendingActionItem,
   PendingInvitation,
+  ProfileVisibility,
+  ProfileVisibilitySections,
+  ProfileVisibilityUpdateRequest,
   QueryServiceResponse,
   UserCodeCommitsResponse,
   UserCodeCommitsRow,
@@ -33,6 +40,8 @@ import {
   UserMetadataUpdateResponse,
   UserPullRequestsResponse,
   UserPullRequestsRow,
+  UserServicePreference,
+  UserServicePreferenceList,
   Vote,
 } from '@lfx-one/shared/interfaces';
 import {
@@ -47,6 +56,8 @@ import {
 import { Request } from 'express';
 
 import { MicroserviceError, ResourceNotFoundError } from '../errors';
+import { getUserServiceBaseUrl } from '../helpers/api-gateway.helper';
+import { gatewayFetch } from '../helpers/gateway-fetch.helper';
 import { enrichMeetingsWithCreatedBy } from '../helpers/meeting.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
@@ -1028,6 +1039,157 @@ export class UserService {
     logger.debug(req, 'get_api_gateway_profile', 'API Gateway profile received', { salesforce_id: Boolean(profile.ID) });
 
     return profile;
+  }
+
+  /**
+   * Reads the master `IsPublic` flag (from the API Gateway profile) plus the section `visibility`
+   * preference. Missing/unknown keys fail closed to defaults; `preferenceId` is null until first save.
+   */
+  public async getProfileVisibility(req: Request): Promise<ProfileVisibility> {
+    const profile = await this.getApiGatewayProfile(req);
+    const sfid = profile.ID;
+
+    if (!sfid) {
+      throw new MicroserviceError('User Salesforce ID not available', 502, 'API_GATEWAY_INVALID_RESPONSE', {
+        operation: 'get_profile_visibility',
+        service: 'user_service',
+      });
+    }
+
+    const pref = await this.fetchVisibilityPreference(req, sfid, 'get_profile_visibility');
+
+    return {
+      isPublic: Boolean(profile.IsPublic),
+      sections: this.parseVisibilitySections(pref?.Value),
+      preferenceId: pref?.ID ?? null,
+    };
+  }
+
+  /**
+   * Updates visibility: patches `IsPublic` only when changed, then upserts the section `visibility`
+   * preference. The client sends the resolved map (cascade is client-side); the server sanitizes it.
+   */
+  public async updateProfileVisibility(req: Request, body: ProfileVisibilityUpdateRequest): Promise<ProfileVisibility> {
+    const profile = await this.getApiGatewayProfile(req);
+    const sfid = profile.ID;
+
+    if (!sfid) {
+      throw new MicroserviceError('User Salesforce ID not available', 502, 'API_GATEWAY_INVALID_RESPONSE', {
+        operation: 'update_profile_visibility',
+        service: 'user_service',
+      });
+    }
+
+    const baseUrl = getUserServiceBaseUrl('update_profile_visibility', 'user_service');
+    const sections = this.sanitizeVisibilitySections(body?.sections);
+    const nextIsPublic = Boolean(body?.isPublic);
+
+    if (nextIsPublic !== Boolean(profile.IsPublic)) {
+      logger.debug(req, 'update_profile_visibility', 'Updating IsPublic flag', { is_public: nextIsPublic });
+      await gatewayFetch<unknown>(req, `${baseUrl}/me`, {
+        operation: 'update_profile_visibility',
+        service: 'user_service',
+        errorMessage: 'Profile public flag update failed',
+        errorCode: 'PROFILE_ISPUBLIC_UPDATE_FAILED',
+        method: 'PATCH',
+        body: { IsPublic: nextIsPublic, AccountID: profile.Account?.ID },
+      });
+    }
+
+    // Read-first upsert: only the preference's Value changes; AppName/Name/Type/System are preserved.
+    const existing = await this.fetchVisibilityPreference(req, sfid, 'update_profile_visibility');
+    const value = JSON.stringify(sections);
+    let preferenceId = existing?.ID ?? null;
+
+    if (existing) {
+      await gatewayFetch<unknown>(req, `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences/${encodeURIComponent(existing.ID)}`, {
+        operation: 'update_profile_visibility',
+        service: 'user_service',
+        errorMessage: 'Visibility preference update failed',
+        errorCode: 'VISIBILITY_PREFERENCE_UPDATE_FAILED',
+        method: 'PATCH',
+        body: { AppName: existing.AppName, Name: existing.Name, Type: existing.Type, System: existing.System, Value: value },
+      });
+    } else {
+      const created = await gatewayFetch<UserServicePreference>(req, `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences`, {
+        operation: 'update_profile_visibility',
+        service: 'user_service',
+        errorMessage: 'Visibility preference creation failed',
+        errorCode: 'VISIBILITY_PREFERENCE_CREATE_FAILED',
+        method: 'POST',
+        body: { AppName: VISIBILITY_PREFERENCE_APP_NAME, Name: VISIBILITY_PREFERENCE_NAME, Type: 'json', System: false, Value: value },
+      });
+      preferenceId = created?.ID ?? null;
+    }
+
+    return { isPublic: nextIsPublic, sections, preferenceId };
+  }
+
+  /**
+   * Fetches the user's `visibility` preference record, or null when none exists. Filters by name
+   * upstream and defensively re-checks the name on the returned rows.
+   */
+  private async fetchVisibilityPreference(req: Request, sfid: string, operation: string): Promise<UserServicePreference | null> {
+    const baseUrl = getUserServiceBaseUrl(operation, 'user_service');
+    const filter = encodeURIComponent(`Name eq '${VISIBILITY_PREFERENCE_NAME}'`);
+    const url = `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences?$filter=${filter}`;
+
+    logger.debug(req, operation, 'Fetching visibility preference');
+
+    const list = await gatewayFetch<UserServicePreferenceList>(req, url, {
+      operation,
+      service: 'user_service',
+      errorMessage: 'Visibility preference fetch failed',
+      errorCode: 'VISIBILITY_PREFERENCE_FETCH_FAILED',
+    });
+
+    return list?.Data?.find((p) => p.Name === VISIBILITY_PREFERENCE_NAME) ?? null;
+  }
+
+  /**
+   * Parses the stored preference `Value` (stringified JSON boolean map) into a full section map,
+   * merged over the all-false defaults. A missing or malformed value fails closed to defaults.
+   */
+  private parseVisibilitySections(rawValue: string | undefined): ProfileVisibilitySections {
+    const sections: ProfileVisibilitySections = { ...PROFILE_VISIBILITY_DEFAULTS };
+
+    if (!rawValue) {
+      return sections;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(rawValue);
+    } catch {
+      return sections;
+    }
+
+    if (parsed && typeof parsed === 'object') {
+      const map = parsed as Record<string, unknown>;
+      for (const key of PROFILE_VISIBILITY_KEYS) {
+        if (typeof map[key] === 'boolean') {
+          sections[key] = map[key] as boolean;
+        }
+      }
+    }
+
+    return sections;
+  }
+
+  /**
+   * Coerces a client-supplied section map to the known keys as strict booleans, filling any missing
+   * key from the all-false defaults. Unknown keys are dropped.
+   */
+  private sanitizeVisibilitySections(raw: Partial<ProfileVisibilitySections> | undefined): ProfileVisibilitySections {
+    const sections: ProfileVisibilitySections = { ...PROFILE_VISIBILITY_DEFAULTS };
+
+    if (raw && typeof raw === 'object') {
+      for (const key of PROFILE_VISIBILITY_KEYS) {
+        sections[key] = Boolean(raw[key]);
+      }
+    }
+
+    return sections;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1081,12 +1081,16 @@ export class UserService {
     }
 
     const baseUrl = getUserServiceBaseUrl('update_profile_visibility', 'user_service');
+    const currentIsPublic = Boolean(profile.IsPublic);
     const nextIsPublic = Boolean(body?.isPublic);
+    const isPublicChanged = nextIsPublic !== currentIsPublic;
+    const becomingPublic = nextIsPublic && !currentIsPublic;
     // Trust the client's resolved section map (sanitized to known keys) — the basic-group cascade is
     // client-side (myprofile-style), so the server persists exactly what it is sent.
     const sections = this.sanitizeVisibilitySections(body?.sections);
+    const value = JSON.stringify(sections);
 
-    if (nextIsPublic !== Boolean(profile.IsPublic)) {
+    const applyIsPublic = async (): Promise<void> => {
       logger.debug(req, 'update_profile_visibility', 'Updating IsPublic flag', { is_public: nextIsPublic });
       await gatewayFetch<unknown>(req, `${baseUrl}/me`, {
         operation: 'update_profile_visibility',
@@ -1096,12 +1100,29 @@ export class UserService {
         method: 'PATCH',
         body: { IsPublic: nextIsPublic, AccountID: profile.Account?.ID },
       });
-    }
+    };
 
     // Read-first upsert: only the preference's Value changes; AppName/Name/Type/System are preserved.
-    const existing = await this.fetchVisibilityPreference(req, sfid, 'update_profile_visibility');
-    const value = JSON.stringify(sections);
-    const preferenceId = await this.upsertVisibilityPreference(req, sfid, existing, value);
+    const applySections = async (): Promise<string | null> => {
+      const existing = await this.fetchVisibilityPreference(req, sfid, 'update_profile_visibility');
+      return this.upsertVisibilityPreference(req, sfid, existing, value);
+    };
+
+    // Order the two upstream writes so a partial failure never leaves sections exposed:
+    // - becoming public: persist the section map BEFORE opening the gate, so a failed section write
+    //   leaves the profile private (no unintended sections in a regenerated artifact).
+    // - becoming private (or unchanged): flip/keep the gate first (hide-first), then persist sections,
+    //   so a failed section write leaves the profile already hidden.
+    let preferenceId: string | null;
+    if (becomingPublic) {
+      preferenceId = await applySections();
+      await applyIsPublic();
+    } else {
+      if (isPublicChanged) {
+        await applyIsPublic();
+      }
+      preferenceId = await applySections();
+    }
 
     return { isPublic: nextIsPublic, sections, preferenceId };
   }

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1099,18 +1099,23 @@ export class UserService {
     // Read-first upsert: only the preference's Value changes; AppName/Name/Type/System are preserved.
     const existing = await this.fetchVisibilityPreference(req, sfid, 'update_profile_visibility');
     const value = JSON.stringify(sections);
-    let preferenceId = existing?.ID ?? null;
+    const preferenceId = await this.upsertVisibilityPreference(req, sfid, existing, value);
 
+    return { isPublic: nextIsPublic, sections, preferenceId };
+  }
+
+  /**
+   * Writes the section `visibility` preference: PATCH when it already exists, else POST. A POST that
+   * races into a 409 (already created, or missed by the read) falls back to a fetch + PATCH so the
+   * auto-saving client stays idempotent.
+   */
+  private async upsertVisibilityPreference(req: Request, sfid: string, existing: UserServicePreference | null, value: string): Promise<string | null> {
     if (existing) {
-      await gatewayFetch<unknown>(req, `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences/${encodeURIComponent(existing.ID)}`, {
-        operation: 'update_profile_visibility',
-        service: 'user_service',
-        errorMessage: 'Visibility preference update failed',
-        errorCode: 'VISIBILITY_PREFERENCE_UPDATE_FAILED',
-        method: 'PATCH',
-        body: { AppName: existing.AppName, Name: existing.Name, Type: existing.Type, System: existing.System, Value: value },
-      });
-    } else {
+      return this.patchVisibilityPreference(req, sfid, existing, value);
+    }
+
+    const baseUrl = getUserServiceBaseUrl('update_profile_visibility', 'user_service');
+    try {
       const created = await gatewayFetch<UserServicePreference>(req, `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences`, {
         operation: 'update_profile_visibility',
         service: 'user_service',
@@ -1119,10 +1124,31 @@ export class UserService {
         method: 'POST',
         body: { AppName: VISIBILITY_PREFERENCE_APP_NAME, Name: VISIBILITY_PREFERENCE_NAME, Type: 'json', System: false, Value: value },
       });
-      preferenceId = created?.ID ?? null;
+      return created?.ID ?? null;
+    } catch (error) {
+      if (error instanceof MicroserviceError && error.statusCode === 409) {
+        logger.warning(req, 'update_profile_visibility', 'Visibility preference already exists; falling back to update', {});
+        const current = await this.fetchVisibilityPreference(req, sfid, 'update_profile_visibility');
+        if (current) {
+          return this.patchVisibilityPreference(req, sfid, current, value);
+        }
+      }
+      throw error;
     }
+  }
 
-    return { isPublic: nextIsPublic, sections, preferenceId };
+  /** PATCH an existing `visibility` preference's `Value`, preserving AppName/Name/Type/System. */
+  private async patchVisibilityPreference(req: Request, sfid: string, existing: UserServicePreference, value: string): Promise<string> {
+    const baseUrl = getUserServiceBaseUrl('update_profile_visibility', 'user_service');
+    await gatewayFetch<unknown>(req, `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences/${encodeURIComponent(existing.ID)}`, {
+      operation: 'update_profile_visibility',
+      service: 'user_service',
+      errorMessage: 'Visibility preference update failed',
+      errorCode: 'VISIBILITY_PREFERENCE_UPDATE_FAILED',
+      method: 'PATCH',
+      body: { AppName: existing.AppName, Name: existing.Name, Type: existing.Type, System: existing.System, Value: value },
+    });
+    return existing.ID;
   }
 
   /**
@@ -1131,7 +1157,10 @@ export class UserService {
    */
   private async fetchVisibilityPreference(req: Request, sfid: string, operation: string): Promise<UserServicePreference | null> {
     const baseUrl = getUserServiceBaseUrl(operation, 'user_service');
-    const filter = encodeURIComponent(`Name eq '${VISIBILITY_PREFERENCE_NAME}'`);
+    // Upstream $filter values are unquoted (`Name eq visibility`); quoting compares against the
+    // literal `'visibility'` and matches nothing. A failed filter returns everything, so the find below
+    // is the real guard — it also disambiguates by AppName (the upstream uniqueness key is AppName+Name).
+    const filter = encodeURIComponent(`Name eq ${VISIBILITY_PREFERENCE_NAME}`);
     const url = `${baseUrl}/users/${encodeURIComponent(sfid)}/preferences?$filter=${filter}`;
 
     logger.debug(req, operation, 'Fetching visibility preference');
@@ -1143,7 +1172,7 @@ export class UserService {
       errorCode: 'VISIBILITY_PREFERENCE_FETCH_FAILED',
     });
 
-    return list?.Data?.find((p) => p.Name === VISIBILITY_PREFERENCE_NAME) ?? null;
+    return list?.Data?.find((p) => p.Name === VISIBILITY_PREFERENCE_NAME && p.AppName === VISIBILITY_PREFERENCE_APP_NAME) ?? null;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -9,6 +9,7 @@ import {
   PROFILE_BIO_MAX_LENGTH,
   PROFILE_VISIBILITY_DEFAULTS,
   PROFILE_VISIBILITY_KEYS,
+  PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS,
   QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
   TSHIRT_SIZES,
   VISIBILITY_PREFERENCE_APP_NAME,
@@ -1081,8 +1082,10 @@ export class UserService {
     }
 
     const baseUrl = getUserServiceBaseUrl('update_profile_visibility', 'user_service');
-    const sections = this.sanitizeVisibilitySections(body?.sections);
     const nextIsPublic = Boolean(body?.isPublic);
+    // A public profile always exposes the basic group (General Profile Information / About Me /
+    // Personal Information). Enforce that server-side so it holds regardless of what the client sends.
+    const sections = this.enforcePublicDefaults(this.sanitizeVisibilitySections(body?.sections), nextIsPublic);
 
     if (nextIsPublic !== Boolean(profile.IsPublic)) {
       logger.debug(req, 'update_profile_visibility', 'Updating IsPublic flag', { is_public: nextIsPublic });
@@ -1219,6 +1222,24 @@ export class UserService {
     }
 
     return sections;
+  }
+
+  /**
+   * When the profile is public, force the basic group (`basic` / `aboutMe` / `personalInfo`) on — a
+   * public profile always exposes General Profile Information, About Me, and Personal Information.
+   * A private profile is left untouched (its section map is otherwise unexposed).
+   */
+  private enforcePublicDefaults(sections: ProfileVisibilitySections, isPublic: boolean): ProfileVisibilitySections {
+    if (!isPublic) {
+      return sections;
+    }
+
+    const enforced = { ...sections };
+    for (const key of PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS) {
+      enforced[key] = true;
+    }
+
+    return enforced;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -9,7 +9,6 @@ import {
   PROFILE_BIO_MAX_LENGTH,
   PROFILE_VISIBILITY_DEFAULTS,
   PROFILE_VISIBILITY_KEYS,
-  PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS,
   QUERY_SERVICE_FILTERS_OR_BATCH_SIZE,
   TSHIRT_SIZES,
   VISIBILITY_PREFERENCE_APP_NAME,
@@ -1083,9 +1082,11 @@ export class UserService {
 
     const baseUrl = getUserServiceBaseUrl('update_profile_visibility', 'user_service');
     const nextIsPublic = Boolean(body?.isPublic);
-    // A public profile always exposes the basic group (General Profile Information / About Me /
-    // Personal Information). Enforce that server-side so it holds regardless of what the client sends.
-    const sections = this.enforcePublicDefaults(this.sanitizeVisibilitySections(body?.sections), nextIsPublic);
+    // Trust the client's resolved section map (sanitized to known keys). The basic group defaults on
+    // when a profile is made public, but that is a client-side cascade — users can then toggle
+    // General Profile Information / About Me / Personal Information off individually, mirroring
+    // myprofile, so the server persists exactly what it is sent.
+    const sections = this.sanitizeVisibilitySections(body?.sections);
 
     if (nextIsPublic !== Boolean(profile.IsPublic)) {
       logger.debug(req, 'update_profile_visibility', 'Updating IsPublic flag', { is_public: nextIsPublic });
@@ -1222,24 +1223,6 @@ export class UserService {
     }
 
     return sections;
-  }
-
-  /**
-   * When the profile is public, force the basic group (`basic` / `aboutMe` / `personalInfo`) on — a
-   * public profile always exposes General Profile Information, About Me, and Personal Information.
-   * A private profile is left untouched (its section map is otherwise unexposed).
-   */
-  private enforcePublicDefaults(sections: ProfileVisibilitySections, isPublic: boolean): ProfileVisibilitySections {
-    if (!isPublic) {
-      return sections;
-    }
-
-    const enforced = { ...sections };
-    for (const key of PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS) {
-      enforced[key] = true;
-    }
-
-    return enforced;
   }
 
   /**

--- a/apps/lfx-one/src/styles.scss
+++ b/apps/lfx-one/src/styles.scss
@@ -387,11 +387,8 @@ html {
   white-space: normal !important;
 }
 
-// Public-profile visibility drawer — Private/Public master control. The drawer appends its content
-// to <body> (PrimeNG default appendTo="body"), so component-scoped styles never reach the select
-// button; it must be styled globally via its wrapper data-testid. Render it as one segmented pill:
-// a single rounded track holding both options, with the selected option as an inset white chip
-// (matching the redesign) rather than two separate pills.
+// Public-profile visibility drawer Private/Public master control. PrimeNG appends the drawer to <body>,
+// so the select button is styled globally via its wrapper data-testid as one segmented pill.
 [data-testid='profile-visibility-drawer-mode'] .p-selectbutton {
   @apply gap-0 rounded-full border border-slate-200 bg-slate-100 p-0.5;
 }

--- a/apps/lfx-one/src/styles.scss
+++ b/apps/lfx-one/src/styles.scss
@@ -386,3 +386,25 @@ html {
   max-width: 100% !important;
   white-space: normal !important;
 }
+
+// Public-profile visibility drawer — Private/Public master control. The drawer appends its content
+// to <body> (PrimeNG default appendTo="body"), so component-scoped styles never reach the select
+// button; it must be styled globally via its wrapper data-testid. Render it as one segmented pill:
+// a single rounded track holding both options, with the selected option as an inset white chip
+// (matching the redesign) rather than two separate pills.
+[data-testid='profile-visibility-drawer-mode'] .p-selectbutton {
+  @apply gap-0 rounded-full border border-slate-200 bg-slate-100 p-0.5;
+}
+
+[data-testid='profile-visibility-drawer-mode'] .p-togglebutton {
+  @apply rounded-full border-0 bg-transparent;
+}
+
+[data-testid='profile-visibility-drawer-mode'] .p-togglebutton .p-togglebutton-content {
+  @apply rounded-full;
+}
+
+// Selected option — the inset white chip.
+[data-testid='profile-visibility-drawer-mode'] .p-togglebutton.p-togglebutton-checked {
+  @apply bg-white shadow-sm;
+}

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -92,3 +92,4 @@ export * from './writer-grants.constants';
 export * from './http-retry.constants';
 export * from './committee-engagement.constants';
 export * from './weekly-brief.constants';
+export * from './profile-visibility.constants';

--- a/packages/shared/src/constants/profile-visibility.constants.ts
+++ b/packages/shared/src/constants/profile-visibility.constants.ts
@@ -1,0 +1,81 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Section-level public-profile visibility, mirroring the myprofile "visibility" preference
+// (`Name='visibility'`, `Type='json'`). Each key gates one public-profile section. See LFXV2-2629.
+
+/**
+ * Ordered visibility keys — drawer render order (`basic` parent, then its children, then activity
+ * sections). Declared `as const` so the union type can be derived from it.
+ */
+export const PROFILE_VISIBILITY_KEYS = [
+  'basic',
+  'aboutMe',
+  'personalInfo',
+  'technical_contribution',
+  'community_roles',
+  'event_activities',
+  'training_activities',
+  'certification_activities',
+  'badges',
+  'skills',
+] as const;
+
+/**
+ * Parent → children map for the drawer cascade: `basic` mirrors to its children; a child recomputes
+ * `basic` as the OR of its children. One source of truth for client and any future server logic.
+ */
+export const PROFILE_VISIBILITY_CASCADE: Readonly<Record<string, readonly string[]>> = {
+  basic: ['aboutMe', 'personalInfo'],
+};
+
+/**
+ * Sections enabled when a profile is switched to public (the `basic` group), matching myprofile's
+ * `updatePreferenceOnUpdateIsPublic`. Making a profile private zeroes everything.
+ */
+export const PROFILE_VISIBILITY_PUBLIC_DEFAULT_KEYS = ['basic', 'aboutMe', 'personalInfo'] as const;
+
+/**
+ * All-false default map: the merge target when parsing the stored preference (so missing keys never
+ * leak) and the reset target when a profile is made private. Fails closed — absent means hidden.
+ */
+export const PROFILE_VISIBILITY_DEFAULTS: Readonly<Record<(typeof PROFILE_VISIBILITY_KEYS)[number], boolean>> = {
+  basic: false,
+  aboutMe: false,
+  personalInfo: false,
+  technical_contribution: false,
+  community_roles: false,
+  event_activities: false,
+  training_activities: false,
+  certification_activities: false,
+  badges: false,
+  skills: false,
+};
+
+/**
+ * Per-key UI metadata for the drawer (label + helper description). `parent` marks a child section so
+ * the drawer indents it under `basic`. Labels follow the PublicProfile redesign "Sections" tab.
+ */
+export const PROFILE_VISIBILITY_SECTIONS: readonly {
+  key: (typeof PROFILE_VISIBILITY_KEYS)[number];
+  name: string;
+  description: string;
+  parent?: (typeof PROFILE_VISIBILITY_KEYS)[number];
+}[] = [
+  { key: 'basic', name: 'General profile information', description: 'Name, title, affiliation, and avatar shown on your public profile.' },
+  { key: 'aboutMe', name: 'About me', description: 'Your long-form bio.', parent: 'basic' },
+  { key: 'personalInfo', name: 'Personal information', description: 'Location and other personal details.', parent: 'basic' },
+  { key: 'technical_contribution', name: 'Project contributions', description: 'Commits, pull requests, and issues across projects.' },
+  { key: 'community_roles', name: 'Committees & groups', description: 'Committee and group memberships and roles.' },
+  { key: 'event_activities', name: 'Event speaking', description: 'Talks and sessions you have presented at events.' },
+  { key: 'training_activities', name: 'Training enrollment', description: 'Training programs you have enrolled in or completed.' },
+  { key: 'certification_activities', name: 'Certifications', description: 'Certifications you have earned.' },
+  { key: 'badges', name: 'Badges', description: 'Credentialing badges earned across projects.' },
+  { key: 'skills', name: 'Skills', description: 'Skills listed on your profile.' },
+];
+
+/** user-service preference `Name` for the section-visibility map. The S3 pipeline matches on this. */
+export const VISIBILITY_PREFERENCE_NAME = 'visibility';
+
+/** user-service preference `AppName`. Preserved from myprofile so the existing pipeline keeps matching. */
+export const VISIBILITY_PREFERENCE_APP_NAME = 'myprofile';

--- a/packages/shared/src/constants/profile-visibility.constants.ts
+++ b/packages/shared/src/constants/profile-visibility.constants.ts
@@ -74,6 +74,15 @@ export const PROFILE_VISIBILITY_SECTIONS: readonly {
   { key: 'skills', name: 'Skills', description: 'Skills listed on your profile.' },
 ];
 
+/**
+ * Segmented Private/Public options for the drawer's master-flag control. `value` is the boolean the
+ * `isPublic` form control binds to (false = Private, true = Public).
+ */
+export const PROFILE_VISIBILITY_MODE_OPTIONS: readonly { label: string; value: boolean }[] = [
+  { label: 'Private', value: false },
+  { label: 'Public', value: true },
+];
+
 /** user-service preference `Name` for the section-visibility map. The S3 pipeline matches on this. */
 export const VISIBILITY_PREFERENCE_NAME = 'visibility';
 

--- a/packages/shared/src/constants/profile-visibility.constants.ts
+++ b/packages/shared/src/constants/profile-visibility.constants.ts
@@ -22,14 +22,6 @@ export const PROFILE_VISIBILITY_KEYS = [
 ] as const;
 
 /**
- * Parent → children map for the drawer cascade: `basic` mirrors to its children; a child recomputes
- * `basic` as the OR of its children. One source of truth for client and any future server logic.
- */
-export const PROFILE_VISIBILITY_CASCADE: Readonly<Record<string, readonly string[]>> = {
-  basic: ['aboutMe', 'personalInfo'],
-};
-
-/**
  * Sections enabled when a profile is switched to public (the `basic` group), matching myprofile's
  * `updatePreferenceOnUpdateIsPublic`. Making a profile private zeroes everything.
  */

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -307,3 +307,6 @@ export * from './committee-engagement.internal.interface';
 
 // Weekly Brief interfaces
 export * from './weekly-brief.interface';
+
+// Public-profile section visibility (LFXV2-2629)
+export * from './profile-visibility.interface';

--- a/packages/shared/src/interfaces/profile-visibility.interface.ts
+++ b/packages/shared/src/interfaces/profile-visibility.interface.ts
@@ -25,6 +25,9 @@ export interface ProfileVisibilityUpdateRequest {
   sections: ProfileVisibilitySections;
 }
 
+/** Drawer auto-save status, driving the inline "Saving… / Saved" indicator (no explicit Save button). */
+export type ProfileVisibilitySaveState = 'idle' | 'saving' | 'saved' | 'error';
+
 /**
  * A single user-service preference record. PascalCase matches the upstream `preferences` contract
  * (casing must be preserved). `Value` is a string — for `Type: 'json'` it holds stringified JSON.

--- a/packages/shared/src/interfaces/profile-visibility.interface.ts
+++ b/packages/shared/src/interfaces/profile-visibility.interface.ts
@@ -1,0 +1,45 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PROFILE_VISIBILITY_KEYS } from '../constants/profile-visibility.constants';
+
+/** One section-visibility key (e.g. `'basic'`, `'badges'`). Derived from the ordered key list. */
+export type ProfileVisibilityKey = (typeof PROFILE_VISIBILITY_KEYS)[number];
+
+/** Boolean map over every section key — `true` means the section is exposed on the public profile. */
+export type ProfileVisibilitySections = Record<ProfileVisibilityKey, boolean>;
+
+/**
+ * Resolved public-profile visibility (from `GET /api/profile/visibility`): the master `isPublic`
+ * flag, the merged `sections` map, and `preferenceId` (`null` until the first save creates it).
+ */
+export interface ProfileVisibility {
+  isPublic: boolean;
+  sections: ProfileVisibilitySections;
+  preferenceId: string | null;
+}
+
+/** Request body for `PATCH /api/profile/visibility`. The client sends the fully resolved state. */
+export interface ProfileVisibilityUpdateRequest {
+  isPublic: boolean;
+  sections: ProfileVisibilitySections;
+}
+
+/**
+ * A single user-service preference record. PascalCase matches the upstream `preferences` contract
+ * (casing must be preserved). `Value` is a string — for `Type: 'json'` it holds stringified JSON.
+ */
+export interface UserServicePreference {
+  ID: string;
+  AppName: string;
+  Name: string;
+  Description?: string;
+  System: boolean;
+  Type: 'text' | 'json' | 'integer';
+  Value: string;
+}
+
+/** List envelope returned by `GET /user-service/v1/users/{id}/preferences`. */
+export interface UserServicePreferenceList {
+  Data: UserServicePreference[];
+}


### PR DESCRIPTION
## Summary

- Add a right-side **Public Profile settings** drawer (LFXV2-2629) letting a
  user control whether their contributor profile is public and which sections
  it exposes, ported from the myprofile app into the Self-serve profile hub.
- Master **Private/Public** flag persists to the user-service `IsPublic` flag
  (`PATCH /me`); per-section toggles persist to the `visibility` preference
  (`GET/POST/PATCH /users/{sfid}/preferences`) via new BFF endpoints
  `GET`/`PATCH /api/profile/visibility`.
- Section toggles are split across two tabs: **Sections** (project
  contributions, committees & groups, event speaking, training,
  certifications, badges, skills) and **Personal Data** (General profile
  information, with About me / Personal information nested beneath it).
- The Personal Data group cascades like myprofile: toggling the parent mirrors
  to both children, and toggling either child ORs back into the parent.
- Making a profile public defaults the basic group on (client-side); users can
  then toggle any section off. The server persists the resolved section map
  as-is. Making a profile private zeroes every section.
- Changes **auto-save** (debounced, flushed on close) with an inline
  saving/saved/error indicator — no explicit Save button.
- Public-profile link row with copy + open affordances (SSR-guarded), shown
  only when the profile is public and the username is known.

Fixes LFXV2-2629
