### PR TITLE
feat(org-lens): add ROI metrics portfolio summary (LFXV2-2980)

### DIFF
--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -1,0 +1,358 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+const ORG_ROI_URL = '/org/roi';
+const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+
+test.setTimeout(120_000);
+
+function fulfillJson(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Let malformed URLs fail naturally.
+  }
+}
+
+async function seedSelectedOrgCookie(page: Page): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: 'lfx-selected-account',
+      value: JSON.stringify({ uid: MOCK_ACCOUNT_ID }),
+      domain: 'localhost',
+      path: '/',
+    },
+  ]);
+}
+
+// Only the year still in progress is labelled partial, so the trend fixtures are anchored to the
+// current year rather than hardcoded — otherwise these assertions would quietly invert next January.
+const CURRENT_YEAR = new Date().getFullYear();
+
+const MOCK_SUMMARY = {
+  orgUid: MOCK_ACCOUNT_ID,
+  method: 'logit',
+  hasData: true,
+  nProjects: 407,
+  totalExpenditure: 147932363.97,
+  totalReturn: 5576366821.32,
+  profit: 5428434457.35,
+  roi: 36.695,
+  bcr: 37.695,
+  yearMin: 2010,
+  yearMax: CURRENT_YEAR,
+  dateMin: '2010-01',
+  dateMax: `${CURRENT_YEAR}-08`,
+};
+
+const MOCK_COVERAGE = { orgUid: MOCK_ACCOUNT_ID, hasData: true, coverageReason: 'covered' };
+
+function annualRow(year: number, totalReturn: number, expenditure: number): unknown {
+  return { year, totalReturn, expenditure, profit: totalReturn - expenditure, roi: 36.5, bcr: 37.5 };
+}
+
+const MOCK_ANNUAL = {
+  method: 'logit',
+  rows: [
+    annualRow(CURRENT_YEAR - 2, 1_200_000_000, 32_000_000),
+    annualRow(CURRENT_YEAR - 1, 1_400_000_000, 38_000_000),
+    annualRow(CURRENT_YEAR, 620_000_000, 17_000_000),
+  ],
+  apportioned: true,
+};
+
+async function stubOrgLensContext(page: Page, options: { hasAccess?: boolean; summary?: unknown; coverage?: unknown; annual?: unknown } = {}): Promise<void> {
+  const hasAccess = options.hasAccess ?? true;
+
+  await page.route('**/api/orgs/*/lens/roi/summary*', (route) => fulfillJson(route, options.summary ?? MOCK_SUMMARY));
+  await page.route('**/api/orgs/*/lens/roi/coverage*', (route) => fulfillJson(route, options.coverage ?? MOCK_COVERAGE));
+  await page.route('**/api/orgs/*/lens/roi/annual*', (route) => fulfillJson(route, options.annual ?? MOCK_ANNUAL));
+
+  await page.route('**/api/user/personas*', (route) =>
+    fulfillJson(route, {
+      personas: ['contributor'],
+      personaProjects: {},
+      projects: [],
+      organizations: hasAccess
+        ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: '', uid: MOCK_ACCOUNT_ID }]
+        : [],
+      isRootWriter: false,
+    })
+  );
+
+  await page.route('**/api/analytics/org-lens-account-context*', (route) =>
+    fulfillJson(route, hasAccess ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: 'Gold' }] : [])
+  );
+
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    fulfillJson(route, {
+      writers: hasAccess ? [MOCK_ACCOUNT_ID] : [],
+      auditors: [],
+      cascadingWriters: [],
+      cascadingAuditors: [],
+      username: 'e2e-org-roi',
+      loaded_at: new Date().toISOString(),
+    })
+  );
+
+  await page.route('**/api/nav/org-items*', (route) =>
+    fulfillJson(route, {
+      items: hasAccess
+        ? [{ uid: MOCK_ACCOUNT_ID, accountId: MOCK_ACCOUNT_ID, name: 'Red Hat, Inc.', logoUrl: null, primaryDomain: 'redhat.com', isMember: true }]
+        : [],
+      next_page_token: null,
+      upstream_failed: false,
+      total: hasAccess ? 1 : 0,
+    })
+  );
+}
+
+async function gotoOrgRoiPage(page: Page): Promise<void> {
+  await seedSelectedOrgCookie(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.goto(ORG_ROI_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  if (!page.url().includes('/org/roi')) {
+    test.skip(true, 'org-lens-roi-enabled flag appears off — /org/roi redirected away');
+  }
+}
+
+test.describe('Org Lens ROI Metrics — portfolio summary', () => {
+  test('renders the page shell and the four headline figures', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-page')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'ROI Metrics' })).toBeVisible();
+    await expect(page.getByTestId('org-roi-window')).toContainText('2010–2026');
+
+    const kpi = page.getByTestId('org-roi-kpi-cards');
+    await expect(kpi).toBeVisible();
+    await expect(kpi).toContainText('$5.6B');
+    await expect(kpi).toContainText('$147.9M');
+    await expect(kpi).toContainText('3669.5%');
+    await expect(kpi).toContainText('36.7×');
+    await expect(kpi).toContainText('407 projects');
+  });
+
+  test('discloses that the investment figure is a modelled cost, not compensation', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-kpi-explanations-toggle').click();
+    const investment = page.getByTestId('org-roi-kpi-explanation-total-expenditure');
+    await expect(investment).toBeVisible();
+    await expect(investment).toContainText('modelled cost');
+    await expect(investment).toContainText('not actual or reported compensation');
+    await expect(investment).toContainText('same for every organization');
+    await expect(investment).toContainText('No salary, payroll, or invoice data is used.');
+  });
+
+  test('renders the annual trend with its apportionment and partial-year disclosures', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const trend = page.getByTestId('org-roi-annual-trend');
+    await expect(trend).toBeVisible();
+    await expect(page.getByTestId('org-roi-annual-trend-chart')).toBeVisible();
+
+    const note = page.getByTestId('org-roi-annual-trend-apportionment-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('apportioned from lifetime totals');
+    await expect(note).toContainText('not measured independently for each year');
+
+    await expect(page.getByTestId('org-roi-annual-trend-partial-year-note')).toContainText(`${CURRENT_YEAR} is a partial year`);
+  });
+
+  test('does not call a completed final year partial', async ({ page }) => {
+    // An organization whose activity stopped years ago has a complete last year. Labelling it
+    // "still accruing" would misexplain a genuine decline as a calendar artefact.
+    await stubOrgLensContext(page, {
+      annual: {
+        ...MOCK_ANNUAL,
+        rows: [annualRow(CURRENT_YEAR - 4, 900_000_000, 24_000_000), annualRow(CURRENT_YEAR - 3, 700_000_000, 19_000_000)],
+      },
+    });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-annual-trend-chart')).toBeVisible();
+    await expect(page.getByTestId('org-roi-annual-trend-partial-year-note')).toHaveCount(0);
+    // The apportionment disclosure is unconditional and must survive independently.
+    await expect(page.getByTestId('org-roi-annual-trend-apportionment-note')).toBeVisible();
+  });
+
+  test('omits the apportionment disclosure when the payload says the figures are measured', async ({ page }) => {
+    await stubOrgLensContext(page, { annual: { ...MOCK_ANNUAL, apportioned: false } });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-annual-trend-chart')).toBeVisible();
+    await expect(page.getByTestId('org-roi-annual-trend-apportionment-note')).toHaveCount(0);
+  });
+
+  test('presents the drawer rate inputs as global constants, not this organization\u2019s figures', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-assumptions-trigger').click();
+    await expect(page.getByTestId('org-roi-assumptions-drawer-title')).toBeVisible();
+
+    const scope = page.getByTestId('org-roi-assumptions-rates-scope');
+    await expect(scope).toContainText('global constants');
+    await expect(scope).toContainText('applied identically to every organization');
+    await expect(scope).toContainText('not specific to your organization');
+
+    await expect(page.getByTestId('org-roi-assumptions-rates')).toContainText('$200,000');
+    await expect(page.getByTestId('org-roi-assumptions-rates')).toContainText('$150,000');
+    await expect(page.getByTestId('org-roi-assumptions-rates-readonly-note')).toContainText('cannot be recalculated');
+    await expect(page.getByTestId('org-roi-assumptions-rates').locator('input')).toHaveCount(0);
+  });
+
+  test('switching estimation method refetches every surface and persists across visits', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    // Assert on the outgoing requests: both methods return the same stub, so a missing refetch is otherwise invisible.
+    const summaryRequest = page.waitForRequest((req) => req.url().includes('/lens/roi/summary') && req.url().includes('method=direct'));
+    const annualRequest = page.waitForRequest((req) => req.url().includes('/lens/roi/annual') && req.url().includes('method=direct'));
+    // Coverage is method-scoped too: it reports whether *this* method produced figures, so a
+    // coverage answer left on the previous method could contradict the summary it explains.
+    const coverageRequest = page.waitForRequest((req) => req.url().includes('/lens/roi/coverage') && req.url().includes('method=direct'));
+
+    await page.getByTestId('org-roi-assumptions-trigger').click();
+    await page.getByTestId('org-roi-assumptions-method-direct').click();
+
+    await summaryRequest;
+    await annualRequest;
+    await coverageRequest;
+
+    const restoredRequest = page.waitForRequest((req) => req.url().includes('/lens/roi/summary') && req.url().includes('method=direct'));
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await restoredRequest;
+
+    await page.getByTestId('org-roi-assumptions-trigger').click();
+    await expect(page.getByTestId('org-roi-assumptions-method-direct')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('explains an unmapped organization without implying a pending fix', async ({ page }) => {
+    await stubOrgLensContext(page, {
+      summary: { ...MOCK_SUMMARY, hasData: false, totalExpenditure: null, totalReturn: null, profit: null, roi: null, bcr: null },
+      coverage: { orgUid: MOCK_ACCOUNT_ID, hasData: false, coverageReason: 'unmapped' },
+    });
+    await gotoOrgRoiPage(page);
+
+    const empty = page.getByTestId('org-roi-empty-state-unmapped');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText("isn't linked to a contributor community record");
+    await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
+  });
+
+  test('explains a mapped-but-unestimated organization without promising later figures', async ({ page }) => {
+    await stubOrgLensContext(page, {
+      summary: { ...MOCK_SUMMARY, hasData: false, totalExpenditure: null, totalReturn: null, profit: null, roi: null, bcr: null },
+      coverage: { orgUid: MOCK_ACCOUNT_ID, hasData: false, coverageReason: 'not_estimated' },
+    });
+    await gotoOrgRoiPage(page);
+
+    const empty = page.getByTestId('org-roi-empty-state-not-estimated');
+    await expect(empty).toBeVisible();
+    await expect(empty).toContainText("didn't produce ROI figures");
+    await expect(empty).toContainText('counted there instead');
+    await expect(empty).not.toContainText('check back');
+    await expect(empty).not.toContainText('later run');
+    await expect(empty).not.toContainText('may appear');
+    await expect(page.getByTestId('org-roi-empty-state-unmapped')).toHaveCount(0);
+  });
+
+  test('renders the no-value indicator rather than zero when there is no investment to divide by', async ({ page }) => {
+    await stubOrgLensContext(page, {
+      summary: { ...MOCK_SUMMARY, totalExpenditure: 0, totalReturn: 0, profit: 0, roi: null, bcr: null },
+    });
+    await gotoOrgRoiPage(page);
+
+    const kpi = page.getByTestId('org-roi-kpi-cards');
+    await expect(kpi).toBeVisible();
+    await expect(kpi).toContainText('—');
+    await expect(kpi).not.toContainText('0.0%');
+  });
+
+  test('refuses an ungranted caller with no ROI figure anywhere in the response', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/**', (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 'FORBIDDEN', message: 'You do not have access to Org Lens data for this organization.' }),
+      })
+    );
+
+    const responses: string[] = [];
+    page.on('response', async (response) => {
+      if (!response.url().includes('/lens/roi/')) return;
+      responses.push(await response.text().catch(() => ''));
+    });
+
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-forbidden')).toBeVisible();
+    await expect(page.getByTestId('org-roi-forbidden')).toContainText('do not have Org Lens access');
+    await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
+
+    expect(responses.length).toBeGreaterThan(0);
+    for (const body of responses) {
+      expect(body).not.toContain('totalExpenditure');
+      expect(body).not.toContain('totalReturn');
+    }
+  });
+
+  test('distinguishes a 503 verification failure from a 403 refusal', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/**', (route) =>
+      route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ code: 'ROLE_GRANTS_UNAVAILABLE' }) })
+    );
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-error')).toBeVisible();
+    await expect(page.getByTestId('org-roi-error')).toContainText("couldn't be loaded");
+    await expect(page.getByTestId('org-roi-forbidden')).toHaveCount(0);
+  });
+
+  test('renders the no-company empty state when no account is selected', async ({ page }) => {
+    await stubOrgLensContext(page, { hasAccess: true });
+    await page.route('**/api/user/personas*', (route) =>
+      fulfillJson(route, { personas: ['contributor'], personaProjects: {}, projects: [], organizations: [], isRootWriter: false })
+    );
+    await page.route('**/api/nav/org-items*', (route) => fulfillJson(route, { items: [], next_page_token: null, upstream_failed: false, total: 0 }));
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await page.goto(ORG_ROI_URL, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    if (!page.url().includes('/org/roi')) {
+      test.skip(true, 'org-lens-roi-enabled flag appears off — /org/roi redirected away');
+    }
+
+    await expect(page.getByTestId('org-roi-no-company-empty-state')).toBeVisible();
+    await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
+  });
+
+  test('renders the no-access state when the caller has no org selector access', async ({ page }) => {
+    await stubOrgLensContext(page, { hasAccess: false });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-no-access-state')).toBeVisible();
+    await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-no-company-empty-state')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -144,7 +144,7 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(kpi).toContainText('$5.6B');
     await expect(kpi).toContainText('$147.9M');
     await expect(kpi).toContainText('3669.5%');
-    await expect(kpi).toContainText('36.7×');
+    await expect(kpi).toContainText('37.7×');
     await expect(kpi).toContainText('407 projects');
   });
 

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -136,7 +136,8 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
 
     await expect(page.getByTestId('org-roi-page')).toBeVisible();
     await expect(page.getByRole('heading', { name: 'ROI Metrics' })).toBeVisible();
-    await expect(page.getByTestId('org-roi-window')).toContainText('2010–2026');
+    // Derived from the same CURRENT_YEAR the fixture uses; a hardcoded end year would fail every January.
+    await expect(page.getByTestId('org-roi-window')).toContainText(`2010–${CURRENT_YEAR}`);
 
     const kpi = page.getByTestId('org-roi-kpi-cards');
     await expect(kpi).toBeVisible();
@@ -273,6 +274,47 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(empty).not.toContainText('later run');
     await expect(empty).not.toContainText('may appear');
     await expect(page.getByTestId('org-roi-empty-state-unmapped')).toHaveCount(0);
+  });
+
+  test('keeps the method control reachable on the empty state', async ({ page }) => {
+    // Coverage is method-scoped, so a method with no rows lands on the empty state. If the drawer
+    // holding the only method control were hidden there, that state would be a dead end — the
+    // viewer could not switch back and previously visible figures would stay unreachable until
+    // browser storage was cleared.
+    await stubOrgLensContext(page, {
+      summary: { ...MOCK_SUMMARY, hasData: false, totalExpenditure: null, totalReturn: null, profit: null, roi: null, bcr: null },
+      coverage: { orgUid: MOCK_ACCOUNT_ID, hasData: false, coverageReason: 'not_estimated' },
+    });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-empty-state')).toBeVisible();
+    const trigger = page.getByTestId('org-roi-assumptions-trigger');
+    await expect(trigger).toBeVisible();
+
+    await trigger.click();
+    await expect(page.getByTestId('org-roi-assumptions-method-logit')).toBeVisible();
+    await expect(page.getByTestId('org-roi-assumptions-method-direct')).toBeVisible();
+  });
+
+  test('exposes the yearly series to assistive technology, not only as a canvas', async ({ page }) => {
+    // The chart is a canvas, so without this table the per-year values are unavailable to a screen
+    // reader. `sr-only` keeps it out of the visual layout while leaving it in the accessibility
+    // tree, so assert on its contents rather than its visibility.
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const table = page.getByTestId('org-roi-annual-trend-table');
+    await expect(table).toBeAttached();
+    await expect(table).toContainText('Year');
+    await expect(table).toContainText('Investment');
+    await expect(table).toContainText('Return');
+    // Same figures as the chart, through the same formatter.
+    await expect(table).toContainText(`${CURRENT_YEAR}`);
+    await expect(table).toContainText('$620M');
+    await expect(table).toContainText('$17M');
+    await expect(table).toContainText('partial year');
+
+    await expect(page.getByTestId('org-roi-annual-trend-chart')).toHaveAttribute('aria-label', /investment and return by year/i);
   });
 
   test('renders the no-value indicator rather than zero when there is no investment to divide by', async ({ page }) => {

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -10,6 +10,7 @@ import { executiveDirectorGuard } from './shared/guards/executive-director.guard
 import { lensRedirectGuard } from './shared/guards/lens-redirect.guard';
 import { newsletterAccessGuard } from './shared/guards/newsletter-access.guard';
 import { orgLensEnabledGuard } from './shared/guards/org-lens-enabled.guard';
+import { orgLensRoiEnabledGuard } from './shared/guards/org-lens-roi-enabled.guard';
 import { akritesEnabledGuard } from './shared/guards/akrites-enabled.guard';
 import { mktgOsAgentsEnabledGuard } from './shared/guards/mktg-os-agents-enabled.guard';
 import { projectQueryParamGuard } from './shared/guards/project-query-param.guard';
@@ -126,11 +127,15 @@ export const routes: Routes = [
             loadComponent: () => import('./modules/dashboards/org/org-project-detail/org-project-detail.component').then((m) => m.OrgProjectDetailComponent),
           },
           {
-            // INFO: Future Epic implementation — the ROI page is hidden; deep links fall
-            // back to the org overview until the org ROI feature is built.
             path: 'roi',
-            redirectTo: 'overview',
-            pathMatch: 'full',
+            canMatch: [orgLensRoiEnabledGuard],
+            data: {
+              lens: 'org',
+              title: 'ROI Metrics',
+              description: "Modelled return on your organization's open source investment.",
+              icon: 'fa-light fa-chart-mixed-up-circle-dollar',
+            },
+            loadComponent: () => import('./modules/dashboards/org/org-roi/org-roi.component').then((m) => m.OrgRoiComponent),
           },
           {
             // INFO: Future Epic implementation — the Governance page is hidden; deep links

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.html
@@ -24,9 +24,34 @@
       <span>No yearly breakdown is available for this organization.</span>
     </div>
   } @else {
-    <div class="h-[280px]" data-testid="org-roi-annual-trend-chart">
+    <div class="h-[280px]" role="img" [attr.aria-label]="chartSummaryLabel()" data-testid="org-roi-annual-trend-chart">
       <lfx-chart type="line" [data]="chartData()" [options]="chartOptions" height="100%" />
     </div>
+
+    <!-- The canvas is otherwise the only presentation of these values, so it is unreadable to a
+         screen reader. This table carries the same series; `sr-only` keeps it out of the visual
+         layout without hiding it from assistive technology (`hidden`/`display:none` would). -->
+    <table class="sr-only" data-testid="org-roi-annual-trend-table">
+      <caption>
+        Investment and return by year
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">Year</th>
+          <th scope="col">Investment</th>
+          <th scope="col">Return</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (row of tableRows(); track row.year) {
+          <tr>
+            <th scope="row">{{ row.year }}{{ row.isPartial ? ' (partial year)' : '' }}</th>
+            <td>{{ row.investment }}</td>
+            <td>{{ row.return }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
 
     <div class="flex flex-col gap-1 border-t border-gray-100 pt-3">
       @if (apportioned()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.html
@@ -1,0 +1,43 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-roi-annual-trend">
+  <h2 class="text-base font-semibold text-gray-900">Investment and return by year</h2>
+
+  @if (loading()) {
+    <div class="flex flex-col gap-2" data-testid="org-roi-annual-trend-loading">
+      <p-skeleton width="100%" height="280px" />
+    </div>
+  } @else if (forbidden()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-annual-trend-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (failed()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-annual-trend-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>The yearly trend couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (!hasRows()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-annual-trend-empty">
+      <i class="fa-light fa-chart-line text-gray-400" aria-hidden="true"></i>
+      <span>No yearly breakdown is available for this organization.</span>
+    </div>
+  } @else {
+    <div class="h-[280px]" data-testid="org-roi-annual-trend-chart">
+      <lfx-chart type="line" [data]="chartData()" [options]="chartOptions" height="100%" />
+    </div>
+
+    <div class="flex flex-col gap-1 border-t border-gray-100 pt-3">
+      @if (apportioned()) {
+        <p class="text-xs text-gray-500" data-testid="org-roi-annual-trend-apportionment-note">
+          Yearly figures are apportioned from lifetime totals by each year's share of investment — they are not measured independently for each year, so
+          movement between years reflects when the activity happened rather than a change in performance.
+        </p>
+      }
+      @if (partialYear() !== null) {
+        <p class="text-xs text-gray-500" data-testid="org-roi-annual-trend-partial-year-note">{{ partialYear() }} is a partial year and is still accruing.</p>
+      }
+    </div>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.ts
@@ -1,0 +1,134 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChartComponent } from '@components/chart/chart.component';
+import { lfxColors, ORG_LENS_ROI_DEFAULT_METHOD } from '@lfx-one/shared/constants';
+import type { OrgLensRoiAnnual, OrgLensRoiMethod } from '@lfx-one/shared/interfaces';
+import { formatCurrency } from '@lfx-one/shared/utils';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensRoiService } from '@services/org-lens-roi.service';
+import type { ChartData, ChartOptions } from 'chart.js';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+
+const EMPTY_ANNUAL: OrgLensRoiAnnual = { method: ORG_LENS_ROI_DEFAULT_METHOD, rows: [], apportioned: false };
+
+@Component({
+  selector: 'lfx-org-roi-annual-trend',
+  imports: [ChartComponent, SkeletonModule],
+  templateUrl: './org-roi-annual-trend.component.html',
+})
+export class OrgRoiAnnualTrendComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly roiService = inject(OrgLensRoiService);
+
+  public readonly method = input.required<OrgLensRoiMethod>();
+
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  protected readonly forbidden = signal(false);
+
+  private readonly annual: Signal<OrgLensRoiAnnual> = this.initAnnual();
+
+  protected readonly hasRows: Signal<boolean> = computed(() => this.annual().rows.length > 0);
+  protected readonly apportioned: Signal<boolean> = computed(() => this.annual().apportioned);
+
+  // Only the calendar year still in progress is partial. An organization whose activity stopped in
+  // an earlier year has a complete final year, and labelling it "still accruing" would be wrong.
+  protected readonly partialYear: Signal<number | null> = computed(() => {
+    const lastYear = this.annual().rows.at(-1)?.year ?? null;
+    return lastYear !== null && lastYear === new Date().getFullYear() ? lastYear : null;
+  });
+
+  protected readonly chartData: Signal<ChartData<'line'>> = computed(() => {
+    const rows = this.annual().rows;
+    return {
+      labels: rows.map((row) => `${row.year}`),
+      datasets: [
+        {
+          label: 'Investment',
+          data: rows.map((row) => row.expenditure),
+          borderColor: lfxColors.blue[500],
+          backgroundColor: lfxColors.blue[500],
+          fill: false,
+        },
+        {
+          label: 'Return',
+          data: rows.map((row) => row.totalReturn),
+          borderColor: lfxColors.emerald[500],
+          backgroundColor: lfxColors.emerald[500],
+          fill: false,
+        },
+      ],
+    };
+  });
+
+  protected readonly chartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    plugins: {
+      legend: { display: true, position: 'top', align: 'end', labels: { boxWidth: 12, usePointStyle: true, color: lfxColors.gray[600] } },
+      tooltip: {
+        backgroundColor: 'rgba(255, 255, 255, 0.98)',
+        titleColor: lfxColors.gray[900],
+        bodyColor: lfxColors.gray[600],
+        borderColor: lfxColors.gray[200],
+        borderWidth: 1,
+        padding: 10,
+        cornerRadius: 6,
+        callbacks: {
+          label: (ctx) => ` ${ctx.dataset.label}: ${formatCurrency(ctx.parsed.y as number)}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        display: true,
+        grid: { display: false },
+        border: { display: true, color: lfxColors.gray[400], width: 1 },
+        ticks: { color: lfxColors.gray[500], font: { size: 12 }, maxRotation: 0 },
+      },
+      y: {
+        display: true,
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: true, color: lfxColors.gray[400], width: 1, dash: [3, 3] },
+        ticks: { color: lfxColors.gray[500], font: { size: 12 }, callback: (v) => formatCurrency(v as number) },
+        beginAtZero: true,
+      },
+    },
+    datasets: { line: { tension: 0.4, borderWidth: 2, pointRadius: 2, pointHoverRadius: 4 } },
+  };
+
+  private initAnnual(): Signal<OrgLensRoiAnnual> {
+    // Keyed by string, not the account object: that object is rewritten in place and would retrigger the fetch.
+    const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.method()}`));
+
+    return toSignal(
+      requestKey$.pipe(
+        map((key) => key.split('|') as [string, OrgLensRoiMethod]),
+        filter(([orgUid]) => !!orgUid),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+        }),
+        switchMap(([orgUid, method]) =>
+          this.roiService.getAnnual(orgUid, method).pipe(
+            tap(() => this.loading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load ROI annual trend', error);
+              this.loading.set(false);
+              if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
+              else this.failed.set(true);
+              return of(EMPTY_ANNUAL);
+            })
+          )
+        )
+      ),
+      { initialValue: EMPTY_ANNUAL }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-annual-trend/org-roi-annual-trend.component.ts
@@ -42,6 +42,27 @@ export class OrgRoiAnnualTrendComponent {
     return lastYear !== null && lastYear === new Date().getFullYear() ? lastYear : null;
   });
 
+  /**
+   * Screen-reader equivalent of the canvas. Pre-formatted here rather than in the template so the
+   * table and the chart tooltips read the same figures through the same formatter.
+   */
+  protected readonly tableRows: Signal<{ year: number; investment: string; return: string; isPartial: boolean }[]> = computed(() => {
+    const partial = this.partialYear();
+    return this.annual().rows.map((row) => ({
+      year: row.year,
+      investment: formatCurrency(row.expenditure),
+      return: formatCurrency(row.totalReturn),
+      isPartial: row.year === partial,
+    }));
+  });
+
+  /** Names what the canvas depicts; the per-year values live in the adjacent table. */
+  protected readonly chartSummaryLabel: Signal<string> = computed(() => {
+    const rows = this.annual().rows;
+    if (rows.length === 0) return 'Investment and return by year';
+    return `Line chart of investment and return by year, ${rows[0].year} to ${rows[rows.length - 1].year}. The same figures follow in a table.`;
+  });
+
   protected readonly chartData: Signal<ChartData<'line'>> = computed(() => {
     const rows = this.annual().rows;
     return {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-assumptions-drawer/org-roi-assumptions-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-assumptions-drawer/org-roi-assumptions-drawer.component.html
@@ -1,0 +1,97 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
+  data-testid="org-roi-assumptions-drawer">
+  <ng-template #header>
+    <div class="flex w-full items-start justify-between gap-4" data-testid="org-roi-assumptions-drawer-header">
+      <div class="flex flex-1 flex-col gap-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="org-roi-assumptions-drawer-title">Model assumptions</h2>
+        <p class="text-sm text-gray-500">How these ROI figures are produced.</p>
+      </div>
+      <button
+        type="button"
+        (click)="onClose()"
+        class="flex-shrink-0 rounded-md p-1 text-gray-400 transition-colors hover:bg-gray-100 hover:text-gray-600"
+        aria-label="Close panel"
+        data-testid="org-roi-assumptions-drawer-close">
+        <i class="fa-light fa-xmark text-xl"></i>
+      </button>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-8 pb-2" data-testid="org-roi-assumptions-drawer-content">
+    <section class="flex flex-col gap-3" data-testid="org-roi-assumptions-method">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Estimation method</h3>
+        <p class="text-sm text-gray-500">Applies to every figure on this page and is remembered on this device.</p>
+      </div>
+      <div class="flex flex-col gap-2">
+        @for (option of methods; track option) {
+          <button
+            type="button"
+            (click)="onSelectMethod(option)"
+            [class]="
+              option === method()
+                ? 'flex items-center gap-3 rounded-md border border-blue-500 bg-blue-50 px-3 py-2 text-left text-sm text-gray-900'
+                : 'flex items-center gap-3 rounded-md border border-gray-200 bg-white px-3 py-2 text-left text-sm text-gray-700 hover:bg-gray-50'
+            "
+            [attr.aria-pressed]="option === method()"
+            [attr.data-testid]="'org-roi-assumptions-method-' + option">
+            <i [class]="option === method() ? 'fa-solid fa-circle-dot text-blue-600' : 'fa-light fa-circle text-gray-400'" aria-hidden="true"></i>
+            {{ methodLabels[option] }}
+          </button>
+        }
+      </div>
+      <p class="text-xs text-gray-500" data-testid="org-roi-assumptions-method-note">
+        Both methods draw on the same investment base and the same target distribution, so switching moves the figures modestly rather than dramatically.
+      </p>
+    </section>
+
+    <!-- Rates must render as stated values, never as inputs. -->
+    <section class="flex flex-col gap-3" data-testid="org-roi-assumptions-rates">
+      <div class="flex flex-col gap-1">
+        <h3 class="text-sm font-semibold text-gray-900">Cost rates used by the model</h3>
+        <p class="text-sm text-gray-500" data-testid="org-roi-assumptions-rates-scope">
+          These are global constants — one rate per contribution type, applied identically to every organization across the Linux Foundation. They are not
+          specific to your organization, and they are not derived from anyone's actual or reported compensation.
+        </p>
+      </div>
+
+      <dl class="flex flex-col divide-y divide-gray-100 rounded-lg border border-gray-200">
+        <div class="flex items-baseline justify-between gap-4 px-3 py-2.5">
+          <dt class="text-sm text-gray-700">Code contribution rate</dt>
+          <dd class="text-sm font-medium text-gray-900">{{ assumptions.codeSalaryUsd | currency: 'USD' : 'symbol' : '1.0-0' }} per FTE-year</dd>
+        </div>
+        <div class="flex items-baseline justify-between gap-4 px-3 py-2.5">
+          <dt class="text-sm text-gray-700">Community contribution rate</dt>
+          <dd class="text-sm font-medium text-gray-900">{{ assumptions.communitySalaryUsd | currency: 'USD' : 'symbol' : '1.0-0' }} per FTE-year</dd>
+        </div>
+        <div class="flex items-baseline justify-between gap-4 px-3 py-2.5">
+          <dt class="text-sm text-gray-700">Overhead multiplier</dt>
+          <dd class="text-sm font-medium text-gray-900">{{ assumptions.overheadMultiplier }}×</dd>
+        </div>
+      </dl>
+
+      <p class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600" data-testid="org-roi-assumptions-rates-readonly-note">
+        <i class="fa-light fa-lock mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span>
+          Shown for transparency only. These rates are set in the data pipeline, so the figures on this page cannot be recalculated with different values here.
+        </span>
+      </p>
+    </section>
+
+    <section class="flex flex-col gap-2" data-testid="org-roi-assumptions-derivation">
+      <h3 class="text-sm font-semibold text-gray-900">How investment is derived</h3>
+      <p class="text-sm text-gray-600">
+        Your organization's public contribution activity is converted to full-time-equivalent effort using a standard time allowance per activity, multiplied by
+        the overhead above, and priced at the rate for that contribution type. Contributor identity is not part of this calculation at any stage.
+      </p>
+    </section>
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-assumptions-drawer/org-roi-assumptions-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-assumptions-drawer/org-roi-assumptions-drawer.component.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { CurrencyPipe } from '@angular/common';
+import { Component, model } from '@angular/core';
+import { ORG_LENS_ROI_GLOBAL_ASSUMPTIONS, ORG_LENS_ROI_METHOD_LABELS, ORG_LENS_ROI_METHODS } from '@lfx-one/shared/constants';
+import type { OrgLensRoiMethod } from '@lfx-one/shared/interfaces';
+import { DrawerModule } from 'primeng/drawer';
+
+@Component({
+  selector: 'lfx-org-roi-assumptions-drawer',
+  imports: [DrawerModule, CurrencyPipe],
+  templateUrl: './org-roi-assumptions-drawer.component.html',
+})
+export class OrgRoiAssumptionsDrawerComponent {
+  public readonly visible = model<boolean>(false);
+  public readonly method = model.required<OrgLensRoiMethod>();
+
+  protected readonly methods = ORG_LENS_ROI_METHODS;
+  protected readonly methodLabels = ORG_LENS_ROI_METHOD_LABELS;
+  protected readonly assumptions = ORG_LENS_ROI_GLOBAL_ASSUMPTIONS;
+
+  protected onSelectMethod(method: OrgLensRoiMethod): void {
+    if (method === this.method()) return;
+    this.method.set(method);
+  }
+
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.html
@@ -1,0 +1,37 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col items-center gap-4 rounded-lg border border-gray-200 bg-white px-6 py-14 text-center" data-testid="org-roi-empty-state">
+  <div class="flex h-14 w-14 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+    <i class="fa-light fa-chart-mixed-up-circle-dollar text-2xl" aria-hidden="true"></i>
+  </div>
+
+  @if (isUnmapped()) {
+    <div class="flex max-w-xl flex-col gap-3" data-testid="org-roi-empty-state-unmapped">
+      <h2 class="text-lg font-semibold text-gray-900">ROI metrics aren't available for this organization</h2>
+      <p class="text-sm text-gray-600">
+        ROI is estimated from open source contribution activity, and this organization isn't linked to a contributor community record. Without that link there's
+        no activity to price, so there are no figures to show.
+      </p>
+      <p class="text-sm text-gray-500">
+        This is how the data stands today rather than a problem with your account — most organizations across the Linux Foundation are in the same position.
+      </p>
+    </div>
+  } @else {
+    <div class="flex max-w-xl flex-col gap-3" data-testid="org-roi-empty-state-not-estimated">
+      <h2 class="text-lg font-semibold text-gray-900">We couldn't produce ROI figures for this organization</h2>
+      <p class="text-sm text-gray-600">
+        This organization is linked to a contributor community record, but the model didn't produce ROI figures for it. That usually means there wasn't enough
+        contribution activity attributed to it to estimate a return.
+      </p>
+      <!-- Must not promise the figures may appear later. ROI is estimated at organization-NAME
+           grain upstream, so where several accounts share a name the figures land wholly on one of
+           them and a later pipeline run reproduces that rather than correcting it. -->
+
+      <p class="text-sm text-gray-500">
+        Activity recorded under a differently-named or related organization is counted there instead, so it won't roll up to this one. If you think that's
+        what's happened, contact us and we can look at how your organization's activity is attributed.
+      </p>
+    </div>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.ts
@@ -1,0 +1,15 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal } from '@angular/core';
+import type { OrgLensRoiCoverageReason } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-org-roi-empty-state',
+  templateUrl: './org-roi-empty-state.component.html',
+})
+export class OrgRoiEmptyStateComponent {
+  public readonly reason = input.required<OrgLensRoiCoverageReason>();
+
+  protected readonly isUnmapped: Signal<boolean> = computed(() => this.reason() === 'unmapped');
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-kpi-cards/org-roi-kpi-cards.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-kpi-cards/org-roi-kpi-cards.component.html
@@ -1,0 +1,34 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="org-roi-kpi-cards">
+  <lfx-stat-card-grid [cards]="cards()" [columns]="4" />
+
+  <details class="group rounded-lg border border-gray-200 bg-white" data-testid="org-roi-kpi-explanations">
+    <summary
+      class="flex cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+      data-testid="org-roi-kpi-explanations-toggle">
+      <i class="fa-light fa-circle-info text-gray-400" aria-hidden="true"></i>
+      How these figures are calculated
+      <i class="fa-light fa-chevron-down ml-auto text-gray-400 transition-transform group-open:rotate-180" aria-hidden="true"></i>
+    </summary>
+    <dl class="flex flex-col gap-4 border-t border-gray-200 px-4 py-4">
+      <div class="flex flex-col gap-1" data-testid="org-roi-kpi-explanation-total-expenditure">
+        <dt class="text-sm font-semibold text-gray-900">Total Investment</dt>
+        <dd class="text-sm text-gray-600">{{ explanation.totalExpenditure }}</dd>
+      </div>
+      <div class="flex flex-col gap-1" data-testid="org-roi-kpi-explanation-total-return">
+        <dt class="text-sm font-semibold text-gray-900">Total Return</dt>
+        <dd class="text-sm text-gray-600">{{ explanation.totalReturn }}</dd>
+      </div>
+      <div class="flex flex-col gap-1" data-testid="org-roi-kpi-explanation-roi">
+        <dt class="text-sm font-semibold text-gray-900">Portfolio ROI</dt>
+        <dd class="text-sm text-gray-600">{{ explanation.roi }}</dd>
+      </div>
+      <div class="flex flex-col gap-1" data-testid="org-roi-kpi-explanation-bcr">
+        <dt class="text-sm font-semibold text-gray-900">Benefit-Cost Ratio</dt>
+        <dd class="text-sm text-gray-600">{{ explanation.bcr }}</dd>
+      </div>
+    </dl>
+  </details>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-kpi-cards/org-roi-kpi-cards.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-kpi-cards/org-roi-kpi-cards.component.ts
@@ -51,16 +51,26 @@ export class OrgRoiKpiCardsComponent {
     ];
   });
 
+  /**
+   * A measure is renderable only if it is actually a finite number. `=== null` is not enough: an
+   * absent key is `undefined`, which slips past it and reaches `toFixed()`. The measures are
+   * nullable by design — the warehouse returns NULL rather than zero when there is no investment to
+   * divide by — so anything non-numeric renders as the no-value indicator, never as 0.
+   */
+  private isRenderable(value: number | null | undefined): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
   private money(value: number | null): string {
-    return value === null ? ORG_LENS_ROI_NO_VALUE : formatCurrency(value);
+    return this.isRenderable(value) ? formatCurrency(value) : ORG_LENS_ROI_NO_VALUE;
   }
 
   private ratioAsPercent(value: number | null): string {
-    return value === null ? ORG_LENS_ROI_NO_VALUE : `${formatPercent(value * 100)}%`;
+    return this.isRenderable(value) ? `${formatPercent(value * 100)}%` : ORG_LENS_ROI_NO_VALUE;
   }
 
   /** A ratio, not a percentage, so it does not go through the percentage formatter. */
   private multiple(value: number | null): string {
-    return value === null ? ORG_LENS_ROI_NO_VALUE : `${value.toFixed(1)}×`;
+    return this.isRenderable(value) ? `${value.toFixed(1)}×` : ORG_LENS_ROI_NO_VALUE;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-kpi-cards/org-roi-kpi-cards.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-kpi-cards/org-roi-kpi-cards.component.ts
@@ -1,0 +1,66 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal } from '@angular/core';
+import { ORG_LENS_ROI_KPI_EXPLANATION, ORG_LENS_ROI_KPI_ICON_CLASS, ORG_LENS_ROI_NO_VALUE } from '@lfx-one/shared/constants';
+import type { OrgLensRoiSummary, StatCardItem } from '@lfx-one/shared/interfaces';
+import { formatCurrency, formatPercent } from '@lfx-one/shared/utils';
+
+import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
+
+@Component({
+  selector: 'lfx-org-roi-kpi-cards',
+  imports: [StatCardGridComponent],
+  templateUrl: './org-roi-kpi-cards.component.html',
+})
+export class OrgRoiKpiCardsComponent {
+  public readonly summary = input.required<OrgLensRoiSummary>();
+
+  protected readonly explanation = ORG_LENS_ROI_KPI_EXPLANATION;
+
+  protected readonly cards: Signal<StatCardItem[]> = computed(() => {
+    const summary = this.summary();
+    const projectLabel = summary.nProjects === 1 ? '1 project' : `${summary.nProjects.toLocaleString('en-US')} projects`;
+    return [
+      {
+        label: 'Total Investment',
+        value: this.money(summary.totalExpenditure),
+        subLine: `Modelled cost across ${projectLabel}`,
+        icon: 'fa-light fa-hand-holding-dollar',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.totalExpenditure,
+      },
+      {
+        label: 'Total Return',
+        value: this.money(summary.totalReturn),
+        subLine: `Net ${this.money(summary.profit)}`,
+        icon: 'fa-light fa-arrow-trend-up',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.totalReturn,
+      },
+      {
+        label: 'Portfolio ROI',
+        value: this.ratioAsPercent(summary.roi),
+        icon: 'fa-light fa-percent',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.roi,
+      },
+      {
+        label: 'Benefit-Cost Ratio',
+        value: this.multiple(summary.bcr),
+        icon: 'fa-light fa-scale-balanced',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.bcr,
+      },
+    ];
+  });
+
+  private money(value: number | null): string {
+    return value === null ? ORG_LENS_ROI_NO_VALUE : formatCurrency(value);
+  }
+
+  private ratioAsPercent(value: number | null): string {
+    return value === null ? ORG_LENS_ROI_NO_VALUE : `${formatPercent(value * 100)}%`;
+  }
+
+  /** A ratio, not a percentage, so it does not go through the percentage formatter. */
+  private multiple(value: number | null): string {
+    return value === null ? ORG_LENS_ROI_NO_VALUE : `${value.toFixed(1)}×`;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -88,7 +88,12 @@
     <lfx-org-roi-kpi-cards [summary]="summary()" />
 
     <lfx-org-roi-annual-trend [method]="method()" />
+  }
 
+  <!-- Mounted outside the branches above, on the same condition as its trigger. Inside the
+       success branch it would not exist on the empty state — the trigger would set `visible`
+       and nothing would open, which is the state the method control has to rescue. -->
+  @if (canChooseMethod()) {
     <lfx-org-roi-assumptions-drawer [(visible)]="drawerVisible" [method]="method()" (methodChange)="setMethod($event)" />
   }
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -1,0 +1,93 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<main class="container mx-auto flex flex-col gap-6 px-4 sm:px-6 lg:px-8" data-testid="org-roi-page">
+  <header class="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between" data-testid="org-roi-header">
+    <div class="flex flex-col gap-2">
+      <h1 class="font-display font-light text-2xl" data-testid="org-roi-title">ROI Metrics</h1>
+      <p class="text-sm text-gray-500" data-testid="org-roi-subtitle">
+        A modelled view of what your organization invested in open source and what came back.
+        @if (windowLabel()) {
+          <span data-testid="org-roi-window">Covering {{ windowLabel() }}.</span>
+        }
+      </p>
+    </div>
+    <!-- Only offered alongside real figures — it explains how they were produced. -->
+    @if (hasRoiData()) {
+      <button
+        type="button"
+        (click)="drawerVisible.set(true)"
+        class="inline-flex items-center gap-2 self-start rounded-md border border-gray-300 bg-white px-3 py-2 text-sm font-medium text-gray-700 transition-colors hover:bg-gray-50 sm:self-auto"
+        data-testid="org-roi-assumptions-trigger">
+        <i class="fa-light fa-sliders" aria-hidden="true"></i>
+        Model assumptions
+      </button>
+    }
+  </header>
+
+  @if (hasNoOrgAccess()) {
+    <section
+      class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-300 bg-white py-16 text-center"
+      data-testid="org-roi-no-access-state">
+      <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+        <i class="fa-light fa-lock text-2xl" aria-hidden="true"></i>
+      </div>
+      <h2 class="text-base font-semibold text-gray-900" data-testid="org-roi-no-access-title">Organization Lens is not available</h2>
+      <p class="max-w-md text-sm text-gray-600" data-testid="org-roi-no-access-description">
+        Organization Lens is only available for an organization's administrators. If you believe you should have access, please contact us.
+      </p>
+    </section>
+  } @else if (!loaded()) {
+    <section class="flex flex-col gap-4" data-testid="org-roi-loading">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        @for (i of [1, 2, 3, 4]; track i) {
+          <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4">
+            <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
+            <p-skeleton width="4rem" height="1.75rem" />
+            <p-skeleton width="80%" height="0.75rem" />
+          </div>
+        }
+      </div>
+    </section>
+  } @else if (!hasCompany()) {
+    <lfx-empty-state icon="fa-light fa-building" title="Select a company via Impersonate to view ROI metrics." data-testid="org-roi-no-company-empty-state" />
+  } @else if (!hasAnalyticsId()) {
+    <lfx-empty-state
+      icon="fa-light fa-triangle-exclamation"
+      title="ROI metrics aren't available for this company right now. Please try again."
+      data-testid="org-roi-no-analytics-id-state" />
+  } @else if (portfolioLoading()) {
+    <section class="flex flex-col gap-4" data-testid="org-roi-portfolio-loading">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        @for (i of [1, 2, 3, 4]; track i) {
+          <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4">
+            <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
+            <p-skeleton width="4rem" height="1.75rem" />
+            <p-skeleton width="80%" height="0.75rem" />
+          </div>
+        }
+      </div>
+    </section>
+  } @else if (portfolioForbidden()) {
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-roi-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (portfolioFailed()) {
+    <!-- Separate from the forbidden branch: a 503 must not read as a permissions message. -->
+    <div class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600" data-testid="org-roi-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>ROI metrics couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (!hasRoiData()) {
+    <lfx-org-roi-empty-state [reason]="coverage().coverageReason" />
+  } @else {
+    <lfx-org-roi-kpi-cards [summary]="summary()" />
+
+    <lfx-org-roi-annual-trend [method]="method()" />
+
+    <lfx-org-roi-assumptions-drawer [(visible)]="drawerVisible" [method]="method()" (methodChange)="setMethod($event)" />
+  }
+</main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -12,8 +12,9 @@
         }
       </p>
     </div>
-    <!-- Only offered alongside real figures — it explains how they were produced. -->
-    @if (hasRoiData()) {
+    <!-- Shown on the empty state too: the drawer holds the only method control, and coverage is
+         method-scoped, so hiding it there would strand a viewer on a method that has no rows. -->
+    @if (canChooseMethod()) {
       <button
         type="button"
         (click)="drawerVisible.set(true)"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -1,0 +1,161 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { afterNextRender, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ORG_LENS_ROI_DEFAULT_METHOD, ORG_LENS_ROI_METHOD_STORAGE_KEY, ORG_LENS_ROI_METHODS } from '@lfx-one/shared/constants';
+import type { OrgLensRoiCoverage, OrgLensRoiMethod, OrgLensRoiSummary } from '@lfx-one/shared/interfaces';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensRoiService } from '@services/org-lens-roi.service';
+import { OrgNavigationService } from '@services/org-navigation.service';
+import { OrgRoleGrantsService } from '@services/org-role-grants.service';
+import { PersonaService } from '@services/persona.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
+
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+
+import { OrgRoiAnnualTrendComponent } from './components/org-roi-annual-trend/org-roi-annual-trend.component';
+import { OrgRoiAssumptionsDrawerComponent } from './components/org-roi-assumptions-drawer/org-roi-assumptions-drawer.component';
+import { OrgRoiEmptyStateComponent } from './components/org-roi-empty-state/org-roi-empty-state.component';
+import { OrgRoiKpiCardsComponent } from './components/org-roi-kpi-cards/org-roi-kpi-cards.component';
+
+const EMPTY_SUMMARY: OrgLensRoiSummary = {
+  orgUid: '',
+  method: ORG_LENS_ROI_DEFAULT_METHOD,
+  hasData: false,
+  nProjects: 0,
+  totalExpenditure: null,
+  totalReturn: null,
+  profit: null,
+  roi: null,
+  bcr: null,
+  yearMin: null,
+  yearMax: null,
+  dateMin: null,
+  dateMax: null,
+};
+
+const EMPTY_COVERAGE: OrgLensRoiCoverage = { orgUid: '', hasData: false, coverageReason: 'unmapped' };
+
+/** Org Lens ROI Metrics (LFXV2-2980). */
+@Component({
+  selector: 'lfx-org-roi',
+  imports: [
+    OrgRoiKpiCardsComponent,
+    OrgRoiAnnualTrendComponent,
+    OrgRoiAssumptionsDrawerComponent,
+    OrgRoiEmptyStateComponent,
+    EmptyStateComponent,
+    SkeletonModule,
+  ],
+  templateUrl: './org-roi.component.html',
+})
+export class OrgRoiComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly orgNavigationService = inject(OrgNavigationService);
+  private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
+  private readonly personaService = inject(PersonaService);
+  private readonly roiService = inject(OrgLensRoiService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  protected readonly method = signal<OrgLensRoiMethod>(ORG_LENS_ROI_DEFAULT_METHOD);
+  protected readonly drawerVisible = signal(false);
+  protected readonly portfolioLoading = signal(true);
+  protected readonly portfolioFailed = signal(false);
+  protected readonly portfolioForbidden = signal(false);
+
+  protected readonly hasNoOrgAccess: Signal<boolean> = computed(
+    () => this.orgRoleGrantsService.loaded() && this.personaService.personaLoaded() && !this.accountContext.hasOrgSelectorAccess()
+  );
+
+  protected readonly loaded: Signal<boolean> = computed(
+    () => this.hasNoOrgAccess() || (this.orgNavigationService.loaded() && this.orgRoleGrantsService.loaded() && this.personaService.personaLoaded())
+  );
+
+  protected readonly hasCompany: Signal<boolean> = computed(
+    () => !!this.accountContext.selectedAccount().uid || !!this.accountContext.selectedAccount().accountId
+  );
+
+  protected readonly hasAnalyticsId: Signal<boolean> = computed(() => !!this.accountContext.selectedAccount().accountId);
+
+  private readonly portfolio: Signal<{ summary: OrgLensRoiSummary; coverage: OrgLensRoiCoverage }> = this.initPortfolio();
+
+  protected readonly summary: Signal<OrgLensRoiSummary> = computed(() => this.portfolio().summary);
+  protected readonly coverage: Signal<OrgLensRoiCoverage> = computed(() => this.portfolio().coverage);
+
+  protected readonly hasRoiData: Signal<boolean> = computed(() => this.summary().hasData);
+
+  protected readonly windowLabel: Signal<string> = computed(() => {
+    const { yearMin, yearMax } = this.summary();
+    if (yearMin === null || yearMax === null) return '';
+    return yearMin === yearMax ? `${yearMin}` : `${yearMin}–${yearMax}`;
+  });
+
+  public constructor() {
+    // Must stay in afterNextRender — restoring the stored method earlier causes a hydration mismatch.
+    afterNextRender(() => this.restoreMethod());
+  }
+
+  public setMethod(method: OrgLensRoiMethod): void {
+    this.method.set(method);
+    this.persistMethod(method);
+  }
+
+  private initPortfolio(): Signal<{ summary: OrgLensRoiSummary; coverage: OrgLensRoiCoverage }> {
+    const defaultValue = { summary: EMPTY_SUMMARY, coverage: EMPTY_COVERAGE };
+    // Keyed by string, not the account object: that object is rewritten in place and would retrigger the fetch.
+    const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.method()}`));
+
+    return toSignal(
+      requestKey$.pipe(
+        map((key) => key.split('|') as [string, OrgLensRoiMethod]),
+        filter(([orgUid]) => !!orgUid),
+        tap(() => {
+          this.portfolioLoading.set(true);
+          this.portfolioFailed.set(false);
+          this.portfolioForbidden.set(false);
+        }),
+        switchMap(([orgUid, method]) =>
+          combineLatest({
+            summary: this.roiService.getSummary(orgUid, method),
+            coverage: this.roiService.getCoverage(orgUid, method),
+          }).pipe(
+            tap(() => this.portfolioLoading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load ROI portfolio summary', error);
+              this.portfolioLoading.set(false);
+              // Only a 403 may show the no-access message; a 503 must not.
+              if ((error as { status?: number })?.status === 403) this.portfolioForbidden.set(true);
+              else this.portfolioFailed.set(true);
+              return of(defaultValue);
+            })
+          )
+        )
+      ),
+      { initialValue: defaultValue }
+    );
+  }
+
+  private restoreMethod(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    try {
+      const stored = localStorage.getItem(ORG_LENS_ROI_METHOD_STORAGE_KEY);
+      if (stored !== null && (ORG_LENS_ROI_METHODS as readonly string[]).includes(stored)) {
+        this.method.set(stored as OrgLensRoiMethod);
+      }
+    } catch {
+      // Ignore unavailable storage.
+    }
+  }
+
+  private persistMethod(method: OrgLensRoiMethod): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    try {
+      localStorage.setItem(ORG_LENS_ROI_METHOD_STORAGE_KEY, method);
+    } catch {
+      // Ignore unavailable storage.
+    }
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -87,6 +87,23 @@ export class OrgRoiComponent {
 
   protected readonly hasRoiData: Signal<boolean> = computed(() => this.summary().hasData);
 
+  /**
+   * The method control has to stay reachable on the empty state, not just alongside figures.
+   * Coverage is method-scoped, so a method with no rows renders the empty state — and if the only
+   * way to change method lived in the success branch, that state would be unrecoverable without
+   * clearing storage, including on a stale method restored from a previous visit.
+   */
+  protected readonly canChooseMethod: Signal<boolean> = computed(
+    () =>
+      this.loaded() &&
+      !this.hasNoOrgAccess() &&
+      this.hasCompany() &&
+      this.hasAnalyticsId() &&
+      !this.portfolioLoading() &&
+      !this.portfolioForbidden() &&
+      !this.portfolioFailed()
+  );
+
   protected readonly windowLabel: Signal<string> = computed(() => {
     const { yearMin, yearMax } = this.summary();
     if (yearMin === null || yearMax === null) return '';

--- a/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
@@ -1,0 +1,38 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { CanMatchFn, Router } from '@angular/router';
+import { ORG_LENS_ROI_ENABLED_FLAG } from '@lfx-one/shared/constants';
+import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
+
+import { FeatureFlagService } from '../services/feature-flag.service';
+
+export const orgLensRoiEnabledGuard: CanMatchFn = async () => {
+  const platformId = inject(PLATFORM_ID);
+
+  // LaunchDarkly is unavailable during SSR, so the browser run of this guard makes the real decision.
+  if (!isPlatformBrowser(platformId)) {
+    return true;
+  }
+
+  const featureFlagService = inject(FeatureFlagService);
+  const router = inject(Router);
+
+  if (!featureFlagService.providerReady()) {
+    const ready = await firstValueFrom(
+      toObservable(featureFlagService.providerReady).pipe(
+        filter((isReady): isReady is true => isReady === true),
+        timeout(5000),
+        catchError(() => of(false))
+      )
+    );
+    if (!ready) {
+      return router.parseUrl('/org/overview');
+    }
+  }
+
+  return featureFlagService.getBooleanFlag(ORG_LENS_ROI_ENABLED_FLAG, false)() ? true : router.parseUrl('/org/overview');
+};

--- a/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient, HttpParams } from '@angular/common/http';
+import { inject, Injectable } from '@angular/core';
+import type { OrgLensRoiAnnual, OrgLensRoiCoverage, OrgLensRoiMethod, OrgLensRoiSummary } from '@lfx-one/shared/interfaces';
+import { Observable } from 'rxjs';
+
+@Injectable({
+  providedIn: 'root',
+})
+export class OrgLensRoiService {
+  private readonly http = inject(HttpClient);
+
+  public getSummary(orgUid: string, method: OrgLensRoiMethod): Observable<OrgLensRoiSummary> {
+    return this.http.get<OrgLensRoiSummary>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/summary`, {
+      params: new HttpParams().set('method', method),
+    });
+  }
+
+  public getCoverage(orgUid: string, method: OrgLensRoiMethod): Observable<OrgLensRoiCoverage> {
+    return this.http.get<OrgLensRoiCoverage>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/coverage`, {
+      params: new HttpParams().set('method', method),
+    });
+  }
+
+  public getAnnual(orgUid: string, method: OrgLensRoiMethod): Observable<OrgLensRoiAnnual> {
+    return this.http.get<OrgLensRoiAnnual>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/annual`, {
+      params: new HttpParams().set('method', method),
+    });
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -12,6 +12,7 @@ import {
   MKTG_OS_AGENTS_ENABLED_FLAG,
   MKTG_OS_AGENTS_LABEL,
   ORG_LENS_ENABLED_FLAG,
+  ORG_LENS_ROI_ENABLED_FLAG,
   SURVEY_LABEL,
   VOTE_LABEL,
 } from '@lfx-one/shared/constants';
@@ -46,6 +47,8 @@ export class SidebarNavService {
   private readonly isAkritesEnabled = this.featureFlagService.getBooleanFlag(AKRITES_ENABLED_FLAG, false);
   /** Dark-launch gate for the Marketing OS agents marketplace; hides the project-lens nav entry when off. */
   private readonly isMktgOsAgentsEnabled = this.featureFlagService.getBooleanFlag(MKTG_OS_AGENTS_ENABLED_FLAG, false);
+  /** Dark-launch gate for the Org Lens ROI Metrics page; hides its org-lens nav entry when off. */
+  private readonly isOrgLensRoiEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ROI_ENABLED_FLAG, false);
 
   private readonly activeLens = this.lensService.activeLens;
 
@@ -71,10 +74,19 @@ export class SidebarNavService {
         return this.canSeeNewsletters() ? [...base, this.projectCommunicationsSection] : base;
       }
       case 'org':
-        return this.isOrgLensEnabled() ? this.orgLensItems : this.visibleMeLensItems();
+        return this.isOrgLensEnabled() ? this.visibleOrgLensItems() : this.visibleMeLensItems();
       default:
         return this.visibleMeLensItems();
     }
+  });
+
+  private readonly visibleOrgLensItems = computed((): SidebarMenuItem[] => {
+    if (!this.isOrgLensRoiEnabled()) return this.orgLensItems;
+    const projectsIndex = this.orgLensItems.findIndex((item) => item.routerLink === '/org/projects');
+    // Append rather than prepend if Projects ever goes away, so ROI can't silently jump to the top.
+    if (projectsIndex === -1) return [...this.orgLensItems, this.orgRoiNavItem];
+    const afterProjects = projectsIndex + 1;
+    return [...this.orgLensItems.slice(0, afterProjects), this.orgRoiNavItem, ...this.orgLensItems.slice(afterProjects)];
   });
 
   // Me Lens nav with feature-flagged sections stripped (Security/Akrites is dark-launched).
@@ -441,6 +453,13 @@ export class SidebarNavService {
     ],
   };
 
+  private readonly orgRoiNavItem: SidebarMenuItem = {
+    label: 'ROI Metrics',
+    icon: 'fa-light fa-chart-mixed-up-circle-dollar',
+    routerLink: '/org/roi',
+    testId: 'sidebar-org-roi',
+  };
+
   private readonly orgLensItems: SidebarMenuItem[] = [
     {
       label: 'Dashboard',
@@ -457,8 +476,8 @@ export class SidebarNavService {
       icon: 'fa-light fa-folder',
       routerLink: '/org/projects',
     },
-    // INFO: Future Epic implementation — ROI and Governance pages are hidden until
-    // built. Restore as top-level items or a section when re-enabled.
+    // INFO: Future Epic implementation — the Governance page is hidden until built. Restore as a
+    // top-level item or a section when re-enabled.
     {
       label: 'Organization Engagement',
       isSection: true,

--- a/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
@@ -1,0 +1,167 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
+const { assertOrgUid, assertOrgLensRead, parseOrgLensRoiMethod, getSummary, getCoverage, getAnnual, logger } = vi.hoisted(() => ({
+  assertOrgUid: vi.fn(),
+  assertOrgLensRead: vi.fn(),
+  parseOrgLensRoiMethod: vi.fn(),
+  getSummary: vi.fn(),
+  getCoverage: vi.fn(),
+  getAnnual: vi.fn(),
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+vi.mock('../helpers/org-uid.helper', () => ({ assertOrgUid }));
+vi.mock('../helpers/org-lens-read-access.helper', () => ({ assertOrgLensRead }));
+vi.mock('../helpers/org-lens-roi-method.helper', () => ({ parseOrgLensRoiMethod }));
+vi.mock('../services/org-lens-roi.service', () => ({
+  OrgLensRoiService: class {
+    public getSummary = getSummary;
+    public getCoverage = getCoverage;
+    public getAnnual = getAnnual;
+  },
+}));
+vi.mock('../services/logger.service', () => ({ logger }));
+
+import { OrgLensRoiController } from './org-lens-roi.controller';
+
+const ORG_UID = '001410000000000AAA';
+
+function buildReq(query: Record<string, unknown> = {}): Request {
+  return { params: { orgUid: ORG_UID }, query, path: '/test' } as unknown as Request;
+}
+
+function buildRes(): Response {
+  return { setHeader: vi.fn(), json: vi.fn() } as unknown as Response;
+}
+
+/**
+ * These endpoints serve organization-level financial aggregates and their only per-organization
+ * authorization barrier is `assertOrgLensRead`. The Playwright suite intercepts the route and
+ * manufactures the 403, so it proves the client handles a refusal — not that the server produces
+ * one. It would stay green if this gate were deleted or moved after the Snowflake read.
+ *
+ * The page's dark-launch flag does not help: flags are evaluated in the browser and gate no
+ * endpoint, so these routes are reachable by any authenticated caller from the moment they ship.
+ *
+ * Hence the ordering assertions below. It is not enough that the gate is called — it must resolve
+ * before the service does any work, or a refused caller still costs a cache read and a warehouse
+ * query, and a cached payload could be served alongside the eventual error.
+ */
+describe('OrgLensRoiController — authorization gate', () => {
+  let controller: OrgLensRoiController;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new OrgLensRoiController();
+    next = vi.fn();
+    assertOrgUid.mockReturnValue(undefined);
+    parseOrgLensRoiMethod.mockReturnValue('logit');
+    assertOrgLensRead.mockResolvedValue(undefined);
+    getSummary.mockResolvedValue({ hasData: false });
+    getCoverage.mockResolvedValue({ coverageReason: 'unmapped' });
+    getAnnual.mockResolvedValue({ rows: [] });
+  });
+
+  const handlers = [
+    { name: 'getSummary', operation: 'get_org_lens_roi_summary', service: getSummary },
+    { name: 'getCoverage', operation: 'get_org_lens_roi_coverage', service: getCoverage },
+    { name: 'getAnnual', operation: 'get_org_lens_roi_annual', service: getAnnual },
+  ] as const;
+
+  describe.each(handlers)('$name', ({ name, operation, service }) => {
+    it('validates the org uid and the method, then checks access — all before the service runs', async () => {
+      const res = buildRes();
+
+      await controller[name](buildReq({ method: 'logit' }), res, next);
+
+      expect(assertOrgUid).toHaveBeenCalledWith(ORG_UID, operation);
+      expect(parseOrgLensRoiMethod).toHaveBeenCalledWith('logit', operation);
+      expect(assertOrgLensRead).toHaveBeenCalledWith(expect.anything(), ORG_UID, operation);
+      expect(service).toHaveBeenCalledTimes(1);
+
+      const uidOrder = assertOrgUid.mock.invocationCallOrder[0];
+      const methodOrder = parseOrgLensRoiMethod.mock.invocationCallOrder[0];
+      const accessOrder = assertOrgLensRead.mock.invocationCallOrder[0];
+      const serviceOrder = service.mock.invocationCallOrder[0];
+      expect(uidOrder).toBeLessThan(methodOrder);
+      // Cheap synchronous validation precedes the awaited grant lookup, so a malformed request
+      // never costs a role-grants round-trip.
+      expect(methodOrder).toBeLessThan(accessOrder);
+      // The assertion that matters: no data access until the caller's grant is resolved.
+      expect(accessOrder).toBeLessThan(serviceOrder);
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('does not touch the service when the caller has no grant, and forwards the 403', async () => {
+      const forbidden = Object.assign(new Error('forbidden'), { statusCode: 403 });
+      assertOrgLensRead.mockRejectedValueOnce(forbidden);
+      const res = buildRes();
+
+      await controller[name](buildReq(), res, next);
+
+      expect(service).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(forbidden);
+    });
+
+    it('does not touch the service when the grant could not be verified, and forwards the 503', async () => {
+      // 503 is deliberately distinct from 403 upstream: a transient outage must not tell a viewer
+      // they lost access they still hold. Both must still fail closed here.
+      const unavailable = Object.assign(new Error('unavailable'), { statusCode: 503 });
+      assertOrgLensRead.mockRejectedValueOnce(unavailable);
+      const res = buildRes();
+
+      await controller[name](buildReq(), res, next);
+
+      expect(service).not.toHaveBeenCalled();
+      expect(res.json).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(unavailable);
+    });
+
+    it('rejects a malformed org uid without checking access or reading data', async () => {
+      const invalid = Object.assign(new Error('invalid orgUid'), { statusCode: 400 });
+      assertOrgUid.mockImplementationOnce(() => {
+        throw invalid;
+      });
+      const res = buildRes();
+
+      await controller[name](buildReq(), res, next);
+
+      expect(assertOrgLensRead).not.toHaveBeenCalled();
+      expect(service).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(invalid);
+    });
+
+    it('rejects an unknown estimation method without checking access or reading data', async () => {
+      // Every ROI route validates `method`, including the ones whose read ignores it, so an
+      // unrecognised value is rejected identically across the surface rather than by whichever
+      // handlers happen to use it.
+      const invalid = Object.assign(new Error('invalid method'), { statusCode: 400 });
+      parseOrgLensRoiMethod.mockImplementationOnce(() => {
+        throw invalid;
+      });
+      const res = buildRes();
+
+      await controller[name](buildReq({ method: 'nope' }), res, next);
+
+      expect(assertOrgLensRead).not.toHaveBeenCalled();
+      expect(service).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(invalid);
+    });
+
+    it('sends the payload with no-store so the browser never caches an authorized read', async () => {
+      const res = buildRes();
+
+      await controller[name](buildReq(), res, next);
+
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
+      expect(res.json).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/apps/lfx-one/src/server/controllers/org-lens-roi.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-roi.controller.ts
@@ -1,0 +1,76 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { NextFunction, Request, Response } from 'express';
+
+import { assertOrgLensRead } from '../helpers/org-lens-read-access.helper';
+import { parseOrgLensRoiMethod } from '../helpers/org-lens-roi-method.helper';
+import { assertOrgUid } from '../helpers/org-uid.helper';
+import { logger } from '../services/logger.service';
+import { OrgLensRoiService } from '../services/org-lens-roi.service';
+
+// `assertOrgLensRead` must run before any cache or Snowflake access in every handler.
+// Feature flags are browser-only and gate none of these endpoints.
+export class OrgLensRoiController {
+  private readonly service: OrgLensRoiService;
+
+  public constructor() {
+    this.service = new OrgLensRoiService();
+  }
+
+  public async getSummary(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_roi_summary';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      const method = parseOrgLensRoiMethod(req.query['method'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const summary = await this.service.getSummary(req, orgUid, method);
+      logger.success(req, operation, startTime, { org_uid: orgUid, method, has_data: summary.hasData });
+      this.send(res, summary);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getCoverage(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_roi_coverage';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      const method = parseOrgLensRoiMethod(req.query['method'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const coverage = await this.service.getCoverage(req, orgUid, method);
+      logger.success(req, operation, startTime, { org_uid: orgUid, coverage_reason: coverage.coverageReason });
+      this.send(res, coverage);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getAnnual(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_roi_annual';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      const method = parseOrgLensRoiMethod(req.query['method'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const annual = await this.service.getAnnual(req, orgUid, method);
+      logger.success(req, operation, startTime, { org_uid: orgUid, method, rows: annual.rows.length });
+      this.send(res, annual);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  private send(res: Response, body: unknown): void {
+    res.setHeader('Cache-Control', 'no-store');
+    res.json(body);
+  }
+}

--- a/apps/lfx-one/src/server/helpers/org-lens-roi-method.helper.ts
+++ b/apps/lfx-one/src/server/helpers/org-lens-roi-method.helper.ts
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_LENS_ROI_DEFAULT_METHOD, ORG_LENS_ROI_METHODS } from '@lfx-one/shared/constants';
+import type { OrgLensRoiMethod } from '@lfx-one/shared/interfaces';
+
+import { ServiceValidationError } from '../errors';
+
+const SUPPORTED = new Set<string>(ORG_LENS_ROI_METHODS);
+
+// Only an absent `method` defaults; any other unrecognized value is rejected, never defaulted.
+export function parseOrgLensRoiMethod(rawMethod: unknown, operation: string): OrgLensRoiMethod {
+  if (rawMethod === undefined) {
+    return ORG_LENS_ROI_DEFAULT_METHOD;
+  }
+  if (typeof rawMethod !== 'string' || !SUPPORTED.has(rawMethod)) {
+    throw ServiceValidationError.forField('method', `method must be one of: ${ORG_LENS_ROI_METHODS.join(', ')}`, { operation });
+  }
+  return rawMethod as OrgLensRoiMethod;
+}

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -16,6 +16,7 @@ import { OrgLensMembershipsController } from '../controllers/org-lens-membership
 import { OrgLensPeopleController } from '../controllers/org-lens-people.controller';
 import { OrgLensProjectDetailController } from '../controllers/org-lens-project-detail.controller';
 import { OrgLensProjectsController } from '../controllers/org-lens-projects.controller';
+import { OrgLensRoiController } from '../controllers/org-lens-roi.controller';
 import { OrgLensGroupsController } from '../controllers/org-lens-groups.controller';
 import { OrgLensTrainingController } from '../controllers/org-lens-training.controller';
 
@@ -34,6 +35,7 @@ function buildOrgsRouter(): Router {
   const orgLensContributionsController = new OrgLensContributionsController();
   const orgLensMeetingsController = new OrgLensMeetingsController();
   const orgLensProjectsController = new OrgLensProjectsController();
+  const orgLensRoiController = new OrgLensRoiController();
   const orgLensProjectDetailController = new OrgLensProjectDetailController();
   const orgIdentityController = new OrgIdentityController();
 
@@ -129,6 +131,12 @@ function buildOrgsRouter(): Router {
   router.get('/:orgUid/lens/meetings/kpi', (req, res, next) => orgLensMeetingsController.getKpi(req, res, next));
   router.get('/:orgUid/lens/meetings/spend', (req, res, next) => orgLensMeetingsController.getSpend(req, res, next));
   router.get('/:orgUid/lens/meetings/influence', (req, res, next) => orgLensMeetingsController.getInfluence(req, res, next));
+
+  // LFXV2-2980 — Org Lens ROI Metrics.
+  // Register literal segments before any `/roi/.../:projectSlug` matcher, or they get consumed as a slug.
+  router.get('/:orgUid/lens/roi/summary', (req, res, next) => orgLensRoiController.getSummary(req, res, next));
+  router.get('/:orgUid/lens/roi/coverage', (req, res, next) => orgLensRoiController.getCoverage(req, res, next));
+  router.get('/:orgUid/lens/roi/annual', (req, res, next) => orgLensRoiController.getAnnual(req, res, next));
 
   // LFXV2-1894 — Org Lens Code Contributions page (KPI strip + repositories table + commits feed).
   router.get('/:orgUid/lens/contributions', (req, res, next) => orgLensContributionsController.getContributions(req, res, next));

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -1,0 +1,223 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ORG_LENS_ROI_CACHE_KEY, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import type {
+  OrgLensRoiAnnual,
+  OrgLensRoiAnnualRow,
+  OrgLensRoiAnnualWarehouseRow,
+  OrgLensRoiCoverage,
+  OrgLensRoiCoverageWarehouseRow,
+  OrgLensRoiMethod,
+  OrgLensRoiSummary,
+  OrgLensRoiSummaryWarehouseRow,
+} from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+
+import { resolveLfxOnePlatinumSchema } from '../helpers/snowflake-schema.helper';
+
+import { logger } from './logger.service';
+import { SnowflakeService } from './snowflake.service';
+import { withOrgCache } from './valkey.service';
+
+export class OrgLensRoiService {
+  private readonly snowflakeService = SnowflakeService.getInstance();
+
+  public async getSummary(req: Request, accountId: string, method: OrgLensRoiMethod): Promise<OrgLensRoiSummary> {
+    return withOrgCache(
+      accountId,
+      `${ORG_LENS_ROI_CACHE_KEY.summary}:${method}`,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        logger.debug(req, 'get_org_lens_roi_summary', 'Cache miss; querying Snowflake', { account_id: accountId, method });
+        const sql = `
+        SELECT
+          N_PROJECTS,
+          TOTAL_EXPENDITURE,
+          TOTAL_RETURN,
+          PROFIT,
+          ROI,
+          BCR,
+          YEAR_MIN,
+          YEAR_MAX,
+          DATE_MIN,
+          DATE_MAX
+        FROM ${this.summaryTable()}
+        WHERE ACCOUNT_ID = ? AND MARKUP_METHOD = ?
+      `;
+        const result = await this.snowflakeService.execute<OrgLensRoiSummaryWarehouseRow>(sql, [accountId, method]);
+        if (result.rows.length > 1) {
+          logger.warning(req, 'get_org_lens_roi_summary', 'Expected at most one summary row for the grain', {
+            account_id: accountId,
+            method,
+            rows: result.rows.length,
+          });
+        }
+        return this.mapSummary(accountId, method, result.rows.at(0) ?? null);
+      },
+      OrgLensRoiService.isSummary
+    );
+  }
+
+  public async getCoverage(req: Request, accountId: string, method: OrgLensRoiMethod): Promise<OrgLensRoiCoverage> {
+    return withOrgCache(
+      accountId,
+      `${ORG_LENS_ROI_CACHE_KEY.coverage}:${method}`,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        logger.debug(req, 'get_org_lens_roi_coverage', 'Cache miss; querying Snowflake', { account_id: accountId, method });
+        // HAS_ROI is scoped to the same method the summary read uses. Counting every method here
+        // would report "covered" for a method that has no rows, and the page would then render an
+        // empty state whose stated reason contradicts it.
+        const sql = `
+        SELECT
+          (SELECT COUNT(*) FROM ${this.summaryTable()} WHERE ACCOUNT_ID = ? AND MARKUP_METHOD = ?) AS HAS_ROI,
+          (SELECT COUNT(*) FROM ${this.mappingTable()} WHERE ACCOUNT_ID = ? AND CDEV_ORG_ID IS NOT NULL) AS IS_MAPPED
+      `;
+        const result = await this.snowflakeService.execute<OrgLensRoiCoverageWarehouseRow>(sql, [accountId, method, accountId]);
+        return this.mapCoverage(accountId, result.rows.at(0) ?? null);
+      },
+      OrgLensRoiService.isCoverage
+    );
+  }
+
+  public async getAnnual(req: Request, accountId: string, method: OrgLensRoiMethod): Promise<OrgLensRoiAnnual> {
+    return withOrgCache(
+      accountId,
+      `${ORG_LENS_ROI_CACHE_KEY.annual}:${method}`,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        logger.debug(req, 'get_org_lens_roi_annual', 'Cache miss; querying Snowflake', { account_id: accountId, method });
+        const sql = `
+        SELECT
+          YEAR,
+          TOTAL_RETURN,
+          EXPENDITURE,
+          PROFIT,
+          ROI,
+          BCR
+        FROM ${this.annualTable()}
+        WHERE ACCOUNT_ID = ? AND MARKUP_METHOD = ?
+        ORDER BY YEAR
+      `;
+        const result = await this.snowflakeService.execute<OrgLensRoiAnnualWarehouseRow>(sql, [accountId, method]);
+        return {
+          method,
+          rows: result.rows.map((row) => this.mapAnnualRow(row)),
+          apportioned: true,
+        };
+      },
+      OrgLensRoiService.isAnnual
+    );
+  }
+
+  private mapSummary(accountId: string, method: OrgLensRoiMethod, row: OrgLensRoiSummaryWarehouseRow | null): OrgLensRoiSummary {
+    if (row === null) {
+      return {
+        orgUid: accountId,
+        method,
+        hasData: false,
+        nProjects: 0,
+        totalExpenditure: null,
+        totalReturn: null,
+        profit: null,
+        roi: null,
+        bcr: null,
+        yearMin: null,
+        yearMax: null,
+        dateMin: null,
+        dateMax: null,
+      };
+    }
+    return {
+      orgUid: accountId,
+      method,
+      hasData: true,
+      nProjects: this.toCount(row.N_PROJECTS),
+      totalExpenditure: this.toNullableNumber(row.TOTAL_EXPENDITURE),
+      totalReturn: this.toNullableNumber(row.TOTAL_RETURN),
+      profit: this.toNullableNumber(row.PROFIT),
+      roi: this.toNullableNumber(row.ROI),
+      bcr: this.toNullableNumber(row.BCR),
+      yearMin: this.toNullableCount(row.YEAR_MIN),
+      yearMax: this.toNullableCount(row.YEAR_MAX),
+      dateMin: this.toNullableLabel(row.DATE_MIN),
+      dateMax: this.toNullableLabel(row.DATE_MAX),
+    };
+  }
+
+  private mapCoverage(accountId: string, row: OrgLensRoiCoverageWarehouseRow | null): OrgLensRoiCoverage {
+    const hasData = this.toCount(row?.HAS_ROI) > 0;
+    if (hasData) {
+      return { orgUid: accountId, hasData: true, coverageReason: 'covered' };
+    }
+    const isMapped = this.toCount(row?.IS_MAPPED) > 0;
+    return { orgUid: accountId, hasData: false, coverageReason: isMapped ? 'not_estimated' : 'unmapped' };
+  }
+
+  private mapAnnualRow(row: OrgLensRoiAnnualWarehouseRow): OrgLensRoiAnnualRow {
+    return {
+      year: this.toCount(row.YEAR),
+      totalReturn: this.toFiniteNumber(row.TOTAL_RETURN),
+      expenditure: this.toFiniteNumber(row.EXPENDITURE),
+      profit: this.toFiniteNumber(row.PROFIT),
+      roi: this.toNullableNumber(row.ROI),
+      bcr: this.toNullableNumber(row.BCR),
+    };
+  }
+
+  private static isSummary(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const summary = value as Record<string, unknown>;
+    return typeof summary['hasData'] === 'boolean' && typeof summary['nProjects'] === 'number' && typeof summary['method'] === 'string';
+  }
+
+  private static isCoverage(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const coverage = value as Record<string, unknown>;
+    return typeof coverage['hasData'] === 'boolean' && typeof coverage['coverageReason'] === 'string';
+  }
+
+  private static isAnnual(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const annual = value as Record<string, unknown>;
+    return Array.isArray(annual['rows']) && typeof annual['apportioned'] === 'boolean' && typeof annual['method'] === 'string';
+  }
+
+  private toFiniteNumber(value: unknown): number {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  }
+
+  private toCount(value: unknown): number {
+    return Math.max(0, Math.round(this.toFiniteNumber(value)));
+  }
+
+  // Keep a warehouse NULL as null; coercing it to 0 would report "broke even" for no investment.
+  private toNullableNumber(value: unknown): number | null {
+    if (value === null || value === undefined) return null;
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+
+  private toNullableCount(value: unknown): number | null {
+    const parsed = this.toNullableNumber(value);
+    return parsed === null ? null : Math.round(parsed);
+  }
+
+  private toNullableLabel(value: unknown): string | null {
+    return typeof value === 'string' && value.length > 0 ? value : null;
+  }
+
+  private summaryTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_SUMMARY`;
+  }
+
+  private annualTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_ANNUAL`;
+  }
+
+  private mappingTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ACCOUNT_TO_CDEV_ORG_MAPPING`;
+  }
+}

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ORG_LENS_ROI_CACHE_KEY, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import { ORG_LENS_ROI_CACHE_KEY, ORG_LENS_ROI_COVERAGE_REASONS, ORG_LENS_ROI_METHODS, VALKEY_CACHE } from '@lfx-one/shared/constants';
 import type {
   OrgLensRoiAnnual,
   OrgLensRoiAnnualRow,
@@ -166,22 +166,56 @@ export class OrgLensRoiService {
     };
   }
 
+  /**
+   * A key that is absent is not the same as one holding null, and the difference reaches the UI: a
+   * nullable measure renders as the no-value indicator, while an absent one used to reach
+   * `toFixed()`. So these check presence explicitly rather than accepting `undefined` as null.
+   */
+  private static isNullableNumber(record: Record<string, unknown>, key: string): boolean {
+    if (!(key in record)) return false;
+    const value = record[key];
+    return value === null || (typeof value === 'number' && Number.isFinite(value));
+  }
+
+  private static isNullableString(record: Record<string, unknown>, key: string): boolean {
+    if (!(key in record)) return false;
+    const value = record[key];
+    return value === null || typeof value === 'string';
+  }
+
   private static isSummary(value: unknown): boolean {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
     const summary = value as Record<string, unknown>;
-    return typeof summary['hasData'] === 'boolean' && typeof summary['nProjects'] === 'number' && typeof summary['method'] === 'string';
+    if (typeof summary['hasData'] !== 'boolean') return false;
+    if (typeof summary['nProjects'] !== 'number') return false;
+    if (!(ORG_LENS_ROI_METHODS as readonly string[]).includes(summary['method'] as string)) return false;
+    const nullableNumbers = ['totalExpenditure', 'totalReturn', 'profit', 'roi', 'bcr', 'yearMin', 'yearMax'];
+    if (!nullableNumbers.every((key) => OrgLensRoiService.isNullableNumber(summary, key))) return false;
+    return ['dateMin', 'dateMax'].every((key) => OrgLensRoiService.isNullableString(summary, key));
   }
 
   private static isCoverage(value: unknown): boolean {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
     const coverage = value as Record<string, unknown>;
-    return typeof coverage['hasData'] === 'boolean' && typeof coverage['coverageReason'] === 'string';
+    if (typeof coverage['hasData'] !== 'boolean') return false;
+    return (ORG_LENS_ROI_COVERAGE_REASONS as readonly string[]).includes(coverage['coverageReason'] as string);
   }
 
   private static isAnnual(value: unknown): boolean {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
     const annual = value as Record<string, unknown>;
-    return Array.isArray(annual['rows']) && typeof annual['apportioned'] === 'boolean' && typeof annual['method'] === 'string';
+    if (typeof annual['apportioned'] !== 'boolean') return false;
+    if (!(ORG_LENS_ROI_METHODS as readonly string[]).includes(annual['method'] as string)) return false;
+    if (!Array.isArray(annual['rows'])) return false;
+    // Rows are what the chart maps over, so a malformed one is as bad as a malformed envelope.
+    return annual['rows'].every((row) => {
+      if (row === null || typeof row !== 'object' || Array.isArray(row)) return false;
+      const entry = row as Record<string, unknown>;
+      if (typeof entry['year'] !== 'number') return false;
+      const required = ['totalReturn', 'expenditure', 'profit'];
+      if (!required.every((key) => typeof entry[key] === 'number' && Number.isFinite(entry[key] as number))) return false;
+      return ['roi', 'bcr'].every((key) => OrgLensRoiService.isNullableNumber(entry, key));
+    });
   }
 
   private toFiniteNumber(value: unknown): number {

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -6,3 +6,5 @@ export const AKRITES_ENABLED_FLAG = 'akrites-enabled';
 export const MKTG_OS_AGENTS_ENABLED_FLAG = 'mktg-os-agents-enabled';
 export const MY_CLAS_ENABLED_FLAG = 'my-clas-enabled';
 export const WG_ENGAGEMENT_METRICS_FLAG = 'wg-engagement-metrics';
+/** Browser-only flag for the Org Lens ROI page — it gates no endpoint. */
+export const ORG_LENS_ROI_ENABLED_FLAG = 'org-lens-roi-enabled';

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -93,3 +93,4 @@ export * from './http-retry.constants';
 export * from './committee-engagement.constants';
 export * from './weekly-brief.constants';
 export * from './profile-visibility.constants';
+export * from './org-lens-roi.constants';

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -1,0 +1,58 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export const ORG_LENS_ROI_METHODS = ['logit', 'direct'] as const;
+
+export const ORG_LENS_ROI_DEFAULT_METHOD = 'logit';
+
+export const ORG_LENS_ROI_METHOD_LABELS: Record<(typeof ORG_LENS_ROI_METHODS)[number], string> = {
+  logit: 'Logistic markup',
+  direct: 'Direct markup',
+};
+
+/** `localStorage` key the selected estimation method persists under. */
+export const ORG_LENS_ROI_METHOD_STORAGE_KEY = 'lfx-org-roi-estimation-method';
+
+export const ORG_LENS_ROI_CACHE_KEY = {
+  summary: 'roi-summary:v1',
+  coverage: 'roi-coverage:v1',
+  annual: 'roi-annual:v1',
+} as const;
+
+/** Order must match the warehouse seed's display order. */
+export const ORG_LENS_ROI_CONTRIBUTION_TYPES = [
+  'code',
+  'community',
+  'meetings',
+  'event_attendance',
+  'event_sponsorship',
+  'membership_project',
+  'membership_tlf',
+  'educ_courses',
+] as const;
+
+/** Disclosure copy only — changing these recalculates nothing; the rates live in the warehouse. */
+export const ORG_LENS_ROI_GLOBAL_ASSUMPTIONS = {
+  codeSalaryUsd: 200_000,
+  communitySalaryUsd: 150_000,
+  overheadMultiplier: 1.5,
+} as const;
+
+export const ORG_LENS_ROI_KPI_ICON_CLASS = {
+  totalExpenditure: 'bg-blue-100 text-blue-600',
+  totalReturn: 'bg-emerald-100 text-emerald-600',
+  roi: 'bg-violet-100 text-violet-600',
+  bcr: 'bg-amber-100 text-amber-600',
+} as const;
+
+/** Rendered wherever a metric is undefined, so an absent value never reads as zero. */
+export const ORG_LENS_ROI_NO_VALUE = '—';
+
+export const ORG_LENS_ROI_KPI_EXPLANATION = {
+  totalExpenditure:
+    'A modelled cost, not actual or reported compensation. We count your organization’s public contribution activity — commits, community participation, meetings, events, memberships, and training — and price it at standard rates that are the same for every organization. No salary, payroll, or invoice data is used.',
+  totalReturn:
+    'The modelled economic value your organization received back from the projects it contributed to, estimated from the wider project ecosystem rather than measured from your own systems.',
+  roi: 'Net return divided by investment, shown as a percentage. 100% means you got back your investment again on top of it. Blank when there is no investment to divide by.',
+  bcr: 'Total return divided by investment. A benefit-cost ratio of 5× means every dollar of modelled investment is associated with five dollars of modelled return. Always exactly one more than ROI.',
+} as const;

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -5,6 +5,12 @@ export const ORG_LENS_ROI_METHODS = ['logit', 'direct'] as const;
 
 export const ORG_LENS_ROI_DEFAULT_METHOD = 'logit';
 
+/**
+ * Why an organization has or hasn't got figures. `unmapped` is permanent; `not_estimated` is
+ * mapped-but-unestimated and must not be described to viewers as arriving on a later run.
+ */
+export const ORG_LENS_ROI_COVERAGE_REASONS = ['covered', 'unmapped', 'not_estimated'] as const;
+
 export const ORG_LENS_ROI_METHOD_LABELS: Record<(typeof ORG_LENS_ROI_METHODS)[number], string> = {
   logit: 'Logistic markup',
   direct: 'Direct markup',

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -310,3 +310,7 @@ export * from './weekly-brief.interface';
 
 // Public-profile section visibility (LFXV2-2629)
 export * from './profile-visibility.interface';
+
+// Org Lens ROI Metrics (LFXV2-2980) interfaces
+export * from './org-lens-roi.interface';
+export * from './org-lens-roi.internal.interface';

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -1,14 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { ORG_LENS_ROI_CONTRIBUTION_TYPES, ORG_LENS_ROI_METHODS } from '../constants/org-lens-roi.constants';
+import type { ORG_LENS_ROI_CONTRIBUTION_TYPES, ORG_LENS_ROI_COVERAGE_REASONS, ORG_LENS_ROI_METHODS } from '../constants/org-lens-roi.constants';
 
 export type OrgLensRoiMethod = (typeof ORG_LENS_ROI_METHODS)[number];
 
 export type OrgLensRoiContributionType = (typeof ORG_LENS_ROI_CONTRIBUTION_TYPES)[number];
 
 /** `unmapped` — no crowd.dev organization to key on; `not_estimated` — mapped but the estimation produced no rows. */
-export type OrgLensRoiCoverageReason = 'covered' | 'unmapped' | 'not_estimated';
+export type OrgLensRoiCoverageReason = (typeof ORG_LENS_ROI_COVERAGE_REASONS)[number];
 
 export interface OrgLensRoiSummary {
   orgUid: string;

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -1,0 +1,49 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { ORG_LENS_ROI_CONTRIBUTION_TYPES, ORG_LENS_ROI_METHODS } from '../constants/org-lens-roi.constants';
+
+export type OrgLensRoiMethod = (typeof ORG_LENS_ROI_METHODS)[number];
+
+export type OrgLensRoiContributionType = (typeof ORG_LENS_ROI_CONTRIBUTION_TYPES)[number];
+
+/** `unmapped` — no crowd.dev organization to key on; `not_estimated` — mapped but the estimation produced no rows. */
+export type OrgLensRoiCoverageReason = 'covered' | 'unmapped' | 'not_estimated';
+
+export interface OrgLensRoiSummary {
+  orgUid: string;
+  method: OrgLensRoiMethod;
+  hasData: boolean;
+  nProjects: number;
+  totalExpenditure: number | null;
+  totalReturn: number | null;
+  profit: number | null;
+  /** Null — never zero — when investment is 0. */
+  roi: number | null;
+  bcr: number | null;
+  yearMin: number | null;
+  yearMax: number | null;
+  dateMin: string | null;
+  dateMax: string | null;
+}
+
+export interface OrgLensRoiCoverage {
+  orgUid: string;
+  hasData: boolean;
+  coverageReason: OrgLensRoiCoverageReason;
+}
+
+export interface OrgLensRoiAnnualRow {
+  year: number;
+  totalReturn: number;
+  expenditure: number;
+  profit: number;
+  roi: number | null;
+  bcr: number | null;
+}
+
+export interface OrgLensRoiAnnual {
+  method: OrgLensRoiMethod;
+  rows: OrgLensRoiAnnualRow[];
+  apportioned: boolean;
+}

--- a/packages/shared/src/interfaces/org-lens-roi.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.internal.interface.ts
@@ -1,0 +1,31 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+export interface OrgLensRoiSummaryWarehouseRow {
+  N_PROJECTS: number;
+  TOTAL_EXPENDITURE: number;
+  TOTAL_RETURN: number;
+  PROFIT: number;
+  /** NULL rather than zero when `TOTAL_EXPENDITURE` is 0. */
+  ROI: number | null;
+  BCR: number | null;
+  YEAR_MIN: number | null;
+  YEAR_MAX: number | null;
+  DATE_MIN: string | null;
+  DATE_MAX: string | null;
+}
+
+export interface OrgLensRoiAnnualWarehouseRow {
+  YEAR: number;
+  TOTAL_RETURN: number;
+  /** Source column is `EXPENDITURE`, not `TOTAL_EXPENDITURE`. */
+  EXPENDITURE: number;
+  PROFIT: number;
+  ROI: number | null;
+  BCR: number | null;
+}
+
+export interface OrgLensRoiCoverageWarehouseRow {
+  HAS_ROI: number;
+  IS_MAPPED: number;
+}

--- a/packages/shared/src/utils/number.utils.spec.ts
+++ b/packages/shared/src/utils/number.utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { formatPercent } from './number.utils';
+import { formatCurrency, formatPercent } from './number.utils';
 
 describe('formatPercent', () => {
   it('rounds a raw Snowflake float to a single decimal place', () => {
@@ -36,5 +36,29 @@ describe('formatPercent', () => {
     expect(formatPercent(Number.NaN)).toBe('0.0');
     expect(formatPercent(Number.POSITIVE_INFINITY)).toBe('0.0');
     expect(formatPercent(Number.NEGATIVE_INFINITY)).toBe('0.0');
+  });
+});
+
+describe('formatCurrency compact thresholds', () => {
+  it('switches to billions at the threshold that would otherwise round to 1000.0M', () => {
+    expect(formatCurrency(999_949_999)).toBe('$999.9M');
+    expect(formatCurrency(999_950_000)).toBe('$1B');
+    expect(formatCurrency(5_576_366_821.32)).toBe('$5.6B');
+  });
+
+  it('keeps the millions and thousands branches unchanged below the billions threshold', () => {
+    expect(formatCurrency(999_949)).toBe('$999.9K');
+    expect(formatCurrency(999_950)).toBe('$1M');
+    expect(formatCurrency(147_932_363.97)).toBe('$147.9M');
+    expect(formatCurrency(999)).toBe('$999');
+  });
+
+  it('places the sign outside the prefix for negative billions', () => {
+    expect(formatCurrency(-2_400_000_000)).toBe('-$2.4B');
+  });
+
+  it('falls back to $0 for non-finite input', () => {
+    expect(formatCurrency(Number.NaN)).toBe('$0');
+    expect(formatCurrency(Number.POSITIVE_INFINITY)).toBe('$0');
   });
 });

--- a/packages/shared/src/utils/number.utils.ts
+++ b/packages/shared/src/utils/number.utils.ts
@@ -4,6 +4,7 @@
 /**
  * Format a number for display using compact notation.
  * - Handles negative numbers, NaN, and Infinity gracefully
+ * - Numbers >= 999,950,000 are displayed as "X.XB"
  * - Numbers >= 999,950 are displayed as "X.XM"
  * - Numbers >= 1,000 are displayed as "X.XK"
  * - Smaller numbers use locale-formatted strings
@@ -16,6 +17,7 @@ export function formatNumber(num: number): string {
 /**
  * Format a number as currency (USD) using compact notation.
  * - Handles negative numbers, NaN, and Infinity gracefully
+ * - Numbers >= 999,950,000 are displayed as "$X.XB"
  * - Numbers >= 999,950 are displayed as "$X.XM"
  * - Numbers >= 1,000 are displayed as "$X.XK"
  * - Smaller numbers use locale-formatted strings with "$" prefix
@@ -29,6 +31,7 @@ export function formatCurrency(num: number): string {
  * Format a monetary value-lost figure using compact notation.
  * Suitable for displaying churn, refund, or write-off amounts.
  * - Handles negative numbers, NaN, and Infinity gracefully
+ * - Values >= 999,950,000 are displayed as "$X.XB"
  * - Values >= 999,950 are displayed as "$X.XM"
  * - Values >= 1,000 are displayed as "$X.XK"
  * - Smaller values use locale-formatted strings with "$" prefix
@@ -57,6 +60,7 @@ export function formatPercent(value: number): string {
  *  and an unpinned toLocaleString() renders different separators per client
  *  locale, causing hydration text mismatches. */
 export function formatCompact(abs: number, sign: string, prefix = ''): string {
+  if (abs >= 999_950_000) return `${sign}${prefix}${stripTrailingZero((abs / 1_000_000_000).toFixed(1))}B`;
   if (abs >= 999_950) return `${sign}${prefix}${stripTrailingZero((abs / 1_000_000).toFixed(1))}M`;
   if (abs >= 1_000) return `${sign}${prefix}${stripTrailingZero((abs / 1_000).toFixed(1))}K`;
   return `${sign}${prefix}${abs.toLocaleString('en-US')}`;


### PR DESCRIPTION
## Summary

Adds the Org Lens **ROI Metrics** page at `/org/roi` — what an organization invested in open source, and what the economic model says came back.

The metric layer already shipped in `lf-dbt` ([#2720](https://github.com/linuxfoundation/lf-dbt/pull/2720), built in production). This wires it to the product: three BFF reads over the platinum `ORG_LENS_ROI_*` models, plus the page shell, KPI band, annual trend, and model-assumptions drawer.

Ticket: **LFXV2-2980** · Spec: `specs/037-org-lens-roi-metrics/` · Scope: **User Story 2 only** (US3–US7 follow separately).

## What's in it

**BFF** — `GET /api/orgs/:orgUid/lens/roi/{summary,coverage,annual}`

Every handler runs `assertOrgUid` → validate `method` → `await assertOrgLensRead` **before** touching cache or Snowflake. `:orgUid` is the analytics filter, never the authorization.

> The page's dark-launch flag is browser-only and gates no endpoint. These routes are callable by any authenticated user the moment this merges, so the in-handler read gate is the only thing protecting the data — it is not deferrable to a later story.

Reads go through `withOrgCache` with versioned per-sub-resource keys and shape guards, and `?`-bound Snowflake queries against a validated schema qualifier. Derived measures (`profit`/`roi`/`bcr`) are **not** recomputed here — they're defined once in the metric layer, which returns `NULL` rather than zero when investment is zero.

**UI** — page shell with a seven-branch gate, KPI band, annual trend, assumptions drawer, and a two-cause empty state. Estimation method persists in `localStorage`, restored in `afterNextRender` so it can't trip hydration.

**Shared** — compact formatter extended to billions. Returns reach $5.5bn and previously rendered as `$5533.8M`.

## Two things reviewers should look at closely

**1. The investment figure is a modelled cost, and the copy is load-bearing.**

Investment is public contribution activity priced at global per-contribution-type rates ($200k code / $150k community / 1.5× overhead) — identical for every organization, with contributor identity discarded upstream of the entire ROI chain. It is not compensation data.

That matters because **19.4% of covered organizations have exactly one code contributor**, so "Code Contribution: $310,000" reads as one person's pay without the derivation stated. Every surface showing an investment figure says so, and the drawer presents the rates as the global constants they are rather than as figures specific to the viewing organization. These are requirements, not polish — e2e asserts each clause individually so they can't be shortened away to fit a layout.

**2. The mapped-but-unestimated empty state deliberately does not promise later figures.**

The spec's original wording was "may change on a later pipeline run". That's wrong: contribution activity is pooled by organization **name** upstream, so where several accounts share a name the figures land wholly on a sibling account, and a re-run reproduces that attribution rather than correcting it. (Measured: 12 names span two accounts, pooling $9.46m — already bounded by `assert_lfx_roi_org_name_collisions_bounded.sql` in lf-dbt.)

The copy names the real mechanism and routes to contact instead. E2E asserts the absence of "check back" / "later run" / "may appear".

Roughly **half of member organizations have no ROI data**, so the empty state is built and reviewed as a primary surface, not a fallback.

## Verification

Verified live against **production** data (all six platinum models built 2026-08-07) with Red Hat LLC — figures reconcile exactly with `ORG_LENS_ROI_SUMMARY`:

| Card | Rendered | Warehouse |
|---|---|---|
| Total Investment | $147.9M · 409 projects | 147,944,168.47 · 409 |
| Total Return | $5.5B (net $5.4B) | 5,533,767,122.14 |
| Portfolio ROI | 3640.4% | 36.4044 |
| Benefit-Cost Ratio | 37.4× | 37.4044 |

Switching to the `direct` method moved return/ROI/BCR while investment stayed constant, confirming expenditure is method-invariant; the choice persisted across a reload. The two-cause empty state was confirmed against Proxima Systems Ltd, a real unestimated account. The LaunchDarkly flag was verified gating both the route and the nav entry with no code override.

Gates: `yarn build`, `yarn lint:check`, `yarn format:check`, `check-headers.sh` all pass; 609 unit tests green (10 new for the billions threshold).

## Known gaps

- **The annual chart's investment series is effectively invisible.** Return runs 36–56× investment, so on a shared linear axis investment sits under 2% of the chart height. Needs a dual or logarithmic y-axis — flagged for design, not guessed at, since it changes how the headline trend reads.
- **`e2e/org-roi-summary.spec.ts` (15 cases) has not been run green.** The suite needs `TEST_USERNAME`/`TEST_PASSWORD` and cluster access; locally every case — including the pre-existing `org-meetings-dashboard.spec.ts` — fails at `page.goto('/')` because auth-gated SSR routes need a real Auth0 issuer. Please run it in CI.
- The empty state and KPI layout had an agent self-review against the spec criteria, **not** a design review with a designer. Open items are recorded in `specs/037-org-lens-roi-metrics/tasks.md` T044.

## Test plan

- [ ] CI runs `e2e/org-roi-summary.spec.ts` green
- [ ] Confirm the LaunchDarkly `org-lens-roi-enabled` default is `false` in **Production** (endpoints are live regardless; the flag only hides the page)
- [ ] Spot-check a second covered org and a genuinely unmapped one
- [ ] Design pass on the annual chart axis and the empty state


Made with [Cursor](https://cursor.com)