### PR TITLE
refactor(enrollment): model enrollment list as a single state signal

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.html
@@ -2,10 +2,11 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-4" data-testid="individual-enrollment-page">
-  @if (displayedEnrollments() === undefined) {
-    <!-- Loading skeletons -->
-    <div class="flex flex-col gap-4" data-testid="individual-enrollment-loading">
-      @for (i of [1]; track i) {
+  @let state = displayState();
+  @switch (state.kind) {
+    @case ('loading') {
+      <!-- Loading skeleton -->
+      <div class="flex flex-col gap-4" data-testid="individual-enrollment-loading">
         <lfx-card>
           <div class="flex flex-col gap-3 p-4">
             <div class="h-5 w-48 animate-pulse rounded bg-gray-200"></div>
@@ -14,173 +15,186 @@
             <div class="h-4 w-3/4 animate-pulse rounded bg-gray-200"></div>
           </div>
         </lfx-card>
-      }
-    </div>
-  } @else if (enrollmentError() !== null) {
-    <lfx-empty-state
-      icon="fa-light fa-circle-exclamation"
-      title="Could not load enrollment products"
-      [subtitle]="enrollmentError() || 'We could not load your enrollment products. Please retry.'"
-      data-testid="individual-enrollment-error" />
-  } @else if (displayedEnrollments()!.length === 0) {
-    <lfx-empty-state
-      icon="fa-light fa-id-card"
-      title="No enrollment products available"
-      subtitle="There are no individual enrollment products at this time."
-      data-testid="individual-enrollment-empty" />
-  } @else {
-    @for (item of displayedEnrollments()!; track item.productId) {
-      <lfx-card data-testid="individual-enrollment-card">
-        <div class="flex flex-col gap-6 p-6">
-          <!-- Header row -->
-          <div class="flex flex-wrap items-start justify-between gap-3">
-            <div class="flex items-center gap-3">
-              @if (item.projectLogo) {
-                <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-gray-200 p-1.5">
-                  <img [src]="item.projectLogo" [alt]="item.projectName" class="h-full w-full object-contain" />
-                </div>
-              }
-              <div class="flex flex-col gap-0.5">
-                @if (!item.membership) {
-                  <span class="text-xs font-medium text-gray-400">Individual Enrollment</span>
-                }
-                <span class="text-lg font-semibold text-gray-900">{{ item.productName }}</span>
-                @if (item.membership) {
-                  <span class="text-sm text-gray-500">{{ item.projectName }}</span>
-                }
-              </div>
-            </div>
-            @if (!item.membership && item.price !== null && item.price !== undefined) {
-              <div class="flex items-baseline gap-1">
-                <span class="text-3xl font-bold text-gray-900">${{ item.price }}</span>
-                <span class="text-sm text-gray-500">/year</span>
-              </div>
-            }
-            @if (item.membership) {
-              <lfx-tag [value]="item.displayStatus" [severity]="item.severity" [dot]="true" data-testid="individual-enrollment-status" />
-            }
-          </div>
-
-          <!-- Enrolled details row -->
-          @if (item.membership) {
-            <hr class="border-gray-200" />
-            <div class="flex flex-wrap items-center gap-12" data-testid="individual-enrollment-details">
-              @if (item.price !== null && item.price !== undefined) {
-                <div class="flex flex-col gap-1" data-testid="individual-enrollment-price">
-                  <div class="flex items-center gap-1.5 text-xs text-gray-400">
-                    <i class="fa-light fa-tag"></i>
-                    <span>Price</span>
-                  </div>
-                  <span class="text-sm font-normal text-gray-900">${{ item.price }}/year</span>
-                </div>
-              }
-              @if (item.membership.purchaseDate) {
-                <div class="flex flex-col gap-1" data-testid="individual-enrollment-purchase-date">
-                  <div class="flex items-center gap-1.5 text-xs text-gray-400">
-                    <i class="fa-light fa-credit-card"></i>
-                    <span>Purchased</span>
-                  </div>
-                  <span class="text-sm font-normal text-gray-900">{{ item.membership.purchaseDate | date: 'mediumDate' : 'UTC' }}</span>
-                </div>
-              }
-              @if (item.membership.endDate) {
-                <div class="flex flex-col gap-1">
-                  <div class="flex items-center gap-1.5 text-xs text-gray-400">
-                    @if (item.displayStatus === 'Expired') {
-                      <i class="fa-light fa-calendar-xmark"></i>
-                    } @else {
-                      <i class="fa-light fa-calendar-check"></i>
+      </div>
+    }
+    @case ('error') {
+      <lfx-empty-state
+        icon="fa-light fa-circle-exclamation"
+        title="Could not load enrollment products"
+        [subtitle]="state.message || 'We could not load your enrollment products. Please retry.'"
+        data-testid="individual-enrollment-error" />
+    }
+    @case ('loaded') {
+      @if (state.items.length === 0) {
+        <lfx-empty-state
+          icon="fa-light fa-id-card"
+          title="No enrollment products available"
+          subtitle="There are no individual enrollment products at this time."
+          data-testid="individual-enrollment-empty" />
+      } @else {
+        @for (item of state.items; track item.productId) {
+          <lfx-card data-testid="individual-enrollment-card">
+            <div class="flex flex-col gap-6 p-6">
+              <!-- Header row -->
+              <div class="flex flex-wrap items-start justify-between gap-3">
+                <div class="flex items-center gap-3">
+                  @if (item.projectLogo) {
+                    <div class="flex h-12 w-12 shrink-0 items-center justify-center rounded-lg border border-gray-200 p-1.5">
+                      <img [src]="item.projectLogo" [alt]="item.projectName" class="h-full w-full object-contain" />
+                    </div>
+                  }
+                  <div class="flex flex-col gap-0.5">
+                    @if (!item.membership) {
+                      <span class="text-xs font-medium text-gray-400">Individual Enrollment</span>
                     }
-                    <span>{{ item.displayStatus === 'Expired' ? 'Expired on' : 'Renews' }}</span>
+                    <span class="text-lg font-semibold text-gray-900">{{ item.productName }}</span>
+                    @if (item.membership) {
+                      <span class="text-sm text-gray-500">{{ item.projectName }}</span>
+                    }
                   </div>
-                  <span class="text-sm font-normal text-gray-900">{{ item.membership.endDate | date: 'mediumDate' : 'UTC' }}</span>
+                </div>
+                @if (!item.membership && item.price !== null && item.price !== undefined) {
+                  <div class="flex items-baseline gap-1">
+                    <span class="text-3xl font-bold text-gray-900">${{ item.price }}</span>
+                    <span class="text-sm text-gray-500">/year</span>
+                  </div>
+                }
+                @if (item.membership) {
+                  <lfx-tag [value]="item.displayStatus" [severity]="item.severity" [dot]="true" data-testid="individual-enrollment-status" />
+                }
+              </div>
+
+              <!-- Enrolled details row -->
+              @if (item.membership) {
+                <hr class="border-gray-200" />
+                <div class="flex flex-wrap items-center gap-12" data-testid="individual-enrollment-details">
+                  @if (item.price !== null && item.price !== undefined) {
+                    <div class="flex flex-col gap-1" data-testid="individual-enrollment-price">
+                      <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                        <i class="fa-light fa-tag"></i>
+                        <span>Price</span>
+                      </div>
+                      <span class="text-sm font-normal text-gray-900">${{ item.price }}/year</span>
+                    </div>
+                  }
+                  @if (item.membership.purchaseDate) {
+                    <div class="flex flex-col gap-1" data-testid="individual-enrollment-purchase-date">
+                      <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                        <i class="fa-light fa-credit-card"></i>
+                        <span>Purchased</span>
+                      </div>
+                      <span class="text-sm font-normal text-gray-900">{{ item.membership.purchaseDate | date: 'mediumDate' : 'UTC' }}</span>
+                    </div>
+                  }
+                  @if (item.membership.endDate) {
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                        @if (item.displayStatus === 'Expired') {
+                          <i class="fa-light fa-calendar-xmark"></i>
+                        } @else {
+                          <i class="fa-light fa-calendar-check"></i>
+                        }
+                        <span>{{ item.displayStatus === 'Expired' ? 'Expired on' : 'Renews' }}</span>
+                      </div>
+                      <span class="text-sm font-normal text-gray-900">{{ item.membership.endDate | date: 'mediumDate' : 'UTC' }}</span>
+                    </div>
+                  }
+                  @if (item.membership.extPaymentType === 'stripe' && item.displayStatus !== 'Expired') {
+                    <div class="flex flex-col gap-1">
+                      <div class="flex items-center gap-1.5 text-xs text-gray-400">
+                        <i class="fa-light fa-arrow-rotate-right"></i>
+                        <span>Auto-renew</span>
+                      </div>
+                      <span class="text-sm font-normal text-gray-900">{{ item.membership.autoRenew ? 'Enabled' : 'Disabled' }}</span>
+                    </div>
+                    @if (item.membership.autoRenew) {
+                      <lfx-button
+                        class="-ml-6"
+                        label="Disable auto-renew"
+                        severity="secondary"
+                        size="small"
+                        [disabled]="item.pending || impersonating()"
+                        (onClick)="onToggleAutoRenew(item, false)"
+                        data-testid="individual-enrollment-auto-renew-toggle" />
+                    } @else {
+                      <lfx-button
+                        class="-ml-6"
+                        label="Enable auto-renew"
+                        icon="fa-light fa-arrow-rotate-right"
+                        severity="secondary"
+                        size="small"
+                        [disabled]="item.pending || impersonating()"
+                        (onClick)="onToggleAutoRenew(item, true)"
+                        data-testid="individual-enrollment-auto-renew-toggle" />
+                    }
+                  }
                 </div>
               }
-              @if (item.membership.extPaymentType === 'stripe' && item.displayStatus !== 'Expired') {
-                <div class="flex flex-col gap-1">
-                  <div class="flex items-center gap-1.5 text-xs text-gray-400">
-                    <i class="fa-light fa-arrow-rotate-right"></i>
-                    <span>Auto-renew</span>
-                  </div>
-                  <span class="text-sm font-normal text-gray-900">{{ item.membership.autoRenew ? 'Enabled' : 'Disabled' }}</span>
+
+              <!-- Benefits list -->
+              @if (item.benefits && item.benefits.length > 0) {
+                <hr class="border-gray-200" />
+                <div class="flex flex-col gap-3" data-testid="individual-enrollment-benefits">
+                  <span class="text-sm font-medium text-gray-700">Benefits:</span>
+                  <ul class="flex flex-col gap-3">
+                    @for (benefit of item.benefits; track benefit) {
+                      <li class="flex items-start gap-2 text-sm text-gray-600">
+                        <i class="fa-light fa-circle-check mt-0.5 text-emerald-500"></i>
+                        {{ benefit }}
+                      </li>
+                    }
+                  </ul>
                 </div>
-                @if (item.membership.autoRenew) {
-                  <lfx-button
-                    class="-ml-6"
-                    label="Disable auto-renew"
-                    severity="secondary"
-                    size="small"
-                    [disabled]="item.pending || impersonating()"
-                    (onClick)="onToggleAutoRenew(item, false)"
-                    data-testid="individual-enrollment-auto-renew-toggle" />
-                } @else {
-                  <lfx-button
-                    class="-ml-6"
-                    label="Enable auto-renew"
-                    icon="fa-light fa-arrow-rotate-right"
-                    severity="secondary"
-                    size="small"
-                    [disabled]="item.pending || impersonating()"
-                    (onClick)="onToggleAutoRenew(item, true)"
-                    data-testid="individual-enrollment-auto-renew-toggle" />
-                }
               }
-            </div>
-          }
 
-          <!-- Benefits list -->
-          @if (item.benefits && item.benefits.length > 0) {
-            <hr class="border-gray-200" />
-            <div class="flex flex-col gap-3" data-testid="individual-enrollment-benefits">
-              <span class="text-sm font-medium text-gray-700">Benefits:</span>
-              <ul class="flex flex-col gap-3">
-                @for (benefit of item.benefits; track benefit) {
-                  <li class="flex items-start gap-2 text-sm text-gray-600">
-                    <i class="fa-light fa-circle-check mt-0.5 text-emerald-500"></i>
-                    {{ benefit }}
-                  </li>
-                }
-              </ul>
-            </div>
-          }
-
-          <!-- CTA (not enrolled / expiring / expired) -->
-          @if (!item.membership || item.displayStatus === 'Expiring Soon' || item.displayStatus === 'Expired') {
-            <div class="flex" data-testid="individual-enrollment-cta">
-              <!-- CTAs link out to the enrollment flow; while impersonating they render disabled (a link
+              <!-- CTA (not enrolled / expiring / expired) -->
+              @if (!item.membership || item.displayStatus === 'Expiring Soon' || item.displayStatus === 'Expired') {
+                <div class="flex" data-testid="individual-enrollment-cta">
+                  <!-- CTAs link out to the enrollment flow; while impersonating they render disabled (a link
                    cannot carry the `disabled` state, so a non-link button variant is used instead). -->
-              @if (!item.membership) {
-                @if (impersonating()) {
-                  <lfx-button
-                    [label]="item.enrollButton || 'Enroll'"
-                    severity="primary"
-                    [disabled]="true"
-                    ariaLabel="Enrollment is unavailable while impersonating another user"
-                    data-testid="individual-enrollment-enroll-button" />
-                } @else {
-                  <lfx-button [label]="item.enrollButton || 'Enroll'" severity="primary" [href]="item.enrollHref" target="_blank" rel="noopener noreferrer" />
-                }
-              } @else if (item.displayStatus === 'Expiring Soon') {
-                @if (impersonating()) {
-                  <lfx-button
-                    label="Renew My Enrollment"
-                    severity="primary"
-                    [disabled]="true"
-                    ariaLabel="Enrollment is unavailable while impersonating another user" />
-                } @else {
-                  <lfx-button label="Renew My Enrollment" severity="primary" [href]="item.renewHref" target="_blank" rel="noopener noreferrer" />
-                }
-              } @else if (item.displayStatus === 'Expired') {
-                @if (impersonating()) {
-                  <lfx-button label="Repurchase" severity="primary" [disabled]="true" ariaLabel="Enrollment is unavailable while impersonating another user" />
-                } @else {
-                  <lfx-button label="Repurchase" severity="primary" [href]="item.enrollHref" target="_blank" rel="noopener noreferrer" />
-                }
+                  @if (!item.membership) {
+                    @if (impersonating()) {
+                      <lfx-button
+                        [label]="item.enrollButton || 'Enroll'"
+                        severity="primary"
+                        [disabled]="true"
+                        ariaLabel="Enrollment is unavailable while impersonating another user"
+                        data-testid="individual-enrollment-enroll-button" />
+                    } @else {
+                      <lfx-button
+                        [label]="item.enrollButton || 'Enroll'"
+                        severity="primary"
+                        [href]="item.enrollHref"
+                        target="_blank"
+                        rel="noopener noreferrer" />
+                    }
+                  } @else if (item.displayStatus === 'Expiring Soon') {
+                    @if (impersonating()) {
+                      <lfx-button
+                        label="Renew My Enrollment"
+                        severity="primary"
+                        [disabled]="true"
+                        ariaLabel="Enrollment is unavailable while impersonating another user" />
+                    } @else {
+                      <lfx-button label="Renew My Enrollment" severity="primary" [href]="item.renewHref" target="_blank" rel="noopener noreferrer" />
+                    }
+                  } @else if (item.displayStatus === 'Expired') {
+                    @if (impersonating()) {
+                      <lfx-button
+                        label="Repurchase"
+                        severity="primary"
+                        [disabled]="true"
+                        ariaLabel="Enrollment is unavailable while impersonating another user" />
+                    } @else {
+                      <lfx-button label="Repurchase" severity="primary" [href]="item.enrollHref" target="_blank" rel="noopener noreferrer" />
+                    }
+                  }
+                </div>
               }
             </div>
-          }
-        </div>
-      </lfx-card>
+          </lfx-card>
+        }
+      }
     }
   }
 </div>

--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -6,7 +6,7 @@
 import { DatePipe, formatDate } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
-import { DisplayEnrollment, EnrollmentsState } from '@lfx-one/shared/interfaces';
+import { DisplayEnrollment, DisplayEnrollmentsState, EnrollmentsState } from '@lfx-one/shared/interfaces';
 import { buildEnrollmentHref, deriveEnrollmentStatus, enrollmentStatusSeverity } from '@lfx-one/shared/utils';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
@@ -40,44 +40,21 @@ export class ProfileIndividualEnrollmentComponent {
   // disabled and the auto-renew write is blocked server-side.
   protected readonly impersonating = this.userService.impersonating;
 
-  protected readonly enrollments = signal<DisplayEnrollment[] | null | undefined>(undefined);
-  protected readonly enrollmentError = signal<string | null>(null);
+  // Single source of truth mirroring the service's loading | loaded | error union — the template
+  // switches on `displayState().kind` so there is no null/undefined tri-state to `!`-assert.
+  private readonly enrollmentState = signal<DisplayEnrollmentsState>({ kind: 'loading' });
   protected readonly pendingIds = signal<Set<string>>(new Set());
 
   /** Local overrides for auto-renew values applied optimistically before PATCH completes. */
   private readonly autoRenewOverrides = signal<Map<string, boolean>>(new Map());
 
-  protected readonly displayedEnrollments: Signal<DisplayEnrollment[] | null | undefined> = this.initDisplayedEnrollments();
+  protected readonly displayState: Signal<DisplayEnrollmentsState> = this.initDisplayState();
 
   public constructor() {
     this.enrollmentService
       .getEnrollments()
       .pipe(takeUntilDestroyed())
-      .subscribe((state: EnrollmentsState) => {
-        if (state.kind === 'loading') {
-          this.enrollments.set(undefined);
-          this.enrollmentError.set(null);
-        } else if (state.kind === 'error') {
-          this.enrollments.set(null);
-          this.enrollmentError.set(state.message);
-        } else {
-          const base = environment.urls.enrollment;
-          this.enrollments.set(
-            state.items.map((item): DisplayEnrollment => {
-              const displayStatus = deriveEnrollmentStatus(item);
-              return {
-                ...item,
-                displayStatus,
-                severity: enrollmentStatusSeverity(displayStatus),
-                enrollHref: buildEnrollmentHref(base, item.ctaPath),
-                renewHref: buildEnrollmentHref(base, item.ctaPath, true),
-                pending: false,
-              };
-            })
-          );
-          this.enrollmentError.set(null);
-        }
-      });
+      .subscribe((state: EnrollmentsState) => this.enrollmentState.set(this.toDisplayState(state)));
   }
 
   protected isPending(item: DisplayEnrollment): boolean {
@@ -150,9 +127,9 @@ export class ProfileIndividualEnrollmentComponent {
   }
 
   private syncAutoRenewValue(membershipId: string, autoRenew: boolean): void {
-    this.enrollments.update((list) => {
-      if (!list) return list;
-      return list.map((item) => {
+    this.enrollmentState.update((state) => {
+      if (state.kind !== 'loaded') return state;
+      const items = state.items.map((item) => {
         if (item.membership?.id === membershipId) {
           const updatedMembership = { ...item.membership, autoRenew };
           const updatedItem = { ...item, membership: updatedMembership };
@@ -161,6 +138,7 @@ export class ProfileIndividualEnrollmentComponent {
         }
         return item;
       });
+      return { kind: 'loaded', items };
     });
   }
 
@@ -172,13 +150,31 @@ export class ProfileIndividualEnrollmentComponent {
     });
   }
 
-  private initDisplayedEnrollments(): Signal<DisplayEnrollment[] | null | undefined> {
+  // Projects the server state into the display shape once, at the subscription boundary.
+  private toDisplayState(state: EnrollmentsState): DisplayEnrollmentsState {
+    if (state.kind !== 'loaded') return state;
+    const base = environment.urls.enrollment;
+    const items = state.items.map((item): DisplayEnrollment => {
+      const displayStatus = deriveEnrollmentStatus(item);
+      return {
+        ...item,
+        displayStatus,
+        severity: enrollmentStatusSeverity(displayStatus),
+        enrollHref: buildEnrollmentHref(base, item.ctaPath),
+        renewHref: buildEnrollmentHref(base, item.ctaPath, true),
+        pending: false,
+      };
+    });
+    return { kind: 'loaded', items };
+  }
+
+  private initDisplayState(): Signal<DisplayEnrollmentsState> {
     return computed(() => {
-      const list = this.enrollments();
+      const state = this.enrollmentState();
+      if (state.kind !== 'loaded') return state;
       const overrides = this.autoRenewOverrides();
       const pending = this.pendingIds();
-      if (!list) return list;
-      return list.map((item) => {
+      const items = state.items.map((item) => {
         const membershipId = item.membership?.id;
         const isPending = membershipId ? pending.has(membershipId) : false;
         if (membershipId && overrides.has(membershipId)) {
@@ -189,6 +185,7 @@ export class ProfileIndividualEnrollmentComponent {
         }
         return { ...item, pending: isPending };
       });
+      return { kind: 'loaded', items };
     });
   }
 }

--- a/packages/shared/src/interfaces/enrollment.interface.ts
+++ b/packages/shared/src/interfaces/enrollment.interface.ts
@@ -57,4 +57,8 @@ export interface DisplayEnrollment extends IndividualEnrollment {
   pending: boolean;
 }
 
-export type EnrollmentsState = { kind: 'loading' } | { kind: 'loaded'; items: IndividualEnrollment[] } | { kind: 'error'; message: string };
+// One state machine (loading | loaded | error) reused for both the raw server items and the
+// component's display projection, so the two variants can't drift apart.
+export type EnrollmentsStateOf<T> = { kind: 'loading' } | { kind: 'loaded'; items: T[] } | { kind: 'error'; message: string };
+export type EnrollmentsState = EnrollmentsStateOf<IndividualEnrollment>;
+export type DisplayEnrollmentsState = EnrollmentsStateOf<DisplayEnrollment>;


### PR DESCRIPTION
## Summary

- Replace the individual-enrollment component's `enrollments: DisplayEnrollment[] | null | undefined` + `enrollmentError: string | null` re-encoding with a single discriminated-union state signal (`loading | loaded | error`), mirroring the service's `EnrollmentsState`.
- Add a shared generic `EnrollmentsStateOf<T>` so the raw (`EnrollmentsState`) and display (`DisplayEnrollmentsState`) variants can't drift apart.
- Template now uses `@let state = displayState();` + `@switch (state.kind)` / `@case`, dropping both `!` non-null assertions and the manual null/undefined tri-state.
- Inline the single-iteration `@for` loading skeleton (no loop).
- Optimistic auto-renew machinery (pending flags + transient overrides) is preserved, now operating on the `loaded` arm.

Refs LFXV2-3035
