### PR TITLE
docs(reviews): document snowflake logic ownership in lf-dbt

### DIFF
--- a/docs/architecture/backend/snowflake-integration.md
+++ b/docs/architecture/backend/snowflake-integration.md
@@ -422,13 +422,13 @@ WITH updated AS (
 )
 SELECT * FROM updated;
 
--- ✅ ALLOWED: Read-only CTE
-WITH user_stats AS (
-  SELECT user_id, COUNT(*) as activity_count
-  FROM activities
-  GROUP BY user_id
+-- ✅ ALLOWED: Read-only retrieval CTE
+WITH active_users AS (
+  SELECT user_id, display_name
+  FROM users
+  WHERE is_active = TRUE
 )
-SELECT * FROM user_stats WHERE activity_count > 10;
+SELECT user_id, display_name FROM active_users;
 ```
 
 The validation uses word boundaries (`\b`) to avoid false positives while catching write operations anywhere in the query text.
@@ -659,21 +659,25 @@ export class AnalyticsController {
 4. **Type Safety**: Define TypeScript interfaces for query result rows
 5. **Error Handling**: Catch and handle Snowflake-specific errors appropriately
 6. **Query Optimization**: Use specific column selection, appropriate WHERE clauses, and leverage Snowflake features
+7. **Logic Ownership**: Define metrics and reusable transformations in [`lf-dbt`](https://github.com/linuxfoundation/lf-dbt); application queries retrieve the modeled columns
 
-### Example with Advanced Features
+### Example with Dynamic Retrieval Filters
+
+Application services own retrieval concerns, not metric definitions. Columns such as `event_count` and `total_value` must already be defined and tested in an `lf-dbt` model. Embedded SQL may add parameterized filters, sorting, and pagination without recalculating those values. See the canonical [Snowflake SQL review rule](../../reviews/shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-should-fix) for the narrow display-scope roll-up exception.
 
 ```typescript
 async getAggregatedMetrics(filters: MetricFilters) {
   const binds: (Bind | Date)[] = [filters.startDate, filters.endDate];
 
-  // Build dynamic query with parameterized filters
+  // Retrieve metrics already modeled at daily project grain in lf-dbt
   let sql = `
     SELECT
-      DATE_TRUNC('day', recorded_at) as date,
-      COUNT(*) as event_count,
-      SUM(metric_value) as total_value
-    FROM analytics_events
-    WHERE recorded_at BETWEEN ? AND ?
+      metric_date,
+      project_id,
+      event_count,
+      total_value
+    FROM analytics_db.platinum_lfx_one.daily_metrics
+    WHERE metric_date BETWEEN ? AND ?
   `;
 
   // Add optional filters with proper parameterization
@@ -682,7 +686,7 @@ async getAggregatedMetrics(filters: MetricFilters) {
     binds.push(...filters.projectIds);
   }
 
-  sql += " GROUP BY DATE_TRUNC('day', recorded_at) ORDER BY date";
+  sql += ' ORDER BY metric_date';
 
   // Execute with type-safe result
   const result = await this.getSnowflakeService().execute<AggregatedMetric>(sql, binds);

--- a/docs/reviews/frontend-checklist.md
+++ b/docs/reviews/frontend-checklist.md
@@ -250,18 +250,18 @@ import { ProjectInterface } from '@lfx-one/shared/interfaces';
 
 ## 12. Additional rules
 
-| Rule                                                                                                                                                                                                                | Severity   |
-| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| No `console.log` — use `console.warn` or `console.error`                                                                                                                                                            | SHOULD FIX |
-| No nested ternaries                                                                                                                                                                                                 | SHOULD FIX |
-| Selector prefix must be `lfx-`                                                                                                                                                                                      | SHOULD FIX |
-| Use `inject()` for DI — never constructor-based injection                                                                                                                                                           | SHOULD FIX |
-| Use `@if`/`@for` template syntax — not `*ngIf`/`*ngFor`                                                                                                                                                             | SHOULD FIX |
-| Use `ReactiveFormsModule` always — never `[(ngModel)]` for forms                                                                                                                                                    | SHOULD FIX |
-| Use `yarn` — never `npm` or `npx` in scripts/docs/CI                                                                                                                                                                | SHOULD FIX |
-| Signals cannot use RxJS pipes (TypeScript compile error — rarely manual)                                                                                                                                            | SHOULD FIX |
-| Always use `templateUrl`, never inline `template: '…'` strings                                                                                                                                                      | SHOULD FIX |
-| No business logic in embedded Snowflake SQL — select precomputed columns from `lf-dbt`; see [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-should-fix) | SHOULD FIX |
+| Rule                                                                                                                                                                                                                                                                                  | Severity   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| No `console.log` — use `console.warn` or `console.error`                                                                                                                                                                                                                              | SHOULD FIX |
+| No nested ternaries                                                                                                                                                                                                                                                                   | SHOULD FIX |
+| Selector prefix must be `lfx-`                                                                                                                                                                                                                                                        | SHOULD FIX |
+| Use `inject()` for DI — never constructor-based injection                                                                                                                                                                                                                             | SHOULD FIX |
+| Use `@if`/`@for` template syntax — not `*ngIf`/`*ngFor`                                                                                                                                                                                                                               | SHOULD FIX |
+| Use `ReactiveFormsModule` always — never `[(ngModel)]` for forms                                                                                                                                                                                                                      | SHOULD FIX |
+| Use `yarn` — never `npm` or `npx` in scripts/docs/CI                                                                                                                                                                                                                                  | SHOULD FIX |
+| Signals cannot use RxJS pipes (TypeScript compile error — rarely manual)                                                                                                                                                                                                              | SHOULD FIX |
+| Always use `templateUrl`, never inline `template: '…'` strings                                                                                                                                                                                                                        | SHOULD FIX |
+| Do not define metrics in embedded Snowflake SQL — retrieve modeled `lf-dbt` columns; parameterized filters and narrow display-scope roll-ups are allowed; see [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-should-fix) | SHOULD FIX |
 
 ---
 
@@ -272,7 +272,7 @@ import { ProjectInterface } from '@lfx-one/shared/interfaces';
 - GET requests use `catchError(() => of(defaultValue))` to prevent error propagation
 - POST/PUT/DELETE use `take(1)` for one-shot subscriptions
 - **Every `HttpClient` call targets a real `/api/...` endpoint** that exists in the backend routes — no mock data, placeholder URLs, or fabricated paths. API paths are relative (`/api/...`); the proxy handles routing.
-- **Snowflake queries belong in `lf-dbt`, not server services.** Backend services that query Snowflake must select precomputed columns only — no `CASE`, metric arithmetic, or transformation logic in embedded SQL. Full rule: [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-should-fix).
+- **Snowflake metric definitions belong in `lf-dbt`.** LFX One server services own retrieval and may use parameterized filters, sorting, pagination, and the narrow display-scope roll-up allowed by the canonical rule. Do not define metrics with `CASE`, arithmetic, or transformations in embedded SQL. Full rule: [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-should-fix).
 
 **Violation:**
 

--- a/docs/reviews/frontend-checklist.md
+++ b/docs/reviews/frontend-checklist.md
@@ -250,18 +250,18 @@ import { ProjectInterface } from '@lfx-one/shared/interfaces';
 
 ## 12. Additional rules
 
-| Rule                                                                                                                                                                                                              | Severity   |
-| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
-| No `console.log` — use `console.warn` or `console.error`                                                                                                                                                          | SHOULD FIX |
-| No nested ternaries                                                                                                                                                                                               | SHOULD FIX |
-| Selector prefix must be `lfx-`                                                                                                                                                                                    | SHOULD FIX |
-| Use `inject()` for DI — never constructor-based injection                                                                                                                                                         | SHOULD FIX |
-| Use `@if`/`@for` template syntax — not `*ngIf`/`*ngFor`                                                                                                                                                           | SHOULD FIX |
-| Use `ReactiveFormsModule` always — never `[(ngModel)]` for forms                                                                                                                                                  | SHOULD FIX |
-| Use `yarn` — never `npm` or `npx` in scripts/docs/CI                                                                                                                                                              | SHOULD FIX |
-| Signals cannot use RxJS pipes (TypeScript compile error — rarely manual)                                                                                                                                          | SHOULD FIX |
-| Always use `templateUrl`, never inline `template: '…'` strings                                                                                                                                                    | SHOULD FIX |
-| No business logic in embedded Snowflake SQL — select precomputed columns from `lf-dbt`; see [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-critical) | CRITICAL   |
+| Rule                                                                                                                                                                                                                | Severity   |
+| ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| No `console.log` — use `console.warn` or `console.error`                                                                                                                                                            | SHOULD FIX |
+| No nested ternaries                                                                                                                                                                                                 | SHOULD FIX |
+| Selector prefix must be `lfx-`                                                                                                                                                                                      | SHOULD FIX |
+| Use `inject()` for DI — never constructor-based injection                                                                                                                                                           | SHOULD FIX |
+| Use `@if`/`@for` template syntax — not `*ngIf`/`*ngFor`                                                                                                                                                             | SHOULD FIX |
+| Use `ReactiveFormsModule` always — never `[(ngModel)]` for forms                                                                                                                                                    | SHOULD FIX |
+| Use `yarn` — never `npm` or `npx` in scripts/docs/CI                                                                                                                                                                | SHOULD FIX |
+| Signals cannot use RxJS pipes (TypeScript compile error — rarely manual)                                                                                                                                            | SHOULD FIX |
+| Always use `templateUrl`, never inline `template: '…'` strings                                                                                                                                                      | SHOULD FIX |
+| No business logic in embedded Snowflake SQL — select precomputed columns from `lf-dbt`; see [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-should-fix) | SHOULD FIX |
 
 ---
 
@@ -272,7 +272,7 @@ import { ProjectInterface } from '@lfx-one/shared/interfaces';
 - GET requests use `catchError(() => of(defaultValue))` to prevent error propagation
 - POST/PUT/DELETE use `take(1)` for one-shot subscriptions
 - **Every `HttpClient` call targets a real `/api/...` endpoint** that exists in the backend routes — no mock data, placeholder URLs, or fabricated paths. API paths are relative (`/api/...`); the proxy handles routing.
-- **Snowflake queries belong in `lf-dbt`, not server services.** Backend services that query Snowflake must select precomputed columns only — no `CASE`, metric arithmetic, or transformation logic in embedded SQL. Full rule: [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-critical).
+- **Snowflake queries belong in `lf-dbt`, not server services.** Backend services that query Snowflake must select precomputed columns only — no `CASE`, metric arithmetic, or transformation logic in embedded SQL. Full rule: [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-should-fix).
 
 **Violation:**
 

--- a/docs/reviews/frontend-checklist.md
+++ b/docs/reviews/frontend-checklist.md
@@ -250,17 +250,18 @@ import { ProjectInterface } from '@lfx-one/shared/interfaces';
 
 ## 12. Additional rules
 
-| Rule                                                                     | Severity   |
-| ------------------------------------------------------------------------ | ---------- |
-| No `console.log` — use `console.warn` or `console.error`                 | SHOULD FIX |
-| No nested ternaries                                                      | SHOULD FIX |
-| Selector prefix must be `lfx-`                                           | SHOULD FIX |
-| Use `inject()` for DI — never constructor-based injection                | SHOULD FIX |
-| Use `@if`/`@for` template syntax — not `*ngIf`/`*ngFor`                  | SHOULD FIX |
-| Use `ReactiveFormsModule` always — never `[(ngModel)]` for forms         | SHOULD FIX |
-| Use `yarn` — never `npm` or `npx` in scripts/docs/CI                     | SHOULD FIX |
-| Signals cannot use RxJS pipes (TypeScript compile error — rarely manual) | SHOULD FIX |
-| Always use `templateUrl`, never inline `template: '…'` strings           | SHOULD FIX |
+| Rule                                                                                                                                                                                                              | Severity   |
+| ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| No `console.log` — use `console.warn` or `console.error`                                                                                                                                                          | SHOULD FIX |
+| No nested ternaries                                                                                                                                                                                               | SHOULD FIX |
+| Selector prefix must be `lfx-`                                                                                                                                                                                    | SHOULD FIX |
+| Use `inject()` for DI — never constructor-based injection                                                                                                                                                         | SHOULD FIX |
+| Use `@if`/`@for` template syntax — not `*ngIf`/`*ngFor`                                                                                                                                                           | SHOULD FIX |
+| Use `ReactiveFormsModule` always — never `[(ngModel)]` for forms                                                                                                                                                  | SHOULD FIX |
+| Use `yarn` — never `npm` or `npx` in scripts/docs/CI                                                                                                                                                              | SHOULD FIX |
+| Signals cannot use RxJS pipes (TypeScript compile error — rarely manual)                                                                                                                                          | SHOULD FIX |
+| Always use `templateUrl`, never inline `template: '…'` strings                                                                                                                                                    | SHOULD FIX |
+| No business logic in embedded Snowflake SQL — select precomputed columns from `lf-dbt`; see [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-critical) | CRITICAL   |
 
 ---
 
@@ -271,6 +272,7 @@ import { ProjectInterface } from '@lfx-one/shared/interfaces';
 - GET requests use `catchError(() => of(defaultValue))` to prevent error propagation
 - POST/PUT/DELETE use `take(1)` for one-shot subscriptions
 - **Every `HttpClient` call targets a real `/api/...` endpoint** that exists in the backend routes — no mock data, placeholder URLs, or fabricated paths. API paths are relative (`/api/...`); the proxy handles routing.
+- **Snowflake queries belong in `lf-dbt`, not server services.** Backend services that query Snowflake must select precomputed columns only — no `CASE`, metric arithmetic, or transformation logic in embedded SQL. Full rule: [shared-and-sql-checklist §10](./shared-and-sql-checklist.md#10-no-business-logic-in-embedded-snowflake-sql-critical).
 
 **Violation:**
 

--- a/docs/reviews/shared-and-sql-checklist.md
+++ b/docs/reviews/shared-and-sql-checklist.md
@@ -242,7 +242,7 @@ const params = { page_size: 50 };
 
 ---
 
-### 10. No business logic in embedded Snowflake SQL (CRITICAL)
+### 10. No business logic in embedded Snowflake SQL (SHOULD FIX)
 
 Metric definitions, derived values, and transformation logic belong in the [`lf-dbt`](https://github.com/linuxfoundation/lf-dbt) repo — typically in silver, gold, or platinum models — not in LFX One server services. Embedded Snowflake queries may **select precomputed columns** and apply **parameterized retrieval** only: explicit column lists, `WHERE` filters with `?` binds, `ORDER BY`, and `LIMIT`.
 

--- a/docs/reviews/shared-and-sql-checklist.md
+++ b/docs/reviews/shared-and-sql-checklist.md
@@ -244,7 +244,9 @@ const params = { page_size: 50 };
 
 ### 10. No business logic in embedded Snowflake SQL (SHOULD FIX)
 
-Metric definitions, derived values, and transformation logic belong in the [`lf-dbt`](https://github.com/linuxfoundation/lf-dbt) repo — typically in silver, gold, or platinum models — not in LFX One server services. Embedded Snowflake queries may **select precomputed columns** and apply **parameterized retrieval** only: explicit column lists, `WHERE` filters with `?` binds, `ORDER BY`, and `LIMIT`.
+Metric definitions, derived values, and reusable transformations belong in the [`lf-dbt`](https://github.com/linuxfoundation/lf-dbt) repo — typically in silver, gold, or platinum models — not in LFX One server services. Embedded Snowflake queries own retrieval concerns: selecting modeled columns and applying parameterized `WHERE` filters, `ORDER BY`, and `LIMIT`.
+
+A narrow `SUM`/`MAX` over already-modeled measures may be used only to combine rows for a display scope that dbt does not yet provide, such as an umbrella foundation. It must not redefine a metric. Prefer adding the exact consumption grain to dbt so the application can select one row.
 
 **Do not embed in LFX One:**
 
@@ -253,7 +255,7 @@ Metric definitions, derived values, and transformation logic belong in the [`lf-
 - `SUM` / `AVG` / `COUNT` / window functions over fact columns
 - Joins, bucketing, or date/metric calculations that define what a number means
 
-If a dashboard needs a new derived field, add it to the appropriate dbt model, document and test it there, then select the named column from LFX One.
+If a dashboard needs a new derived field or queryable scope, add it to the appropriate dbt model, document and test it there, then select the named columns from LFX One.
 
 **Violation:**
 
@@ -278,31 +280,64 @@ const overviewQuery = `
 
 **Fix:**
 
+Add a dbt model at the exact consumption grain. This example preserves the original growth calculation while producing one row for every supported scope, including the `tlf` umbrella. Add `unique` and `not_null` tests for `scope_slug` in the model YAML.
+
 ```sql
--- lf-dbt: models/platinum/lfx_one/platinum_lfx_one_social_media_overview.sql
--- Define follower_growth_pct once, with dbt tests in platinum_lfx_one_tests.yml
-CASE
-  WHEN SUM(prior_total_followers) > 0
-    THEN ROUND(
-      (SUM(CASE WHEN prior_total_followers IS NOT NULL THEN followers_count END)
-        - SUM(prior_total_followers))
-      / SUM(prior_total_followers) * 100,
-      1
-    )
-END AS follower_growth_pct
+-- lf-dbt: platinum_lfx_one_social_media_overview_by_scope.sql
+WITH foundation_scopes AS (
+  SELECT
+    foundation_slug AS scope_slug,
+    total_followers,
+    platforms_active,
+    prior_total_followers
+  FROM {{ ref('platinum_lfx_one_social_media_overview') }}
+),
+
+all_scopes AS (
+  SELECT
+    scope_slug,
+    total_followers,
+    platforms_active,
+    prior_total_followers
+  FROM foundation_scopes
+  WHERE scope_slug <> 'tlf'
+
+  UNION ALL
+
+  SELECT
+    'tlf' AS scope_slug,
+    SUM(total_followers) AS total_followers,
+    MAX(platforms_active) AS platforms_active,
+    SUM(prior_total_followers) AS prior_total_followers
+  FROM foundation_scopes
+)
+
+SELECT
+  scope_slug,
+  total_followers,
+  platforms_active,
+  CASE
+    WHEN prior_total_followers > 0
+      THEN ROUND(
+        (total_followers - prior_total_followers)
+        / prior_total_followers * 100,
+        1
+      )
+  END AS follower_growth_pct
+FROM all_scopes
 ```
 
 ```typescript
 const overviewQuery = `
   SELECT
-    total_followers,
-    platforms_active,
-    follower_growth_pct
-  FROM ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_OVERVIEW
-  WHERE 1=1
-    ${foundationFilter}
+    TOTAL_FOLLOWERS,
+    PLATFORMS_ACTIVE,
+    FOLLOWER_GROWTH_PCT
+  FROM ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_OVERVIEW_BY_SCOPE
+  WHERE SCOPE_SLUG = ?
 `;
-// Select only — no metric logic in the server
+const result = await snowflakeService.execute(overviewQuery, [foundationSlug]);
+// Exactly one modeled row for both foundation and umbrella scopes
 ```
 
-**Allowed in LFX One:** filtering by route params (foundation slug, date range), sorting, pagination, and simple `SUM`/`MAX` only when aggregating **already-modeled** rows for display scope (e.g. umbrella foundation roll-up) — and only if that roll-up is not already provided by a dbt model. When in doubt, push the logic to dbt.
+**Allowed in LFX One:** filtering by route params (foundation slug, date range), sorting, pagination, and a narrow `SUM`/`MAX` only when combining **already-modeled** measures for a display scope that dbt does not provide. When in doubt, add the scope or logic to dbt.

--- a/docs/reviews/shared-and-sql-checklist.md
+++ b/docs/reviews/shared-and-sql-checklist.md
@@ -287,10 +287,12 @@ Add a dbt model at the exact consumption grain. This example preserves the origi
 WITH foundation_scopes AS (
   SELECT
     foundation_slug AS scope_slug,
-    total_followers,
-    platforms_active,
-    prior_total_followers
+    SUM(total_followers) AS total_followers,
+    MAX(platforms_active) AS platforms_active,
+    SUM(prior_total_followers) AS prior_total_followers
   FROM {{ ref('platinum_lfx_one_social_media_overview') }}
+  WHERE foundation_slug IS NOT NULL
+  GROUP BY 1
 ),
 
 all_scopes AS (

--- a/docs/reviews/shared-and-sql-checklist.md
+++ b/docs/reviews/shared-and-sql-checklist.md
@@ -239,3 +239,70 @@ const params = { limit: 50, offset: 0 };
 const params = { page_size: 50 };
 // For next page: { page_size: 50, page_token: previousResponse.nextPageToken }
 ```
+
+---
+
+### 10. No business logic in embedded Snowflake SQL (CRITICAL)
+
+Metric definitions, derived values, and transformation logic belong in the [`lf-dbt`](https://github.com/linuxfoundation/lf-dbt) repo — typically in silver, gold, or platinum models — not in LFX One server services. Embedded Snowflake queries may **select precomputed columns** and apply **parameterized retrieval** only: explicit column lists, `WHERE` filters with `?` binds, `ORDER BY`, and `LIMIT`.
+
+**Do not embed in LFX One:**
+
+- `CASE` expressions that compute business metrics
+- Arithmetic on raw columns (percentages, rates, growth, ratios)
+- `SUM` / `AVG` / `COUNT` / window functions over fact columns
+- Joins, bucketing, or date/metric calculations that define what a number means
+
+If a dashboard needs a new derived field, add it to the appropriate dbt model, document and test it there, then select the named column from LFX One.
+
+**Violation:**
+
+```typescript
+const overviewQuery = `
+  SELECT
+    SUM(TOTAL_FOLLOWERS) AS TOTAL_FOLLOWERS,
+    MAX(PLATFORMS_ACTIVE) AS PLATFORMS_ACTIVE,
+    CASE
+      WHEN SUM(PRIOR_TOTAL_FOLLOWERS) > 0
+        THEN ROUND(
+          (SUM(TOTAL_FOLLOWERS) - SUM(PRIOR_TOTAL_FOLLOWERS))
+          / SUM(PRIOR_TOTAL_FOLLOWERS) * 100, 1
+        )
+    END AS FOLLOWER_GROWTH_PCT
+  FROM ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_OVERVIEW
+  WHERE 1=1
+    ${foundationFilter}
+`;
+// Recomputes follower_growth_pct in the app — logic belongs in dbt
+```
+
+**Fix:**
+
+```sql
+-- lf-dbt: models/platinum/lfx_one/platinum_lfx_one_social_media_overview.sql
+-- Define follower_growth_pct once, with dbt tests in platinum_lfx_one_tests.yml
+CASE
+  WHEN SUM(prior_total_followers) > 0
+    THEN ROUND(
+      (SUM(CASE WHEN prior_total_followers IS NOT NULL THEN followers_count END)
+        - SUM(prior_total_followers))
+      / SUM(prior_total_followers) * 100,
+      1
+    )
+END AS follower_growth_pct
+```
+
+```typescript
+const overviewQuery = `
+  SELECT
+    total_followers,
+    platforms_active,
+    follower_growth_pct
+  FROM ANALYTICS.PLATINUM_LFX_ONE.SOCIAL_MEDIA_OVERVIEW
+  WHERE 1=1
+    ${foundationFilter}
+`;
+// Select only — no metric logic in the server
+```
+
+**Allowed in LFX One:** filtering by route params (foundation slug, date range), sorting, pagination, and simple `SUM`/`MAX` only when aggregating **already-modeled** rows for display scope (e.g. umbrella foundation roll-up) — and only if that roll-up is not already provided by a dbt model. When in doubt, push the logic to dbt.


### PR DESCRIPTION
## Summary

- Add **§10 — No business logic in embedded Snowflake SQL (SHOULD FIX)** to `docs/reviews/shared-and-sql-checklist.md`, establishing that metric definitions and reusable transformations belong in `lf-dbt` while LFX One owns retrieval concerns
- Document the narrow display-scope roll-up exception and show an exact-grain dbt model that preserves the existing growth formula while materializing one row per scope, including `tlf`
- Cross-reference the canonical rule from `docs/reviews/frontend-checklist.md` and distinguish metric ownership from permitted filtering, sorting, pagination, and display-scope retrieval
- Align `docs/architecture/backend/snowflake-integration.md` by replacing application-side `DATE_TRUNC`/`COUNT`/`SUM` guidance with retrieval of precomputed dbt columns

## Test plan

- [x] Prettier formatting on all three edited files
- [x] markdownlint-cli2 passes with 0 issues
- [x] Review feedback replied to and all review threads resolved

Made with [Cursor](https://cursor.com)