### PR TITLE
docs(cla): correct pdf-url ownership comment scope

### DIFF
--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -51,9 +51,12 @@ export class ClasController {
       const signatureId = (req.params['signatureId'] ?? '').trim();
 
       // EasyCLA's /v4/my-clas/{id}/pdf enforces ownership + ICLA eligibility against the
-      // session's identity and returns 404 for unknown, not-owned and ECLA IDs (never 403),
-      // so it never leaks whether an ID exists. SS just resolves the session identity and
-      // passes it through — no separate ownership pre-check needed.
+      // session's identity and returns a uniform 404 for unknown, not-owned and ECLA IDs,
+      // so a well-formed ID never reveals whether it exists. SS just resolves the session
+      // identity and passes it through — no separate ownership pre-check needed.
+      // Note this holds for well-formed IDs only: a malformed ID is rejected before the
+      // upstream handler runs (422 from schema validation, 403 from the gateway on path
+      // traversal), and getPdfUrl normalizes only 404, so those statuses reach the client.
       const identity = await this.claService.resolveIdentity(req);
       const pdf = await this.claService.getPdfUrl(req, signatureId, identity);
       if (!pdf) {


### PR DESCRIPTION
## Summary

Corrects a code comment in `clas.controller.ts` that overstated what the `/v4/my-clas/{id}/pdf` endpoint guarantees. **Comment only — no behaviour change.**

The old comment claimed the endpoint returns 404 "(never 403)" and "never leaks whether an ID exists". Neither holds universally:

- **422** — go-swagger's UUID format validation rejects malformed IDs before EasyCLA's handler runs
- **403** — the gateway rejects path traversal, also upstream of the handler

`getPdfUrl` normalizes only 404, so both statuses reach the client and *do* distinguish malformed input from unknown IDs. The uniform-404 guarantee is real, but only for well-formed IDs.

This is why reading `my_clas/handlers.go` alone makes the finding look invalid — that handler returns only 401/400/404/500/200. The 422/403 originate upstream of it, and both were captured live during QA.

## Why comment-only

The underlying error-mapping gap is low severity: no CLA data is exposed and the UI shows a generic toast in every case. Correcting the false guarantee is the proportionate fix; widening the catch in `getPdfUrl` would be a behaviour change and belongs in its own PR if wanted.

## Context

Found during M1 QA for "My CLAs" (SS-1). Full QA record lives in the private `easyclav2-migration-planning` repo.

Refs linuxfoundation/lfx-self-serve#1313