### PR TITLE
feat(newsletters): add web-hosted view for a newsletter edition

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -20,6 +20,17 @@ import { settingsLensRedirectGuard } from './shared/guards/settings-lens-redirec
 const loadOrgProfilePage = () => import('./modules/dashboards/org/org-profile/org-profile.component').then((m) => m.OrgProfileComponent);
 
 export const routes: Routes = [
+  // Public "View Online" newsletter edition (LFXV2-2579). Sibling of the
+  // authGuard'd root — and placed AHEAD of it — so an anonymous recipient who
+  // clicks the permalink from their mail client reaches it without being
+  // bounced to /login. It must NOT live under NEWSLETTER_ROUTES (which is
+  // mounted behind lensRedirectGuard/newsletterAccessGuard) nor the authGuard
+  // root. The exact 4-segment path wins over the greedy empty-path root; the Go
+  // service gates access (project_uid match + status=sent), so no client guard.
+  {
+    path: 'newsletters/:projectUid/:id/view',
+    loadComponent: () => import('./modules/newsletters/newsletter-public-view/newsletter-public-view.component').then((m) => m.NewsletterPublicViewComponent),
+  },
   {
     path: '',
     canActivate: [authGuard],

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.html
@@ -1,0 +1,19 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8 py-6" data-testid="newsletter-public-view">
+  @if (loading()) {
+    <div class="flex flex-col gap-4">
+      <p-skeleton width="60%" height="2rem"></p-skeleton>
+      <p-skeleton width="30%" height="1rem"></p-skeleton>
+      <p-skeleton width="100%" height="24rem"></p-skeleton>
+    </div>
+  } @else if (loadError(); as err) {
+    <lfx-empty-state icon="fa-light fa-envelope" title="Could not load newsletter" [subtitle]="err"></lfx-empty-state>
+  } @else if (view(); as v) {
+    <div class="flex flex-col gap-4">
+      <p class="text-sm text-gray-500" data-testid="newsletter-public-view-sent-at">Sent {{ v.sent_at | date: 'MMM d, y, h:mm a' }}</p>
+      <lfx-newsletter-preview [subject]="v.subject" [bodyHtml]="v.body_html" [displayName]="v.project_name" />
+    </div>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.spec.ts
@@ -1,0 +1,105 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { PublicNewsletterView } from '@lfx-one/shared/interfaces';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { NewsletterPublicViewComponent } from './newsletter-public-view.component';
+import { NewsletterService } from '@services/newsletter.service';
+
+function makeView(overrides: Partial<PublicNewsletterView> = {}): PublicNewsletterView {
+  return {
+    subject: 'January Update',
+    body_html: '<p>Hello</p>',
+    project_name: 'Kubernetes',
+    sent_at: '2026-01-15T12:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('NewsletterPublicViewComponent', () => {
+  let component: NewsletterPublicViewComponent;
+  let fixture: ComponentFixture<NewsletterPublicViewComponent>;
+  let newsletterService: NewsletterService;
+  let paramMap$: BehaviorSubject<Map<string, string>>;
+
+  async function setup(
+    params: [string, string][] = [
+      ['projectUid', 'proj-1'],
+      ['id', 'news-1'],
+    ]
+  ) {
+    paramMap$ = new BehaviorSubject(new Map(params));
+    await TestBed.configureTestingModule({
+      imports: [NewsletterPublicViewComponent],
+      providers: [
+        { provide: NewsletterService, useValue: { getPublicView: vi.fn() } },
+        { provide: ActivatedRoute, useValue: { paramMap: paramMap$ } },
+      ],
+    }).compileComponents();
+    newsletterService = TestBed.inject(NewsletterService);
+  }
+
+  function create() {
+    fixture = TestBed.createComponent(NewsletterPublicViewComponent);
+    component = fixture.componentInstance;
+  }
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('renders the projection on a successful load, clearing loading/error', async () => {
+    await setup();
+    vi.mocked(newsletterService.getPublicView).mockReturnValue(of(makeView()));
+
+    create();
+
+    expect(newsletterService.getPublicView).toHaveBeenCalledWith('proj-1', 'news-1');
+    expect(component['view']()).toEqual(makeView());
+    expect(component['loading']()).toBe(false);
+    expect(component['loadError']()).toBeNull();
+  });
+
+  it('guards a missing path param without calling the service', async () => {
+    await setup([['projectUid', 'proj-1']]); // no `id`
+    vi.mocked(newsletterService.getPublicView).mockReturnValue(of(makeView()));
+
+    create();
+
+    expect(newsletterService.getPublicView).not.toHaveBeenCalled();
+    expect(component['view']()).toBeNull();
+    expect(component['loading']()).toBe(false);
+    expect(component['loadError']()).toContain('missing required information');
+  });
+
+  it('maps a 404 to the "no longer available" message (quietly, no console.error)', async () => {
+    await setup();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(newsletterService.getPublicView).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    create();
+
+    expect(component['loadError']()).toBe('This newsletter is no longer available.');
+    expect(component['view']()).toBeNull();
+    expect(component['loading']()).toBe(false);
+    expect(errSpy).not.toHaveBeenCalled();
+  });
+
+  it('maps an unexpected (non-404) error to a generic message and logs it', async () => {
+    await setup();
+    const errSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    vi.mocked(newsletterService.getPublicView).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+
+    create();
+
+    expect(component['loadError']()).toBe('Could not load this newsletter. Please try again.');
+    expect(component['view']()).toBeNull();
+    expect(component['loading']()).toBe(false);
+    expect(errSpy).toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.ts
@@ -1,0 +1,74 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { PublicNewsletterView } from '@lfx-one/shared/interfaces';
+import { NewsletterService } from '@services/newsletter.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, finalize, of, switchMap } from 'rxjs';
+
+import { NewsletterPreviewComponent } from '../components/newsletter-preview/newsletter-preview.component';
+
+/**
+ * Public "View Online" page for a sent newsletter edition (LFXV2-2579).
+ *
+ * Unauthenticated by design — reached without a session, matching this route's
+ * `auth: 'public'` classification in auth.middleware.ts. Access is gated
+ * entirely by the Go service (project_uid match + status=sent, else 404), so
+ * this component never checks permissions itself and never attaches a bearer
+ * token: `NewsletterService.getPublicView` calls the `/public/api/...` route.
+ */
+@Component({
+  selector: 'lfx-newsletter-public-view',
+  imports: [DatePipe, EmptyStateComponent, SkeletonModule, NewsletterPreviewComponent],
+  templateUrl: './newsletter-public-view.component.html',
+})
+export class NewsletterPublicViewComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly newsletterService = inject(NewsletterService);
+
+  protected readonly view = signal<PublicNewsletterView | null>(null);
+  protected readonly loading = signal<boolean>(true);
+  protected readonly loadError = signal<string | null>(null);
+
+  public constructor() {
+    // Both segments are required per newsletters.routes.ts, so the URL alone
+    // carries everything needed — no ambient project context to wait on.
+    this.route.paramMap
+      .pipe(
+        switchMap((params) => {
+          const id = params.get('id');
+          const projectUid = params.get('projectUid');
+          if (!id || !projectUid) {
+            this.loading.set(false);
+            this.loadError.set('This newsletter link is missing required information.');
+            return of(null);
+          }
+          this.loading.set(true);
+          this.loadError.set(null);
+          return this.newsletterService.getPublicView(projectUid, id).pipe(
+            catchError((err: HttpErrorResponse) => {
+              if (err.status === 404) {
+                // Expected: the edition isn't sent / doesn't exist — quiet, user-facing message only.
+                this.loadError.set('This newsletter is no longer available.');
+              } else {
+                console.error('Failed to load public newsletter view', err);
+                this.loadError.set('Could not load this newsletter. Please try again.');
+              }
+              return of(null);
+            }),
+            finalize(() => this.loading.set(false))
+          );
+        }),
+        takeUntilDestroyed()
+      )
+      .subscribe((data) => {
+        this.view.set(data);
+      });
+  }
+}

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-public-view/newsletter-public-view.component.ts
@@ -1,0 +1,68 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ActivatedRoute } from '@angular/router';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { PublicNewsletterView } from '@lfx-one/shared/interfaces';
+import { NewsletterService } from '@services/newsletter.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, finalize, of, switchMap } from 'rxjs';
+
+import { NewsletterPreviewComponent } from '../components/newsletter-preview/newsletter-preview.component';
+
+/**
+ * Public "View Online" page for a sent newsletter edition (LFXV2-2579).
+ *
+ * Unauthenticated by design — reached without a session, matching this route's
+ * `auth: 'public'` classification in auth.middleware.ts. Access is gated
+ * entirely by the Go service (project_uid match + status=sent, else 404), so
+ * this component never checks permissions itself and never attaches a bearer
+ * token: `NewsletterService.getPublicView` calls the `/public/api/...` route.
+ */
+@Component({
+  selector: 'lfx-newsletter-public-view',
+  imports: [DatePipe, EmptyStateComponent, SkeletonModule, NewsletterPreviewComponent],
+  templateUrl: './newsletter-public-view.component.html',
+})
+export class NewsletterPublicViewComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly newsletterService = inject(NewsletterService);
+
+  protected readonly view = signal<PublicNewsletterView | null>(null);
+  protected readonly loading = signal<boolean>(true);
+  protected readonly loadError = signal<string | null>(null);
+
+  public constructor() {
+    // Both segments are required per newsletters.routes.ts, so the URL alone
+    // carries everything needed — no ambient project context to wait on.
+    this.route.paramMap
+      .pipe(
+        switchMap((params) => {
+          const id = params.get('id');
+          const projectUid = params.get('projectUid');
+          if (!id || !projectUid) {
+            this.loading.set(false);
+            this.loadError.set('This newsletter link is missing required information.');
+            return of(null);
+          }
+          this.loading.set(true);
+          this.loadError.set(null);
+          return this.newsletterService.getPublicView(projectUid, id).pipe(
+            catchError((err: HttpErrorResponse) => {
+              this.loadError.set(err.status === 404 ? 'This newsletter is no longer available.' : 'Could not load this newsletter. Please try again.');
+              return of(null);
+            }),
+            finalize(() => this.loading.set(false))
+          );
+        }),
+        takeUntilDestroyed()
+      )
+      .subscribe((data) => {
+        this.view.set(data);
+      });
+  }
+}

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -54,4 +54,10 @@ export const NEWSLETTER_ROUTES: Routes = [
   // newsletterAccessGuard) — either mount would break the any-authenticated-user
   // access model. The reader is mounted directly in app.routes.ts, ahead of the
   // flat mount.
+  //
+  // The public "View Online" page (/newsletters/:projectUid/:id/view, LFXV2-2579)
+  // is likewise NOT a child here — it is mounted directly in app.routes.ts ahead
+  // of the authGuard root so anonymous recipients reach it without a login
+  // bounce. This mount sits behind lensRedirectGuard/newsletterAccessGuard, which
+  // would defeat that.
 ];

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -47,4 +47,13 @@ export const NEWSLETTER_ROUTES: Routes = [
     loadComponent: () => import('./newsletter-analytics/newsletter-analytics.component').then((m) => m.NewsletterAnalyticsComponent),
     data: { preload: false },
   },
+  {
+    // Public "View Online" page for a sent newsletter edition (LFXV2-2579).
+    // No canActivate — unauthenticated visitors reach this route, matching
+    // its `auth: 'public'` classification in auth.middleware.ts. Access is
+    // gated entirely by the Go service (project_uid match + status=sent).
+    path: ':projectUid/:id/view',
+    loadComponent: () => import('./newsletter-public-view/newsletter-public-view.component').then((m) => m.NewsletterPublicViewComponent),
+    data: { preload: false },
+  },
 ];

--- a/apps/lfx-one/src/app/shared/services/newsletter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/newsletter.service.ts
@@ -18,6 +18,7 @@ import {
   NewsletterRecipientsResponse,
   NewsletterSendResult,
   NewsletterTestSendPayload,
+  PublicNewsletterView,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of, take } from 'rxjs';
@@ -68,6 +69,16 @@ export class NewsletterService {
 
   public getAnalytics(projectUid: string, newsletterUid: string): Observable<NewsletterAnalytics> {
     return this.http.get<NewsletterAnalytics>(`/api/projects/${this.enc(projectUid)}/newsletters/${this.enc(newsletterUid)}/analytics`).pipe(take(1));
+  }
+
+  /**
+   * Public "View Online" projection of a sent newsletter (LFXV2-2579). Hits the
+   * unauthenticated `/public/api/newsletters/:projectUid/:newsletterUid` route —
+   * no bearer token is attached or required, matching the route's `auth:
+   * 'public'` classification in auth.middleware.ts.
+   */
+  public getPublicView(projectUid: string, newsletterUid: string): Observable<PublicNewsletterView> {
+    return this.http.get<PublicNewsletterView>(`/public/api/newsletters/${this.enc(projectUid)}/${this.enc(newsletterUid)}`).pipe(take(1));
   }
 
   public listOptOuts(projectUid: string): Observable<NewsletterOptOutListResponse> {

--- a/apps/lfx-one/src/app/shared/services/newsletter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/newsletter.service.ts
@@ -21,6 +21,7 @@ import {
   NewsletterScheduleResult,
   NewsletterSendResult,
   NewsletterTestSendPayload,
+  PublicNewsletterView,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { catchError, Observable, of, take } from 'rxjs';
@@ -83,6 +84,16 @@ export class NewsletterService {
     return this.http
       .get<NewsletterRecipientEngagementResponse>(`/api/projects/${this.enc(projectUid)}/newsletters/${this.enc(newsletterUid)}/analytics/recipients`)
       .pipe(take(1));
+  }
+
+  /**
+   * Public "View Online" projection of a sent newsletter (LFXV2-2579). Hits the
+   * unauthenticated `/public/api/newsletters/:projectUid/:newsletterUid` route —
+   * no bearer token is attached or required, matching the route's `auth:
+   * 'public'` classification in auth.middleware.ts.
+   */
+  public getPublicView(projectUid: string, newsletterUid: string): Observable<PublicNewsletterView> {
+    return this.http.get<PublicNewsletterView>(`/public/api/newsletters/${this.enc(projectUid)}/${this.enc(newsletterUid)}`).pipe(take(1));
   }
 
   public listOptOuts(projectUid: string): Observable<NewsletterOptOutListResponse> {

--- a/apps/lfx-one/src/server/controllers/public-newsletter.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-newsletter.controller.spec.ts
@@ -1,0 +1,94 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PROJECT_UID = 'project-1111';
+const NEWSLETTER_UID = '11111111-1111-4111-8111-111111111111';
+
+const { getPublicViewMock } = vi.hoisted(() => ({
+  getPublicViewMock: vi.fn(),
+}));
+
+vi.mock('@lfx-one/shared/utils', () => ({
+  isUuid: (value: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value),
+}));
+vi.mock('../services/newsletter.service', () => ({
+  NewsletterService: vi.fn(function () {
+    return { getPublicView: getPublicViewMock };
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { PublicNewsletterController } from './public-newsletter.controller';
+
+function buildReqRes(params: Record<string, string>) {
+  // No `bearerToken` field at all — this route is classified `auth: 'public'` in
+  // auth.middleware.ts, so a request reaching this controller never carries one.
+  const req = { params, path: `/public/api/newsletters/${params['projectUid']}/${params['newsletterUid']}`, log: {} } as any;
+  const res = { json: vi.fn() } as any;
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('PublicNewsletterController.getPublicView', () => {
+  let controller: PublicNewsletterController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicNewsletterController();
+  });
+
+  it('returns the public projection for valid path params, never reading a bearer token', async () => {
+    const view = { subject: 'Hello', body_html: '<p>Hi</p>', project_name: 'Proj', sent_at: '2026-01-01T00:00:00Z' };
+    getPublicViewMock.mockResolvedValue(view);
+    const { req, res, next } = buildReqRes({ projectUid: PROJECT_UID, newsletterUid: NEWSLETTER_UID });
+    expect(req.bearerToken).toBeUndefined();
+
+    await controller.getPublicView(req, res, next);
+
+    expect(getPublicViewMock).toHaveBeenCalledWith(req, PROJECT_UID, NEWSLETTER_UID);
+    expect(res.json).toHaveBeenCalledWith(view);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing projectUid without calling the newsletter service', async () => {
+    const { req, res, next } = buildReqRes({ projectUid: '', newsletterUid: NEWSLETTER_UID });
+
+    await controller.getPublicView(req, res, next);
+
+    expect(getPublicViewMock).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a non-UUID newsletterUid without calling the newsletter service', async () => {
+    const { req, res, next } = buildReqRes({ projectUid: PROJECT_UID, newsletterUid: 'not-a-uuid' });
+
+    await controller.getPublicView(req, res, next);
+
+    expect(getPublicViewMock).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a 404 from the upstream service via next(error)', async () => {
+    const notFound = Object.assign(new Error('not found'), { statusCode: 404 });
+    getPublicViewMock.mockRejectedValue(notFound);
+    const { req, res, next } = buildReqRes({ projectUid: PROJECT_UID, newsletterUid: NEWSLETTER_UID });
+
+    await controller.getPublicView(req, res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(notFound);
+  });
+});

--- a/apps/lfx-one/src/server/controllers/public-newsletter.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-newsletter.controller.spec.ts
@@ -1,0 +1,124 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const PROJECT_UID = 'project-1111';
+const NEWSLETTER_UID = '11111111-1111-4111-8111-111111111111';
+
+const { getPublicViewMock } = vi.hoisted(() => ({
+  getPublicViewMock: vi.fn(),
+}));
+
+vi.mock('@lfx-one/shared/utils', () => ({
+  isUuid: (value: string) => /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value),
+}));
+vi.mock('../services/newsletter.service', () => ({
+  NewsletterService: vi.fn(function () {
+    return { getPublicView: getPublicViewMock };
+  }),
+}));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    info: vi.fn(),
+  },
+}));
+
+import { PublicNewsletterController } from './public-newsletter.controller';
+
+function buildReqRes(params: Record<string, string>) {
+  // No `bearerToken` field at all — this route is classified `auth: 'public'` in
+  // auth.middleware.ts, so a request reaching this controller never carries one.
+  const req = { params, path: `/public/api/newsletters/${params['projectUid']}/${params['newsletterUid']}`, log: {} } as any;
+  const res = { json: vi.fn() } as any;
+  const next = vi.fn();
+  return { req, res, next };
+}
+
+describe('PublicNewsletterController.getPublicView', () => {
+  let controller: PublicNewsletterController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicNewsletterController();
+  });
+
+  it('returns the public projection for valid path params, never reading a bearer token', async () => {
+    const view = { subject: 'Hello', body_html: '<p>Hi</p>', project_name: 'Proj', sent_at: '2026-01-01T00:00:00Z' };
+    getPublicViewMock.mockResolvedValue(view);
+    const { req, res, next } = buildReqRes({ projectUid: PROJECT_UID, newsletterUid: NEWSLETTER_UID });
+    expect(req.bearerToken).toBeUndefined();
+
+    await controller.getPublicView(req, res, next);
+
+    expect(getPublicViewMock).toHaveBeenCalledWith(req, PROJECT_UID, NEWSLETTER_UID);
+    expect(res.json).toHaveBeenCalledWith(view);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('strips any non-allow-listed field the upstream returns (runtime PII guard)', async () => {
+    // Upstream widens with fields that must never reach an anonymous client.
+    getPublicViewMock.mockResolvedValue({
+      subject: 'Hello',
+      body_html: '<p>Hi</p>',
+      project_name: 'Proj',
+      sent_at: '2026-01-01T00:00:00Z',
+      id: 'nl-uuid',
+      committee_uids: ['c1'],
+      ed_reply_email: 'ed@example.com',
+      created_by: 'someone',
+      version: 3,
+    });
+    const { req, res, next } = buildReqRes({ projectUid: PROJECT_UID, newsletterUid: NEWSLETTER_UID });
+
+    await controller.getPublicView(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith({
+      subject: 'Hello',
+      body_html: '<p>Hi</p>',
+      project_name: 'Proj',
+      sent_at: '2026-01-01T00:00:00Z',
+    });
+    const sent = (res.json as unknown as { mock: { calls: unknown[][] } }).mock.calls[0][0] as Record<string, unknown>;
+    for (const leaked of ['id', 'committee_uids', 'ed_reply_email', 'created_by', 'version']) {
+      expect(sent).not.toHaveProperty(leaked);
+    }
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('rejects a missing projectUid without calling the newsletter service', async () => {
+    const { req, res, next } = buildReqRes({ projectUid: '', newsletterUid: NEWSLETTER_UID });
+
+    await controller.getPublicView(req, res, next);
+
+    expect(getPublicViewMock).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a non-UUID newsletterUid without calling the newsletter service', async () => {
+    const { req, res, next } = buildReqRes({ projectUid: PROJECT_UID, newsletterUid: 'not-a-uuid' });
+
+    await controller.getPublicView(req, res, next);
+
+    expect(getPublicViewMock).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('forwards a 404 from the upstream service via next(error)', async () => {
+    const notFound = Object.assign(new Error('not found'), { statusCode: 404 });
+    getPublicViewMock.mockRejectedValue(notFound);
+    const { req, res, next } = buildReqRes({ projectUid: PROJECT_UID, newsletterUid: NEWSLETTER_UID });
+
+    await controller.getPublicView(req, res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(notFound);
+  });
+});

--- a/apps/lfx-one/src/server/controllers/public-newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-newsletter.controller.ts
@@ -1,0 +1,65 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isUuid } from '@lfx-one/shared/utils';
+import { NextFunction, Request, Response } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { logger } from '../services/logger.service';
+import { NewsletterService } from '../services/newsletter.service';
+
+/**
+ * Public newsletter controller — the unauthenticated "View Online" surface for
+ * a sent newsletter edition.
+ *
+ * This route is mounted under `/public/api/newsletters` and classified `auth:
+ * 'public'` in auth.middleware.ts, so `req.bearerToken` is never set on
+ * requests that reach here. Access is entirely gated by the Go service
+ * (project_uid match + status=sent, else 404) — this controller does not
+ * perform any authorization of its own, matching the narrow, deliberately
+ * unauthenticated `PublicNewsletterView` projection it returns.
+ */
+export class PublicNewsletterController {
+  private newsletterService: NewsletterService = new NewsletterService();
+
+  /**
+   * GET /public/api/newsletters/:projectUid/:newsletterUid
+   */
+  public async getPublicView(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const projectUid = this.requireProjectUid(req);
+      const newsletterUid = this.requireNewsletterUid(req);
+      const startTime = logger.startOperation(req, 'newsletter_public_view', { project_uid: projectUid, newsletter_id: newsletterUid });
+
+      const view = await this.newsletterService.getPublicView(req, projectUid, newsletterUid);
+      logger.success(req, 'newsletter_public_view', startTime, { project_uid: projectUid, newsletter_id: newsletterUid });
+      res.json(view);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private requireProjectUid(req: Request): string {
+    const projectUid = String(req.params['projectUid'] || '').trim();
+    if (!projectUid) {
+      throw ServiceValidationError.forField('projectUid', 'projectUid path parameter is required', {
+        operation: 'public_newsletter_controller',
+        service: 'public_newsletter_controller',
+        path: req.path,
+      });
+    }
+    return projectUid;
+  }
+
+  private requireNewsletterUid(req: Request): string {
+    const newsletterUid = String(req.params['newsletterUid'] || '').trim();
+    if (!isUuid(newsletterUid)) {
+      throw ServiceValidationError.forField('newsletterUid', 'newsletterUid path parameter must be a UUID', {
+        operation: 'public_newsletter_controller',
+        service: 'public_newsletter_controller',
+        path: req.path,
+      });
+    }
+    return newsletterUid;
+  }
+}

--- a/apps/lfx-one/src/server/controllers/public-newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-newsletter.controller.ts
@@ -1,0 +1,76 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isUuid } from '@lfx-one/shared/utils';
+import { NextFunction, Request, Response } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { logger } from '../services/logger.service';
+import { NewsletterService } from '../services/newsletter.service';
+
+/**
+ * Public newsletter controller — the unauthenticated "View Online" surface for
+ * a sent newsletter edition.
+ *
+ * This route is mounted under `/public/api/newsletters` and classified `auth:
+ * 'public'` in auth.middleware.ts, so `req.bearerToken` is never set on
+ * requests that reach here. Access is entirely gated by the Go service
+ * (project_uid match + status=sent, else 404) — this controller does not
+ * perform any authorization of its own, matching the narrow, deliberately
+ * unauthenticated `PublicNewsletterView` projection it returns.
+ */
+export class PublicNewsletterController {
+  private newsletterService: NewsletterService = new NewsletterService();
+
+  /**
+   * GET /public/api/newsletters/:projectUid/:newsletterUid
+   */
+  public async getPublicView(req: Request, res: Response, next: NextFunction): Promise<void> {
+    try {
+      const projectUid = this.requireProjectUid(req);
+      const newsletterUid = this.requireNewsletterUid(req);
+      const startTime = logger.startOperation(req, 'newsletter_public_view', { project_uid: projectUid, newsletter_id: newsletterUid });
+
+      const view = await this.newsletterService.getPublicView(req, projectUid, newsletterUid);
+      logger.success(req, 'newsletter_public_view', startTime, { project_uid: projectUid, newsletter_id: newsletterUid });
+      // Explicitly project to the public allow-list. `PublicNewsletterView` is a
+      // compile-time type only — it does not strip excess runtime properties, so
+      // forwarding the raw upstream object could leak `id`, `committee_uids`,
+      // `ed_reply_email`, `created_by`, or `version` if the upstream response
+      // ever widens. Build the response field-by-field on this unauthenticated
+      // surface.
+      res.json({
+        subject: view.subject,
+        body_html: view.body_html,
+        project_name: view.project_name,
+        sent_at: view.sent_at,
+      });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  private requireProjectUid(req: Request): string {
+    const projectUid = String(req.params['projectUid'] || '').trim();
+    if (!projectUid) {
+      throw ServiceValidationError.forField('projectUid', 'projectUid path parameter is required', {
+        operation: 'public_newsletter_controller',
+        service: 'public_newsletter_controller',
+        path: req.path,
+      });
+    }
+    return projectUid;
+  }
+
+  private requireNewsletterUid(req: Request): string {
+    const newsletterUid = String(req.params['newsletterUid'] || '').trim();
+    if (!isUuid(newsletterUid)) {
+      throw ServiceValidationError.forField('newsletterUid', 'newsletterUid path parameter must be a UUID', {
+        operation: 'public_newsletter_controller',
+        service: 'public_newsletter_controller',
+        path: req.path,
+      });
+    }
+    return newsletterUid;
+  }
+}

--- a/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
@@ -207,4 +207,62 @@ describe('authMiddleware route classification', () => {
 
     expect(res.oidc.login).toHaveBeenCalledTimes(1);
   });
+
+  // LFXV2-2579 — public "View Online" newsletter page and its backing API route.
+  // Both must be public (no login redirect / no 401) and must not fail-open onto
+  // sibling authenticated newsletter routes.
+
+  it('allows an anonymous GET to the public newsletter "View Online" SSR page', async () => {
+    const req = buildReq({ path: '/newsletters/project-123/nl-456/view' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('allows an anonymous GET to the public newsletter "View Online" API route', async () => {
+    const req = buildReq({ path: '/public/api/newsletters/project-123/nl-456' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('still redirects an anonymous GET to the authenticated newsletter edit route (no fail-open)', async () => {
+    const req = buildReq({ path: '/newsletters/project-123/nl-456/edit' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('still redirects an anonymous GET to the authenticated newsletter analytics route (no fail-open)', async () => {
+    const req = buildReq({ path: '/newsletters/project-123/nl-456/analytics' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('still redirects an anonymous GET to the authenticated "my newsletters" route (no fail-open)', async () => {
+    const req = buildReq({ path: '/newsletters/my' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
@@ -78,4 +78,62 @@ describe('authMiddleware route classification', () => {
 
     expect(res.oidc.login).toHaveBeenCalledTimes(1);
   });
+
+  // LFXV2-2579 — public "View Online" newsletter page and its backing API route.
+  // Both must be public (no login redirect / no 401) and must not fail-open onto
+  // sibling authenticated newsletter routes.
+
+  it('allows an anonymous GET to the public newsletter "View Online" SSR page', async () => {
+    const req = buildReq({ path: '/newsletters/project-123/nl-456/view' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('allows an anonymous GET to the public newsletter "View Online" API route', async () => {
+    const req = buildReq({ path: '/public/api/newsletters/project-123/nl-456' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('still redirects an anonymous GET to the authenticated newsletter edit route (no fail-open)', async () => {
+    const req = buildReq({ path: '/newsletters/project-123/nl-456/edit' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('still redirects an anonymous GET to the authenticated newsletter analytics route (no fail-open)', async () => {
+    const req = buildReq({ path: '/newsletters/project-123/nl-456/analytics' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('still redirects an anonymous GET to the authenticated "my newsletters" route (no fail-open)', async () => {
+    const req = buildReq({ path: '/newsletters/my' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -23,6 +23,13 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   { pattern: '/livez', type: 'api', auth: 'public' },
   { pattern: '/readyz', type: 'api', auth: 'public' },
 
+  // Public "View Online" newsletter projection (LFXV2-2579) — `public` (not `optional`) skips bearer
+  // extraction entirely, since the Go service alone gates access (project_uid match + status=sent).
+  // Must come BEFORE the broad `/public/api` row below, which would otherwise classify this as
+  // `optional` and still attempt token extraction. Anchored regex so `startsWith`-style matching
+  // can't fail-open onto an unrelated future `/public/api/newsletters-admin` route.
+  { pattern: /^\/public\/api\/newsletters\/[^/]+\/[^/]+\/?$/, type: 'api', auth: 'public' },
+
   // Public API routes - optional authentication with token benefits
   { pattern: '/public/api', type: 'api', auth: 'optional', tokenRequired: false },
 
@@ -99,6 +106,12 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // or `/robots.txt-foo` (per `classifyRoute`'s string-pattern semantics on Line 84).
   { pattern: /^\/sitemap\.xml$/, type: 'ssr', auth: 'public' },
   { pattern: /^\/robots\.txt$/, type: 'ssr', auth: 'public' },
+
+  // Public "View Online" newsletter page (LFXV2-2579) — unauthenticated access to a sent newsletter
+  // edition. Anchored regex bounds the match to exactly `/newsletters/:projectUid/:id/view` so
+  // `startsWith` semantics can't fail-open onto `/newsletters/:projectUid/:id/edit` or the
+  // authenticated `/newsletters` list/manage routes, which must still require login.
+  { pattern: /^\/newsletters\/[^/]+\/[^/]+\/view\/?$/, type: 'ssr', auth: 'public' },
 
   // All other routes - Angular SSR routes requiring authentication
   { pattern: '/', type: 'ssr', auth: 'required' },

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -23,6 +23,13 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   { pattern: '/livez', type: 'api', auth: 'public' },
   { pattern: '/readyz', type: 'api', auth: 'public' },
 
+  // Public "View Online" newsletter projection (LFXV2-2579) — `public` (not `optional`) skips bearer
+  // extraction entirely, since the Go service alone gates access (project_uid match + status=sent).
+  // Must come BEFORE the broad `/public/api` row below, which would otherwise classify this as
+  // `optional` and still attempt token extraction. Anchored regex so `startsWith`-style matching
+  // can't fail-open onto an unrelated future `/public/api/newsletters-admin` route.
+  { pattern: /^\/public\/api\/newsletters\/[^/]+\/[^/]+\/?$/, type: 'api', auth: 'public' },
+
   // Public API routes - optional authentication with token benefits
   { pattern: '/public/api', type: 'api', auth: 'optional', tokenRequired: false },
 
@@ -85,6 +92,12 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // or `/robots.txt-foo` (per `classifyRoute`'s string-pattern semantics on Line 84).
   { pattern: /^\/sitemap\.xml$/, type: 'ssr', auth: 'public' },
   { pattern: /^\/robots\.txt$/, type: 'ssr', auth: 'public' },
+
+  // Public "View Online" newsletter page (LFXV2-2579) — unauthenticated access to a sent newsletter
+  // edition. Anchored regex bounds the match to exactly `/newsletters/:projectUid/:id/view` so
+  // `startsWith` semantics can't fail-open onto `/newsletters/:projectUid/:id/edit` or the
+  // authenticated `/newsletters` list/manage routes, which must still require login.
+  { pattern: /^\/newsletters\/[^/]+\/[^/]+\/view\/?$/, type: 'ssr', auth: 'public' },
 
   // Generic not-found page — public so anonymous users land on a branded 404 instead of a login
   // prompt when redirected here from an unrecognized URL. Anchored regex prevents startsWith

--- a/apps/lfx-one/src/server/routes/public-newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/public-newsletters.route.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { PublicNewsletterController } from '../controllers/public-newsletter.controller';
+
+const router = Router();
+const publicNewsletterController = new PublicNewsletterController();
+
+// GET /public/api/newsletters/:projectUid/:newsletterUid - get the "View Online" projection of a sent newsletter (public access, no authentication required)
+router.get('/:projectUid/:newsletterUid', (req, res, next) => publicNewsletterController.getPublicView(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -49,6 +49,7 @@ import publicCommitteesRouter from './routes/public-committees.route';
 import publicFoundationsRouter from './routes/public-foundations.route';
 import publicGroupsRouter from './routes/public-groups.route';
 import publicMeetingsRouter from './routes/public-meetings.route';
+import publicNewslettersRouter from './routes/public-newsletters.route';
 import publicProfileRouter from './routes/public-profile.route';
 import publicProjectsRouter from './routes/public-projects.route';
 import rewardsRouter from './routes/rewards.route';
@@ -311,6 +312,7 @@ app.use('/public/api/meetings', publicMeetingsRouter);
 app.use('/public/api/committees', publicCommitteesRouter);
 app.use('/public/api/foundations', publicFoundationsRouter);
 app.use('/public/api/groups', publicGroupsRouter);
+app.use('/public/api/newsletters', publicNewslettersRouter);
 app.use('/public/api/profile', publicProfileRouter);
 app.use('/public/api/projects', publicProjectsRouter);
 

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -48,6 +48,7 @@ import publicCommitteesRouter from './routes/public-committees.route';
 import publicFoundationsRouter from './routes/public-foundations.route';
 import publicGroupsRouter from './routes/public-groups.route';
 import publicMeetingsRouter from './routes/public-meetings.route';
+import publicNewslettersRouter from './routes/public-newsletters.route';
 import publicProfileRouter from './routes/public-profile.route';
 import publicProjectsRouter from './routes/public-projects.route';
 import rewardsRouter from './routes/rewards.route';
@@ -311,6 +312,7 @@ app.use('/public/api/meetings', publicMeetingsRouter);
 app.use('/public/api/committees', publicCommitteesRouter);
 app.use('/public/api/foundations', publicFoundationsRouter);
 app.use('/public/api/groups', publicGroupsRouter);
+app.use('/public/api/newsletters', publicNewslettersRouter);
 app.use('/public/api/profile', publicProfileRouter);
 app.use('/public/api/projects', publicProjectsRouter);
 

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -18,6 +18,7 @@ import {
   NewsletterScheduleResult,
   NewsletterSendResult,
   NewsletterTestSendPayload,
+  PublicNewsletterView,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
@@ -42,6 +43,22 @@ export class NewsletterServiceClient {
 
   public async getNewsletter(req: Request, projectUid: string, newsletterUid: string): Promise<Newsletter> {
     return this.microserviceProxy.proxyRequest<Newsletter>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletters/${newsletterUid}`, 'GET');
+  }
+
+  /**
+   * Unauthenticated projection of a sent newsletter for the public "View
+   * Online" page. Backed entirely by the Go service's own gating (project_uid
+   * match + status=sent, else 404) — this call must never carry a bearer
+   * token; that is enforced by classifying the calling route as `auth:
+   * 'public'` in auth.middleware.ts, not by anything here.
+   */
+  public async getPublicView(req: Request, projectUid: string, newsletterUid: string): Promise<PublicNewsletterView> {
+    return this.microserviceProxy.proxyRequest<PublicNewsletterView>(
+      req,
+      'LFX_V2_SERVICE',
+      `/projects/${projectUid}/newsletters/${newsletterUid}/public`,
+      'GET'
+    );
   }
 
   public async listNewsletters(req: Request, projectUid: string, params: NewsletterListParams): Promise<NewsletterListResponse> {

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -15,6 +15,7 @@ import {
   NewsletterRecipientsResponse,
   NewsletterSendResult,
   NewsletterTestSendPayload,
+  PublicNewsletterView,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
@@ -39,6 +40,22 @@ export class NewsletterServiceClient {
 
   public async getNewsletter(req: Request, projectUid: string, newsletterUid: string): Promise<Newsletter> {
     return this.microserviceProxy.proxyRequest<Newsletter>(req, 'LFX_V2_SERVICE', `/projects/${projectUid}/newsletters/${newsletterUid}`, 'GET');
+  }
+
+  /**
+   * Unauthenticated projection of a sent newsletter for the public "View
+   * Online" page. Backed entirely by the Go service's own gating (project_uid
+   * match + status=sent, else 404) — this call must never carry a bearer
+   * token; that is enforced by classifying the calling route as `auth:
+   * 'public'` in auth.middleware.ts, not by anything here.
+   */
+  public async getPublicView(req: Request, projectUid: string, newsletterUid: string): Promise<PublicNewsletterView> {
+    return this.microserviceProxy.proxyRequest<PublicNewsletterView>(
+      req,
+      'LFX_V2_SERVICE',
+      `/projects/${projectUid}/newsletters/${newsletterUid}/public`,
+      'GET'
+    );
   }
 
   public async listNewsletters(req: Request, projectUid: string, params: NewsletterListParams): Promise<NewsletterListResponse> {

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -15,6 +15,7 @@ import {
   NewsletterRecipientsResponse,
   NewsletterSendResult,
   NewsletterTestSendPayload,
+  PublicNewsletterView,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
@@ -112,6 +113,10 @@ export class NewsletterService {
 
   public getNewsletter(req: Request, projectUid: string, newsletterUid: string): Promise<Newsletter> {
     return this.newsletterClient.getNewsletter(req, projectUid, newsletterUid);
+  }
+
+  public getPublicView(req: Request, projectUid: string, newsletterUid: string): Promise<PublicNewsletterView> {
+    return this.newsletterClient.getPublicView(req, projectUid, newsletterUid);
   }
 
   public listNewsletters(req: Request, projectUid: string, params: NewsletterListParams): Promise<NewsletterListResponse> {

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -18,6 +18,7 @@ import {
   NewsletterScheduleResult,
   NewsletterSendResult,
   NewsletterTestSendPayload,
+  PublicNewsletterView,
   UpdateNewsletterRequest,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
@@ -115,6 +116,10 @@ export class NewsletterService {
 
   public getNewsletter(req: Request, projectUid: string, newsletterUid: string): Promise<Newsletter> {
     return this.newsletterClient.getNewsletter(req, projectUid, newsletterUid);
+  }
+
+  public getPublicView(req: Request, projectUid: string, newsletterUid: string): Promise<PublicNewsletterView> {
+    return this.newsletterClient.getPublicView(req, projectUid, newsletterUid);
   }
 
   public listNewsletters(req: Request, projectUid: string, params: NewsletterListParams): Promise<NewsletterListResponse> {

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -232,6 +232,18 @@ export interface NewsletterChartData {
   datasets: NewsletterChartDataset[];
 }
 
+/**
+ * Response of GET …/newsletters/{newsletter_uid}/public: a deliberately narrow,
+ * unauthenticated projection of a sent newsletter. Never includes `id`,
+ * `committee_uids`, `ed_reply_email`, `created_by`, or `version`.
+ */
+export interface PublicNewsletterView {
+  subject: string;
+  body_html: string;
+  project_name: string;
+  sent_at: string;
+}
+
 export interface NewsletterOptOut {
   id: string;
   email: string;

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -471,6 +471,18 @@ export interface NewsletterLinkRow extends NewsletterLinkClicks {
   href: string | null;
 }
 
+/**
+ * Response of GET …/newsletters/{newsletter_uid}/public: a deliberately narrow,
+ * unauthenticated projection of a sent newsletter. Never includes `id`,
+ * `committee_uids`, `ed_reply_email`, `created_by`, or `version`.
+ */
+export interface PublicNewsletterView {
+  subject: string;
+  body_html: string;
+  project_name: string;
+  sent_at: string;
+}
+
 export interface NewsletterOptOut {
   id: string;
   email: string;


### PR DESCRIPTION
**Tracking:** [LFXV2-2579](https://linuxfoundation.atlassian.net/browse/LFXV2-2579) · Refs #16

Adds the public, unauthenticated **"View Online"** page for a sent newsletter edition (the permalink from the email footer):

- A public `newsletters/:projectUid/:id/view` route, mounted **ahead of** the auth guard and classified `auth: 'public'` in the auth middleware.
- The BFF endpoint returns a **field-by-field PII allow-list** (`subject`, `body_html`, `project_name`, `sent_at`) built explicitly, so no upstream field can leak on this unauthenticated surface even if the upstream response widens.
- No bearer token attached — access is gated entirely by the Go service (only `status='sent'` rows scoped to the path project; everything else is an indistinguishable 404).

## ⚠️ Deployment dependency

This is the front-end/BFF half. It requires the backend half — **`lfx-v2-newsletter-service` PR #73 (LFXV2-2579)** — to be **merged and deployed first**. That PR adds the anonymous `GET /projects/{uid}/newsletters/{id}/public` endpoint (returning the `PublicNewsletterView` projection incl. `project_name`) and its `allow_all` gateway rule.

## Protected files touched

- `apps/lfx-one/src/server/server.ts` — mounts the public newsletter router.
- `apps/lfx-one/src/server/middleware/auth.middleware.ts` — classifies the two new public paths (anchored regexes, ordered before the broad `/public/api` prefix). Spec updated to pin both the allow and deny sides.

Both are bootstrap/auth-infra files; flagged for code-owner awareness.

## Notes

- Unit spec added for the public-view component (404 / missing-param / generic-error branches); controller spec pins the PII-stripping.
- Rebased on latest `main`.


[LFXV2-2579]: https://linuxfoundation.atlassian.net/browse/LFXV2-2579?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ