### PR TITLE
feat(newsletters): add end-to-end send flow with analytics and e2e tests

### DIFF
--- a/apps/lfx-one/e2e/newsletter-live-send-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-live-send-robust.spec.ts
@@ -1,0 +1,159 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Newsletter Live Send → Analytics — Structural Tests — LFXV2-2389.
+ *
+ * Companion to `newsletter-live-send.spec.ts`. Asserts the `data-testid`
+ * contract the send-and-analytics flow depends on, isolated from copy /
+ * wording changes that the content spec exercises. Per
+ * `docs/architecture/testing/e2e-testing.md`, every feature with E2E coverage
+ * gets a content spec AND a structural (`-robust`) spec.
+ *
+ * This spec also runs against live services (no `page.route()` mocking) —
+ * the send pipeline can't be meaningfully stubbed without re-implementing the
+ * newsletter-service/committee-service/email-service contracts, so the
+ * structural assertions below run inline in the same live flow rather than
+ * against a fixture-seeded page load like the rest of the `-robust` specs in
+ * this tree.
+ *
+ * Same environment prerequisites as `newsletter-live-send.spec.ts`:
+ * TEST_USERNAME, TEST_PASSWORD, TEST_NEWSLETTER_PROJECT_SLUG (and optionally
+ * TEST_NEWSLETTER_COMMITTEE_NAME).
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(120_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+const SEND_ACK_TIMEOUT = 20_000;
+
+const PROJECT_SLUG = process.env.TEST_NEWSLETTER_PROJECT_SLUG;
+const COMMITTEE_NAME = process.env.TEST_NEWSLETTER_COMMITTEE_NAME;
+
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenPrereqsMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+  if (!PROJECT_SLUG) {
+    test.skip(true, 'TEST_NEWSLETTER_PROJECT_SLUG not configured — this spec needs a real, seeded project to send against');
+  }
+}
+
+const RUN_SUBJECT = `E2E Live Send Structural ${Date.now()}`;
+
+async function gotoCreate(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto(`/${PROJECT_SLUG}/newsletters/create?project=${PROJECT_SLUG}`, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('newsletter-manage')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+}
+
+test.describe('Newsletter Live Send — Structural Tests', () => {
+  test.beforeEach(() => {
+    skipWhenPrereqsMissing();
+  });
+
+  test.describe('Create wizard — stepper testid contract', () => {
+    test('audience, content, and send steps expose their root testids in order', async ({ page }) => {
+      await gotoCreate(page);
+
+      await expect(page.getByTestId('newsletter-manage-stepper')).toBeAttached();
+      await expect(page.getByTestId('newsletter-manage-step-1')).toBeAttached();
+      await expect(page.getByTestId('newsletter-manage-step-2')).toBeAttached();
+      await expect(page.getByTestId('newsletter-manage-step-3')).toBeAttached();
+      await expect(page.getByTestId('newsletter-audience-step')).toBeAttached();
+      await expect(page.getByTestId('newsletter-audience-committees')).toBeAttached();
+    });
+
+    test('the audience step gates Next until a committee is selected', async ({ page }) => {
+      await gotoCreate(page);
+
+      const nextButton = page.getByTestId('newsletter-manage-next-btn');
+      await expect(nextButton).toBeAttached();
+      await expect(nextButton).toBeDisabled();
+
+      const committeeSelect = page.getByTestId('newsletter-audience-committees');
+      await committeeSelect.click();
+      const option = COMMITTEE_NAME ? page.getByRole('option', { name: COMMITTEE_NAME }) : page.getByRole('option').first();
+      await option.click();
+
+      await expect(page.getByTestId('newsletter-audience-recipient-pill')).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+      await expect(nextButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    });
+  });
+
+  test.describe('Send step — action testid contract', () => {
+    test('send step exposes send-test and send-now actions and a confirm dialog mount point', async ({ page }) => {
+      await gotoCreate(page);
+
+      const committeeSelect = page.getByTestId('newsletter-audience-committees');
+      await committeeSelect.click();
+      const option = COMMITTEE_NAME ? page.getByRole('option', { name: COMMITTEE_NAME }) : page.getByRole('option').first();
+      await option.click();
+      await expect(page.getByTestId('newsletter-audience-recipient-pill')).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+
+      await page.getByTestId('newsletter-manage-next-btn').click();
+      await expect(page.getByTestId('newsletter-content-step')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT });
+      await page.getByTestId('newsletter-content-subject').locator('input').fill(RUN_SUBJECT);
+      await page.getByTestId('newsletter-content-body').locator('.ql-editor').fill('Structural spec body content.');
+
+      await page.getByTestId('newsletter-manage-next-btn').click();
+      await expect(page.getByTestId('newsletter-send-step')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT });
+
+      await expect(page.getByTestId('newsletter-send-step-summary')).toBeAttached();
+      await expect(page.getByTestId('newsletter-send-test-button')).toBeAttached();
+      await expect(page.getByTestId('newsletter-send-now-button')).toBeAttached();
+
+      // p-confirmDialog mount point lives on the parent manage component, keyed
+      // 'newsletter-manage' — attached regardless of which step is showing.
+      await expect(page.locator('p-confirmdialog')).toBeAttached();
+    });
+  });
+
+  test.describe('Sent list + analytics — testid contract', () => {
+    test('a sent newsletter row links into an analytics page exposing the recipients/opens testid contract', async ({ page }) => {
+      await gotoCreate(page);
+
+      const committeeSelect = page.getByTestId('newsletter-audience-committees');
+      await committeeSelect.click();
+      const option = COMMITTEE_NAME ? page.getByRole('option', { name: COMMITTEE_NAME }) : page.getByRole('option').first();
+      await option.click();
+      await expect(page.getByTestId('newsletter-audience-recipient-pill')).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+
+      await page.getByTestId('newsletter-manage-next-btn').click();
+      await page.getByTestId('newsletter-content-subject').locator('input').fill(RUN_SUBJECT);
+      await page.getByTestId('newsletter-content-body').locator('.ql-editor').fill('Structural spec body content.');
+
+      await page.getByTestId('newsletter-manage-next-btn').click();
+      await expect(page.getByTestId('newsletter-send-step')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT });
+
+      const sendNowButton = page.getByTestId('newsletter-send-now-button');
+      await expect(sendNowButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+      await sendNowButton.click();
+
+      const confirmDialog = page.locator('.p-confirmdialog');
+      await expect(confirmDialog).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+      await confirmDialog.getByRole('button', { name: /send now/i }).click();
+
+      await expect(page).toHaveURL(/\/newsletters\/list\?.*tab=sent/, { timeout: SEND_ACK_TIMEOUT });
+      await expect(page.getByTestId('newsletter-list-table')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT });
+
+      const row = page.locator('[data-testid^="newsletter-row-"]').filter({ hasText: RUN_SUBJECT });
+      await expect(row).toBeAttached({ timeout: ELEMENT_TIMEOUT });
+      await row.click();
+
+      await expect(page.getByTestId('newsletter-analytics')).toBeAttached({ timeout: PAGE_LOAD_TIMEOUT });
+      await expect(page.getByTestId('newsletter-analytics-subject')).toBeAttached();
+      await expect(page.getByTestId('newsletter-analytics-recipients')).toBeAttached();
+      await expect(page.getByTestId('newsletter-analytics-unique-opens')).toBeAttached();
+      await expect(page.getByTestId('newsletter-analytics-total-opens')).toBeAttached();
+      await expect(page.getByTestId('newsletter-analytics-open-rate')).toBeAttached();
+    });
+  });
+});

--- a/apps/lfx-one/e2e/newsletter-live-send.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-live-send.spec.ts
@@ -1,0 +1,182 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Newsletter Live Send → Analytics — LFXV2-2389.
+ *
+ * End-to-end coverage of the real send-to-committee-to-analytics pipeline, with
+ * NO `page.route()` mocking. Every request in this spec hits the real newsletter
+ * BFF proxy, the real newsletter-service, and (once a send is accepted) the real
+ * email provider fan-out. This is deliberately different from the rest of the
+ * `e2e/` tree, which stubs the backend for determinism — this spec exists
+ * specifically to prove the send → deliver → analytics contract holds against
+ * live services, matching the newsletter-service, committee-service, and
+ * email-service contracts documented in their respective repos.
+ *
+ * Environment prerequisites (this spec skips itself, loudly, when unmet):
+ *   - TEST_USERNAME / TEST_PASSWORD — real Auth0 credentials (see global-setup.ts).
+ *   - TEST_NEWSLETTER_PROJECT_SLUG — slug of a real, seeded project/foundation
+ *     with a writer-accessible "Newsletter" category committee that has at
+ *     least one member with a deliverable mailbox (e.g. Mailpit locally, or a
+ *     real inbox in a shared environment).
+ *   - TEST_NEWSLETTER_COMMITTEE_NAME (optional) — exact committee name to pick
+ *     from the audience group selector. Falls back to the first available
+ *     "Newsletter" category committee for the project when unset.
+ *
+ * Scope note: this spec asserts on DELIVERED counts only (`delivered`,
+ * `total_recipients`), not on open-tracking counts (`unique_opens`,
+ * `total_opens`). Open tracking depends on a recipient's mail client actually
+ * fetching the tracking pixel, which no automated flow can trigger
+ * deterministically. See the spec's "Environment prerequisite" note.
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(120_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+const SEND_ACK_TIMEOUT = 20_000;
+const ANALYTICS_POLL_TIMEOUT = 60_000;
+const ANALYTICS_POLL_INTERVAL = 3_000;
+
+const PROJECT_SLUG = process.env.TEST_NEWSLETTER_PROJECT_SLUG;
+const COMMITTEE_NAME = process.env.TEST_NEWSLETTER_COMMITTEE_NAME;
+
+// Gated on env vars, not on URL sniffing, so a genuine auth-flow regression
+// (expired storageState, broken Auth0 login helper) still fails loudly when
+// creds ARE configured. See newsletter-reopen-review.spec.ts for the same pattern.
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenPrereqsMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+  if (!PROJECT_SLUG) {
+    test.skip(true, 'TEST_NEWSLETTER_PROJECT_SLUG not configured — this spec needs a real, seeded project to send against');
+  }
+}
+
+// Unique per run so the sent-list lookup can't match a newsletter left over
+// from a previous (possibly failed) run of this same spec.
+const RUN_SUBJECT = `E2E Live Send ${Date.now()}`;
+
+async function gotoCreate(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto(`/${PROJECT_SLUG}/newsletters/create?project=${PROJECT_SLUG}`, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('newsletter-manage')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+}
+
+async function selectAudienceCommittee(page: Page): Promise<void> {
+  await expect(page.getByTestId('newsletter-manage-step-1')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  await expect(page.getByTestId('newsletter-audience-step')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  const committeeSelect = page.getByTestId('newsletter-audience-committees');
+  await expect(committeeSelect).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await committeeSelect.click();
+
+  const option = COMMITTEE_NAME ? page.getByRole('option', { name: COMMITTEE_NAME }) : page.getByRole('option').first();
+  await expect(option).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await option.click();
+
+  // Recipient count resolves async (real backend call to committee-service via
+  // the newsletter BFF) — wait for it to settle before moving on so "Next" is enabled.
+  await expect(page.getByTestId('newsletter-audience-recipient-pill')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+}
+
+async function fillContent(page: Page): Promise<void> {
+  await page.getByTestId('newsletter-manage-next-btn').click();
+  await expect(page.getByTestId('newsletter-manage-step-2')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await expect(page.getByTestId('newsletter-content-step')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  await page.getByTestId('newsletter-content-subject').locator('input').fill(RUN_SUBJECT);
+  await page.getByTestId('newsletter-content-body').locator('.ql-editor').fill('This newsletter was sent by an automated end-to-end test against live services.');
+}
+
+async function goToSendStepAndSend(page: Page): Promise<void> {
+  await page.getByTestId('newsletter-manage-next-btn').click();
+  await expect(page.getByTestId('newsletter-manage-step-3')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await expect(page.getByTestId('newsletter-send-step')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  const sendNowButton = page.getByTestId('newsletter-send-now-button');
+  await expect(sendNowButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+  await sendNowButton.click();
+
+  const confirmDialog = page.locator('.p-confirmdialog');
+  await expect(confirmDialog).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await confirmDialog.getByRole('button', { name: /send now/i }).click();
+
+  // The component deliberately has no in-app "sending" progress indicator — an
+  // accepted send (202 sending, or a fast-settled sent) always redirects to the
+  // Sent tab of the list. That redirect, plus the acknowledgement toast, IS the
+  // send-accepted signal this spec asserts on.
+  await expect(page.locator('.p-toast')).toContainText(/sending newsletter|newsletter sent/i, { timeout: SEND_ACK_TIMEOUT });
+  await expect(page).toHaveURL(/\/newsletters\/list\?.*tab=sent/, { timeout: SEND_ACK_TIMEOUT });
+}
+
+async function openSentAnalytics(page: Page): Promise<void> {
+  await expect(page.getByTestId('newsletter-list-table')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  const row = page.locator('[data-testid^="newsletter-row-"]').filter({ hasText: RUN_SUBJECT });
+  await expect(row).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await row.click();
+
+  await expect(page).toHaveURL(/\/newsletters\/[^/]+\/[^/]+\/analytics/, { timeout: PAGE_LOAD_TIMEOUT });
+  await expect(page.getByTestId('newsletter-analytics')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+}
+
+async function waitForDeliveryConfirmedAnalytics(page: Page): Promise<{ totalRecipients: number; delivered: number }> {
+  const deadline = Date.now() + ANALYTICS_POLL_TIMEOUT;
+  let totalRecipients = 0;
+  let delivered = 0;
+
+  while (Date.now() < deadline) {
+    const recipientsText = await page.getByTestId('newsletter-analytics-recipients').innerText();
+    totalRecipients = Number(recipientsText.trim());
+
+    if (totalRecipients > 0) {
+      const summaryText = await page.getByTestId('newsletter-analytics-recipients').locator('..').innerText();
+      const deliveredMatch = summaryText.match(/(\d+)\s+delivered/i);
+      delivered = deliveredMatch ? Number(deliveredMatch[1]) : 0;
+      if (delivered > 0) {
+        return { totalRecipients, delivered };
+      }
+    }
+
+    await page.waitForTimeout(ANALYTICS_POLL_INTERVAL);
+    await page.reload({ waitUntil: 'domcontentloaded' });
+    await expect(page.getByTestId('newsletter-analytics')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  }
+
+  return { totalRecipients, delivered };
+}
+
+test.describe.serial('Newsletter live send → analytics (live services)', () => {
+  test.beforeEach(() => {
+    skipWhenPrereqsMissing();
+  });
+
+  test('creates a draft, sends it to a real committee, and lands on the Sent list', async ({ page }) => {
+    await gotoCreate(page);
+    await selectAudienceCommittee(page);
+    await fillContent(page);
+    await goToSendStepAndSend(page);
+  });
+
+  test('analytics reflects delivery-confirmed recipients once the send settles', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await page.goto(`/${PROJECT_SLUG}/newsletters/list?project=${PROJECT_SLUG}&tab=sent`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await openSentAnalytics(page);
+
+    const { totalRecipients, delivered } = await waitForDeliveryConfirmedAnalytics(page);
+
+    expect(totalRecipients, 'the sent newsletter should have at least one resolved recipient').toBeGreaterThan(0);
+    expect(delivered, 'at least one recipient should show as delivered once the async send settles').toBeGreaterThan(0);
+    expect(delivered).toBeLessThanOrEqual(totalRecipients);
+  });
+});

--- a/apps/lfx-one/e2e/newsletter-send-failure.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-send-failure.spec.ts
@@ -1,0 +1,140 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Newsletter Send Failure — LFXV2-2389.
+ *
+ * Covers the error path of the send pipeline that `newsletter-live-send.spec.ts`
+ * deliberately doesn't exercise: the upstream `/send` call itself fails. Only
+ * that one endpoint is mocked (`page.route()`, per the documented "Error-state
+ * coverage via route mocking" pattern) — draft creation, the recipient-count
+ * lookup, and the post-failure status refetch all hit the real backend, so
+ * this spec also proves `handleSendError()` in
+ * `newsletter-manage.component.ts` correctly branches back to "still a draft"
+ * against a live re-fetch rather than a second mock.
+ *
+ * `handleSendError()` refetches the newsletter after a failed send and
+ * branches on its real status before deciding whether to show "Send failed" —
+ * this exists specifically to avoid the duplicate-send regression from
+ * LFXV2-2604. Since only the `/send` call is mocked, that refetch hits the
+ * real, unmodified backend and reports the newsletter is still a draft, which
+ * is what drives the "Send failed" toast and kept-on-page assertions below.
+ *
+ * Same environment prerequisites as the live-send specs:
+ * TEST_USERNAME, TEST_PASSWORD, TEST_NEWSLETTER_PROJECT_SLUG (and optionally
+ * TEST_NEWSLETTER_COMMITTEE_NAME).
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const PAGE_LOAD_TIMEOUT = 20_000;
+const ELEMENT_TIMEOUT = 10_000;
+const TOAST_TIMEOUT = 15_000;
+
+const PROJECT_SLUG = process.env.TEST_NEWSLETTER_PROJECT_SLUG;
+const COMMITTEE_NAME = process.env.TEST_NEWSLETTER_COMMITTEE_NAME;
+
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenPrereqsMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+  if (!PROJECT_SLUG) {
+    test.skip(true, 'TEST_NEWSLETTER_PROJECT_SLUG not configured — this spec needs a real, seeded project to create a draft against');
+  }
+}
+
+const RUN_SUBJECT = `E2E Send Failure ${Date.now()}`;
+
+// Matches POST /api/projects/:projectUid/newsletters/:newsletterUid/send only —
+// not the GET on the same newsletter resource (the refetch handleSendError()
+// issues), and not the list/create/update endpoints under the same prefix.
+const SEND_ENDPOINT_PATTERN = /\/api\/projects\/[^/]+\/newsletters\/[^/]+\/send$/;
+
+async function createDraftThroughSendStep(page: Page): Promise<void> {
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await page.goto(`/${PROJECT_SLUG}/newsletters/create?project=${PROJECT_SLUG}`, { waitUntil: 'domcontentloaded' });
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('newsletter-manage')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  await expect(page.getByTestId('newsletter-audience-step')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  const committeeSelect = page.getByTestId('newsletter-audience-committees');
+  await expect(committeeSelect).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await committeeSelect.click();
+  const option = COMMITTEE_NAME ? page.getByRole('option', { name: COMMITTEE_NAME }) : page.getByRole('option').first();
+  await expect(option).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  await option.click();
+  await expect(page.getByTestId('newsletter-audience-recipient-pill')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+  await page.getByTestId('newsletter-manage-next-btn').click();
+  await expect(page.getByTestId('newsletter-content-step')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+  await page.getByTestId('newsletter-content-subject').locator('input').fill(RUN_SUBJECT);
+  await page.getByTestId('newsletter-content-body').locator('.ql-editor').fill('This draft is used to exercise the send-failure path.');
+
+  await page.getByTestId('newsletter-manage-next-btn').click();
+  await expect(page.getByTestId('newsletter-send-step')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+  // The draft is created (and its id becomes part of the URL) as a side effect
+  // of leaving step 1/2 via autosave/next — wait for that to land so the id
+  // segment is present before /send is invoked, matching real usage.
+  await expect(page).toHaveURL(/\/newsletters\/[^/]+\/[^/]+(\?|$)/, { timeout: ELEMENT_TIMEOUT });
+}
+
+test.describe('Newsletter Send Failure', () => {
+  test.beforeEach(async ({ page }) => {
+    skipWhenPrereqsMissing();
+    await page.route(SEND_ENDPOINT_PATTERN, (route) => route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ message: 'Simulated send failure' }) }));
+  });
+
+  test('shows a Send failed toast and leaves the draft unsent when /send fails', async ({ page }) => {
+    const draftUrl = await test.step('create a draft through the Send step', async () => {
+      await createDraftThroughSendStep(page);
+      return page.url();
+    });
+
+    const sendNowButton = page.getByTestId('newsletter-send-now-button');
+    await expect(sendNowButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+    await sendNowButton.click();
+
+    const confirmDialog = page.locator('.p-confirmdialog');
+    await expect(confirmDialog).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await confirmDialog.getByRole('button', { name: /send now/i }).click();
+
+    // handleSendError() refetches the real (unmocked) newsletter, sees it's
+    // still a draft, and shows this exact toast. The success-path toast text
+    // ("sending newsletter" / "newsletter sent") must NOT appear.
+    const toast = page.locator('.p-toast');
+    await expect(toast).toContainText('Send failed', { timeout: TOAST_TIMEOUT });
+    await expect(toast).not.toContainText(/sending newsletter|newsletter sent/i);
+
+    // Draft stays on the manage/send-step page — no redirect to the Sent tab.
+    await expect(page).not.toHaveURL(/\/newsletters\/list\?.*tab=sent/);
+    await expect(page).toHaveURL(draftUrl);
+    await expect(page.getByTestId('newsletter-send-step')).toBeVisible();
+
+    // Re-affirm the send button is still present and enabled — a real retry
+    // is possible, not just a dead-end error state.
+    await expect(sendNowButton).toBeEnabled({ timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('Save as Draft still succeeds while /send is mocked — proves only /send was intercepted', async ({ page }) => {
+    await createDraftThroughSendStep(page);
+
+    await page.getByTestId('newsletter-manage-previous-btn').click();
+    await expect(page.getByTestId('newsletter-content-step')).toBeVisible({ timeout: PAGE_LOAD_TIMEOUT });
+
+    const updatedSubject = `${RUN_SUBJECT} (edited)`;
+    await page.getByTestId('newsletter-content-subject').locator('input').fill(updatedSubject);
+
+    await page.getByTestId('newsletter-manage-draft-btn').click();
+
+    // This PUT goes to the real backend (unmocked) — a successful "Draft
+    // saved" toast confirms the /send interception in this spec is scoped to
+    // that one endpoint and isn't silently swallowing other newsletter calls.
+    await expect(page.locator('.p-toast')).toContainText('Draft saved', { timeout: TOAST_TIMEOUT });
+  });
+});


### PR DESCRIPTION
**Tracking:** [LFXV2-2389](https://linuxfoundation.atlassian.net/browse/LFXV2-2389)

Implements End-to-end newsletter send + analytics wiring + Playwright E2E.

[LFXV2-2389]: https://linuxfoundation.atlassian.net/browse/LFXV2-2389?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ