### PR TITLE
feat(campaigns): serve job status from campaign-service behind a flag

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -504,27 +504,28 @@
         class="rounded-lg border p-5"
         [class.border-green-200]="anyPlatformCreated()"
         [class.bg-green-50]="anyPlatformCreated()"
-        [class.border-red-200]="!anyPlatformCreated()"
-        [class.bg-red-50]="!anyPlatformCreated()"
+        [class.border-amber-200]="!anyPlatformCreated()"
+        [class.bg-amber-50]="!anyPlatformCreated()"
         data-testid="implementation-platform-results">
         <div class="mb-3 flex items-center gap-2">
           @if (anyPlatformCreated()) {
             <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
           } @else {
-            <i class="fa-light fa-circle-xmark text-red-600" aria-hidden="true"></i>
+            <i class="fa-light fa-triangle-exclamation text-amber-600" aria-hidden="true"></i>
           }
           <h3 class="text-sm font-semibold text-gray-900">
-            {{ anyPlatformCreated() ? 'Campaigns Created' : 'No Campaigns Created' }}
+            {{ anyPlatformCreated() ? 'Campaigns Created' : 'Campaign Status Unconfirmed' }}
           </h3>
         </div>
         <div class="flex flex-col gap-2">
           <!--
-            Three states, not two. `ok: false` covers two outcomes that must not both read as a
-            red failure: an ORPHAN (the upstream paid campaign was created and only the database
-            write failed — `campaignId` is populated on purpose so the id is not lost) and a SKIP
-            (a concurrent request owns this platform, which campaign-service explicitly calls not
-            a failure). The classification is computed in `platformOutcomes` — see it for why the
-            skip is not detected by matching its message.
+            Three states, not two, and the third is UNCONFIRMED rather than "not created".
+            `ok: false` covers an ORPHAN (the upstream paid campaign was created and only the
+            database write failed — `campaignId` is populated on purpose so the id is not lost)
+            and an id-less remainder that mixes genuine rejections, concurrent-dispatch skips and
+            responses whose upstream id was lost. Only the first is safely reportable as an
+            absence, and nothing on the wire distinguishes them. The classification and the
+            reasoning live in `platformOutcomes`.
           -->
           @for (row of platformOutcomes(); track row.result.platform) {
             @let pr = row.result;
@@ -532,8 +533,7 @@
             <div
               class="rounded-md border bg-white p-3"
               [class.border-green-200]="outcome === 'created'"
-              [class.border-amber-200]="outcome === 'orphaned'"
-              [class.border-red-200]="outcome === 'not-created'"
+              [class.border-amber-200]="outcome !== 'created'"
               [attr.data-testid]="'implementation-platform-result-' + pr.platform">
               <div class="flex items-center gap-2">
                 @switch (outcome) {
@@ -544,7 +544,7 @@
                     <i class="fa-light fa-triangle-exclamation text-amber-600" aria-hidden="true"></i>
                   }
                   @default {
-                    <i class="fa-light fa-circle-xmark text-red-600" aria-hidden="true"></i>
+                    <i class="fa-light fa-circle-question text-amber-600" aria-hidden="true"></i>
                   }
                 }
                 <p class="text-sm font-medium text-gray-900">
@@ -563,7 +563,7 @@
                         created upstream but not recorded — needs reconciliation
                       }
                       @default {
-                        not created
+                        could not be confirmed — check the ad account before creating it again
                       }
                     }
                   </span>
@@ -573,7 +573,7 @@
                 }
               </div>
               @if (pr.error) {
-                <p class="mt-1 text-xs" [class.text-amber-700]="outcome === 'orphaned'" [class.text-red-700]="outcome !== 'orphaned'">
+                <p class="mt-1 text-xs" [class.text-amber-700]="outcome !== 'created'" [class.text-gray-600]="outcome === 'created'">
                   {{ pr.error }}
                 </p>
               }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -518,33 +518,62 @@
           </h3>
         </div>
         <div class="flex flex-col gap-2">
+          <!--
+            Three states, not two. `ok: false` covers two outcomes that must not both read as a
+            red failure: an ORPHAN (the upstream paid campaign was created and only the database
+            write failed — `campaignId` is populated on purpose so the id is not lost) and a SKIP
+            (a concurrent request owns this platform, which campaign-service explicitly calls not
+            a failure). See `outcomeOf` for why the skip is not detected by matching its message.
+          -->
           @for (pr of platformResults(); track pr.platform) {
+            @let outcome = outcomeOf(pr);
             <div
               class="rounded-md border bg-white p-3"
-              [class.border-green-200]="pr.ok"
-              [class.border-red-200]="!pr.ok"
+              [class.border-green-200]="outcome === 'created'"
+              [class.border-amber-200]="outcome === 'orphaned'"
+              [class.border-red-200]="outcome === 'not-created'"
               [attr.data-testid]="'implementation-platform-result-' + pr.platform">
               <div class="flex items-center gap-2">
-                @if (pr.ok) {
-                  <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
-                } @else {
-                  <i class="fa-light fa-circle-xmark text-red-600" aria-hidden="true"></i>
+                @switch (outcome) {
+                  @case ('created') {
+                    <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
+                  }
+                  @case ('orphaned') {
+                    <i class="fa-light fa-triangle-exclamation text-amber-600" aria-hidden="true"></i>
+                  }
+                  @default {
+                    <i class="fa-light fa-circle-xmark text-red-600" aria-hidden="true"></i>
+                  }
                 }
                 <p class="text-sm font-medium text-gray-900">
                   {{ pr.platform }}
                   <!--
                     The icon is aria-hidden and the colour is not announced, so without this the
                     row reads as a bare platform name. `error` is optional on the wire, so it
-                    cannot be relied on to carry the outcome for a failed platform.
+                    cannot be relied on to carry the outcome.
                   -->
-                  <span class="sr-only">{{ pr.ok ? 'created' : 'failed' }}</span>
+                  <span class="sr-only">
+                    @switch (outcome) {
+                      @case ('created') {
+                        created
+                      }
+                      @case ('orphaned') {
+                        created upstream but not recorded — needs reconciliation
+                      }
+                      @default {
+                        not created
+                      }
+                    }
+                  </span>
                 </p>
                 @if (pr.campaignId) {
                   <p class="text-xs text-gray-500">campaign {{ pr.campaignId }}</p>
                 }
               </div>
               @if (pr.error) {
-                <p class="mt-1 text-xs text-red-700">{{ pr.error }}</p>
+                <p class="mt-1 text-xs" [class.text-amber-700]="outcome === 'orphaned'" [class.text-red-700]="outcome !== 'orphaned'">
+                  {{ pr.error }}
+                </p>
               }
             </div>
           }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -499,7 +499,7 @@
       reaches the page. An unconditionally green "Campaigns Created" panel would announce an
       all-failed result as a success.
     -->
-    @if (platformResults().length > 0) {
+    @if (platformOutcomes().length > 0) {
       <div
         class="rounded-lg border p-5"
         [class.border-green-200]="anyPlatformCreated()"
@@ -523,10 +523,12 @@
             red failure: an ORPHAN (the upstream paid campaign was created and only the database
             write failed — `campaignId` is populated on purpose so the id is not lost) and a SKIP
             (a concurrent request owns this platform, which campaign-service explicitly calls not
-            a failure). See `outcomeOf` for why the skip is not detected by matching its message.
+            a failure). The classification is computed in `platformOutcomes` — see it for why the
+            skip is not detected by matching its message.
           -->
-          @for (pr of platformResults(); track pr.platform) {
-            @let outcome = outcomeOf(pr);
+          @for (row of platformOutcomes(); track row.result.platform) {
+            @let pr = row.result;
+            @let outcome = row.outcome;
             <div
               class="rounded-md border bg-white p-3"
               [class.border-green-200]="outcome === 'created'"

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -527,9 +527,8 @@
             absence, and nothing on the wire distinguishes them. The classification and the
             reasoning live in `platformOutcomes`.
           -->
-          @for (row of platformOutcomes(); track row.result.platform) {
-            @let pr = row.result;
-            @let outcome = row.outcome;
+          @for (pr of platformOutcomes(); track pr.platform) {
+            @let outcome = pr.outcome;
             <div
               class="rounded-md border bg-white p-3"
               [class.border-green-200]="outcome === 'created'"

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -487,6 +487,41 @@
       </div>
     }
 
+    <!--
+      Campaign-service reports per-platform outcomes only: which platform, whether the create
+      succeeded, the upstream campaign id, and the failure reason. It does not report ad-group,
+      keyword or ad counts, so this block deliberately shows fewer facts than the block above
+      rather than showing the same facts as zeros.
+    -->
+    @if (platformResults().length > 0) {
+      <div class="rounded-lg border border-green-200 bg-green-50 p-5" data-testid="implementation-platform-results">
+        <div class="mb-3 flex items-center gap-2">
+          <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
+          <h3 class="text-sm font-semibold text-gray-900">Campaigns Created</h3>
+        </div>
+        <div class="flex flex-col gap-2">
+          @for (pr of platformResults(); track pr.platform) {
+            <div class="rounded-md border border-green-200 bg-white p-3" [attr.data-testid]="'implementation-platform-result-' + pr.platform">
+              <div class="flex items-center gap-2">
+                @if (pr.ok) {
+                  <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
+                } @else {
+                  <i class="fa-light fa-circle-xmark text-red-600" aria-hidden="true"></i>
+                }
+                <p class="text-sm font-medium text-gray-900">{{ pr.platform }}</p>
+                @if (pr.campaignId) {
+                  <p class="text-xs text-gray-500">campaign {{ pr.campaignId }}</p>
+                }
+              </div>
+              @if (pr.error) {
+                <p class="mt-1 text-xs text-red-700">{{ pr.error }}</p>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    }
+
     @if (errors().length > 0) {
       <div class="rounded-lg border border-red-200 bg-red-50 p-5">
         <h3 class="mb-2 text-sm font-semibold text-red-800">Errors</h3>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.html
@@ -493,22 +493,52 @@
       keyword or ad counts, so this block deliberately shows fewer facts than the block above
       rather than showing the same facts as zeros.
     -->
+    <!--
+      Heading and colour are conditional because a FAILED job carries per-platform rows too —
+      that is the only route by which an orphaned campaign id (created upstream, not recorded)
+      reaches the page. An unconditionally green "Campaigns Created" panel would announce an
+      all-failed result as a success.
+    -->
     @if (platformResults().length > 0) {
-      <div class="rounded-lg border border-green-200 bg-green-50 p-5" data-testid="implementation-platform-results">
+      <div
+        class="rounded-lg border p-5"
+        [class.border-green-200]="anyPlatformCreated()"
+        [class.bg-green-50]="anyPlatformCreated()"
+        [class.border-red-200]="!anyPlatformCreated()"
+        [class.bg-red-50]="!anyPlatformCreated()"
+        data-testid="implementation-platform-results">
         <div class="mb-3 flex items-center gap-2">
-          <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
-          <h3 class="text-sm font-semibold text-gray-900">Campaigns Created</h3>
+          @if (anyPlatformCreated()) {
+            <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
+          } @else {
+            <i class="fa-light fa-circle-xmark text-red-600" aria-hidden="true"></i>
+          }
+          <h3 class="text-sm font-semibold text-gray-900">
+            {{ anyPlatformCreated() ? 'Campaigns Created' : 'No Campaigns Created' }}
+          </h3>
         </div>
         <div class="flex flex-col gap-2">
           @for (pr of platformResults(); track pr.platform) {
-            <div class="rounded-md border border-green-200 bg-white p-3" [attr.data-testid]="'implementation-platform-result-' + pr.platform">
+            <div
+              class="rounded-md border bg-white p-3"
+              [class.border-green-200]="pr.ok"
+              [class.border-red-200]="!pr.ok"
+              [attr.data-testid]="'implementation-platform-result-' + pr.platform">
               <div class="flex items-center gap-2">
                 @if (pr.ok) {
                   <i class="fa-light fa-circle-check text-green-600" aria-hidden="true"></i>
                 } @else {
                   <i class="fa-light fa-circle-xmark text-red-600" aria-hidden="true"></i>
                 }
-                <p class="text-sm font-medium text-gray-900">{{ pr.platform }}</p>
+                <p class="text-sm font-medium text-gray-900">
+                  {{ pr.platform }}
+                  <!--
+                    The icon is aria-hidden and the colour is not announced, so without this the
+                    row reads as a bare platform name. `error` is optional on the wire, so it
+                    cannot be relied on to carry the outcome for a failed platform.
+                  -->
+                  <span class="sr-only">{{ pr.ok ? 'created' : 'failed' }}</span>
+                </p>
                 @if (pr.campaignId) {
                   <p class="text-xs text-gray-500">campaign {{ pr.campaignId }}</p>
                 }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -88,14 +88,25 @@ export class ImplementationTabComponent implements OnInit {
   protected readonly platformResults = signal<CampaignPlatformResult[]>([]);
 
   /**
-   * Whether ANY platform in `platformResults` succeeded.
+   * Whether ANY platform in `platformResults` has a campaign upstream.
    *
    * The panel used to be unconditionally green and headed "Campaigns Created", which was true
    * while only successful jobs carried per-platform rows. A failed job carries them too — that
    * is how an orphaned `campaignId` reaches the page at all — so an all-failed result would
    * otherwise be announced as a success in green.
+   *
+   * `ok` alone is NOT the test, and the orphan case is exactly why. campaign-service sets
+   * `campaign_id` on one specific failure — the upstream (paid) campaign WAS created and
+   * recording it into Postgres failed (`orchestrator.go`: "created upstream campaign but failed
+   * to record it") — precisely so the orphaned id is not lost. Its Goa design says so on the
+   * field: "Present when ok; also set on the specific failure where the upstream campaign was
+   * created but recording it failed". A result that is all-orphaned therefore has real campaigns
+   * running and real money being spent, and gating on `ok` would head that page "No Campaigns
+   * Created" while printing the ids of the campaigns it claims do not exist. Wrong in the
+   * expensive direction: the reader's next move is to create them again.
    */
-  protected readonly anyPlatformCreated = computed(() => this.platformResults().some((r) => r.ok));
+  protected readonly anyPlatformCreated = computed(() => this.platformResults().some((r) => r.ok || !!r.campaignId));
+
   protected readonly errors = signal<string[]>([]);
   protected readonly briefKeywords = signal<CampaignKeyword[]>([]);
   protected readonly briefHsToken = signal<string | null>(null);
@@ -174,6 +185,7 @@ export class ImplementationTabComponent implements OnInit {
   private jobSubscription: Subscription | null = null;
 
   // === Lifecycle ===
+
   public constructor() {
     effect(() => {
       const brief = this.briefData();
@@ -213,6 +225,28 @@ export class ImplementationTabComponent implements OnInit {
   }
 
   // === Protected Methods ===
+  /**
+   * One platform row's outcome, as three states rather than the boolean the wire carries.
+   *
+   * Kept here rather than inlined in the template so the classification is stated once and can
+   * be tested directly.
+   *
+   * `not-created` deliberately does NOT claim "failed". A skip lands here too: when a concurrent
+   * request already owns a (brief, platform) pair, campaign-service sends `ok: false` with the
+   * message "skipped: a concurrent request already owns this platform's campaign creation (not a
+   * failure)". Its `aggregateStatus` does not count a skip as a failure either. The wire has no
+   * dedicated `skipped` field yet (LFXV2-2665 tracks adding one), and this must not be inferred
+   * by matching that human-readable sentence — a message reworded upstream would silently flip
+   * the UI's verdict. So the row states only what is certain, that no campaign was created for
+   * it, and lets the accompanying message say which of the two it was.
+   */
+  protected outcomeOf(result: CampaignPlatformResult): 'created' | 'orphaned' | 'not-created' {
+    if (result.ok) {
+      return 'created';
+    }
+    return result.campaignId ? 'orphaned' : 'not-created';
+  }
+
   protected addHeadline(): void {
     (this.campaignForm.controls.headlines as FormArray).push(
       this.fb.control('', [Validators.required, Validators.maxLength(CAMPAIGN_CHAR_LIMITS.searchHeadline)])

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -36,6 +36,20 @@ import type {
 
 type ImplementationStep = 'form' | 'creating' | 'results';
 
+/** One campaign-service platform result paired with the three-state outcome the row renders. */
+interface PlatformResultRow {
+  result: CampaignPlatformResult;
+  outcome: 'created' | 'orphaned' | 'not-created';
+}
+
+/** See `ImplementationTabComponent.platformOutcomes` for why `ok` alone is not the test. */
+function toPlatformResultRow(result: CampaignPlatformResult): PlatformResultRow {
+  if (result.ok) {
+    return { result, outcome: 'created' };
+  }
+  return { result, outcome: result.campaignId ? 'orphaned' : 'not-created' };
+}
+
 @Component({
   selector: 'lfx-implementation-tab',
   imports: [ReactiveFormsModule, ButtonComponent, SlicePipe],
@@ -88,24 +102,35 @@ export class ImplementationTabComponent implements OnInit {
   protected readonly platformResults = signal<CampaignPlatformResult[]>([]);
 
   /**
-   * Whether ANY platform in `platformResults` has a campaign upstream.
-   *
-   * The panel used to be unconditionally green and headed "Campaigns Created", which was true
-   * while only successful jobs carried per-platform rows. A failed job carries them too — that
-   * is how an orphaned `campaignId` reaches the page at all — so an all-failed result would
-   * otherwise be announced as a success in green.
+   * `platformResults` with each row's outcome resolved to three states rather than the boolean
+   * the wire carries. Derived here rather than in the template because only signal reads,
+   * computed values and pipes may appear there (`docs/reviews/frontend-checklist.md` §4).
    *
    * `ok` alone is NOT the test, and the orphan case is exactly why. campaign-service sets
    * `campaign_id` on one specific failure — the upstream (paid) campaign WAS created and
    * recording it into Postgres failed (`orchestrator.go`: "created upstream campaign but failed
    * to record it") — precisely so the orphaned id is not lost. Its Goa design says so on the
    * field: "Present when ok; also set on the specific failure where the upstream campaign was
-   * created but recording it failed". A result that is all-orphaned therefore has real campaigns
-   * running and real money being spent, and gating on `ok` would head that page "No Campaigns
-   * Created" while printing the ids of the campaigns it claims do not exist. Wrong in the
-   * expensive direction: the reader's next move is to create them again.
+   * created but recording it failed". Such a row has a real campaign running and real money
+   * being spent, so calling it a plain failure is wrong in the expensive direction: the reader's
+   * next move is to create it again.
+   *
+   * `not-created` deliberately does NOT claim "failed". A skip lands here too — campaign-service
+   * explicitly calls a skip not a failure — and the wire has no dedicated `skipped` field yet
+   * (LFXV2-2665 tracks adding one). It must not be inferred by matching the human-readable
+   * sentence, because a message reworded upstream would silently flip the UI's verdict.
    */
-  protected readonly anyPlatformCreated = computed(() => this.platformResults().some((r) => r.ok || !!r.campaignId));
+  protected readonly platformOutcomes = computed<PlatformResultRow[]>(() => this.platformResults().map(toPlatformResultRow));
+
+  /**
+   * Whether ANY platform has a campaign upstream — an orphan counts, per the reasoning above.
+   *
+   * The panel used to be unconditionally green and headed "Campaigns Created", which was true
+   * while only successful jobs carried per-platform rows. A failed job carries them too — that
+   * is how an orphaned `campaignId` reaches the page at all — so an all-failed result would
+   * otherwise be announced as a success in green.
+   */
+  protected readonly anyPlatformCreated = computed(() => this.platformOutcomes().some((r) => r.outcome !== 'not-created'));
 
   protected readonly errors = signal<string[]>([]);
   protected readonly briefKeywords = signal<CampaignKeyword[]>([]);
@@ -225,27 +250,6 @@ export class ImplementationTabComponent implements OnInit {
   }
 
   // === Protected Methods ===
-  /**
-   * One platform row's outcome, as three states rather than the boolean the wire carries.
-   *
-   * Kept here rather than inlined in the template so the classification is stated once and can
-   * be tested directly.
-   *
-   * `not-created` deliberately does NOT claim "failed". A skip lands here too: when a concurrent
-   * request already owns a (brief, platform) pair, campaign-service sends `ok: false` with the
-   * message "skipped: a concurrent request already owns this platform's campaign creation (not a
-   * failure)". Its `aggregateStatus` does not count a skip as a failure either. The wire has no
-   * dedicated `skipped` field yet (LFXV2-2665 tracks adding one), and this must not be inferred
-   * by matching that human-readable sentence — a message reworded upstream would silently flip
-   * the UI's verdict. So the row states only what is certain, that no campaign was created for
-   * it, and lets the accompanying message say which of the two it was.
-   */
-  protected outcomeOf(result: CampaignPlatformResult): 'created' | 'orphaned' | 'not-created' {
-    if (result.ok) {
-      return 'created';
-    }
-    return result.campaignId ? 'orphaned' : 'not-created';
-  }
 
   protected addHeadline(): void {
     (this.campaignForm.controls.headlines as FormArray).push(

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -39,7 +39,7 @@ type ImplementationStep = 'form' | 'creating' | 'results';
 /** One campaign-service platform result paired with the three-state outcome the row renders. */
 interface PlatformResultRow {
   result: CampaignPlatformResult;
-  outcome: 'created' | 'orphaned' | 'not-created';
+  outcome: 'created' | 'orphaned' | 'unconfirmed';
 }
 
 /** See `ImplementationTabComponent.platformOutcomes` for why `ok` alone is not the test. */
@@ -47,7 +47,7 @@ function toPlatformResultRow(result: CampaignPlatformResult): PlatformResultRow 
   if (result.ok) {
     return { result, outcome: 'created' };
   }
-  return { result, outcome: result.campaignId ? 'orphaned' : 'not-created' };
+  return { result, outcome: result.campaignId ? 'orphaned' : 'unconfirmed' };
 }
 
 @Component({
@@ -115,10 +115,21 @@ export class ImplementationTabComponent implements OnInit {
    * being spent, so calling it a plain failure is wrong in the expensive direction: the reader's
    * next move is to create it again.
    *
-   * `not-created` deliberately does NOT claim "failed". A skip lands here too — campaign-service
-   * explicitly calls a skip not a failure — and the wire has no dedicated `skipped` field yet
-   * (LFXV2-2665 tracks adding one). It must not be inferred by matching the human-readable
-   * sentence, because a message reworded upstream would silently flip the UI's verdict.
+   * The third state is `unconfirmed`, NOT "not created", and the absence of a `campaign_id` is
+   * not evidence that nothing was created. `orchestrator.go` emits `ok: false` with no id for at
+   * least four distinct situations: a genuine upstream rejection (:869), a concurrent dispatch
+   * that skipped this platform (:780 — which campaign-service explicitly calls a skip, not a
+   * failure), and two responses in which an upstream campaign may well exist but its id did not
+   * survive — "dispatcher returned no campaign" (:879) and "dispatcher returned no upstream
+   * campaign id" (:887). Rendering all four as a definite "not created" tells an ED that no paid
+   * artifact exists, and their next move is to create a second one that really does spend money.
+   *
+   * So the row states what is known — this platform's campaign could not be confirmed — and
+   * leaves the reader to check. That over-warns on the genuine-rejection and skip cases, which is
+   * the cheap direction: a needless look at the ad account costs a minute, a duplicate paid
+   * campaign costs budget. Note the skip is NOT detected by matching its human-readable sentence;
+   * the wire has no dedicated `skipped` field yet (LFXV2-2665 tracks adding one) and a message
+   * reworded upstream would silently flip the UI's verdict.
    */
   protected readonly platformOutcomes = computed<PlatformResultRow[]>(() => this.platformResults().map(toPlatformResultRow));
 
@@ -129,8 +140,12 @@ export class ImplementationTabComponent implements OnInit {
    * while only successful jobs carried per-platform rows. A failed job carries them too — that
    * is how an orphaned `campaignId` reaches the page at all — so an all-failed result would
    * otherwise be announced as a success in green.
+   *
+   * The negative case is headed "Campaign Status Unconfirmed" rather than "No Campaigns Created"
+   * for the same reason the row state is named `unconfirmed`: a heading is the one line a reader
+   * acts on without reading further, and this one must not assert an absence nobody verified.
    */
-  protected readonly anyPlatformCreated = computed(() => this.platformOutcomes().some((r) => r.outcome !== 'not-created'));
+  protected readonly anyPlatformCreated = computed(() => this.platformOutcomes().some((r) => r.outcome !== 'unconfirmed'));
 
   protected readonly errors = signal<string[]>([]);
   protected readonly briefKeywords = signal<CampaignKeyword[]>([]);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -86,6 +86,16 @@ export class ImplementationTabComponent implements OnInit {
    * folding it into `results` would mean rendering zeros for numbers nobody measured.
    */
   protected readonly platformResults = signal<CampaignPlatformResult[]>([]);
+
+  /**
+   * Whether ANY platform in `platformResults` succeeded.
+   *
+   * The panel used to be unconditionally green and headed "Campaigns Created", which was true
+   * while only successful jobs carried per-platform rows. A failed job carries them too — that
+   * is how an orphaned `campaignId` reaches the page at all — so an all-failed result would
+   * otherwise be announced as a success in green.
+   */
+  protected readonly anyPlatformCreated = computed(() => this.platformResults().some((r) => r.ok));
   protected readonly errors = signal<string[]>([]);
   protected readonly briefKeywords = signal<CampaignKeyword[]>([]);
   protected readonly briefHsToken = signal<string | null>(null);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -36,18 +36,24 @@ import type {
 
 type ImplementationStep = 'form' | 'creating' | 'results';
 
-/** One campaign-service platform result paired with the three-state outcome the row renders. */
-interface PlatformResultRow {
-  result: CampaignPlatformResult;
-  outcome: 'created' | 'orphaned' | 'unconfirmed';
-}
+/**
+ * One campaign-service platform result paired with the three-state outcome the row renders.
+ *
+ * A local intersection rather than a `@lfx-one/shared` interface: it is this component's view
+ * model, derived from `CampaignPlatformResult` and consumed only by this template, so it is not
+ * part of any contract between the tiers. Two repo rules meet here and an intersection is the
+ * only form satisfying both — `CLAUDE.md:176` prohibits the local `interface Foo {}` form inside
+ * `apps/lfx-one/`, while ESLint's `@typescript-eslint/consistent-type-definitions` rejects a
+ * plain `type X = { … }` object literal.
+ */
+type PlatformResultRow = CampaignPlatformResult & { outcome: 'created' | 'orphaned' | 'unconfirmed' };
 
 /** See `ImplementationTabComponent.platformOutcomes` for why `ok` alone is not the test. */
 function toPlatformResultRow(result: CampaignPlatformResult): PlatformResultRow {
   if (result.ok) {
-    return { result, outcome: 'created' };
+    return { ...result, outcome: 'created' };
   }
-  return { result, outcome: result.campaignId ? 'orphaned' : 'unconfirmed' };
+  return { ...result, outcome: result.campaignId ? 'orphaned' : 'unconfirmed' };
 }
 
 @Component({

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -20,10 +20,11 @@ import { map, startWith, Subscription, take } from 'rxjs';
 import type { Signal } from '@angular/core';
 import type {
   CampaignBriefOutput,
-  CampaignCreateResponse,
   CampaignCreateResult,
+  CampaignJobOutcome,
   CampaignKeyword,
   CampaignPlatform,
+  CampaignPlatformResult,
   CampaignType,
   LinkedInAccount,
   LinkedInCreativeVariant,
@@ -78,6 +79,13 @@ export class ImplementationTabComponent implements OnInit {
   protected readonly step = signal<ImplementationStep>('form');
   protected readonly creationProgress = signal<string[]>([]);
   protected readonly results = signal<CampaignCreateResult[]>([]);
+  /**
+   * Per-platform outcomes as lfx-v2-campaign-service reports them, used when the server is
+   * serving job status from that service instead of the in-process job map. Kept separate from
+   * `results` because campaign-service does not report ad-group, keyword or ad counts, and
+   * folding it into `results` would mean rendering zeros for numbers nobody measured.
+   */
+  protected readonly platformResults = signal<CampaignPlatformResult[]>([]);
   protected readonly errors = signal<string[]>([]);
   protected readonly briefKeywords = signal<CampaignKeyword[]>([]);
   protected readonly briefHsToken = signal<string | null>(null);
@@ -190,6 +198,7 @@ export class ImplementationTabComponent implements OnInit {
     this.step.set('form');
     this.creationProgress.set([]);
     this.results.set([]);
+    this.platformResults.set([]);
     this.errors.set([]);
   }
 
@@ -277,6 +286,7 @@ export class ImplementationTabComponent implements OnInit {
     this.step.set('creating');
     this.creationProgress.set(['Submitting campaign...']);
     this.results.set([]);
+    this.platformResults.set([]);
     this.errors.set([]);
 
     const form = this.campaignForm.getRawValue();
@@ -392,6 +402,7 @@ export class ImplementationTabComponent implements OnInit {
     this.step.set('form');
     this.creationProgress.set([]);
     this.results.set([]);
+    this.platformResults.set([]);
     this.errors.set([]);
     const details = brief.eventDetails;
     this.campaignForm.patchValue({
@@ -482,10 +493,11 @@ export class ImplementationTabComponent implements OnInit {
       .getCreateResult(jobId)
       .pipe(take(MAX_POLLS), takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (result: CampaignCreateResponse | null) => {
-          if (result) {
-            this.results.set(result.campaigns);
-            this.errors.set(result.errors);
+        next: (outcome: CampaignJobOutcome | null) => {
+          if (outcome) {
+            this.results.set(outcome.campaigns);
+            this.platformResults.set(outcome.platformResults ?? []);
+            this.errors.set(outcome.errors);
             this.step.set('results');
           }
         },

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -70,6 +70,12 @@ export class CampaignService {
           return {
             campaigns: status.result?.campaigns ?? [],
             errors: status.result?.errors ?? (status.error ? [status.error] : []),
+            // NOT coalesced to `[]`, unlike the two above, and the asymmetry is deliberate.
+            // `campaigns` and `errors` are non-optional on `CampaignJobOutcome`, so a caller
+            // may iterate them unguarded. `platformResults` is optional precisely so that
+            // "this path does not report per-platform outcomes" (the vendor-direct path)
+            // stays distinguishable from "it does, and every platform failed". Defaulting it
+            // to `[]` here would erase that distinction at the only place it is still visible.
             platformResults: status.platformResults,
           };
         }

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -27,6 +27,7 @@ import {
   RedditMonitorResponse,
   SSEEvent,
 } from '@lfx-one/shared/interfaces';
+import { retryTransientHttpError } from '@shared/utils/http-error.utils';
 import { exhaustMap, last, map, Observable, of, take, takeWhile, timer } from 'rxjs';
 
 import { SseService } from './sse.service';
@@ -147,11 +148,28 @@ export class CampaignService {
     return this.http.post<BulkKeywordActionResponse>('/api/campaigns/keywords/actions', request);
   }
 
+  /**
+   * Polls one create job until it reaches a terminal state, or until the five-minute budget runs out.
+   *
+   * The retry sits INSIDE `exhaustMap`, on the single status read, and that placement is the whole
+   * point: an error raised in the outer pipe kills `timer` itself, so without it one 502 from a
+   * redeploying pod ends the poll permanently while the job it was watching carries on creating paid
+   * campaigns upstream. The user is then shown a failure next to a "Create Another" button, and the
+   * campaigns that did get made are invisible to this system. Retrying the outer pipe instead would
+   * restart the timer and re-run the whole schedule, which is not the same thing.
+   *
+   * Only transient reads are retried — `retryTransientHttpError` re-throws 4xx immediately, so an
+   * expired session still surfaces at once rather than after two pointless round trips. Two attempts
+   * past the first, rather than the shared default of one, because the cost of giving up early here
+   * is an orphaned paid campaign and the cost of trying again is one more GET. A failure that
+   * outlives all three still propagates: `getCreateResult` reports it, which is correct, because at
+   * that point the job status genuinely is unknown.
+   */
   private pollJobStatus(jobId: string): Observable<CampaignJobStatus> {
     const maxPolls = Math.ceil(300_000 / CAMPAIGN_JOB_POLL_INTERVAL_MS);
     return timer(0, CAMPAIGN_JOB_POLL_INTERVAL_MS).pipe(
       take(maxPolls),
-      exhaustMap(() => this.http.get<CampaignJobStatus>(`/api/campaigns/jobs/${encodeURIComponent(jobId)}`)),
+      exhaustMap(() => this.http.get<CampaignJobStatus>(`/api/campaigns/jobs/${encodeURIComponent(jobId)}`).pipe(retryTransientHttpError(2))),
       takeWhile((status) => status.status === 'running', true)
     );
   }

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -3,7 +3,7 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { CAMPAIGN_JOB_POLL_INTERVAL_MS } from '@lfx-one/shared/constants';
+import { CAMPAIGN_JOB_POLL_INTERVAL_MS, JOB_LOST_MESSAGE } from '@lfx-one/shared/constants';
 import {
   AudienceDemographics,
   BulkKeywordActionRequest,
@@ -93,7 +93,7 @@ export class CampaignService {
           }
           throw new Error(message);
         }
-        if (status.status === 'not_found') throw new Error('Lost connection to the campaign creation process. Please try again.');
+        if (status.status === 'not_found') throw new Error(JOB_LOST_MESSAGE);
         throw new Error('Campaign creation is taking longer than expected. Check Google Ads to see if your campaign was created.');
       })
     );

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -12,6 +12,7 @@ import {
   CampaignBriefRequest,
   CampaignCreateRequest,
   CampaignCreateResponse,
+  CampaignJobOutcome,
   CampaignJobStatus,
   CampaignMonitorResponse,
   CampaignSSEEventType,
@@ -53,7 +54,7 @@ export class CampaignService {
     return this.http.post<{ jobId: string; result?: CampaignCreateResponse; error?: string }>('/api/campaigns/create', request);
   }
 
-  public getCreateResult(jobId: string): Observable<CampaignCreateResponse | null> {
+  public getCreateResult(jobId: string): Observable<CampaignJobOutcome | null> {
     if (!jobId) {
       return of(null);
     }
@@ -61,7 +62,17 @@ export class CampaignService {
     return this.pollJobStatus(jobId).pipe(
       last(),
       map((status) => {
-        if (status.status === 'done') return status.result ?? null;
+        // A `done` job always yields an outcome, even when neither field is populated.
+        // Returning null for a finished job would leave the caller unable to tell "the job
+        // ended" from "there is nothing yet", and the caller's timeout branch would then
+        // report a completed create as one that took too long.
+        if (status.status === 'done') {
+          return {
+            campaigns: status.result?.campaigns ?? [],
+            errors: status.result?.errors ?? (status.error ? [status.error] : []),
+            platformResults: status.platformResults,
+          };
+        }
         if (status.status === 'error') throw new Error(status.error || 'Campaign creation was unsuccessful. Please try again.');
         if (status.status === 'not_found') throw new Error('Lost connection to the campaign creation process. Please try again.');
         throw new Error('Campaign creation is taking longer than expected. Check Google Ads to see if your campaign was created.');

--- a/apps/lfx-one/src/app/shared/services/campaign.service.ts
+++ b/apps/lfx-one/src/app/shared/services/campaign.service.ts
@@ -79,7 +79,20 @@ export class CampaignService {
             platformResults: status.platformResults,
           };
         }
-        if (status.status === 'error') throw new Error(status.error || 'Campaign creation was unsuccessful. Please try again.');
+        if (status.status === 'error') {
+          const message = status.error || 'Campaign creation was unsuccessful. Please try again.';
+          // A failed job that still reported per-platform results is a terminal OUTCOME, not a
+          // bare error, and it must not be flattened into a thrown message. campaign-service
+          // attaches `result` to `failed` jobs as well as successful ones, and a failed entry
+          // can carry a `campaignId`: the campaign really was created upstream and only the
+          // recording of it failed. That orphaned id is the one piece of state nobody can
+          // recover from anywhere else — throwing here would leave real paid campaigns running
+          // with nothing in this system pointing at them. Report the failure AND the rows.
+          if (status.platformResults?.length) {
+            return { campaigns: [], errors: [message], platformResults: status.platformResults };
+          }
+          throw new Error(message);
+        }
         if (status.status === 'not_found') throw new Error('Lost connection to the campaign creation process. Please try again.');
         throw new Error('Campaign creation is taking longer than expected. Check Google Ads to see if your campaign was created.');
       })

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -52,11 +52,18 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
 
 /**
  * Whether an error is worth retrying — a beat of time could plausibly fix a network drop (0),
- * rate limit (429), or upstream 5xx, but not a client error like an expired session (401) or a
- * permission/not-found response (403/404).
+ * rate limit (429), request timeout (408), or upstream 5xx, but not a client error like an
+ * expired session (401) or a permission/not-found response (403/404).
+ *
+ * 408 is in the list despite being a 4xx because in this app it is not a client error at all:
+ * it is the status this server mints for its OWN abort, when an upstream microservice call
+ * exceeds the configured timeout (`ApiClientService.executeRequest`). Nothing about the request
+ * is wrong, and the next attempt may well land inside the budget — treating it as permanent
+ * would abandon exactly the case retrying exists for. The rest of the 4xx range keeps failing
+ * fast, so authentication and validation errors still surface on the first response.
  */
 export function isTransientHttpError(error: unknown): boolean {
-  return error instanceof HttpErrorResponse && (error.status === 0 || error.status === 429 || error.status >= 500);
+  return error instanceof HttpErrorResponse && (error.status === 0 || error.status === 408 || error.status === 429 || error.status >= 500);
 }
 
 /**

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -22,7 +22,7 @@ import { validateScrapeUrl } from '../helpers/url-validation';
 import { isServerFeatureEnabled, ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { getLinkedInConfig } from '../services/linkedin-ads.service';
 import { CampaignProxyService } from '../services/campaign-proxy.service';
-import { CampaignServiceClient } from '../services/campaign-service.service';
+import { CampaignServiceClient, isCampaignServiceJobId } from '../services/campaign-service.service';
 import { logger } from '../services/logger.service';
 import { addShutdownHook, isShuttingDown } from '../utils/shutdown';
 
@@ -257,9 +257,18 @@ export class CampaignController {
     // other (see `adaptJobPollResponse` — the status vocabularies differ, and campaign-service
     // reports per-platform results rather than the vendor-direct path's `CampaignCreateResponse`).
     // The client therefore sees one `CampaignJobStatus` either way, with `result` set on the
-    // in-process path and `platformResults` on the campaign-service path. Rollback stays an env
-    // change rather than a deploy.
-    const viaCampaignService = isServerFeatureEnabled(ServerFeatureFlag.CampaignServiceJobs);
+    // in-process path and `platformResults` on the campaign-service path.
+    //
+    // The flag is necessary but NOT sufficient to route: creation is not cut over, so
+    // `createCampaign` above still mints `job_<epoch>_<rand>` into the in-process map, and
+    // campaign-service's `get-job` declares `Format(FormatUUID)` on `job_id` — it would answer
+    // 400 for every one of them. Flag-only routing would therefore break all polling the moment
+    // the flag went on, which is the failure the flag exists to fix. `isCampaignServiceJobId`
+    // adds the second condition, and it needs no separate flag of its own: a `job_` id can only
+    // have come from this process and a UUID can only have come from campaign-service, so ids
+    // minted either side of the create cutover keep resolving against the store that holds them.
+    // Rollback stays an env change (plus the pod rollout that applies it) rather than a deploy.
+    const viaCampaignService = isServerFeatureEnabled(ServerFeatureFlag.CampaignServiceJobs) && isCampaignServiceJobId(jobId);
     const startTime = logger.startOperation(req, 'campaign_job_status', { jobId, source: viaCampaignService ? 'campaign_service' : 'in_process' });
 
     try {

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -19,8 +19,10 @@ import { META_ACCOUNTS, REDDIT_ACCOUNTS } from '../constants';
 import { ServiceValidationError } from '../errors';
 import { CampaignMetricsService, LinkedInMetricsService, MetaMetricsService, RedditMetricsService } from '../services/campaign-metrics.service';
 import { validateScrapeUrl } from '../helpers/url-validation';
+import { isServerFeatureEnabled, ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { getLinkedInConfig } from '../services/linkedin-ads.service';
 import { CampaignProxyService } from '../services/campaign-proxy.service';
+import { CampaignServiceClient } from '../services/campaign-service.service';
 import { logger } from '../services/logger.service';
 import { addShutdownHook, isShuttingDown } from '../utils/shutdown';
 
@@ -31,6 +33,7 @@ const NUMERIC_ID_RE = /^\d+$/;
 
 export class CampaignController {
   private readonly proxyService = new CampaignProxyService();
+  private readonly campaignServiceClient = new CampaignServiceClient();
   private readonly metricsService = new CampaignMetricsService();
   private readonly linkedInMetricsService = new LinkedInMetricsService();
   private readonly redditMetricsService = new RedditMetricsService();
@@ -249,11 +252,25 @@ export class CampaignController {
       return;
     }
 
-    const startTime = logger.startOperation(req, 'campaign_job_status', { jobId });
+    // First endpoint of the campaign-service cutover. The flag selects the SOURCE; the two
+    // sources do NOT speak the same shape, so `CampaignServiceClient` adapts one onto the
+    // other (see `adaptJobPollResponse` — the status vocabularies differ, and campaign-service
+    // reports per-platform results rather than the vendor-direct path's `CampaignCreateResponse`).
+    // The client therefore sees one `CampaignJobStatus` either way, with `result` set on the
+    // in-process path and `platformResults` on the campaign-service path. Rollback stays an env
+    // change rather than a deploy.
+    const viaCampaignService = isServerFeatureEnabled(ServerFeatureFlag.CampaignServiceJobs);
+    const startTime = logger.startOperation(req, 'campaign_job_status', { jobId, source: viaCampaignService ? 'campaign_service' : 'in_process' });
 
     try {
-      const status = await this.proxyService.getJobStatus(req, jobId);
-      logger.success(req, 'campaign_job_status', startTime, { jobId, status: status.status });
+      // No try/catch fallback to the in-process map when the proxied call fails. The
+      // in-process map does not hold this job unless this same pod created it, so a
+      // fallback would answer "not found" for a job that campaign-service knows is
+      // running — turning a transient outage into a spurious terminal state the client
+      // stops polling on. Letting the error through keeps the failure visible and the
+      // flag is the way back.
+      const status = viaCampaignService ? await this.campaignServiceClient.getJobStatus(req, jobId) : await this.proxyService.getJobStatus(req, jobId);
+      logger.success(req, 'campaign_job_status', startTime, { jobId, status: status.status, source: viaCampaignService ? 'campaign_service' : 'in_process' });
       res.json(status);
     } catch (error) {
       next(error);

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.spec.ts
@@ -1,0 +1,39 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterEach, describe, expect, it } from 'vitest';
+
+import { isServerFeatureEnabled, ServerFeatureFlag } from './server-feature-flag.helper';
+
+const FLAG = ServerFeatureFlag.CampaignServiceJobs;
+
+afterEach(() => {
+  delete process.env[FLAG];
+});
+
+describe('isServerFeatureEnabled', () => {
+  it('is OFF when the variable is unset', () => {
+    expect(isServerFeatureEnabled(FLAG)).toBe(false);
+  });
+
+  it.each(['true', 'TRUE', ' True ', '1', 'yes', 'on'])('is ON for the affirmative value %j', (raw) => {
+    process.env[FLAG] = raw;
+    expect(isServerFeatureEnabled(FLAG)).toBe(true);
+  });
+
+  // Default-deny is the whole safety property. `flase` is invisible in a values.yaml diff, and
+  // if an unrecognised value defaulted to ON it would route production traffic at a service the
+  // operator believed was still dark. A typo must fail towards the path already known to work.
+  it.each(['', 'false', '0', 'no', 'off', 'flase', 'enabled'])('is OFF for the non-affirmative value %j', (raw) => {
+    process.env[FLAG] = raw;
+    expect(isServerFeatureEnabled(FLAG)).toBe(false);
+  });
+
+  // Read per call, not captured at module load: a flag frozen at import time cannot be rolled
+  // back without a restart, which is the point of putting it in an env var at all.
+  it('reflects a change made after the module was imported', () => {
+    expect(isServerFeatureEnabled(FLAG)).toBe(false);
+    process.env[FLAG] = 'true';
+    expect(isServerFeatureEnabled(FLAG)).toBe(true);
+  });
+});

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.spec.ts
@@ -29,8 +29,10 @@ describe('isServerFeatureEnabled', () => {
     expect(isServerFeatureEnabled(FLAG)).toBe(false);
   });
 
-  // Read per call, not captured at module load: a flag frozen at import time cannot be rolled
-  // back without a restart, which is the point of putting it in an env var at all.
+  // Read per call, not captured at module load. This buys nothing operationally — changing a
+  // container's environment still means replacing the pod — and what it buys is exactly this
+  // test: a value frozen at import time could not be varied across cases without module-registry
+  // surgery. Pinned so a later "optimisation" to a module-level constant fails here.
   it('reflects a change made after the module was imported', () => {
     expect(isServerFeatureEnabled(FLAG)).toBe(false);
     process.env[FLAG] = 'true';

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -1,0 +1,45 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Server-side feature flags.
+ *
+ * The existing `feature-flag.service.ts` is the OpenFeature **Web** SDK: it runs in the
+ * browser and returns Angular `Signal<T>`, so it cannot gate an Express handler. This
+ * helper covers the server side only, and deliberately stays small — it exists so the
+ * campaign-service cutover can move one endpoint at a time and roll a bad one back by
+ * changing an environment variable, without shipping code.
+ *
+ * Env vars are read on EVERY call rather than captured at module load. A flag whose value
+ * is frozen at import time cannot be rolled back without a restart, which defeats the point,
+ * and it also makes the flag untestable without module-registry surgery. The cost is a map
+ * lookup per request, which is nothing next to the proxied HTTP call it gates.
+ */
+
+/** Every server-side flag, and what turning it ON does. */
+export enum ServerFeatureFlag {
+  /**
+   * Serve `GET /api/campaigns/jobs/:jobId` from lfx-v2-campaign-service instead of the
+   * in-process job map in `campaign-proxy.service.ts`. OFF keeps the current behaviour
+   * byte-for-byte.
+   */
+  CampaignServiceJobs = 'LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS',
+}
+
+/**
+ * True only for an explicit affirmative value. Everything else — unset, empty, `0`,
+ * `false`, or a typo — is OFF.
+ *
+ * Default-deny is the whole safety property here. If an unrecognised value defaulted to ON,
+ * `LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS=flase` would silently route production traffic at a
+ * service the operator believed was still dark, and the misspelling is invisible in a
+ * values.yaml diff. A typo must fail towards the path that is already known to work.
+ */
+export function isServerFeatureEnabled(flag: ServerFeatureFlag): boolean {
+  const raw = process.env[flag];
+  if (!raw) {
+    return false;
+  }
+  const normalized = raw.trim().toLowerCase();
+  return normalized === 'true' || normalized === '1' || normalized === 'yes' || normalized === 'on';
+}

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -10,10 +10,22 @@
  * campaign-service cutover can move one endpoint at a time and roll a bad one back by
  * changing an environment variable, without shipping code.
  *
- * Env vars are read on EVERY call rather than captured at module load. A flag whose value
- * is frozen at import time cannot be rolled back without a restart, which defeats the point,
- * and it also makes the flag untestable without module-registry surgery. The cost is a map
- * lookup per request, which is nothing next to the proxied HTTP call it gates.
+ * Be precise about what that buys, because "env var" reads as "instant" and it is not. The
+ * chart injects these as container environment variables, so changing one edits the Deployment
+ * pod template and reaches a process only through a rolling restart. What is avoided is a code
+ * change, a build and an image promotion — not a rollout. Plan for the rollout: with the
+ * default three replicas and a RollingUpdate, flag-on and flag-off pods overlap for its
+ * duration. That overlap is harmless HERE only because routing also depends on the job id's
+ * shape (`isCampaignServiceJobId`): a `job_` id goes to the in-process map on every pod
+ * regardless of the flag, and a UUID cannot exist until creation is cut over. A future flag
+ * whose two paths can both claim the same request needs a no-overlap rollout, or a runtime
+ * configuration source every replica observes at once.
+ *
+ * Env vars are read on EVERY call rather than captured at module load. Not for hot reload —
+ * see above, there is none — but because a value frozen at import time is untestable without
+ * module-registry surgery, and because a process that is sent a new value by any means (a
+ * `kubectl set env` on the pod, a future dynamic source) then honours it without a special
+ * case. The cost is a map lookup per request, which is nothing next to the HTTP call it gates.
  */
 
 /** Every server-side flag, and what turning it ON does. */

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -21,11 +21,15 @@
  * whose two paths can both claim the same request needs a no-overlap rollout, or a runtime
  * configuration source every replica observes at once.
  *
- * Env vars are read on EVERY call rather than captured at module load. Not for hot reload —
- * see above, there is none — but because a value frozen at import time is untestable without
- * module-registry surgery, and because a process that is sent a new value by any means (a
- * `kubectl set env` on the pod, a future dynamic source) then honours it without a special
- * case. The cost is a map lookup per request, which is nothing next to the HTTP call it gates.
+ * Env vars are read on EVERY call rather than captured at module load. This buys NOTHING
+ * operationally and the reason is worth stating, because per-request reads look like they
+ * should: a running process's environment cannot be changed from outside. `kubectl set env`
+ * patches the Deployment template and replaces pods; it does not reach into a live container.
+ * So a per-call read and a module-load read behave identically in the cluster. The reason to
+ * read per call is testability — a value frozen at import time cannot be varied across cases
+ * without module-registry surgery — plus keeping the door open for a future dynamic source
+ * that mutates `process.env` in-process. The cost is a map lookup per request, which is
+ * nothing next to the HTTP call it gates.
  */
 
 /** Every server-side flag, and what turning it ON does. */

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -53,6 +53,17 @@ if (globalThis.fetch) {
 
 const REQUIRED_ENV_VARS = ['GADS_CLIENT_ID', 'GADS_CLIENT_SECRET', 'GADS_DEVELOPER_TOKEN', 'GADS_CUSTOMER_ID', 'GADS_REFRESH_TOKEN'];
 
+/**
+ * What a poll for an unknown job reports.
+ *
+ * Exported so `campaign-service.service.ts` can return the SAME string for campaign-service's
+ * 404, rather than a second copy of it. The two are the flag-off and flag-on sides of one
+ * cutover (LFXV2-3070), and a user-visible message that differs by which side served the
+ * request is a behaviour change smuggled in by an environment variable. One definition makes
+ * that impossible rather than merely unlikely.
+ */
+export const JOB_LOST_MESSAGE = 'Lost connection to the campaign creation process. Please try again.';
+
 let envChecked = false;
 
 function checkRequiredEnv(req?: Request): void {
@@ -899,7 +910,7 @@ export class CampaignProxyService {
     const job = jobs.get(jobId);
     if (!job) {
       logger.warning(req, 'campaign_job_status', `Job ${jobId} not found on this instance — likely routed to a different replica`, { jobId });
-      return { status: 'not_found', error: 'Lost connection to the campaign creation process. Please try again.' };
+      return { status: 'not_found', error: JOB_LOST_MESSAGE };
     }
     return job;
   }

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { AI_MODEL, META_CHAR_LIMITS } from '@lfx-one/shared/constants';
+import { AI_MODEL, JOB_LOST_MESSAGE, META_CHAR_LIMITS } from '@lfx-one/shared/constants';
 
 import type {
   BulkKeywordActionRequest,
@@ -52,17 +52,6 @@ if (globalThis.fetch) {
 // ---------------------------------------------------------------------------
 
 const REQUIRED_ENV_VARS = ['GADS_CLIENT_ID', 'GADS_CLIENT_SECRET', 'GADS_DEVELOPER_TOKEN', 'GADS_CUSTOMER_ID', 'GADS_REFRESH_TOKEN'];
-
-/**
- * What a poll for an unknown job reports.
- *
- * Exported so `campaign-service.service.ts` can return the SAME string for campaign-service's
- * 404, rather than a second copy of it. The two are the flag-off and flag-on sides of one
- * cutover (LFXV2-3070), and a user-visible message that differs by which side served the
- * request is a behaviour change smuggled in by an environment variable. One definition makes
- * that impossible rather than merely unlikely.
- */
-export const JOB_LOST_MESSAGE = 'Lost connection to the campaign creation process. Please try again.';
 
 let envChecked = false;
 

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -16,6 +16,8 @@ vi.mock('./microservice-proxy.service', () => ({
 
 import type { Request } from 'express';
 
+import { MicroserviceError } from '../errors/microservice.error';
+import { JOB_LOST_MESSAGE } from './campaign-proxy.service';
 import { adaptJobPollResponse, CampaignServiceClient, isCampaignServiceJobId } from './campaign-service.service';
 
 const req = {} as unknown as Request;
@@ -132,5 +134,25 @@ describe('CampaignServiceClient.getJobStatus', () => {
 
     await new CampaignServiceClient().getJobStatus(req, 'a/b');
     expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/tlf/jobs/a%2Fb', 'GET');
+  });
+
+  // The flag-off path returns a `not_found` STATUS for an unknown job, and the poller has an
+  // arm for it. A thrown 404 would take a different branch in the component, so the two sides
+  // of the cutover would disagree on an outcome only the expired-job case reaches.
+  it('translates an upstream 404 into the not_found status the in-process path returns', async () => {
+    proxyRequest.mockRejectedValue(new MicroserviceError('not found', 404, 'NOT_FOUND'));
+
+    await expect(new CampaignServiceClient().getJobStatus(req, 'j1')).resolves.toEqual({
+      status: 'not_found',
+      error: JOB_LOST_MESSAGE,
+    });
+  });
+
+  // Only 404. Anything else means the status is UNKNOWN, and reporting unknown as `not_found`
+  // tells the user their campaign creation was lost when it may be running fine.
+  it.each([401, 500, 503])('rethrows a %i rather than reporting the job lost', async (statusCode) => {
+    proxyRequest.mockRejectedValue(new MicroserviceError('upstream', statusCode, 'ERR'));
+
+    await expect(new CampaignServiceClient().getJobStatus(req, 'j1')).rejects.toMatchObject({ statusCode });
   });
 });

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -1,0 +1,152 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Same shape as access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into
+// this app's vitest config, so runtime collaborators are mocked. This file's own imports from
+// `@lfx-one/shared/interfaces` are type-only, so esbuild elides them.
+const { proxyRequest, getProjectIdBySlug } = vi.hoisted(() => ({ proxyRequest: vi.fn(), getProjectIdBySlug: vi.fn() }));
+
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = proxyRequest;
+  },
+}));
+vi.mock('./project.service', () => ({
+  ProjectService: class {
+    public getProjectIdBySlug = getProjectIdBySlug;
+  },
+}));
+
+import type { Request } from 'express';
+
+import { adaptJobPollResponse, CampaignServiceClient } from './campaign-service.service';
+
+const req = {} as unknown as Request;
+
+describe('adaptJobPollResponse', () => {
+  // The poller terminates on `takeWhile((s) => s.status === 'running', true)`. `queued` is the
+  // state every job is in on its first tick, so forwarding it raw stops the poll immediately
+  // and reports a finished create with no campaigns — for a job that has not started.
+  it('maps queued to running so the first poll does not terminate the job', () => {
+    expect(adaptJobPollResponse({ job_id: 'j1', status: 'queued' })).toEqual({ status: 'running' });
+  });
+
+  it('maps running to running', () => {
+    expect(adaptJobPollResponse({ job_id: 'j1', status: 'running' })).toEqual({ status: 'running' });
+  });
+
+  // The mirror-image failure: `succeeded` forwarded raw is not `'running'` either, so it would
+  // never terminate the poll and the page would spin to the 300s cap on a job that is finished.
+  it('maps succeeded to done and converts the per-platform results', () => {
+    expect(
+      adaptJobPollResponse({
+        job_id: 'j1',
+        status: 'succeeded',
+        result: [{ platform: 'google-ads', ok: true, campaign_id: '123' }],
+      })
+    ).toEqual({
+      status: 'done',
+      platformResults: [{ platform: 'google-ads', ok: true, campaignId: '123', error: undefined }],
+      error: undefined,
+    });
+  });
+
+  // A partial job created real campaigns. Reporting the JOB as failed would hide them; each
+  // platform's own `ok` flag carries the per-platform truth.
+  it('maps partial to done and keeps both the succeeded and the failed platform', () => {
+    const adapted = adaptJobPollResponse({
+      job_id: 'j1',
+      status: 'partial',
+      result: [
+        { platform: 'google-ads', ok: true, campaign_id: '123' },
+        { platform: 'meta-ads', ok: false, error: 'budget rejected' },
+      ],
+    });
+
+    expect(adapted.status).toBe('done');
+    expect(adapted.platformResults).toEqual([
+      { platform: 'google-ads', ok: true, campaignId: '123', error: undefined },
+      { platform: 'meta-ads', ok: false, campaignId: undefined, error: 'budget rejected' },
+    ]);
+  });
+
+  it('maps failed to error and always carries a message', () => {
+    expect(adaptJobPollResponse({ job_id: 'j1', status: 'failed' })).toEqual({
+      status: 'error',
+      platformResults: undefined,
+      error: 'campaign creation failed',
+    });
+    expect(adaptJobPollResponse({ job_id: 'j1', status: 'failed', error: 'no credentials' }).error).toBe('no credentials');
+  });
+
+  // An unrecognised status is a contract change, not a terminal state. `done` would claim
+  // campaigns exist that nobody verified.
+  it('treats an unrecognised status as an error rather than as done', () => {
+    const adapted = adaptJobPollResponse({ job_id: 'j1', status: 'cancelled' } as never);
+    expect(adapted.status).toBe('error');
+    expect(adapted.error).toContain('cancelled');
+  });
+
+  // campaign-service reports neither ad-group/keyword/ad counts nor a campaign URL. Synthesising
+  // a `result` here would make the implementation tab render "0 ad groups · 0 keywords · 0 ads"
+  // and an empty link for a campaign that really has them.
+  it('never synthesises a CampaignCreateResponse result', () => {
+    const adapted = adaptJobPollResponse({ job_id: 'j1', status: 'succeeded', result: [{ platform: 'google-ads', ok: true, campaign_id: '1' }] });
+    expect(adapted.result).toBeUndefined();
+  });
+});
+
+describe('CampaignServiceClient.resolveLfProjectUid', () => {
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    getProjectIdBySlug.mockReset();
+  });
+
+  it('resolves the tlf project and caches the successful lookup', async () => {
+    getProjectIdBySlug.mockResolvedValue({ uid: 'uid-1', slug: 'tlf', exists: true });
+    const client = new CampaignServiceClient();
+
+    await expect(client.resolveLfProjectUid(req)).resolves.toBe('uid-1');
+    await expect(client.resolveLfProjectUid(req)).resolves.toBe('uid-1');
+    expect(getProjectIdBySlug).toHaveBeenCalledTimes(1);
+    expect(getProjectIdBySlug).toHaveBeenCalledWith(req, 'tlf');
+  });
+
+  // `getProjectIdBySlug` reports `exists: false` for a NATS timeout as well as for a genuinely
+  // missing project. Caching the negative would turn one blip into a campaigns page that stays
+  // broken for the life of the pod.
+  it('does not cache a failed lookup, and reports it as 503 rather than 404', async () => {
+    getProjectIdBySlug.mockResolvedValueOnce({ slug: 'tlf', exists: false });
+    const client = new CampaignServiceClient();
+
+    await expect(client.resolveLfProjectUid(req)).rejects.toMatchObject({ statusCode: 503 });
+
+    getProjectIdBySlug.mockResolvedValueOnce({ uid: 'uid-1', slug: 'tlf', exists: true });
+    await expect(client.resolveLfProjectUid(req)).resolves.toBe('uid-1');
+    expect(getProjectIdBySlug).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe('CampaignServiceClient.getJobStatus', () => {
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    getProjectIdBySlug.mockReset();
+    getProjectIdBySlug.mockResolvedValue({ uid: 'uid-1', slug: 'tlf', exists: true });
+  });
+
+  it('scopes the request to the resolved project and adapts the response', async () => {
+    proxyRequest.mockResolvedValue({ job_id: 'j1', status: 'queued' });
+
+    await expect(new CampaignServiceClient().getJobStatus(req, 'j1')).resolves.toEqual({ status: 'running' });
+    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/uid-1/jobs/j1', 'GET');
+  });
+
+  it('encodes the job id into the path', async () => {
+    proxyRequest.mockResolvedValue({ job_id: 'a/b', status: 'running' });
+
+    await new CampaignServiceClient().getJobStatus(req, 'a/b');
+    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/uid-1/jobs/a%2Fb', 'GET');
+  });
+});

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -34,8 +34,11 @@ describe('adaptJobPollResponse', () => {
     expect(adaptJobPollResponse({ job_id: 'j1', status: 'running' })).toEqual({ status: 'running' });
   });
 
-  // The mirror-image failure: `succeeded` forwarded raw is not `'running'` either, so it would
-  // never terminate the poll and the page would spin to the 300s cap on a job that is finished.
+  // The mirror-image failure, and NOT a hang — `takeWhile(..., true)` is inclusive, so a raw
+  // `succeeded` is emitted and the poll completes promptly. The damage is downstream:
+  // `getCreateResult` matches none of its arms on that status, falls through to its last
+  // `throw`, and reports "Campaign creation is taking longer than expected" for a job that
+  // finished immediately and successfully — with the campaigns it created never rendered.
   it('maps succeeded to done and converts the per-platform results', () => {
     expect(
       adaptJobPollResponse({

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -142,13 +142,27 @@ describe('CampaignServiceClient.getJobStatus', () => {
   // The flag-off path returns a `not_found` STATUS for an unknown job, and the poller has an
   // arm for it. A thrown 404 would take a different branch in the component, so the two sides
   // of the cutover would disagree on an outcome only the expired-job case reaches.
-  it('translates an upstream 404 into the not_found status the in-process path returns', async () => {
-    proxyRequest.mockRejectedValue(new MicroserviceError('not found', 404, 'NOT_FOUND'));
+  it('translates campaign-service own typed 404 into the not_found status the in-process path returns', async () => {
+    proxyRequest.mockRejectedValue(new MicroserviceError('not found', 404, 'NOT_FOUND', { errorBody: { code: '404', message: 'the resource was not found' } }));
 
     await expect(new CampaignServiceClient().getJobStatus(req, 'j1')).resolves.toEqual({
       status: 'not_found',
       error: JOB_LOST_MESSAGE,
     });
+  });
+
+  // The cutover's most likely first-deploy failure: the campaign-service route is absent or
+  // misrouted and the GATEWAY answers 404. `not_found` is terminal for the poller, so accepting
+  // that 404 would tell the user a running campaign was lost AND bury the misconfiguration.
+  // Traefik's 404 is plain text, which `api-client.service.ts` leaves as a null `errorBody`.
+  it.each([
+    ['a plain-text gateway 404 (null body)', null],
+    ['an untyped JSON 404', { error: 'not found' }],
+    ['a 404 whose code is not the literal string', { code: 404, message: 'nope' }],
+  ])('rethrows %s rather than reporting the job lost', async (_label, errorBody) => {
+    proxyRequest.mockRejectedValue(new MicroserviceError('not found', 404, 'NOT_FOUND', { errorBody }));
+
+    await expect(new CampaignServiceClient().getJobStatus(req, 'j1')).rejects.toMatchObject({ statusCode: 404 });
   });
 
   // Only 404. Anything else means the status is UNKNOWN, and reporting unknown as `not_found`

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -14,10 +14,10 @@ vi.mock('./microservice-proxy.service', () => ({
   },
 }));
 
+import { JOB_LOST_MESSAGE } from '@lfx-one/shared/constants';
 import type { Request } from 'express';
 
 import { MicroserviceError } from '../errors/microservice.error';
-import { JOB_LOST_MESSAGE } from './campaign-proxy.service';
 import { adaptJobPollResponse, CampaignServiceClient, isCampaignServiceJobId } from './campaign-service.service';
 
 const req = {} as unknown as Request;

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -6,22 +6,17 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // Same shape as access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into
 // this app's vitest config, so runtime collaborators are mocked. This file's own imports from
 // `@lfx-one/shared/interfaces` are type-only, so esbuild elides them.
-const { proxyRequest, getProjectIdBySlug } = vi.hoisted(() => ({ proxyRequest: vi.fn(), getProjectIdBySlug: vi.fn() }));
+const { proxyRequest } = vi.hoisted(() => ({ proxyRequest: vi.fn() }));
 
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
     public proxyRequest = proxyRequest;
   },
 }));
-vi.mock('./project.service', () => ({
-  ProjectService: class {
-    public getProjectIdBySlug = getProjectIdBySlug;
-  },
-}));
 
 import type { Request } from 'express';
 
-import { adaptJobPollResponse, CampaignServiceClient } from './campaign-service.service';
+import { adaptJobPollResponse, CampaignServiceClient, isCampaignServiceJobId } from './campaign-service.service';
 
 const req = {} as unknown as Request;
 
@@ -98,55 +93,44 @@ describe('adaptJobPollResponse', () => {
   });
 });
 
-describe('CampaignServiceClient.resolveLfProjectUid', () => {
-  beforeEach(() => {
-    proxyRequest.mockReset();
-    getProjectIdBySlug.mockReset();
+describe('isCampaignServiceJobId', () => {
+  // Creation is NOT cut over: it still mints `job_<epoch>_<rand>` in `campaign-proxy.service.ts`,
+  // and campaign-service's `get-job` declares `Format(FormatUUID)` on the path parameter. Routing
+  // on the flag alone would 400 every poll the moment the flag was turned on — breaking the exact
+  // flow the flag exists to fix. The shape is what makes the two sources distinguishable.
+  it('accepts a campaign-service UUID job id', () => {
+    expect(isCampaignServiceJobId('3f2504e0-4f89-11d3-9a0c-0305e82c3301')).toBe(true);
+    expect(isCampaignServiceJobId('3F2504E0-4F89-11D3-9A0C-0305E82C3301')).toBe(true);
   });
 
-  it('resolves the tlf project and caches the successful lookup', async () => {
-    getProjectIdBySlug.mockResolvedValue({ uid: 'uid-1', slug: 'tlf', exists: true });
-    const client = new CampaignServiceClient();
-
-    await expect(client.resolveLfProjectUid(req)).resolves.toBe('uid-1');
-    await expect(client.resolveLfProjectUid(req)).resolves.toBe('uid-1');
-    expect(getProjectIdBySlug).toHaveBeenCalledTimes(1);
-    expect(getProjectIdBySlug).toHaveBeenCalledWith(req, 'tlf');
-  });
-
-  // `getProjectIdBySlug` reports `exists: false` for a NATS timeout as well as for a genuinely
-  // missing project. Caching the negative would turn one blip into a campaigns page that stays
-  // broken for the life of the pod.
-  it('does not cache a failed lookup, and reports it as 503 rather than 404', async () => {
-    getProjectIdBySlug.mockResolvedValueOnce({ slug: 'tlf', exists: false });
-    const client = new CampaignServiceClient();
-
-    await expect(client.resolveLfProjectUid(req)).rejects.toMatchObject({ statusCode: 503 });
-
-    getProjectIdBySlug.mockResolvedValueOnce({ uid: 'uid-1', slug: 'tlf', exists: true });
-    await expect(client.resolveLfProjectUid(req)).resolves.toBe('uid-1');
-    expect(getProjectIdBySlug).toHaveBeenCalledTimes(2);
+  it('rejects the in-process job id shape so those polls keep their current source', () => {
+    expect(isCampaignServiceJobId('job_1754812800000_a1b2c3')).toBe(false);
+    expect(isCampaignServiceJobId('')).toBe(false);
+    expect(isCampaignServiceJobId('3f2504e0-4f89-11d3-9a0c-0305e82c330')).toBe(false);
+    expect(isCampaignServiceJobId('3f2504e0-4f89-11d3-9a0c-0305e82c3301-extra')).toBe(false);
   });
 });
 
 describe('CampaignServiceClient.getJobStatus', () => {
   beforeEach(() => {
     proxyRequest.mockReset();
-    getProjectIdBySlug.mockReset();
-    getProjectIdBySlug.mockResolvedValue({ uid: 'uid-1', slug: 'tlf', exists: true });
   });
 
-  it('scopes the request to the resolved project and adapts the response', async () => {
+  // The SLUG goes on the wire, deliberately un-resolved. `create-brief` accepts a slug only
+  // (`Pattern(^[a-z0-9]+(-[a-z0-9]+)*$)`, which a UUID fails) and stores exactly that string;
+  // `GetJob` then scopes with an EXACT `b.project_id = $2`. Polling under the project's uid
+  // would look more canonical and never find the job.
+  it('scopes the request to the tlf slug, not to a resolved uid', async () => {
     proxyRequest.mockResolvedValue({ job_id: 'j1', status: 'queued' });
 
     await expect(new CampaignServiceClient().getJobStatus(req, 'j1')).resolves.toEqual({ status: 'running' });
-    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/uid-1/jobs/j1', 'GET');
+    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/tlf/jobs/j1', 'GET');
   });
 
   it('encodes the job id into the path', async () => {
     proxyRequest.mockResolvedValue({ job_id: 'a/b', status: 'running' });
 
     await new CampaignServiceClient().getJobStatus(req, 'a/b');
-    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/uid-1/jobs/a%2Fb', 'GET');
+    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/tlf/jobs/a%2Fb', 'GET');
   });
 });

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -4,6 +4,8 @@
 import type { CampaignJobStatus, CampaignPlatformResult } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
+import { MicroserviceError } from '../errors/microservice.error';
+import { JOB_LOST_MESSAGE } from './campaign-proxy.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
 /**
@@ -88,15 +90,33 @@ export class CampaignServiceClient {
    * (`campaign-proxy.service.ts`), which only works while every poll happens to land on the
    * pod that started the job — the code already logs that symptom by name. campaign-service
    * persists jobs, so this survives a replica switch.
+   *
+   * An upstream 404 becomes `not_found`, not a thrown error, because that is what the path
+   * being replaced returns for an unknown job — and the poller has an arm for it
+   * (`campaign.service.ts` renders "Lost connection to the campaign creation process"). A
+   * flagged cutover whose two sides disagree on a reachable outcome is not a cutover; it is a
+   * second behaviour hidden behind an environment variable, and the difference would surface
+   * only for the expired-job case nobody exercises before shipping.
+   *
+   * ONLY 404. Every other failure — a 401, a 503, a gateway timeout — is rethrown, because
+   * those mean the status is UNKNOWN, and reporting unknown as `not_found` would tell the user
+   * their campaign creation was lost when it may be running perfectly well.
    */
   public async getJobStatus(req: Request, jobId: string): Promise<CampaignJobStatus> {
-    const response = await this.microserviceProxy.proxyRequest<CampaignServiceJobPollResponse>(
-      req,
-      'LFX_V2_CAMPAIGN_SERVICE',
-      `/projects/${encodeURIComponent(LF_PROJECT_SLUG)}/jobs/${encodeURIComponent(jobId)}`,
-      'GET'
-    );
-    return adaptJobPollResponse(response);
+    try {
+      const response = await this.microserviceProxy.proxyRequest<CampaignServiceJobPollResponse>(
+        req,
+        'LFX_V2_CAMPAIGN_SERVICE',
+        `/projects/${encodeURIComponent(LF_PROJECT_SLUG)}/jobs/${encodeURIComponent(jobId)}`,
+        'GET'
+      );
+      return adaptJobPollResponse(response);
+    } catch (error) {
+      if (error instanceof MicroserviceError && error.statusCode === 404) {
+        return { status: 'not_found', error: JOB_LOST_MESSAGE };
+      }
+      throw error;
+    }
   }
 }
 

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -98,9 +98,21 @@ export class CampaignServiceClient {
    * second behaviour hidden behind an environment variable, and the difference would surface
    * only for the expired-job case nobody exercises before shipping.
    *
-   * ONLY 404. Every other failure — a 401, a 503, a gateway timeout — is rethrown, because
+   * ONLY campaign-service's OWN 404, and the distinction matters most during the cutover this
+   * flag gates. A bare `statusCode === 404` also catches a 404 the GATEWAY produced because the
+   * campaign-service route is absent or misrouted — the single most likely way the cutover fails
+   * on first deploy. Because `not_found` is terminal for the poller, that misconfiguration would
+   * be reported to the user as a lost campaign and the real fault would never surface. So the
+   * translation requires the typed body campaign-service returns for an unknown job,
+   * `{"code":"404","message":...}` (its Goa `not-found-error`, populated at
+   * `internal/service/brief.go`: `&briefs.NotFoundError{Code: "404", ...}`). Traefik's own 404 is
+   * plain text, which `api-client.service.ts` leaves as a null `errorBody`, so it cannot pass.
+   *
+   * Every other failure — a 401, a 503, a gateway timeout, an untyped 404 — is rethrown, because
    * those mean the status is UNKNOWN, and reporting unknown as `not_found` would tell the user
-   * their campaign creation was lost when it may be running perfectly well.
+   * their campaign creation was lost when it may be running perfectly well. Note the asymmetry is
+   * deliberate: if campaign-service ever changes that body shape, a real expired job surfaces as
+   * an error rather than as a false "lost" — loud instead of quietly wrong.
    */
   public async getJobStatus(req: Request, jobId: string): Promise<CampaignJobStatus> {
     try {
@@ -112,12 +124,28 @@ export class CampaignServiceClient {
       );
       return adaptJobPollResponse(response);
     } catch (error) {
-      if (error instanceof MicroserviceError && error.statusCode === 404) {
+      if (error instanceof MicroserviceError && error.statusCode === 404 && isCampaignServiceNotFound(error.errorBody)) {
         return { status: 'not_found', error: JOB_LOST_MESSAGE };
       }
       throw error;
     }
   }
+}
+
+/**
+ * Whether a 404's body is campaign-service's own typed not-found rather than someone else's 404.
+ *
+ * Its Goa `not-found-error` requires both `code` and `message` as strings, and the service
+ * populates `code` with the literal `"404"`. Anything that fails this test — a null body from a
+ * plain-text Traefik 404, or a differently shaped JSON error from another hop — is NOT evidence
+ * that the job is gone. Exported for the spec.
+ */
+export function isCampaignServiceNotFound(errorBody: unknown): boolean {
+  if (typeof errorBody !== 'object' || errorBody === null) {
+    return false;
+  }
+  const body = errorBody as { code?: unknown; message?: unknown };
+  return body.code === '404' && typeof body.message === 'string';
 }
 
 /**

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -140,6 +140,11 @@ export class CampaignServiceClient {
  * campaigns that were really created.
  */
 export function adaptJobPollResponse(response: CampaignServiceJobPollResponse): CampaignJobStatus {
+  // Stays `undefined` when campaign-service sent no `result` — it is NOT defaulted to `[]`.
+  // An empty array would assert "the job reported on zero platforms", which is a different
+  // claim from "the job reported nothing yet"; the poller reaches here for terminal states
+  // that legitimately carry no result (a job that failed before dispatch). The component
+  // coalesces to `[]` at the point of rendering, where the distinction no longer matters.
   const platformResults: CampaignPlatformResult[] | undefined = response.result?.map((r) => ({
     platform: r.platform,
     ok: r.ok,

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -1,0 +1,165 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { CampaignJobStatus, CampaignPlatformResult } from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+
+import { MicroserviceError } from '../errors';
+import { MicroserviceProxyService } from './microservice-proxy.service';
+import { ProjectService } from './project.service';
+
+/**
+ * `job-poll-response` as lfx-v2-campaign-service publishes it (`design/brief.go`).
+ *
+ * Declared here rather than in `@lfx-one/shared` on purpose: it is the WIRE shape of another
+ * service, not a type this application exchanges between its own tiers. Putting it in the
+ * shared package would invite a component to import it, and then a contract change upstream
+ * would reach the browser instead of stopping at the adapter below.
+ */
+interface CampaignServiceJobPollResponse {
+  job_id: string;
+  status: 'queued' | 'running' | 'succeeded' | 'partial' | 'failed';
+  result?: {
+    platform: string;
+    ok: boolean;
+    campaign_id?: string;
+    error?: string;
+  }[];
+  error?: string;
+}
+
+/**
+ * The canonical slug for The Linux Foundation's own project row.
+ *
+ * `/foundation/campaigns` is a fixed route with no project or slug segment — it is
+ * LF-scoped by construction, gated by `executiveDirectorGuard` rather than by a per-project
+ * permission. lfx-v2-campaign-service, by contrast, is `/projects/{projectId}/…` scoped
+ * throughout and authorises on `campaign_manager` for that project. Bridging the two means
+ * resolving one fixed slug, and this is it. Not 'the-linux-foundation' — 'tlf' is the
+ * canonical form; the longer spelling resolves to nothing.
+ */
+const LF_PROJECT_SLUG = 'tlf';
+
+/**
+ * Client for lfx-v2-campaign-service.
+ *
+ * Separate from `campaign-proxy.service.ts` on purpose: that file talks to the VENDOR APIs
+ * (Google Ads, Meta Graph, LinkedIn, Reddit, HubSpot) with credentials held in this tier,
+ * and it is what the cutover retires. Keeping the two apart means each endpoint's migration
+ * is an addition here plus a branch at the call site, and a rollback is the flag alone —
+ * rather than an edit tangled through the vendor code that has to be reverted by hand.
+ */
+export class CampaignServiceClient {
+  private readonly microserviceProxy: MicroserviceProxyService;
+  private readonly projectService: ProjectService;
+
+  /**
+   * Memoised LF project uid. A slug→uid mapping is immutable for the life of a project, so
+   * caching it avoids a NATS round-trip on every campaign request.
+   *
+   * Only a SUCCESSFUL resolution is ever cached. `getProjectIdBySlug` converts a NATS
+   * timeout or a 503 no-responder into `exists: false` — indistinguishable, at this layer,
+   * from "there is no such project" — so caching a negative would turn one blip in the NATS
+   * connection into a permanently broken campaigns page for the lifetime of the pod, fixable
+   * only by a restart. An uncached negative costs one retry per request instead, which is
+   * the correct trade.
+   */
+  private lfProjectUid: string | null = null;
+
+  public constructor(microserviceProxy?: MicroserviceProxyService, projectService?: ProjectService) {
+    this.microserviceProxy = microserviceProxy ?? new MicroserviceProxyService();
+    this.projectService = projectService ?? new ProjectService();
+  }
+
+  /**
+   * Resolve the LF project uid that scopes every campaign-service path.
+   *
+   * Throws rather than returning a sentinel when resolution fails. The caller's alternative
+   * would be to fall back to the vendor-direct path, and a SILENT fallback is the worst
+   * available outcome: the page keeps working, so nobody investigates, and the cutover is
+   * reported as verified while every request is still being served by the code it was
+   * supposed to replace. A loud failure is recoverable by turning the flag off.
+   */
+  public async resolveLfProjectUid(req: Request): Promise<string> {
+    if (this.lfProjectUid) {
+      return this.lfProjectUid;
+    }
+
+    const result = await this.projectService.getProjectIdBySlug(req, LF_PROJECT_SLUG);
+    if (!result.exists || !result.uid) {
+      // 503, not 404. `getProjectIdBySlug` reports `exists: false` for BOTH "no such project"
+      // and "the query timed out / no NATS responder", and the two are indistinguishable from
+      // here. A 404 would tell the operator the LF project is missing — it is not — and would
+      // read as a permanent, client-side condition on a fault that is transient and ours.
+      throw new MicroserviceError(`could not resolve the '${LF_PROJECT_SLUG}' project needed to reach campaign-service`, 503, 'SERVICE_UNAVAILABLE', {
+        operation: 'resolve_lf_project_uid',
+        service: 'campaign_service_client',
+      });
+    }
+
+    this.lfProjectUid = result.uid;
+    return result.uid;
+  }
+
+  /**
+   * Read a campaign-creation job's status.
+   *
+   * The path this replaces keeps jobs in an in-process `Map`
+   * (`campaign-proxy.service.ts`), which only works while every poll happens to land on the
+   * pod that started the job — the code already logs that symptom by name. campaign-service
+   * persists jobs, so this survives a replica switch.
+   */
+  public async getJobStatus(req: Request, jobId: string): Promise<CampaignJobStatus> {
+    const projectUid = await this.resolveLfProjectUid(req);
+    const response = await this.microserviceProxy.proxyRequest<CampaignServiceJobPollResponse>(
+      req,
+      'LFX_V2_CAMPAIGN_SERVICE',
+      `/projects/${encodeURIComponent(projectUid)}/jobs/${encodeURIComponent(jobId)}`,
+      'GET'
+    );
+    return adaptJobPollResponse(response);
+  }
+}
+
+/**
+ * Translate campaign-service's `job-poll-response` into the shape the poller expects.
+ *
+ * This is NOT a pass-through, and the difference matters more than it looks. The Angular
+ * poller terminates on `takeWhile((s) => s.status === 'running', true)`
+ * (`campaign.service.ts`), so the status vocabulary is load-bearing:
+ *
+ *   - `queued` is the state a job is in for its first tick. Forwarded raw it is not
+ *     `'running'`, so the poll STOPS on the first response and the UI reports a finished
+ *     create with no campaigns — for a job that has not started yet.
+ *   - `succeeded` forwarded raw is likewise not `'running'`, so it would never terminate the
+ *     poll either; the page would spin to the 300s cap on a job that finished immediately.
+ *
+ * Both failures are silent, which is why the mapping is explicit and tested rather than
+ * inferred. `partial` maps to `done`: some platforms succeeded, and each platform's own `ok`
+ * flag carries the per-platform truth, so reporting the JOB as failed would hide the
+ * campaigns that were really created.
+ */
+export function adaptJobPollResponse(response: CampaignServiceJobPollResponse): CampaignJobStatus {
+  const platformResults: CampaignPlatformResult[] | undefined = response.result?.map((r) => ({
+    platform: r.platform,
+    ok: r.ok,
+    campaignId: r.campaign_id,
+    error: r.error,
+  }));
+
+  switch (response.status) {
+    case 'queued':
+    case 'running':
+      return { status: 'running' };
+    case 'succeeded':
+    case 'partial':
+      return { status: 'done', platformResults, error: response.error };
+    case 'failed':
+      return { status: 'error', platformResults, error: response.error ?? 'campaign creation failed' };
+    default:
+      // An unrecognised status is a contract change, not a terminal state. Reporting it as
+      // `done` would claim campaigns exist that nobody verified; `error` at least stops the
+      // poll and says so out loud.
+      return { status: 'error', error: `unrecognised job status '${response.status}' from campaign-service` };
+  }
+}

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -4,9 +4,7 @@
 import type { CampaignJobStatus, CampaignPlatformResult } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
-import { MicroserviceError } from '../errors';
 import { MicroserviceProxyService } from './microservice-proxy.service';
-import { ProjectService } from './project.service';
 
 /**
  * `job-poll-response` as lfx-v2-campaign-service publishes it (`design/brief.go`).
@@ -35,10 +33,37 @@ interface CampaignServiceJobPollResponse {
  * LF-scoped by construction, gated by `executiveDirectorGuard` rather than by a per-project
  * permission. lfx-v2-campaign-service, by contrast, is `/projects/{projectId}/…` scoped
  * throughout and authorises on `campaign_manager` for that project. Bridging the two means
- * resolving one fixed slug, and this is it. Not 'the-linux-foundation' — 'tlf' is the
- * canonical form; the longer spelling resolves to nothing.
+ * one fixed slug, and this is it. Not 'the-linux-foundation' — 'tlf' is the canonical form;
+ * the longer spelling resolves to nothing.
+ *
+ * This value goes on the wire AS THE SLUG, deliberately un-resolved. campaign-service's
+ * `create-brief` accepts a slug ONLY — its `project_id` carries `Pattern(^[a-z0-9]+(-[a-z0-9]+)*$)`,
+ * which a UUID fails — and it stores exactly that string in `campaign_briefs.project_id`.
+ * `GetJob` then scopes by joining `b.project_id = $2` with an EXACT comparison, so a job
+ * written under `tlf` is invisible to a poll made under the project's uid. Resolving the slug
+ * to a uid here would look more canonical and find nothing.
  */
 const LF_PROJECT_SLUG = 'tlf';
+
+/**
+ * True when `jobId` is a job campaign-service could possibly know about.
+ *
+ * The flag alone is not a safe router, and this is the reason. Campaign CREATION has not been
+ * cut over: `campaign-proxy.service.ts` still mints `job_<epoch>_<rand>` ids into an in-process
+ * `Map`. campaign-service's `get-job` declares `Format(FormatUUID)` on `job_id`, so such an id
+ * is rejected by the request decoder with a 400 before any lookup happens — and even without
+ * that validation there is no row to find, because nothing created one. Routing purely on the
+ * flag would therefore break every poll the moment the flag went on, which is the exact failure
+ * the flag exists to fix.
+ *
+ * Routing on the id's SHAPE is safe in both directions and needs no second flag: a `job_` id can
+ * only have come from this process, and a UUID can only have come from campaign-service. When
+ * creation is cut over, new ids become UUIDs and start taking the new path on their own; ids
+ * minted before the cutover keep resolving against the map that holds them.
+ */
+export function isCampaignServiceJobId(jobId: string): boolean {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(jobId);
+}
 
 /**
  * Client for lfx-v2-campaign-service.
@@ -51,54 +76,9 @@ const LF_PROJECT_SLUG = 'tlf';
  */
 export class CampaignServiceClient {
   private readonly microserviceProxy: MicroserviceProxyService;
-  private readonly projectService: ProjectService;
 
-  /**
-   * Memoised LF project uid. A slug→uid mapping is immutable for the life of a project, so
-   * caching it avoids a NATS round-trip on every campaign request.
-   *
-   * Only a SUCCESSFUL resolution is ever cached. `getProjectIdBySlug` converts a NATS
-   * timeout or a 503 no-responder into `exists: false` — indistinguishable, at this layer,
-   * from "there is no such project" — so caching a negative would turn one blip in the NATS
-   * connection into a permanently broken campaigns page for the lifetime of the pod, fixable
-   * only by a restart. An uncached negative costs one retry per request instead, which is
-   * the correct trade.
-   */
-  private lfProjectUid: string | null = null;
-
-  public constructor(microserviceProxy?: MicroserviceProxyService, projectService?: ProjectService) {
+  public constructor(microserviceProxy?: MicroserviceProxyService) {
     this.microserviceProxy = microserviceProxy ?? new MicroserviceProxyService();
-    this.projectService = projectService ?? new ProjectService();
-  }
-
-  /**
-   * Resolve the LF project uid that scopes every campaign-service path.
-   *
-   * Throws rather than returning a sentinel when resolution fails. The caller's alternative
-   * would be to fall back to the vendor-direct path, and a SILENT fallback is the worst
-   * available outcome: the page keeps working, so nobody investigates, and the cutover is
-   * reported as verified while every request is still being served by the code it was
-   * supposed to replace. A loud failure is recoverable by turning the flag off.
-   */
-  public async resolveLfProjectUid(req: Request): Promise<string> {
-    if (this.lfProjectUid) {
-      return this.lfProjectUid;
-    }
-
-    const result = await this.projectService.getProjectIdBySlug(req, LF_PROJECT_SLUG);
-    if (!result.exists || !result.uid) {
-      // 503, not 404. `getProjectIdBySlug` reports `exists: false` for BOTH "no such project"
-      // and "the query timed out / no NATS responder", and the two are indistinguishable from
-      // here. A 404 would tell the operator the LF project is missing — it is not — and would
-      // read as a permanent, client-side condition on a fault that is transient and ours.
-      throw new MicroserviceError(`could not resolve the '${LF_PROJECT_SLUG}' project needed to reach campaign-service`, 503, 'SERVICE_UNAVAILABLE', {
-        operation: 'resolve_lf_project_uid',
-        service: 'campaign_service_client',
-      });
-    }
-
-    this.lfProjectUid = result.uid;
-    return result.uid;
   }
 
   /**
@@ -110,11 +90,10 @@ export class CampaignServiceClient {
    * persists jobs, so this survives a replica switch.
    */
   public async getJobStatus(req: Request, jobId: string): Promise<CampaignJobStatus> {
-    const projectUid = await this.resolveLfProjectUid(req);
     const response = await this.microserviceProxy.proxyRequest<CampaignServiceJobPollResponse>(
       req,
       'LFX_V2_CAMPAIGN_SERVICE',
-      `/projects/${encodeURIComponent(projectUid)}/jobs/${encodeURIComponent(jobId)}`,
+      `/projects/${encodeURIComponent(LF_PROJECT_SLUG)}/jobs/${encodeURIComponent(jobId)}`,
       'GET'
     );
     return adaptJobPollResponse(response);
@@ -131,8 +110,12 @@ export class CampaignServiceClient {
  *   - `queued` is the state a job is in for its first tick. Forwarded raw it is not
  *     `'running'`, so the poll STOPS on the first response and the UI reports a finished
  *     create with no campaigns — for a job that has not started yet.
- *   - `succeeded` forwarded raw is likewise not `'running'`, so it would never terminate the
- *     poll either; the page would spin to the 300s cap on a job that finished immediately.
+ *   - `succeeded` forwarded raw is likewise not `'running'`, and `takeWhile`'s inclusive form
+ *     emits that final value before completing — so the poll ends promptly, but on a status
+ *     `getCreateResult` matches none of its arms. It falls through to the last `throw` and
+ *     reports "Campaign creation is taking longer than expected" for a job that finished
+ *     immediately and successfully. The failure is not a hang; it is a completed create
+ *     reported as a timeout, with the campaigns it made never rendered.
  *
  * Both failures are silent, which is why the mapping is explicit and tested rather than
  * inferred. `partial` maps to `done`: some platforms succeeded, and each platform's own `ok`

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -1,11 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { JOB_LOST_MESSAGE } from '@lfx-one/shared/constants';
 import type { CampaignJobStatus, CampaignPlatformResult } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 
 import { MicroserviceError } from '../errors/microservice.error';
-import { JOB_LOST_MESSAGE } from './campaign-proxy.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
 
 /**

--- a/apps/lfx-one/src/server/services/microservice-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/microservice-proxy.service.ts
@@ -148,13 +148,15 @@ export class MicroserviceProxyService {
     return this.apiClient.streamRequest(method, endpoint, token, mergedQuery, customHeaders);
   }
 
-  // Single source of truth for per-service base URLs. LFX_V2_MEMBER_SERVICE and
-  // LFX_V2_COMMITTEE_SERVICE fall back to LFX_V2_SERVICE (the gateway) when unset.
+  // Single source of truth for per-service base URLs. LFX_V2_MEMBER_SERVICE,
+  // LFX_V2_COMMITTEE_SERVICE and LFX_V2_CAMPAIGN_SERVICE fall back to LFX_V2_SERVICE
+  // (the gateway) when unset.
   private resolveBaseUrl(service: keyof MicroserviceUrls): string {
     const urls: MicroserviceUrls = {
       LFX_V2_SERVICE: process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
       LFX_V2_MEMBER_SERVICE: process.env['LFX_V2_MEMBER_SERVICE'] || process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
       LFX_V2_COMMITTEE_SERVICE: process.env['LFX_V2_COMMITTEE_SERVICE'] || process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
+      LFX_V2_CAMPAIGN_SERVICE: process.env['LFX_V2_CAMPAIGN_SERVICE'] || process.env['LFX_V2_SERVICE'] || 'http://lfx-api.k8s.orb.local',
     };
     // Strip trailing slashes so a config value like `https://host/` can't produce `host//path`.
     return urls[service].replace(/\/+$/, '');

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -184,10 +184,18 @@ Campaign endpoints are being moved off this application's vendor-direct integrat
 lfx-v2-campaign-service one at a time (LFXV2-3070). Each move is gated so it can be reversed by
 changing a value here rather than by shipping a revert.
 
-| Parameter                                       | Description                                                                                           | Required | Default          |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------- | ---------------- |
-| `environment.LFX_V2_CAMPAIGN_SERVICE`           | Campaign-service base URL; falls back to the gateway                                                  | No       | `LFX_V2_SERVICE` |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` | `"true"` serves campaign job status from campaign-service; anything else keeps the in-process job map | No       | off              |
+| Parameter                                       | Description                                                                                           | Required | Default |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` | `"true"` serves campaign job status from campaign-service; anything else keeps the in-process job map | No       | off     |
+
+Campaign traffic reaches campaign-service **through the gateway**, at `environment.LFX_V2_SERVICE`.
+There is deliberately no chart parameter for a campaign-service base URL. The application does read
+`LFX_V2_CAMPAIGN_SERVICE` and falls back to `LFX_V2_SERVICE` when it is unset — the same shape as
+`LFX_V2_MEMBER_SERVICE` and `LFX_V2_COMMITTEE_SERVICE`, neither of which this chart declares either.
+Leaving it undeclared is the point: Heimdall and OpenFGA enforce `campaign_manager` on the project
+in front of campaign-service, and the service's own token check authenticates the caller without
+authorizing them for that project. A base URL aimed at a service instance would therefore let any
+caller with a valid token act on a project it holds no grant for, given a job id.
 
 #### AI Service Configuration
 

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -178,6 +178,17 @@ environment:
 | `environment.QUERY_SERVICE_URL` | Query service URL for resource queries | No       | `http://query-service.default.svc.cluster.local/query/resources` |
 | `environment.NATS_URL`          | NATS messaging server URL              | **Yes**  | -                                                                |
 
+#### Campaign Service Cutover
+
+Campaign endpoints are being moved off this application's vendor-direct integrations and onto
+lfx-v2-campaign-service one at a time (LFXV2-3070). Each move is gated so it can be reversed by
+changing a value here rather than by shipping a revert.
+
+| Parameter                                       | Description                                                                                           | Required | Default          |
+| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------- | ---------------- |
+| `environment.LFX_V2_CAMPAIGN_SERVICE`           | Campaign-service base URL; falls back to the gateway                                                  | No       | `LFX_V2_SERVICE` |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` | `"true"` serves campaign job status from campaign-service; anything else keeps the in-process job map | No       | off              |
+
 #### AI Service Configuration
 
 | Parameter                  | Description                              | Required | Default |

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -206,10 +206,20 @@ Campaign traffic reaches campaign-service **through the gateway**, at `environme
 There is deliberately no chart parameter for a campaign-service base URL. The application does read
 `LFX_V2_CAMPAIGN_SERVICE` and falls back to `LFX_V2_SERVICE` when it is unset — the same shape as
 `LFX_V2_MEMBER_SERVICE` and `LFX_V2_COMMITTEE_SERVICE`, neither of which this chart declares either.
-Leaving it undeclared is the point: Heimdall and OpenFGA enforce `campaign_manager` on the project
-in front of campaign-service, and the service's own token check authenticates the caller without
-authorizing them for that project. A base URL aimed at a service instance would therefore let any
-caller with a valid token act on a project it holds no grant for, given a job id.
+The fallback is what makes the gateway the default, and the gateway is where the authorization
+lives: Heimdall and OpenFGA enforce `campaign_manager` on the project in front of campaign-service,
+while the service's own token check authenticates the caller without authorizing them for that
+project. A base URL aimed at a service instance would therefore let any caller with a valid token
+act on a project it holds no grant for, given a job id.
+
+Omitting the key from `values.yaml` does not by itself close that path — `templates/deployment.yaml`
+emits every entry in `.Values.environment`, so an override adds the variable without touching this
+chart. All three variables are therefore rejected at render time by
+`lfx-self-serve.environment.gatewayOnlyValidate`, and `helm template` fails with the reason rather
+than producing a pod that silently bypasses the gateway. Declaring the key with an empty value is
+still fine: the container treats it as unset and the application resolves it to `LFX_V2_SERVICE`. A
+deployment that genuinely needs a direct address should drop the variable from that list in a
+reviewed chart commit — a values override is invisible to review, a chart change is not.
 
 #### AI Service Configuration
 

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -184,9 +184,16 @@ Campaign endpoints are being moved off this application's vendor-direct integrat
 lfx-v2-campaign-service one at a time (LFXV2-3070). Each move is gated so it can be reversed by
 changing a value here rather than by shipping a revert.
 
-| Parameter                                       | Description                                                                                           | Required | Default |
-| ----------------------------------------------- | ----------------------------------------------------------------------------------------------------- | -------- | ------- |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` | `"true"` serves campaign job status from campaign-service; anything else keeps the in-process job map | No       | off     |
+| Parameter                                       | Description                                                                     | Required | Default |
+| ----------------------------------------------- | ------------------------------------------------------------------------------- | -------- | ------- |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` | Serves campaign job status from campaign-service; see the accepted values below | No       | off     |
+
+`LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` is ON for `true`, `1`, `yes`, or `on` — trimmed and matched
+case-insensitively, so `"True"` and `" on "` also enable it. Every other value is OFF, including
+unset, empty, `0`, `false`, and any misspelling. Do not read "only `true` works" into that: an
+operator setting `yes` and expecting it to be ignored would route production traffic at
+campaign-service. The default-deny half is the deliberate part — a typo like `flase` is invisible
+in a values.yaml diff, so an unrecognised value has to fail towards the path already known to work.
 
 Campaign traffic reaches campaign-service **through the gateway**, at `environment.LFX_V2_SERVICE`.
 There is deliberately no chart parameter for a campaign-service base URL. The application does read

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -195,6 +195,13 @@ operator setting `yes` and expecting it to be ignored would route production tra
 campaign-service. The default-deny half is the deliberate part — a typo like `flase` is invisible
 in a values.yaml diff, so an unrecognised value has to fail towards the path already known to work.
 
+The flag is necessary but not sufficient: a poll reaches campaign-service only when the job id is
+also a UUID, which is the shape campaign-service mints. Creation is not cut over yet and still
+mints `job_<epoch>_<rand>` ids in this application, so with the flag ON today every real poll
+still goes to the in-process job map. Do not read "flag on, no errors" as a verified cutover —
+until creation moves, no production request has taken the new path, and the first traffic to
+exercise it will arrive with that later change rather than with this switch.
+
 Campaign traffic reaches campaign-service **through the gateway**, at `environment.LFX_V2_SERVICE`.
 There is deliberately no chart parameter for a campaign-service base URL. The application does read
 `LFX_V2_CAMPAIGN_SERVICE` and falls back to `LFX_V2_SERVICE` when it is unset — the same shape as

--- a/charts/lfx-self-serve/templates/_helpers.tpl
+++ b/charts/lfx-self-serve/templates/_helpers.tpl
@@ -226,3 +226,46 @@ Args (dict):
 {{- fail (printf "ConfigMap name %q exceeds the 253-char DNS-1123 subdomain limit (release fullname + staticConfigMaps key %q is too long)" $cmName $name) -}}
 {{- end -}}
 {{- end }}
+
+{{/*
+Reject a per-service base URL that would route traffic around the gateway.
+
+`microservice-proxy.service.ts` resolves each of LFX_V2_CAMPAIGN_SERVICE,
+LFX_V2_MEMBER_SERVICE and LFX_V2_COMMITTEE_SERVICE to its own value when set
+and to LFX_V2_SERVICE otherwise. The fallback is what makes the gateway the
+default, and the gateway is where the authorization lives: Heimdall and
+OpenFGA enforce the per-project grant in front of these services, while a
+service's own token check authenticates the caller without authorizing them
+for the project they named. A base URL aimed straight at a service instance
+therefore lets any caller holding a valid token act on a project it has no
+grant for.
+
+Leaving the keys out of values.yaml was never enough on its own —
+deployment.yaml emits every entry in `.Values.environment`, so an override
+adds the variable without touching this chart. This is the render-time check
+that makes the omission binding, and failing here means the mistake surfaces
+in a diff-able `helm template` run rather than in a running pod.
+
+An empty value is allowed: `LFX_V2_MEMBER_SERVICE: {value: }` declares the key
+without setting it, which the container start-up treats as unset and which the
+application then resolves to LFX_V2_SERVICE — the intended routing.
+
+A deployment that genuinely needs a direct address (a mesh path that still
+enforces the grant, say) should change this list in a reviewed chart commit,
+which is the point: a values override is invisible to review, a chart change
+is not.
+
+Call once at the top of any template that renders .Values.environment:
+  {{- include "lfx-self-serve.environment.gatewayOnlyValidate" . }}
+*/}}
+{{- define "lfx-self-serve.environment.gatewayOnlyValidate" -}}
+{{- $env := .Values.environment | default dict -}}
+{{- range $name := (list "LFX_V2_CAMPAIGN_SERVICE" "LFX_V2_MEMBER_SERVICE" "LFX_V2_COMMITTEE_SERVICE") -}}
+{{- $cfg := index $env $name -}}
+{{- if kindIs "map" $cfg -}}
+{{- if or (and (hasKey $cfg "value") $cfg.value) (hasKey $cfg "valueFrom") -}}
+{{- fail (printf "environment.%s must not be set: it overrides the gateway base URL (LFX_V2_SERVICE), and the gateway is where Heimdall/OpenFGA enforce the per-project grant. Pointing the application at a service instance directly lets any caller with a valid token act on a project it has no grant for. Remove the override, or drop %s from the gateway-only list in templates/_helpers.tpl in a reviewed chart change." $name $name) -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+{{- end }}

--- a/charts/lfx-self-serve/templates/deployment.yaml
+++ b/charts/lfx-self-serve/templates/deployment.yaml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: MIT
 
 {{- include "lfx-self-serve.staticConfigMaps.rootValidate" . }}
+{{- include "lfx-self-serve.environment.gatewayOnlyValidate" . }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -348,12 +348,16 @@ environment:
   # make that a supported, documented deployment; not declaring it keeps the bypass out of the
   # chart's surface. It is not needed for the cutover flag below, which is a separate variable.
 
-  # Campaign-service cutover, one endpoint at a time (LFXV2-3070). Set to "true" to serve
+  # Campaign-service cutover, one endpoint at a time (LFXV2-3070). Serves
   # GET /api/campaigns/jobs/:jobId from lfx-v2-campaign-service instead of the in-process job
   # map, which only answers correctly when the poll lands on the pod that started the job.
-  # Anything other than an explicit affirmative — including empty, and including a typo —
-  # keeps the existing behaviour, so a rollback is this value alone: no code change, no build,
-  # no image promotion.
+  #
+  # ON for "true", "1", "yes" or "on", trimmed and case-insensitive. Everything else is OFF,
+  # including empty, "0", "false", and any misspelling — so a rollback is this value alone:
+  # no code change, no build, no image promotion. Note that "yes" and "on" DO enable it; this
+  # is not a `== "true"` comparison, and setting one of them expecting to be ignored would
+  # route production traffic. Default-deny is the deliberate half: `flase` is invisible in a
+  # values.yaml diff, so an unrecognised value fails towards the path known to work.
   #
   # It is NOT a live switch. This is a container environment variable, so changing it edits the
   # pod template and takes effect only as pods are replaced; with the default replica count and

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -348,7 +348,17 @@ environment:
   # GET /api/campaigns/jobs/:jobId from lfx-v2-campaign-service instead of the in-process job
   # map, which only answers correctly when the poll lands on the pod that started the job.
   # Anything other than an explicit affirmative — including empty, and including a typo —
-  # keeps the existing behaviour, so a rollback is this value alone.
+  # keeps the existing behaviour, so a rollback is this value alone: no code change, no build,
+  # no image promotion.
+  #
+  # It is NOT a live switch. This is a container environment variable, so changing it edits the
+  # pod template and takes effect only as pods are replaced; with the default replica count and
+  # a RollingUpdate, flag-on and flag-off pods serve side by side for the length of the rollout.
+  # That is safe for THIS flag because the source is chosen by the job id's shape as well as by
+  # the flag: a `job_...` id is answered from the in-process map on every pod, flag or no flag,
+  # and a UUID job id cannot exist until campaign creation is cut over too. Do not copy the
+  # "rollback is one value" line onto a future flag whose two paths could both claim the same
+  # request — that one needs a no-overlap rollout or a shared runtime configuration source.
   LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS:
     value:
 

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -344,9 +344,13 @@ environment:
   # `campaign_manager` on the project in front of campaign-service; the service's own token
   # check is an authentication check, not a project-scoped authorization one, so a base URL
   # pointing straight at a service instance would let any caller holding a valid token act on
-  # a project it has no grant for, by knowing a job id. Declaring the variable is what would
-  # make that a supported, documented deployment; not declaring it keeps the bypass out of the
-  # chart's surface. It is not needed for the cutover flag below, which is a separate variable.
+  # a project it has no grant for, by knowing a job id.
+  #
+  # Omitting them here is not the enforcement, though — `templates/deployment.yaml` emits every
+  # entry in this map, so an override adds the variable without touching the chart. All three
+  # are rejected at render time by `lfx-self-serve.environment.gatewayOnlyValidate`; a
+  # deployment that genuinely needs a direct address drops one from that list in a reviewed
+  # chart commit. None of this is needed for the cutover flag below, a separate variable.
 
   # Campaign-service cutover, one endpoint at a time (LFXV2-3070). Serves
   # GET /api/campaigns/jobs/:jobId from lfx-v2-campaign-service instead of the in-process job

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -337,12 +337,16 @@ environment:
   LFX_V2_SERVICE:
     value:
 
-  # Base URL for lfx-v2-campaign-service. Leave empty to reach it through the gateway at
-  # LFX_V2_SERVICE, which is the normal deployment; set it only to pin campaign traffic at a
-  # specific instance. Declared here so the value is settable — an unwired variable makes the
-  # cutover flag below unreachable in the cluster.
-  LFX_V2_CAMPAIGN_SERVICE:
-    value:
+  # `LFX_V2_CAMPAIGN_SERVICE` is deliberately NOT declared here, and neither are the sibling
+  # `LFX_V2_MEMBER_SERVICE` / `LFX_V2_COMMITTEE_SERVICE`. Each one falls back in code to
+  # `LFX_V2_SERVICE`, so leaving it unset routes campaign traffic through the gateway — and
+  # the gateway is where the authorization lives. Heimdall and OpenFGA enforce
+  # `campaign_manager` on the project in front of campaign-service; the service's own token
+  # check is an authentication check, not a project-scoped authorization one, so a base URL
+  # pointing straight at a service instance would let any caller holding a valid token act on
+  # a project it has no grant for, by knowing a job id. Declaring the variable is what would
+  # make that a supported, documented deployment; not declaring it keeps the bypass out of the
+  # chart's surface. It is not needed for the cutover flag below, which is a separate variable.
 
   # Campaign-service cutover, one endpoint at a time (LFXV2-3070). Set to "true" to serve
   # GET /api/campaigns/jobs/:jobId from lfx-v2-campaign-service instead of the in-process job

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -337,6 +337,21 @@ environment:
   LFX_V2_SERVICE:
     value:
 
+  # Base URL for lfx-v2-campaign-service. Leave empty to reach it through the gateway at
+  # LFX_V2_SERVICE, which is the normal deployment; set it only to pin campaign traffic at a
+  # specific instance. Declared here so the value is settable — an unwired variable makes the
+  # cutover flag below unreachable in the cluster.
+  LFX_V2_CAMPAIGN_SERVICE:
+    value:
+
+  # Campaign-service cutover, one endpoint at a time (LFXV2-3070). Set to "true" to serve
+  # GET /api/campaigns/jobs/:jobId from lfx-v2-campaign-service instead of the in-process job
+  # map, which only answers correctly when the poll lands on the pod that started the job.
+  # Anything other than an explicit affirmative — including empty, and including a typo —
+  # keeps the existing behaviour, so a rollback is this value alone.
+  LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS:
+    value:
+
   # Set to 'live' to proxy WG Weekly Brief endpoints to committee-service (LFXV2-2175/2176).
   # The BFF refuses to serve mock brief data when NODE_ENV=production and this
   # isn't 'live' — leaving it unset here would 500 on every weekly-brief request.

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -237,3 +237,13 @@ export const REDDIT_OBJECTIVE_LABELS: Readonly<Record<RedditObjective, string>> 
   conversions: 'Conversions',
   video_views: 'Video Views',
 } as const;
+
+/**
+ * Shown when a creation job can no longer be found on either polling source.
+ *
+ * Lives in shared constants rather than in `campaign-proxy.service.ts` because both tiers
+ * render it: the Express `not_found` outcome and the Angular poller's `not_found` arm. Keeping
+ * it beside the vendor-direct service would also point the campaign-service client at the very
+ * module the cutover exists to retire.
+ */
+export const JOB_LOST_MESSAGE = 'Lost connection to the campaign creation process. Please try again.';

--- a/packages/shared/src/interfaces/api.interface.ts
+++ b/packages/shared/src/interfaces/api.interface.ts
@@ -49,6 +49,8 @@ export interface MicroserviceUrls {
   LFX_V2_MEMBER_SERVICE: string;
   /** Committee-service base URL; defaults to LFX_V2_SERVICE. Override to route only `/committees/*` calls elsewhere (e.g. a locally-run committee-service). */
   LFX_V2_COMMITTEE_SERVICE: string;
+  /** Campaign-service base URL; defaults to LFX_V2_SERVICE. Override to route only the project-scoped briefs, campaigns and jobs calls elsewhere (e.g. a locally-run campaign-service). */
+  LFX_V2_CAMPAIGN_SERVICE: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -509,9 +509,14 @@ export interface CampaignPlatformResult {
  * What a finished creation job left behind, normalised across both sources.
  *
  * `campaigns` is populated by the vendor-direct path and `platformResults` by the
- * campaign-service path; exactly one of them is non-empty. Kept as one type so the caller has
- * a single "the job is over, here is what happened" value rather than a nullable
- * `CampaignCreateResponse` that reads as "nothing happened" on the campaign-service path.
+ * campaign-service path — never both. Neither is a guarantee of content: the vendor-direct path
+ * calls `completeJob` unconditionally (`campaign-proxy.service.ts`), so a run in which every
+ * platform failed finishes as `done` with an empty `campaigns` and a populated `errors`. Read
+ * `errors` and each result's own flag; do not treat "the job is over" as "a campaign exists".
+ *
+ * Kept as one type so the caller has a single "the job is over, here is what happened" value
+ * rather than a nullable `CampaignCreateResponse` that reads as "nothing happened" on the
+ * campaign-service path.
  */
 export interface CampaignJobOutcome {
   campaigns: CampaignCreateResult[];

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -485,9 +485,46 @@ export interface CampaignCreateResponse {
   errors: string[];
 }
 
+/**
+ * One platform's outcome as lfx-v2-campaign-service reports it.
+ *
+ * Deliberately NOT a `CampaignCreateResult`. That interface carries `type`, `campaignName`,
+ * `adGroupCount`, `keywordCount`, `adCount`, `campaignUrl` and `steps`, and campaign-service's
+ * `platform-result` carries none of them — it knows the platform, whether the create
+ * succeeded, the upstream campaign id, and the failure reason. Widening this into a
+ * `CampaignCreateResult` with zeros and empty strings would make the implementation tab
+ * render "0 ad groups · 0 keywords · 0 ads" and an empty link for a campaign that really has
+ * them, which reports a successful create as an empty one. A separate, smaller type keeps the
+ * absent fields absent, so nothing can render a number nobody measured.
+ */
+export interface CampaignPlatformResult {
+  platform: string;
+  ok: boolean;
+  /** Upstream platform campaign id. Present when ok, and also when the create succeeded but recording it did not — so the orphaned id is not lost. */
+  campaignId?: string;
+  error?: string;
+}
+
+/**
+ * What a finished creation job left behind, normalised across both sources.
+ *
+ * `campaigns` is populated by the vendor-direct path and `platformResults` by the
+ * campaign-service path; exactly one of them is non-empty. Kept as one type so the caller has
+ * a single "the job is over, here is what happened" value rather than a nullable
+ * `CampaignCreateResponse` that reads as "nothing happened" on the campaign-service path.
+ */
+export interface CampaignJobOutcome {
+  campaigns: CampaignCreateResult[];
+  errors: string[];
+  platformResults?: CampaignPlatformResult[];
+}
+
 export interface CampaignJobStatus {
   status: 'running' | 'done' | 'error' | 'not_found';
+  /** Populated by the in-process (vendor-direct) path only. */
   result?: CampaignCreateResponse;
+  /** Populated by the campaign-service path only. See `CampaignPlatformResult` for why the two differ. */
+  platformResults?: CampaignPlatformResult[];
   error?: string;
 }
 


### PR DESCRIPTION
## Summary

First increment of the lfx-one → lfx-v2-campaign-service cutover (epic LFXV2-2023). It lands the three pieces every later endpoint needs, and cuts over the simplest endpoint — job status.

Today `/foundation/campaigns` talks to no Go microservice: `campaign-proxy.service.ts` calls the vendor APIs directly with credentials held in the UI tier, and keeps creation jobs in an in-process `Map`. `campaign-proxy.service.ts:901` already logs the symptom as shipped — _"Job ${jobId} not found on this instance — likely routed to a different replica"_. With more than one replica, polling fails whenever the poll lands on a different pod than the create did. campaign-service persists jobs in Postgres, so proxying is what removes the class.

**This PR does not yet close that bug, and an earlier version of this description wrongly said it did.** Creation is still served by `campaign-proxy.service.ts`, which mints `job_<epoch>_<rand>` ids into the in-process map, and polls route on the id's SHAPE as well as on the flag — so with the flag on, every id that exists today still resolves against the map. That is deliberate: routing on the flag alone would send `job_…` ids at a service whose `get-job` declares `Format(FormatUUID)` and 400s them, breaking every poll the moment the flag flipped. It also makes flag-on and flag-off pods safe to serve side by side during a rolling update. What this PR delivers is the path, tested and reachable; the multi-replica fix arrives when campaign creation is cut over and job ids become UUIDs, at which point they take this path with no further flag.

## What's in it

1. **Proxy wiring** — `LFX_V2_CAMPAIGN_SERVICE` added to `MicroserviceUrls` and to `resolveBaseUrl`, falling back to `LFX_V2_SERVICE` exactly like the member and committee entries already do. It is deliberately NOT a chart parameter: authorization for campaign-service lives at the gateway (Heimdall/OpenFGA enforce `campaign_manager` on the project), and the service's own token check authenticates without authorizing, so a settable base URL aimed at an instance would be a project-scoped bypass. Member and committee are undeclared in the chart for the same reason.
2. **Project scoping by slug, with no resolution step** — campaign-service is `/projects/{projectId}/…` scoped throughout; the UI route is a fixed `foundation/campaigns` with no project param. The canonical slug `tlf` goes on the wire as-is. An earlier revision of this branch resolved that slug to a uid over NATS and memoised it, and an earlier version of this description still described that code after it was removed — there is no resolution, no cache, and no NATS call in this PR. The removal was the correction, not the omission: `create-brief` accepts a slug ONLY (`project_id` carries `Pattern(^[a-z0-9]+(-[a-z0-9]+)*$)`, which a UUID fails) and stores that exact string, and `GetJob` scopes with an exact `b.project_id = $2`. Polling under a resolved uid would look more canonical and would never find the job.
3. **Server-side feature flag** — none existed (`feature-flag.service.ts` is the OpenFeature *Web* SDK, returns Angular Signals, browser-only, so it cannot gate an Express handler). `server-feature-flag.helper.ts` is default-deny and reads env on every call. That per-call read buys nothing operationally — changing an in-cluster value still means replacing the pod, so rollback is a redeploy, not a live switch; it is done that way so the helper's own spec can vary the value across cases without module-registry surgery.
4. **Job status cut over** behind that flag. Flag off ⇒ the current in-memory path, verbatim.

The flag is wired into `charts/lfx-self-serve/values.yaml` (empty ⇒ off) and documented in the chart README, so it is actually flippable in-cluster rather than dead config. It is ON for `true`, `1`, `yes` or `on` (trimmed, case-insensitive) and OFF for everything else including any misspelling; the README lists all four rather than implying only `true` works.

## Why this is an adapter and not a pass-through

The ticket originally called job status "a clean 1:1 map". It isn't, and I've corrected the ticket. `adaptJobPollResponse` exists because a pass-through fails **silently** in three ways:

- **The status vocabulary differs.** The poller terminates on `takeWhile((s) => s.status === 'running', true)`. campaign-service emits `queued | running | succeeded | partial | failed`. Forwarded raw, `queued` — the state every job is in on its first tick — is not `'running'`, so the poll stops on the first response and the UI reports a finished create with no campaigns. Mirror image: `succeeded` is not `'running'` either, so it would never terminate the poll and the page would spin to the 300s cap on a job that finished immediately. An unrecognised status maps to `error`, not `done`: a contract change is not a terminal state, and `done` would claim campaigns exist that nobody verified.
- **The result shape differs.** campaign-service returns `{platform, ok, campaign_id, error}`; the vendor path returns `CampaignCreateResponse` with `adGroupCount`, `keywordCount`, `adCount`, `campaignUrl`. Widening one into the other would render "0 ad groups · 0 keywords · 0 ads" and an empty link for a campaign that really has them. New `CampaignPlatformResult` carries the reduced shape, with its own template block.
- **It exposes a pre-existing UI bug.** `getCreateResult` returned `status.result ?? null`; with `result` undefined on the new path that's null, the component's `if (result)` is false, `step` stays `'creating'`, and the completion handler reports "Campaign creation is taking longer than expected" for a job that had finished. Fixed with `CampaignJobOutcome`, which is always non-null on `done`.

`partial` maps to `done` deliberately: some platforms succeeded, and each platform's own `ok` flag carries the per-platform truth, so reporting the *job* as failed would hide campaigns that were really created.

## Deliberate choices worth a reviewer's eye

- **No silent fallback.** If the campaign-service call fails, the request errors rather than quietly falling back to the vendor path. A silent fallback is the worst outcome available here: the page keeps working, nobody investigates, and the cutover gets reported as verified while every request is still served by the code it was meant to replace. Recovery is turning the flag off.
- **404 is the ONE exception, and it is a translation rather than a fallback.** An unknown job becomes the `not_found` status the in-process path returns, because the poller has a dedicated arm for it. A flagged cutover whose two sides disagree on a reachable outcome is not a rollback switch; it is a second behaviour hidden behind an environment variable. Everything else — 401, 500, 503, a gateway timeout — is rethrown, because those mean the status is UNKNOWN, and reporting unknown as `not_found` would tell a user their campaign creation was lost when it may be running fine.
- **The wire type stays out of `@lfx-one/shared`.** `CampaignServiceJobPollResponse` is another service's shape; putting it in the shared package would invite a component to import it, and an upstream contract change would then reach the browser instead of stopping at the adapter.

## Testing

15 tests in `campaign-service.service.spec.ts`, all passing — including the 404 case, where campaign-service's response for an unknown job is translated to the same `not_found` status the in-process path returns, while a 401/500/503 still throws because those mean the status is unknown rather than lost. Each was verified by reverting its fix and confirming a meaningful failure — e.g. moving `case 'queued'` into the done arm gives `expected { status: 'done', …(2) } to deeply equal { status: 'running' }`; changing 503→404 gives `expected MicroserviceError … to match object { statusCode: 503 }`.

Full gate green: `yarn lint:check` (one pre-existing warning in an untouched file), `yarn test` (652 + 703), `yarn build`, `yarn format:check`, `helm lint`.

Browser verification on port 4200 got as far as the app building and serving and redirecting to Auth0; I did not drive the consent screen. The default path is flag-off and byte-identical to today.

## Not in this PR

Brief generate/refine/create (a model change, not a proxy change — needs the LiteLLM copy pipeline on main first), the monitor/accounts endpoints (shape change, needs the account-discovery PRs), and retiring the vendor-direct services and their env vars.

Ticket: [LFXV2-3070](https://linuxfoundation.atlassian.net/browse/LFXV2-3070)


[LFXV2-3070]: https://linuxfoundation.atlassian.net/browse/LFXV2-3070?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ


