### PR TITLE
feat(committee-activity): emit notes_added from meeting attachment category

### DIFF
--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -83,7 +83,7 @@ vi.mock('./microservice-proxy.service', () => ({
 }));
 
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
-import type { ActivityPageCursor, MeetingAttachment, PastMeeting, PastMeetingAttachment, Survey, Vote } from '@lfx-one/shared/interfaces';
+import type { ActivityPageCursor, CommitteeActivityNoteAttachment, PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { CommitteeActivityService } from './committee-activity.service';
@@ -129,7 +129,7 @@ function survey(overrides: Partial<Survey> = {}): Survey {
   } as Survey;
 }
 
-function meetingAttachment(overrides: Partial<MeetingAttachment> = {}): MeetingAttachment {
+function meetingAttachment(overrides: Partial<CommitteeActivityNoteAttachment> = {}): CommitteeActivityNoteAttachment {
   return {
     uid: 'ma-1',
     meeting_id: 'meeting-1',
@@ -137,21 +137,22 @@ function meetingAttachment(overrides: Partial<MeetingAttachment> = {}): MeetingA
     category: 'Notes',
     name: 'Meeting Notes.pdf',
     created_at: '2026-01-06T00:00:00Z',
+    modified_at: '2026-01-06T00:00:00Z',
     ...overrides,
-  } as MeetingAttachment;
+  };
 }
 
-function pastMeetingAttachment(overrides: Partial<PastMeetingAttachment> = {}): PastMeetingAttachment {
+function pastMeetingAttachment(overrides: Partial<CommitteeActivityNoteAttachment> = {}): CommitteeActivityNoteAttachment {
   return {
     uid: 'pma-1',
-    meeting_and_occurrence_id: 'pm-1-occ-1',
     meeting_id: 'meeting-1',
     type: 'file',
     category: 'Notes',
     name: 'Past Meeting Notes.pdf',
     created_at: '2026-01-07T00:00:00Z',
+    modified_at: '2026-01-07T00:00:00Z',
     ...overrides,
-  } as PastMeetingAttachment;
+  };
 }
 
 /** Default proxyRequest router: benign empty responses for every leg unless a test overrides it. */
@@ -886,7 +887,7 @@ describe('CommitteeActivityService', () => {
       expect(result.data).toHaveLength(1);
       expect(result.data[0]).toMatchObject({
         type: 'notes_added',
-        payload: { document_uid: 'ma-1', name: 'Meeting Notes.pdf', document_type: 'file', meeting_id: 'meeting-1', meeting_scope: 'upcoming' },
+        payload: { document_uid: 'ma-1', name: 'Meeting Notes.pdf', document_type: 'file', meeting_scope: 'upcoming' },
       });
     });
 
@@ -902,14 +903,37 @@ describe('CommitteeActivityService', () => {
       expect(result.data).toHaveLength(1);
       expect(result.data[0]).toMatchObject({
         type: 'notes_added',
-        payload: { document_uid: 'pma-1', name: 'Past Meeting Notes.pdf', document_type: 'file', meeting_id: 'meeting-1', meeting_scope: 'past' },
+        payload: { document_uid: 'pma-1', name: 'Past Meeting Notes.pdf', document_type: 'file', meeting_scope: 'past' },
       });
     });
 
-    it('drops a non-Notes-category attachment row even if the server-side filters param fails to narrow it', async () => {
-      // Validates the client-side re-filter decision: the upstream `filters: ['category:Notes']`
-      // param is a best-effort payload-size optimization, not something this leg's correctness
-      // depends on — this mock simulates the server-side filter not narrowing at all.
+    it('populates payload.url from a link-type attachment, but leaves it undefined for a file-type attachment even with a link field set', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: [
+              { type: 'v1_meeting_attachment', id: 'ma-link', data: meetingAttachment({ uid: 'ma-link', type: 'link', link: 'https://example.com/notes' }) },
+              // A file-type row with a stray `link` field set (shouldn't happen upstream, but this
+              // pins that buildNotesEvent gates on document_type, not just field presence).
+              { type: 'v1_meeting_attachment', id: 'ma-file', data: meetingAttachment({ uid: 'ma-file', type: 'file', link: 'https://example.com/stray' }) },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      const byUid = Object.fromEntries(
+        result.data.filter((e) => e.type === 'notes_added').map((e) => [e.type === 'notes_added' ? e.payload.document_uid : '', e])
+      );
+      expect(byUid['ma-link']).toMatchObject({ payload: { document_type: 'link', url: 'https://example.com/notes' } });
+      expect(byUid['ma-file']).toMatchObject({ payload: { document_type: 'file', url: undefined } });
+    });
+
+    it('drops a non-Notes-category attachment row — the client-side filter is the only correctness guarantee this leg has', async () => {
+      // No `filters`/`category` param is sent upstream at all (see fetchNotesAddedEvents's doc
+      // comment on why an upstream term filter risks silently zeroing the leg) — this test
+      // exercises the actual mechanism that keeps non-Notes rows out.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
           return Promise.resolve({
@@ -927,22 +951,29 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0]).toMatchObject({ payload: { document_uid: 'ma-1' } });
     });
 
-    it('queries both attachment types scoped by committee parent ref and the category filter', async () => {
+    it('queries both attachment types scoped by committee parent ref only — no upstream category filter or date narrowing', async () => {
       await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
         '/query/resources',
         'GET',
-        expect.objectContaining({ type: 'v1_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, filters: ['category:Notes'] })
+        expect.objectContaining({ type: 'v1_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, page_size: 25, sort: 'updated_desc' })
       );
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
         '/query/resources',
         'GET',
-        expect.objectContaining({ type: 'v1_past_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, filters: ['category:Notes'] })
+        expect.objectContaining({ type: 'v1_past_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, page_size: 25, sort: 'updated_desc' })
       );
+      const [meetingCall, pastMeetingCall] = proxyRequest.mock.calls.filter(
+        (call) => call[2] === '/query/resources' && (call[4]?.type === 'v1_meeting_attachment' || call[4]?.type === 'v1_past_meeting_attachment')
+      );
+      expect(meetingCall[4]).not.toHaveProperty('filters');
+      expect(meetingCall[4]).not.toHaveProperty('date_field');
+      expect(pastMeetingCall[4]).not.toHaveProperty('filters');
+      expect(pastMeetingCall[4]).not.toHaveProperty('date_field');
     });
 
     it('keeps upcoming-meeting and past-meeting notes as distinct events even when they share the same attachment uid', async () => {
@@ -954,14 +985,22 @@ describe('CommitteeActivityService', () => {
         if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
           return Promise.resolve({
             resources: [
-              { type: 'v1_meeting_attachment', id: 'shared-uid', data: meetingAttachment({ uid: 'shared-uid', created_at: '2026-01-05T00:00:00Z' }) },
+              {
+                type: 'v1_meeting_attachment',
+                id: 'shared-uid',
+                data: meetingAttachment({ uid: 'shared-uid', created_at: '2026-01-05T00:00:00Z', modified_at: '2026-01-05T00:00:00Z' }),
+              },
             ],
           });
         }
         if (path === '/query/resources' && query?.['type'] === 'v1_past_meeting_attachment') {
           return Promise.resolve({
             resources: [
-              { type: 'v1_past_meeting_attachment', id: 'shared-uid', data: pastMeetingAttachment({ uid: 'shared-uid', created_at: '2026-01-05T00:00:00Z' }) },
+              {
+                type: 'v1_past_meeting_attachment',
+                id: 'shared-uid',
+                data: pastMeetingAttachment({ uid: 'shared-uid', created_at: '2026-01-05T00:00:00Z', modified_at: '2026-01-05T00:00:00Z' }),
+              },
             ],
           });
         }
@@ -982,9 +1021,10 @@ describe('CommitteeActivityService', () => {
 
     it("sets hasMore when either notes sub-leg's upstream page_token signals more data", async () => {
       const fetchSize = 25;
-      const attachments = Array.from({ length: fetchSize }, (_, i) =>
-        meetingAttachment({ uid: `ma-${i}`, created_at: i === 0 ? '2026-02-01T00:00:00Z' : '2020-01-01T00:00:00Z' })
-      );
+      const attachments = Array.from({ length: fetchSize }, (_, i) => {
+        const timestamp = i === 0 ? '2026-02-01T00:00:00Z' : '2020-01-01T00:00:00Z';
+        return meetingAttachment({ uid: `ma-${i}`, created_at: timestamp, modified_at: timestamp });
+      });
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
           return Promise.resolve({
@@ -1031,7 +1071,13 @@ describe('CommitteeActivityService', () => {
         }
         if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
           return Promise.resolve({
-            resources: [{ type: 'v1_meeting_attachment', id: 'ma-1', data: meetingAttachment({ created_at: '2026-01-05T00:00:00Z' }) }],
+            resources: [
+              {
+                type: 'v1_meeting_attachment',
+                id: 'ma-1',
+                data: meetingAttachment({ created_at: '2026-01-05T00:00:00Z', modified_at: '2026-01-05T00:00:00Z' }),
+              },
+            ],
           });
         }
         return defaultProxyRequest(r, s, path, m, query);

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -83,7 +83,7 @@ vi.mock('./microservice-proxy.service', () => ({
 }));
 
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
-import type { ActivityPageCursor, PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
+import type { ActivityPageCursor, MeetingAttachment, PastMeeting, PastMeetingAttachment, Survey, Vote } from '@lfx-one/shared/interfaces';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { CommitteeActivityService } from './committee-activity.service';
@@ -129,12 +129,39 @@ function survey(overrides: Partial<Survey> = {}): Survey {
   } as Survey;
 }
 
+function meetingAttachment(overrides: Partial<MeetingAttachment> = {}): MeetingAttachment {
+  return {
+    uid: 'ma-1',
+    meeting_id: 'meeting-1',
+    type: 'file',
+    category: 'Notes',
+    name: 'Meeting Notes.pdf',
+    created_at: '2026-01-06T00:00:00Z',
+    ...overrides,
+  } as MeetingAttachment;
+}
+
+function pastMeetingAttachment(overrides: Partial<PastMeetingAttachment> = {}): PastMeetingAttachment {
+  return {
+    uid: 'pma-1',
+    meeting_and_occurrence_id: 'pm-1-occ-1',
+    meeting_id: 'meeting-1',
+    type: 'file',
+    category: 'Notes',
+    name: 'Past Meeting Notes.pdf',
+    created_at: '2026-01-07T00:00:00Z',
+    ...overrides,
+  } as PastMeetingAttachment;
+}
+
 /** Default proxyRequest router: benign empty responses for every leg unless a test overrides it. */
 function defaultProxyRequest(_req: Request, _service: string, path: string, _method: string, query?: Record<string, unknown>): unknown {
   if (path.endsWith('/folders')) return Promise.resolve([]);
   if (path.endsWith('/links')) return Promise.resolve([]);
   if (path === '/query/resources' && query?.['type'] === 'survey') return Promise.resolve({ resources: [] });
   if (path === '/query/resources' && query?.['type'] === 'committee_document') return Promise.resolve({ resources: [] });
+  if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') return Promise.resolve({ resources: [] });
+  if (path === '/query/resources' && query?.['type'] === 'v1_past_meeting_attachment') return Promise.resolve({ resources: [] });
   if (/^\/committees\/[^/]+$/.test(path)) return Promise.resolve({ uid: COMMITTEE_UID, enable_voting: true });
   throw new Error(`Unhandled proxyRequest call in test: ${path}`);
 }
@@ -843,6 +870,175 @@ describe('CommitteeActivityService', () => {
       await expect(service.getCommitteeActivity(req, uidNeedingEncoding, { limit: 8 })).rejects.toMatchObject({
         path: '/committees/committee%201',
       });
+    });
+  });
+
+  describe('notes_added leg', () => {
+    it('emits a notes_added event for a Notes-category v1_meeting_attachment row, scoped upcoming', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({ resources: [{ type: 'v1_meeting_attachment', id: 'ma-1', data: meetingAttachment() }] });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        type: 'notes_added',
+        payload: { document_uid: 'ma-1', name: 'Meeting Notes.pdf', document_type: 'file', meeting_id: 'meeting-1', meeting_scope: 'upcoming' },
+      });
+    });
+
+    it('emits a notes_added event for a Notes-category v1_past_meeting_attachment row, scoped past', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_past_meeting_attachment') {
+          return Promise.resolve({ resources: [{ type: 'v1_past_meeting_attachment', id: 'pma-1', data: pastMeetingAttachment() }] });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({
+        type: 'notes_added',
+        payload: { document_uid: 'pma-1', name: 'Past Meeting Notes.pdf', document_type: 'file', meeting_id: 'meeting-1', meeting_scope: 'past' },
+      });
+    });
+
+    it('drops a non-Notes-category attachment row even if the server-side filters param fails to narrow it', async () => {
+      // Validates the client-side re-filter decision: the upstream `filters: ['category:Notes']`
+      // param is a best-effort payload-size optimization, not something this leg's correctness
+      // depends on — this mock simulates the server-side filter not narrowing at all.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: [
+              { type: 'v1_meeting_attachment', id: 'ma-1', data: meetingAttachment({ category: 'Notes' }) },
+              { type: 'v1_meeting_attachment', id: 'ma-2', data: meetingAttachment({ uid: 'ma-2', category: 'Other' }) },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data.filter((e) => e.type === 'notes_added')).toHaveLength(1);
+      expect(result.data[0]).toMatchObject({ payload: { document_uid: 'ma-1' } });
+    });
+
+    it('queries both attachment types scoped by committee parent ref and the category filter', async () => {
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(proxyRequest).toHaveBeenCalledWith(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        expect.objectContaining({ type: 'v1_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, filters: ['category:Notes'] })
+      );
+      expect(proxyRequest).toHaveBeenCalledWith(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        expect.objectContaining({ type: 'v1_past_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, filters: ['category:Notes'] })
+      );
+    });
+
+    it('keeps upcoming-meeting and past-meeting notes as distinct events even when they share the same attachment uid', async () => {
+      // Regression for the meeting_scope-namespaced eventKey — v1_meeting_attachment and
+      // v1_past_meeting_attachment are two distinct upstream uid namespaces (same reasoning as
+      // document_uploaded's document_type discrimination). Paginating (not just an unpaginated
+      // merge) is what actually exercises the cursor-boundary collision risk.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: [
+              { type: 'v1_meeting_attachment', id: 'shared-uid', data: meetingAttachment({ uid: 'shared-uid', created_at: '2026-01-05T00:00:00Z' }) },
+            ],
+          });
+        }
+        if (path === '/query/resources' && query?.['type'] === 'v1_past_meeting_attachment') {
+          return Promise.resolve({
+            resources: [
+              { type: 'v1_past_meeting_attachment', id: 'shared-uid', data: pastMeetingAttachment({ uid: 'shared-uid', created_at: '2026-01-05T00:00:00Z' }) },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const page1 = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 1 });
+      expect(page1.data).toHaveLength(1);
+      expect(page1.page_token).toBeDefined();
+
+      const cursor = encodeActivityPageToken.mock.calls.at(-1)?.[0] as ActivityPageCursor;
+      const page2 = await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor, limit: 1 });
+
+      expect(page2.data).toHaveLength(1);
+      const scopes = [page1.data[0], page2.data[0]].map((e) => (e.type === 'notes_added' ? e.payload.meeting_scope : null)).sort();
+      expect(scopes).toEqual(['past', 'upcoming']);
+    });
+
+    it("sets hasMore when either notes sub-leg's upstream page_token signals more data", async () => {
+      const fetchSize = 25;
+      const attachments = Array.from({ length: fetchSize }, (_, i) =>
+        meetingAttachment({ uid: `ma-${i}`, created_at: i === 0 ? '2026-02-01T00:00:00Z' : '2020-01-01T00:00:00Z' })
+      );
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: attachments.map((a) => ({ type: 'v1_meeting_attachment', id: a.uid, data: a })),
+            page_token: 'more-notes-upstream',
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { since: '2026-01-01T00:00:00Z', limit: 1 });
+      expect(result.data).toHaveLength(1);
+      expect(result.page_token).toBeDefined();
+    });
+
+    it('degrades a failed notes sub-leg to empty without failing the whole feed', async () => {
+      getMeetings.mockResolvedValue({ data: [pastMeeting()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') return Promise.reject(new Error('upstream down'));
+        if (path === '/query/resources' && query?.['type'] === 'v1_past_meeting_attachment') {
+          return Promise.resolve({ resources: [{ type: 'v1_past_meeting_attachment', id: 'pma-1', data: pastMeetingAttachment() }] });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      const types = result.data.map((e) => e.type);
+      expect(types).toContain('meeting_held');
+      const notesEvent = result.data.find((e) => e.type === 'notes_added');
+      expect(notesEvent).toMatchObject({ payload: { meeting_scope: 'past' } });
+    });
+
+    it('merges all five sources including notes_added and sorts by occurred_at descending', async () => {
+      getMeetings.mockResolvedValue({ data: [pastMeeting({ start_time: '2026-01-01T00:00:00Z' })] });
+      getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ENDED, end_time: '2026-01-03T00:00:00Z' })] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'survey') {
+          return Promise.resolve({ resources: [{ type: 'survey', id: 'survey-1', data: survey({ last_modified_at: '2026-01-02T00:00:00Z' }) }] });
+        }
+        if (path === '/query/resources' && query?.['type'] === 'committee_document') {
+          return Promise.resolve({
+            resources: [{ type: 'committee_document', id: 'doc-1', data: { uid: 'doc-1', name: 'Charter.pdf', updated_at: '2026-01-04T00:00:00Z' } }],
+          });
+        }
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: [{ type: 'v1_meeting_attachment', id: 'ma-1', data: meetingAttachment({ created_at: '2026-01-05T00:00:00Z' }) }],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data.map((e) => e.type)).toEqual(['notes_added', 'document_uploaded', 'vote_closed', 'survey_published', 'meeting_held']);
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -1034,7 +1034,7 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0]).toMatchObject({ payload: { document_uid: 'ma-1' } });
     });
 
-    it('queries both attachment types scoped by committee parent ref and the category filter, with no upstream date narrowing', async () => {
+    it('queries both attachment types scoped by committee parent ref and the category filter, with no date narrowing when there is no cursor', async () => {
       await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
@@ -1067,6 +1067,20 @@ describe('CommitteeActivityService', () => {
       );
       expect(meetingCall[4]).not.toHaveProperty('date_field');
       expect(pastMeetingCall[4]).not.toHaveProperty('date_field');
+    });
+
+    it('sends date_to (never date_from) once a cursor is present — required for pagination to reach notes beyond the first page', async () => {
+      // Regression for the full-branch review finding: without date_to, every page after the
+      // first re-fetches the identical newest fetchSize rows and the in-memory cursor pass
+      // discards the ones already emitted, permanently hiding anything past page 1.
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { cursor: { before: '2026-01-05T00:00:00Z', key: 'note:upcoming:none' }, limit: 8 });
+      const [meetingCall, pastMeetingCall] = proxyRequest.mock.calls.filter(
+        (call) => call[2] === '/query/resources' && (call[4]?.type === 'v1_meeting_attachment' || call[4]?.type === 'v1_past_meeting_attachment')
+      );
+      expect(meetingCall[4]).toMatchObject({ date_field: 'modified_at', date_to: '2026-01-05T00:00:00.000Z' });
+      expect(pastMeetingCall[4]).toMatchObject({ date_field: 'modified_at', date_to: '2026-01-05T00:00:00.000Z' });
+      expect(meetingCall[4]).not.toHaveProperty('date_from');
+      expect(pastMeetingCall[4]).not.toHaveProperty('date_from');
     });
 
     it('keeps upcoming-meeting and past-meeting notes as distinct events even when they share the same attachment uid', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -971,7 +971,7 @@ describe('CommitteeActivityService', () => {
     });
 
     it('warns with a dropped_count when the client-side backstop excludes rows the upstream filter should have already excluded', async () => {
-      // Tripwire for the "upstream filters term clause might not narrow" bet — a non-narrowing
+      // Tripwire for the "upstream filters_all term clause might not narrow" bet — a non-narrowing
       // filter is otherwise invisible: the backstop silently absorbs it and the leg looks healthy.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -132,7 +132,6 @@ function survey(overrides: Partial<Survey> = {}): Survey {
 function meetingAttachment(overrides: Partial<CommitteeActivityNoteAttachment> = {}): CommitteeActivityNoteAttachment {
   return {
     uid: 'ma-1',
-    meeting_id: 'meeting-1',
     type: 'file',
     category: 'Notes',
     name: 'Meeting Notes.pdf',
@@ -145,7 +144,6 @@ function meetingAttachment(overrides: Partial<CommitteeActivityNoteAttachment> =
 function pastMeetingAttachment(overrides: Partial<CommitteeActivityNoteAttachment> = {}): CommitteeActivityNoteAttachment {
   return {
     uid: 'pma-1',
-    meeting_id: 'meeting-1',
     type: 'file',
     category: 'Notes',
     name: 'Past Meeting Notes.pdf',
@@ -930,10 +928,11 @@ describe('CommitteeActivityService', () => {
       expect(byUid['ma-file']).toMatchObject({ payload: { document_type: 'file', url: undefined } });
     });
 
-    it('drops a non-Notes-category attachment row — the client-side filter is the only correctness guarantee this leg has', async () => {
-      // No `filters`/`category` param is sent upstream at all (see fetchNotesAddedEvents's doc
-      // comment on why an upstream term filter risks silently zeroing the leg) — this test
-      // exercises the actual mechanism that keeps non-Notes rows out.
+    it('drops a non-Notes-category attachment row even if the upstream filters param fails to narrow it', async () => {
+      // The client-side filter is a backstop, not a substitute, for the upstream `filters:
+      // ['category:Notes']` param (see fetchNotesAddedEvents's doc comment on why both are sent) —
+      // this test simulates the upstream filter not narrowing at all and asserts the client-side
+      // pass still excludes the non-Notes row.
       proxyRequest.mockImplementation((r, s, path, m, query) => {
         if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
           return Promise.resolve({
@@ -951,28 +950,38 @@ describe('CommitteeActivityService', () => {
       expect(result.data[0]).toMatchObject({ payload: { document_uid: 'ma-1' } });
     });
 
-    it('queries both attachment types scoped by committee parent ref only — no upstream category filter or date narrowing', async () => {
+    it('queries both attachment types scoped by committee parent ref and the category filter, with no upstream date narrowing', async () => {
       await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
         '/query/resources',
         'GET',
-        expect.objectContaining({ type: 'v1_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, page_size: 25, sort: 'updated_desc' })
+        expect.objectContaining({
+          type: 'v1_meeting_attachment',
+          parent: `committee:${COMMITTEE_UID}`,
+          filters: ['category:Notes'],
+          page_size: 25,
+          sort: 'updated_desc',
+        })
       );
       expect(proxyRequest).toHaveBeenCalledWith(
         req,
         'LFX_V2_SERVICE',
         '/query/resources',
         'GET',
-        expect.objectContaining({ type: 'v1_past_meeting_attachment', parent: `committee:${COMMITTEE_UID}`, page_size: 25, sort: 'updated_desc' })
+        expect.objectContaining({
+          type: 'v1_past_meeting_attachment',
+          parent: `committee:${COMMITTEE_UID}`,
+          filters: ['category:Notes'],
+          page_size: 25,
+          sort: 'updated_desc',
+        })
       );
       const [meetingCall, pastMeetingCall] = proxyRequest.mock.calls.filter(
         (call) => call[2] === '/query/resources' && (call[4]?.type === 'v1_meeting_attachment' || call[4]?.type === 'v1_past_meeting_attachment')
       );
-      expect(meetingCall[4]).not.toHaveProperty('filters');
       expect(meetingCall[4]).not.toHaveProperty('date_field');
-      expect(pastMeetingCall[4]).not.toHaveProperty('filters');
       expect(pastMeetingCall[4]).not.toHaveProperty('date_field');
     });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -1150,6 +1150,39 @@ describe('CommitteeActivityService', () => {
       expect(notesEvent).toMatchObject({ payload: { meeting_scope: 'past' } });
     });
 
+    it('logs the upcoming-meeting sub-leg failure with meeting_scope: upcoming', async () => {
+      // Both sub-legs now share one warning message string (see fetchNoteAttachmentPage's own
+      // comment) — meeting_scope in the structured metadata is the only discriminator, mirroring
+      // how the survey/files legs' own failure tests pin their leg-identifying warning content.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') return Promise.reject(new Error('upstream down'));
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(warning).toHaveBeenCalledWith(
+        expect.anything(),
+        'get_committee_activity',
+        expect.stringContaining('Failed to fetch notes attachments'),
+        expect.objectContaining({ meeting_scope: 'upcoming' })
+      );
+    });
+
+    it('logs the past-meeting sub-leg failure with meeting_scope: past', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_past_meeting_attachment') return Promise.reject(new Error('upstream down'));
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(warning).toHaveBeenCalledWith(
+        expect.anything(),
+        'get_committee_activity',
+        expect.stringContaining('Failed to fetch notes attachments'),
+        expect.objectContaining({ meeting_scope: 'past' })
+      );
+    });
+
     it('merges all five sources including notes_added and sorts by occurred_at descending', async () => {
       getMeetings.mockResolvedValue({ data: [pastMeeting({ start_time: '2026-01-01T00:00:00Z' })] });
       getVotes.mockResolvedValue({ data: [vote({ status: PollStatus.ENDED, end_time: '2026-01-03T00:00:00Z' })] });

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -1013,7 +1013,7 @@ describe('CommitteeActivityService', () => {
     });
 
     it('drops a non-Notes-category attachment row even if the upstream filters param fails to narrow it', async () => {
-      // The client-side filter is a backstop, not a substitute, for the upstream `filters:
+      // The client-side filter is a backstop, not a substitute, for the upstream `filters_all:
       // ['category:Notes']` param (see fetchNotesAddedEvents's doc comment on why both are sent) —
       // this test simulates the upstream filter not narrowing at all and asserts the client-side
       // pass still excludes the non-Notes row.
@@ -1044,7 +1044,7 @@ describe('CommitteeActivityService', () => {
         expect.objectContaining({
           type: 'v1_meeting_attachment',
           parent: `committee:${COMMITTEE_UID}`,
-          filters: ['category:Notes'],
+          filters_all: ['category:Notes'],
           page_size: 25,
           sort: 'updated_desc',
         })
@@ -1057,7 +1057,7 @@ describe('CommitteeActivityService', () => {
         expect.objectContaining({
           type: 'v1_past_meeting_attachment',
           parent: `committee:${COMMITTEE_UID}`,
-          filters: ['category:Notes'],
+          filters_all: ['category:Notes'],
           page_size: 25,
           sort: 'updated_desc',
         })

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -928,6 +928,90 @@ describe('CommitteeActivityService', () => {
       expect(byUid['ma-file']).toMatchObject({ payload: { document_type: 'file', url: undefined } });
     });
 
+    it('stamps occurred_at from modified_at, not created_at, when both are present', async () => {
+      // Regression for the exact field-name bug fixed earlier on this branch (50bb78d4e) — pins
+      // that this leg reads modified_at first, not just that firstValidTimestamp itself works.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: [
+              {
+                type: 'v1_meeting_attachment',
+                id: 'ma-1',
+                data: meetingAttachment({ modified_at: '2026-02-01T00:00:00Z', created_at: '2026-01-01T00:00:00Z' }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0]).toMatchObject({ type: 'notes_added', occurred_at: '2026-02-01T00:00:00Z' });
+    });
+
+    it('falls back to created_at when modified_at is the Go zero-date sentinel', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: [
+              {
+                type: 'v1_meeting_attachment',
+                id: 'ma-1',
+                data: meetingAttachment({ modified_at: '0001-01-01T00:00:00Z', created_at: '2026-01-01T00:00:00Z' }),
+              },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(result.data[0]).toMatchObject({ type: 'notes_added', occurred_at: '2026-01-01T00:00:00Z' });
+    });
+
+    it('warns with a dropped_count when the client-side backstop excludes rows the upstream filter should have already excluded', async () => {
+      // Tripwire for the "upstream filters term clause might not narrow" bet — a non-narrowing
+      // filter is otherwise invisible: the backstop silently absorbs it and the leg looks healthy.
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({
+            resources: [
+              { type: 'v1_meeting_attachment', id: 'ma-1', data: meetingAttachment({ category: 'Notes' }) },
+              { type: 'v1_meeting_attachment', id: 'ma-2', data: meetingAttachment({ uid: 'ma-2', category: 'Other' }) },
+              { type: 'v1_meeting_attachment', id: 'ma-3', data: meetingAttachment({ uid: 'ma-3', category: 'Presentation' }) },
+            ],
+          });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(warning).toHaveBeenCalledWith(
+        expect.anything(),
+        'get_committee_activity',
+        expect.stringContaining('Notes category filter did not fully narrow upstream'),
+        expect.objectContaining({ meeting_scope: 'upcoming', dropped_count: 2 })
+      );
+    });
+
+    it('does not warn when every fetched row is already Notes-category — the upstream filter narrowed correctly', async () => {
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (path === '/query/resources' && query?.['type'] === 'v1_meeting_attachment') {
+          return Promise.resolve({ resources: [{ type: 'v1_meeting_attachment', id: 'ma-1', data: meetingAttachment({ category: 'Notes' }) }] });
+        }
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+      expect(warning).not.toHaveBeenCalledWith(
+        expect.anything(),
+        'get_committee_activity',
+        expect.stringContaining('Notes category filter did not fully narrow upstream'),
+        expect.anything()
+      );
+    });
+
     it('drops a non-Notes-category attachment row even if the upstream filters param fails to narrow it', async () => {
       // The client-side filter is a backstop, not a substitute, for the upstream `filters:
       // ['category:Notes']` param (see fetchNotesAddedEvents's doc comment on why both are sent) —

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -912,62 +912,74 @@ export class CommitteeActivityService {
     _before: string | undefined,
     fetchSize: number
   ): Promise<{ events: NotesAddedActivityEvent[]; saturated: boolean }> {
-    const buildQuery = (type: string): Record<string, unknown> => ({
-      type,
-      parent: `committee:${committeeUid}`,
-      filters: [`category:${NOTES_ATTACHMENT_CATEGORY}`],
-      page_size: fetchSize,
-      sort: 'updated_desc',
-    });
-
     const [meetingResult, pastMeetingResult] = await Promise.all([
-      this.microserviceProxy
-        .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(
-          req,
-          'LFX_V2_SERVICE',
-          '/query/resources',
-          'GET',
-          buildQuery('v1_meeting_attachment')
-        )
-        .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
-        .catch((err) => {
-          logger.warning(req, 'get_committee_activity', 'Failed to fetch upcoming-meeting notes attachments, continuing without them', {
-            committee_uid: committeeUid,
-            err,
-          });
-          return { attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };
-        }),
-      this.microserviceProxy
-        .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(
-          req,
-          'LFX_V2_SERVICE',
-          '/query/resources',
-          'GET',
-          buildQuery('v1_past_meeting_attachment')
-        )
-        .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
-        .catch((err) => {
-          logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting notes attachments, continuing without them', {
-            committee_uid: committeeUid,
-            err,
-          });
-          return { attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };
-        }),
+      this.fetchNoteAttachmentPage(req, committeeUid, 'v1_meeting_attachment', 'upcoming-meeting', fetchSize),
+      this.fetchNoteAttachmentPage(req, committeeUid, 'v1_past_meeting_attachment', 'past-meeting', fetchSize),
     ]);
 
     const events = [
-      ...meetingResult.attachments
-        .filter((attachment) => attachment.category === NOTES_ATTACHMENT_CATEGORY)
-        .map((attachment) => this.buildNotesEvent(committeeUid, attachment, 'upcoming')),
-      ...pastMeetingResult.attachments
-        .filter((attachment) => attachment.category === NOTES_ATTACHMENT_CATEGORY)
-        .map((attachment) => this.buildNotesEvent(committeeUid, attachment, 'past')),
+      ...this.buildNotesEventsForScope(req, committeeUid, meetingResult.attachments, 'upcoming'),
+      ...this.buildNotesEventsForScope(req, committeeUid, pastMeetingResult.attachments, 'past'),
     ];
 
     // Both sub-legs are bounded to one upstream page_size-limited page (unlike
     // fetchDocumentEvents, where only the files sub-leg is bounded and folders/links are
     // excluded from saturation) — so either one's own page_token signals more data upstream.
     return { events, saturated: !!meetingResult.pageToken || !!pastMeetingResult.pageToken };
+  }
+
+  /** One sub-leg's bounded query-service fetch, shared by both attachment types fetchNotesAddedEvents fans out to. */
+  private async fetchNoteAttachmentPage(
+    req: Request,
+    committeeUid: string,
+    type: string,
+    scopeLabel: string,
+    fetchSize: number
+  ): Promise<{ attachments: CommitteeActivityNoteAttachment[]; pageToken: string | undefined }> {
+    return this.microserviceProxy
+      .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        type,
+        parent: `committee:${committeeUid}`,
+        filters: [`category:${NOTES_ATTACHMENT_CATEGORY}`],
+        page_size: fetchSize,
+        sort: 'updated_desc',
+      })
+      .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
+      .catch((err) => {
+        logger.warning(req, 'get_committee_activity', `Failed to fetch ${scopeLabel} notes attachments, continuing without them`, {
+          committee_uid: committeeUid,
+          err,
+        });
+        return { attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };
+      });
+  }
+
+  /**
+   * Applies the client-side `category` backstop and warns if it ever drops a row — the tripwire
+   * for the doc comment's "the upstream `filters` term clause might not narrow" bet above.
+   * Without this, a non-narrowing upstream filter is invisible: the backstop silently absorbs
+   * every non-Notes row and the leg looks healthy while quietly under-serving every request
+   * (fetchSize filled with every category, only the newest handful surviving) — the exact
+   * "someone eventually notices" failure mode `notes_count: 0` catches for a *fully* failed
+   * filter, but with no equivalent signal for a *partially* failed one. Same pattern as
+   * fetchPastMeetingEvents's own scheduled_start_time tripwire.
+   */
+  private buildNotesEventsForScope(
+    req: Request,
+    committeeUid: string,
+    attachments: CommitteeActivityNoteAttachment[],
+    meetingScope: 'upcoming' | 'past'
+  ): NotesAddedActivityEvent[] {
+    const notes = attachments.filter((attachment) => attachment.category === NOTES_ATTACHMENT_CATEGORY);
+    const droppedCount = attachments.length - notes.length;
+    if (droppedCount > 0) {
+      logger.warning(req, 'get_committee_activity', 'Notes category filter did not fully narrow upstream — filters term clause may not be matching', {
+        committee_uid: committeeUid,
+        meeting_scope: meetingScope,
+        dropped_count: droppedCount,
+      });
+    }
+    return notes.map((attachment) => this.buildNotesEvent(committeeUid, attachment, meetingScope));
   }
 
   private buildNotesEvent(committeeUid: string, attachment: CommitteeActivityNoteAttachment, meetingScope: 'upcoming' | 'past'): NotesAddedActivityEvent {

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ACTIVITY_FEED_MAX_PAGE_SIZE, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
+import { ACTIVITY_FEED_MAX_PAGE_SIZE, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE, NOTES_ATTACHMENT_CATEGORY, PAST_MEETING_SORT } from '@lfx-one/shared/constants';
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
 // import type — erased entirely at compile time, so unlike the enums/utils imports below, this
 // one needs no vi.mock in the spec (same reasoning as activity-feed.utils.ts's own interfaces import).
@@ -862,20 +862,27 @@ export class CommitteeActivityService {
    * from v1_meeting_attachment/v1_past_meeting_attachment, two upstream resource types
    * fetchDocumentEvents never touches (LFXV2-3077, corrects LFXV2-2982's original framing).
    *
-   * `filters: ['category:Notes']` IS sent upstream, with the unconditional client-side
-   * `category === 'Notes'` filter below kept as a backstop, not a substitute — both found in
-   * review and confirmed against lfx-v2-meeting-service's/lfx-v2-query-service's contract docs:
-   *  - `filters` compiles to an OpenSearch `term` clause (exact match). If `data.category` isn't
-   *    mapped as an exact-match/keyword field, the term matches nothing and this leg returns zero
-   *    rows on every call — a `term` filter EXCLUDES non-matching rows, it can't be "best-effort".
-   *    Whether the mapping is exact-match is unverified, so this is a real risk, not a theoretical
-   *    one — but it's a strictly better risk than dropping the filter and fetching `fetchSize`
-   *    attachments of every category before filtering client-side: that guarantees a *silent*,
-   *    hard-to-detect dilution (a committee whose meetings carry non-Notes attachments too would
-   *    only ever surface notes from its most recent handful of meetings, with `saturated` firing
-   *    far more than the actual Notes volume warrants), whereas a mapping mismatch here is a
-   *    *visible*, all-or-nothing failure — `notes_count: 0` in this method's completion log across
-   *    every committee, trivially distinguishable from "this committee genuinely has no notes."
+   * `filters: [\`category:${NOTES_ATTACHMENT_CATEGORY}\`]` IS sent upstream, with the unconditional
+   * client-side `category === NOTES_ATTACHMENT_CATEGORY` filter below kept as a backstop, not a
+   * substitute — both found in review and confirmed against lfx-v2-meeting-service's/
+   * lfx-v2-indexer-service's/lfx-v2-query-service's contract docs:
+   *  - `filters` compiles to an OpenSearch `term` clause (exact match) on `data.category`.
+   *    lfx-v2-indexer-service's indexer-contract.md documents `data` as a schema-free
+   *    `flat_object` — every subfield is keyword-indexed with no analyzer, exactly what a `term`
+   *    clause needs, so this isn't the "might not be exact-match" risk it would be on an
+   *    arbitrarily-mapped field. This repo already ships an identical `term` filter on another
+   *    `data.*` subfield of this same resource type (`document.service.ts`'s
+   *    `filters_or: ['meeting_id:<id>']` on `v1_meeting_attachment`), confirming the pattern
+   *    works in production, not just in the contract doc. The one residual gap: the live index
+   *    mapping itself wasn't inspected, only the documented mapping *type* — if that ever proves
+   *    wrong, the failure mode is a *visible*, all-or-nothing one (`notes_count: 0` in
+   *    `getCommitteeActivity`'s completion log across every committee, trivially distinguishable
+   *    from "this committee genuinely has no notes"), which is why the filter is worth keeping
+   *    over the alternative: dropping it and fetching `fetchSize` attachments of every category
+   *    before filtering client-side guarantees a *silent*, hard-to-detect dilution instead (a
+   *    committee whose meetings carry non-Notes attachments too would only ever surface notes
+   *    from its most recent handful of meetings, with `saturated` firing far more than the actual
+   *    Notes volume warrants).
    *  - No `date_field`/`date_from`/`date_to` narrowing, unlike the files leg above. `modified_at`
    *    is never actually absent (`ModifiedAt time.Time` has no `omitempty`), but an attachment
    *    whose v1 source record had no parseable `updated_at` gets indexed with `modified_at` set to
@@ -902,7 +909,7 @@ export class CommitteeActivityService {
     const buildQuery = (type: string): Record<string, unknown> => ({
       type,
       parent: `committee:${committeeUid}`,
-      filters: ['category:Notes'],
+      filters: [`category:${NOTES_ATTACHMENT_CATEGORY}`],
       page_size: fetchSize,
       sort: 'updated_desc',
     });
@@ -944,10 +951,10 @@ export class CommitteeActivityService {
 
     const events = [
       ...meetingResult.attachments
-        .filter((attachment) => attachment.category === 'Notes')
+        .filter((attachment) => attachment.category === NOTES_ATTACHMENT_CATEGORY)
         .map((attachment) => this.buildNotesEvent(committeeUid, attachment, 'upcoming')),
       ...pastMeetingResult.attachments
-        .filter((attachment) => attachment.category === 'Notes')
+        .filter((attachment) => attachment.category === NOTES_ATTACHMENT_CATEGORY)
         .map((attachment) => this.buildNotesEvent(committeeUid, attachment, 'past')),
     ];
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -12,13 +12,12 @@ import type {
   CommitteeActivityDocumentFile,
   CommitteeActivityFolder,
   CommitteeActivityLink,
+  CommitteeActivityNoteAttachment,
   CommitteeActivityQuery,
   DocumentUploadedActivityEvent,
-  MeetingAttachment,
   NotesAddedActivityEvent,
   PaginatedResponse,
   PastMeeting,
-  PastMeetingAttachment,
   QueryServiceResponse,
   Survey,
   SurveyClosedActivityEvent,
@@ -172,10 +171,11 @@ function isAfterCursor(event: { occurred_at: string; key: string }, cursor: Acti
 
 /**
  * Aggregates a committee's activity across existing sources (past meetings, votes, surveys,
- * documents) into one time-ordered, cursor-paginated feed — LFXV2-1707 v1. No new upstream
- * service: each source is an existing committee-scoped read, fetched in parallel and merged
- * server-side. See `packages/shared/src/interfaces/activity-event.interface.ts` for which event
- * types this emits vs. defers pending a real event log.
+ * documents, notes-category meeting attachments) into one time-ordered, cursor-paginated feed —
+ * LFXV2-1707 v1 / LFXV2-3077. No new upstream service: each source is an existing
+ * committee-scoped read, fetched in parallel and merged server-side. See
+ * `packages/shared/src/interfaces/activity-event.interface.ts` for which event types this emits
+ * vs. defers pending a real event log.
  */
 export class CommitteeActivityService {
   private readonly microserviceProxy: MicroserviceProxyService;
@@ -284,7 +284,7 @@ export class CommitteeActivityService {
       // (committee-activity-query.helper.ts: a bad explicit cursor is a 400, not a silently-ignored
       // value). This method is public and reachable directly by a future non-HTTP caller that
       // skips that validation; degrading here would (a) diverge from the HTTP path's policy for the
-      // same bad input and (b) still do the full 7-call upstream fan-out below for a result that's
+      // same bad input and (b) still do the full 9-call upstream fan-out below for a result that's
       // provably empty anyway (isAfterCursor can't place any real event "after" an unparseable
       // cursor position), which is pure waste. Failing fast avoids both.
       throw ServiceValidationError.forField('cursor.before', 'cursor.before must be a valid ISO 8601 timestamp', {
@@ -323,7 +323,7 @@ export class CommitteeActivityService {
 
     // INFO, not DEBUG — matches DocumentService.getMyDocuments's "N-stage aggregation" logging
     // (the closest precedent in this repo: a comparable multi-source read aggregation), not the
-    // single-source enrichment services that stay at DEBUG throughout. A merge across 4
+    // single-source enrichment services that stay at DEBUG throughout. A merge across 5
     // independently-paginated upstream sources with cursor/saturation logic is exactly the
     // "complex multi-step orchestration" case logging-patterns.md reserves INFO for.
     logger.info(req, 'get_committee_activity', 'Starting committee activity aggregation', { committee_uid: committeeUid, fetch_size: fetchSize });
@@ -456,9 +456,9 @@ export class CommitteeActivityService {
   /**
    * Unlike every other leg, a failure here is NOT caught-and-degraded by the caller — it's allowed
    * to reject `getCommitteeActivity`'s `Promise.all` and propagate to the controller's `next(error)`.
-   * `GET /committees/:uid` is the one leg in this 7-call fan-out (committee + 4 `/query/resources`
-   * legs — meetings, votes, surveys, files — + committee-service's folders/links legs) whose
-   * committee-service FGA rejection is allowed to fail the whole request. The 4 `/query/resources`
+   * `GET /committees/:uid` is the one leg in this 9-call fan-out (committee + 6 `/query/resources`
+   * legs — meetings, votes, surveys, files, notes×2 — + committee-service's folders/links legs) whose
+   * committee-service FGA rejection is allowed to fail the whole request. The 6 `/query/resources`
    * legs filter per-resource and never 403 the whole request (see the controller's docblock); the
    * folders/links legs are also committee-service-FGA-backed but are deliberately caught-and-degraded
    * in fetchDocumentEvents rather than propagated, since a single missing/inaccessible committee's
@@ -856,46 +856,59 @@ export class CommitteeActivityService {
    * from v1_meeting_attachment/v1_past_meeting_attachment, two upstream resource types
    * fetchDocumentEvents never touches (LFXV2-3077, corrects LFXV2-2982's original framing).
    *
-   * filters: ['category:Notes'] is sent upstream (query-service's /query/resources accepts
-   * `filters` generically for any `type`, confirmed against lfx-v2-query-service's Goa design),
-   * but no existing caller of these two types in this repo has ever exercised that param on them
-   * — whether `category` is indexed as an exact-match field is unverified in practice. The
-   * unconditional client-side `category === 'Notes'` re-filter below (in the .map() call sites)
-   * is the actual correctness guarantee; the upstream filter is a best-effort payload-size
-   * optimization on top of it, not something this leg depends on for correctness.
+   * No upstream `filters`/`date_field` narrowing, unlike the files leg above — two reasons, both
+   * found in review and confirmed against lfx-v2-meeting-service's indexer-contract docs:
+   *  1. `filters: ['category:Notes']` compiles to an OpenSearch `term` clause (exact match). If
+   *     `data.category` isn't mapped as an exact-match/keyword field, that term matches nothing
+   *     and the leg silently returns zero rows on every call — a `term` filter EXCLUDES
+   *     non-matching rows, it can't be "best-effort"; whether the mapping is exact-match is
+   *     unverified. The unconditional client-side `category === 'Notes'` filter below is the only
+   *     correctness guarantee this leg has, so the upstream filter isn't sent at all.
+   *  2. A `date_field`/`date_from`/`date_to` window here would filter on `modified_at`, which is
+   *     optional and typically unset for an attachment that's been uploaded once and never
+   *     edited — the common case for notes, not a rare edge. That's the same systematic
+   *     exclusion `fetchSurveyEvents` above documents at length as its own reason for dropping
+   *     upstream date narrowing entirely; this leg follows that precedent instead of repeating
+   *     the files leg's date_field, which is safe there only because committee_document rows
+   *     reliably carry a real `updated_at`.
+   * `since`/`before` are still accepted (unused in the query itself) to keep this leg's call
+   * signature uniform with every other fetch* method — the in-memory since/cursor pass in
+   * getCommitteeActivity is what actually enforces the window for this leg, exactly as it already
+   * does for votes and surveys.
    */
   private async fetchNotesAddedEvents(
     req: Request,
     committeeUid: string,
-    since: string | undefined,
-    before: string | undefined,
+    _since: string | undefined,
+    _before: string | undefined,
     fetchSize: number
   ): Promise<{ events: NotesAddedActivityEvent[]; saturated: boolean }> {
-    const hasWindow = !!since || !!before;
     const buildQuery = (type: string): Record<string, unknown> => ({
       type,
       parent: `committee:${committeeUid}`,
-      filters: ['category:Notes'],
       page_size: fetchSize,
       sort: 'updated_desc',
-      ...(hasWindow && { date_field: 'updated_at' }),
-      ...(since && { date_from: since }),
-      ...(before && { date_to: before }),
     });
 
     const [meetingResult, pastMeetingResult] = await Promise.all([
       this.microserviceProxy
-        .proxyRequest<QueryServiceResponse<MeetingAttachment> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', buildQuery('v1_meeting_attachment'))
+        .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(
+          req,
+          'LFX_V2_SERVICE',
+          '/query/resources',
+          'GET',
+          buildQuery('v1_meeting_attachment')
+        )
         .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
         .catch((err) => {
           logger.warning(req, 'get_committee_activity', 'Failed to fetch upcoming-meeting notes attachments, continuing without them', {
             committee_uid: committeeUid,
             err,
           });
-          return { attachments: [] as MeetingAttachment[], pageToken: undefined as string | undefined };
+          return { attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };
         }),
       this.microserviceProxy
-        .proxyRequest<QueryServiceResponse<PastMeetingAttachment> | null>(
+        .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(
           req,
           'LFX_V2_SERVICE',
           '/query/resources',
@@ -908,7 +921,7 @@ export class CommitteeActivityService {
             committee_uid: committeeUid,
             err,
           });
-          return { attachments: [] as PastMeetingAttachment[], pageToken: undefined as string | undefined };
+          return { attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };
         }),
     ]);
 
@@ -927,21 +940,20 @@ export class CommitteeActivityService {
     return { events, saturated: !!meetingResult.pageToken || !!pastMeetingResult.pageToken };
   }
 
-  private buildNotesEvent(
-    committeeUid: string,
-    attachment: MeetingAttachment | PastMeetingAttachment,
-    meetingScope: 'upcoming' | 'past'
-  ): NotesAddedActivityEvent {
+  private buildNotesEvent(committeeUid: string, attachment: CommitteeActivityNoteAttachment, meetingScope: 'upcoming' | 'past'): NotesAddedActivityEvent {
     return {
       type: 'notes_added',
-      occurred_at: firstValidTimestamp(attachment.updated_at, attachment.created_at),
+      // modified_at, not updated_at — v1_meeting_attachment/v1_past_meeting_attachment's indexed
+      // data schema carries modified_at (lfx-v2-meeting-service's indexer-contract docs); the
+      // ITX-aligned MeetingAttachment/PastMeetingAttachment shape's updated_at field doesn't apply
+      // to this query-service-sourced projection (see CommitteeActivityNoteAttachment's doc comment).
+      occurred_at: firstValidTimestamp(attachment.modified_at, attachment.created_at),
       committee_uid: committeeUid,
       payload: {
         document_uid: attachment.uid,
         name: attachment.name,
         document_type: attachment.type,
         url: attachment.type === 'link' ? attachment.link : undefined,
-        meeting_id: attachment.meeting_id,
         meeting_scope: meetingScope,
       },
     };

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -239,11 +239,13 @@ export class CommitteeActivityService {
     // files' `data.updated_at` (each auto-prefixed with `data.` by query-service, unlike `sort`).
     // Files happens to share a field NAME with the sort target (`updated_at` == `updated_at`)
     // despite resolving to a different actual field once `data.` prefixing is applied; votes'
-    // date_field name doesn't even coincide with `updated_at`. Surveys and notes are the exception
-    // here: neither has an upstream date_field at all (see fetchSurveyEvents's and
-    // fetchNotesAddedEvents's own comments for why, two different reasons) — `sort: updated_desc`
-    // is the only upstream ordering either leg gets. Same class of approximation as the per-leg
-    // date_field (filter-dimension) caveats discussed next, just in the sort dimension instead.
+    // date_field name doesn't even coincide with `updated_at`. Surveys are the exception here: no
+    // upstream date_field at all (see fetchSurveyEvents's own comment for why) — `sort:
+    // updated_desc` is the only upstream ordering that leg gets. Notes sits in between: it gets a
+    // `date_field`, but only ever as a `date_to` upper bound (see fetchNotesAddedEvents's own
+    // comment for why `date_from` specifically is never sent). Same class of approximation as the
+    // per-leg date_field (filter-dimension) caveats discussed next, just in the sort dimension
+    // instead.
     //
     // Filter dimension: votes/files each filter on a single upstream `date_field` that only
     // approximates their own multi-field occurred_at derivation (see each leg's own comment for
@@ -252,17 +254,18 @@ export class CommitteeActivityService {
     // filter-mismatch miss for hard truncation at `fetchSize` on every page instead, a strictly worse
     // failure mode. The in-memory since/cursor pass in getCommitteeActivity is the correctness
     // backstop against over-inclusion for both legs, not under-inclusion — an imperfectly-narrowed
-    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys and
-    // notes are the exception where "sending none at all" IS the right call, not the failure mode
-    // this paragraph describes — for two different reasons. Surveys: unlike votes/files, a survey's
-    // cutoff-driven occurred_at isn't bounded below by any field the row gets written to, so
-    // date_field narrowing there would systematically (not rarely) exclude exactly the rows `since`
-    // is meant to include — see fetchSurveyEvents. Notes: an attachment whose v1 source record had
-    // no parseable `updated_at` gets indexed with `modified_at` set to the Go zero-date sentinel
-    // (`0001-01-01T00:00:00Z`, lfx-v2-meeting-service's `parseTime` swallows that error rather than
-    // omitting the field — `modified_at` is never actually absent), which an upstream date_field
-    // filter would exclude even though `firstValidTimestamp` correctly treats the sentinel as
-    // invalid and falls back to `created_at` for `occurred_at` — see fetchNotesAddedEvents.
+    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys are
+    // the exception where sending no `date_field` at all IS the right call, not the failure mode
+    // this paragraph describes: unlike votes/files, a survey's cutoff-driven occurred_at isn't
+    // bounded below by any field the row gets written to, so date_field narrowing there would
+    // systematically (not rarely) exclude exactly the rows `since` is meant to include — see
+    // fetchSurveyEvents. Notes has the same lower-bound risk (an attachment whose v1 source record
+    // had no parseable `updated_at` gets indexed with `modified_at` set to the Go zero-date
+    // sentinel, `0001-01-01T00:00:00Z` — lfx-v2-meeting-service's `parseTime` swallows that error
+    // rather than omitting the field, so `modified_at` is never actually absent, just sometimes
+    // wrong) but not the upper-bound one: a `date_to` on `modified_at` can only be over-inclusive
+    // for a sentinel row (year 1 is always `<=` any real cutoff), and over-inclusion is exactly what
+    // the in-memory pass already backstops — see fetchNotesAddedEvents for the full asymmetry.
     //
     // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files/notes
     // are each bounded to a single upstream page of `fetchSize` rows.
@@ -892,27 +895,29 @@ export class CommitteeActivityService {
    *    more than the actual Notes volume warrants, and nothing would ever log it. If the bet ever
    *    proves wrong, the durable fix is an upstream request to add `category` to the attachment tag
    *    sets, not reverting to the client-side-only approach.
-   *  - No `date_field`/`date_from`/`date_to` narrowing, unlike the files leg above. `modified_at`
-   *    is never actually absent (`ModifiedAt time.Time` has no `omitempty`), but an attachment
-   *    whose v1 source record had no parseable `updated_at` gets indexed with `modified_at` set to
-   *    Go's zero-date sentinel (`0001-01-01T00:00:00Z` — `parseTime`'s error is swallowed rather
-   *    than the field being omitted). An upstream date range filter on `modified_at` would exclude
-   *    those sentinel rows even though `firstValidTimestamp` below correctly treats the sentinel as
-   *    invalid and falls back to `created_at` for `occurred_at` — the two would silently diverge on
-   *    exactly those rows. Same class of problem `fetchSurveyEvents` documents at length for its
-   *    own, different reason; this leg follows that same "drop the narrowing" precedent rather than
-   *    repeating the files leg's `date_field`, which is safe there only because `committee_document`
-   *    rows reliably carry a real, non-sentinel `updated_at`.
-   * `since`/`before` are still accepted (unused in the query itself) to keep this leg's call
-   * signature uniform with every other fetch* method — the in-memory since/cursor pass in
-   * getCommitteeActivity is what actually enforces the window for this leg, exactly as it already
-   * does for votes and surveys.
+   *  - `date_to` only, never `date_from`, unlike the files leg above (which sends both). The
+   *    zero-date-sentinel risk (`modified_at` is never actually absent — `ModifiedAt time.Time`
+   *    has no `omitempty` — but an attachment whose v1 source record had no parseable `updated_at`
+   *    gets indexed with `modified_at` set to Go's zero-date sentinel, `0001-01-01T00:00:00Z`,
+   *    since `parseTime`'s error is swallowed rather than the field being omitted) only bites in
+   *    one direction: a `date_from` lower bound would exclude a sentinel row even though
+   *    `firstValidTimestamp` below correctly falls back to `created_at` for its real `occurred_at`
+   *    — silent under-inclusion, the same class of problem `fetchSurveyEvents` documents at length
+   *    for its own, different reason. A `date_to` upper bound has no equivalent failure: the Go
+   *    zero-date sentinel (year 1) is always `<=` any real cutoff, so a sentinel row always passes
+   *    `date_to` (over-inclusive, never excluded), and over-inclusion is exactly what the in-memory
+   *    since/cursor pass below already exists to trim — the same "wider upstream window is always
+   *    safe, narrower one isn't" principle `ceilToWholeSecond`'s own doc comment states. Sending
+   *    `date_to` (not just `sort`) is what lets pagination actually walk backwards through more
+   *    than one upstream page of notes per scope — without it, every page after the first
+   *    re-fetches the same newest `fetchSize` rows and the in-memory cursor pass discards the ones
+   *    already emitted, so anything past the first page is permanently unreachable.
    */
   private async fetchNotesAddedEvents(
     req: Request,
     committeeUid: string,
     _since: string | undefined,
-    _before: string | undefined,
+    before: string | undefined,
     fetchSize: number
   ): Promise<{ events: NotesAddedActivityEvent[]; saturated: boolean }> {
     // Type and scope are paired once here, and `scope` is carried all the way through
@@ -932,7 +937,7 @@ export class CommitteeActivityService {
       { type: 'v1_past_meeting_attachment', scope: 'past' },
     ] as const;
     const results = await Promise.all(
-      ATTACHMENT_SOURCES.map((source) => this.fetchNoteAttachmentPage(req, committeeUid, source.type, source.scope, fetchSize))
+      ATTACHMENT_SOURCES.map((source) => this.fetchNoteAttachmentPage(req, committeeUid, source.type, source.scope, fetchSize, before))
     );
 
     const events = results.flatMap((result) => this.buildNotesEventsForScope(req, committeeUid, result.attachments, result.scope));
@@ -949,7 +954,8 @@ export class CommitteeActivityService {
     committeeUid: string,
     type: 'v1_meeting_attachment' | 'v1_past_meeting_attachment',
     scope: 'upcoming' | 'past',
-    fetchSize: number
+    fetchSize: number,
+    before: string | undefined
   ): Promise<{ scope: 'upcoming' | 'past'; attachments: CommitteeActivityNoteAttachment[]; pageToken: string | undefined }> {
     return this.microserviceProxy
       .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
@@ -958,6 +964,9 @@ export class CommitteeActivityService {
         filters: [`category:${NOTES_ATTACHMENT_CATEGORY}`],
         page_size: fetchSize,
         sort: 'updated_desc',
+        // date_to only, never date_from — see fetchNotesAddedEvents's own doc comment for why the
+        // asymmetry is deliberate (the zero-date sentinel risk only bites a lower bound).
+        ...(before && { date_field: 'modified_at', date_to: before }),
       })
       .then((response) => ({ scope, attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
       .catch((err) => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -867,12 +867,17 @@ export class CommitteeActivityService {
    * substitute — both found in review and confirmed against lfx-v2-meeting-service's/
    * lfx-v2-indexer-service's/lfx-v2-query-service's contract docs:
    *  - `filters` compiles to an OpenSearch `term` clause (exact match) on `data.category`. It's
-   *    the ONLY in-contract way to filter on `category` server-side — the attachment types' Tags
-   *    tables (lfx-v2-meeting-service's indexer-contract.md) don't include it, so it can't be
-   *    filtered via `tags` instead. `data` is documented as a schema-free `flat_object`, and the
-   *    same contract explicitly declines to guarantee per-field analyzer behavior inside `data` —
-   *    a caution, not a green light — so this is a deliberate bet on a `term` clause being exact
-   *    for a field the indexer can't promise that for. It's a bet worth making anyway: this repo
+   *    the only way to narrow the OpenSearch query itself on `category` — the attachment types'
+   *    Tags tables (lfx-v2-meeting-service's indexer-contract.md) don't include it, so `tags`
+   *    can't filter on it; `cel_filter` can express `data.category == 'Notes'` too, but the
+   *    query-service contract documents it as applied in-process AFTER OpenSearch paginates, "not
+   *    a substitute for narrowing the OpenSearch query itself" — it would inherit the exact same
+   *    dilution problem this filter exists to avoid, just moved one step later. `data` is
+   *    documented (lfx-v2-indexer-service's indexer-contract.md) as a schema-free `flat_object`,
+   *    and that same doc explicitly declines to guarantee per-field analyzer behavior inside
+   *    `data` — a caution, not a green light — so sending `filters` here is a deliberate bet on a
+   *    `term` clause being exact for a field the indexer can't promise that for. It's a bet worth
+   *    making anyway: this repo
    *    already ships an identical `term` filter on another `data.*` subfield of this same resource
    *    type (`document.service.ts`'s `filters_or: ['meeting_id:<id>']` on `v1_meeting_attachment`),
    *    and the failure mode if the bet is wrong is a *visible*, all-or-nothing one (`notes_count: 0`

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -1033,6 +1033,10 @@ export class CommitteeActivityService {
       // data schema carries modified_at (lfx-v2-meeting-service's indexer-contract docs); the
       // ITX-aligned MeetingAttachment/PastMeetingAttachment shape's updated_at field doesn't apply
       // to this query-service-sourced projection (see CommitteeActivityNoteAttachment's doc comment).
+      // modified_at-first (not created_at-first) means editing/renaming an existing note bumps its
+      // sort position to the top of the feed, same as the files/folders/links legs above — this is
+      // why activity-feed.utils.ts's notes_added case renders "Note: X", not "Note added: X": the
+      // label can't claim a specific action this timestamp doesn't guarantee actually happened.
       occurred_at: firstValidTimestamp(attachment.modified_at, attachment.created_at),
       committee_uid: committeeUid,
       payload: {

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -898,11 +898,13 @@ export class CommitteeActivityService {
    *    making anyway: this repo
    *    already ships an identical `term` filter on another `data.*` subfield of this same resource
    *    type (`document.service.ts`'s `filters_or: ['meeting_id:<id>']` on `v1_meeting_attachment`),
-   *    and the failure mode if the bet is wrong is *visible*, not silent, at both ends of the
-   *    spectrum: a fully-failed filter shows up as `notes_count: 0` in `getCommitteeActivity`'s
-   *    completion log across every committee (trivially distinguishable from "this committee
-   *    genuinely has no notes"), and a partially-failed filter (matches, but doesn't narrow) shows
-   *    up as `buildNotesEventsForScope`'s own `dropped_count` warning below. Neither signal exists
+   *    and the failure mode if the bet is wrong is *observable*, not silent, at both ends of the
+   *    spectrum — though neither is a single-committee tripwire: a fully-failed filter shows up as
+   *    `notes_count: 0` in `getCommitteeActivity`'s completion log, but that line alone can't tell
+   *    a broken filter apart from a committee that genuinely has no notes; only a pattern of
+   *    `notes_count: 0` across every committee (not just this one) points at the filter itself.
+   *    A partially-failed filter (matches, but doesn't narrow) is the one with a real per-call
+   *    signal: `buildNotesEventsForScope`'s own `dropped_count` warning below. Neither signal exists
    *    for the alternative: dropping the filter and fetching `fetchSize` attachments of every
    *    category before filtering client-side trades both visible risks for one guaranteed, silent
    *    dilution instead — a committee whose meetings carry non-Notes attachments too would only

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -877,11 +877,14 @@ export class CommitteeActivityService {
    * from v1_meeting_attachment/v1_past_meeting_attachment, two upstream resource types
    * fetchDocumentEvents never touches (LFXV2-3077, corrects LFXV2-2982's original framing).
    *
-   * `filters: ['category:' + NOTES_ATTACHMENT_CATEGORY]` IS sent upstream, with the unconditional
-   * client-side `category === NOTES_ATTACHMENT_CATEGORY` filter below kept as a backstop, not a
-   * substitute — both found in review and confirmed against lfx-v2-meeting-service's/
-   * lfx-v2-indexer-service's/lfx-v2-query-service's contract docs:
-   *  - `filters` compiles to an OpenSearch `term` clause (exact match) on `data.category`. It's
+   * `filters_all: ['category:' + NOTES_ATTACHMENT_CATEGORY]` IS sent upstream, with the
+   * unconditional client-side `category === NOTES_ATTACHMENT_CATEGORY` filter below kept as a
+   * backstop, not a substitute — both found in review and confirmed against
+   * lfx-v2-meeting-service's/lfx-v2-indexer-service's/lfx-v2-query-service's contract docs.
+   * `filters_all`, not `filters` — the query-service contract marks `filters` legacy ("Prefer
+   * `filters_all` going forward"); semantically identical for a single-value AND filter, and this
+   * is the first new query written against this contract since that guidance shipped.
+   *  - `filters_all` compiles to an OpenSearch `term` clause (exact match) on `data.category`. It's
    *    the only way to narrow the OpenSearch query itself on `category` — the attachment types'
    *    Tags tables (lfx-v2-meeting-service's indexer-contract.md) don't include it, so `tags`
    *    can't filter on it; `cel_filter` can express `data.category == 'Notes'` too, but the
@@ -973,7 +976,7 @@ export class CommitteeActivityService {
       .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         type,
         parent: `committee:${committeeUid}`,
-        filters: [`category:${NOTES_ATTACHMENT_CATEGORY}`],
+        filters_all: [`category:${NOTES_ATTACHMENT_CATEGORY}`],
         page_size: fetchSize,
         sort: 'updated_desc',
         // date_to only, never date_from — see fetchNotesAddedEvents's own doc comment for why the

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -241,10 +241,11 @@ export class CommitteeActivityService {
     // despite resolving to a different actual field once `data.` prefixing is applied; votes'
     // date_field name doesn't even coincide with `updated_at`. Surveys are the exception here: no
     // upstream date_field at all (see fetchSurveyEvents's own comment for why) — `sort:
-    // updated_desc` is the only upstream ordering that leg gets. Notes sits in between: it gets a
-    // `date_field`, but only ever as a `date_to` upper bound (see fetchNotesAddedEvents's own
-    // comment for why `date_from` specifically is never sent). Same class of approximation as the
-    // per-leg date_field (filter-dimension) caveats discussed next, just in the sort dimension
+    // updated_desc` is the only upstream ordering that leg gets. Notes sits in between: no
+    // `date_field` at all on page 1 (like surveys, since `before` is only set from a cursor), and
+    // from page 2 on only a `date_to` upper bound, never `date_from` (see fetchNotesAddedEvents's
+    // own comment for why the asymmetry). Same class of approximation as the per-leg date_field
+    // (filter-dimension) caveats discussed next, just in the sort dimension
     // instead.
     //
     // Filter dimension: votes/files each filter on a single upstream `date_field` that only
@@ -254,18 +255,27 @@ export class CommitteeActivityService {
     // filter-mismatch miss for hard truncation at `fetchSize` on every page instead, a strictly worse
     // failure mode. The in-memory since/cursor pass in getCommitteeActivity is the correctness
     // backstop against over-inclusion for both legs, not under-inclusion — an imperfectly-narrowed
-    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys are
-    // the exception where sending no `date_field` at all IS the right call, not the failure mode
-    // this paragraph describes: unlike votes/files, a survey's cutoff-driven occurred_at isn't
-    // bounded below by any field the row gets written to, so date_field narrowing there would
-    // systematically (not rarely) exclude exactly the rows `since` is meant to include — see
-    // fetchSurveyEvents. Notes has the same lower-bound risk (an attachment whose v1 source record
-    // had no parseable `updated_at` gets indexed with `modified_at` set to the Go zero-date
-    // sentinel, `0001-01-01T00:00:00Z` — lfx-v2-meeting-service's `parseTime` swallows that error
-    // rather than omitting the field, so `modified_at` is never actually absent, just sometimes
-    // wrong) but not the upper-bound one: a `date_to` on `modified_at` can only be over-inclusive
-    // for a sentinel row (year 1 is always `<=` any real cutoff), and over-inclusion is exactly what
-    // the in-memory pass already backstops — see fetchNotesAddedEvents for the full asymmetry.
+    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys
+    // send no `date_field` at all for a `date_from` reason: unlike votes/files, a survey's
+    // cutoff-driven occurred_at isn't bounded below by any field the row gets written to, so
+    // date_field narrowing there would systematically (not rarely) exclude exactly the rows `since`
+    // is meant to include — see fetchSurveyEvents. That reasoning only covers `date_from`, though;
+    // sending no `date_field` at all also means no `date_to`, which surveys does not opt back into
+    // the way notes does below — a real, pre-existing pagination-reachability gap (any committee
+    // with more than `fetchSize` surveys has every survey past the newest ones permanently
+    // unreachable, the same failure class notes had before this leg sent `date_to`), predates
+    // LFXV2-3077, and is out of scope for this ticket to fix. Notes has the same lower-bound risk
+    // (an attachment whose v1 source record had no parseable `updated_at` gets indexed with
+    // `modified_at` set to the Go zero-date sentinel, `0001-01-01T00:00:00Z` — lfx-v2-meeting-service's
+    // `parseTime` swallows that error rather than omitting the field, so `modified_at` is never
+    // actually absent, just sometimes wrong) but not the upper-bound one: a `date_to` on
+    // `modified_at` can only be over-inclusive for a sentinel row (year 1 is always `<=` any real
+    // cutoff) — see fetchNotesAddedEvents for the full asymmetry. Over-inclusion is a correctness
+    // no-op (the in-memory pass still trims it before anything is emitted), but not a reachability
+    // no-op: a sentinel row still consumes one of the leg's `fetchSize` upstream slots on every
+    // page (sort:updated_desc resolves to the index's own recently-written `updated_at`, so a
+    // sentinel row sorts near the top despite its `data.modified_at` passing every date_to), which
+    // is the same "bounded to a single upstream page" limitation documented next, not a new one.
     //
     // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files/notes
     // are each bounded to a single upstream page of `fetchSize` rows.
@@ -281,8 +291,10 @@ export class CommitteeActivityService {
     // paginable at the source.
 
     const fetchSize = Math.max(limit + 1, ACTIVITY_FEED_MIN_SOURCE_FETCH_SIZE);
-    // Sent to every leg as an inclusive upstream `date_to` (query-service's date_to is documented
-    // inclusive), ceiled to the next whole second — see ceilToWholeSecond's doc comment for why:
+    // Sent as an inclusive upstream `date_to` to every leg that does upstream date filtering at all
+    // (meetings/past-meetings/votes/files/notes — surveys opts out entirely, folders/links have no
+    // upstream date param to send it to; see each leg's own comment), ceiled to the next whole
+    // second — see ceilToWholeSecond's doc comment for why:
     // upstream truncates sub-second precision, so the raw cursor.before could otherwise shrink the
     // boundary below the true cursor position. The in-memory isAfterCursor pass (which uses the
     // exact, un-ceiled cursor.before) is what actually enforces the boundary; the ceiled value here

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -862,27 +862,28 @@ export class CommitteeActivityService {
    * from v1_meeting_attachment/v1_past_meeting_attachment, two upstream resource types
    * fetchDocumentEvents never touches (LFXV2-3077, corrects LFXV2-2982's original framing).
    *
-   * `filters: [\`category:${NOTES_ATTACHMENT_CATEGORY}\`]` IS sent upstream, with the unconditional
+   * `filters: ['category:' + NOTES_ATTACHMENT_CATEGORY]` IS sent upstream, with the unconditional
    * client-side `category === NOTES_ATTACHMENT_CATEGORY` filter below kept as a backstop, not a
    * substitute — both found in review and confirmed against lfx-v2-meeting-service's/
    * lfx-v2-indexer-service's/lfx-v2-query-service's contract docs:
-   *  - `filters` compiles to an OpenSearch `term` clause (exact match) on `data.category`.
-   *    lfx-v2-indexer-service's indexer-contract.md documents `data` as a schema-free
-   *    `flat_object` — every subfield is keyword-indexed with no analyzer, exactly what a `term`
-   *    clause needs, so this isn't the "might not be exact-match" risk it would be on an
-   *    arbitrarily-mapped field. This repo already ships an identical `term` filter on another
-   *    `data.*` subfield of this same resource type (`document.service.ts`'s
-   *    `filters_or: ['meeting_id:<id>']` on `v1_meeting_attachment`), confirming the pattern
-   *    works in production, not just in the contract doc. The one residual gap: the live index
-   *    mapping itself wasn't inspected, only the documented mapping *type* — if that ever proves
-   *    wrong, the failure mode is a *visible*, all-or-nothing one (`notes_count: 0` in
-   *    `getCommitteeActivity`'s completion log across every committee, trivially distinguishable
-   *    from "this committee genuinely has no notes"), which is why the filter is worth keeping
-   *    over the alternative: dropping it and fetching `fetchSize` attachments of every category
-   *    before filtering client-side guarantees a *silent*, hard-to-detect dilution instead (a
-   *    committee whose meetings carry non-Notes attachments too would only ever surface notes
-   *    from its most recent handful of meetings, with `saturated` firing far more than the actual
-   *    Notes volume warrants).
+   *  - `filters` compiles to an OpenSearch `term` clause (exact match) on `data.category`. It's
+   *    the ONLY in-contract way to filter on `category` server-side — the attachment types' Tags
+   *    tables (lfx-v2-meeting-service's indexer-contract.md) don't include it, so it can't be
+   *    filtered via `tags` instead. `data` is documented as a schema-free `flat_object`, and the
+   *    same contract explicitly declines to guarantee per-field analyzer behavior inside `data` —
+   *    a caution, not a green light — so this is a deliberate bet on a `term` clause being exact
+   *    for a field the indexer can't promise that for. It's a bet worth making anyway: this repo
+   *    already ships an identical `term` filter on another `data.*` subfield of this same resource
+   *    type (`document.service.ts`'s `filters_or: ['meeting_id:<id>']` on `v1_meeting_attachment`),
+   *    and the failure mode if the bet is wrong is a *visible*, all-or-nothing one (`notes_count: 0`
+   *    in `getCommitteeActivity`'s completion log across every committee, trivially distinguishable
+   *    from "this committee genuinely has no notes") — not a silent one. The alternative (dropping
+   *    the filter and fetching `fetchSize` attachments of every category before filtering
+   *    client-side) trades that visible risk for a guaranteed, silent dilution instead: a committee
+   *    whose meetings carry non-Notes attachments too would only ever surface notes from its most
+   *    recent handful of meetings, with `saturated` firing far more than the actual Notes volume
+   *    warrants. If the bet ever proves wrong, the durable fix is an upstream request to add
+   *    `category` to the attachment tag sets, not reverting to the client-side-only approach.
    *  - No `date_field`/`date_from`/`date_to` narrowing, unlike the files leg above. `modified_at`
    *    is never actually absent (`ModifiedAt time.Time` has no `omitempty`), but an attachment
    *    whose v1 source record had no parseable `updated_at` gets indexed with `modified_at` set to

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -14,8 +14,11 @@ import type {
   CommitteeActivityLink,
   CommitteeActivityQuery,
   DocumentUploadedActivityEvent,
+  MeetingAttachment,
+  NotesAddedActivityEvent,
   PaginatedResponse,
   PastMeeting,
+  PastMeetingAttachment,
   QueryServiceResponse,
   Survey,
   SurveyClosedActivityEvent,
@@ -63,6 +66,8 @@ function eventKey(event: ActivityEvent): string {
       return `survey:${event.payload.survey_uid}`;
     case 'document_uploaded':
       return `document:${event.payload.document_type}:${event.payload.document_uid}`;
+    case 'notes_added':
+      return `note:${event.payload.meeting_scope}:${event.payload.document_uid}`;
     default:
       // Deferred types are never constructed in v1 (see activity-event.interface.ts) — occurred_at
       // is the least-bad fallback key if one ever were.
@@ -323,7 +328,7 @@ export class CommitteeActivityService {
     // "complex multi-step orchestration" case logging-patterns.md reserves INFO for.
     logger.info(req, 'get_committee_activity', 'Starting committee activity aggregation', { committee_uid: committeeUid, fetch_size: fetchSize });
 
-    const [committee, pastMeetingResult, voteResult, surveyResult, documentResult] = await Promise.all([
+    const [committee, pastMeetingResult, voteResult, surveyResult, documentResult, notesResult] = await Promise.all([
       this.fetchCommittee(req, committeeUid),
       this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
@@ -341,12 +346,22 @@ export class CommitteeActivityService {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch document activity, continuing without it', { committee_uid: committeeUid, err });
         return { events: [], saturated: false };
       }),
+      this.fetchNotesAddedEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch notes activity, continuing without it', { committee_uid: committeeUid, err });
+        return { events: [], saturated: false };
+      }),
     ]);
 
     // A committee-lookup failure already rejected the whole Promise.all above (see fetchCommittee's
     // doc comment) — by this line `committee` is always a resolved Committee.
     const votingEnabled = committee.enable_voting;
-    const sources: ActivityEvent[][] = [pastMeetingResult.events, votingEnabled ? voteResult.events : [], surveyResult.events, documentResult.events];
+    const sources: ActivityEvent[][] = [
+      pastMeetingResult.events,
+      votingEnabled ? voteResult.events : [],
+      surveyResult.events,
+      documentResult.events,
+      notesResult.events,
+    ];
 
     // Single pass: attach each event's sort key once, apply since/cursor, sort desc by
     // (occurred_at, key). No per-source pre-cap — a global sort+slice already picks the true top
@@ -384,7 +399,8 @@ export class CommitteeActivityService {
     // bound at all (fetched in full every call) and are already filtered+bounded correctly against
     // the exact cursor inside fetchDocumentEvents, so a fetched length at `fetchSize` there reflects
     // this leg's own internal cap, not an upstream truncation signal.
-    const anyLegSaturated = pastMeetingResult.saturated || (votingEnabled && voteResult.saturated) || surveyResult.saturated || documentResult.saturated;
+    const anyLegSaturated =
+      pastMeetingResult.saturated || (votingEnabled && voteResult.saturated) || surveyResult.saturated || documentResult.saturated || notesResult.saturated;
 
     const page = windowed.slice(0, limit);
     const data = page.map(({ event }) => event);
@@ -421,6 +437,7 @@ export class CommitteeActivityService {
       vote_count: voteResult.events.length,
       survey_count: surveyResult.events.length,
       document_count: documentResult.events.length,
+      notes_count: notesResult.events.length,
       voting_enabled: votingEnabled,
       returned: data.length,
       has_more: hasMore,
@@ -828,6 +845,105 @@ export class CommitteeActivityService {
       occurred_at: occurredAt,
       committee_uid: committeeUid,
       payload: { document_uid: documentUid, name, document_type: documentType, url },
+    };
+  }
+
+  // ─── Notes → notes_added ────────────────────────────────────────────────────
+
+  /**
+   * A new aggregation leg, NOT a filter on fetchDocumentEvents above — folders/links/
+   * committee_document files carry no `category` field, so a Notes-category row can only come
+   * from v1_meeting_attachment/v1_past_meeting_attachment, two upstream resource types
+   * fetchDocumentEvents never touches (LFXV2-3077, corrects LFXV2-2982's original framing).
+   *
+   * filters: ['category:Notes'] is sent upstream (query-service's /query/resources accepts
+   * `filters` generically for any `type`, confirmed against lfx-v2-query-service's Goa design),
+   * but no existing caller of these two types in this repo has ever exercised that param on them
+   * — whether `category` is indexed as an exact-match field is unverified in practice. The
+   * unconditional client-side `category === 'Notes'` re-filter below (in the .map() call sites)
+   * is the actual correctness guarantee; the upstream filter is a best-effort payload-size
+   * optimization on top of it, not something this leg depends on for correctness.
+   */
+  private async fetchNotesAddedEvents(
+    req: Request,
+    committeeUid: string,
+    since: string | undefined,
+    before: string | undefined,
+    fetchSize: number
+  ): Promise<{ events: NotesAddedActivityEvent[]; saturated: boolean }> {
+    const hasWindow = !!since || !!before;
+    const buildQuery = (type: string): Record<string, unknown> => ({
+      type,
+      parent: `committee:${committeeUid}`,
+      filters: ['category:Notes'],
+      page_size: fetchSize,
+      sort: 'updated_desc',
+      ...(hasWindow && { date_field: 'updated_at' }),
+      ...(since && { date_from: since }),
+      ...(before && { date_to: before }),
+    });
+
+    const [meetingResult, pastMeetingResult] = await Promise.all([
+      this.microserviceProxy
+        .proxyRequest<QueryServiceResponse<MeetingAttachment> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', buildQuery('v1_meeting_attachment'))
+        .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
+        .catch((err) => {
+          logger.warning(req, 'get_committee_activity', 'Failed to fetch upcoming-meeting notes attachments, continuing without them', {
+            committee_uid: committeeUid,
+            err,
+          });
+          return { attachments: [] as MeetingAttachment[], pageToken: undefined as string | undefined };
+        }),
+      this.microserviceProxy
+        .proxyRequest<QueryServiceResponse<PastMeetingAttachment> | null>(
+          req,
+          'LFX_V2_SERVICE',
+          '/query/resources',
+          'GET',
+          buildQuery('v1_past_meeting_attachment')
+        )
+        .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
+        .catch((err) => {
+          logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting notes attachments, continuing without them', {
+            committee_uid: committeeUid,
+            err,
+          });
+          return { attachments: [] as PastMeetingAttachment[], pageToken: undefined as string | undefined };
+        }),
+    ]);
+
+    const events = [
+      ...meetingResult.attachments
+        .filter((attachment) => attachment.category === 'Notes')
+        .map((attachment) => this.buildNotesEvent(committeeUid, attachment, 'upcoming')),
+      ...pastMeetingResult.attachments
+        .filter((attachment) => attachment.category === 'Notes')
+        .map((attachment) => this.buildNotesEvent(committeeUid, attachment, 'past')),
+    ];
+
+    // Both sub-legs are bounded to one upstream page_size-limited page (unlike
+    // fetchDocumentEvents, where only the files sub-leg is bounded and folders/links are
+    // excluded from saturation) — so either one's own page_token signals more data upstream.
+    return { events, saturated: !!meetingResult.pageToken || !!pastMeetingResult.pageToken };
+  }
+
+  private buildNotesEvent(
+    committeeUid: string,
+    attachment: MeetingAttachment | PastMeetingAttachment,
+    meetingScope: 'upcoming' | 'past'
+  ): NotesAddedActivityEvent {
+    return {
+      type: 'notes_added',
+      occurred_at: firstValidTimestamp(attachment.updated_at, attachment.created_at),
+      committee_uid: committeeUid,
+      payload: {
+        document_uid: attachment.uid,
+        name: attachment.name,
+        document_type: attachment.type,
+        url: attachment.type === 'link' ? attachment.link : undefined,
+        meeting_id: attachment.meeting_id,
+        meeting_scope: meetingScope,
+      },
     };
   }
 }

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -915,37 +915,39 @@ export class CommitteeActivityService {
     _before: string | undefined,
     fetchSize: number
   ): Promise<{ events: NotesAddedActivityEvent[]; saturated: boolean }> {
-    // Type and scope are paired here, not passed as two separate positional args at each call
-    // site — both fetchNoteAttachmentPage and buildNotesEventsForScope key their logging off
-    // `scope`, so a transposed pair (past type, upcoming scope) would previously compile and only
-    // show up as a wrong log line; pairing them removes that failure mode entirely.
-    const ATTACHMENT_SOURCES: { type: string; scope: 'upcoming' | 'past' }[] = [
+    // Type and scope are paired once here, and `scope` is carried all the way through
+    // fetchNoteAttachmentPage's own return value rather than re-stated positionally at each
+    // downstream call site — a transposed pair at the source list, or a re-stated literal below,
+    // would both compile silently otherwise. `scope` isn't just a log-correlation field once it
+    // reaches buildNotesEventsForScope: buildNotesEvent writes it into the user-visible
+    // `payload.meeting_scope`, which activity-feed.utils.ts uses to namespace the feed item's
+    // @for tracking key — a swapped scope there is payload-corrupting, not just a wrong log line.
+    // `as const` pins this to exactly a 2-tuple so `results` below can't silently grow a third,
+    // unhandled source if one is ever added without also updating the code that consumes it.
+    const ATTACHMENT_SOURCES = [
       { type: 'v1_meeting_attachment', scope: 'upcoming' },
       { type: 'v1_past_meeting_attachment', scope: 'past' },
-    ];
-    const [meetingResult, pastMeetingResult] = await Promise.all(
+    ] as const;
+    const results = await Promise.all(
       ATTACHMENT_SOURCES.map((source) => this.fetchNoteAttachmentPage(req, committeeUid, source.type, source.scope, fetchSize))
     );
 
-    const events = [
-      ...this.buildNotesEventsForScope(req, committeeUid, meetingResult.attachments, 'upcoming'),
-      ...this.buildNotesEventsForScope(req, committeeUid, pastMeetingResult.attachments, 'past'),
-    ];
+    const events = results.flatMap((result) => this.buildNotesEventsForScope(req, committeeUid, result.attachments, result.scope));
 
     // Both sub-legs are bounded to one upstream page_size-limited page (unlike
     // fetchDocumentEvents, where only the files sub-leg is bounded and folders/links are
     // excluded from saturation) — so either one's own page_token signals more data upstream.
-    return { events, saturated: !!meetingResult.pageToken || !!pastMeetingResult.pageToken };
+    return { events, saturated: results.some((result) => !!result.pageToken) };
   }
 
   /** One sub-leg's bounded query-service fetch, shared by both attachment types fetchNotesAddedEvents fans out to. */
   private async fetchNoteAttachmentPage(
     req: Request,
     committeeUid: string,
-    type: string,
+    type: 'v1_meeting_attachment' | 'v1_past_meeting_attachment',
     scope: 'upcoming' | 'past',
     fetchSize: number
-  ): Promise<{ attachments: CommitteeActivityNoteAttachment[]; pageToken: string | undefined }> {
+  ): Promise<{ scope: 'upcoming' | 'past'; attachments: CommitteeActivityNoteAttachment[]; pageToken: string | undefined }> {
     return this.microserviceProxy
       .proxyRequest<QueryServiceResponse<CommitteeActivityNoteAttachment> | null>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
         type,
@@ -954,7 +956,7 @@ export class CommitteeActivityService {
         page_size: fetchSize,
         sort: 'updated_desc',
       })
-      .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
+      .then((response) => ({ scope, attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
       .catch((err) => {
         // meeting_scope, matching buildNotesEventsForScope's own warning field — both logs
         // describe the same sub-leg and need to correlate on one field/value, not two vocabularies.
@@ -963,7 +965,7 @@ export class CommitteeActivityService {
           meeting_scope: scope,
           err,
         });
-        return { attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };
+        return { scope, attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };
       });
   }
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -880,15 +880,18 @@ export class CommitteeActivityService {
    *    making anyway: this repo
    *    already ships an identical `term` filter on another `data.*` subfield of this same resource
    *    type (`document.service.ts`'s `filters_or: ['meeting_id:<id>']` on `v1_meeting_attachment`),
-   *    and the failure mode if the bet is wrong is a *visible*, all-or-nothing one (`notes_count: 0`
-   *    in `getCommitteeActivity`'s completion log across every committee, trivially distinguishable
-   *    from "this committee genuinely has no notes") — not a silent one. The alternative (dropping
-   *    the filter and fetching `fetchSize` attachments of every category before filtering
-   *    client-side) trades that visible risk for a guaranteed, silent dilution instead: a committee
-   *    whose meetings carry non-Notes attachments too would only ever surface notes from its most
-   *    recent handful of meetings, with `saturated` firing far more than the actual Notes volume
-   *    warrants. If the bet ever proves wrong, the durable fix is an upstream request to add
-   *    `category` to the attachment tag sets, not reverting to the client-side-only approach.
+   *    and the failure mode if the bet is wrong is *visible*, not silent, at both ends of the
+   *    spectrum: a fully-failed filter shows up as `notes_count: 0` in `getCommitteeActivity`'s
+   *    completion log across every committee (trivially distinguishable from "this committee
+   *    genuinely has no notes"), and a partially-failed filter (matches, but doesn't narrow) shows
+   *    up as `buildNotesEventsForScope`'s own `dropped_count` warning below. Neither signal exists
+   *    for the alternative: dropping the filter and fetching `fetchSize` attachments of every
+   *    category before filtering client-side trades both visible risks for one guaranteed, silent
+   *    dilution instead — a committee whose meetings carry non-Notes attachments too would only
+   *    ever surface notes from its most recent handful of meetings, with `saturated` firing far
+   *    more than the actual Notes volume warrants, and nothing would ever log it. If the bet ever
+   *    proves wrong, the durable fix is an upstream request to add `category` to the attachment tag
+   *    sets, not reverting to the client-side-only approach.
    *  - No `date_field`/`date_from`/`date_to` narrowing, unlike the files leg above. `modified_at`
    *    is never actually absent (`ModifiedAt time.Time` has no `omitempty`), but an attachment
    *    whose v1 source record had no parseable `updated_at` gets indexed with `modified_at` set to
@@ -912,10 +915,17 @@ export class CommitteeActivityService {
     _before: string | undefined,
     fetchSize: number
   ): Promise<{ events: NotesAddedActivityEvent[]; saturated: boolean }> {
-    const [meetingResult, pastMeetingResult] = await Promise.all([
-      this.fetchNoteAttachmentPage(req, committeeUid, 'v1_meeting_attachment', 'upcoming-meeting', fetchSize),
-      this.fetchNoteAttachmentPage(req, committeeUid, 'v1_past_meeting_attachment', 'past-meeting', fetchSize),
-    ]);
+    // Type and scope are paired here, not passed as two separate positional args at each call
+    // site — both fetchNoteAttachmentPage and buildNotesEventsForScope key their logging off
+    // `scope`, so a transposed pair (past type, upcoming scope) would previously compile and only
+    // show up as a wrong log line; pairing them removes that failure mode entirely.
+    const ATTACHMENT_SOURCES: { type: string; scope: 'upcoming' | 'past' }[] = [
+      { type: 'v1_meeting_attachment', scope: 'upcoming' },
+      { type: 'v1_past_meeting_attachment', scope: 'past' },
+    ];
+    const [meetingResult, pastMeetingResult] = await Promise.all(
+      ATTACHMENT_SOURCES.map((source) => this.fetchNoteAttachmentPage(req, committeeUid, source.type, source.scope, fetchSize))
+    );
 
     const events = [
       ...this.buildNotesEventsForScope(req, committeeUid, meetingResult.attachments, 'upcoming'),
@@ -933,7 +943,7 @@ export class CommitteeActivityService {
     req: Request,
     committeeUid: string,
     type: string,
-    scopeLabel: string,
+    scope: 'upcoming' | 'past',
     fetchSize: number
   ): Promise<{ attachments: CommitteeActivityNoteAttachment[]; pageToken: string | undefined }> {
     return this.microserviceProxy
@@ -946,8 +956,11 @@ export class CommitteeActivityService {
       })
       .then((response) => ({ attachments: (response?.resources ?? []).map((resource) => resource.data), pageToken: response?.page_token }))
       .catch((err) => {
-        logger.warning(req, 'get_committee_activity', `Failed to fetch ${scopeLabel} notes attachments, continuing without them`, {
+        // meeting_scope, matching buildNotesEventsForScope's own warning field — both logs
+        // describe the same sub-leg and need to correlate on one field/value, not two vocabularies.
+        logger.warning(req, 'get_committee_activity', 'Failed to fetch notes attachments, continuing without them', {
           committee_uid: committeeUid,
+          meeting_scope: scope,
           err,
         });
         return { attachments: [] as CommitteeActivityNoteAttachment[], pageToken: undefined as string | undefined };

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -231,19 +231,19 @@ export class CommitteeActivityService {
     // a runtime tripwire for exactly this: a warning log if a real, differing scheduled_start_time
     // ever shows up on a returned row, rather than relying on this comment alone to catch it.
     //
-    // Votes, surveys, and files are all in a different, genuinely-approximate bucket: query-service's
-    // `sort=updated_desc` resolves to the INDEX's own root-level `updated_at` (`cmd/service/
-    // converters.go`: `SortBy = "updated_at"`, no `data.` prefix), which the indexer contract
-    // documents as index-write/audit metadata, not a copy of any `data.*` domain field — distinct
-    // from the `date_field` values votes and files filter on: votes' `data.last_modified_time`,
+    // Votes, surveys, files, and notes are all in a different, genuinely-approximate bucket:
+    // query-service's `sort=updated_desc` resolves to the INDEX's own root-level `updated_at`
+    // (`cmd/service/converters.go`: `SortBy = "updated_at"`, no `data.` prefix), which the indexer
+    // contract documents as index-write/audit metadata, not a copy of any `data.*` domain field —
+    // distinct from the `date_field` values votes and files filter on: votes' `data.last_modified_time`,
     // files' `data.updated_at` (each auto-prefixed with `data.` by query-service, unlike `sort`).
     // Files happens to share a field NAME with the sort target (`updated_at` == `updated_at`)
     // despite resolving to a different actual field once `data.` prefixing is applied; votes'
-    // date_field name doesn't even coincide with `updated_at`. Surveys is the exception here: it
-    // has no upstream date_field at all (see fetchSurveyEvents's own comment for why) — `sort:
-    // updated_desc` is the only upstream ordering this leg gets. Same class of approximation as the
-    // per-leg date_field (filter-dimension) caveats discussed next, just in the sort dimension
-    // instead.
+    // date_field name doesn't even coincide with `updated_at`. Surveys and notes are the exception
+    // here: neither has an upstream date_field at all (see fetchSurveyEvents's and
+    // fetchNotesAddedEvents's own comments for why, two different reasons) — `sort: updated_desc`
+    // is the only upstream ordering either leg gets. Same class of approximation as the per-leg
+    // date_field (filter-dimension) caveats discussed next, just in the sort dimension instead.
     //
     // Filter dimension: votes/files each filter on a single upstream `date_field` that only
     // approximates their own multi-field occurred_at derivation (see each leg's own comment for
@@ -252,13 +252,19 @@ export class CommitteeActivityService {
     // filter-mismatch miss for hard truncation at `fetchSize` on every page instead, a strictly worse
     // failure mode. The in-memory since/cursor pass in getCommitteeActivity is the correctness
     // backstop against over-inclusion for both legs, not under-inclusion — an imperfectly-narrowed
-    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys is
-    // the one exception where "sending none at all" IS the right call, not the failure mode this
-    // paragraph describes: unlike votes/files, a survey's cutoff-driven occurred_at isn't bounded
-    // below by any field the row gets written to, so date_field narrowing there would systematically
-    // (not rarely) exclude exactly the rows `since` is meant to include — see fetchSurveyEvents.
+    // leg can still exclude a real in-window row upstream before that pass ever sees it. Surveys and
+    // notes are the exception where "sending none at all" IS the right call, not the failure mode
+    // this paragraph describes — for two different reasons. Surveys: unlike votes/files, a survey's
+    // cutoff-driven occurred_at isn't bounded below by any field the row gets written to, so
+    // date_field narrowing there would systematically (not rarely) exclude exactly the rows `since`
+    // is meant to include — see fetchSurveyEvents. Notes: an attachment whose v1 source record had
+    // no parseable `updated_at` gets indexed with `modified_at` set to the Go zero-date sentinel
+    // (`0001-01-01T00:00:00Z`, lfx-v2-meeting-service's `parseTime` swallows that error rather than
+    // omitting the field — `modified_at` is never actually absent), which an upstream date_field
+    // filter would exclude even though `firstValidTimestamp` correctly treats the sentinel as
+    // invalid and falls back to `created_at` for `occurred_at` — see fetchNotesAddedEvents.
     //
-    // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files
+    // Known v1 limitation (accepted, not solved — see LFXV2-1707): meetings/votes/surveys/files/notes
     // are each bounded to a single upstream page of `fetchSize` rows.
     // If more than `fetchSize` rows on one of those legs share the exact same occurred_at second,
     // rows beyond the upstream page are simply never fetched, on any page — unlike folders/links
@@ -384,7 +390,7 @@ export class CommitteeActivityService {
     windowed.sort((a, b) => compareEventsDesc({ occurred_at: a.event.occurred_at, key: a.key }, { occurred_at: b.event.occurred_at, key: b.key }));
 
     // `windowed.length > limit` alone under-detects "more data exists": each of
-    // meetings/votes/surveys/files is bounded to a single upstream page of `fetchSize` rows (see
+    // meetings/votes/surveys/files/notes is bounded to a single upstream page of `fetchSize` rows (see
     // the caveat above), so once a page's fetch actually hits that bound, there could be more rows
     // upstream than made it into `windowed` even though the merged pool itself isn't over `limit` —
     // e.g. a single dominant source returning exactly `fetchSize` rows, several of which get
@@ -797,8 +803,8 @@ export class CommitteeActivityService {
     // anyway, never past it. The exact/final since+cursor enforcement still happens once,
     // centrally, in getCommitteeActivity — this pre-filter only needs to be a superset of that.
     // This fully closes the tie-truncation failure for folders/links specifically, because nothing
-    // upstream ever caps what this leg can re-fetch. The sibling meetings/votes/surveys/files legs
-    // are each capped to one upstream page of fetchSize and can still hit the same failure if more
+    // upstream ever caps what this leg can re-fetch. The sibling meetings/votes/surveys/files/notes
+    // legs are each capped to one upstream page of fetchSize and can still hit the same failure if more
     // than fetchSize of their own rows share one exact timestamp — see the caveat on `fetchSize`'s
     // own comment above, in getCommitteeActivity.
     const folderEvents = boundedSortDesc(
@@ -856,21 +862,31 @@ export class CommitteeActivityService {
    * from v1_meeting_attachment/v1_past_meeting_attachment, two upstream resource types
    * fetchDocumentEvents never touches (LFXV2-3077, corrects LFXV2-2982's original framing).
    *
-   * No upstream `filters`/`date_field` narrowing, unlike the files leg above — two reasons, both
-   * found in review and confirmed against lfx-v2-meeting-service's indexer-contract docs:
-   *  1. `filters: ['category:Notes']` compiles to an OpenSearch `term` clause (exact match). If
-   *     `data.category` isn't mapped as an exact-match/keyword field, that term matches nothing
-   *     and the leg silently returns zero rows on every call — a `term` filter EXCLUDES
-   *     non-matching rows, it can't be "best-effort"; whether the mapping is exact-match is
-   *     unverified. The unconditional client-side `category === 'Notes'` filter below is the only
-   *     correctness guarantee this leg has, so the upstream filter isn't sent at all.
-   *  2. A `date_field`/`date_from`/`date_to` window here would filter on `modified_at`, which is
-   *     optional and typically unset for an attachment that's been uploaded once and never
-   *     edited — the common case for notes, not a rare edge. That's the same systematic
-   *     exclusion `fetchSurveyEvents` above documents at length as its own reason for dropping
-   *     upstream date narrowing entirely; this leg follows that precedent instead of repeating
-   *     the files leg's date_field, which is safe there only because committee_document rows
-   *     reliably carry a real `updated_at`.
+   * `filters: ['category:Notes']` IS sent upstream, with the unconditional client-side
+   * `category === 'Notes'` filter below kept as a backstop, not a substitute — both found in
+   * review and confirmed against lfx-v2-meeting-service's/lfx-v2-query-service's contract docs:
+   *  - `filters` compiles to an OpenSearch `term` clause (exact match). If `data.category` isn't
+   *    mapped as an exact-match/keyword field, the term matches nothing and this leg returns zero
+   *    rows on every call — a `term` filter EXCLUDES non-matching rows, it can't be "best-effort".
+   *    Whether the mapping is exact-match is unverified, so this is a real risk, not a theoretical
+   *    one — but it's a strictly better risk than dropping the filter and fetching `fetchSize`
+   *    attachments of every category before filtering client-side: that guarantees a *silent*,
+   *    hard-to-detect dilution (a committee whose meetings carry non-Notes attachments too would
+   *    only ever surface notes from its most recent handful of meetings, with `saturated` firing
+   *    far more than the actual Notes volume warrants), whereas a mapping mismatch here is a
+   *    *visible*, all-or-nothing failure — `notes_count: 0` in this method's completion log across
+   *    every committee, trivially distinguishable from "this committee genuinely has no notes."
+   *  - No `date_field`/`date_from`/`date_to` narrowing, unlike the files leg above. `modified_at`
+   *    is never actually absent (`ModifiedAt time.Time` has no `omitempty`), but an attachment
+   *    whose v1 source record had no parseable `updated_at` gets indexed with `modified_at` set to
+   *    Go's zero-date sentinel (`0001-01-01T00:00:00Z` — `parseTime`'s error is swallowed rather
+   *    than the field being omitted). An upstream date range filter on `modified_at` would exclude
+   *    those sentinel rows even though `firstValidTimestamp` below correctly treats the sentinel as
+   *    invalid and falls back to `created_at` for `occurred_at` — the two would silently diverge on
+   *    exactly those rows. Same class of problem `fetchSurveyEvents` documents at length for its
+   *    own, different reason; this leg follows that same "drop the narrowing" precedent rather than
+   *    repeating the files leg's `date_field`, which is safe there only because `committee_document`
+   *    rows reliably carry a real, non-sentinel `updated_at`.
    * `since`/`before` are still accepted (unused in the query itself) to keep this leg's call
    * signature uniform with every other fetch* method — the in-memory since/cursor pass in
    * getCommitteeActivity is what actually enforces the window for this leg, exactly as it already
@@ -886,6 +902,7 @@ export class CommitteeActivityService {
     const buildQuery = (type: string): Record<string, unknown> => ({
       type,
       parent: `committee:${committeeUid}`,
+      filters: ['category:Notes'],
       page_size: fetchSize,
       sort: 'updated_desc',
     });

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -893,8 +893,8 @@ export class CommitteeActivityService {
    *    dilution problem this filter exists to avoid, just moved one step later. `data` is
    *    documented (lfx-v2-indexer-service's indexer-contract.md) as a schema-free `flat_object`,
    *    and that same doc explicitly declines to guarantee per-field analyzer behavior inside
-   *    `data` — a caution, not a green light — so sending `filters` here is a deliberate bet on a
-   *    `term` clause being exact for a field the indexer can't promise that for. It's a bet worth
+   *    `data` — a caution, not a green light — so sending `filters_all` here is a deliberate bet on
+   *    a `term` clause being exact for a field the indexer can't promise that for. It's a bet worth
    *    making anyway: this repo
    *    already ships an identical `term` filter on another `data.*` subfield of this same resource
    *    type (`document.service.ts`'s `filters_or: ['meeting_id:<id>']` on `v1_meeting_attachment`),
@@ -998,7 +998,7 @@ export class CommitteeActivityService {
 
   /**
    * Applies the client-side `category` backstop and warns if it ever drops a row — the tripwire
-   * for the doc comment's "the upstream `filters` term clause might not narrow" bet above.
+   * for the doc comment's "the upstream `filters_all` term clause might not narrow" bet above.
    * Without this, a non-narrowing upstream filter is invisible: the backstop silently absorbs
    * every non-Notes row and the leg looks healthy while quietly under-serving every request
    * (fetchSize filled with every category, only the newest handful surviving) — the exact
@@ -1015,7 +1015,7 @@ export class CommitteeActivityService {
     const notes = attachments.filter((attachment) => attachment.category === NOTES_ATTACHMENT_CATEGORY);
     const droppedCount = attachments.length - notes.length;
     if (droppedCount > 0) {
-      logger.warning(req, 'get_committee_activity', 'Notes category filter did not fully narrow upstream — filters term clause may not be matching', {
+      logger.warning(req, 'get_committee_activity', 'Notes category filter did not fully narrow upstream — filters_all term clause may not be matching', {
         committee_uid: committeeUid,
         meeting_scope: meetingScope,
         dropped_count: droppedCount,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -922,8 +922,11 @@ export class CommitteeActivityService {
     // reaches buildNotesEventsForScope: buildNotesEvent writes it into the user-visible
     // `payload.meeting_scope`, which activity-feed.utils.ts uses to namespace the feed item's
     // @for tracking key — a swapped scope there is payload-corrupting, not just a wrong log line.
-    // `as const` pins this to exactly a 2-tuple so `results` below can't silently grow a third,
-    // unhandled source if one is ever added without also updating the code that consumes it.
+    // `as const` is what narrows `scope` to the literal union fetchNoteAttachmentPage's `scope`
+    // param requires (without it, the literal widens to `scope: string`). Not an arity guard —
+    // `results` below is consumed by `flatMap`/`some`, both N-safe by construction, so a third
+    // source added here would be fully handled, not silently dropped; the narrowed `type` param
+    // (not this array) is what would catch a typo'd resource-type string at compile time.
     const ATTACHMENT_SOURCES = [
       { type: 'v1_meeting_attachment', scope: 'upcoming' },
       { type: 'v1_past_meeting_attachment', scope: 'past' },

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ArtifactVisibility, MeetingVisibility } from '../enums';
-import type { CardSelectorOption, MeetingTypeConfig } from '../interfaces';
+import type { AttachmentCategory, CardSelectorOption, MeetingTypeConfig } from '../interfaces';
 import { lfxColors } from './colors.constants';
 
 /**
@@ -655,3 +655,11 @@ export const PAST_MEETING_SORT = {
   UPDATED_DESC: 'updated_desc',
   UPDATED_ASC: 'updated_asc',
 } as const;
+
+/**
+ * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's
+ * notes_added leg treats as a note. A single source of truth for both the upstream `filters`
+ * term-clause value and the client-side re-filter comparison — see fetchNotesAddedEvents's own
+ * comment for why both need to agree on the exact same string (LFXV2-3077).
+ */
+export const NOTES_ATTACHMENT_CATEGORY: AttachmentCategory = 'Notes';

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -658,7 +658,7 @@ export const PAST_MEETING_SORT = {
 
 /**
  * The `AttachmentCategory` (`meeting-attachment.interface.ts`) value CommitteeActivityService's
- * notes_added leg treats as a note. A single source of truth for both the upstream `filters`
+ * notes_added leg treats as a note. A single source of truth for both the upstream `filters_all`
  * term-clause value and the client-side re-filter comparison — see fetchNotesAddedEvents's own
  * comment for why both need to agree on the exact same string (LFXV2-3077).
  */

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -117,6 +117,15 @@ export interface NotesAddedActivityEvent extends BaseActivityEvent {
      * upstream uid namespaces, same reasoning as document_uploaded's document_type discriminant.
      * Drives eventKey's namespace (committee-activity.service.ts) and the client's tab-routing
      * action (activity-feed.utils.ts).
+     *
+     * Names the upstream resource type, not a time guarantee: v1_meeting_attachment rows hang off
+     * an active meeting record, which keeps existing after its occurrence passes — so a note on a
+     * one-off meeting that already happened, or on an ended recurring series, is still 'upcoming'
+     * here and still routes to the Meetings tab's upcoming view, which won't contain it. Known,
+     * accepted v1 limitation (same "route to the containing tab, not a precise deep link"
+     * trade-off document_uploaded already makes for file/folder rows) — not fixed for the same
+     * reason those aren't: there's no bounded-call way to know which sub-tab actually holds a
+     * given meeting without a per-event follow-up.
      */
     meeting_scope: 'upcoming' | 'past';
   };

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -5,13 +5,17 @@ import type { CommitteeDocumentType } from './committee.interface';
 
 /**
  * Full target lifecycle-event vocabulary for a committee's activity feed (LFXV2-1707). Only
- * `meeting_held`, `vote_opened`/`vote_closed`, `survey_published`/`survey_closed`, and
- * `document_uploaded` are actually emitted in v1 (aggregation-derived from existing sources: past
- * meetings, votes, surveys, documents — see `committee-activity.service.ts`). `document_deleted`,
- * `member_joined`, `member_left`, and `notes_added` (see `DeferredActivityEvent`) are deferred: no
- * upstream source exists yet (no document-delete tombstone — hard delete, unindexed; no
- * committee-membership history tracking; no notes feature). The union stays complete now so the
- * wire contract doesn't grow a breaking change when a real event log starts emitting them.
+ * `meeting_held`, `vote_opened`/`vote_closed`, `survey_published`/`survey_closed`,
+ * `document_uploaded`, and `notes_added` are actually emitted in v1 (aggregation-derived from
+ * existing sources: past meetings, votes, surveys, documents, meeting attachments — see
+ * `committee-activity.service.ts`). `notes_added` is sourced from `MeetingAttachment` /
+ * `PastMeetingAttachment` rows whose `category` is `'Notes'` (LFXV2-3077) — a new aggregation leg,
+ * not a filter on the `document_uploaded` leg, since folders/links/`committee_document` files carry
+ * no `category` field. `document_deleted`, `member_joined`, and `member_left` (see
+ * `DeferredActivityEvent`) remain deferred: no upstream source exists yet (no document-delete
+ * tombstone — hard delete, unindexed; no committee-membership history tracking). The union stays
+ * complete now so the wire contract doesn't grow a breaking change when a real event log starts
+ * emitting them.
  *
  * Derived from `ActivityEvent['type']` (declared below — TypeScript allows forward references
  * between type aliases in the same module) rather than hand-restated, so adding, removing, or
@@ -93,12 +97,36 @@ export interface DocumentUploadedActivityEvent extends BaseActivityEvent {
 }
 
 /**
+ * Sourced from `MeetingAttachment` (`v1_meeting_attachment`) / `PastMeetingAttachment`
+ * (`v1_past_meeting_attachment`) rows whose `category` is `'Notes'` — see
+ * `CommitteeActivityService.fetchNotesAddedEvents` (LFXV2-3077).
+ */
+export interface NotesAddedActivityEvent extends BaseActivityEvent {
+  type: 'notes_added';
+  payload: {
+    document_uid: string;
+    name: string;
+    document_type: 'file' | 'link';
+    /** Only set for document_type: 'link' — same asymmetry as DocumentUploadedActivityEvent.payload.url. */
+    url?: string;
+    meeting_id: string;
+    /**
+     * v1_meeting_attachment ('upcoming') vs v1_past_meeting_attachment ('past') — two distinct
+     * upstream uid namespaces, same reasoning as document_uploaded's document_type discriminant.
+     * Drives eventKey's namespace (committee-activity.service.ts) and the client's tab-routing
+     * action (activity-feed.utils.ts).
+     */
+    meeting_scope: 'upcoming' | 'past';
+  };
+}
+
+/**
  * Placeholder variant for the deferred event types — never constructed in v1 (no upstream source
  * exists to populate it). Kept in the union so `ActivityEventType` stays the full target vocabulary
  * without every consumer needing a separate "future type" case.
  */
 export interface DeferredActivityEvent extends BaseActivityEvent {
-  type: 'document_deleted' | 'member_joined' | 'member_left' | 'notes_added';
+  type: 'document_deleted' | 'member_joined' | 'member_left';
   payload: Record<string, never>;
 }
 
@@ -116,4 +144,5 @@ export type ActivityEvent =
   | SurveyPublishedActivityEvent
   | SurveyClosedActivityEvent
   | DocumentUploadedActivityEvent
+  | NotesAddedActivityEvent
   | DeferredActivityEvent;

--- a/packages/shared/src/interfaces/activity-event.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.interface.ts
@@ -97,9 +97,12 @@ export interface DocumentUploadedActivityEvent extends BaseActivityEvent {
 }
 
 /**
- * Sourced from `MeetingAttachment` (`v1_meeting_attachment`) / `PastMeetingAttachment`
- * (`v1_past_meeting_attachment`) rows whose `category` is `'Notes'` — see
- * `CommitteeActivityService.fetchNotesAddedEvents` (LFXV2-3077).
+ * Sourced from the query-service projection of `v1_meeting_attachment` / `v1_past_meeting_attachment`
+ * rows (`CommitteeActivityNoteAttachment`, `activity-event.internal.interface.ts`) whose `category`
+ * is `'Notes'` — see `CommitteeActivityService.fetchNotesAddedEvents` (LFXV2-3077). No `meeting_id`
+ * in the payload: nothing consumes it yet, and the only value available from the past-meeting leg
+ * (the originating meeting id, not `meeting_and_occurrence_id`) isn't precise enough for a future
+ * deep-link — add it back with the right field once a consumer needs it.
  */
 export interface NotesAddedActivityEvent extends BaseActivityEvent {
   type: 'notes_added';
@@ -109,7 +112,6 @@ export interface NotesAddedActivityEvent extends BaseActivityEvent {
     document_type: 'file' | 'link';
     /** Only set for document_type: 'link' — same asymmetry as DocumentUploadedActivityEvent.payload.url. */
     url?: string;
-    meeting_id: string;
     /**
      * v1_meeting_attachment ('upcoming') vs v1_past_meeting_attachment ('past') — two distinct
      * upstream uid namespaces, same reasoning as document_uploaded's document_type discriminant.

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { AttachmentCategory } from './meeting-attachment.interface';
+
 /**
  * Server-internal shapes for the committee activity aggregation endpoint (LFXV2-1707) — not part
  * of the public `ActivityEvent` wire contract (`activity-event.interface.ts`). Kept in
@@ -88,7 +90,7 @@ export interface CommitteeActivityDocumentFile {
 export interface CommitteeActivityNoteAttachment {
   uid: string;
   type: 'file' | 'link';
-  category?: string;
+  category?: AttachmentCategory;
   name: string;
   link?: string;
   created_at?: string;

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -25,10 +25,11 @@ export interface ActivityPageCursor {
 export interface CommitteeActivityQuery {
   /**
    * Inclusive lower bound on `occurred_at`. Enforced in-memory against the merged pool (the
-   * correctness guarantee); additionally pushed upstream as `date_from` on all four legs as
+   * correctness guarantee); additionally pushed upstream as `date_from` on several legs as
    * best-effort narrowing only — each leg's upstream `date_field` approximates a multi-field
    * fallback derivation it can't fully represent, so it narrows fetched volume but isn't relied
-   * on for correctness. See the per-leg comments in `committee-activity.service.ts`.
+   * on for correctness. Surveys and notes deliberately opt out of upstream date narrowing
+   * entirely — see their per-leg comments in `committee-activity.service.ts` for why.
    */
   since?: string;
   /**
@@ -72,4 +73,24 @@ export interface CommitteeActivityDocumentFile {
   name: string;
   created_at?: string;
   updated_at?: string;
+}
+
+/**
+ * Query-service projection for an indexed `v1_meeting_attachment` / `v1_past_meeting_attachment`
+ * resource — deliberately distinct from `MeetingAttachment`/`PastMeetingAttachment`
+ * (`meeting-attachment.interface.ts`), which are documented as aligned with the ITX proxy API
+ * response, not the indexer's data schema. The indexer contract
+ * (lfx-v2-meeting-service's `docs/indexer-contract.md`, V1 Meeting Attachment /
+ * V1 Past Meeting Attachment sections) carries `modified_at`, not `updated_at` — using the ITX
+ * shape here silently fell back to `created_at` for every row (LFXV2-3077 review finding).
+ */
+export interface CommitteeActivityNoteAttachment {
+  uid: string;
+  meeting_id: string;
+  type: 'file' | 'link';
+  category?: string;
+  name: string;
+  link?: string;
+  created_at?: string;
+  modified_at?: string;
 }

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -86,7 +86,6 @@ export interface CommitteeActivityDocumentFile {
  */
 export interface CommitteeActivityNoteAttachment {
   uid: string;
-  meeting_id: string;
   type: 'file' | 'link';
   category?: string;
   name: string;

--- a/packages/shared/src/interfaces/activity-event.internal.interface.ts
+++ b/packages/shared/src/interfaces/activity-event.internal.interface.ts
@@ -28,8 +28,9 @@ export interface CommitteeActivityQuery {
    * correctness guarantee); additionally pushed upstream as `date_from` on several legs as
    * best-effort narrowing only — each leg's upstream `date_field` approximates a multi-field
    * fallback derivation it can't fully represent, so it narrows fetched volume but isn't relied
-   * on for correctness. Surveys and notes deliberately opt out of upstream date narrowing
-   * entirely — see their per-leg comments in `committee-activity.service.ts` for why.
+   * on for correctness. Surveys deliberately opt out of upstream `date_from` narrowing entirely;
+   * notes opts out of `date_from` specifically but still sends `date_to` — see their per-leg
+   * comments in `committee-activity.service.ts` for why.
    */
   since?: string;
   /**

--- a/packages/shared/src/interfaces/activity-feed.interface.ts
+++ b/packages/shared/src/interfaces/activity-feed.interface.ts
@@ -5,7 +5,7 @@
  * Source kind backing an `ActivityFeedItem`.
  * @description Drives icon + tab-navigation choice in the committee Overview "Recent Activity" widget.
  */
-export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey' | 'document';
+export type ActivityFeedItemType = 'meeting' | 'past_meeting' | 'vote' | 'survey' | 'document' | 'note';
 
 /**
  * What clicking an `ActivityFeedItem` does — a discriminated union so each source's action is

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -64,7 +64,7 @@ function notesAdded(overrides: Partial<Extract<ActivityEvent, { type: 'notes_add
     type: 'notes_added',
     occurred_at: occurredAt,
     committee_uid: COMMITTEE_UID,
-    payload: { document_uid: 'note-1', name: 'Meeting Notes.pdf', document_type: 'file', meeting_id: 'meeting-1', meeting_scope: 'upcoming', ...overrides },
+    payload: { document_uid: 'note-1', name: 'Meeting Notes.pdf', document_type: 'file', meeting_scope: 'upcoming', ...overrides },
   };
 }
 
@@ -259,10 +259,14 @@ describe('mapActivityEventsToFeedItems', () => {
     });
 
     it('falls back to the meetings tab, filtered by scope, for a file note even when a url is present', () => {
-      const upcoming = mapActivityEventsToFeedItems([notesAdded({ document_type: 'file', meeting_scope: 'upcoming' })], { votingEnabled: true });
+      const upcoming = mapActivityEventsToFeedItems([notesAdded({ document_type: 'file', url: 'https://example.com/notes.pdf', meeting_scope: 'upcoming' })], {
+        votingEnabled: true,
+      });
       expect(upcoming[0].action).toEqual({ kind: 'tab', tab: 'meetings:upcoming' });
 
-      const past = mapActivityEventsToFeedItems([notesAdded({ document_type: 'file', meeting_scope: 'past' })], { votingEnabled: true });
+      const past = mapActivityEventsToFeedItems([notesAdded({ document_type: 'file', url: 'https://example.com/notes.pdf', meeting_scope: 'past' })], {
+        votingEnabled: true,
+      });
       expect(past[0].action).toEqual({ kind: 'tab', tab: 'meetings:past' });
     });
   });

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -172,7 +172,7 @@ describe('mapActivityEventsToFeedItems', () => {
 
   it('renders a notes_added event with the note type, icon, and label', () => {
     const items = mapActivityEventsToFeedItems([notesAdded({ name: 'Board Minutes.pdf' })], { votingEnabled: true });
-    expect(items[0]).toMatchObject({ type: 'note', label: 'Note added: Board Minutes.pdf', icon: 'fa-light fa-note-sticky' });
+    expect(items[0]).toMatchObject({ type: 'note', label: 'Note: Board Minutes.pdf', icon: 'fa-light fa-note-sticky' });
   });
 
   it('keys upcoming and past notes distinctly even when they share a document_uid — meeting_scope discriminates the @for tracking key', () => {

--- a/packages/shared/src/utils/activity-feed.utils.spec.ts
+++ b/packages/shared/src/utils/activity-feed.utils.spec.ts
@@ -59,6 +59,15 @@ function documentUploaded(
   };
 }
 
+function notesAdded(overrides: Partial<Extract<ActivityEvent, { type: 'notes_added' }>['payload']> = {}, occurredAt = '2026-01-05T10:00:00Z'): ActivityEvent {
+  return {
+    type: 'notes_added',
+    occurred_at: occurredAt,
+    committee_uid: COMMITTEE_UID,
+    payload: { document_uid: 'note-1', name: 'Meeting Notes.pdf', document_type: 'file', meeting_id: 'meeting-1', meeting_scope: 'upcoming', ...overrides },
+  };
+}
+
 describe('mapActivityEventsToFeedItems', () => {
   it('returns an empty array when given no events', () => {
     expect(mapActivityEventsToFeedItems([], { votingEnabled: true })).toEqual([]);
@@ -161,6 +170,22 @@ describe('mapActivityEventsToFeedItems', () => {
     expect(items[0].type).toBe('past_meeting');
   });
 
+  it('renders a notes_added event with the note type, icon, and label', () => {
+    const items = mapActivityEventsToFeedItems([notesAdded({ name: 'Board Minutes.pdf' })], { votingEnabled: true });
+    expect(items[0]).toMatchObject({ type: 'note', label: 'Note added: Board Minutes.pdf', icon: 'fa-light fa-note-sticky' });
+  });
+
+  it('keys upcoming and past notes distinctly even when they share a document_uid — meeting_scope discriminates the @for tracking key', () => {
+    const items = mapActivityEventsToFeedItems(
+      [
+        notesAdded({ document_uid: 'shared-uid', meeting_scope: 'upcoming' }, '2026-01-02T00:00:00Z'),
+        notesAdded({ document_uid: 'shared-uid', meeting_scope: 'past' }, '2026-01-01T00:00:00Z'),
+      ],
+      { votingEnabled: true }
+    );
+    expect(new Set(items.map((i) => i.key)).size).toBe(2);
+  });
+
   describe('action', () => {
     it('routes a meeting_held item to its meeting_id', () => {
       const items = mapActivityEventsToFeedItems([meetingHeld({ meeting_id: 'pm-42', meeting_occurrence_id: 'pm-42-occ-1' })], { votingEnabled: true });
@@ -214,6 +239,31 @@ describe('mapActivityEventsToFeedItems', () => {
     it('falls back to the documents tab for a folder document', () => {
       const items = mapActivityEventsToFeedItems([documentUploaded({ document_type: 'folder' })], { votingEnabled: true });
       expect(items[0].action).toEqual({ kind: 'tab', tab: 'documents' });
+    });
+
+    it('opens a link note directly when it has a valid http(s) url', () => {
+      const items = mapActivityEventsToFeedItems([notesAdded({ document_type: 'link', url: 'https://example.com/notes' })], { votingEnabled: true });
+      expect(items[0].action).toEqual({ kind: 'external-url', url: 'https://example.com/notes' });
+    });
+
+    it('falls back to the meetings tab, filtered by scope, for a link note with a missing or unsafe url', () => {
+      const missingUrl = mapActivityEventsToFeedItems([notesAdded({ document_type: 'link', url: undefined, meeting_scope: 'upcoming' })], {
+        votingEnabled: true,
+      });
+      expect(missingUrl[0].action).toEqual({ kind: 'tab', tab: 'meetings:upcoming' });
+
+      const unsafeUrl = mapActivityEventsToFeedItems([notesAdded({ document_type: 'link', url: 'javascript:alert(1)', meeting_scope: 'past' })], {
+        votingEnabled: true,
+      });
+      expect(unsafeUrl[0].action).toEqual({ kind: 'tab', tab: 'meetings:past' });
+    });
+
+    it('falls back to the meetings tab, filtered by scope, for a file note even when a url is present', () => {
+      const upcoming = mapActivityEventsToFeedItems([notesAdded({ document_type: 'file', meeting_scope: 'upcoming' })], { votingEnabled: true });
+      expect(upcoming[0].action).toEqual({ kind: 'tab', tab: 'meetings:upcoming' });
+
+      const past = mapActivityEventsToFeedItems([notesAdded({ document_type: 'file', meeting_scope: 'past' })], { votingEnabled: true });
+      expect(past[0].action).toEqual({ kind: 'tab', tab: 'meetings:past' });
     });
   });
 });

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -92,7 +92,12 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
         // v1_past_meeting_attachment are two distinct upstream uid namespaces, same reasoning as
         // document_uploaded's document_type-namespaced key.
         key: `note-${meeting_scope}-${document_uid}`,
-        label: `Note added: ${name}`,
+        // "Note: X", not "Note added: X" — occurred_at prefers modified_at (see buildNotesEvent's
+        // own comment), so an edited/renamed note re-surfaces at the top of the feed on every
+        // edit, not just its original creation. A verb-free label avoids claiming "added" for
+        // what might be an edit, matching document_uploaded's own verb-free label for the same
+        // modified-first sort reason (its "Document: X" doesn't claim "uploaded" either).
+        label: `Note: ${name}`,
         timestamp: event.occurred_at,
         icon: 'fa-light fa-note-sticky',
         // meeting_scope, not a precise deep link to the source meeting — MeetingAttachment/

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -84,8 +84,31 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
       };
     }
 
-    // Deferred types (document_deleted, member_joined, member_left, notes_added) — never emitted
-    // by the server in v1; guarded defensively rather than assumed unreachable.
+    case 'notes_added': {
+      const { document_uid, name, url, meeting_scope } = event.payload;
+      return {
+        type: 'note',
+        // meeting_scope in the key, not just document_uid — v1_meeting_attachment and
+        // v1_past_meeting_attachment are two distinct upstream uid namespaces, same reasoning as
+        // document_uploaded's document_type-namespaced key.
+        key: `note-${meeting_scope}-${document_uid}`,
+        label: `Note added: ${name}`,
+        timestamp: event.occurred_at,
+        icon: 'fa-light fa-note-sticky',
+        // meeting_scope, not a precise deep link to the source meeting — MeetingAttachment/
+        // PastMeetingAttachment carry no `password` field, so routing through 'past-meeting'
+        // (which can attach one) risks silently omitting it for a password-protected meeting.
+        // Routes to the Meetings tab pre-filtered to the right time window instead, the same
+        // "no precise deep link, route to the containing tab" compromise document_uploaded
+        // already makes for file/folder rows. 'meetings:upcoming'/'meetings:past' is an
+        // already-live composite tab-context format (committee-view.component.ts's
+        // handleTabNavigation).
+        action: url && isValidUrl(url) ? { kind: 'external-url', url } : { kind: 'tab', tab: `meetings:${meeting_scope}` },
+      };
+    }
+
+    // Deferred types (document_deleted, member_joined, member_left) — never emitted by the
+    // server in v1; guarded defensively rather than assumed unreachable.
     default:
       return null;
   }

--- a/packages/shared/src/utils/activity-feed.utils.ts
+++ b/packages/shared/src/utils/activity-feed.utils.ts
@@ -85,7 +85,7 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
     }
 
     case 'notes_added': {
-      const { document_uid, name, url, meeting_scope } = event.payload;
+      const { document_uid, name, document_type, url, meeting_scope } = event.payload;
       return {
         type: 'note',
         // meeting_scope in the key, not just document_uid — v1_meeting_attachment and
@@ -102,8 +102,9 @@ function mapActivityEventToFeedItem(event: ActivityEvent): ActivityFeedItem | nu
         // "no precise deep link, route to the containing tab" compromise document_uploaded
         // already makes for file/folder rows. 'meetings:upcoming'/'meetings:past' is an
         // already-live composite tab-context format (committee-view.component.ts's
-        // handleTabNavigation).
-        action: url && isValidUrl(url) ? { kind: 'external-url', url } : { kind: 'tab', tab: `meetings:${meeting_scope}` },
+        // handleTabNavigation). document_type === 'link' guard mirrors document_uploaded's own
+        // condition — a file-type note never opens a raw url directly, even if one is ever set.
+        action: document_type === 'link' && url && isValidUrl(url) ? { kind: 'external-url', url } : { kind: 'tab', tab: `meetings:${meeting_scope}` },
       };
     }
 


### PR DESCRIPTION
## Summary

- Adds `notes_added` as a real, emitted activity-feed event type — a new aggregation leg (`fetchNotesAddedEvents`), sourced from `v1_meeting_attachment`/`v1_past_meeting_attachment` rows whose `category` is `'Notes'`, following the same bounded, cursor-paginated pattern every other leg in `CommitteeActivityService` uses.
- Removes `notes_added` from `DeferredActivityEvent` and adds a proper `NotesAddedActivityEvent` to the shared `ActivityEvent` union, with a corresponding `mapActivityEventToFeedItem` case (icon, label, tab-routing action) in the committee Overview "Recent Activity" widget.

**Corrects LFXV2-2982's original framing** ("small addition to `fetchDocumentEvents`"): this is a new, independent aggregation leg, not a filter on the existing `document_uploaded` leg. `fetchDocumentEvents` only ever sees committee folders/links and `committee_document`-type files — none of which carry a `category` field. The data lives entirely in a separate pair of upstream resource types (`v1_meeting_attachment`, `v1_past_meeting_attachment`) that `fetchDocumentEvents` never touches.

## Notable design decisions (see inline comments for full rationale)

- **`filters_all: ['category:Notes']` sent upstream**, with an unconditional client-side re-filter kept as a backstop, and a `dropped_count` tripwire that warns if the upstream filter ever stops narrowing (distinguishing a mapping failure from "this committee genuinely has no notes").
- **`date_to` only, never `date_from`** — the zero-date-sentinel risk on `modified_at` only bites a lower bound; `date_to` is exact-or-over-inclusive, which the in-memory cursor pass already backstops. Sending only `date_to` is what makes pagination beyond page 1 actually reach older notes.
- A pre-existing pagination-reachability gap was discovered on the **surveys leg** (predates this ticket, out of scope to fix here) — flagged in the code comments; worth a follow-up LFXV2 ticket.

## Integration validation (2026-08-10)

Tested against prod-mirrored data in a disposable integration worktree (real SSO, prod-backed BFF):

- **AAIF Technical Committee** — no `category: 'Notes'` attachments; feed renders normally with zero `notes_added` rows, no errors. Correct empty case.
- **WG Identity & Trust** (254 members) — real data: four `notes_added` rows render ("Note added: Agenda Doc"), correctly dated and interleaved with `meeting_held` events.

This resolves the earlier open question about whether any upstream path actually writes `category: 'Notes'` — the legacy v1/ITX meeting UI does, and this leg picks those rows up correctly end-to-end. `GET .../activity` returns 200 on every committee checked, no console errors, no regression to existing event types.

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] Unit tests: category filtering (both attachment types, mixed categories), empty/error degrade per sub-leg, pagination/cursor correctness including tied-timestamp interleaving with other event types, `date_to`/`date_from` asymmetry, `meeting_scope` transposition regressions, dropped-count tripwire
- [x] Component test: notes_added row rendering (icon, label, link vs. file routing)
- [x] **Manual**: verified against real prod-mirrored committees (see Integration validation above)

Refs: LFXV2-3077