### PR TITLE
refactor(enrollment): tighten display-state projection type narrowing

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/individual-enrollment/profile-individual-enrollment.component.ts
@@ -152,6 +152,8 @@ export class ProfileIndividualEnrollmentComponent {
 
   // Projects the server state into the display shape once, at the subscription boundary.
   private toDisplayState(state: EnrollmentsState): DisplayEnrollmentsState {
+    // The loading/error arms are structurally identical across both unions (only the loaded arm's
+    // item type differs), so returning `state` verbatim is intentional, not a missed projection.
     if (state.kind !== 'loaded') return state;
     const base = environment.urls.enrollment;
     const items = state.items.map((item): DisplayEnrollment => {
@@ -175,11 +177,11 @@ export class ProfileIndividualEnrollmentComponent {
       const overrides = this.autoRenewOverrides();
       const pending = this.pendingIds();
       const items = state.items.map((item) => {
-        const membershipId = item.membership?.id;
-        const isPending = membershipId ? pending.has(membershipId) : false;
-        if (membershipId && overrides.has(membershipId)) {
-          const autoRenew = overrides.get(membershipId)!;
-          const updatedMembership = { ...item.membership!, autoRenew };
+        const membership = item.membership;
+        const isPending = membership ? pending.has(membership.id) : false;
+        if (membership && overrides.has(membership.id)) {
+          const autoRenew = overrides.get(membership.id) ?? false;
+          const updatedMembership = { ...membership, autoRenew };
           const displayStatus = deriveEnrollmentStatus({ ...item, membership: updatedMembership });
           return { ...item, membership: updatedMembership, displayStatus, severity: enrollmentStatusSeverity(displayStatus), pending: isPending };
         }


### PR DESCRIPTION
## Summary

- In `initDisplayState`, capture `item.membership` into a local so the type narrows through the guard, removing the two residual `!` non-null assertions (`overrides.get(id)!` and `...item.membership!`) and deriving the auto-renew value with a `?? false` fallback.
- Document the pass-through in `toDisplayState`: the `loading`/`error` arms are shared verbatim between the raw and display state unions (only the `loaded` arm's item type differs), so returning `state` directly is intentional.

Fixes LFXV2-3091
