### PR TITLE
feat(newsletters): show per-recipient open engagement on analytics page

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
@@ -1,0 +1,166 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+@if (loading()) {
+  <lfx-card>
+    <div class="flex justify-center items-center py-8">
+      <i class="fa-light fa-spinner-third fa-spin text-2xl text-blue-600"></i>
+    </div>
+  </lfx-card>
+} @else if (hidden()) {
+  <!-- No `auditor` access (403) or the endpoint doesn't exist yet (404) — hide
+       silently. The chart and stat cards above remain fully usable. -->
+} @else if (loadErrorMessage(); as errorMessage) {
+  <lfx-card data-testid="newsletter-recipient-engagement-error">
+    <div class="flex items-center gap-2 text-sm text-gray-500 py-2">
+      <i class="fa-light fa-triangle-exclamation text-amber-500"></i>
+      <span>{{ errorMessage }}</span>
+    </div>
+  </lfx-card>
+} @else if (rows().length > 0) {
+  <lfx-card data-testid="newsletter-recipient-engagement">
+    <div class="flex flex-col gap-4 p-2">
+      <div class="flex flex-col gap-1">
+        <h2 class="text-base font-semibold text-gray-900">Recipient engagement</h2>
+        @if (showCompletenessNote()) {
+          <p class="text-xs text-gray-500" data-testid="newsletter-recipient-engagement-partial-note">
+            Showing {{ rows().length }} of {{ response()?.total_recipients }} recipients — some records are still processing.
+          </p>
+        }
+      </div>
+
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-3">
+        <div class="flex flex-wrap items-center gap-2" data-testid="newsletter-recipient-engagement-chips">
+          @for (chip of chipConfig(); track chip.key) {
+            <button
+              type="button"
+              class="px-3 py-1.5 rounded-full text-sm font-medium transition-colors"
+              [attr.aria-pressed]="activeChip() === chip.key"
+              [class]="activeChip() === chip.key ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'"
+              (click)="selectChip(chip.key)"
+              [attr.data-testid]="'newsletter-recipient-engagement-segment-' + chip.key">
+              {{ chip.label }} ({{ chip.count }})
+            </button>
+          }
+        </div>
+        <div class="w-full md:w-64">
+          <lfx-input-text
+            [form]="filterForm"
+            control="search"
+            placeholder="Search recipients..."
+            icon="fa-light fa-search"
+            styleClass="w-full"
+            size="small"
+            data-testid="newsletter-recipient-engagement-search">
+          </lfx-input-text>
+        </div>
+      </div>
+
+      <lfx-table
+        [value]="filteredRows()"
+        [paginator]="true"
+        [rows]="10"
+        [rowsPerPageOptions]="[10, 25, 50]"
+        [showCurrentPageReport]="true"
+        currentPageReportTemplate="Showing {first} to {last} of {totalRecords} recipients"
+        styleClass="p-datatable-sm"
+        dataKey="email"
+        data-testid="newsletter-recipient-engagement-table">
+        <!-- Header Template -->
+        <ng-template #header>
+          <tr>
+            <th class="w-8"></th>
+            <th>Recipient</th>
+            <th>Delivery</th>
+            <th>Engagement</th>
+            <th>Opens</th>
+            <th>Last opened</th>
+          </tr>
+        </ng-template>
+
+        <!-- Body Template -->
+        <ng-template #body let-row>
+          <tr [attr.data-testid]="'newsletter-recipient-engagement-row-' + row.email">
+            <td class="w-8">
+              @if (row.open_count > 0) {
+                <button
+                  type="button"
+                  class="text-gray-400 hover:text-gray-600"
+                  (click)="toggleTimeline(row.email)"
+                  [attr.aria-expanded]="expandedEmails().has(row.email)"
+                  [attr.data-testid]="'newsletter-recipient-engagement-expand-' + row.email">
+                  <i class="fa-light" [class.fa-chevron-down]="expandedEmails().has(row.email)" [class.fa-chevron-right]="!expandedEmails().has(row.email)"></i>
+                </button>
+              }
+            </td>
+            <td>
+              <div class="flex items-center gap-2">
+                <lfx-person-avatar [name]="row.displayName" [identity]="row.email" size="sm" />
+                <div class="flex flex-col">
+                  <span class="text-sm font-medium text-gray-900">{{ row.displayName }}</span>
+                  @if (row.name) {
+                    <a [href]="'mailto:' + row.email" class="text-xs text-blue-600 hover:underline">{{ row.email }}</a>
+                  }
+                </div>
+              </div>
+            </td>
+            <td>
+              @if (row.failed) {
+                <lfx-tag value="Failed" severity="danger" />
+              } @else if (row.delivered) {
+                <lfx-tag value="Delivered" severity="success" />
+              } @else {
+                <lfx-tag value="Pending" severity="secondary" />
+              }
+            </td>
+            <td>
+              @if (row.opened) {
+                <lfx-tag value="Opened" severity="success" />
+              } @else {
+                <lfx-tag value="Not opened" severity="secondary" />
+              }
+            </td>
+            <td>
+              <lfx-badge [value]="row.open_count" severity="info" />
+            </td>
+            <td>
+              @if (row.last_opened_at) {
+                <span class="text-sm text-gray-700" [title]="row.last_opened_at | date: 'MMM d, y, h:mm a'">{{ relativeOpened(row.last_opened_at) }}</span>
+              } @else {
+                <span class="text-sm text-gray-400">—</span>
+              }
+            </td>
+          </tr>
+          @if (expandedEmails().has(row.email)) {
+            <tr [attr.data-testid]="'newsletter-recipient-engagement-timeline-' + row.email">
+              <td></td>
+              <td colspan="5" class="bg-gray-50 py-3">
+                <div class="flex flex-col gap-1 pl-2">
+                  <span class="text-xs uppercase tracking-wide text-gray-500">Open timeline</span>
+                  <ul class="flex flex-col gap-1">
+                    @for (openedAt of row.opened_at_list; track openedAt) {
+                      <li class="text-sm text-gray-700">{{ openedAt | date: 'MMM d, y, h:mm a' }}</li>
+                    }
+                  </ul>
+                  @if (row.open_count > row.opened_at_list.length) {
+                    <span class="text-xs text-gray-400">+{{ row.open_count - row.opened_at_list.length }} earlier opens</span>
+                  }
+                </div>
+              </td>
+            </tr>
+          }
+        </ng-template>
+
+        <!-- Empty Message Template -->
+        <ng-template #emptymessage>
+          <tr>
+            <td colspan="6" class="text-center py-8">
+              <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2"></i>
+              <p class="text-sm text-gray-500">No recipients match this filter</p>
+            </td>
+          </tr>
+        </ng-template>
+      </lfx-table>
+    </div>
+  </lfx-card>
+}

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
@@ -17,14 +17,14 @@
       <span>{{ errorMessage }}</span>
     </div>
   </lfx-card>
-} @else if (rows().length > 0) {
+} @else if (rows().length > 0 || showCompletenessNote()) {
   <lfx-card data-testid="newsletter-recipient-engagement">
     <div class="flex flex-col gap-4 p-2">
       <div class="flex flex-col gap-1">
         <h2 class="text-base font-semibold text-gray-900">Recipient engagement</h2>
         @if (showCompletenessNote()) {
           <p class="text-xs text-gray-500" data-testid="newsletter-recipient-engagement-partial-note">
-            Showing {{ rows().length }} of {{ response()?.total_recipients }} recipients — some records are still processing.
+            Showing {{ rows().length }} of {{ response()?.total_recipients }} recipients — some records could not be retrieved.
           </p>
         }
       </div>
@@ -126,7 +126,7 @@
             </td>
             <td>
               @if (row.last_opened_at) {
-                <span class="text-sm text-gray-700" [title]="row.last_opened_at | date: 'MMM d, y, h:mm a'">{{ relativeOpened(row.last_opened_at) }}</span>
+                <span class="text-sm text-gray-700" [title]="row.last_opened_at | date: 'MMM d, y, h:mm a'">{{ row.lastOpenedRelative }}</span>
               } @else {
                 <span class="text-sm text-gray-400">—</span>
               }

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
@@ -88,6 +88,7 @@
                   class="text-gray-400 hover:text-gray-600"
                   (click)="toggleTimeline(row.email)"
                   [attr.aria-expanded]="expandedEmails().has(row.email)"
+                  [attr.aria-label]="(expandedEmails().has(row.email) ? 'Collapse' : 'Expand') + ' open timeline for ' + row.displayName"
                   [attr.data-testid]="'newsletter-recipient-engagement-expand-' + row.email">
                   <i class="fa-light" [class.fa-chevron-down]="expandedEmails().has(row.email)" [class.fa-chevron-right]="!expandedEmails().has(row.email)"></i>
                 </button>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
@@ -139,7 +139,9 @@
                 <div class="flex flex-col gap-1 pl-2">
                   <span class="text-xs uppercase tracking-wide text-gray-500">Open timeline</span>
                   <ul class="flex flex-col gap-1">
-                    @for (openedAt of row.opened_at_list; track openedAt) {
+                    <!-- track $index, not the value: opened_at_list is second-precision (upstream SendGrid),
+                         so two opens in the same second collide on value and throw NG0955. -->
+                    @for (openedAt of row.opened_at_list; track $index) {
                       <li class="text-sm text-gray-700">{{ openedAt | date: 'MMM d, y, h:mm a' }}</li>
                     }
                   </ul>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
@@ -60,6 +60,10 @@ describe('NewsletterRecipientEngagementComponent', () => {
     return fixture.nativeElement.querySelector(`[data-testid="${testid}"]`);
   }
 
+  // Component debounces search input by 300ms (debounceTime(300)); the extra
+  // 50ms is slack against timer jitter, not a magic number tied to nothing.
+  const SEARCH_DEBOUNCE_WAIT_MS = 350;
+
   beforeEach(async () => {
     newsletterService = { getRecipientEngagement: vi.fn() };
     await TestBed.configureTestingModule({
@@ -106,7 +110,7 @@ describe('NewsletterRecipientEngagementComponent', () => {
     await createComponent();
 
     fixture.componentInstance.filterForm.get('search')!.setValue('bob');
-    await new Promise((resolve) => setTimeout(resolve, 350));
+    await new Promise((resolve) => setTimeout(resolve, SEARCH_DEBOUNCE_WAIT_MS));
     await fixture.whenStable();
 
     const rows = fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]');
@@ -114,21 +118,57 @@ describe('NewsletterRecipientEngagementComponent', () => {
     expect(rows[0].getAttribute('data-testid')).toBe('newsletter-recipient-engagement-row-bob@acme.io');
   });
 
-  it('toggles the open timeline for a recipient with opens', async () => {
+  it('toggles the open timeline for a recipient with opens, updating the expand button aria-label', async () => {
     newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
     await createComponent();
 
     expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).toBeNull();
+    const expandButton = card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement;
+    expect(expandButton.getAttribute('aria-label')).toBe('Expand open timeline for Jane Doe');
 
-    (card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement).click();
+    expandButton.click();
     await fixture.whenStable();
 
     expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).not.toBeNull();
+    expect(expandButton.getAttribute('aria-label')).toBe('Collapse open timeline for Jane Doe');
 
-    (card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement).click();
+    expandButton.click();
     await fixture.whenStable();
 
     expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).toBeNull();
+    expect(expandButton.getAttribute('aria-label')).toBe('Expand open timeline for Jane Doe');
+  });
+
+  // bob@acme.io has no `name` — displayName falls back to email, and the
+  // expand affordance should only appear because RESPONSE gives bob open_count: 0.
+  // Use a nameless recipient with opens to prove the aria-label fallback too.
+  it('toggles the open timeline for a recipient without a name, falling back to email in the aria-label', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(
+      of({
+        ...RESPONSE,
+        recipients: [
+          {
+            email: 'noname@acme.io',
+            delivered: true,
+            failed: false,
+            opened: true,
+            open_count: 1,
+            last_opened_at: '2026-08-09T10:00:00Z',
+            opened_at_list: ['2026-08-09T10:00:00Z'],
+          },
+        ],
+      })
+    );
+    await createComponent();
+
+    const expandButton = card('newsletter-recipient-engagement-expand-noname@acme.io') as HTMLButtonElement;
+    expect(expandButton.getAttribute('aria-label')).toBe('Expand open timeline for noname@acme.io');
+
+    expandButton.click();
+    await fixture.whenStable();
+
+    expect(card('newsletter-recipient-engagement-timeline-noname@acme.io')).not.toBeNull();
+    expect(expandButton.getAttribute('aria-label')).toBe('Collapse open timeline for noname@acme.io');
   });
 
   it('hides the section silently on a 403 (no auditor access)', async () => {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
@@ -1,0 +1,167 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NewsletterRecipientEngagementResponse } from '@lfx-one/shared/interfaces';
+import { NewsletterService } from '@services/newsletter.service';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { NewsletterRecipientEngagementComponent } from './newsletter-recipient-engagement.component';
+
+const RESPONSE: NewsletterRecipientEngagementResponse = {
+  newsletter_id: 'nl-1',
+  total_recipients: 3,
+  complete: true,
+  recipients: [
+    {
+      name: 'Jane Doe',
+      email: 'jane@acme.io',
+      delivered: true,
+      failed: false,
+      opened: true,
+      open_count: 2,
+      last_opened_at: '2026-08-09T10:00:00Z',
+      opened_at_list: ['2026-08-08T10:00:00Z', '2026-08-09T10:00:00Z'],
+    },
+    {
+      email: 'bob@acme.io',
+      delivered: true,
+      failed: false,
+      opened: false,
+      open_count: 0,
+      opened_at_list: [],
+    },
+    {
+      email: 'broken@acme.io',
+      delivered: false,
+      failed: true,
+      opened: false,
+      open_count: 0,
+      opened_at_list: [],
+    },
+  ],
+};
+
+describe('NewsletterRecipientEngagementComponent', () => {
+  let fixture: ComponentFixture<NewsletterRecipientEngagementComponent>;
+  let newsletterService: { getRecipientEngagement: ReturnType<typeof vi.fn> };
+
+  async function createComponent(status: 'draft' | 'sending' | 'sent' = 'sent'): Promise<void> {
+    fixture = TestBed.createComponent(NewsletterRecipientEngagementComponent);
+    fixture.componentRef.setInput('projectUid', 'proj-1');
+    fixture.componentRef.setInput('newsletterUid', 'nl-1');
+    fixture.componentRef.setInput('status', status);
+    await fixture.whenStable();
+  }
+
+  function card(testid: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${testid}"]`);
+  }
+
+  beforeEach(async () => {
+    newsletterService = { getRecipientEngagement: vi.fn() };
+    await TestBed.configureTestingModule({
+      imports: [NewsletterRecipientEngagementComponent],
+      providers: [{ provide: NewsletterService, useValue: newsletterService }],
+    }).compileComponents();
+  });
+
+  it('does not fetch and renders nothing for a draft newsletter', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+
+    await createComponent('draft');
+
+    expect(newsletterService.getRecipientEngagement).not.toHaveBeenCalled();
+    expect(card('newsletter-recipient-engagement')).toBeNull();
+  });
+
+  it('renders every recipient row and the chip counts once loaded', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement')).not.toBeNull();
+    expect(fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]')).toHaveLength(3);
+    expect(card('newsletter-recipient-engagement-segment-opened')?.textContent?.trim()).toBe('Opened (1)');
+    expect(card('newsletter-recipient-engagement-segment-not-opened')?.textContent?.trim()).toBe('Not opened (1)');
+    expect(card('newsletter-recipient-engagement-segment-failed')?.textContent?.trim()).toBe('Failed (1)');
+  });
+
+  it('filters rows to the selected engagement chip', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+    await createComponent();
+
+    (card('newsletter-recipient-engagement-segment-opened') as HTMLButtonElement).click();
+    await fixture.whenStable();
+
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].getAttribute('data-testid')).toBe('newsletter-recipient-engagement-row-jane@acme.io');
+  });
+
+  it('filters rows by search term across name and email', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+    await createComponent();
+
+    fixture.componentInstance.filterForm.get('search')!.setValue('bob');
+    await new Promise((resolve) => setTimeout(resolve, 350));
+    await fixture.whenStable();
+
+    const rows = fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]');
+    expect(rows).toHaveLength(1);
+    expect(rows[0].getAttribute('data-testid')).toBe('newsletter-recipient-engagement-row-bob@acme.io');
+  });
+
+  it('toggles the open timeline for a recipient with opens', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).toBeNull();
+
+    (card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement).click();
+    await fixture.whenStable();
+
+    expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).not.toBeNull();
+
+    (card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement).click();
+    await fixture.whenStable();
+
+    expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).toBeNull();
+  });
+
+  it('hides the section silently on a 403 (no auditor access)', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 403 })));
+
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement')).toBeNull();
+    expect(card('newsletter-recipient-engagement-error')).toBeNull();
+  });
+
+  it('hides the section silently on a 404 (endpoint not deployed yet)', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement')).toBeNull();
+  });
+
+  it('shows an inline error note on other failures instead of hiding', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 500 })));
+
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement-error')).not.toBeNull();
+    expect(card('newsletter-recipient-engagement')).toBeNull();
+  });
+
+  it('shows the partial-data note when the upstream response is incomplete', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(of({ ...RESPONSE, complete: false, total_recipients: 10 }));
+
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement-partial-note')?.textContent).toContain('3 of 10');
+  });
+});

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
@@ -171,6 +171,24 @@ describe('NewsletterRecipientEngagementComponent', () => {
     expect(expandButton.getAttribute('aria-label')).toBe('Collapse open timeline for noname@acme.io');
   });
 
+  // Regression: a recipient who opened before later bouncing/being marked spam
+  // carries both `opened: true` and `failed: true`. The Failed chip (and the
+  // Delivery column's own "Failed" tag) must win so the two stay consistent.
+  it('classifies a recipient with both opened and failed as failed', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(
+      of({
+        ...RESPONSE,
+        recipients: [
+          { email: 'bounced-after-open@acme.io', delivered: true, failed: true, opened: true, open_count: 1, opened_at_list: ['2026-08-08T10:00:00Z'] },
+        ],
+      })
+    );
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement-segment-failed')?.textContent?.trim()).toBe('Failed (1)');
+    expect(card('newsletter-recipient-engagement-segment-opened')?.textContent?.trim()).toBe('Opened (0)');
+  });
+
   it('hides the section silently on a 403 (no auditor access)', async () => {
     newsletterService.getRecipientEngagement.mockReturnValue(throwError(() => new HttpErrorResponse({ status: 403 })));
 
@@ -203,5 +221,17 @@ describe('NewsletterRecipientEngagementComponent', () => {
     await createComponent();
 
     expect(card('newsletter-recipient-engagement-partial-note')?.textContent).toContain('3 of 10');
+  });
+
+  // Regression: when the provider omits every record (not just some), the card
+  // must still render so the partial-data note is visible instead of the whole
+  // section silently disappearing.
+  it('still renders the partial-data note when the incomplete response has zero recipients', async () => {
+    newsletterService.getRecipientEngagement.mockReturnValue(of({ ...RESPONSE, complete: false, total_recipients: 10, recipients: [] }));
+
+    await createComponent();
+
+    expect(card('newsletter-recipient-engagement')).not.toBeNull();
+    expect(card('newsletter-recipient-engagement-partial-note')?.textContent).toContain('0 of 10');
   });
 });

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
@@ -88,10 +88,6 @@ export class NewsletterRecipientEngagementComponent {
     this.activeChip.set(key);
   }
 
-  public relativeOpened(iso: string): string {
-    return formatRelativeTime(new Date(iso));
-  }
-
   private initializeFilterForm(): FormGroup {
     return new FormGroup({
       search: new FormControl(''),
@@ -134,9 +130,12 @@ export class NewsletterRecipientEngagementComponent {
       });
   }
 
+  // `failed` takes precedence over `opened`: a recipient can bounce or be marked
+  // as spam *after* an earlier open, so `opened && failed` must classify as
+  // 'failed' to stay consistent with the Delivery column's own tag precedence.
   private classifySegment(recipient: NewsletterRecipientEngagement): NewsletterRecipientEngagementSegment {
-    if (recipient.opened) return 'opened';
     if (recipient.failed) return 'failed';
+    if (recipient.opened) return 'opened';
     return 'not-opened';
   }
 
@@ -148,6 +147,7 @@ export class NewsletterRecipientEngagementComponent {
           ...recipient,
           displayName: recipient.name || recipient.email,
           segment: this.classifySegment(recipient),
+          lastOpenedRelative: recipient.last_opened_at ? formatRelativeTime(new Date(recipient.last_opened_at)) : null,
         }))
         .sort((a, b) => {
           if (a.opened !== b.opened) return a.opened ? -1 : 1;

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
@@ -1,0 +1,191 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DatePipe } from '@angular/common';
+import { HttpErrorResponse } from '@angular/common/http';
+import { Component, computed, DestroyRef, inject, input, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { BadgeComponent } from '@components/badge/badge.component';
+import { CardComponent } from '@components/card/card.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
+import { TableComponent } from '@components/table/table.component';
+import { TagComponent } from '@components/tag/tag.component';
+import {
+  NewsletterRecipientEngagement,
+  NewsletterRecipientEngagementChipConfig,
+  NewsletterRecipientEngagementChipKey,
+  NewsletterRecipientEngagementResponse,
+  NewsletterRecipientEngagementSegment,
+  NewsletterRecipientRow,
+  NewsletterStatus,
+} from '@lfx-one/shared/interfaces';
+import { formatRelativeTime } from '@lfx-one/shared/utils';
+import { NewsletterService } from '@services/newsletter.service';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap } from 'rxjs';
+
+/**
+ * "Who received this and did they open it" — sits below the aggregate
+ * "Opens over time" chart on the newsletter analytics page. Self-contained:
+ * owns its own fetch/loading/error/visibility so it can hide itself (e.g. on
+ * 403 — the upstream endpoint is PII-gated behind the `auditor` relation,
+ * stricter than the aggregate analytics' `viewer` gate) without the parent
+ * needing to know why.
+ */
+@Component({
+  selector: 'lfx-newsletter-recipient-engagement',
+  imports: [DatePipe, ReactiveFormsModule, CardComponent, TableComponent, InputTextComponent, PersonAvatarComponent, TagComponent, BadgeComponent],
+  templateUrl: './newsletter-recipient-engagement.component.html',
+})
+export class NewsletterRecipientEngagementComponent {
+  private readonly newsletterService = inject(NewsletterService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // === Inputs ===
+  public readonly projectUid = input.required<string>();
+  public readonly newsletterUid = input.required<string>();
+  public readonly status = input.required<NewsletterStatus>();
+
+  // === Simple state ===
+  public readonly response = signal<NewsletterRecipientEngagementResponse | null>(null);
+  public readonly loading = signal<boolean>(false);
+  // True on 403 (no `auditor` access) or 404 — the section renders nothing at all.
+  public readonly hidden = signal<boolean>(false);
+  // Set on other failures (500/503) — the section stays visible with an inline note
+  // instead of hiding, since the aggregate analytics above remain usable.
+  public readonly loadErrorMessage = signal<string | null>(null);
+  public readonly expandedEmails = signal<Set<string>>(new Set());
+  public readonly activeChip = signal<NewsletterRecipientEngagementChipKey>('all');
+
+  // Filter form
+  public readonly filterForm: FormGroup;
+  public readonly searchTerm: Signal<string>;
+
+  // === Computed (complex bodies extracted to private init* methods) ===
+  public readonly rows: Signal<NewsletterRecipientRow[]> = this.initRows();
+  public readonly chipConfig: Signal<NewsletterRecipientEngagementChipConfig[]> = this.initChipConfig();
+  public readonly filteredRows: Signal<NewsletterRecipientRow[]> = this.initFilteredRows();
+  public readonly showCompletenessNote = computed(() => this.response()?.complete === false);
+
+  public constructor() {
+    this.filterForm = this.initializeFilterForm();
+    this.searchTerm = this.initializeSearchTerm();
+    this.initializeResponse();
+  }
+
+  public toggleTimeline(email: string): void {
+    const next = new Set(this.expandedEmails());
+    if (next.has(email)) {
+      next.delete(email);
+    } else {
+      next.add(email);
+    }
+    this.expandedEmails.set(next);
+  }
+
+  public selectChip(key: NewsletterRecipientEngagementChipKey): void {
+    this.activeChip.set(key);
+  }
+
+  public relativeOpened(iso: string): string {
+    return formatRelativeTime(new Date(iso));
+  }
+
+  private initializeFilterForm(): FormGroup {
+    return new FormGroup({
+      search: new FormControl(''),
+    });
+  }
+
+  private initializeSearchTerm(): Signal<string> {
+    return toSignal(this.filterForm.get('search')!.valueChanges.pipe(startWith(''), debounceTime(300), distinctUntilChanged()), { initialValue: '' });
+  }
+
+  private initializeResponse(): void {
+    combineLatest([toObservable(this.projectUid), toObservable(this.newsletterUid), toObservable(this.status)])
+      .pipe(
+        switchMap(([projectUid, newsletterUid, status]) => {
+          if (status !== 'sent' || !projectUid || !newsletterUid) {
+            this.loading.set(false);
+            return of(null);
+          }
+
+          this.loading.set(true);
+          this.hidden.set(false);
+          this.loadErrorMessage.set(null);
+
+          return this.newsletterService.getRecipientEngagement(projectUid, newsletterUid).pipe(
+            catchError((err: HttpErrorResponse) => {
+              if (err.status === 403 || err.status === 404) {
+                this.hidden.set(true);
+              } else {
+                this.loadErrorMessage.set('Could not load recipient details. Please try again.');
+              }
+              return of(null);
+            }),
+            finalize(() => this.loading.set(false))
+          );
+        }),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((data) => {
+        this.response.set(data);
+      });
+  }
+
+  private classifySegment(recipient: NewsletterRecipientEngagement): NewsletterRecipientEngagementSegment {
+    if (recipient.opened) return 'opened';
+    if (recipient.failed) return 'failed';
+    return 'not-opened';
+  }
+
+  private initRows(): Signal<NewsletterRecipientRow[]> {
+    return computed(() => {
+      const recipients = this.response()?.recipients ?? [];
+      return recipients
+        .map((recipient) => ({
+          ...recipient,
+          displayName: recipient.name || recipient.email,
+          segment: this.classifySegment(recipient),
+        }))
+        .sort((a, b) => {
+          if (a.opened !== b.opened) return a.opened ? -1 : 1;
+          return b.open_count - a.open_count;
+        });
+    });
+  }
+
+  private initChipConfig(): Signal<NewsletterRecipientEngagementChipConfig[]> {
+    return computed(() => {
+      const rows = this.rows();
+      const openedCount = rows.filter((row) => row.segment === 'opened').length;
+      const notOpenedCount = rows.filter((row) => row.segment === 'not-opened').length;
+      const failedCount = rows.filter((row) => row.segment === 'failed').length;
+      return [
+        { key: 'all', label: 'All', count: rows.length },
+        { key: 'opened', label: 'Opened', count: openedCount },
+        { key: 'not-opened', label: 'Not opened', count: notOpenedCount },
+        { key: 'failed', label: 'Failed', count: failedCount },
+      ];
+    });
+  }
+
+  private initFilteredRows(): Signal<NewsletterRecipientRow[]> {
+    return computed(() => {
+      let filtered = this.rows();
+
+      const chip = this.activeChip();
+      if (chip !== 'all') {
+        filtered = filtered.filter((row) => row.segment === chip);
+      }
+
+      const term = this.searchTerm().toLowerCase().trim();
+      if (term) {
+        filtered = filtered.filter((row) => row.displayName.toLowerCase().includes(term) || row.email.toLowerCase().includes(term));
+      }
+
+      return filtered;
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
@@ -47,6 +47,10 @@ export class NewsletterRecipientEngagementComponent {
   public readonly newsletterUid = input.required<string>();
   public readonly status = input.required<NewsletterStatus>();
 
+  // Filter form
+  public readonly filterForm: FormGroup;
+  public readonly searchTerm: Signal<string>;
+
   // === Simple state ===
   public readonly response = signal<NewsletterRecipientEngagementResponse | null>(null);
   public readonly loading = signal<boolean>(false);
@@ -57,10 +61,6 @@ export class NewsletterRecipientEngagementComponent {
   public readonly loadErrorMessage = signal<string | null>(null);
   public readonly expandedEmails = signal<Set<string>>(new Set());
   public readonly activeChip = signal<NewsletterRecipientEngagementChipKey>('all');
-
-  // Filter form
-  public readonly filterForm: FormGroup;
-  public readonly searchTerm: Signal<string>;
 
   // === Computed (complex bodies extracted to private init* methods) ===
   public readonly rows: Signal<NewsletterRecipientRow[]> = this.initRows();

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
@@ -96,6 +96,8 @@
         </div>
       </lfx-card>
 
+      <lfx-newsletter-recipient-engagement [projectUid]="projectUid()" [newsletterUid]="newsletterId()" [status]="a.status" />
+
       <lfx-newsletter-failed-recipients-drawer [(visible)]="failedDrawerVisible" [failedRecipients]="a.failed_recipients ?? []" [failedCount]="a.failed" />
     </div>
   }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
@@ -17,10 +17,19 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, finalize, of, switchMap, take } from 'rxjs';
 
 import { NewsletterFailedRecipientsDrawerComponent } from '../components/newsletter-failed-recipients-drawer/newsletter-failed-recipients-drawer.component';
+import { NewsletterRecipientEngagementComponent } from '../components/newsletter-recipient-engagement/newsletter-recipient-engagement.component';
 
 @Component({
   selector: 'lfx-newsletter-analytics',
-  imports: [DatePipe, CardComponent, ChartComponent, EmptyStateComponent, SkeletonModule, NewsletterFailedRecipientsDrawerComponent],
+  imports: [
+    DatePipe,
+    CardComponent,
+    ChartComponent,
+    EmptyStateComponent,
+    SkeletonModule,
+    NewsletterFailedRecipientsDrawerComponent,
+    NewsletterRecipientEngagementComponent,
+  ],
   templateUrl: './newsletter-analytics.component.html',
   styleUrl: './newsletter-analytics.component.scss',
 })
@@ -38,6 +47,9 @@ export class NewsletterAnalyticsComponent {
   protected readonly loadError = signal<string | null>(null);
   protected readonly canRenderChart = signal<boolean>(false);
   protected readonly failedDrawerVisible = signal<boolean>(false);
+  // Route params, retained for the recipient engagement child component's inputs.
+  protected readonly projectUid = signal<string>('');
+  protected readonly newsletterId = signal<string>('');
 
   // === Computed (complex bodies extracted to private init* methods) ===
   protected readonly openRatePercent: Signal<number | null> = this.initOpenRatePercent();
@@ -68,6 +80,8 @@ export class NewsletterAnalyticsComponent {
             this.loadError.set('Missing newsletter id or project.');
             return of(null);
           }
+          this.projectUid.set(projectUid);
+          this.newsletterId.set(id);
           this.loading.set(true);
           this.loadError.set(null);
           return this.newsletterService.getAnalytics(projectUid, id).pipe(

--- a/apps/lfx-one/src/app/shared/services/newsletter.service.ts
+++ b/apps/lfx-one/src/app/shared/services/newsletter.service.ts
@@ -15,6 +15,7 @@ import {
   NewsletterOptOutListResponse,
   NewsletterRecipientCount,
   NewsletterRecipientCountPayload,
+  NewsletterRecipientEngagementResponse,
   NewsletterRecipientsResponse,
   NewsletterSendResult,
   NewsletterTestSendPayload,
@@ -68,6 +69,18 @@ export class NewsletterService {
 
   public getAnalytics(projectUid: string, newsletterUid: string): Observable<NewsletterAnalytics> {
     return this.http.get<NewsletterAnalytics>(`/api/projects/${this.enc(projectUid)}/newsletters/${this.enc(newsletterUid)}/analytics`).pipe(take(1));
+  }
+
+  /**
+   * Per-recipient engagement: who the newsletter went to, delivery outcome,
+   * and every recorded open. PII-gated upstream (requires the `auditor`
+   * relation) — callers should handle 403 distinctly from getAnalytics, which
+   * a broader set of users can reach.
+   */
+  public getRecipientEngagement(projectUid: string, newsletterUid: string): Observable<NewsletterRecipientEngagementResponse> {
+    return this.http
+      .get<NewsletterRecipientEngagementResponse>(`/api/projects/${this.enc(projectUid)}/newsletters/${this.enc(newsletterUid)}/analytics/recipients`)
+      .pipe(take(1));
   }
 
   public listOptOuts(projectUid: string): Observable<NewsletterOptOutListResponse> {

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -289,6 +289,27 @@ export class NewsletterController {
   }
 
   /**
+   * GET /api/projects/:projectUid/newsletters/:newsletterUid/analytics/recipients
+   */
+  public async getRecipientEngagement(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const projectUid = this.requireProjectUid(req);
+    const newsletterUid = this.requireNewsletterUid(req);
+    const startTime = logger.startOperation(req, 'newsletter_recipient_engagement', { project_uid: projectUid, newsletter_id: newsletterUid });
+
+    try {
+      const engagement = await this.newsletterService.getRecipientEngagement(req, projectUid, newsletterUid);
+      logger.success(req, 'newsletter_recipient_engagement', startTime, {
+        newsletter_id: newsletterUid,
+        total_recipients: engagement.total_recipients,
+        complete: engagement.complete,
+      });
+      res.json(engagement);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /api/projects/:projectUid/newsletters/opt-outs
    */
   public async listOptOuts(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/controllers/newsletter.controller.ts
+++ b/apps/lfx-one/src/server/controllers/newsletter.controller.ts
@@ -292,11 +292,12 @@ export class NewsletterController {
    * GET /api/projects/:projectUid/newsletters/:newsletterUid/analytics/recipients
    */
   public async getRecipientEngagement(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const projectUid = this.requireProjectUid(req);
-    const newsletterUid = this.requireNewsletterUid(req);
-    const startTime = logger.startOperation(req, 'newsletter_recipient_engagement', { project_uid: projectUid, newsletter_id: newsletterUid });
-
+    // Validation must run inside the try: Express 4 doesn't forward async
+    // rejections, so a throw before the catch would hang the request.
     try {
+      const projectUid = this.requireProjectUid(req);
+      const newsletterUid = this.requireNewsletterUid(req);
+      const startTime = logger.startOperation(req, 'newsletter_recipient_engagement', { project_uid: projectUid, newsletter_id: newsletterUid });
       const engagement = await this.newsletterService.getRecipientEngagement(req, projectUid, newsletterUid);
       logger.success(req, 'newsletter_recipient_engagement', startTime, {
         newsletter_id: newsletterUid,

--- a/apps/lfx-one/src/server/routes/newsletters.route.ts
+++ b/apps/lfx-one/src/server/routes/newsletters.route.ts
@@ -45,5 +45,6 @@ router.put('/:newsletterUid', (req, res, next) => newsletterController.updateNew
 router.delete('/:newsletterUid', (req, res, next) => newsletterController.deleteNewsletter(req, res, next));
 router.post('/:newsletterUid/send', (req, res, next) => newsletterController.sendNewsletter(req, res, next));
 router.get('/:newsletterUid/analytics', (req, res, next) => newsletterController.getAnalytics(req, res, next));
+router.get('/:newsletterUid/analytics/recipients', (req, res, next) => newsletterController.getRecipientEngagement(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/newsletter-service.client.ts
+++ b/apps/lfx-one/src/server/services/newsletter-service.client.ts
@@ -12,6 +12,7 @@ import {
   NewsletterOptOutListResponse,
   NewsletterRecipientCount,
   NewsletterRecipientCountPayload,
+  NewsletterRecipientEngagementResponse,
   NewsletterRecipientsResponse,
   NewsletterSendResult,
   NewsletterTestSendPayload,
@@ -160,6 +161,21 @@ export class NewsletterServiceClient {
       req,
       'LFX_V2_SERVICE',
       `/projects/${projectUid}/newsletters/${newsletterUid}/analytics`,
+      'GET'
+    );
+  }
+
+  /**
+   * Per-recipient engagement: who the newsletter went to, delivery outcome,
+   * and every recorded open. PII-gated upstream (requires the `auditor`
+   * relation, fail-closed) — stricter than getAnalytics's `viewer` gate, so
+   * this call can 403 for a user who can see the aggregate analytics.
+   */
+  public async getRecipientEngagement(req: Request, projectUid: string, newsletterUid: string): Promise<NewsletterRecipientEngagementResponse> {
+    return this.microserviceProxy.proxyRequest<NewsletterRecipientEngagementResponse>(
+      req,
+      'LFX_V2_SERVICE',
+      `/projects/${projectUid}/newsletters/${newsletterUid}/analytics/recipients`,
       'GET'
     );
   }

--- a/apps/lfx-one/src/server/services/newsletter.service.ts
+++ b/apps/lfx-one/src/server/services/newsletter.service.ts
@@ -12,6 +12,7 @@ import {
   NewsletterOptOutListResponse,
   NewsletterRecipientCount,
   NewsletterRecipientCountPayload,
+  NewsletterRecipientEngagementResponse,
   NewsletterRecipientsResponse,
   NewsletterSendResult,
   NewsletterTestSendPayload,
@@ -150,6 +151,10 @@ export class NewsletterService {
 
   public getAnalytics(req: Request, projectUid: string, newsletterUid: string): Promise<NewsletterAnalytics> {
     return this.newsletterClient.getAnalytics(req, projectUid, newsletterUid);
+  }
+
+  public getRecipientEngagement(req: Request, projectUid: string, newsletterUid: string): Promise<NewsletterRecipientEngagementResponse> {
+    return this.newsletterClient.getRecipientEngagement(req, projectUid, newsletterUid);
   }
 
   public listOptOuts(req: Request, projectUid: string): Promise<NewsletterOptOutListResponse> {

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -262,6 +262,9 @@ export type NewsletterRecipientEngagementSegment = 'opened' | 'not-opened' | 'fa
 export interface NewsletterRecipientRow extends NewsletterRecipientEngagement {
   displayName: string;
   segment: NewsletterRecipientEngagementSegment;
+  // Precomputed so the template never calls a component method for formatting
+  // (re-runs every CD cycle) — null when there's no last_opened_at to format.
+  lastOpenedRelative: string | null;
 }
 
 /** Filter chip key for the recipient engagement table — `'all'` plus every `NewsletterRecipientEngagementSegment`. */

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -207,6 +207,73 @@ export interface NewsletterAnalytics {
   last_event_at?: string;
 }
 
+/**
+ * One recipient's row from the per-recipient engagement endpoint
+ * (GET …/newsletters/{id}/analytics/recipients). Mirrors the upstream DTO
+ * (lfx-v2-newsletter-service PR #74) field-for-field.
+ */
+export interface NewsletterRecipientEngagement {
+  // Best-effort display name resolved from the newsletter's committees at read
+  // time. Absent when the member no longer appears in the committees, has no
+  // name on file, or the committee lookup failed — clients fall back to email.
+  name?: string;
+  email: string;
+  sent_at?: string;
+  delivered: boolean;
+  delivered_at?: string;
+  failed: boolean;
+  failed_at?: string;
+  opened: boolean;
+  open_count: number;
+  last_opened_at?: string;
+  // Every recorded open timestamp, ascending. Always present (empty array when
+  // the recipient never opened); capped at the 500 most recent opens.
+  opened_at_list: string[];
+}
+
+/**
+ * Body of GET …/newsletters/{id}/analytics/recipients. This endpoint is
+ * PII-gated upstream (requires the `auditor` relation, fail-closed) — stricter
+ * than the aggregate `/analytics` endpoint's `viewer` gate, so callers must
+ * handle 403 distinctly (a user who can see NewsletterAnalytics may still lack
+ * access here).
+ */
+export interface NewsletterRecipientEngagementResponse {
+  newsletter_id: string;
+  // The newsletter's send-time audience snapshot.
+  total_recipients: number;
+  // False when the provider returned fewer per-recipient records than
+  // total_recipients — clients must treat the list as partial, not as proof
+  // the absent recipients were never sent to.
+  complete: boolean;
+  // Sorted by email ascending; always present; no pagination (upstream returns
+  // the full committee-bounded audience in one response).
+  recipients: NewsletterRecipientEngagement[];
+}
+
+export type NewsletterRecipientEngagementSegment = 'opened' | 'not-opened' | 'failed';
+
+/**
+ * UI view-model row derived from NewsletterRecipientEngagement for the
+ * recipient engagement table: adds the resolved display fallback and the
+ * bucket used for the filter chips, keeping the template free of nested
+ * ternaries.
+ */
+export interface NewsletterRecipientRow extends NewsletterRecipientEngagement {
+  displayName: string;
+  segment: NewsletterRecipientEngagementSegment;
+}
+
+/** Filter chip key for the recipient engagement table — `'all'` plus every `NewsletterRecipientEngagementSegment`. */
+export type NewsletterRecipientEngagementChipKey = 'all' | NewsletterRecipientEngagementSegment;
+
+/** One filter chip above the recipient engagement table, with its live count. */
+export interface NewsletterRecipientEngagementChipConfig {
+  key: NewsletterRecipientEngagementChipKey;
+  label: string;
+  count: number;
+}
+
 export interface NewsletterRow extends NewsletterListItem {
   openRateLabel: string;
   /** UI-populated: true while the row's analytics fetch is in flight. */


### PR DESCRIPTION
## Summary

Adds a **Recipient engagement** section to the newsletter analytics page, below the existing "Opens over time" chart — surfacing who received a newsletter and whether/when they opened it, not just aggregate counts.

- Filter chips (All / Opened / Not opened / Failed) with live counts
- Search across recipient name and email
- Expandable open timeline per recipient (`opened_at_list`)
- Client-side paginated table (10/25/50 rows)
- Partial-data note when the upstream response is incomplete (`complete: false`)

## Access handling

The new `/analytics/recipients` endpoint is **PII-gated** upstream (requires the `auditor` relation, fail-closed) — stricter than the aggregate `/analytics` endpoint's `viewer` gate. The section:

- **Hides silently** on 403 (no `auditor` access) or 404 (endpoint not yet deployed) — the chart and stat cards above remain fully usable.
- Shows a small inline note on other failures (500/503) instead of hiding, since the aggregate analytics stay usable.
- Renders nothing for drafts/unsent newsletters.

## Upstream dependency

Consumes `GET /projects/{project_uid}/newsletters/{newsletter_uid}/analytics/recipients`, added in linuxfoundation/lfx-v2-newsletter-service#74. **This PR is safe to merge ahead of that upstream deploying** — the section hides itself if the endpoint 403s/404s — but recipient data won't actually render until the upstream change is live in the target environment.

## Changes

- **Shared** (`packages/shared/src/interfaces/newsletter.interface.ts`): new `NewsletterRecipientEngagement`, `NewsletterRecipientEngagementResponse`, `NewsletterRecipientRow`, and filter-chip types, mirroring the upstream DTO field-for-field.
- **Server**: thin proxy chain (route → controller → service → client) mirroring the existing `getAnalytics` pattern; user bearer token (not M2M), per repo auth convention.
- **Frontend**: new self-contained `lfx-newsletter-recipient-engagement` component (owns its own fetch/loading/error/visibility state) wired into `newsletter-analytics.component.html`.
- **Tests**: new `newsletter-recipient-engagement.component.spec.ts` — happy path, chip/search filtering, timeline expand/collapse (incl. aria-label + no-name fallback), and 403/404/500 error handling.

## Verification

- `yarn check-types`, `yarn lint`, `yarn build` (SSR-safe) all pass.
- New unit test spec: 10/10 passing.
- Reviewed via the local post-commit reviewer trio (emulated — `lfx-skills` plugin agents unavailable in this session) on every commit, plus a full-branch sweep against `origin/main`; all clean.
- `/lfx-self-serve-pr-readiness` and `/preflight` both clean.

Manual QA against a real auditor-gated environment (403 path, `complete:false` path) is still recommended before/after merge, since local dev doesn't currently exercise the upstream PII gate end-to-end.