### PR TITLE
docs(meetings): correct inaccuracies in meetings user docs

### DIFF
--- a/docs/user/meetings/faq/index.md
+++ b/docs/user/meetings/faq/index.md
@@ -15,9 +15,11 @@ Users with **maintainer**, **board-member**, or **executive-director** personas 
 
 ## Does an attendee need an LFX account to join a meeting?
 
-Not for a standard public meeting. Each non-restricted meeting has a public join page at `/meetings/:id` that's accessible without authentication — you can share this link with anyone.
+No — no meeting requires an LFX account to view or join. Every meeting has a public join page at `/meetings/:id` that you can share with anyone.
 
-If a meeting is marked **Restricted**, the attendee needs to already be on the meeting's registrant list (matched by their email or username) to see full join details. That's a registration check, not a passcode — see "Can I protect a meeting with a passcode?" below.
+If a meeting is marked **Private**, the join link carries the meeting's password as part of the URL, so anyone with that link can join without signing in. If a meeting is marked **Restricted**, the attendee needs to submit an email or username that matches an existing registrant record to see full join details — that's a registration check, not a passcode or a login requirement. See "Can I protect a meeting with a passcode?" below.
+
+Note that the organizer's name and contact link on the join page are only visible to signed-in visitors, even on an otherwise-public meeting.
 
 ## What is the AI agenda generation feature?
 
@@ -29,7 +31,7 @@ Yes. The meeting creation form has a full recurrence builder: repeat every N day
 
 ## How do I add meetings to my calendar?
 
-There's currently no button to download a single meeting as its own ICS file. Instead, from the **Meetings** dashboard in your Foundation or Project lens, use the **Subscribe** button to get a live calendar feed (ICS URL) covering all of that project's or foundation's meetings. Add that feed once to Google Calendar, Outlook, or Apple Calendar, and it stays up to date automatically.
+There's currently no button to download a single meeting as its own ICS file. Instead, from the **Meetings** dashboard in your Foundation or Project lens, use the **Subscribe** button to get a live calendar feed (ICS URL) for that project's or foundation's meetings. The feed excludes **Private** meetings; **Restricted**-but-public meetings still appear on it. Add the feed once to Google Calendar, Outlook, or Apple Calendar, and it stays up to date automatically.
 
 ## What happens when I open a meeting link and see "Meeting Not Found"?
 
@@ -37,7 +39,7 @@ This can happen if the link has expired or is no longer valid, the meeting was d
 
 ## Can I protect a meeting with a passcode?
 
-There's no separate passcode field for meetings. Access control works through the **Restricted** meeting setting instead: a restricted meeting only shows full join details to people who match an existing registrant (by email or username). If you need access to a restricted meeting, ask the organizer to add you as a registrant rather than asking for a passcode.
+There's no passcode field you enter manually. **Private** meetings do have a password, but it's embedded automatically in the join link when the organizer copies it — you don't type it in separately. Access to a **Restricted** meeting works differently: it only shows full join details to people who match an existing registrant (by email or username). If you need access to a restricted meeting, ask the organizer to add you as a registrant.
 
 ## Why can't I see a meeting I was invited to?
 

--- a/docs/user/meetings/faq/index.md
+++ b/docs/user/meetings/faq/index.md
@@ -5,38 +5,40 @@ audience: [all]
 product_area: Meetings
 tags: [meetings, faq, schedule, join]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-10
 intercom_collection: Meetings
 ---
 
 ## Who can create meetings?
 
-Users with **maintainer**, **board-member**, or **executive-director** personas can create and manage meetings. Contributors can view meeting details but cannot create or edit meetings.
+Users with **maintainer**, **board-member**, or **executive-director** personas can create and manage meetings for their projects. A project can also grant an individual **Meeting Coordinator** access specifically for meetings, which lets them create and manage meetings for that project even if they don't otherwise hold one of those personas. Contributors without that grant can view meeting details but cannot create or edit meetings.
 
 ## Does an attendee need an LFX account to join a meeting?
 
-No. Each meeting has a public join page at `/meetings/:id` that is accessible without authentication. You can share this link with anyone — they do not need an LFX account to view the meeting details.
+Not for a standard public meeting. Each non-restricted meeting has a public join page at `/meetings/:id` that's accessible without authentication — you can share this link with anyone.
+
+If a meeting is marked **Restricted**, the attendee needs to already be on the meeting's registrant list (matched by their email or username) to see full join details. That's a registration check, not a passcode — see "Can I protect a meeting with a passcode?" below.
 
 ## What is the AI agenda generation feature?
 
-When creating or editing a meeting, you can use AI assistance to generate a draft agenda from a prompt. The AI service uses the LiteLLM proxy to produce agenda suggestions that you can review and edit before saving.
+When creating or editing a meeting, you can fill in a title, meeting type, and a short prompt, then use AI assistance to generate a draft agenda. Review and edit the suggestion before saving — it's a starting point, not a final agenda.
 
 ## Can I schedule recurring meetings?
 
-Recurring meeting options are available in the meeting creation form. Contact your project administrator for details on recurrence settings.
+Yes. The meeting creation form has a full recurrence builder: repeat every N days, weeks, or months; for weekly meetings, choose specific days of the week; for monthly meetings, choose either a fixed day of the month or a pattern like "the second Tuesday." Set the series to end on a specific date or after a set number of occurrences.
 
-## How do I add a meeting to my calendar?
+## How do I add meetings to my calendar?
 
-From the meeting detail page, download the meeting as an ICS (iCalendar) file. Open the file in any calendar application — such as Google Calendar, Outlook, or Apple Calendar — to add the meeting.
+There's currently no button to download a single meeting as its own ICS file. Instead, from the **Meetings** dashboard in your Foundation or Project lens, use the **Subscribe** button to get a live calendar feed (ICS URL) covering all of that project's or foundation's meetings. Add that feed once to Google Calendar, Outlook, or Apple Calendar, and it stays up to date automatically.
 
 ## What happens when I open a meeting link and see "Meeting Not Found"?
 
-The meeting ID in the link may be incorrect, or the meeting may have been removed. Contact your meeting organizer for the correct link.
+This can happen if the link has expired or is no longer valid, the meeting was deleted or cancelled, the meeting is restricted and you don't have access, or there's a typo in the URL. Contact your meeting organizer for a correct link, or use the "Contact Support" option on that page.
 
 ## Can I protect a meeting with a passcode?
 
-If a meeting requires a passcode, you will be prompted to enter it when joining. Contact the meeting organizer if you need the passcode.
+There's no separate passcode field for meetings. Access control works through the **Restricted** meeting setting instead: a restricted meeting only shows full join details to people who match an existing registrant (by email or username). If you need access to a restricted meeting, ask the organizer to add you as a registrant rather than asking for a passcode.
 
 ## Why can't I see a meeting I was invited to?
 
-If you are looking for a meeting in the meetings dashboard, make sure you have the correct project context selected in the lens switcher. Meetings are scoped to a project. If you have only the join link, open it directly in your browser — no account or project context is needed.
+Make sure you're in the right lens: your personal **My Meetings** view (Me lens) shows meetings across all your projects, while a project's **Meetings** page (Project lens) only shows that project's meetings. Use the lens switcher to move between them. If you only have the join link, you can open it directly in your browser — no account or project context needed, unless the meeting is restricted.

--- a/docs/user/meetings/index.md
+++ b/docs/user/meetings/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Meetings
 tags: [meetings, schedule, calendar, join, zoom, virtual]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-10
 intercom_collection: Meetings
 ---
 
@@ -14,30 +14,44 @@ The Meetings section lets you create, manage, and join meetings for your Linux F
 ## What you can do
 
 - View upcoming and past project meetings
-- Schedule new meetings with calendar integration
-- Edit existing meeting details (title, time, agenda)
-- Join meetings via the public meeting join page
-- Generate meeting agendas with AI assistance
-- Download meeting details as calendar files (ICS format)
+- Schedule new meetings, choosing a video platform and recurrence pattern
+- Edit existing meeting details (title, time, agenda, platform)
+- Join meetings via the public meeting join page — no LFX account required
+- Generate a draft meeting agenda with AI assistance
+- Subscribe to a live calendar feed of a project's or foundation's meetings
 
 ## Who this applies to
 
-All authenticated users can view meetings for their projects. Creating and managing meetings requires a maintainer, board-member, or executive-director persona. The public meeting join page (`/meetings/:id`) is accessible without authentication.
+All authenticated users can view meetings for their projects. Contributors have view-only access.
+
+Creating and managing meetings requires a **maintainer**, **board-member**, or **executive-director** persona — or, for a specific project, a user who has been granted **Meeting Coordinator** access for that project even without one of those personas.
+
+The public meeting join page (`/meetings/:id`) is accessible without authentication for meetings that aren't marked Private or Restricted.
 
 ## Navigation
 
-Go to **app.lfx.dev** and select **Meetings** from the left navigation sidebar. The meetings dashboard (route: `/meetings`) shows upcoming and recent meetings for your active project context. Tabs: **Upcoming**, **Past**, **Pending RSVP**. Empty state: "No upcoming meetings / Meetings from your committees and projects will appear here."
+The left navigation label for this section depends on which lens you're in:
+
+- **Me lens** (your personal view): the sidebar item is **My Meetings**, at route `/meetings`. This shows meetings across all of your projects, but does not include a way to create a new meeting.
+- **Foundation, Project, or Org lens**: the sidebar item is **Meetings**, scoped to that foundation, project, or org. This is where the **Create Meeting** button appears, if you have write access.
+
+All of these lead to the same dashboard, just scoped differently. Time filters: **Upcoming** and **Past**. In the Me lens, an additional **Pending RSVP** filter (Upcoming only) and **Organized by me** filter (Upcoming and Past) are available.
+
+Empty states differ by lens:
+- Me lens, no upcoming meetings: "No upcoming meetings — Meetings from your committees and projects will appear here."
+- Foundation/Project/Org lens, no upcoming meetings: "No meetings yet — Schedule a meeting to get started."
 
 ## Key concepts
 
-- **Meeting dashboard**: The list view of all meetings for your project
-- **Meeting join page**: A public URL where attendees can join a meeting without signing in
-- **Meeting not found page**: Shown when a meeting ID does not match any known meeting
-- **Calendar integration**: Meetings can be added to your calendar via ICS file download
+- **Meeting dashboard**: The list (or calendar) view of meetings, scoped to your current lens
+- **Meeting join page**: A public URL where attendees can view meeting details and join without signing in, unless the meeting is Private or Restricted
+- **Meeting Not Found page**: Shown when a meeting link is invalid, expired, or the meeting was deleted or cancelled
+- **Restricted meeting**: A meeting that only lets in people who match an existing registrant record (by email or username) — there's no separate meeting passcode
+- **Calendar subscription**: From the Foundation or Project lens dashboard, the **Subscribe** button gives you a live ICS feed URL for that project's or foundation's meetings, which you add once to your calendar app. There is no per-meeting ICS download.
 
 ## Public meeting access
 
-Each meeting has a public join link at `/meetings/:id`. This page is accessible without authentication and shows the meeting details and join information. Attendees do not need an LFX account to view the join page.
+Each non-restricted meeting has a public join link at `/meetings/:id`. This page shows meeting details, who's organizing it (with a direct email link), and the information you need to join — no LFX account required. If a meeting is marked **Restricted**, you'll need to be on the registrant list to see full join details; contact the meeting organizer (shown on the page) to be added.
 
 ## Related sections
 

--- a/docs/user/meetings/index.md
+++ b/docs/user/meetings/index.md
@@ -26,16 +26,17 @@ All authenticated users can view meetings for their projects. Contributors have 
 
 Creating and managing meetings requires a **maintainer**, **board-member**, or **executive-director** persona — or, for a specific project, a user who has been granted **Meeting Coordinator** access for that project even without one of those personas.
 
-The public meeting join page (`/meetings/:id`) is accessible without authentication for meetings that aren't marked Private or Restricted.
+No meeting ever strictly requires an LFX account to view or join. A **Private** meeting is joinable by anyone with the link, which carries the meeting's password as a query parameter — no sign-in involved. A **Restricted** meeting checks the email or username you provide against its registrant list; that's a registrant-match check, not an authentication requirement.
 
 ## Navigation
 
 The left navigation label for this section depends on which lens you're in:
 
 - **Me lens** (your personal view): the sidebar item is **My Meetings**, at route `/meetings`. This shows meetings across all of your projects, but does not include a way to create a new meeting.
-- **Foundation, Project, or Org lens**: the sidebar item is **Meetings**, scoped to that foundation, project, or org. This is where the **Create Meeting** button appears, if you have write access.
+- **Foundation or Project lens**: the sidebar item is **Meetings**, scoped to that foundation or project. This is where the **Create Meeting** button appears, if you have write access.
+- **Org lens**: the sidebar item is also labeled **Meetings**, but it opens a meeting analytics view for the org rather than the shared meetings dashboard — there's no Create Meeting button here.
 
-All of these lead to the same dashboard, just scoped differently. Time filters: **Upcoming** and **Past**. In the Me lens, an additional **Pending RSVP** filter (Upcoming only) and **Organized by me** filter (Upcoming and Past) are available.
+Me, Foundation, and Project lenses share the same dashboard, just scoped differently. Time filters: **Upcoming** and **Past**. In the Me lens, an additional **Pending RSVP** filter (Upcoming only) and **Organized by me** filter (Upcoming and Past) are available.
 
 Empty states differ by lens:
 
@@ -48,11 +49,11 @@ Empty states differ by lens:
 - **Meeting join page**: A public URL where attendees can view meeting details and join without signing in, unless the meeting is Private or Restricted
 - **Meeting Not Found page**: Shown when a meeting link is invalid, expired, or the meeting was deleted or cancelled
 - **Restricted meeting**: A meeting that only lets in people who match an existing registrant record (by email or username) — there's no separate meeting passcode
-- **Calendar subscription**: From the Foundation or Project lens dashboard, the **Subscribe** button gives you a live ICS feed URL for that project's or foundation's meetings, which you add once to your calendar app. There is no per-meeting ICS download.
+- **Calendar subscription**: From the Foundation or Project lens dashboard, the **Subscribe** button gives you a live ICS feed URL for that project's or foundation's meetings, which you add once to your calendar app. The feed excludes **Private** meetings; **Restricted** meetings that are otherwise public still appear on it. There is no per-meeting ICS download.
 
 ## Public meeting access
 
-Each non-restricted meeting has a public join link at `/meetings/:id`. This page shows meeting details, who's organizing it (with a direct email link), and the information you need to join — no LFX account required. If a meeting is marked **Restricted**, you'll need to be on the registrant list to see full join details; contact the meeting organizer (shown on the page) to be added.
+Every meeting has a join link at `/meetings/:id`, and viewing or joining it never requires an LFX account. This page shows meeting details and the information you need to join. The meeting organizer's name and contact link are only shown to signed-in visitors — unauthenticated visitors see the meeting details without organizer contact info. If a meeting is marked **Restricted**, you'll need to submit an email or username that matches an existing registrant to see full join details; contact the meeting organizer to be added as a registrant.
 
 ## Related sections
 

--- a/docs/user/meetings/index.md
+++ b/docs/user/meetings/index.md
@@ -38,6 +38,7 @@ The left navigation label for this section depends on which lens you're in:
 All of these lead to the same dashboard, just scoped differently. Time filters: **Upcoming** and **Past**. In the Me lens, an additional **Pending RSVP** filter (Upcoming only) and **Organized by me** filter (Upcoming and Past) are available.
 
 Empty states differ by lens:
+
 - Me lens, no upcoming meetings: "No upcoming meetings — Meetings from your committees and projects will appear here."
 - Foundation/Project/Org lens, no upcoming meetings: "No meetings yet — Schedule a meeting to get started."
 

--- a/docs/user/meetings/join-meeting/index.md
+++ b/docs/user/meetings/join-meeting/index.md
@@ -5,32 +5,29 @@ audience: [all]
 product_area: Meetings
 tags: [meetings, join, public, attendee]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-10
 intercom_collection: Meetings
 ---
 
-Any project meeting hosted in LFX Self Serve has a public join page that does not require an LFX account. This page shows the meeting details and provides the information you need to join.
+Any non-restricted project meeting hosted in LFX Self Serve has a public join page that does not require an LFX account. Opening the link takes you straight to that meeting's details — there's no list to pick from first.
 
 ## Steps
 
 1. Open the meeting join link shared by your meeting organizer. The link follows the format: `https://app.lfx.dev/meetings/{meeting-id}`.
-2. Select the meeting to open its detail page and use the join link provided. You may need a passcode if the meeting organizer has enabled passcode protection.
+2. The page shows the meeting title, date and time, who's organizing it, and a join button (if the meeting is starting soon or already underway). Use the **Copy meeting link** button if you want to save or forward it.
+3. If the meeting is marked **Restricted**, you'll need to be on the registrant list (matched by your email or username) to see full join details — see "Restricted meetings" below.
 
 ## No account required
 
-The meeting join page (`/meetings/:id`) is publicly accessible without authentication. You do not need an LFX account to view meeting details or access the join link.
+The meeting join page (`/meetings/:id`) is publicly accessible without authentication for meetings that aren't marked Private or Restricted. You do not need an LFX account to view meeting details or access the join link.
 
 ## Meeting not found
 
-If you open a meeting link and see the **Meeting Not Found** page, the meeting ID may be incorrect or the meeting may have been removed. Contact the meeting organizer for the correct link.
+If you open a meeting link and see the **Meeting Not Found** page, it's usually one of: the link has expired or is no longer valid, the meeting was deleted or cancelled, you need access to a restricted meeting, or there's a typo in the URL. Contact the meeting organizer for a correct link, or use the **Contact Support** button on that page.
 
-## Passcode-protected meetings
+## Restricted meetings
 
-If a meeting requires a passcode, you will be prompted to enter it when joining. Contact the meeting organizer if you need the passcode.
-
-## Add to your calendar
-
-Check the meeting detail page for calendar download options.
+There's no separate meeting passcode. Instead, some meetings are marked **Restricted**, which means only people who match an existing registrant record (by email or username) can see full join details. If you hit this, contact the meeting organizer — their name is shown on the join page and, in most cases, is a direct mailto link — and ask to be added as a registrant.
 
 ## Related
 

--- a/docs/user/meetings/join-meeting/index.md
+++ b/docs/user/meetings/join-meeting/index.md
@@ -9,17 +9,17 @@ last_updated: 2026-08-10
 intercom_collection: Meetings
 ---
 
-Any non-restricted project meeting hosted in LFX Self Serve has a public join page that does not require an LFX account. Opening the link takes you straight to that meeting's details — there's no list to pick from first.
+Every project meeting hosted in LFX Self Serve has a join page that does not require an LFX account, including Private and Restricted meetings. Opening the link takes you straight to that meeting's details — there's no list to pick from first.
 
 ## Steps
 
 1. Open the meeting join link shared by your meeting organizer. The link follows the format: `https://app.lfx.dev/meetings/{meeting-id}`.
-2. The page shows the meeting title, date and time, who's organizing it, and a join button (if the meeting is starting soon or already underway). Use the **Copy meeting link** button if you want to save or forward it.
-3. If the meeting is marked **Restricted**, you'll need to be on the registrant list (matched by your email or username) to see full join details — see "Restricted meetings" below.
+2. The page shows the meeting title, date and time, and a join button (if the meeting is starting soon or already underway). If you're signed in, it also shows who's organizing the meeting. Use the **Copy meeting link** button if you want to save or forward it.
+3. If the meeting is marked **Restricted**, you'll need to submit an email or username that matches an existing registrant to see full join details — see "Restricted meetings" below.
 
 ## No account required
 
-The meeting join page (`/meetings/:id`) is publicly accessible without authentication for meetings that aren't marked Private or Restricted. You do not need an LFX account to view meeting details or access the join link.
+The meeting join page (`/meetings/:id`) never requires an LFX account, for any meeting. A **Private** meeting's join link carries the meeting's password as a query parameter, so anyone with the link can join without signing in. A **Restricted** meeting checks the email or username you submit against its registrant list instead of requiring sign-in.
 
 ## Meeting not found
 
@@ -27,7 +27,7 @@ If you open a meeting link and see the **Meeting Not Found** page, it's usually 
 
 ## Restricted meetings
 
-There's no separate meeting passcode. Instead, some meetings are marked **Restricted**, which means only people who match an existing registrant record (by email or username) can see full join details. If you hit this, contact the meeting organizer — their name is shown on the join page and, in most cases, is a direct mailto link — and ask to be added as a registrant.
+There's no passcode you enter manually. Instead, some meetings are marked **Restricted**, which means only people who submit an email or username matching an existing registrant record can see full join details. If you hit this, ask the meeting organizer to add you as a registrant. Note that the organizer's name and contact link are only shown on the join page to signed-in visitors — if you're not signed in, sign in or ask whoever shared the link with you to reach the organizer on your behalf.
 
 ## Related
 

--- a/docs/user/meetings/manage-meetings/index.md
+++ b/docs/user/meetings/manage-meetings/index.md
@@ -5,38 +5,41 @@ audience: [maintainer, board-member, executive-director]
 product_area: Meetings
 tags: [meetings, manage, edit, cancel]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-10
 intercom_collection: Meetings
 ---
 
-This article applies to users with **maintainer**, **board-member**, or **executive-director** personas. Use this guide to update or cancel existing meetings.
+This article applies to users with **maintainer**, **board-member**, or **executive-director** personas, or anyone granted **Meeting Coordinator** access for the project. Use this guide to update or cancel existing meetings.
 
 ## View meetings
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
-2. Select **Meetings** from the left navigation sidebar.
-3. The meetings dashboard lists upcoming and past meetings for your active project context. Tabs: **Upcoming**, **Past**, **Pending RSVP**. If no meetings are scheduled, the page shows "No upcoming meetings / Meetings from your committees and projects will appear here."
-4. Select a meeting to open its detail view.
+2. Switch to your **Project** or **Foundation** lens using the lens switcher, then select **Meetings** from the left navigation. (In your personal **My Meetings** view — the Me lens — you can see meetings across your projects, but you can't create or manage them from there.)
+3. The dashboard lists meetings for your active project context, with **Upcoming** and **Past** tabs. If no meetings are scheduled, the Upcoming tab shows "No meetings yet / Schedule a meeting to get started."
+4. Each meeting you organize shows **Edit** and **Delete** icon buttons directly on its card in the list. You can also select a meeting to open its full detail view.
 
 ## Edit a meeting
 
-Select a meeting to open its detail view. Use the available options to edit meeting details or cancel the meeting.
+Select the edit (pencil) icon on a meeting you organize, or open the meeting's detail view and choose to edit it. Editing is only available for upcoming meetings. You can update the title, date, time, agenda, recurrence pattern, and platform/feature settings.
 
 ## Cancel or delete a meeting
 
-Select a meeting to open its detail view. Use the available options to edit meeting details or cancel the meeting.
+Select the delete (trash) icon on a meeting you organize.
 
-## Download a meeting as a calendar file
+- For a one-time meeting, you'll confirm the cancellation.
+- For a meeting that's part of a recurring series, you'll be asked to choose between **Cancel This Occurrence** (only that instance is cancelled; the rest of the series continues) or **Delete Entire Series** (the whole recurring series is permanently deleted).
 
-From the meeting detail page, select the option to download the meeting as an ICS file. This allows you to add the meeting to any calendar application that supports the ICS format.
+## Subscribe to a calendar feed
+
+There's no button to download a single meeting as an ICS file. Instead, from the Meetings dashboard in your Foundation or Project lens, select **Subscribe** to get a live calendar feed (ICS URL) for all of that project's or foundation's meetings. Add it once to Google Calendar, Outlook, or Apple Calendar to keep it in sync automatically.
 
 ## Share the meeting join link
 
-Each meeting has a unique public URL at `/meetings/:id`. Copy this link from the meeting detail page and share it with attendees. No LFX account is required to access the join page.
+Each meeting has a unique public URL at `/meetings/:id`. Use the **Copy meeting link** button on the meeting's join page, or copy it from the meeting detail view, and share it with attendees. No LFX account is required to access a non-restricted meeting's join page.
 
 ## Switch project context
 
-Meetings are scoped to a project. Use the lens switcher to change your active project context. The meetings list updates automatically.
+Meetings are scoped to a project (or foundation). Use the lens switcher to change your active context. The meetings list updates automatically.
 
 ## Related
 

--- a/docs/user/meetings/manage-meetings/index.md
+++ b/docs/user/meetings/manage-meetings/index.md
@@ -1,7 +1,6 @@
 ---
 title: Manage Meetings
 description: How to edit, update, and cancel project meetings in LFX Self Serve.
-audience: [maintainer, board-member, executive-director]
 product_area: Meetings
 tags: [meetings, manage, edit, cancel]
 last_generated: 2026-05-22

--- a/docs/user/meetings/manage-meetings/index.md
+++ b/docs/user/meetings/manage-meetings/index.md
@@ -14,7 +14,7 @@ This article applies to users with **maintainer**, **board-member**, or **execut
 ## View meetings
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
-2. Switch to your **Project** or **Foundation** lens using the lens switcher, then select **Meetings** from the left navigation. (In your personal **My Meetings** view — the Me lens — you can see meetings across your projects, but you can't create or manage them from there.)
+2. Switch to your **Project** or **Foundation** lens using the lens switcher, then select **Meetings** from the left navigation. Your personal **My Meetings** view (Me lens) also shows meetings across your projects, and Edit/Delete still appear there for meetings you organize — that view just doesn't have a **Create Meeting** button.
 3. The dashboard lists meetings for your active project context, with **Upcoming** and **Past** tabs. If no meetings are scheduled, the Upcoming tab shows "No meetings yet / Schedule a meeting to get started."
 4. Each meeting you organize shows **Edit** and **Delete** icon buttons directly on its card in the list. You can also select a meeting to open its full detail view.
 
@@ -22,20 +22,20 @@ This article applies to users with **maintainer**, **board-member**, or **execut
 
 Select the edit (pencil) icon on a meeting you organize, or open the meeting's detail view and choose to edit it. Editing is only available for upcoming meetings. You can update the title, date, time, agenda, recurrence pattern, and platform/feature settings.
 
-## Cancel or delete a meeting
+## Delete a meeting
 
 Select the delete (trash) icon on a meeting you organize.
 
-- For a one-time meeting, you'll confirm the cancellation.
+- For a one-time meeting, you'll confirm with **Delete Meeting** — the meeting is permanently deleted; this can't be undone.
 - For a meeting that's part of a recurring series, you'll be asked to choose between **Cancel This Occurrence** (only that instance is cancelled; the rest of the series continues) or **Delete Entire Series** (the whole recurring series is permanently deleted).
 
 ## Subscribe to a calendar feed
 
-There's no button to download a single meeting as an ICS file. Instead, from the Meetings dashboard in your Foundation or Project lens, select **Subscribe** to get a live calendar feed (ICS URL) for all of that project's or foundation's meetings. Add it once to Google Calendar, Outlook, or Apple Calendar to keep it in sync automatically.
+There's no button to download a single meeting as an ICS file. Instead, from the Meetings dashboard in your Foundation or Project lens, select **Subscribe** to get a live calendar feed (ICS URL) for that project's or foundation's meetings. The feed excludes **Private** meetings; **Restricted**-but-public meetings still appear on it. Add it once to Google Calendar, Outlook, or Apple Calendar to keep it in sync automatically.
 
 ## Share the meeting join link
 
-Each meeting has a unique public URL at `/meetings/:id`. Use the **Copy meeting link** button on the meeting's join page, or copy it from the meeting detail view, and share it with attendees. No LFX account is required to access a non-restricted meeting's join page.
+Each meeting has a unique join URL at `/meetings/:id`. Use the **Copy meeting link** button on the meeting's join page or card, or copy it from the meeting detail view, and share it with attendees. No LFX account is ever required to access a meeting's join page — for a **Private** meeting, the copied link automatically carries the meeting's password.
 
 ## Switch project context
 

--- a/docs/user/meetings/schedule-meeting/index.md
+++ b/docs/user/meetings/schedule-meeting/index.md
@@ -5,31 +5,38 @@ audience: [maintainer, board-member, executive-director]
 product_area: Meetings
 tags: [meetings, schedule, create, calendar]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-10
 intercom_collection: Meetings
 ---
 
-This article applies to users with **maintainer**, **board-member**, or **executive-director** personas. Use this workflow to create a new meeting for your project group.
+This article applies to users with **maintainer**, **board-member**, or **executive-director** personas, or anyone granted **Meeting Coordinator** access for the project. Use this workflow to create a new meeting for your project group.
 
 ## Before you begin
 
-Confirm you have the correct project and group selected. Meetings are associated with a specific project committee or group. The active project context in your lens switcher determines which project the meeting is linked to.
+Confirm you have the correct project selected. Meetings are associated with a specific project (or committee within it). The active context in your lens switcher determines which project the meeting is linked to.
 
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
-2. Select **My Meetings** from the left navigation.
-3. Select the option to schedule a new meeting.
-4. Fill in the meeting details, including title, date, time, and any recurrence or conferencing settings.
+2. Switch to your **Project** or **Foundation** lens using the lens switcher, then select **Meetings** from the left navigation. (Your personal **My Meetings** view doesn't have a Create Meeting option — you need to be in a Project or Foundation lens.)
+3. Select **Create Meeting**.
+4. Work through the meeting form:
+   - **Meeting Type**
+   - **Meeting Details** — title, date, time, and recurrence, if this is a recurring series
+   - **Platform & Features** — choose your video platform and enable features like recording or transcripts
+   - **Resources & Links**
+   - **Invite Guests**
 5. Save the meeting.
+
+You can also use AI assistance to draft a starting agenda once you've filled in the title, meeting type, and a short prompt.
 
 ## After scheduling
 
-The meeting appears on the **Upcoming** tab of My Meetings. Invited participants will see it in their meetings list.
+The meeting appears on the **Upcoming** tab of the project's **Meetings** dashboard, and in your own **My Meetings** view. Invited participants will see it in their meetings list.
 
 ## Add the meeting to your calendar
 
-After saving, download the meeting as an ICS file to add it to your calendar application. The ICS file includes the meeting title, time, and join link.
+There's no button to download a single meeting as its own ICS file. To keep a calendar in sync with all of a project's or foundation's meetings, go to that project's or foundation's **Meetings** dashboard and select **Subscribe** to get a live calendar feed (ICS URL) — add it once to Google Calendar, Outlook, or Apple Calendar.
 
 ## Related
 

--- a/docs/user/meetings/schedule-meeting/index.md
+++ b/docs/user/meetings/schedule-meeting/index.md
@@ -1,7 +1,6 @@
 ---
 title: Schedule a Meeting
 description: How to create a new project meeting in LFX Self Serve.
-audience: [maintainer, board-member, executive-director]
 product_area: Meetings
 tags: [meetings, schedule, create, calendar]
 last_generated: 2026-05-22

--- a/docs/user/meetings/schedule-meeting/index.md
+++ b/docs/user/meetings/schedule-meeting/index.md
@@ -36,7 +36,7 @@ The meeting appears on the **Upcoming** tab of the project's **Meetings** dashbo
 
 ## Add the meeting to your calendar
 
-There's no button to download a single meeting as its own ICS file. To keep a calendar in sync with all of a project's or foundation's meetings, go to that project's or foundation's **Meetings** dashboard and select **Subscribe** to get a live calendar feed (ICS URL) — add it once to Google Calendar, Outlook, or Apple Calendar.
+There's no button to download a single meeting as its own ICS file. To keep a calendar in sync with a project's or foundation's meetings, go to that project's or foundation's **Meetings** dashboard and select **Subscribe** to get a live calendar feed (ICS URL) — add it once to Google Calendar, Outlook, or Apple Calendar. The feed excludes **Private** meetings; **Restricted**-but-public meetings still appear on it.
 
 ## Related
 


### PR DESCRIPTION
## Summary

The Meetings user docs (`docs/user/meetings/**/index.md`) were verified against the actual app source and found to contain several materially inaccurate claims. This PR replaces the content of all 5 pages — `index.md`, `faq/index.md`, `join-meeting/index.md`, `manage-meetings/index.md`, `schedule-meeting/index.md` — with corrected content. Frontmatter fields are unchanged except `last_updated`.

Refs II-294, II-309

## Biggest issues fixed (affect multiple pages)

**1. No per-meeting ICS download exists.**
Every page previously claimed you could "download the meeting as an ICS file from the meeting detail page." No such button exists anywhere in the meeting detail, meeting card, or join-page components. The only calendar-export feature is a **Subscribe** button on the Foundation/Project lens dashboard, which returns a live ICS *feed* URL for all of that project's/foundation's meetings.
- Feed endpoints: `apps/lfx-one/src/server/routes/public-projects.route.ts:17`, `apps/lfx-one/src/server/routes/public-committees.route.ts:15`
- Subscribe button: `apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts:274-287`, gated by `canShowCalendarView` (`meetings-dashboard.component.ts:101`, foundation/project lens only)
- ICS builder confirms no join-link field is embedded: `apps/lfx-one/src/server/helpers/ics.helper.ts:65-80`

**2. There's no meeting passcode — it's a "Restricted" registrant check.**
FAQ and Join a Meeting both described entering a passcode. No passcode field exists anywhere in the frontend. Access control is a `restricted` boolean on the meeting; restricted meetings check whether the visitor matches an existing registrant by email/username.
- `apps/lfx-one/src/server/controllers/public-meeting.controller.ts:477-478, 570-571, 741` (`restrictedMeetingCheck`)
- UI badge: `meeting-join.component.html:46-47` (`Restricted` tag, no passcode input anywhere in that file)

**3. Sidebar label is "My Meetings" in some contexts, "Meetings" in others — lens-dependent, not a typo.**
`apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts:112` (Me lens → "My Meetings", route `/meetings`), `:261` and `:394` (Foundation/Project lens → "Meetings"), `:512` (Org lens → "Meetings"). Confirmed by the page header: `meetings-dashboard.component.html:14`. Matters because **Create Meeting only appears outside the Me lens** — `meetings-dashboard.component.html:15-16` (`@if (activeLens() !== 'me' && canWriteMeetings())`). The old "Schedule a Meeting" doc told people to use My Meetings to create one, which doesn't work.

**4. "Pending RSVP" is not a third tab.**
Only two time tabs exist: Upcoming, Past (`meetings-top-bar.component.ts:37-40`). "Pending RSVP" and "Organized by me" are separate filter pills, both scoped to the Me lens only (`meetings-dashboard.component.html:186-190`, `meetings-top-bar.component.ts:45,48`).

**5. Empty-state copy differs by lens; the docs only quoted one variant.**
`meetings-dashboard.component.html:272-273, 279-280`:
- Me lens / upcoming: "No upcoming meetings" / "Meetings from your committees and projects will appear here."
- Other lens / upcoming: "No meetings yet" / "Schedule a meeting to get started."
- Me lens / past: "Your past meetings will appear here."
- Other lens / past: "Past meetings will appear here once they have occurred."

## Other corrections

- **Meeting Coordinator role**: creating/managing meetings isn't strictly limited to the three named personas — a project can grant a specific user `meeting_coordinator` access independent of persona. `meetings-dashboard.component.ts:352-365`, FGA relation confirmed in `apps/lfx-one/src/server/services/project.service.ts:324-349`.
- **Edit/Delete are real, distinct, one-click actions** — icon buttons on each meeting card: `meeting-card.component.html:58-79`, gated on `meeting().organizer` (delete) and `meeting().project_slug && meeting().organizer && !pastMeeting()` (edit, upcoming only).
- **Recurring cancel/delete is a real, described choice**: "Cancel This Occurrence" vs. "Delete Entire Series" — `meeting-delete-type-selection.component.html:7-58`.
- **Recurring meeting options are fully self-service**, not "contact your admin" — interval, weekly by day, monthly by date or weekday pattern, end-by-date or end-after-N-occurrences: `meeting-recurrence-pattern.component.html`.
- **"Conferencing settings" = the "Platform & Features" wizard step** — choose a video platform, toggle recording/transcripts: `meeting-platform-features.component.html:1-50`.
- **The 5-step create/edit wizard**: Meeting Type → Meeting Details → Platform & Features → Resources & Links → Invite Guests — `meeting-manage.component.html:85-90`.
- **AI agenda generation is real**, requires title, meeting type, and a prompt first (`meeting-details.component.ts:194`); simplified to "an AI service" in the docs since naming the internal proxy adds nothing for users.
- **Meeting Not Found reasons**, quoted from actual page copy: expired/invalid link, deleted/cancelled meeting, restricted access, typo in URL — `meeting-not-found.component.html:29-42`.
- **Organizer contact is a visible mailto link on the join page** — `meeting-organizer.component.html:4-20`.

## Caveat

Verified against repo source (`docs/user/meetings/**/index.md` on `main`), and the fetched live `app.lfx.dev/docs/meetings` pages matched this repo's content byte-for-byte at time of writing — but I haven't independently confirmed the live site deploys from this exact branch. Worth a quick sanity check after merge.
