### PR TITLE
fix(profile): make edit-pencil badge decorative for a11y

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -30,20 +30,21 @@
         }
       </div>
       <!--
-        Decorative duplicate of the "Edit profile" pill below. Kept clickable for mouse users, but
-        removed from the a11y tree (aria-hidden) and tab order (tabindex=-1) so screen-reader and
-        keyboard users get a single actionable control (the labeled pill) for one destination.
+        Decorative duplicate of the "Edit profile" pill below. A plain span (not a button) so it is
+        never focusable, keeping it out of both the a11y tree (aria-hidden) and tab/focus order:
+        screen-reader and keyboard users get a single actionable control (the labeled pill) for one
+        destination. Stays mouse-clickable; while impersonating, pointer-events-none blocks the click
+        (onEdit() is a no-op then anyway) and opacity-40 mirrors the disabled look.
       -->
-      <button
-        type="button"
+      <span
         (click)="onEdit()"
-        [disabled]="impersonating()"
         aria-hidden="true"
-        tabindex="-1"
-        class="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
+        [class.pointer-events-none]="impersonating()"
+        [class.opacity-40]="impersonating()"
+        class="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition-colors hover:bg-slate-50"
         data-testid="profile-panel-edit-badge">
         <i class="fa-light fa-pencil text-xs"></i>
-      </button>
+      </span>
     </div>
 
     <!-- Name + handle -->

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -29,11 +29,17 @@
           {{ initials() }}
         }
       </div>
+      <!--
+        Decorative duplicate of the "Edit profile" pill below. Kept clickable for mouse users, but
+        removed from the a11y tree (aria-hidden) and tab order (tabindex=-1) so screen-reader and
+        keyboard users get a single actionable control (the labeled pill) for one destination.
+      -->
       <button
         type="button"
         (click)="onEdit()"
         [disabled]="impersonating()"
-        [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : 'Edit profile'"
+        aria-hidden="true"
+        tabindex="-1"
         class="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
         data-testid="profile-panel-edit-badge">
         <i class="fa-light fa-pencil text-xs"></i>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -16,9 +16,9 @@ import { ChangeDetectionStrategy, Component, computed, input, output, signal } f
  * the fixed rail's height (mirrors lfx-sidebar's `:host { height: 100% }`); without host sizing
  * the height chain breaks and the rail cannot scroll independently.
  *
- * Rows render only when their value is present. GitHub is sourced from the user's
- * connected identities (bound by the parent); About me and LinkedIn are stubbed for now
- * (no source yet) and therefore stay hidden until wired in a follow-up.
+ * Rows render only when their value is present. About me (from the profile bio) and GitHub
+ * (from the user's connected identities) are sourced and bound by the parent; LinkedIn is
+ * stubbed for now (no source yet) and therefore stays hidden until wired in a follow-up.
  */
 @Component({
   selector: 'lfx-profile-panel',


### PR DESCRIPTION
## Summary

Follow-up to a deferred a11y nit from #1134 (LFXV2-2740).

- The avatar pencil badge and the "Edit profile" pill both call `onEdit()`, so
  screen-reader and keyboard users hit two adjacent tab stops that announce the
  same action ("Edit profile") for one destination.
- Mark the pencil badge decorative — `aria-hidden="true"` + `tabindex="-1"` — so
  the labeled pill is the single actionable control. The badge stays
  mouse-clickable and remains disabled while impersonating; only its
  accessibility-tree and tab-order presence changes.
- Correct the `ProfilePanelComponent` JSDoc: About me is now sourced from the
  profile bio and bound by the parent, so only LinkedIn remains a stub.

Ref: LFXV2-2740