### PR TITLE
feat(org-roi): add ROI category and projects donuts (LFXV2-2980)

### DIFF
--- a/apps/lfx-one/e2e/helpers/org-roi.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-roi.helper.ts
@@ -1,0 +1,235 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+export const ORG_ROI_URL = '/org/roi';
+export const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+
+/**
+ * Only the year still in progress is labelled partial, so every year-bearing fixture is anchored to
+ * the current year rather than hardcoded — otherwise these assertions would quietly invert next
+ * January. One of the three defects US2 shipped to review was a hardcoded end year.
+ */
+export const CURRENT_YEAR = new Date().getFullYear();
+
+export function fulfillJson(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+export function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Let malformed URLs fail naturally.
+  }
+}
+
+export async function seedSelectedOrgCookie(page: Page): Promise<void> {
+  await page.context().addCookies([
+    {
+      name: 'lfx-selected-account',
+      value: JSON.stringify({ uid: MOCK_ACCOUNT_ID }),
+      domain: 'localhost',
+      path: '/',
+    },
+  ]);
+}
+
+/**
+ * Real production proportions for Red Hat, with `code` carrying the balance so the eight categories
+ * sum to a round-tripped total. Three of them (`meetings`, `membership_tlf`, `educ_courses`) sit
+ * under the 2% display threshold, so this fixture also exercises the FR-025 remainder.
+ */
+export const MOCK_CATEGORY_ROWS = [
+  { type: 'code', label: 'Code Contribution', expenditure: 101_904_741.07 },
+  { type: 'community', label: 'Community Contribution', expenditure: 13_877_843.18 },
+  { type: 'meetings', label: 'Meetings', expenditure: 201_358.17 },
+  { type: 'event_attendance', label: 'Event Attendance', expenditure: 10_614_558.63 },
+  { type: 'event_sponsorship', label: 'Event Sponsorship', expenditure: 4_951_172.72 },
+  { type: 'membership_project', label: 'Project Membership', expenditure: 13_650_145.36 },
+  { type: 'membership_tlf', label: 'Foundation Membership', expenditure: 2_731_354.84 },
+  { type: 'educ_courses', label: 'Education', expenditure: 1_190.0 },
+];
+
+/** Three categories fall below the threshold, so the donut renders a remainder for exactly these. */
+export const SUB_THRESHOLD_CATEGORY_COUNT = 3;
+
+/**
+ * Summed from the rows rather than written down beside them. FR-026 requires the category total and
+ * the KPI investment figure to be identical, so they must be the *same number* in the fixture —
+ * two independently typed literals could drift by a cent and make the test assert the opposite of
+ * the requirement.
+ */
+export const TOTAL_INVESTMENT = MOCK_CATEGORY_ROWS.reduce((sum, row) => sum + row.expenditure, 0);
+
+export const MOCK_INVESTMENT_BREAKDOWN = { rows: MOCK_CATEGORY_ROWS, total: TOTAL_INVESTMENT };
+
+export const MOCK_TOTAL_RETURN = 5_576_366_821.32;
+
+export const MOCK_SUMMARY = {
+  orgUid: MOCK_ACCOUNT_ID,
+  method: 'logit',
+  hasData: true,
+  nProjects: 407,
+  totalExpenditure: TOTAL_INVESTMENT,
+  totalReturn: MOCK_TOTAL_RETURN,
+  profit: MOCK_TOTAL_RETURN - TOTAL_INVESTMENT,
+  roi: 36.695,
+  bcr: 37.695,
+  yearMin: 2010,
+  yearMax: CURRENT_YEAR,
+  dateMin: '2010-01',
+  dateMax: `${CURRENT_YEAR}-08`,
+};
+
+export const MOCK_COVERAGE = { orgUid: MOCK_ACCOUNT_ID, hasData: true, coverageReason: 'covered' };
+
+export function annualRow(year: number, totalReturn: number, expenditure: number): unknown {
+  return { year, totalReturn, expenditure, profit: totalReturn - expenditure, roi: 36.5, bcr: 37.5 };
+}
+
+export const MOCK_ANNUAL = {
+  method: 'logit',
+  rows: [
+    annualRow(CURRENT_YEAR - 2, 1_200_000_000, 32_000_000),
+    annualRow(CURRENT_YEAR - 1, 1_400_000_000, 38_000_000),
+    annualRow(CURRENT_YEAR, 620_000_000, 17_000_000),
+  ],
+  apportioned: true,
+};
+
+/**
+ * Splits a project's investment across three categories, with the last carrying the balance so the
+ * parts sum to the whole exactly (FR-031). Nothing rescales this client-side.
+ */
+function projectCategories(totalExpenditure: number): { type: string; label: string; expenditure: number }[] {
+  const code = Math.round(totalExpenditure * 0.7 * 100) / 100;
+  const community = Math.round(totalExpenditure * 0.2 * 100) / 100;
+  return [
+    { type: 'code', label: 'Code Contribution', expenditure: code },
+    { type: 'community', label: 'Community Contribution', expenditure: community },
+    { type: 'meetings', label: 'Meetings', expenditure: totalExpenditure - code - community },
+  ];
+}
+
+/**
+ * `profit`, `roi` and `bcr` are derived once here, standing in for the metric layer that defines
+ * them once (FR-007). The client must never re-derive them from the other fields.
+ */
+function projectRow(projectSlug: string, projectName: string, totalExpenditure: number, totalReturn: number): unknown {
+  const profit = totalReturn - totalExpenditure;
+  return {
+    projectId: `prj-${projectSlug}`,
+    projectSlug,
+    projectName,
+    totalExpenditure,
+    totalReturn,
+    profit,
+    roi: totalExpenditure > 0 ? profit / totalExpenditure : null,
+    bcr: totalExpenditure > 0 ? totalReturn / totalExpenditure : null,
+    breakevenMarkup: 0.331,
+    categories: projectCategories(totalExpenditure),
+  };
+}
+
+/**
+ * Eight projects: enough that the leading slices leave a labelled remainder on every measure, and
+ * two of them lose money. Negative net return is 6.45% of production project rows across 775
+ * organizations — a mainline path, so the fixture carries it by default rather than in a variant.
+ */
+export const MOCK_PROJECT_INPUTS = [
+  { slug: 'kubernetes', name: 'Kubernetes', expenditure: 60_000_000, return: 3_000_000_000 },
+  { slug: 'openstack', name: 'OpenStack', expenditure: 40_000_000, return: 1_500_000_000 },
+  { slug: 'ceph', name: 'Ceph', expenditure: 25_000_000, return: 700_000_000 },
+  { slug: 'podman', name: 'Podman', expenditure: 12_000_000, return: 200_000_000 },
+  { slug: 'fedora-infra', name: 'Fedora Infrastructure', expenditure: 6_000_000, return: 80_000_000 },
+  { slug: 'ansible-docs', name: 'Ansible Docs', expenditure: 3_000_000, return: 20_000_000 },
+  { slug: 'legacy-bridge', name: 'Legacy Bridge', expenditure: 2_000_000, return: 500_000 },
+  { slug: 'sunset-tooling', name: 'Sunset Tooling', expenditure: 1_000_000, return: 250_000 },
+];
+
+export const MOCK_PROJECTS = {
+  method: 'logit',
+  rows: MOCK_PROJECT_INPUTS.map((input) => projectRow(input.slug, input.name, input.expenditure, input.return)),
+};
+
+/** The two loss-making projects, in the order the donut ranks them (net return, descending). */
+export const NEGATIVE_PROJECTS = MOCK_PROJECT_INPUTS.filter((input) => input.return < input.expenditure)
+  .map((input) => ({ name: input.name, profit: input.return - input.expenditure }))
+  .sort((a, b) => b.profit - a.profit);
+
+export const NEGATIVE_PROJECTS_TOTAL = NEGATIVE_PROJECTS.reduce((sum, project) => sum + project.profit, 0);
+
+interface StubOptions {
+  hasAccess?: boolean;
+  summary?: unknown;
+  coverage?: unknown;
+  annual?: unknown;
+  investmentBreakdown?: unknown;
+  projects?: unknown;
+}
+
+export async function stubOrgLensContext(page: Page, options: StubOptions = {}): Promise<void> {
+  const hasAccess = options.hasAccess ?? true;
+
+  await page.route('**/api/orgs/*/lens/roi/summary*', (route) => fulfillJson(route, options.summary ?? MOCK_SUMMARY));
+  await page.route('**/api/orgs/*/lens/roi/coverage*', (route) => fulfillJson(route, options.coverage ?? MOCK_COVERAGE));
+  await page.route('**/api/orgs/*/lens/roi/annual*', (route) => fulfillJson(route, options.annual ?? MOCK_ANNUAL));
+  await page.route('**/api/orgs/*/lens/roi/investment-breakdown*', (route) => fulfillJson(route, options.investmentBreakdown ?? MOCK_INVESTMENT_BREAKDOWN));
+  await page.route('**/api/orgs/*/lens/roi/projects*', (route) => fulfillJson(route, options.projects ?? MOCK_PROJECTS));
+
+  await page.route('**/api/user/personas*', (route) =>
+    fulfillJson(route, {
+      personas: ['contributor'],
+      personaProjects: {},
+      projects: [],
+      organizations: hasAccess
+        ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: '', uid: MOCK_ACCOUNT_ID }]
+        : [],
+      isRootWriter: false,
+    })
+  );
+
+  await page.route('**/api/analytics/org-lens-account-context*', (route) =>
+    fulfillJson(route, hasAccess ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: 'Gold' }] : [])
+  );
+
+  await page.route('**/api/orgs/me/role-grants', (route) =>
+    fulfillJson(route, {
+      writers: hasAccess ? [MOCK_ACCOUNT_ID] : [],
+      auditors: [],
+      cascadingWriters: [],
+      cascadingAuditors: [],
+      username: 'e2e-org-roi',
+      loaded_at: new Date().toISOString(),
+    })
+  );
+
+  await page.route('**/api/nav/org-items*', (route) =>
+    fulfillJson(route, {
+      items: hasAccess
+        ? [{ uid: MOCK_ACCOUNT_ID, accountId: MOCK_ACCOUNT_ID, name: 'Red Hat, Inc.', logoUrl: null, primaryDomain: 'redhat.com', isMember: true }]
+        : [],
+      next_page_token: null,
+      upstream_failed: false,
+      total: hasAccess ? 1 : 0,
+    })
+  );
+}
+
+export async function gotoOrgRoiPage(page: Page): Promise<void> {
+  await seedSelectedOrgCookie(page);
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await page.reload({ waitUntil: 'domcontentloaded' });
+  await page.goto(ORG_ROI_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  if (!page.url().includes('/org/roi')) {
+    test.skip(true, 'org-lens-roi-enabled flag appears off — /org/roi redirected away');
+  }
+}

--- a/apps/lfx-one/e2e/helpers/org-roi.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-roi.helper.ts
@@ -9,7 +9,8 @@ export const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 /**
  * Only the year still in progress is labelled partial, so every year-bearing fixture is anchored to
  * the current year rather than hardcoded — otherwise these assertions would quietly invert next
- * January. One of the three defects US2 shipped to review was a hardcoded end year.
+ * January. A hardcoded end year was one of three defects that reached review on the earlier
+ * portfolio-summary work.
  */
 export const CURRENT_YEAR = new Date().getFullYear();
 
@@ -42,7 +43,7 @@ export async function seedSelectedOrgCookie(page: Page): Promise<void> {
 /**
  * Real production proportions for Red Hat, with `code` carrying the balance so the eight categories
  * sum to a round-tripped total. Three of them (`meetings`, `membership_tlf`, `educ_courses`) sit
- * under the 2% display threshold, so this fixture also exercises the FR-025 remainder.
+ * under the 2% display threshold, so this fixture also exercises the collapsed remainder.
  */
 export const MOCK_CATEGORY_ROWS = [
   { type: 'code', label: 'Code Contribution', expenditure: 101_904_741.07 },
@@ -59,10 +60,10 @@ export const MOCK_CATEGORY_ROWS = [
 export const SUB_THRESHOLD_CATEGORY_COUNT = 3;
 
 /**
- * Summed from the rows rather than written down beside them. FR-026 requires the category total and
- * the KPI investment figure to be identical, so they must be the *same number* in the fixture —
+ * Summed from the rows rather than written down beside them. The category total and the KPI
+ * investment figure must be identical, so they must be the *same number* in the fixture —
  * two independently typed literals could drift by a cent and make the test assert the opposite of
- * the requirement.
+ * the invariant it exists to check.
  */
 export const TOTAL_INVESTMENT = MOCK_CATEGORY_ROWS.reduce((sum, row) => sum + row.expenditure, 0);
 
@@ -104,7 +105,7 @@ export const MOCK_ANNUAL = {
 
 /**
  * Splits a project's investment across three categories, with the last carrying the balance so the
- * parts sum to the whole exactly (FR-031). Nothing rescales this client-side.
+ * parts sum to the whole exactly. Nothing rescales this client-side.
  */
 function projectCategories(totalExpenditure: number): { type: string; label: string; expenditure: number }[] {
   const code = Math.round(totalExpenditure * 0.7 * 100) / 100;
@@ -118,7 +119,7 @@ function projectCategories(totalExpenditure: number): { type: string; label: str
 
 /**
  * `profit`, `roi` and `bcr` are derived once here, standing in for the metric layer that defines
- * them once (FR-007). The client must never re-derive them from the other fields.
+ * them once. The client must never re-derive them from the other fields.
  */
 function projectRow(projectSlug: string, projectName: string, totalExpenditure: number, totalReturn: number): unknown {
   const profit = totalReturn - totalExpenditure;

--- a/apps/lfx-one/e2e/org-roi-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-projects.spec.ts
@@ -74,7 +74,7 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
     await expect(note).toBeVisible();
     await expect(note).toContainText(`${NEGATIVE_PROJECTS.length} projects have a negative net return`);
     await expect(note).toContainText(formatCurrency(NEGATIVE_PROJECTS_TOTAL));
-    await expect(note).toContainText('cannot be drawn as a slice');
+    await expect(note).toContainText('cannot be sized as a slice');
 
     const list = page.getByTestId('org-roi-projects-donut-negative-list');
     for (const project of NEGATIVE_PROJECTS) {
@@ -85,6 +85,12 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
 
     // The chart still renders, sized by the profitable projects alone.
     await expect(page.getByTestId('org-roi-projects-donut-chart')).toBeVisible();
+
+    // Loss-making projects are in exactly one place. They are excluded from the remainder as well
+    // as from the arcs, so the remainder counts only the four profitable projects left over —
+    // reporting them both here and inside "Other" would double-count them.
+    const profitable = MOCK_PROJECT_INPUTS.filter((input) => input.return > input.expenditure);
+    await expect(page.getByTestId('org-roi-projects-donut-legend')).toContainText(`Other (${profitable.length - 2} projects)`);
   });
 
   test('does not claim a negative net return on a measure that has none', async ({ page }) => {
@@ -115,8 +121,7 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
     await expect(list).toContainText(formatCurrency(KUBERNETES.expenditure / 4 - KUBERNETES.expenditure));
   });
 
-  test('carries the modelled-cost disclosure on the investment measure only', async ({ page }) => {
-    // FR-039a binds surfaces that show an *investment* figure. Return and Net Return are not that.
+  test('carries the modelled-cost disclosure wherever a figure derives from modelled cost', async ({ page }) => {
     await stubOrgLensContext(page);
     await gotoOrgRoiPage(page);
 
@@ -127,6 +132,12 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
     await expect(note).toContainText('same for every organization');
     await expect(note).toContainText('No salary, payroll, or invoice data is used.');
 
+    // Net Return is totalReturn − totalExpenditure, so it is a direct function of the modelled
+    // cost and owes the same disclosure — the per-project loss figures render on this tab.
+    await page.getByTestId('org-roi-projects-donut-measure-netReturn').click();
+    await expect(page.getByTestId('org-roi-projects-donut-modelled-cost-note')).toBeVisible();
+
+    // Total Return alone is not derived from investment, so it does not.
     await page.getByTestId('org-roi-projects-donut-measure-return').click();
     await expect(page.getByTestId('org-roi-projects-donut-modelled-cost-note')).toHaveCount(0);
   });

--- a/apps/lfx-one/e2e/org-roi-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-projects.spec.ts
@@ -62,8 +62,8 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
   });
 
   test('reports the true signed value of a negative net return', async ({ page }) => {
-    // FR-028. An arc cannot be negative, so the geometry is clamped — but the figure must survive
-    // that clamp intact, or a loss-making project silently reads as costless.
+    // An arc cannot be negative, so the geometry is clamped — but the figure must survive that
+    // clamp intact, or a loss-making project silently reads as costless.
     await stubOrgLensContext(page);
     await gotoOrgRoiPage(page);
 
@@ -143,8 +143,8 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
   });
 
   test('serves the complete project set rather than a capped subset', async ({ page }) => {
-    // DR-005 / FR-033. The donut summarises, but the payload behind it must carry every project —
-    // the projects section and table in US5 read the same response.
+    // The donut summarises, but the payload behind it must carry every project — the forthcoming
+    // projects section and its table read the same response.
     const payloads: { rows: unknown[] }[] = [];
     page.on('response', async (response) => {
       if (!/\/lens\/roi\/projects(\?|$)/.test(response.url())) return;

--- a/apps/lfx-one/e2e/org-roi-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-projects.spec.ts
@@ -1,0 +1,186 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, test } from '@playwright/test';
+// Imported from the module, not the `utils` barrel: the barrel re-exports form.utils, which pulls
+// in @angular/common and fails to load outside the Angular app with a JIT compiler error.
+import { formatCurrency } from '@lfx-one/shared/utils/number.utils';
+
+import { gotoOrgRoiPage, MOCK_PROJECT_INPUTS, MOCK_PROJECTS, NEGATIVE_PROJECTS, NEGATIVE_PROJECTS_TOTAL, stubOrgLensContext } from './helpers/org-roi.helper';
+
+test.setTimeout(120_000);
+
+/**
+ * Every expected string is derived from the fixture through the same formatter the component uses.
+ * The fixture's eight projects are shaped so each measure leaves a differently sized remainder, and
+ * so two of them lose money — negative net return is 6.45% of production project rows across 775
+ * organizations, so it is exercised here as a mainline path rather than as a variant fixture.
+ */
+const [KUBERNETES, OPENSTACK, CEPH] = MOCK_PROJECT_INPUTS;
+
+const ALL_LOSS_MAKING = {
+  method: 'logit',
+  rows: MOCK_PROJECTS.rows.map((row) => {
+    const project = row as { totalExpenditure: number; totalReturn: number; profit: number };
+    return { ...project, totalReturn: project.totalExpenditure / 4, profit: project.totalExpenditure / 4 - project.totalExpenditure };
+  }),
+};
+
+test.describe('Org Lens ROI Metrics — leading projects', () => {
+  test('ranks projects by investment and labels the remainder with its project count', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const donut = page.getByTestId('org-roi-projects-donut');
+    await expect(donut).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-donut-measure-investment')).toHaveAttribute('aria-pressed', 'true');
+
+    const legend = page.getByTestId('org-roi-projects-donut-legend');
+    await expect(legend).toContainText(KUBERNETES.name);
+    await expect(legend).toContainText(formatCurrency(KUBERNETES.expenditure));
+    await expect(legend).toContainText(OPENSTACK.name);
+    await expect(legend).toContainText(CEPH.name);
+    // Three projects cover 83.9% of investment, so the other five collapse into one entry.
+    await expect(legend).toContainText('Other (5 projects)');
+  });
+
+  test('reorders and re-groups when the measure changes', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const legend = page.getByTestId('org-roi-projects-donut-legend');
+    await expect(legend).toContainText(CEPH.name);
+
+    await page.getByTestId('org-roi-projects-donut-measure-return').click();
+    await expect(page.getByTestId('org-roi-projects-donut-measure-return')).toHaveAttribute('aria-pressed', 'true');
+
+    // Two projects already cover 81.8% of return, so Ceph moves from a slice into the remainder.
+    await expect(legend).toContainText(formatCurrency(KUBERNETES.return));
+    await expect(legend).toContainText(formatCurrency(OPENSTACK.return));
+    await expect(legend).toContainText('Other (6 projects)');
+    await expect(legend).not.toContainText(CEPH.name);
+  });
+
+  test('reports the true signed value of a negative net return', async ({ page }) => {
+    // FR-028. An arc cannot be negative, so the geometry is clamped — but the figure must survive
+    // that clamp intact, or a loss-making project silently reads as costless.
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-projects-donut-measure-netReturn').click();
+    await expect(page.getByTestId('org-roi-projects-donut-measure-netReturn')).toHaveAttribute('aria-pressed', 'true');
+
+    const note = page.getByTestId('org-roi-projects-donut-negative-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText(`${NEGATIVE_PROJECTS.length} projects have a negative net return`);
+    await expect(note).toContainText(formatCurrency(NEGATIVE_PROJECTS_TOTAL));
+    await expect(note).toContainText('cannot be drawn as a slice');
+
+    const list = page.getByTestId('org-roi-projects-donut-negative-list');
+    for (const project of NEGATIVE_PROJECTS) {
+      await expect(list).toContainText(project.name);
+      // The signed figure itself, not just the project's name.
+      await expect(list).toContainText(formatCurrency(project.profit));
+    }
+
+    // The chart still renders, sized by the profitable projects alone.
+    await expect(page.getByTestId('org-roi-projects-donut-chart')).toBeVisible();
+  });
+
+  test('does not claim a negative net return on a measure that has none', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    // Investment is never negative, so the disclosure must not follow the viewer across tabs.
+    await expect(page.getByTestId('org-roi-projects-donut-negative-note')).toHaveCount(0);
+
+    await page.getByTestId('org-roi-projects-donut-measure-netReturn').click();
+    await expect(page.getByTestId('org-roi-projects-donut-negative-note')).toBeVisible();
+
+    await page.getByTestId('org-roi-projects-donut-measure-investment').click();
+    await expect(page.getByTestId('org-roi-projects-donut-negative-note')).toHaveCount(0);
+  });
+
+  test('drops the chart but keeps the figures when no project has a positive net return', async ({ page }) => {
+    await stubOrgLensContext(page, { projects: ALL_LOSS_MAKING });
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-projects-donut-measure-netReturn').click();
+
+    await expect(page.getByTestId('org-roi-projects-donut-no-positive')).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-donut-chart')).toHaveCount(0);
+    // The absence of a drawable magnitude must not take the numbers with it.
+    const list = page.getByTestId('org-roi-projects-donut-negative-list');
+    await expect(list).toContainText(KUBERNETES.name);
+    await expect(list).toContainText(formatCurrency(KUBERNETES.expenditure / 4 - KUBERNETES.expenditure));
+  });
+
+  test('carries the modelled-cost disclosure on the investment measure only', async ({ page }) => {
+    // FR-039a binds surfaces that show an *investment* figure. Return and Net Return are not that.
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const note = page.getByTestId('org-roi-projects-donut-modelled-cost-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('modelled cost');
+    await expect(note).toContainText('not actual or reported compensation');
+    await expect(note).toContainText('same for every organization');
+    await expect(note).toContainText('No salary, payroll, or invoice data is used.');
+
+    await page.getByTestId('org-roi-projects-donut-measure-return').click();
+    await expect(page.getByTestId('org-roi-projects-donut-modelled-cost-note')).toHaveCount(0);
+  });
+
+  test('serves the complete project set rather than a capped subset', async ({ page }) => {
+    // DR-005 / FR-033. The donut summarises, but the payload behind it must carry every project —
+    // the projects section and table in US5 read the same response.
+    const payloads: { rows: unknown[] }[] = [];
+    page.on('response', async (response) => {
+      if (!/\/lens\/roi\/projects(\?|$)/.test(response.url())) return;
+      const body = (await response.json().catch(() => null)) as { rows: unknown[] } | null;
+      if (body !== null) payloads.push(body);
+    });
+
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+    await expect(page.getByTestId('org-roi-projects-donut-chart')).toBeVisible();
+
+    expect(payloads.length).toBeGreaterThan(0);
+    expect(payloads[0].rows).toHaveLength(MOCK_PROJECT_INPUTS.length);
+  });
+
+  test('names the chart for assistive technology and lists its values as text', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-donut-chart')).toHaveAttribute('aria-label', /doughnut chart of the leading projects by investment/i);
+    await expect(page.getByTestId('org-roi-projects-donut-legend')).toBeVisible();
+  });
+
+  test('refuses an ungranted caller without rendering any project figure', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/projects*', (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 'FORBIDDEN', message: 'You do not have access to Org Lens data for this organization.' }),
+      })
+    );
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-donut-forbidden')).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-donut-legend')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-projects-donut-chart')).toHaveCount(0);
+  });
+
+  test('distinguishes a 503 from a refusal on the projects read', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/projects*', (route) =>
+      route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ code: 'ROLE_GRANTS_UNAVAILABLE' }) })
+    );
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-donut-error')).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-donut-forbidden')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -335,6 +335,20 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     }
   });
 
+  test('surfaces an error rather than a skeleton when the failed request cleared the summary', async ({ page }) => {
+    // A failure empties the summary, so it stops matching the selected organization. If the
+    // org-identity check were tested before the failure branches, every error would render as a
+    // permanent loading skeleton and neither refusal nor outage would ever reach the viewer.
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/**', (route) =>
+      route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ code: 'ROLE_GRANTS_UNAVAILABLE' }) })
+    );
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-error')).toBeVisible();
+    await expect(page.getByTestId('org-roi-portfolio-loading')).toHaveCount(0);
+  });
+
   test('distinguishes a 503 verification failure from a 403 refusal', async ({ page }) => {
     await stubOrgLensContext(page);
     await page.route('**/api/orgs/*/lens/roi/**', (route) =>

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -428,4 +428,17 @@ test.describe('Org Lens ROI Metrics — investment by category', () => {
     await expect(page.getByTestId('org-roi-category-donut-empty')).toBeVisible();
     await expect(page.getByTestId('org-roi-category-donut-chart')).toHaveCount(0);
   });
+
+  test('says so rather than drawing a blank chart when categories sum to zero', async ({ page }) => {
+    // Rows present but nothing to draw from them. Keying the template off the row count alone
+    // rendered an empty canvas beside an empty legend, which reads as a broken widget.
+    await stubOrgLensContext(page, {
+      investmentBreakdown: { rows: MOCK_CATEGORY_ROWS.map((row) => ({ ...row, expenditure: 0 })), total: 0 },
+    });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-category-donut-empty')).toBeVisible();
+    await expect(page.getByTestId('org-roi-category-donut-chart')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-category-donut-legend')).toHaveCount(0);
+  });
 });

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -157,6 +157,32 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(page.getByTestId('org-roi-assumptions-method-direct')).toHaveAttribute('aria-pressed', 'true');
   });
 
+  test('does not refetch the category breakdown when only the estimation method changes', async ({ page }) => {
+    // Asserting the URL carries no `method=` is not enough — it stayed true while the component
+    // was being torn down and remounted by the loading branch on every switch, re-issuing the
+    // identical request. This counts the requests instead.
+    const breakdownRequests: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/lens/roi/investment-breakdown')) breakdownRequests.push(request.url());
+    });
+
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+    await expect(page.getByTestId('org-roi-category-donut-chart')).toBeVisible();
+    const beforeSwitch = breakdownRequests.length;
+    expect(beforeSwitch).toBeGreaterThan(0);
+
+    // Wait on a method-scoped sibling so the switch has demonstrably completed before counting.
+    const projectsRefetch = page.waitForRequest((req) => req.url().includes('/lens/roi/projects') && req.url().includes('method=direct'));
+    await page.getByTestId('org-roi-assumptions-trigger').click();
+    await page.getByTestId('org-roi-assumptions-method-direct').click();
+    await projectsRefetch;
+
+    expect(breakdownRequests.length).toBe(beforeSwitch);
+    // And it stayed on screen rather than flashing away and back.
+    await expect(page.getByTestId('org-roi-category-donut-chart')).toBeVisible();
+  });
+
   test('never sends an estimation method to the category breakdown, which cannot vary by one', async ({ page }) => {
     // The source table has no MARKUP_METHOD column, so a method-bearing request would imply a
     // distinction the warehouse does not make — and invite a pointless refetch on every switch.

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -1,133 +1,42 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { expect, Page, Route, test } from '@playwright/test';
+import { expect, test } from '@playwright/test';
+// Imported from the module, not the `utils` barrel: the barrel re-exports form.utils, which pulls
+// in @angular/common and fails to load outside the Angular app with a JIT compiler error.
+import { formatCurrency, formatPercent } from '@lfx-one/shared/utils/number.utils';
 
-const ORG_ROI_URL = '/org/roi';
-const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
+import {
+  annualRow,
+  CURRENT_YEAR,
+  fulfillJson,
+  gotoOrgRoiPage,
+  MOCK_ACCOUNT_ID,
+  MOCK_ANNUAL,
+  MOCK_CATEGORY_ROWS,
+  MOCK_SUMMARY,
+  ORG_ROI_URL,
+  skipWhenAuthMissing,
+  stubOrgLensContext,
+  SUB_THRESHOLD_CATEGORY_COUNT,
+  TOTAL_INVESTMENT,
+} from './helpers/org-roi.helper';
 
 test.setTimeout(120_000);
 
-function fulfillJson(route: Route, body: unknown): Promise<void> {
-  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-}
+/**
+ * Every expected string below is derived from the fixture through the same formatter the component
+ * uses — never written out by hand. US2 shipped three defects to human review that this rule would
+ * have caught on its own, including a benefit-cost expectation of `36.7×` for a fixture that
+ * renders `37.7×`.
+ */
+const EXPECTED_INVESTMENT = formatCurrency(TOTAL_INVESTMENT);
+const EXPECTED_RETURN = formatCurrency(MOCK_SUMMARY.totalReturn);
+const EXPECTED_ROI = `${formatPercent(MOCK_SUMMARY.roi * 100)}%`;
+const EXPECTED_BCR = `${MOCK_SUMMARY.bcr.toFixed(1)}×`;
+const EXPECTED_PROJECT_COUNT = `${MOCK_SUMMARY.nProjects.toLocaleString('en-US')} projects`;
 
-function skipWhenAuthMissing(page: Page): void {
-  try {
-    const { hostname } = new URL(page.url());
-    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
-      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
-    }
-  } catch {
-    // Let malformed URLs fail naturally.
-  }
-}
-
-async function seedSelectedOrgCookie(page: Page): Promise<void> {
-  await page.context().addCookies([
-    {
-      name: 'lfx-selected-account',
-      value: JSON.stringify({ uid: MOCK_ACCOUNT_ID }),
-      domain: 'localhost',
-      path: '/',
-    },
-  ]);
-}
-
-// Only the year still in progress is labelled partial, so the trend fixtures are anchored to the
-// current year rather than hardcoded — otherwise these assertions would quietly invert next January.
-const CURRENT_YEAR = new Date().getFullYear();
-
-const MOCK_SUMMARY = {
-  orgUid: MOCK_ACCOUNT_ID,
-  method: 'logit',
-  hasData: true,
-  nProjects: 407,
-  totalExpenditure: 147932363.97,
-  totalReturn: 5576366821.32,
-  profit: 5428434457.35,
-  roi: 36.695,
-  bcr: 37.695,
-  yearMin: 2010,
-  yearMax: CURRENT_YEAR,
-  dateMin: '2010-01',
-  dateMax: `${CURRENT_YEAR}-08`,
-};
-
-const MOCK_COVERAGE = { orgUid: MOCK_ACCOUNT_ID, hasData: true, coverageReason: 'covered' };
-
-function annualRow(year: number, totalReturn: number, expenditure: number): unknown {
-  return { year, totalReturn, expenditure, profit: totalReturn - expenditure, roi: 36.5, bcr: 37.5 };
-}
-
-const MOCK_ANNUAL = {
-  method: 'logit',
-  rows: [
-    annualRow(CURRENT_YEAR - 2, 1_200_000_000, 32_000_000),
-    annualRow(CURRENT_YEAR - 1, 1_400_000_000, 38_000_000),
-    annualRow(CURRENT_YEAR, 620_000_000, 17_000_000),
-  ],
-  apportioned: true,
-};
-
-async function stubOrgLensContext(page: Page, options: { hasAccess?: boolean; summary?: unknown; coverage?: unknown; annual?: unknown } = {}): Promise<void> {
-  const hasAccess = options.hasAccess ?? true;
-
-  await page.route('**/api/orgs/*/lens/roi/summary*', (route) => fulfillJson(route, options.summary ?? MOCK_SUMMARY));
-  await page.route('**/api/orgs/*/lens/roi/coverage*', (route) => fulfillJson(route, options.coverage ?? MOCK_COVERAGE));
-  await page.route('**/api/orgs/*/lens/roi/annual*', (route) => fulfillJson(route, options.annual ?? MOCK_ANNUAL));
-
-  await page.route('**/api/user/personas*', (route) =>
-    fulfillJson(route, {
-      personas: ['contributor'],
-      personaProjects: {},
-      projects: [],
-      organizations: hasAccess
-        ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: '', uid: MOCK_ACCOUNT_ID }]
-        : [],
-      isRootWriter: false,
-    })
-  );
-
-  await page.route('**/api/analytics/org-lens-account-context*', (route) =>
-    fulfillJson(route, hasAccess ? [{ accountId: MOCK_ACCOUNT_ID, accountName: 'Red Hat, Inc.', accountSlug: 'red-hat', membershipTier: 'Gold' }] : [])
-  );
-
-  await page.route('**/api/orgs/me/role-grants', (route) =>
-    fulfillJson(route, {
-      writers: hasAccess ? [MOCK_ACCOUNT_ID] : [],
-      auditors: [],
-      cascadingWriters: [],
-      cascadingAuditors: [],
-      username: 'e2e-org-roi',
-      loaded_at: new Date().toISOString(),
-    })
-  );
-
-  await page.route('**/api/nav/org-items*', (route) =>
-    fulfillJson(route, {
-      items: hasAccess
-        ? [{ uid: MOCK_ACCOUNT_ID, accountId: MOCK_ACCOUNT_ID, name: 'Red Hat, Inc.', logoUrl: null, primaryDomain: 'redhat.com', isMember: true }]
-        : [],
-      next_page_token: null,
-      upstream_failed: false,
-      total: hasAccess ? 1 : 0,
-    })
-  );
-}
-
-async function gotoOrgRoiPage(page: Page): Promise<void> {
-  await seedSelectedOrgCookie(page);
-  await page.goto('/', { waitUntil: 'domcontentloaded' });
-  skipWhenAuthMissing(page);
-  await page.reload({ waitUntil: 'domcontentloaded' });
-  await page.goto(ORG_ROI_URL, { waitUntil: 'domcontentloaded' });
-  skipWhenAuthMissing(page);
-  await expect(page).not.toHaveURL(/auth0\.com/);
-  if (!page.url().includes('/org/roi')) {
-    test.skip(true, 'org-lens-roi-enabled flag appears off — /org/roi redirected away');
-  }
-}
+const LATEST_ANNUAL = MOCK_ANNUAL.rows[MOCK_ANNUAL.rows.length - 1] as { year: number; totalReturn: number; expenditure: number };
 
 test.describe('Org Lens ROI Metrics — portfolio summary', () => {
   test('renders the page shell and the four headline figures', async ({ page }) => {
@@ -141,11 +50,11 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
 
     const kpi = page.getByTestId('org-roi-kpi-cards');
     await expect(kpi).toBeVisible();
-    await expect(kpi).toContainText('$5.6B');
-    await expect(kpi).toContainText('$147.9M');
-    await expect(kpi).toContainText('3669.5%');
-    await expect(kpi).toContainText('37.7×');
-    await expect(kpi).toContainText('407 projects');
+    await expect(kpi).toContainText(EXPECTED_RETURN);
+    await expect(kpi).toContainText(EXPECTED_INVESTMENT);
+    await expect(kpi).toContainText(EXPECTED_ROI);
+    await expect(kpi).toContainText(EXPECTED_BCR);
+    await expect(kpi).toContainText(EXPECTED_PROJECT_COUNT);
   });
 
   test('discloses that the investment figure is a modelled cost, not compensation', async ({ page }) => {
@@ -230,6 +139,7 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     // Coverage is method-scoped too: it reports whether *this* method produced figures, so a
     // coverage answer left on the previous method could contradict the summary it explains.
     const coverageRequest = page.waitForRequest((req) => req.url().includes('/lens/roi/coverage') && req.url().includes('method=direct'));
+    const projectsRequest = page.waitForRequest((req) => req.url().includes('/lens/roi/projects') && req.url().includes('method=direct'));
 
     await page.getByTestId('org-roi-assumptions-trigger').click();
     await page.getByTestId('org-roi-assumptions-method-direct').click();
@@ -237,6 +147,7 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await summaryRequest;
     await annualRequest;
     await coverageRequest;
+    await projectsRequest;
 
     const restoredRequest = page.waitForRequest((req) => req.url().includes('/lens/roi/summary') && req.url().includes('method=direct'));
     await page.reload({ waitUntil: 'domcontentloaded' });
@@ -244,6 +155,24 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
 
     await page.getByTestId('org-roi-assumptions-trigger').click();
     await expect(page.getByTestId('org-roi-assumptions-method-direct')).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  test('never sends an estimation method to the category breakdown, which cannot vary by one', async ({ page }) => {
+    // The source table has no MARKUP_METHOD column, so a method-bearing request would imply a
+    // distinction the warehouse does not make — and invite a pointless refetch on every switch.
+    const breakdownUrls: string[] = [];
+    page.on('request', (request) => {
+      if (request.url().includes('/lens/roi/investment-breakdown')) breakdownUrls.push(request.url());
+    });
+
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+    await expect(page.getByTestId('org-roi-category-donut-chart')).toBeVisible();
+
+    expect(breakdownUrls.length).toBeGreaterThan(0);
+    for (const url of breakdownUrls) {
+      expect(url).not.toContain('method=');
+    }
   });
 
   test('explains an unmapped organization without implying a pending fix', async ({ page }) => {
@@ -257,6 +186,7 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(empty).toBeVisible();
     await expect(empty).toContainText("isn't linked to a contributor community record");
     await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-category-donut')).toHaveCount(0);
   });
 
   test('explains a mapped-but-unestimated organization without promising later figures', async ({ page }) => {
@@ -310,8 +240,8 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(table).toContainText('Return');
     // Same figures as the chart, through the same formatter.
     await expect(table).toContainText(`${CURRENT_YEAR}`);
-    await expect(table).toContainText('$620M');
-    await expect(table).toContainText('$17M');
+    await expect(table).toContainText(formatCurrency(LATEST_ANNUAL.totalReturn));
+    await expect(table).toContainText(formatCurrency(LATEST_ANNUAL.expenditure));
     await expect(table).toContainText('partial year');
 
     await expect(page.getByTestId('org-roi-annual-trend-chart')).toHaveAttribute('aria-label', /investment and return by year/i);
@@ -355,6 +285,9 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     for (const body of responses) {
       expect(body).not.toContain('totalExpenditure');
       expect(body).not.toContain('totalReturn');
+      // US3 and US4 added two more payloads that carry investment; a refusal must leak neither.
+      expect(body).not.toContain('expenditure');
+      expect(body).not.toContain('categories');
     }
   });
 
@@ -396,5 +329,103 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(page.getByTestId('org-roi-no-access-state')).toBeVisible();
     await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
     await expect(page.getByTestId('org-roi-no-company-empty-state')).toHaveCount(0);
+  });
+});
+
+test.describe('Org Lens ROI Metrics — investment by category', () => {
+  test('renders every above-threshold category with its shared label', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const legend = page.getByTestId('org-roi-category-donut-legend');
+    await expect(page.getByTestId('org-roi-category-donut')).toBeVisible();
+    await expect(legend).toBeVisible();
+
+    // The labels come from the warehouse seed, so the fixture's own labels are the expectation.
+    for (const row of MOCK_CATEGORY_ROWS) {
+      const isSubThreshold = row.expenditure / TOTAL_INVESTMENT < 0.02;
+      if (isSubThreshold) continue;
+      await expect(legend).toContainText(row.label);
+      await expect(legend).toContainText(formatCurrency(row.expenditure));
+    }
+  });
+
+  test('collapses sub-threshold categories into one remainder labelled with its count', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const legend = page.getByTestId('org-roi-category-donut-legend');
+    await expect(legend).toContainText(`Other (${SUB_THRESHOLD_CATEGORY_COUNT} categories)`);
+
+    // The smallest category is $1,190 against a $148M total — a slice too thin to see and a legend
+    // entry too small to read, which is what FR-025's threshold exists to prevent.
+    const smallest = MOCK_CATEGORY_ROWS.reduce((min, row) => (row.expenditure < min.expenditure ? row : min));
+    await expect(legend).not.toContainText(smallest.label);
+  });
+
+  test('reports a category total identical to the KPI investment figure', async ({ page }) => {
+    // FR-026 / SC-011. The warehouse reconciles these by construction and a dbt singular test
+    // asserts it per account, so any difference here is a defect — never rescaled client-side to
+    // force agreement, which is what the reference implementation does (FR-011b).
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    // Tie the rendered total to the category rows themselves, not merely to the fixture's `total`
+    // field: a component that displayed anything else would otherwise pass.
+    const summedFromCategories = formatCurrency(MOCK_CATEGORY_ROWS.reduce((sum, row) => sum + row.expenditure, 0));
+
+    await expect(page.getByTestId('org-roi-category-donut-total')).toHaveText(summedFromCategories);
+    await expect(page.getByTestId('org-roi-kpi-cards')).toContainText(summedFromCategories);
+    expect(summedFromCategories).toBe(EXPECTED_INVESTMENT);
+  });
+
+  test('switches the category display between currency and share of total', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const legend = page.getByTestId('org-roi-category-donut-legend');
+    const code = MOCK_CATEGORY_ROWS[0];
+    const codeShare = `${formatPercent((code.expenditure / TOTAL_INVESTMENT) * 100)}%`;
+
+    await expect(legend).toContainText(formatCurrency(code.expenditure));
+
+    await page.getByTestId('org-roi-category-donut-units-share').click();
+    await expect(legend).toContainText(codeShare);
+    await expect(legend).not.toContainText(formatCurrency(code.expenditure));
+
+    await page.getByTestId('org-roi-category-donut-units-amount').click();
+    await expect(legend).toContainText(formatCurrency(code.expenditure));
+    // The total stays a currency figure in both modes — it is the reconciliation anchor.
+    await expect(page.getByTestId('org-roi-category-donut-total')).toHaveText(EXPECTED_INVESTMENT);
+  });
+
+  test('carries the modelled-cost disclosure on the category breakdown', async ({ page }) => {
+    // The surface the privacy audit was most concerned about: 19.4% of covered organizations have a
+    // single code contributor, so "Code Contribution: $101.9M" can read as one person's pay.
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const note = page.getByTestId('org-roi-category-donut-modelled-cost-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('modelled cost');
+    await expect(note).toContainText('not actual or reported compensation');
+    await expect(note).toContainText('same for every organization');
+    await expect(note).toContainText('No salary, payroll, or invoice data is used.');
+  });
+
+  test('names the chart for assistive technology and lists its values as text', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-category-donut-chart')).toHaveAttribute('aria-label', /doughnut chart of modelled investment/i);
+    await expect(page.getByTestId('org-roi-category-donut-legend')).toBeVisible();
+  });
+
+  test('shows an empty category breakdown without erroring', async ({ page }) => {
+    await stubOrgLensContext(page, { investmentBreakdown: { rows: [], total: 0 } });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-category-donut-empty')).toBeVisible();
+    await expect(page.getByTestId('org-roi-category-donut-chart')).toHaveCount(0);
   });
 });

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -183,6 +183,19 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(page.getByTestId('org-roi-category-donut-chart')).toBeVisible();
   });
 
+  test('hides the figures and the date window when the summary is for another organization', async ({ page }) => {
+    // The summary keeps its previous value while a new request is in flight, so anything derived
+    // from it describes the organization the viewer just left. Both surfaces key off the payload's
+    // own orgUid rather than assuming the summary in hand belongs to the selected account.
+    await stubOrgLensContext(page, { summary: { ...MOCK_SUMMARY, orgUid: '001410000000000XYZ' } });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-page')).toBeVisible();
+    await expect(page.getByTestId('org-roi-window')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-category-donut')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-projects-donut')).toHaveCount(0);
+  });
+
   test('never sends an estimation method to the category breakdown, which cannot vary by one', async ({ page }) => {
     // The source table has no MARKUP_METHOD column, so a method-bearing request would imply a
     // distinction the warehouse does not make — and invite a pointless refetch on every switch.

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -194,6 +194,11 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await expect(page.getByTestId('org-roi-window')).toHaveCount(0);
     await expect(page.getByTestId('org-roi-category-donut')).toHaveCount(0);
     await expect(page.getByTestId('org-roi-projects-donut')).toHaveCount(0);
+    // The headline band carries the largest figures on the page, so it is the one surface that
+    // must not slip through: it renders from the same summary and needs the same identity check.
+    await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-annual-trend')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-portfolio-loading')).toBeVisible();
   });
 
   test('never sends an estimation method to the category breakdown, which cannot vary by one', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -26,9 +26,9 @@ test.setTimeout(120_000);
 
 /**
  * Every expected string below is derived from the fixture through the same formatter the component
- * uses — never written out by hand. US2 shipped three defects to human review that this rule would
- * have caught on its own, including a benefit-cost expectation of `36.7×` for a fixture that
- * renders `37.7×`.
+ * uses — never written out by hand. Three defects reached human review that this rule would have
+ * caught on its own, including a benefit-cost expectation of `36.7×` for a fixture that renders
+ * `37.7×`.
  */
 const EXPECTED_INVESTMENT = formatCurrency(TOTAL_INVESTMENT);
 const EXPECTED_RETURN = formatCurrency(MOCK_SUMMARY.totalReturn);
@@ -311,7 +311,7 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     for (const body of responses) {
       expect(body).not.toContain('totalExpenditure');
       expect(body).not.toContain('totalReturn');
-      // US3 and US4 added two more payloads that carry investment; a refusal must leak neither.
+      // The category and project payloads also carry investment; a refusal must leak neither.
       expect(body).not.toContain('expenditure');
       expect(body).not.toContain('categories');
     }
@@ -384,15 +384,15 @@ test.describe('Org Lens ROI Metrics — investment by category', () => {
     await expect(legend).toContainText(`Other (${SUB_THRESHOLD_CATEGORY_COUNT} categories)`);
 
     // The smallest category is $1,190 against a $148M total — a slice too thin to see and a legend
-    // entry too small to read, which is what FR-025's threshold exists to prevent.
+    // entry too small to read, which is what the display threshold exists to prevent.
     const smallest = MOCK_CATEGORY_ROWS.reduce((min, row) => (row.expenditure < min.expenditure ? row : min));
     await expect(legend).not.toContainText(smallest.label);
   });
 
   test('reports a category total identical to the KPI investment figure', async ({ page }) => {
-    // FR-026 / SC-011. The warehouse reconciles these by construction and a dbt singular test
-    // asserts it per account, so any difference here is a defect — never rescaled client-side to
-    // force agreement, which is what the reference implementation does (FR-011b).
+    // The warehouse reconciles these by construction and a dbt singular test asserts it per
+    // account, so any difference here is a defect — never rescaled client-side to force
+    // agreement, which is what the reference implementation does.
     await stubOrgLensContext(page);
     await gotoOrgRoiPage(page);
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.html
@@ -5,7 +5,7 @@
   <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
     <h2 class="text-base font-semibold text-gray-900">Investment by contribution category</h2>
 
-    @if (hasRows()) {
+    @if (hasSlices()) {
       <div class="inline-flex self-start rounded-md border border-gray-200 p-0.5" role="group" aria-label="Category display units">
         <button
           type="button"
@@ -49,7 +49,7 @@
       <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
       <span>The category breakdown couldn't be loaded. Please try again.</span>
     </div>
-  } @else if (!hasRows()) {
+  } @else if (!hasSlices()) {
     <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-category-donut-empty">
       <i class="fa-light fa-chart-pie text-gray-400" aria-hidden="true"></i>
       <span>No category breakdown is available for this organization.</span>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.html
@@ -1,0 +1,85 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-roi-category-donut">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <h2 class="text-base font-semibold text-gray-900">Investment by contribution category</h2>
+
+    @if (hasRows()) {
+      <div class="inline-flex self-start rounded-md border border-gray-200 p-0.5" role="group" aria-label="Category display units">
+        <button
+          type="button"
+          (click)="toggleShare(false)"
+          [class]="
+            !asShare()
+              ? 'rounded px-3 py-1 text-xs font-medium bg-blue-50 text-blue-700'
+              : 'rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50'
+          "
+          [attr.aria-pressed]="!asShare()"
+          data-testid="org-roi-category-donut-units-amount">
+          Amount
+        </button>
+        <button
+          type="button"
+          (click)="toggleShare(true)"
+          [class]="
+            asShare()
+              ? 'rounded px-3 py-1 text-xs font-medium bg-blue-50 text-blue-700'
+              : 'rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50'
+          "
+          [attr.aria-pressed]="asShare()"
+          data-testid="org-roi-category-donut-units-share">
+          Share
+        </button>
+      </div>
+    }
+  </div>
+
+  @if (loading()) {
+    <div class="flex flex-col gap-2" data-testid="org-roi-category-donut-loading">
+      <p-skeleton width="100%" height="280px" />
+    </div>
+  } @else if (forbidden()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-category-donut-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (failed()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-category-donut-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>The category breakdown couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (!hasRows()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-category-donut-empty">
+      <i class="fa-light fa-chart-pie text-gray-400" aria-hidden="true"></i>
+      <span>No category breakdown is available for this organization.</span>
+    </div>
+  } @else {
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center">
+      <div class="h-[280px] lg:w-1/2" role="img" [attr.aria-label]="chartSummaryLabel()" data-testid="org-roi-category-donut-chart">
+        <lfx-chart type="doughnut" [data]="chartData()" [options]="chartOptions()" height="100%" />
+      </div>
+
+      <!-- Real text, not a canvas: this is the accessible equivalent of the chart as well as its
+           legend, and it is where the amount/share toggle visibly takes effect. -->
+      <dl class="flex flex-col gap-2 lg:w-1/2" data-testid="org-roi-category-donut-legend">
+        @for (row of legendRows(); track row.key) {
+          <div class="flex items-baseline justify-between gap-4 text-sm">
+            <dt class="flex items-center gap-2 text-gray-700">
+              <span class="h-2.5 w-2.5 flex-shrink-0 rounded-full" [style.background-color]="row.color" aria-hidden="true"></span>
+              {{ row.label }}
+            </dt>
+            <dd class="font-medium text-gray-900">{{ row.display }}</dd>
+          </div>
+        }
+      </dl>
+    </div>
+
+    <div class="flex items-baseline justify-between gap-4 border-t border-gray-100 pt-3">
+      <span class="text-sm text-gray-600">Total investment</span>
+      <span class="text-sm font-semibold text-gray-900" data-testid="org-roi-category-donut-total">{{ totalLabel() }}</span>
+    </div>
+
+    <p class="text-xs text-gray-500" data-testid="org-roi-category-donut-modelled-cost-note">{{ investmentExplanation }}</p>
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.html
@@ -10,11 +10,11 @@
         <button
           type="button"
           (click)="toggleShare(false)"
-          [class]="
-            !asShare()
-              ? 'rounded px-3 py-1 text-xs font-medium bg-blue-50 text-blue-700'
-              : 'rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50'
-          "
+          class="rounded px-3 py-1 text-xs font-medium"
+          [class.bg-blue-50]="!asShare()"
+          [class.text-blue-700]="!asShare()"
+          [class.text-gray-600]="asShare()"
+          [class.hover:bg-gray-50]="asShare()"
           [attr.aria-pressed]="!asShare()"
           data-testid="org-roi-category-donut-units-amount">
           Amount
@@ -22,11 +22,11 @@
         <button
           type="button"
           (click)="toggleShare(true)"
-          [class]="
-            asShare()
-              ? 'rounded px-3 py-1 text-xs font-medium bg-blue-50 text-blue-700'
-              : 'rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50'
-          "
+          class="rounded px-3 py-1 text-xs font-medium"
+          [class.bg-blue-50]="asShare()"
+          [class.text-blue-700]="asShare()"
+          [class.text-gray-600]="!asShare()"
+          [class.hover:bg-gray-50]="!asShare()"
           [attr.aria-pressed]="asShare()"
           data-testid="org-roi-category-donut-units-share">
           Share

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.ts
@@ -1,0 +1,214 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChartComponent } from '@components/chart/chart.component';
+import {
+  lfxColors,
+  ORG_LENS_ROI_CATEGORY_REMAINDER_THRESHOLD,
+  ORG_LENS_ROI_DONUT_PALETTE,
+  ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
+  ORG_LENS_ROI_KPI_EXPLANATION,
+  ORG_LENS_ROI_NO_VALUE,
+} from '@lfx-one/shared/constants';
+import type { OrgLensRoiInvestmentBreakdown } from '@lfx-one/shared/interfaces';
+import { formatCurrency, formatPercent } from '@lfx-one/shared/utils';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensRoiService } from '@services/org-lens-roi.service';
+import type { ChartData, ChartOptions } from 'chart.js';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, filter, of, switchMap, tap } from 'rxjs';
+
+const EMPTY_BREAKDOWN: OrgLensRoiInvestmentBreakdown = { rows: [], total: 0 };
+
+interface CategorySlice {
+  key: string;
+  label: string;
+  expenditure: number;
+  share: number;
+  color: string;
+}
+
+/** Investment by contribution category (US3, FR-023 to FR-026). */
+@Component({
+  selector: 'lfx-org-roi-category-donut',
+  imports: [ChartComponent, SkeletonModule],
+  templateUrl: './org-roi-category-donut.component.html',
+})
+export class OrgRoiCategoryDonutComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly roiService = inject(OrgLensRoiService);
+
+  /**
+   * FR-039a. The same string the KPI band shows, not a paraphrase of it — the two surfaces state
+   * the same disclosure, so they cannot drift apart when either is edited (DR-015).
+   */
+  protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
+
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  protected readonly forbidden = signal(false);
+
+  /** FR-024 — currency or share of total. Presentation only; the underlying values never change. */
+  protected readonly asShare = signal(false);
+
+  private readonly breakdown: Signal<OrgLensRoiInvestmentBreakdown> = this.initBreakdown();
+
+  protected readonly total: Signal<number> = computed(() => this.breakdown().total);
+
+  protected readonly hasRows: Signal<boolean> = computed(() => this.breakdown().rows.length > 0);
+
+  /**
+   * The reconciliation anchor (FR-026, SC-011). It is the sum of exactly the rows drawn below, and
+   * the warehouse already guarantees it equals the KPI investment figure — a dbt singular test
+   * asserts it per account. Nothing here rescales to force the two to agree: if they ever differ,
+   * that is a defect to raise, not a discrepancy to paper over (FR-011b).
+   */
+  protected readonly totalLabel: Signal<string> = computed(() => {
+    const total = this.total();
+    return Number.isFinite(total) ? formatCurrency(total) : ORG_LENS_ROI_NO_VALUE;
+  });
+
+  /**
+   * FR-025 — categories under the display threshold collapse into one labelled remainder, so a
+   * $1,190 education line does not render as an invisible sliver with an unreachable legend entry.
+   */
+  protected readonly slices: Signal<CategorySlice[]> = computed(() => {
+    const { rows, total } = this.breakdown();
+    if (rows.length === 0 || !(total > 0)) return [];
+
+    const kept: CategorySlice[] = [];
+    const collapsed: { expenditure: number; count: number } = { expenditure: 0, count: 0 };
+
+    for (const row of rows) {
+      const share = row.expenditure / total;
+      if (share < ORG_LENS_ROI_CATEGORY_REMAINDER_THRESHOLD) {
+        collapsed.expenditure += row.expenditure;
+        collapsed.count += 1;
+        continue;
+      }
+      kept.push({
+        key: row.type,
+        label: row.label,
+        expenditure: row.expenditure,
+        share,
+        color: ORG_LENS_ROI_DONUT_PALETTE[kept.length % ORG_LENS_ROI_DONUT_PALETTE.length],
+      });
+    }
+
+    if (collapsed.count === 0) return kept;
+    return [
+      ...kept,
+      {
+        key: 'remainder',
+        label: collapsed.count === 1 ? 'Other (1 category)' : `Other (${collapsed.count} categories)`,
+        expenditure: collapsed.expenditure,
+        share: collapsed.expenditure / total,
+        color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
+      },
+    ];
+  });
+
+  /**
+   * The legend is rendered as real text beside the canvas rather than mirrored into an `sr-only`
+   * table as the annual trend does. Both satisfy "a canvas cannot be the only presentation of its
+   * data"; a visible list is the better fit here because there are at most nine categories, and
+   * because FR-024's currency/share toggle needs somewhere visible to take effect — switching only
+   * the tooltips would leave the choice invisible until the viewer hovered a slice.
+   *
+   * Pre-formatted so the legend and the tooltip cannot disagree.
+   */
+  protected readonly legendRows: Signal<{ key: string; label: string; amount: string; share: string; display: string; color: string }[]> = computed(() => {
+    const asShare = this.asShare();
+    return this.slices().map((slice) => {
+      const amount = formatCurrency(slice.expenditure);
+      const share = `${formatPercent(slice.share * 100)}%`;
+      return { key: slice.key, label: slice.label, amount, share, display: asShare ? share : amount, color: slice.color };
+    });
+  });
+
+  protected readonly chartSummaryLabel: Signal<string> = computed(
+    () => `Doughnut chart of modelled investment across ${this.slices().length} contribution categories. The same figures are listed beside it.`
+  );
+
+  protected readonly chartData: Signal<ChartData<'doughnut'>> = computed(() => {
+    const slices = this.slices();
+    return {
+      labels: slices.map((slice) => slice.label),
+      datasets: [
+        {
+          data: slices.map((slice) => slice.expenditure),
+          backgroundColor: slices.map((slice) => slice.color),
+          borderColor: lfxColors.gray[50],
+          borderWidth: 2,
+        },
+      ],
+    };
+  });
+
+  protected readonly chartOptions: Signal<ChartOptions<'doughnut'>> = computed(() => {
+    const asShare = this.asShare();
+    const total = this.total();
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      cutout: '60%',
+      plugins: {
+        // The adjacent list is the legend; the canvas one would only repeat it.
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(255, 255, 255, 0.98)',
+          titleColor: lfxColors.gray[900],
+          bodyColor: lfxColors.gray[600],
+          borderColor: lfxColors.gray[200],
+          borderWidth: 1,
+          padding: 10,
+          cornerRadius: 6,
+          callbacks: {
+            label: (ctx) => {
+              const value = ctx.parsed;
+              if (!asShare) return ` ${ctx.label}: ${formatCurrency(value)}`;
+              return ` ${ctx.label}: ${formatPercent(total > 0 ? (value / total) * 100 : 0)}%`;
+            },
+          },
+        },
+      },
+    };
+  });
+
+  public toggleShare(asShare: boolean): void {
+    this.asShare.set(asShare);
+  }
+
+  private initBreakdown(): Signal<OrgLensRoiInvestmentBreakdown> {
+    // Keyed by the account id alone: category investment carries no estimation method, so a method
+    // change is not a reason to refetch this surface.
+    const accountId$ = toObservable(computed(() => this.accountContext.selectedAccount()?.accountId ?? ''));
+
+    return toSignal(
+      accountId$.pipe(
+        filter((orgUid) => !!orgUid),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+        }),
+        switchMap((orgUid) =>
+          this.roiService.getInvestmentBreakdown(orgUid).pipe(
+            tap(() => this.loading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load ROI investment breakdown', error);
+              this.loading.set(false);
+              // Only a 403 may show the no-access message; a 503 must not.
+              if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
+              else this.failed.set(true);
+              return of(EMPTY_BREAKDOWN);
+            })
+          )
+        )
+      ),
+      { initialValue: EMPTY_BREAKDOWN }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.ts
@@ -12,7 +12,7 @@ import {
   ORG_LENS_ROI_KPI_EXPLANATION,
   ORG_LENS_ROI_NO_VALUE,
 } from '@lfx-one/shared/constants';
-import type { OrgLensRoiInvestmentBreakdown } from '@lfx-one/shared/interfaces';
+import type { OrgLensRoiCategoryRow, OrgLensRoiCategorySlice, OrgLensRoiInvestmentBreakdown } from '@lfx-one/shared/interfaces';
 import { formatCurrency, formatPercent } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensRoiService } from '@services/org-lens-roi.service';
@@ -21,14 +21,6 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, filter, of, switchMap, tap } from 'rxjs';
 
 const EMPTY_BREAKDOWN: OrgLensRoiInvestmentBreakdown = { rows: [], total: 0 };
-
-interface CategorySlice {
-  key: string;
-  label: string;
-  expenditure: number;
-  share: number;
-  color: string;
-}
 
 /** Investment by contribution category (US3, FR-023 to FR-026). */
 @Component({
@@ -57,7 +49,12 @@ export class OrgRoiCategoryDonutComponent {
 
   protected readonly total: Signal<number> = computed(() => this.breakdown().total);
 
-  protected readonly hasRows: Signal<boolean> = computed(() => this.breakdown().rows.length > 0);
+  /**
+   * Gate on the slices, not on the row count. An organization can have category rows that sum to
+   * zero investment, and there is nothing to draw from those — keying the template off row count
+   * alone rendered a blank canvas beside an empty legend instead of saying so.
+   */
+  protected readonly hasSlices: Signal<boolean> = computed(() => this.slices().length > 0);
 
   /**
    * The reconciliation anchor (FR-026, SC-011). It is the sum of exactly the rows drawn below, and
@@ -74,18 +71,17 @@ export class OrgRoiCategoryDonutComponent {
    * FR-025 — categories under the display threshold collapse into one labelled remainder, so a
    * $1,190 education line does not render as an invisible sliver with an unreachable legend entry.
    */
-  protected readonly slices: Signal<CategorySlice[]> = computed(() => {
+  protected readonly slices: Signal<OrgLensRoiCategorySlice[]> = computed(() => {
     const { rows, total } = this.breakdown();
     if (rows.length === 0 || !(total > 0)) return [];
 
-    const kept: CategorySlice[] = [];
-    const collapsed: { expenditure: number; count: number } = { expenditure: 0, count: 0 };
+    const kept: OrgLensRoiCategorySlice[] = [];
+    const collapsed: OrgLensRoiCategoryRow[] = [];
 
     for (const row of rows) {
       const share = row.expenditure / total;
       if (share < ORG_LENS_ROI_CATEGORY_REMAINDER_THRESHOLD) {
-        collapsed.expenditure += row.expenditure;
-        collapsed.count += 1;
+        collapsed.push(row);
         continue;
       }
       kept.push({
@@ -97,14 +93,32 @@ export class OrgRoiCategoryDonutComponent {
       });
     }
 
-    if (collapsed.count === 0) return kept;
+    if (collapsed.length === 0) return kept;
+
+    // A remainder standing for a single category is strictly worse than the category itself: it
+    // hides a real name behind "Other (1 category)" and saves no space.
+    if (collapsed.length === 1) {
+      const only = collapsed[0];
+      return [
+        ...kept,
+        {
+          key: only.type,
+          label: only.label,
+          expenditure: only.expenditure,
+          share: only.expenditure / total,
+          color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
+        },
+      ];
+    }
+
+    const collapsedTotal = collapsed.reduce((sum, row) => sum + row.expenditure, 0);
     return [
       ...kept,
       {
         key: 'remainder',
-        label: collapsed.count === 1 ? 'Other (1 category)' : `Other (${collapsed.count} categories)`,
-        expenditure: collapsed.expenditure,
-        share: collapsed.expenditure / total,
+        label: `Other (${collapsed.length} categories)`,
+        expenditure: collapsedTotal,
+        share: collapsedTotal / total,
         color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
       },
     ];
@@ -128,8 +142,13 @@ export class OrgRoiCategoryDonutComponent {
     });
   });
 
+  /**
+   * Counts the underlying categories, not the slices. A remainder slice stands for several, so
+   * announcing the slice count told a screen-reader user "6 categories" for an organization with
+   * eight — a number no sighted user is shown to contradict.
+   */
   protected readonly chartSummaryLabel: Signal<string> = computed(
-    () => `Doughnut chart of modelled investment across ${this.slices().length} contribution categories. The same figures are listed beside it.`
+    () => `Doughnut chart of modelled investment across ${this.breakdown().rows.length} contribution categories. The same figures are listed beside it.`
   );
 
   protected readonly chartData: Signal<ChartData<'doughnut'>> = computed(() => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-category-donut/org-roi-category-donut.component.ts
@@ -22,7 +22,6 @@ import { catchError, filter, of, switchMap, tap } from 'rxjs';
 
 const EMPTY_BREAKDOWN: OrgLensRoiInvestmentBreakdown = { rows: [], total: 0 };
 
-/** Investment by contribution category (US3, FR-023 to FR-026). */
 @Component({
   selector: 'lfx-org-roi-category-donut',
   imports: [ChartComponent, SkeletonModule],
@@ -33,8 +32,8 @@ export class OrgRoiCategoryDonutComponent {
   private readonly roiService = inject(OrgLensRoiService);
 
   /**
-   * FR-039a. The same string the KPI band shows, not a paraphrase of it — the two surfaces state
-   * the same disclosure, so they cannot drift apart when either is edited (DR-015).
+   * The same string the KPI band shows, not a paraphrase of it — the two surfaces state the same
+   * disclosure, so they cannot drift apart when either is edited.
    */
   protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
 
@@ -42,7 +41,7 @@ export class OrgRoiCategoryDonutComponent {
   protected readonly failed = signal(false);
   protected readonly forbidden = signal(false);
 
-  /** FR-024 — currency or share of total. Presentation only; the underlying values never change. */
+  /** Currency or share of total. Presentation only; the underlying values never change. */
   protected readonly asShare = signal(false);
 
   private readonly breakdown: Signal<OrgLensRoiInvestmentBreakdown> = this.initBreakdown();
@@ -57,10 +56,10 @@ export class OrgRoiCategoryDonutComponent {
   protected readonly hasSlices: Signal<boolean> = computed(() => this.slices().length > 0);
 
   /**
-   * The reconciliation anchor (FR-026, SC-011). It is the sum of exactly the rows drawn below, and
-   * the warehouse already guarantees it equals the KPI investment figure — a dbt singular test
-   * asserts it per account. Nothing here rescales to force the two to agree: if they ever differ,
-   * that is a defect to raise, not a discrepancy to paper over (FR-011b).
+   * The reconciliation anchor. It is the sum of exactly the rows drawn below, and the warehouse
+   * already guarantees it equals the KPI investment figure — a dbt singular test asserts it per
+   * account. Nothing here rescales to force the two to agree: if they ever differ, that is a defect
+   * to raise, not a discrepancy to paper over.
    */
   protected readonly totalLabel: Signal<string> = computed(() => {
     const total = this.total();
@@ -68,8 +67,8 @@ export class OrgRoiCategoryDonutComponent {
   });
 
   /**
-   * FR-025 — categories under the display threshold collapse into one labelled remainder, so a
-   * $1,190 education line does not render as an invisible sliver with an unreachable legend entry.
+   * Categories under the display threshold collapse into one labelled remainder, so a $1,190
+   * education line does not render as an invisible sliver with an unreachable legend entry.
    */
   protected readonly slices: Signal<OrgLensRoiCategorySlice[]> = computed(() => {
     const { rows, total } = this.breakdown();
@@ -106,7 +105,9 @@ export class OrgRoiCategoryDonutComponent {
           label: only.label,
           expenditure: only.expenditure,
           share: only.expenditure / total,
-          color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
+          // A palette colour, not the remainder gray: this slice is a named category, and the gray
+          // reads as "everything else" to anyone matching the legend dot against the other arcs.
+          color: ORG_LENS_ROI_DONUT_PALETTE[kept.length % ORG_LENS_ROI_DONUT_PALETTE.length],
         },
       ];
     }
@@ -126,10 +127,10 @@ export class OrgRoiCategoryDonutComponent {
 
   /**
    * The legend is rendered as real text beside the canvas rather than mirrored into an `sr-only`
-   * table as the annual trend does. Both satisfy "a canvas cannot be the only presentation of its
-   * data"; a visible list is the better fit here because there are at most nine categories, and
-   * because FR-024's currency/share toggle needs somewhere visible to take effect — switching only
-   * the tooltips would leave the choice invisible until the viewer hovered a slice.
+   * table as the annual trend does. Both keep the figures available outside the canvas; a visible
+   * list is the better fit here because there are at most nine categories, and
+   * because the currency/share toggle needs somewhere visible to take effect — switching only the
+   * tooltips would leave the choice invisible until the viewer hovered a slice.
    *
    * Pre-formatted so the legend and the tooltip cannot disagree.
    */

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.html
@@ -10,11 +10,11 @@
         <button
           type="button"
           (click)="setMeasure(option)"
-          [class]="
-            option === measure()
-              ? 'rounded px-3 py-1 text-xs font-medium bg-blue-50 text-blue-700'
-              : 'rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50'
-          "
+          class="rounded px-3 py-1 text-xs font-medium"
+          [class.bg-blue-50]="option === measure()"
+          [class.text-blue-700]="option === measure()"
+          [class.text-gray-600]="option !== measure()"
+          [class.hover:bg-gray-50]="option !== measure()"
           [attr.aria-pressed]="option === measure()"
           [attr.data-testid]="'org-roi-projects-donut-measure-' + option">
           {{ measureLabels[option] }}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.html
@@ -1,0 +1,93 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-roi-projects-donut">
+  <div class="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <h2 class="text-base font-semibold text-gray-900">Leading projects</h2>
+
+    <div class="inline-flex self-start rounded-md border border-gray-200 p-0.5" role="group" aria-label="Project measure">
+      @for (option of measures; track option) {
+        <button
+          type="button"
+          (click)="setMeasure(option)"
+          [class]="
+            option === measure()
+              ? 'rounded px-3 py-1 text-xs font-medium bg-blue-50 text-blue-700'
+              : 'rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50'
+          "
+          [attr.aria-pressed]="option === measure()"
+          [attr.data-testid]="'org-roi-projects-donut-measure-' + option">
+          {{ measureLabels[option] }}
+        </button>
+      }
+    </div>
+  </div>
+
+  @if (loading()) {
+    <div class="flex flex-col gap-2" data-testid="org-roi-projects-donut-loading">
+      <p-skeleton width="100%" height="280px" />
+    </div>
+  } @else if (forbidden()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-donut-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (failed()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-donut-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>The project breakdown couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (!hasRows()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-donut-empty">
+      <i class="fa-light fa-chart-pie text-gray-400" aria-hidden="true"></i>
+      <span>No project breakdown is available for this organization.</span>
+    </div>
+  } @else {
+    <div class="flex flex-col gap-4 lg:flex-row lg:items-center">
+      @if (slices().length > 0) {
+        <div class="h-[280px] lg:w-1/2" role="img" [attr.aria-label]="chartSummaryLabel()" data-testid="org-roi-projects-donut-chart">
+          <lfx-chart type="doughnut" [data]="chartData()" [options]="chartOptions()" height="100%" />
+        </div>
+      } @else {
+        <!-- Reachable on Net Return for an organization whose every project lost money: there is no
+             positive magnitude to draw, but the figures below still have to be reported. -->
+        <div class="flex items-center gap-2 py-6 text-sm text-gray-600 lg:w-1/2" data-testid="org-roi-projects-donut-no-positive">
+          <i class="fa-light fa-chart-pie text-gray-400" aria-hidden="true"></i>
+          <span>No project has a positive {{ measureLabel() }} to chart.</span>
+        </div>
+      }
+
+      <!-- Real text, not a canvas: the accessible equivalent of the chart as well as its legend. -->
+      <dl class="flex flex-col gap-2 lg:w-1/2" data-testid="org-roi-projects-donut-legend">
+        @for (row of legendRows(); track row.key) {
+          <div class="flex items-baseline justify-between gap-4 text-sm">
+            <dt class="flex items-center gap-2 text-gray-700">
+              <span class="h-2.5 w-2.5 flex-shrink-0 rounded-full" [style.background-color]="row.color" aria-hidden="true"></span>
+              {{ row.label }}
+            </dt>
+            <dd class="font-medium text-gray-900">{{ row.amount }}</dd>
+          </div>
+        }
+      </dl>
+    </div>
+
+    @if (negatives().count > 0) {
+      <p class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600" data-testid="org-roi-projects-donut-negative-note">
+        <i class="fa-light fa-circle-minus mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span>{{ negativeSummary() }}</span>
+      </p>
+      <ul class="flex flex-col gap-1" data-testid="org-roi-projects-donut-negative-list">
+        @for (row of negatives().rows; track row.key) {
+          <li class="flex items-baseline justify-between gap-4 text-xs text-gray-600">
+            <span>{{ row.label }}</span>
+            <span class="font-medium text-gray-900">{{ row.amount }}</span>
+          </li>
+        }
+      </ul>
+    }
+
+    @if (showsInvestment()) {
+      <p class="text-xs text-gray-500" data-testid="org-roi-projects-donut-modelled-cost-note">{{ investmentExplanation }}</p>
+    }
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.html
@@ -86,7 +86,7 @@
       </ul>
     }
 
-    @if (showsInvestment()) {
+    @if (showsModelledCost()) {
       <p class="text-xs text-gray-500" data-testid="org-roi-projects-donut-modelled-cost-note">{{ investmentExplanation }}</p>
     }
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
@@ -1,0 +1,244 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ChartComponent } from '@components/chart/chart.component';
+import {
+  lfxColors,
+  ORG_LENS_ROI_DEFAULT_METHOD,
+  ORG_LENS_ROI_DONUT_PALETTE,
+  ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
+  ORG_LENS_ROI_KPI_EXPLANATION,
+  ORG_LENS_ROI_PROJECT_DONUT_COVERAGE,
+  ORG_LENS_ROI_PROJECT_DONUT_MAX_SLICES,
+  ORG_LENS_ROI_PROJECT_MEASURE_LABELS,
+  ORG_LENS_ROI_PROJECT_MEASURES,
+} from '@lfx-one/shared/constants';
+import type { OrgLensRoiMethod, OrgLensRoiProjectMeasure, OrgLensRoiProjectRow, OrgLensRoiProjects } from '@lfx-one/shared/interfaces';
+import { formatCurrency } from '@lfx-one/shared/utils';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensRoiService } from '@services/org-lens-roi.service';
+import type { ChartData, ChartOptions } from 'chart.js';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+
+const EMPTY_PROJECTS: OrgLensRoiProjects = { method: ORG_LENS_ROI_DEFAULT_METHOD, rows: [] };
+
+interface ProjectSlice {
+  key: string;
+  label: string;
+  /** The true signed measure. Negative for a loss-making project on the Net Return tab. */
+  value: number;
+  /** What the arc is sized by — never negative, because an arc cannot be. */
+  weight: number;
+  color: string;
+}
+
+/** Highest-contributing projects by a selectable measure (US4, FR-027, FR-028). */
+@Component({
+  selector: 'lfx-org-roi-projects-donut',
+  imports: [ChartComponent, SkeletonModule],
+  templateUrl: './org-roi-projects-donut.component.html',
+})
+export class OrgRoiProjectsDonutComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly roiService = inject(OrgLensRoiService);
+
+  public readonly method = input.required<OrgLensRoiMethod>();
+
+  protected readonly measures = ORG_LENS_ROI_PROJECT_MEASURES;
+  protected readonly measureLabels = ORG_LENS_ROI_PROJECT_MEASURE_LABELS;
+
+  /** FR-039a — the same wording the KPI band uses, shown only where an investment figure is (DR-015). */
+  protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
+
+  protected readonly measure = signal<OrgLensRoiProjectMeasure>('investment');
+
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  protected readonly forbidden = signal(false);
+
+  private readonly projects: Signal<OrgLensRoiProjects> = this.initProjects();
+
+  protected readonly hasRows: Signal<boolean> = computed(() => this.projects().rows.length > 0);
+
+  protected readonly showsInvestment: Signal<boolean> = computed(() => this.measure() === 'investment');
+
+  protected readonly measureLabel: Signal<string> = computed(() => this.measureLabels[this.measure()]);
+
+  /** Ranked by the selected measure, signed values intact. */
+  private readonly ranked: Signal<{ row: OrgLensRoiProjectRow; value: number }[]> = computed(() => {
+    const measure = this.measure();
+    return this.projects()
+      .rows.map((row) => ({ row, value: this.measureValue(row, measure) }))
+      .filter((entry) => Number.isFinite(entry.value))
+      .sort((a, b) => b.value - a.value || a.row.projectId.localeCompare(b.row.projectId));
+  });
+
+  /**
+   * Net return is negative for 6.45% of project rows across 775 organizations — a mainline path,
+   * not an edge case. A doughnut arc cannot be negative, so the geometry is clamped at zero while
+   * the label keeps the true signed figure (FR-028). The projects concerned are named explicitly
+   * below rather than silently vanishing into a zero-width arc.
+   */
+  protected readonly negatives: Signal<{ count: number; total: number; rows: { key: string; label: string; amount: string }[] }> = computed(() => {
+    const losing = this.ranked().filter((entry) => entry.value < 0);
+    return {
+      count: losing.length,
+      total: losing.reduce((sum, entry) => sum + entry.value, 0),
+      // Each carries its own signed figure; a count alone would not satisfy FR-028.
+      rows: losing.map((entry) => ({ key: entry.row.projectId, label: entry.row.projectName, amount: formatCurrency(entry.value) })),
+    };
+  });
+
+  protected readonly negativeSummary: Signal<string> = computed(() => {
+    const { count, total } = this.negatives();
+    const subject = count === 1 ? '1 project has' : `${count.toLocaleString('en-US')} projects have`;
+    return `${subject} a negative net return, totalling ${formatCurrency(total)}. A negative value cannot be drawn as a slice, so it is excluded from the chart and listed here instead.`;
+  });
+
+  /**
+   * FR-027 — slices cover the leading share of the measure and everything else collapses into one
+   * remainder labelled with its project count. The cap is a second stop condition: a flat portfolio
+   * would otherwise reach the coverage target only after hundreds of unreadable slivers.
+   */
+  protected readonly slices: Signal<ProjectSlice[]> = computed(() => {
+    const ranked = this.ranked();
+    const totalWeight = ranked.reduce((sum, entry) => sum + Math.max(0, entry.value), 0);
+    if (ranked.length === 0 || !(totalWeight > 0)) return [];
+
+    const kept: ProjectSlice[] = [];
+    let covered = 0;
+    let index = 0;
+
+    while (index < ranked.length && kept.length < ORG_LENS_ROI_PROJECT_DONUT_MAX_SLICES && covered < ORG_LENS_ROI_PROJECT_DONUT_COVERAGE) {
+      const entry = ranked[index];
+      const weight = Math.max(0, entry.value);
+      // A non-positive value contributes no arc; stop rather than emit invisible slices.
+      if (weight <= 0) break;
+      kept.push({
+        key: entry.row.projectId,
+        label: entry.row.projectName,
+        value: entry.value,
+        weight,
+        color: ORG_LENS_ROI_DONUT_PALETTE[kept.length % ORG_LENS_ROI_DONUT_PALETTE.length],
+      });
+      covered += weight / totalWeight;
+      index += 1;
+    }
+
+    const rest = ranked.slice(index);
+    if (rest.length === 0) return kept;
+
+    const restValue = rest.reduce((sum, entry) => sum + entry.value, 0);
+    const restWeight = rest.reduce((sum, entry) => sum + Math.max(0, entry.value), 0);
+    return [
+      ...kept,
+      {
+        key: 'remainder',
+        label: rest.length === 1 ? 'Other (1 project)' : `Other (${rest.length.toLocaleString('en-US')} projects)`,
+        value: restValue,
+        weight: restWeight,
+        color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
+      },
+    ];
+  });
+
+  /**
+   * The accessible equivalent of the canvas and its legend, in real text beside it. Each entry
+   * carries the **signed** value, so a remainder that nets out negative reads as such rather than
+   * as the clamped magnitude its arc was drawn from (FR-028).
+   */
+  protected readonly legendRows: Signal<{ key: string; label: string; amount: string; color: string }[]> = computed(() =>
+    this.slices().map((slice) => ({ key: slice.key, label: slice.label, amount: formatCurrency(slice.value), color: slice.color }))
+  );
+
+  protected readonly chartSummaryLabel: Signal<string> = computed(
+    () => `Doughnut chart of the leading projects by ${this.measureLabels[this.measure()].toLowerCase()}. The same figures are listed beside it.`
+  );
+
+  protected readonly chartData: Signal<ChartData<'doughnut'>> = computed(() => {
+    const slices = this.slices();
+    return {
+      labels: slices.map((slice) => slice.label),
+      datasets: [
+        {
+          // Clamped weights, not the signed values — see `negatives` for how those are reported.
+          data: slices.map((slice) => slice.weight),
+          backgroundColor: slices.map((slice) => slice.color),
+          borderColor: lfxColors.gray[50],
+          borderWidth: 2,
+        },
+      ],
+    };
+  });
+
+  protected readonly chartOptions: Signal<ChartOptions<'doughnut'>> = computed(() => {
+    const slices = this.slices();
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      cutout: '60%',
+      plugins: {
+        // The adjacent list is the legend; the canvas one would only repeat it.
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(255, 255, 255, 0.98)',
+          titleColor: lfxColors.gray[900],
+          bodyColor: lfxColors.gray[600],
+          borderColor: lfxColors.gray[200],
+          borderWidth: 1,
+          padding: 10,
+          cornerRadius: 6,
+          callbacks: {
+            // The tooltip reports the signed value, not the clamped weight the arc was drawn from.
+            label: (ctx) => ` ${ctx.label}: ${formatCurrency(slices[ctx.dataIndex]?.value ?? 0)}`,
+          },
+        },
+      },
+    };
+  });
+
+  public setMeasure(measure: OrgLensRoiProjectMeasure): void {
+    this.measure.set(measure);
+  }
+
+  /** Never re-derived: profit is defined once in the metric layer and carried through (FR-007). */
+  private measureValue(row: OrgLensRoiProjectRow, measure: OrgLensRoiProjectMeasure): number {
+    if (measure === 'investment') return row.totalExpenditure;
+    if (measure === 'return') return row.totalReturn;
+    return row.profit;
+  }
+
+  private initProjects(): Signal<OrgLensRoiProjects> {
+    // Keyed by string, not the account object: that object is rewritten in place and would retrigger the fetch.
+    const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.method()}`));
+
+    return toSignal(
+      requestKey$.pipe(
+        map((key) => key.split('|') as [string, OrgLensRoiMethod]),
+        filter(([orgUid]) => !!orgUid),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+        }),
+        switchMap(([orgUid, method]) =>
+          this.roiService.getProjects(orgUid, method).pipe(
+            tap(() => this.loading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load ROI projects', error);
+              this.loading.set(false);
+              // Only a 403 may show the no-access message; a 503 must not.
+              if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
+              else this.failed.set(true);
+              return of(EMPTY_PROJECTS);
+            })
+          )
+        )
+      ),
+      { initialValue: EMPTY_PROJECTS }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
@@ -15,7 +15,7 @@ import {
   ORG_LENS_ROI_PROJECT_MEASURE_LABELS,
   ORG_LENS_ROI_PROJECT_MEASURES,
 } from '@lfx-one/shared/constants';
-import type { OrgLensRoiMethod, OrgLensRoiProjectMeasure, OrgLensRoiProjectRow, OrgLensRoiProjects } from '@lfx-one/shared/interfaces';
+import type { OrgLensRoiMethod, OrgLensRoiProjectMeasure, OrgLensRoiProjectRow, OrgLensRoiProjects, OrgLensRoiProjectSlice } from '@lfx-one/shared/interfaces';
 import { formatCurrency } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensRoiService } from '@services/org-lens-roi.service';
@@ -24,16 +24,6 @@ import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
 
 const EMPTY_PROJECTS: OrgLensRoiProjects = { method: ORG_LENS_ROI_DEFAULT_METHOD, rows: [] };
-
-interface ProjectSlice {
-  key: string;
-  label: string;
-  /** The true signed measure. Negative for a loss-making project on the Net Return tab. */
-  value: number;
-  /** What the arc is sized by — never negative, because an arc cannot be. */
-  weight: number;
-  color: string;
-}
 
 /** Highest-contributing projects by a selectable measure (US4, FR-027, FR-028). */
 @Component({
@@ -63,7 +53,12 @@ export class OrgRoiProjectsDonutComponent {
 
   protected readonly hasRows: Signal<boolean> = computed(() => this.projects().rows.length > 0);
 
-  protected readonly showsInvestment: Signal<boolean> = computed(() => this.measure() === 'investment');
+  /**
+   * FR-039a names the investment figure, but Net Return is `totalReturn - totalExpenditure` — a
+   * direct function of the modelled cost — and the negative list below renders per-project money on
+   * that tab. Total Return alone owes no modelled-cost disclosure; the other two do.
+   */
+  protected readonly showsModelledCost: Signal<boolean> = computed(() => this.measure() !== 'return');
 
   protected readonly measureLabel: Signal<string> = computed(() => this.measureLabels[this.measure()]);
 
@@ -95,7 +90,9 @@ export class OrgRoiProjectsDonutComponent {
   protected readonly negativeSummary: Signal<string> = computed(() => {
     const { count, total } = this.negatives();
     const subject = count === 1 ? '1 project has' : `${count.toLocaleString('en-US')} projects have`;
-    return `${subject} a negative net return, totalling ${formatCurrency(total)}. A negative value cannot be drawn as a slice, so it is excluded from the chart and listed here instead.`;
+    // Accurate about the partition: these are in neither a slice nor the remainder, so the chart
+    // above genuinely does not represent them and this list is their only reporting.
+    return `${subject} a negative net return, totalling ${formatCurrency(total)}. A negative value cannot be sized as a slice, so these are excluded from the chart and from its remainder, and reported here instead.`;
   });
 
   /**
@@ -103,43 +100,54 @@ export class OrgRoiProjectsDonutComponent {
    * remainder labelled with its project count. The cap is a second stop condition: a flat portfolio
    * would otherwise reach the coverage target only after hundreds of unreadable slivers.
    */
-  protected readonly slices: Signal<ProjectSlice[]> = computed(() => {
-    const ranked = this.ranked();
-    const totalWeight = ranked.reduce((sum, entry) => sum + Math.max(0, entry.value), 0);
-    if (ranked.length === 0 || !(totalWeight > 0)) return [];
+  protected readonly slices: Signal<OrgLensRoiProjectSlice[]> = computed(() => {
+    // Partition once, at zero, and let the chart and the negative disclosure own disjoint halves.
+    // Folding loss-making projects into the remainder as well as naming them below would report
+    // them twice, and would leave the remainder's arc (drawn from clamped magnitudes) disagreeing
+    // with its own legend figure (summed signed) with nothing to explain the gap. Every entry here
+    // is >= 0, so `weight` equals `value` throughout and each arc matches the number beside it.
+    const chartable = this.ranked().filter((entry) => entry.value >= 0);
+    const totalWeight = chartable.reduce((sum, entry) => sum + entry.value, 0);
+    if (chartable.length === 0 || !(totalWeight > 0)) return [];
 
-    const kept: ProjectSlice[] = [];
+    const kept: OrgLensRoiProjectSlice[] = [];
     let covered = 0;
     let index = 0;
 
-    while (index < ranked.length && kept.length < ORG_LENS_ROI_PROJECT_DONUT_MAX_SLICES && covered < ORG_LENS_ROI_PROJECT_DONUT_COVERAGE) {
-      const entry = ranked[index];
-      const weight = Math.max(0, entry.value);
-      // A non-positive value contributes no arc; stop rather than emit invisible slices.
-      if (weight <= 0) break;
+    while (index < chartable.length && kept.length < ORG_LENS_ROI_PROJECT_DONUT_MAX_SLICES && covered < ORG_LENS_ROI_PROJECT_DONUT_COVERAGE) {
+      const entry = chartable[index];
       kept.push({
         key: entry.row.projectId,
         label: entry.row.projectName,
         value: entry.value,
-        weight,
+        weight: entry.value,
         color: ORG_LENS_ROI_DONUT_PALETTE[kept.length % ORG_LENS_ROI_DONUT_PALETTE.length],
       });
-      covered += weight / totalWeight;
+      covered += entry.value / totalWeight;
       index += 1;
     }
 
-    const rest = ranked.slice(index);
+    const rest = chartable.slice(index);
     if (rest.length === 0) return kept;
 
+    // A remainder standing for a single project hides a real name behind "Other (1 project)" and
+    // saves no space. Name it instead.
+    if (rest.length === 1) {
+      const only = rest[0];
+      return [
+        ...kept,
+        { key: only.row.projectId, label: only.row.projectName, value: only.value, weight: only.value, color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR },
+      ];
+    }
+
     const restValue = rest.reduce((sum, entry) => sum + entry.value, 0);
-    const restWeight = rest.reduce((sum, entry) => sum + Math.max(0, entry.value), 0);
     return [
       ...kept,
       {
         key: 'remainder',
-        label: rest.length === 1 ? 'Other (1 project)' : `Other (${rest.length.toLocaleString('en-US')} projects)`,
+        label: `Other (${rest.length.toLocaleString('en-US')} projects)`,
         value: restValue,
-        weight: restWeight,
+        weight: restValue,
         color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
       },
     ];

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
@@ -6,7 +6,6 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ChartComponent } from '@components/chart/chart.component';
 import {
   lfxColors,
-  ORG_LENS_ROI_DEFAULT_METHOD,
   ORG_LENS_ROI_DONUT_PALETTE,
   ORG_LENS_ROI_DONUT_REMAINDER_COLOR,
   ORG_LENS_ROI_KPI_EXPLANATION,
@@ -15,15 +14,13 @@ import {
   ORG_LENS_ROI_PROJECT_MEASURE_LABELS,
   ORG_LENS_ROI_PROJECT_MEASURES,
 } from '@lfx-one/shared/constants';
-import type { OrgLensRoiMethod, OrgLensRoiProjectMeasure, OrgLensRoiProjectRow, OrgLensRoiProjects, OrgLensRoiProjectSlice } from '@lfx-one/shared/interfaces';
+import type { OrgLensRoiMethod, OrgLensRoiProjectMeasure, OrgLensRoiProjectRow, OrgLensRoiProjectSlice } from '@lfx-one/shared/interfaces';
 import { formatCurrency } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensRoiService } from '@services/org-lens-roi.service';
 import type { ChartData, ChartOptions } from 'chart.js';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
-
-const EMPTY_PROJECTS: OrgLensRoiProjects = { method: ORG_LENS_ROI_DEFAULT_METHOD, rows: [] };
 
 /** Highest-contributing projects by a selectable measure. */
 @Component({
@@ -49,9 +46,14 @@ export class OrgRoiProjectsDonutComponent {
   protected readonly failed = signal(false);
   protected readonly forbidden = signal(false);
 
-  private readonly projects: Signal<OrgLensRoiProjects> = this.initProjects();
+  /**
+   * The rows alone, not the whole response. Holding the envelope meant inventing a `method` for the
+   * pre-fetch sentinel, which then disagreed with the bound input whenever a non-default method was
+   * restored — a contradiction with nothing to resolve it, since nothing here reads that field.
+   */
+  private readonly projectRows: Signal<OrgLensRoiProjectRow[]> = this.initProjectRows();
 
-  protected readonly hasRows: Signal<boolean> = computed(() => this.projects().rows.length > 0);
+  protected readonly hasRows: Signal<boolean> = computed(() => this.projectRows().length > 0);
 
   /**
    * The disclosure names the investment figure, but Net Return is `totalReturn - totalExpenditure`
@@ -65,8 +67,8 @@ export class OrgRoiProjectsDonutComponent {
   /** Ranked by the selected measure, signed values intact. */
   private readonly ranked: Signal<{ row: OrgLensRoiProjectRow; value: number }[]> = computed(() => {
     const measure = this.measure();
-    return this.projects()
-      .rows.map((row) => ({ row, value: this.measureValue(row, measure) }))
+    return this.projectRows()
+      .map((row) => ({ row, value: this.measureValue(row, measure) }))
       .filter((entry) => Number.isFinite(entry.value))
       .sort((a, b) => b.value - a.value || this.compareProjectIds(a.row.projectId, b.row.projectId));
   });
@@ -236,7 +238,7 @@ export class OrgRoiProjectsDonutComponent {
     return row.profit;
   }
 
-  private initProjects(): Signal<OrgLensRoiProjects> {
+  private initProjectRows(): Signal<OrgLensRoiProjectRow[]> {
     // Keyed by string, not the account object: that object is rewritten in place and would retrigger the fetch.
     const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.method()}`));
 
@@ -252,18 +254,19 @@ export class OrgRoiProjectsDonutComponent {
         switchMap(([orgUid, method]) =>
           this.roiService.getProjects(orgUid, method).pipe(
             tap(() => this.loading.set(false)),
+            map((projects) => projects.rows),
             catchError((error: unknown) => {
               console.error('Failed to load ROI projects', error);
               this.loading.set(false);
               // Only a 403 may show the no-access message; a 503 must not.
               if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
               else this.failed.set(true);
-              return of(EMPTY_PROJECTS);
+              return of([] as OrgLensRoiProjectRow[]);
             })
           )
         )
       ),
-      { initialValue: EMPTY_PROJECTS }
+      { initialValue: [] as OrgLensRoiProjectRow[] }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
@@ -25,7 +25,7 @@ import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
 
 const EMPTY_PROJECTS: OrgLensRoiProjects = { method: ORG_LENS_ROI_DEFAULT_METHOD, rows: [] };
 
-/** Highest-contributing projects by a selectable measure (US4, FR-027, FR-028). */
+/** Highest-contributing projects by a selectable measure. */
 @Component({
   selector: 'lfx-org-roi-projects-donut',
   imports: [ChartComponent, SkeletonModule],
@@ -40,7 +40,7 @@ export class OrgRoiProjectsDonutComponent {
   protected readonly measures = ORG_LENS_ROI_PROJECT_MEASURES;
   protected readonly measureLabels = ORG_LENS_ROI_PROJECT_MEASURE_LABELS;
 
-  /** FR-039a — the same wording the KPI band uses, shown only where an investment figure is (DR-015). */
+  /** The same wording the KPI band uses, shown only where an investment figure is. */
   protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
 
   protected readonly measure = signal<OrgLensRoiProjectMeasure>('investment');
@@ -54,9 +54,9 @@ export class OrgRoiProjectsDonutComponent {
   protected readonly hasRows: Signal<boolean> = computed(() => this.projects().rows.length > 0);
 
   /**
-   * FR-039a names the investment figure, but Net Return is `totalReturn - totalExpenditure` — a
-   * direct function of the modelled cost — and the negative list below renders per-project money on
-   * that tab. Total Return alone owes no modelled-cost disclosure; the other two do.
+   * The disclosure names the investment figure, but Net Return is `totalReturn - totalExpenditure`
+   * — a direct function of the modelled cost — and the negative list below renders per-project
+   * money on that tab. Total Return alone owes no modelled-cost disclosure; the other two do.
    */
   protected readonly showsModelledCost: Signal<boolean> = computed(() => this.measure() !== 'return');
 
@@ -74,15 +74,15 @@ export class OrgRoiProjectsDonutComponent {
   /**
    * Net return is negative for 6.45% of project rows across 775 organizations — a mainline path,
    * not an edge case. A doughnut arc cannot be negative, so the geometry is clamped at zero while
-   * the label keeps the true signed figure (FR-028). The projects concerned are named explicitly
-   * below rather than silently vanishing into a zero-width arc.
+   * the label keeps the true signed figure. The projects concerned are named explicitly below
+   * rather than silently vanishing into a zero-width arc.
    */
   protected readonly negatives: Signal<{ count: number; total: number; rows: { key: string; label: string; amount: string }[] }> = computed(() => {
     const losing = this.ranked().filter((entry) => entry.value < 0);
     return {
       count: losing.length,
       total: losing.reduce((sum, entry) => sum + entry.value, 0),
-      // Each carries its own signed figure; a count alone would not satisfy FR-028.
+      // Each carries its own signed figure; a count alone would not disclose the losses.
       rows: losing.map((entry) => ({ key: entry.row.projectId, label: entry.row.projectName, amount: formatCurrency(entry.value) })),
     };
   });
@@ -96,9 +96,9 @@ export class OrgRoiProjectsDonutComponent {
   });
 
   /**
-   * FR-027 — slices cover the leading share of the measure and everything else collapses into one
-   * remainder labelled with its project count. The cap is a second stop condition: a flat portfolio
-   * would otherwise reach the coverage target only after hundreds of unreadable slivers.
+   * Slices cover the leading share of the measure and everything else collapses into one remainder
+   * labelled with its project count. The cap is a second stop condition: a flat portfolio would
+   * otherwise reach the coverage target only after hundreds of unreadable slivers.
    */
   protected readonly slices: Signal<OrgLensRoiProjectSlice[]> = computed(() => {
     // Partition once, at zero, and let the chart and the negative disclosure own disjoint halves.
@@ -136,7 +136,15 @@ export class OrgRoiProjectsDonutComponent {
       const only = rest[0];
       return [
         ...kept,
-        { key: only.row.projectId, label: only.row.projectName, value: only.value, weight: only.value, color: ORG_LENS_ROI_DONUT_REMAINDER_COLOR },
+        {
+          key: only.row.projectId,
+          label: only.row.projectName,
+          value: only.value,
+          weight: only.value,
+          // A palette colour, not the remainder gray: this slice is a named project, and the gray
+          // reads as "everything else" to anyone matching the legend dot against the other arcs.
+          color: ORG_LENS_ROI_DONUT_PALETTE[kept.length % ORG_LENS_ROI_DONUT_PALETTE.length],
+        },
       ];
     }
 
@@ -156,7 +164,7 @@ export class OrgRoiProjectsDonutComponent {
   /**
    * The accessible equivalent of the canvas and its legend, in real text beside it. Each entry
    * carries the **signed** value, so a remainder that nets out negative reads as such rather than
-   * as the clamped magnitude its arc was drawn from (FR-028).
+   * as the clamped magnitude its arc was drawn from.
    */
   protected readonly legendRows: Signal<{ key: string; label: string; amount: string; color: string }[]> = computed(() =>
     this.slices().map((slice) => ({ key: slice.key, label: slice.label, amount: formatCurrency(slice.value), color: slice.color }))
@@ -221,7 +229,7 @@ export class OrgRoiProjectsDonutComponent {
     return Number(a > b) - Number(a < b);
   }
 
-  /** Never re-derived: profit is defined once in the metric layer and carried through (FR-007). */
+  /** Never re-derived: profit is defined once in the metric layer and carried through. */
   private measureValue(row: OrgLensRoiProjectRow, measure: OrgLensRoiProjectMeasure): number {
     if (measure === 'investment') return row.totalExpenditure;
     if (measure === 'return') return row.totalReturn;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-donut/org-roi-projects-donut.component.ts
@@ -68,7 +68,7 @@ export class OrgRoiProjectsDonutComponent {
     return this.projects()
       .rows.map((row) => ({ row, value: this.measureValue(row, measure) }))
       .filter((entry) => Number.isFinite(entry.value))
-      .sort((a, b) => b.value - a.value || a.row.projectId.localeCompare(b.row.projectId));
+      .sort((a, b) => b.value - a.value || this.compareProjectIds(a.row.projectId, b.row.projectId));
   });
 
   /**
@@ -210,6 +210,15 @@ export class OrgRoiProjectsDonutComponent {
 
   public setMeasure(measure: OrgLensRoiProjectMeasure): void {
     this.measure.set(measure);
+  }
+
+  /**
+   * Codepoint order, deliberately not `localeCompare`. The tie-break key is an opaque warehouse id,
+   * so collation carries no meaning — and an unpinned locale would let Node and the browser order
+   * ties differently, which for an SSR-rendered legend is a hydration mismatch.
+   */
+  private compareProjectIds(a: string, b: string): number {
+    return Number(a > b) - Number(a < b);
   }
 
   /** Never re-derived: profit is defined once in the metric layer and carried through (FR-007). */

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -93,9 +93,9 @@
   <!-- Mounted outside the state chain above, which swaps the whole populated block for a skeleton
        on every request — including a method-only one. Inside it, the category donut remounted on
        each method switch and re-issued a read whose response cannot vary by method. Out here it
-       survives the switch, so its account-keyed request never re-emits. An org change still keys
-       it differently, and each donut raises its own loading state, so neither can show one
-       organization's figures under another's header. -->
+       survives the switch. An org change is different and must not survive: `showsFigures()`
+       checks the summary's own orgUid against the selected account, so it goes false immediately
+       rather than leaving one company's figures on another company's page. -->
   @if (showsFigures()) {
     <!-- No [method]: category investment has no estimation method in the warehouse. -->
     <lfx-org-roi-category-donut />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -88,9 +88,16 @@
     <lfx-org-roi-kpi-cards [summary]="summary()" />
 
     <lfx-org-roi-annual-trend [method]="method()" />
+  }
 
-    <!-- No [method]: category investment has no estimation method in the warehouse, so this
-         surface is identical under both and refetching it on a switch would be wasted work. -->
+  <!-- Mounted outside the state chain above, which swaps the whole populated block for a skeleton
+       on every request — including a method-only one. Inside it, the category donut remounted on
+       each method switch and re-issued a read whose response cannot vary by method. Out here it
+       survives the switch, so its account-keyed request never re-emits. An org change still keys
+       it differently, and each donut raises its own loading state, so neither can show one
+       organization's figures under another's header. -->
+  @if (showsFigures()) {
+    <!-- No [method]: category investment has no estimation method in the warehouse. -->
     <lfx-org-roi-category-donut />
 
     <lfx-org-roi-projects-donut [method]="method()" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -57,6 +57,23 @@
       icon="fa-light fa-triangle-exclamation"
       title="ROI metrics aren't available for this company right now. Please try again."
       data-testid="org-roi-no-analytics-id-state" />
+  } @else if (portfolioForbidden()) {
+    <!-- Both failure branches sit ahead of the loading one. A failed request clears the summary,
+         which leaves it not matching the selected organization, so a loading condition tested
+         first would swallow every error into a permanent skeleton. Each new request resets these
+         flags, so ordering them first cannot strand a stale error over a fresh load. -->
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-roi-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (portfolioFailed()) {
+    <!-- Separate from the forbidden branch: a 503 must not read as a permissions message. -->
+    <div class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600" data-testid="org-roi-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>ROI metrics couldn't be loaded. Please try again.</span>
+    </div>
   } @else if (portfolioLoading() || !summaryMatchesSelectedOrg()) {
     <!-- The org-identity check belongs in the loading condition, not only on the figures below:
          the summary keeps its previous value until the next response lands, and `portfolioLoading`
@@ -74,19 +91,6 @@
         }
       </div>
     </section>
-  } @else if (portfolioForbidden()) {
-    <div
-      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
-      data-testid="org-roi-forbidden">
-      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
-      <span>You do not have Org Lens access for this organization.</span>
-    </div>
-  } @else if (portfolioFailed()) {
-    <!-- Separate from the forbidden branch: a 503 must not read as a permissions message. -->
-    <div class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600" data-testid="org-roi-error">
-      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
-      <span>ROI metrics couldn't be loaded. Please try again.</span>
-    </div>
   } @else if (!hasRoiData()) {
     <lfx-org-roi-empty-state [reason]="coverage().coverageReason" />
   } @else {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -57,7 +57,12 @@
       icon="fa-light fa-triangle-exclamation"
       title="ROI metrics aren't available for this company right now. Please try again."
       data-testid="org-roi-no-analytics-id-state" />
-  } @else if (portfolioLoading()) {
+  } @else if (portfolioLoading() || !summaryMatchesSelectedOrg()) {
+    <!-- The org-identity check belongs in the loading condition, not only on the figures below:
+         the summary keeps its previous value until the next response lands, and `portfolioLoading`
+         is raised only on the following effect flush. Without it this branch loses to the populated
+         one for that window, putting the previous organization's headline amounts under the newly
+         selected one. -->
     <section class="flex flex-col gap-4" data-testid="org-roi-portfolio-loading">
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
         @for (i of [1, 2, 3, 4]; track i) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -88,6 +88,12 @@
     <lfx-org-roi-kpi-cards [summary]="summary()" />
 
     <lfx-org-roi-annual-trend [method]="method()" />
+
+    <!-- No [method]: category investment has no estimation method in the warehouse, so this
+         surface is identical under both and refetching it on a switch would be wasted work. -->
+    <lfx-org-roi-category-donut />
+
+    <lfx-org-roi-projects-donut [method]="method()" />
   }
 
   <!-- Mounted outside the branches above, on the same condition as its trigger. Inside the

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -117,7 +117,7 @@ export class OrgRoiComponent {
    * it flips in the same change-detection pass as the switch — unlike the donuts' internal loading
    * flags, which are driven by `toObservable` and therefore only settle on the next effect flush.
    */
-  private readonly summaryMatchesSelectedOrg: Signal<boolean> = computed(() => {
+  protected readonly summaryMatchesSelectedOrg: Signal<boolean> = computed(() => {
     const selected = this.accountContext.selectedAccount()?.accountId ?? '';
     return selected !== '' && this.summary().orgUid === selected;
   });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -18,8 +18,10 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 
 import { OrgRoiAnnualTrendComponent } from './components/org-roi-annual-trend/org-roi-annual-trend.component';
 import { OrgRoiAssumptionsDrawerComponent } from './components/org-roi-assumptions-drawer/org-roi-assumptions-drawer.component';
+import { OrgRoiCategoryDonutComponent } from './components/org-roi-category-donut/org-roi-category-donut.component';
 import { OrgRoiEmptyStateComponent } from './components/org-roi-empty-state/org-roi-empty-state.component';
 import { OrgRoiKpiCardsComponent } from './components/org-roi-kpi-cards/org-roi-kpi-cards.component';
+import { OrgRoiProjectsDonutComponent } from './components/org-roi-projects-donut/org-roi-projects-donut.component';
 
 const EMPTY_SUMMARY: OrgLensRoiSummary = {
   orgUid: '',
@@ -45,6 +47,8 @@ const EMPTY_COVERAGE: OrgLensRoiCoverage = { orgUid: '', hasData: false, coverag
   imports: [
     OrgRoiKpiCardsComponent,
     OrgRoiAnnualTrendComponent,
+    OrgRoiCategoryDonutComponent,
+    OrgRoiProjectsDonutComponent,
     OrgRoiAssumptionsDrawerComponent,
     OrgRoiEmptyStateComponent,
     EmptyStateComponent,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -108,6 +108,31 @@ export class OrgRoiComponent {
       !this.portfolioFailed()
   );
 
+  /**
+   * True whenever this organization has figures to show — deliberately **without**
+   * `portfolioLoading`, unlike the state-branch chain in the template.
+   *
+   * The chain swaps the whole populated block for a skeleton on every request, including a
+   * method-only one. That tore down and remounted the category donut on each method switch,
+   * re-issuing a read whose response cannot vary by method — the opposite of what its own comment
+   * claimed. Mounting the donuts on this condition instead keeps them alive across a method
+   * change, so the category donut's account-keyed request simply never re-emits.
+   *
+   * It is safe against the obvious hazard — showing one organization's figures under another's
+   * header — because each donut keys its own fetch on the account id and flips its own loading
+   * state the moment that changes, so an org switch renders its skeleton rather than stale money.
+   */
+  protected readonly showsFigures: Signal<boolean> = computed(
+    () =>
+      this.loaded() &&
+      !this.hasNoOrgAccess() &&
+      this.hasCompany() &&
+      this.hasAnalyticsId() &&
+      !this.portfolioForbidden() &&
+      !this.portfolioFailed() &&
+      this.hasRoiData()
+  );
+
   protected readonly windowLabel: Signal<string> = computed(() => {
     const { yearMin, yearMax } = this.summary();
     if (yearMin === null || yearMax === null) return '';

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -109,6 +109,20 @@ export class OrgRoiComponent {
   );
 
   /**
+   * Whether the summary in hand actually describes the organization now selected.
+   *
+   * `summary()` holds its previous value while a new request is in flight, so during an org switch
+   * every measure derived from it belongs to the organization the viewer just navigated away from.
+   * Comparing the payload's own `orgUid` to the selected account is a synchronous signal read, so
+   * it flips in the same change-detection pass as the switch — unlike the donuts' internal loading
+   * flags, which are driven by `toObservable` and therefore only settle on the next effect flush.
+   */
+  private readonly summaryMatchesSelectedOrg: Signal<boolean> = computed(() => {
+    const selected = this.accountContext.selectedAccount()?.accountId ?? '';
+    return selected !== '' && this.summary().orgUid === selected;
+  });
+
+  /**
    * True whenever this organization has figures to show — deliberately **without**
    * `portfolioLoading`, unlike the state-branch chain in the template.
    *
@@ -118,9 +132,10 @@ export class OrgRoiComponent {
    * claimed. Mounting the donuts on this condition instead keeps them alive across a method
    * change, so the category donut's account-keyed request simply never re-emits.
    *
-   * It is safe against the obvious hazard — showing one organization's figures under another's
-   * header — because each donut keys its own fetch on the account id and flips its own loading
-   * state the moment that changes, so an org switch renders its skeleton rather than stale money.
+   * An org switch is the case that must NOT survive, and the identity check is what separates the
+   * two: the account id changes while the summary still describes the previous organization, so
+   * this goes false immediately and the donuts unmount rather than rendering one company's
+   * investment under another's page.
    */
   protected readonly showsFigures: Signal<boolean> = computed(
     () =>
@@ -130,10 +145,17 @@ export class OrgRoiComponent {
       this.hasAnalyticsId() &&
       !this.portfolioForbidden() &&
       !this.portfolioFailed() &&
+      this.summaryMatchesSelectedOrg() &&
       this.hasRoiData()
   );
 
+  /**
+   * Blank until the summary describes the selected organization. The header sits outside the
+   * state-branch chain, so without this it would keep showing the previous organization's date
+   * window for the whole of the next request — seconds, on a warehouse read.
+   */
   protected readonly windowLabel: Signal<string> = computed(() => {
+    if (!this.summaryMatchesSelectedOrg()) return '';
     const { yearMin, yearMax } = this.summary();
     if (yearMin === null || yearMax === null) return '';
     return yearMin === yearMax ? `${yearMin}` : `${yearMin}–${yearMax}`;

--- a/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
@@ -3,7 +3,14 @@
 
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import type { OrgLensRoiAnnual, OrgLensRoiCoverage, OrgLensRoiMethod, OrgLensRoiSummary } from '@lfx-one/shared/interfaces';
+import type {
+  OrgLensRoiAnnual,
+  OrgLensRoiCoverage,
+  OrgLensRoiInvestmentBreakdown,
+  OrgLensRoiMethod,
+  OrgLensRoiProjects,
+  OrgLensRoiSummary,
+} from '@lfx-one/shared/interfaces';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -26,6 +33,21 @@ export class OrgLensRoiService {
 
   public getAnnual(orgUid: string, method: OrgLensRoiMethod): Observable<OrgLensRoiAnnual> {
     return this.http.get<OrgLensRoiAnnual>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/annual`, {
+      params: new HttpParams().set('method', method),
+    });
+  }
+
+  /**
+   * No `method` parameter, unlike every other read here: category investment has no
+   * `MARKUP_METHOD` in the warehouse, so the response is identical whichever method is selected and
+   * sending one would only invite a pointless refetch when the viewer switches.
+   */
+  public getInvestmentBreakdown(orgUid: string): Observable<OrgLensRoiInvestmentBreakdown> {
+    return this.http.get<OrgLensRoiInvestmentBreakdown>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/investment-breakdown`);
+  }
+
+  public getProjects(orgUid: string, method: OrgLensRoiMethod): Observable<OrgLensRoiProjects> {
+    return this.http.get<OrgLensRoiProjects>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/projects`, {
       params: new HttpParams().set('method', method),
     });
   }

--- a/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
@@ -5,15 +5,19 @@ import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { assertOrgUid, assertOrgLensRead, parseOrgLensRoiMethod, getSummary, getCoverage, getAnnual, logger } = vi.hoisted(() => ({
-  assertOrgUid: vi.fn(),
-  assertOrgLensRead: vi.fn(),
-  parseOrgLensRoiMethod: vi.fn(),
-  getSummary: vi.fn(),
-  getCoverage: vi.fn(),
-  getAnnual: vi.fn(),
-  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
-}));
+const { assertOrgUid, assertOrgLensRead, parseOrgLensRoiMethod, getSummary, getCoverage, getAnnual, getInvestmentBreakdown, getProjects, logger } = vi.hoisted(
+  () => ({
+    assertOrgUid: vi.fn(),
+    assertOrgLensRead: vi.fn(),
+    parseOrgLensRoiMethod: vi.fn(),
+    getSummary: vi.fn(),
+    getCoverage: vi.fn(),
+    getAnnual: vi.fn(),
+    getInvestmentBreakdown: vi.fn(),
+    getProjects: vi.fn(),
+    logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
+  })
+);
 
 vi.mock('../helpers/org-uid.helper', () => ({ assertOrgUid }));
 vi.mock('../helpers/org-lens-read-access.helper', () => ({ assertOrgLensRead }));
@@ -23,6 +27,8 @@ vi.mock('../services/org-lens-roi.service', () => ({
     public getSummary = getSummary;
     public getCoverage = getCoverage;
     public getAnnual = getAnnual;
+    public getInvestmentBreakdown = getInvestmentBreakdown;
+    public getProjects = getProjects;
   },
 }));
 vi.mock('../services/logger.service', () => ({ logger }));
@@ -66,13 +72,33 @@ describe('OrgLensRoiController — authorization gate', () => {
     getSummary.mockResolvedValue({ hasData: false });
     getCoverage.mockResolvedValue({ coverageReason: 'unmapped' });
     getAnnual.mockResolvedValue({ rows: [] });
+    getInvestmentBreakdown.mockResolvedValue({ rows: [], total: 0 });
+    getProjects.mockResolvedValue({ method: 'logit', rows: [] });
   });
 
+  // Every handler on the controller belongs here. A new endpoint added without a row is silently
+  // exempt from the ordering and refusal coverage below, which is the failure this list exists to
+  // prevent — not merely a gap in the count.
   const handlers = [
     { name: 'getSummary', operation: 'get_org_lens_roi_summary', service: getSummary },
     { name: 'getCoverage', operation: 'get_org_lens_roi_coverage', service: getCoverage },
     { name: 'getAnnual', operation: 'get_org_lens_roi_annual', service: getAnnual },
+    { name: 'getInvestmentBreakdown', operation: 'get_org_lens_roi_investment_breakdown', service: getInvestmentBreakdown },
+    { name: 'getProjects', operation: 'get_org_lens_roi_projects', service: getProjects },
   ] as const;
+
+  it('covers every request handler the controller exposes', () => {
+    // Without this, adding a sixth endpoint and forgetting the list above would leave it with no
+    // authorization coverage at all — and the suite would still report every test passing.
+    const prototype = Object.getPrototypeOf(controller) as Record<string, unknown>;
+    const requestHandlers = Object.getOwnPropertyNames(prototype).filter((key) => {
+      const value = prototype[key];
+      // Express handlers take (req, res, next); `send` and the constructor do not.
+      return key !== 'constructor' && typeof value === 'function' && value.length === 3;
+    });
+
+    expect(requestHandlers.sort()).toEqual(handlers.map((handler) => handler.name).sort());
+  });
 
   describe.each(handlers)('$name', ({ name, operation, service }) => {
     it('validates the org uid and the method, then checks access — all before the service runs', async () => {

--- a/apps/lfx-one/src/server/controllers/org-lens-roi.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-roi.controller.ts
@@ -69,6 +69,43 @@ export class OrgLensRoiController {
     }
   }
 
+  public async getInvestmentBreakdown(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_roi_investment_breakdown';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      // Validated but not passed on: the breakdown genuinely cannot vary by method (its source table
+      // has no MARKUP_METHOD column). Rejecting an unknown value anyway keeps the 400 uniform across
+      // every ROI route rather than depending on which handler happens to use the parameter.
+      parseOrgLensRoiMethod(req.query['method'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const breakdown = await this.service.getInvestmentBreakdown(req, orgUid);
+      logger.success(req, operation, startTime, { org_uid: orgUid, rows: breakdown.rows.length });
+      this.send(res, breakdown);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getProjects(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_roi_projects';
+    const orgUid = req.params['orgUid'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid });
+    try {
+      assertOrgUid(orgUid, operation);
+      const method = parseOrgLensRoiMethod(req.query['method'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const projects = await this.service.getProjects(req, orgUid, method);
+      logger.success(req, operation, startTime, { org_uid: orgUid, method, rows: projects.rows.length });
+      this.send(res, projects);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
   private send(res: Response, body: unknown): void {
     res.setHeader('Cache-Control', 'no-store');
     res.json(body);

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -133,8 +133,9 @@ function buildOrgsRouter(): Router {
   router.get('/:orgUid/lens/meetings/influence', (req, res, next) => orgLensMeetingsController.getInfluence(req, res, next));
 
   // LFXV2-2980 — Org Lens ROI Metrics.
-  // Every literal /roi/* route below MUST stay registered before the /roi/projects/:projectSlug
-  // matcher, so 'investment-breakdown' isn't consumed as a project slug.
+  // Keep every literal /roi/* segment below ahead of any parameterized matcher added at the same
+  // depth, or the literal gets captured as the parameter — the trap the /lens/projects/search
+  // comment further down records.
   router.get('/:orgUid/lens/roi/summary', (req, res, next) => orgLensRoiController.getSummary(req, res, next));
   router.get('/:orgUid/lens/roi/coverage', (req, res, next) => orgLensRoiController.getCoverage(req, res, next));
   router.get('/:orgUid/lens/roi/annual', (req, res, next) => orgLensRoiController.getAnnual(req, res, next));

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -133,10 +133,13 @@ function buildOrgsRouter(): Router {
   router.get('/:orgUid/lens/meetings/influence', (req, res, next) => orgLensMeetingsController.getInfluence(req, res, next));
 
   // LFXV2-2980 — Org Lens ROI Metrics.
-  // Register literal segments before any `/roi/.../:projectSlug` matcher, or they get consumed as a slug.
+  // Every literal /roi/* route below MUST stay registered before the /roi/projects/:projectSlug
+  // matcher, so 'investment-breakdown' isn't consumed as a project slug.
   router.get('/:orgUid/lens/roi/summary', (req, res, next) => orgLensRoiController.getSummary(req, res, next));
   router.get('/:orgUid/lens/roi/coverage', (req, res, next) => orgLensRoiController.getCoverage(req, res, next));
   router.get('/:orgUid/lens/roi/annual', (req, res, next) => orgLensRoiController.getAnnual(req, res, next));
+  router.get('/:orgUid/lens/roi/investment-breakdown', (req, res, next) => orgLensRoiController.getInvestmentBreakdown(req, res, next));
+  router.get('/:orgUid/lens/roi/projects', (req, res, next) => orgLensRoiController.getProjects(req, res, next));
 
   // LFXV2-1894 — Org Lens Code Contributions page (KPI strip + repositories table + commits feed).
   router.get('/:orgUid/lens/contributions', (req, res, next) => orgLensContributionsController.getContributions(req, res, next));

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -1,13 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import {
-  ORG_LENS_ROI_CACHE_KEY,
-  ORG_LENS_ROI_CONTRIBUTION_TYPES,
-  ORG_LENS_ROI_COVERAGE_REASONS,
-  ORG_LENS_ROI_METHODS,
-  VALKEY_CACHE,
-} from '@lfx-one/shared/constants';
+import { ORG_LENS_ROI_CACHE_KEY, ORG_LENS_ROI_COVERAGE_REASONS, ORG_LENS_ROI_METHODS, VALKEY_CACHE } from '@lfx-one/shared/constants';
 import type {
   OrgLensRoiAnnual,
   OrgLensRoiAnnualRow,
@@ -34,6 +28,13 @@ import { SnowflakeService } from './snowflake.service';
 import { withOrgCache } from './valkey.service';
 
 export class OrgLensRoiService {
+  /**
+   * Floating-point slack when re-checking that category rows still sum to their stated total. The
+   * warehouse residual measured across all covered accounts is ~6e-08 on a $145M base, so a cent is
+   * several orders of magnitude of headroom while still catching a genuinely wrong total.
+   */
+  private static readonly reconciliationEpsilonUsd = 0.01;
+
   private readonly snowflakeService = SnowflakeService.getInstance();
 
   public async getSummary(req: Request, accountId: string, method: OrgLensRoiMethod): Promise<OrgLensRoiSummary> {
@@ -198,6 +199,10 @@ export class OrgLensRoiService {
         LEFT JOIN ${this.projectsBreakdownTable()} b
           ON b.ACCOUNT_ID = p.ACCOUNT_ID AND b.PROJECT_ID = p.PROJECT_ID
         WHERE p.ACCOUNT_ID = ? AND p.MARKUP_METHOD = ?
+        -- PROJECT_ID keeps a project's category rows contiguous and makes ties deterministic;
+        -- DISPLAY_ORDER fixes category order within a project. TOTAL_RETURN DESC is the payload's
+        -- default ranking: the donut re-sorts by the selected measure, but US5's table (FR-033a)
+        -- pages the set in this order and needs it stable across requests.
         ORDER BY p.TOTAL_RETURN DESC, p.PROJECT_ID, b.DISPLAY_ORDER
       `;
         const result = await this.snowflakeService.execute<OrgLensRoiProjectWarehouseRow>(sql, [accountId, method]);
@@ -216,7 +221,9 @@ export class OrgLensRoiService {
         project = {
           projectId: row.PROJECT_ID,
           projectSlug: this.toNullableLabel(row.PROJECT_SLUG) ?? '',
-          projectName: this.toNullableLabel(row.PROJECT_NAME) ?? '',
+          // Falls back rather than emptying: the name is what every surface labels a project with,
+          // and a blank legend entry is worse than an unlovely slug.
+          projectName: this.toNullableLabel(row.PROJECT_NAME) ?? this.toNullableLabel(row.PROJECT_SLUG) ?? row.PROJECT_ID,
           totalExpenditure: this.toFiniteNumber(row.TOTAL_EXPENDITURE),
           totalReturn: this.toFiniteNumber(row.TOTAL_RETURN),
           profit: this.toFiniteNumber(row.PROFIT),
@@ -354,13 +361,25 @@ export class OrgLensRoiService {
     return typeof value === 'number' && Number.isFinite(value);
   }
 
-  /** Per-row, not just per-envelope: the donut maps over these, so one malformed entry is enough to break a render. */
+  /**
+   * Per-row, not just per-envelope: the donut maps over these, so one malformed entry is enough to
+   * break a render.
+   *
+   * `type` is checked for shape, deliberately **not** against
+   * `ORG_LENS_ROI_CONTRIBUTION_TYPES`. The vocabulary is already enforced upstream by an
+   * `accepted_values` dbt test, and enforcing it again here would only create a write/read
+   * asymmetry: the mapper writes whatever the warehouse returns, so a seed that gained a ninth
+   * contribution type before this constant did would write entries this guard then rejected on
+   * every read — permanently defeating the cache for that organization and re-running the
+   * ~1,200-row join on every request. Dropping the unknown row instead would be worse still: the
+   * category total would silently stop reconciling with the KPI figure (FR-026).
+   */
   private static isCategoryRows(value: unknown): boolean {
     if (!Array.isArray(value)) return false;
     return value.every((row) => {
       if (row === null || typeof row !== 'object' || Array.isArray(row)) return false;
       const entry = row as Record<string, unknown>;
-      if (!(ORG_LENS_ROI_CONTRIBUTION_TYPES as readonly string[]).includes(entry['type'] as string)) return false;
+      if (typeof entry['type'] !== 'string' || entry['type'].length === 0) return false;
       if (typeof entry['label'] !== 'string') return false;
       return OrgLensRoiService.isFiniteNumber(entry['expenditure']);
     });
@@ -370,7 +389,15 @@ export class OrgLensRoiService {
     if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
     const breakdown = value as Record<string, unknown>;
     if (!OrgLensRoiService.isFiniteNumber(breakdown['total'])) return false;
-    return OrgLensRoiService.isCategoryRows(breakdown['rows']);
+    if (!OrgLensRoiService.isCategoryRows(breakdown['rows'])) return false;
+
+    // The write path sums `total` from these same rows, so the two agree by construction. The read
+    // path had no such guarantee: any finite `total` was accepted alongside any rows, letting a
+    // corrupt or stale entry render a headline investment figure that contradicts the slices under
+    // it — the misleading-money outcome the reconciliation invariant exists to prevent.
+    const rows = breakdown['rows'] as { expenditure: number }[];
+    const summed = rows.reduce((sum, row) => sum + row.expenditure, 0);
+    return Math.abs(summed - (breakdown['total'] as number)) <= OrgLensRoiService.reconciliationEpsilonUsd;
   }
 
   private static isProjects(value: unknown): boolean {

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -136,7 +136,7 @@ export class OrgLensRoiService {
    *
    * `total` is summed from the same rows the client renders, so the figure under the donut and the
    * slices in it can never disagree. It reconciles with `/summary.totalExpenditure` in the
-   * warehouse (FR-026), asserted by a dbt singular test — never reconciled here.
+   * warehouse, asserted by a dbt singular test — never reconciled here.
    */
   public async getInvestmentBreakdown(req: Request, accountId: string): Promise<OrgLensRoiInvestmentBreakdown> {
     return withOrgCache(
@@ -163,9 +163,9 @@ export class OrgLensRoiService {
   }
 
   /**
-   * The complete, uncapped project set with each project's category breakdown in one payload
-   * (DR-005, FR-033). Measured against production, the largest organization serializes to ~241 KB
-   * against the 1 MiB `VALKEY_CACHE.MAX_VALUE_BYTES` ceiling, so every organization caches.
+   * The complete, uncapped project set with each project's category breakdown in one payload.
+   * Measured against production, the largest organization serializes to ~241 KB against the 1 MiB
+   * `VALKEY_CACHE.MAX_VALUE_BYTES` ceiling, so every organization caches.
    *
    * One round-trip, not two: the projects and their breakdown are a single consistent fact, and
    * fetching them separately would let the pair drift between calls — the same reasoning that made
@@ -180,7 +180,10 @@ export class OrgLensRoiService {
       async () => {
         logger.debug(req, 'get_org_lens_roi_projects', 'Cache miss; querying Snowflake', { account_id: accountId, method });
         // The breakdown table carries no MARKUP_METHOD — category spend is method-invariant, so it
-        // joins on the project alone. PROFIT_SIGN_CHECK is deliberately not selected (DR-003, FR-041).
+        // joins on the project alone. PROFIT_SIGN_CHECK is deliberately left out: it is an internal
+        // model-consistency flag, not a figure any surface renders, and a loss-making project is a
+        // legitimate result already conveyed by its net return — filtering on it would hide real
+        // outcomes from the viewer.
         const sql = `
         SELECT
           p.PROJECT_ID,
@@ -201,8 +204,8 @@ export class OrgLensRoiService {
         WHERE p.ACCOUNT_ID = ? AND p.MARKUP_METHOD = ?
         -- PROJECT_ID keeps a project's category rows contiguous and makes ties deterministic;
         -- DISPLAY_ORDER fixes category order within a project. TOTAL_RETURN DESC is the payload's
-        -- default ranking: the donut re-sorts by the selected measure, but US5's table (FR-033a)
-        -- pages the set in this order and needs it stable across requests.
+        -- default ranking: the donut re-sorts by the selected measure, but the forthcoming projects
+        -- table will page the set in this order and needs it stable across requests.
         ORDER BY p.TOTAL_RETURN DESC, p.PROJECT_ID, b.DISPLAY_ORDER
       `;
         const result = await this.snowflakeService.execute<OrgLensRoiProjectWarehouseRow>(sql, [accountId, method]);
@@ -372,7 +375,7 @@ export class OrgLensRoiService {
    * contribution type before this constant did would write entries this guard then rejected on
    * every read — permanently defeating the cache for that organization and re-running the
    * ~1,200-row join on every request. Dropping the unknown row instead would be worse still: the
-   * category total would silently stop reconciling with the KPI figure (FR-026).
+   * category total would silently stop reconciling with the KPI figure.
    */
   private static isCategoryRows(value: unknown): boolean {
     if (!Array.isArray(value)) return false;
@@ -411,7 +414,19 @@ export class OrgLensRoiService {
       if (!['projectId', 'projectSlug', 'projectName'].every((key) => typeof entry[key] === 'string')) return false;
       if (!['totalExpenditure', 'totalReturn', 'profit'].every((key) => OrgLensRoiService.isFiniteNumber(entry[key]))) return false;
       if (!['roi', 'bcr', 'breakevenMarkup'].every((key) => OrgLensRoiService.isNullableNumber(entry, key))) return false;
-      return OrgLensRoiService.isCategoryRows(entry['categories']);
+      if (!OrgLensRoiService.isCategoryRows(entry['categories'])) return false;
+
+      // Same reconciliation the breakdown guard applies, per project: a project's categories sum to
+      // its own expenditure by warehouse construction, so an entry where they don't is corrupt.
+      // Measured across all 32,890 production project rows: none is off by more than 1.9e-09.
+      //
+      // Enforced only when categories are present. The read is a LEFT JOIN, so a project the
+      // breakdown has no rows for legitimately arrives empty; failing on that would reject the
+      // whole payload on every read and leave the organization permanently uncacheable.
+      const categories = entry['categories'] as { expenditure: number }[];
+      if (categories.length === 0) return true;
+      const summed = categories.reduce((sum, category) => sum + category.expenditure, 0);
+      return Math.abs(summed - (entry['totalExpenditure'] as number)) <= OrgLensRoiService.reconciliationEpsilonUsd;
     });
   }
 

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -1,14 +1,27 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ORG_LENS_ROI_CACHE_KEY, ORG_LENS_ROI_COVERAGE_REASONS, ORG_LENS_ROI_METHODS, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import {
+  ORG_LENS_ROI_CACHE_KEY,
+  ORG_LENS_ROI_CONTRIBUTION_TYPES,
+  ORG_LENS_ROI_COVERAGE_REASONS,
+  ORG_LENS_ROI_METHODS,
+  VALKEY_CACHE,
+} from '@lfx-one/shared/constants';
 import type {
   OrgLensRoiAnnual,
   OrgLensRoiAnnualRow,
   OrgLensRoiAnnualWarehouseRow,
+  OrgLensRoiCategoryRow,
+  OrgLensRoiContributionType,
   OrgLensRoiCoverage,
   OrgLensRoiCoverageWarehouseRow,
+  OrgLensRoiInvestmentBreakdown,
+  OrgLensRoiInvestmentBreakdownWarehouseRow,
   OrgLensRoiMethod,
+  OrgLensRoiProjectRow,
+  OrgLensRoiProjects,
+  OrgLensRoiProjectWarehouseRow,
   OrgLensRoiSummary,
   OrgLensRoiSummaryWarehouseRow,
 } from '@lfx-one/shared/interfaces';
@@ -109,6 +122,125 @@ export class OrgLensRoiService {
       },
       OrgLensRoiService.isAnnual
     );
+  }
+
+  /**
+   * Investment by contribution category.
+   *
+   * The cache key carries **no method suffix**, and unlike `/coverage` that is a property of the
+   * source rather than an assumption about it: `ORG_LENS_ROI_INVESTMENT_BREAKDOWN` has no
+   * `MARKUP_METHOD` column at all, because the levels table it derives from has none. The markup
+   * method scales return, not spend. `/coverage` looked similar but was only method-invariant in
+   * practice, so it was made method-scoped anyway; this one cannot vary by construction.
+   *
+   * `total` is summed from the same rows the client renders, so the figure under the donut and the
+   * slices in it can never disagree. It reconciles with `/summary.totalExpenditure` in the
+   * warehouse (FR-026), asserted by a dbt singular test — never reconciled here.
+   */
+  public async getInvestmentBreakdown(req: Request, accountId: string): Promise<OrgLensRoiInvestmentBreakdown> {
+    return withOrgCache(
+      accountId,
+      ORG_LENS_ROI_CACHE_KEY.investmentBreakdown,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        logger.debug(req, 'get_org_lens_roi_investment_breakdown', 'Cache miss; querying Snowflake', { account_id: accountId });
+        const sql = `
+        SELECT
+          CONTRIBUTION_TYPE,
+          CONTRIBUTION_LABEL,
+          EXPENDITURE
+        FROM ${this.investmentBreakdownTable()}
+        WHERE ACCOUNT_ID = ?
+        ORDER BY DISPLAY_ORDER
+      `;
+        const result = await this.snowflakeService.execute<OrgLensRoiInvestmentBreakdownWarehouseRow>(sql, [accountId]);
+        const rows = result.rows.map((row) => this.mapCategoryRow(row.CONTRIBUTION_TYPE, row.CONTRIBUTION_LABEL, row.EXPENDITURE));
+        return { rows, total: rows.reduce((sum, row) => sum + row.expenditure, 0) };
+      },
+      OrgLensRoiService.isInvestmentBreakdown
+    );
+  }
+
+  /**
+   * The complete, uncapped project set with each project's category breakdown in one payload
+   * (DR-005, FR-033). Measured against production, the largest organization serializes to ~241 KB
+   * against the 1 MiB `VALKEY_CACHE.MAX_VALUE_BYTES` ceiling, so every organization caches.
+   *
+   * One round-trip, not two: the projects and their breakdown are a single consistent fact, and
+   * fetching them separately would let the pair drift between calls — the same reasoning that made
+   * `/coverage` one query. The join fans out to one row per project × category (~1,200 rows at the
+   * largest), regrouped below.
+   */
+  public async getProjects(req: Request, accountId: string, method: OrgLensRoiMethod): Promise<OrgLensRoiProjects> {
+    return withOrgCache(
+      accountId,
+      `${ORG_LENS_ROI_CACHE_KEY.projects}:${method}`,
+      VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS,
+      async () => {
+        logger.debug(req, 'get_org_lens_roi_projects', 'Cache miss; querying Snowflake', { account_id: accountId, method });
+        // The breakdown table carries no MARKUP_METHOD — category spend is method-invariant, so it
+        // joins on the project alone. PROFIT_SIGN_CHECK is deliberately not selected (DR-003, FR-041).
+        const sql = `
+        SELECT
+          p.PROJECT_ID,
+          p.PROJECT_SLUG,
+          p.PROJECT_NAME,
+          p.TOTAL_EXPENDITURE,
+          p.TOTAL_RETURN,
+          p.PROFIT,
+          p.ROI,
+          p.BCR,
+          p.BREAKEVEN_MARKUP,
+          b.CONTRIBUTION_TYPE,
+          b.CONTRIBUTION_LABEL,
+          b.EXPENDITURE AS CATEGORY_EXPENDITURE
+        FROM ${this.projectsTable()} p
+        LEFT JOIN ${this.projectsBreakdownTable()} b
+          ON b.ACCOUNT_ID = p.ACCOUNT_ID AND b.PROJECT_ID = p.PROJECT_ID
+        WHERE p.ACCOUNT_ID = ? AND p.MARKUP_METHOD = ?
+        ORDER BY p.TOTAL_RETURN DESC, p.PROJECT_ID, b.DISPLAY_ORDER
+      `;
+        const result = await this.snowflakeService.execute<OrgLensRoiProjectWarehouseRow>(sql, [accountId, method]);
+        return { method, rows: this.groupProjectRows(result.rows) };
+      },
+      OrgLensRoiService.isProjects
+    );
+  }
+
+  /** Collapses the fanned-out join back to one entry per project, preserving the SQL ordering. */
+  private groupProjectRows(rows: OrgLensRoiProjectWarehouseRow[]): OrgLensRoiProjectRow[] {
+    const byProject = new Map<string, OrgLensRoiProjectRow>();
+    for (const row of rows) {
+      let project = byProject.get(row.PROJECT_ID);
+      if (project === undefined) {
+        project = {
+          projectId: row.PROJECT_ID,
+          projectSlug: this.toNullableLabel(row.PROJECT_SLUG) ?? '',
+          projectName: this.toNullableLabel(row.PROJECT_NAME) ?? '',
+          totalExpenditure: this.toFiniteNumber(row.TOTAL_EXPENDITURE),
+          totalReturn: this.toFiniteNumber(row.TOTAL_RETURN),
+          profit: this.toFiniteNumber(row.PROFIT),
+          roi: this.toNullableNumber(row.ROI),
+          bcr: this.toNullableNumber(row.BCR),
+          breakevenMarkup: this.toNullableNumber(row.BREAKEVEN_MARKUP),
+          categories: [],
+        };
+        byProject.set(row.PROJECT_ID, project);
+      }
+      // Null for a project the breakdown has no rows for — the LEFT JOIN's unmatched side.
+      if (row.CONTRIBUTION_TYPE !== null && row.CONTRIBUTION_TYPE !== undefined) {
+        project.categories.push(this.mapCategoryRow(row.CONTRIBUTION_TYPE, row.CONTRIBUTION_LABEL, row.CATEGORY_EXPENDITURE));
+      }
+    }
+    return [...byProject.values()];
+  }
+
+  private mapCategoryRow(type: string, label: string | null, expenditure: unknown): OrgLensRoiCategoryRow {
+    return {
+      type: type as OrgLensRoiContributionType,
+      label: this.toNullableLabel(label) ?? type,
+      expenditure: this.toFiniteNumber(expenditure),
+    };
   }
 
   private mapSummary(accountId: string, method: OrgLensRoiMethod, row: OrgLensRoiSummaryWarehouseRow | null): OrgLensRoiSummary {
@@ -218,6 +350,44 @@ export class OrgLensRoiService {
     });
   }
 
+  private static isFiniteNumber(value: unknown): boolean {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  /** Per-row, not just per-envelope: the donut maps over these, so one malformed entry is enough to break a render. */
+  private static isCategoryRows(value: unknown): boolean {
+    if (!Array.isArray(value)) return false;
+    return value.every((row) => {
+      if (row === null || typeof row !== 'object' || Array.isArray(row)) return false;
+      const entry = row as Record<string, unknown>;
+      if (!(ORG_LENS_ROI_CONTRIBUTION_TYPES as readonly string[]).includes(entry['type'] as string)) return false;
+      if (typeof entry['label'] !== 'string') return false;
+      return OrgLensRoiService.isFiniteNumber(entry['expenditure']);
+    });
+  }
+
+  private static isInvestmentBreakdown(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const breakdown = value as Record<string, unknown>;
+    if (!OrgLensRoiService.isFiniteNumber(breakdown['total'])) return false;
+    return OrgLensRoiService.isCategoryRows(breakdown['rows']);
+  }
+
+  private static isProjects(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const projects = value as Record<string, unknown>;
+    if (!(ORG_LENS_ROI_METHODS as readonly string[]).includes(projects['method'] as string)) return false;
+    if (!Array.isArray(projects['rows'])) return false;
+    return projects['rows'].every((row) => {
+      if (row === null || typeof row !== 'object' || Array.isArray(row)) return false;
+      const entry = row as Record<string, unknown>;
+      if (!['projectId', 'projectSlug', 'projectName'].every((key) => typeof entry[key] === 'string')) return false;
+      if (!['totalExpenditure', 'totalReturn', 'profit'].every((key) => OrgLensRoiService.isFiniteNumber(entry[key]))) return false;
+      if (!['roi', 'bcr', 'breakevenMarkup'].every((key) => OrgLensRoiService.isNullableNumber(entry, key))) return false;
+      return OrgLensRoiService.isCategoryRows(entry['categories']);
+    });
+  }
+
   private toFiniteNumber(value: unknown): number {
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : 0;
@@ -249,6 +419,18 @@ export class OrgLensRoiService {
 
   private annualTable(): string {
     return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_ANNUAL`;
+  }
+
+  private investmentBreakdownTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_INVESTMENT_BREAKDOWN`;
+  }
+
+  private projectsTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_PROJECTS`;
+  }
+
+  private projectsBreakdownTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_PROJECTS_BREAKDOWN`;
   }
 
   private mappingTable(): string {

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -70,11 +70,12 @@ export const ORG_LENS_ROI_PROJECT_DONUT_MAX_SLICES = 10;
 
 export const ORG_LENS_ROI_PROJECT_MEASURES = ['investment', 'return', 'netReturn'] as const;
 
-export const ORG_LENS_ROI_PROJECT_MEASURE_LABELS = {
+/** Annotated like `ORG_LENS_ROI_METHOD_LABELS`, so adding a measure without a label fails here rather than at each index site. */
+export const ORG_LENS_ROI_PROJECT_MEASURE_LABELS: Record<(typeof ORG_LENS_ROI_PROJECT_MEASURES)[number], string> = {
   investment: 'Investment',
   return: 'Return',
   netReturn: 'Net Return',
-} as const;
+};
 
 /** Ends in gray so the remainder slice reads as "everything else" rather than as another category. */
 export const ORG_LENS_ROI_DONUT_PALETTE: readonly string[] = [

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -59,10 +59,10 @@ export const ORG_LENS_ROI_KPI_ICON_CLASS = {
 /** Rendered wherever a metric is undefined, so an absent value never reads as zero. */
 export const ORG_LENS_ROI_NO_VALUE = '—';
 
-/** Categories holding less than this share of total investment collapse into one labelled remainder (FR-025). */
+/** Categories holding less than this share of total investment collapse into one labelled remainder. */
 export const ORG_LENS_ROI_CATEGORY_REMAINDER_THRESHOLD = 0.02;
 
-/** Projects are drawn as slices until they cover this share of the measure; the rest collapse into one remainder (FR-027). */
+/** Projects are drawn as slices until they cover this share of the measure; the rest collapse into one remainder. */
 export const ORG_LENS_ROI_PROJECT_DONUT_COVERAGE = 0.8;
 
 /** A ceiling on slice count regardless of coverage — a flat distribution would otherwise draw hundreds of unreadable slivers. */

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { lfxColors } from './colors.constants';
+
 export const ORG_LENS_ROI_METHODS = ['logit', 'direct'] as const;
 
 export const ORG_LENS_ROI_DEFAULT_METHOD = 'logit';
@@ -23,6 +25,9 @@ export const ORG_LENS_ROI_CACHE_KEY = {
   summary: 'roi-summary:v1',
   coverage: 'roi-coverage:v1',
   annual: 'roi-annual:v1',
+  /** Unlike its siblings this key carries no method suffix — see the read in `org-lens-roi.service.ts`. */
+  investmentBreakdown: 'roi-investment-breakdown:v1',
+  projects: 'roi-projects:v1',
 } as const;
 
 /** Order must match the warehouse seed's display order. */
@@ -53,6 +58,39 @@ export const ORG_LENS_ROI_KPI_ICON_CLASS = {
 
 /** Rendered wherever a metric is undefined, so an absent value never reads as zero. */
 export const ORG_LENS_ROI_NO_VALUE = '—';
+
+/** Categories holding less than this share of total investment collapse into one labelled remainder (FR-025). */
+export const ORG_LENS_ROI_CATEGORY_REMAINDER_THRESHOLD = 0.02;
+
+/** Projects are drawn as slices until they cover this share of the measure; the rest collapse into one remainder (FR-027). */
+export const ORG_LENS_ROI_PROJECT_DONUT_COVERAGE = 0.8;
+
+/** A ceiling on slice count regardless of coverage — a flat distribution would otherwise draw hundreds of unreadable slivers. */
+export const ORG_LENS_ROI_PROJECT_DONUT_MAX_SLICES = 10;
+
+export const ORG_LENS_ROI_PROJECT_MEASURES = ['investment', 'return', 'netReturn'] as const;
+
+export const ORG_LENS_ROI_PROJECT_MEASURE_LABELS = {
+  investment: 'Investment',
+  return: 'Return',
+  netReturn: 'Net Return',
+} as const;
+
+/** Ends in gray so the remainder slice reads as "everything else" rather than as another category. */
+export const ORG_LENS_ROI_DONUT_PALETTE: readonly string[] = [
+  lfxColors.blue[600],
+  lfxColors.emerald[500],
+  lfxColors.violet[500],
+  lfxColors.amber[500],
+  lfxColors.blue[400],
+  lfxColors.emerald[400],
+  lfxColors.violet[400],
+  lfxColors.amber[400],
+  lfxColors.blue[300],
+  lfxColors.emerald[300],
+];
+
+export const ORG_LENS_ROI_DONUT_REMAINDER_COLOR = lfxColors.gray[400];
 
 export const ORG_LENS_ROI_KPI_EXPLANATION = {
   totalExpenditure:

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -89,3 +89,23 @@ export interface OrgLensRoiProjects {
   /** The complete, uncapped project set (DR-005). */
   rows: OrgLensRoiProjectRow[];
 }
+
+/** One rendered arc of the category donut. A view model — never serialized, never a wire contract. */
+export interface OrgLensRoiCategorySlice {
+  key: string;
+  label: string;
+  expenditure: number;
+  share: number;
+  color: string;
+}
+
+/** One rendered arc of the projects donut. A view model — never serialized, never a wire contract. */
+export interface OrgLensRoiProjectSlice {
+  key: string;
+  label: string;
+  /** The true signed measure, which is what the label reports. */
+  value: number;
+  /** What the arc is sized by. Never negative, because an arc cannot be. */
+  weight: number;
+  color: string;
+}

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -1,9 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { ORG_LENS_ROI_CONTRIBUTION_TYPES, ORG_LENS_ROI_COVERAGE_REASONS, ORG_LENS_ROI_METHODS } from '../constants/org-lens-roi.constants';
+import type {
+  ORG_LENS_ROI_CONTRIBUTION_TYPES,
+  ORG_LENS_ROI_COVERAGE_REASONS,
+  ORG_LENS_ROI_METHODS,
+  ORG_LENS_ROI_PROJECT_MEASURES,
+} from '../constants/org-lens-roi.constants';
 
 export type OrgLensRoiMethod = (typeof ORG_LENS_ROI_METHODS)[number];
+
+/** Which measure the projects donut ranks and sizes projects by. */
+export type OrgLensRoiProjectMeasure = (typeof ORG_LENS_ROI_PROJECT_MEASURES)[number];
 
 export type OrgLensRoiContributionType = (typeof ORG_LENS_ROI_CONTRIBUTION_TYPES)[number];
 
@@ -46,4 +54,38 @@ export interface OrgLensRoiAnnual {
   method: OrgLensRoiMethod;
   rows: OrgLensRoiAnnualRow[];
   apportioned: boolean;
+}
+
+/** One contribution category's modelled investment. Shared by the portfolio breakdown and each project's. */
+export interface OrgLensRoiCategoryRow {
+  type: OrgLensRoiContributionType;
+  label: string;
+  expenditure: number;
+}
+
+export interface OrgLensRoiInvestmentBreakdown {
+  rows: OrgLensRoiCategoryRow[];
+  /** Equals `/summary.totalExpenditure` exactly (FR-026). A difference is a defect, not a caveat to render. */
+  total: number;
+}
+
+export interface OrgLensRoiProjectRow {
+  projectId: string;
+  projectSlug: string;
+  projectName: string;
+  totalExpenditure: number;
+  totalReturn: number;
+  profit: number;
+  /** Null — never zero — when the project has no investment to divide by. */
+  roi: number | null;
+  bcr: number | null;
+  breakevenMarkup: number | null;
+  /** Sums to `totalExpenditure` by construction (FR-031); never rescale client-side. */
+  categories: OrgLensRoiCategoryRow[];
+}
+
+export interface OrgLensRoiProjects {
+  method: OrgLensRoiMethod;
+  /** The complete, uncapped project set (DR-005). */
+  rows: OrgLensRoiProjectRow[];
 }

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -65,7 +65,7 @@ export interface OrgLensRoiCategoryRow {
 
 export interface OrgLensRoiInvestmentBreakdown {
   rows: OrgLensRoiCategoryRow[];
-  /** Equals `/summary.totalExpenditure` exactly (FR-026). A difference is a defect, not a caveat to render. */
+  /** Equals `/summary.totalExpenditure` exactly. A difference is a defect, not a caveat to render. */
   total: number;
 }
 
@@ -80,13 +80,13 @@ export interface OrgLensRoiProjectRow {
   roi: number | null;
   bcr: number | null;
   breakevenMarkup: number | null;
-  /** Sums to `totalExpenditure` by construction (FR-031); never rescale client-side. */
+  /** Sums to `totalExpenditure` by construction; never rescale client-side. */
   categories: OrgLensRoiCategoryRow[];
 }
 
 export interface OrgLensRoiProjects {
   method: OrgLensRoiMethod;
-  /** The complete, uncapped project set (DR-005). */
+  /** The complete, uncapped project set. */
   rows: OrgLensRoiProjectRow[];
 }
 

--- a/packages/shared/src/interfaces/org-lens-roi.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.internal.interface.ts
@@ -29,3 +29,30 @@ export interface OrgLensRoiCoverageWarehouseRow {
   HAS_ROI: number;
   IS_MAPPED: number;
 }
+
+/** `ORG_LENS_ROI_INVESTMENT_BREAKDOWN` has no `MARKUP_METHOD` column — the levels source carries none. */
+export interface OrgLensRoiInvestmentBreakdownWarehouseRow {
+  CONTRIBUTION_TYPE: string;
+  CONTRIBUTION_LABEL: string;
+  EXPENDITURE: number;
+}
+
+/**
+ * One row per project × contribution category, from `ORG_LENS_ROI_PROJECTS` left-joined to
+ * `ORG_LENS_ROI_PROJECTS_BREAKDOWN`. The project columns repeat across a project's category rows;
+ * `CONTRIBUTION_TYPE` is null for a project with no breakdown rows.
+ */
+export interface OrgLensRoiProjectWarehouseRow {
+  PROJECT_ID: string;
+  PROJECT_SLUG: string;
+  PROJECT_NAME: string;
+  TOTAL_EXPENDITURE: number;
+  TOTAL_RETURN: number;
+  PROFIT: number;
+  ROI: number | null;
+  BCR: number | null;
+  BREAKEVEN_MARKUP: number | null;
+  CONTRIBUTION_TYPE: string | null;
+  CONTRIBUTION_LABEL: string | null;
+  CATEGORY_EXPENDITURE: number | null;
+}


### PR DESCRIPTION
## Summary

US3 and US4 of Org Lens ROI Metrics, extending the page shell [#1352](https://github.com/linuxfoundation/lfx-self-serve/pull/1352) landed. Jira: **LFXV2-2980**.

Two new BFF reads behind the same in-handler authorization gate as their siblings, and two new chart surfaces on `/org/roi`:

- `GET /:orgUid/lens/roi/investment-breakdown` → **investment by contribution category** donut, with an amount/share toggle and a labelled remainder for sub-threshold categories.
- `GET /:orgUid/lens/roi/projects` → **leading projects** donut over Investment / Return / Net Return, with a labelled remainder and explicit reporting of negative net return.

## Notable decisions

**`/investment-breakdown` is deliberately not method-scoped, and its cache key carries no method suffix.** Unlike `/coverage` — where "cannot vary by method" was an unasserted assumption about upstream grain, and review correctly made it method-scoped anyway — this one cannot vary by construction: `ORG_LENS_ROI_INVESTMENT_BREAKDOWN` has no `MARKUP_METHOD` column, because the markup scales return, not spend. Verified against production: Red Hat's total is identical to the last significant digit under both methods. Both routes still validate `method`, so an unknown value is a uniform 400.

**`/projects` serves the complete uncapped set** (DR-005) with each project's category breakdown in one payload and one round trip. Measured against production rather than assumed: the largest of all 2,380 covered accounts serializes to **241 KB** against the 1 MiB `VALKEY_CACHE.MAX_VALUE_BYTES` ceiling — about 4.3× headroom, so every organization caches and none silently bypasses.

**Reconciliation is never forced client-side.** The category total equals the KPI investment figure by construction in the warehouse, asserted by a dbt singular test. Confirmed live at −5.96e-08 on a $145M base. Nothing rescales to make the numbers agree (FR-011b).

**Negative net return is treated as the mainline path it is** — 6.45% of production project rows across 775 accounts. An arc cannot be negative, so the geometry is clamped, but the true signed value survives into the label. The measure is partitioned once at zero: the chart and its remainder cover only non-negative values, and loss-making projects are reported solely by a named disclosure list. This was a review finding — the first implementation folded them into the remainder *and* listed them separately, double-reporting them and leaving the remainder's arc disagreeing with its own legend figure.

**Both surfaces carry the FR-039a modelled-cost disclosure** by rendering the shared `ORG_LENS_ROI_KPI_EXPLANATION` constant verbatim rather than paraphrasing it, so they cannot drift from the KPI band. This is the disclosure the aggregate-only privacy posture rests on (DR-015): 19.4% of covered organizations have a single code contributor, so "Code Contribution: $98.9M" can read as one person's pay without it.

## Verified live against production data

Run locally against dev with Playwright, as Red Hat, Inc. (`0014100000Te2QjAAJ`):

- $144.9M investment across 408 projects, $5.3B return, 3532.0% ROI, 36.3× BCR — BCR is exactly ROI + 1, live.
- KPI band and category donut both render **$144.9M**, asserted string-equal in the DOM.
- Three sub-2% categories collapse into `Other (3 categories)`, and the chart's accessible label correctly reports 8 categories behind 6 legend rows.
- Net Return shows **24 Red Hat projects with a negative net return totalling −$390.3K**, each named with its signed figure, and a remainder of `Other (374 projects)` — 408 total − 24 negative − 10 slices.
- No console error from any `/api/orgs/*/lens/roi/*` endpoint.

## Review

Four audit lanes ran pre-PR (secrets/critical-constants, repo conventions, privacy+ADR, Bugbot). No blocking authorization, secrets, SQL-injection or ADR finding; Bugbot found nothing. One blocking correctness defect (the double-counted negatives above) and seven smaller findings were fixed in `fix(org-roi): address review findings`.

The per-project grain question was put to the privacy lane explicitly — US3/US4 serve a finer cell than DR-015 measured — and answered no: DR-015 already withdrew its size-dependent argument, and each replacement leg is grain-independent. Recorded as a scope note on DR-015 in the umbrella repo, not a new decision record.

## Test plan

- [x] `yarn format:check`, `yarn lint:check` (0 errors), `yarn check-types`, `yarn build`, `./check-headers.sh`
- [x] `yarn test` — 1,387 unit tests pass
- [x] `org-lens-roi.controller.spec.ts` extended to all five handlers (31 cases), plus a guard that fails if a future handler is omitted from the parity list. Mutation-tested both ways.
- [x] Manual verification against production Red Hat data (above)
- [ ] ⚠️ **`yarn e2e` has still never executed.** The two ROI spec files (35 cases) compile and enumerate via `playwright test --list`, but the suite cannot run locally (auth-gated SSR) and the CI job that would run it is commented out in `quality-check.yml`. Every expectation is derived from its fixture through the real formatter rather than hand-written — the `--list` gate caught a barrel import that broke both files. **Treat the e2e assertions as unverified.**

## Follow-ups (not in this PR)

- Getting `yarn e2e` into CI remains the highest-value follow-up on this feature.
- `/projects` ships per-project `categories` that no component here renders yet — contract-sanctioned so US5's bar and sankey views need only one round trip.
- On first load after an org switch, the grant lookup can return 503 `ROLE_GRANTS_UNAVAILABLE` under five concurrent gated reads. Pre-existing (`/annual` is US2 code) and it fails closed correctly, but the concurrency is worth a look.

Made with [Cursor](https://cursor.com)