### PR TITLE
feat(org-roi): add projects section with four views (LFXV2-2980)

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,6 +37,11 @@ on:
         required: false
         default: false
         type: boolean
+      blocking:
+        description: 'Fail the job when tests fail. Set false to report results without gating the merge.'
+        required: false
+        default: true
+        type: boolean
     secrets:
       TEST_USERNAME:
         description: 'Username for test authentication'
@@ -248,7 +253,9 @@ jobs:
         id: run-tests-all
         if: ${{ inputs.browser == 'all' && steps.validate-secrets.outputs.can_run_tests == 'true' }}
         working-directory: apps/lfx-one
-        continue-on-error: true
+        # Honours `blocking` like the single-browser step below. Previously hardcoded `true`, which
+        # would have made `blocking: true` silently mean the opposite for an all-browser caller.
+        continue-on-error: ${{ !inputs.blocking }}
         run: |
           if [ -n "$TEST_USERNAME" ] && [ -n "$TEST_PASSWORD" ]; then
             echo "🔐 Running authenticated E2E tests on all browsers"
@@ -266,6 +273,9 @@ jobs:
       - name: Run E2E tests (Specific browser)
         if: ${{ inputs.browser != 'all' && steps.validate-secrets.outputs.can_run_tests == 'true' }}
         working-directory: apps/lfx-one
+        # A failure here still surfaces in the summary step and the PR comment, which read
+        # Playwright's own .last-run.json rather than this step's outcome.
+        continue-on-error: ${{ !inputs.blocking }}
         run: |
           if [ -n "$TEST_USERNAME" ] && [ -n "$TEST_PASSWORD" ]; then
             echo "🔐 Running authenticated E2E tests on ${{ inputs.browser }}"
@@ -305,10 +315,20 @@ jobs:
             echo "⏭️ E2E tests skipped (no test credentials)"
             echo "results=skipped" >> $GITHUB_OUTPUT
           elif [ -f "test-results/.last-run.json" ]; then
-            echo "✅ E2E tests completed successfully"
-            echo "results=success" >> $GITHUB_OUTPUT
+            # Playwright records the run's own verdict here. The file's mere existence means the
+            # run happened, not that it passed — reporting on presence alone made a failing suite
+            # read as green, which matters most when the job is non-blocking and this summary is
+            # the only signal.
+            status=$(node -p "require('./test-results/.last-run.json').status" 2>/dev/null || echo unknown)
+            if [ "$status" == "passed" ]; then
+              echo "✅ E2E tests completed successfully"
+              echo "results=success" >> $GITHUB_OUTPUT
+            else
+              echo "❌ E2E tests failed (status: $status)"
+              echo "results=failure" >> $GITHUB_OUTPUT
+            fi
           else
-            echo "❌ E2E tests failed"
+            echo "❌ E2E tests failed (no run record produced)"
             echo "results=failure" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -37,11 +37,6 @@ on:
         required: false
         default: false
         type: boolean
-      blocking:
-        description: 'Fail the job when tests fail. Set false to report results without gating the merge.'
-        required: false
-        default: true
-        type: boolean
     secrets:
       TEST_USERNAME:
         description: 'Username for test authentication'
@@ -253,9 +248,7 @@ jobs:
         id: run-tests-all
         if: ${{ inputs.browser == 'all' && steps.validate-secrets.outputs.can_run_tests == 'true' }}
         working-directory: apps/lfx-one
-        # Honours `blocking` like the single-browser step below. Previously hardcoded `true`, which
-        # would have made `blocking: true` silently mean the opposite for an all-browser caller.
-        continue-on-error: ${{ !inputs.blocking }}
+        continue-on-error: true
         run: |
           if [ -n "$TEST_USERNAME" ] && [ -n "$TEST_PASSWORD" ]; then
             echo "🔐 Running authenticated E2E tests on all browsers"
@@ -273,9 +266,6 @@ jobs:
       - name: Run E2E tests (Specific browser)
         if: ${{ inputs.browser != 'all' && steps.validate-secrets.outputs.can_run_tests == 'true' }}
         working-directory: apps/lfx-one
-        # A failure here still surfaces in the summary step and the PR comment, which read
-        # Playwright's own .last-run.json rather than this step's outcome.
-        continue-on-error: ${{ !inputs.blocking }}
         run: |
           if [ -n "$TEST_USERNAME" ] && [ -n "$TEST_PASSWORD" ]; then
             echo "🔐 Running authenticated E2E tests on ${{ inputs.browser }}"
@@ -315,20 +305,10 @@ jobs:
             echo "⏭️ E2E tests skipped (no test credentials)"
             echo "results=skipped" >> $GITHUB_OUTPUT
           elif [ -f "test-results/.last-run.json" ]; then
-            # Playwright records the run's own verdict here. The file's mere existence means the
-            # run happened, not that it passed — reporting on presence alone made a failing suite
-            # read as green, which matters most when the job is non-blocking and this summary is
-            # the only signal.
-            status=$(node -p "require('./test-results/.last-run.json').status" 2>/dev/null || echo unknown)
-            if [ "$status" == "passed" ]; then
-              echo "✅ E2E tests completed successfully"
-              echo "results=success" >> $GITHUB_OUTPUT
-            else
-              echo "❌ E2E tests failed (status: $status)"
-              echo "results=failure" >> $GITHUB_OUTPUT
-            fi
+            echo "✅ E2E tests completed successfully"
+            echo "results=success" >> $GITHUB_OUTPUT
           else
-            echo "❌ E2E tests failed (no run record produced)"
+            echo "❌ E2E tests failed"
             echo "results=failure" >> $GITHUB_OUTPUT
           fi
 

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -52,17 +52,38 @@ jobs:
       - name: Build project
         run: yarn build
 
-  # e2e-tests:
-  #   name: E2E Tests
-  #   needs: quality-checks
-  #   uses: ./.github/workflows/e2e-tests.yml
-  #   with:
-  #     node-version: "22"
-  #     test-command: "e2e"
-  #     browser: "chromium" # Use only Chromium for PR testing for faster feedback
-  #     skip-build: false
-  #   secrets:
-  #     TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-  #     TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-  #     AI_API_KEY: ${{ secrets.AI_API_KEY }}
-  #     AI_PROXY_URL: ${{ secrets.AI_PROXY_URL }}
+  # Enabled non-blocking (`blocking: false`): the suite has never executed anywhere, so its first
+  # runs are as likely to expose a bad assertion as a real defect, and gating merges on an unproven
+  # gate would strand the repo. Results land in the summary and the PR comment. Flip `blocking` to
+  # true — and require this check in branch protection — once it has been green for a few runs.
+  #
+  # `blocking: false` covers *test failures* only. A dependency install, a build, or the AWS OIDC
+  # secret fetch failing inside the called workflow still fails this job red, which is intended —
+  # those are infrastructure faults, not unproven assertions.
+  #
+  # `continue-on-error` cannot be used here: a job that calls a reusable workflow only supports
+  # name / needs / if / permissions / uses / with / secrets / strategy / concurrency. The input is
+  # applied to the test step inside the called workflow instead.
+  e2e-tests:
+    name: E2E Tests
+    needs: quality-checks
+    # A called workflow cannot hold more permission than its caller, so these must be granted here
+    # even though e2e-tests.yml declares them: id-token for the AWS OIDC secret fetch, and
+    # pull-requests/issues for the results comment.
+    permissions:
+      id-token: write
+      contents: read
+      issues: write
+      pull-requests: write
+    uses: ./.github/workflows/e2e-tests.yml
+    with:
+      node-version: "22"
+      test-command: "e2e"
+      browser: "chromium" # Use only Chromium for PR testing for faster feedback
+      skip-build: false
+      blocking: false
+    secrets:
+      TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+      AI_API_KEY: ${{ secrets.AI_API_KEY }}
+      AI_PROXY_URL: ${{ secrets.AI_PROXY_URL }}

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -52,38 +52,17 @@ jobs:
       - name: Build project
         run: yarn build
 
-  # Enabled non-blocking (`blocking: false`): the suite has never executed anywhere, so its first
-  # runs are as likely to expose a bad assertion as a real defect, and gating merges on an unproven
-  # gate would strand the repo. Results land in the summary and the PR comment. Flip `blocking` to
-  # true — and require this check in branch protection — once it has been green for a few runs.
-  #
-  # `blocking: false` covers *test failures* only. A dependency install, a build, or the AWS OIDC
-  # secret fetch failing inside the called workflow still fails this job red, which is intended —
-  # those are infrastructure faults, not unproven assertions.
-  #
-  # `continue-on-error` cannot be used here: a job that calls a reusable workflow only supports
-  # name / needs / if / permissions / uses / with / secrets / strategy / concurrency. The input is
-  # applied to the test step inside the called workflow instead.
-  e2e-tests:
-    name: E2E Tests
-    needs: quality-checks
-    # A called workflow cannot hold more permission than its caller, so these must be granted here
-    # even though e2e-tests.yml declares them: id-token for the AWS OIDC secret fetch, and
-    # pull-requests/issues for the results comment.
-    permissions:
-      id-token: write
-      contents: read
-      issues: write
-      pull-requests: write
-    uses: ./.github/workflows/e2e-tests.yml
-    with:
-      node-version: "22"
-      test-command: "e2e"
-      browser: "chromium" # Use only Chromium for PR testing for faster feedback
-      skip-build: false
-      blocking: false
-    secrets:
-      TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
-      TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
-      AI_API_KEY: ${{ secrets.AI_API_KEY }}
-      AI_PROXY_URL: ${{ secrets.AI_PROXY_URL }}
+  # e2e-tests:
+  #   name: E2E Tests
+  #   needs: quality-checks
+  #   uses: ./.github/workflows/e2e-tests.yml
+  #   with:
+  #     node-version: "22"
+  #     test-command: "e2e"
+  #     browser: "chromium" # Use only Chromium for PR testing for faster feedback
+  #     skip-build: false
+  #   secrets:
+  #     TEST_USERNAME: ${{ secrets.TEST_USERNAME }}
+  #     TEST_PASSWORD: ${{ secrets.TEST_PASSWORD }}
+  #     AI_API_KEY: ${{ secrets.AI_API_KEY }}
+  #     AI_PROXY_URL: ${{ secrets.AI_PROXY_URL }}

--- a/apps/lfx-one/e2e/helpers/org-roi.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-roi.helper.ts
@@ -2,6 +2,23 @@
 // SPDX-License-Identifier: MIT
 
 import { expect, Page, Route, test } from '@playwright/test';
+// Deep-imported, not from the `constants` barrel: the barrel pulls in modules that depend on
+// @angular/common and fail to load outside the app, the same trap the specs hit with `utils`.
+// Importing the real constants rather than restating their values means changing a ceiling or the
+// no-value indicator fails a test instead of silently diverging from what a viewer sees.
+import {
+  ORG_LENS_ROI_NO_VALUE,
+  ORG_LENS_ROI_PROJECT_BAR_MAX_ROWS,
+  ORG_LENS_ROI_PROJECT_BUBBLE_MAX_POINTS,
+  ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT,
+  ORG_LENS_ROI_PROJECT_SANKEY_MAX_PROJECTS,
+} from '@lfx-one/shared/constants/org-lens-roi.constants';
+
+export const PICKER_DEFAULT_COUNT = ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT;
+export const BAR_MAX_ROWS = ORG_LENS_ROI_PROJECT_BAR_MAX_ROWS;
+export const SANKEY_MAX_PROJECTS = ORG_LENS_ROI_PROJECT_SANKEY_MAX_PROJECTS;
+export const BUBBLE_MAX_POINTS = ORG_LENS_ROI_PROJECT_BUBBLE_MAX_POINTS;
+export const NO_VALUE = ORG_LENS_ROI_NO_VALUE;
 
 export const ORG_ROI_URL = '/org/roi';
 export const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
@@ -9,8 +26,7 @@ export const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 /**
  * Only the year still in progress is labelled partial, so every year-bearing fixture is anchored to
  * the current year rather than hardcoded — otherwise these assertions would quietly invert next
- * January. A hardcoded end year was one of three defects that reached review on the earlier
- * portfolio-summary work.
+ * January.
  */
 export const CURRENT_YEAR = new Date().getFullYear();
 
@@ -164,6 +180,54 @@ export const NEGATIVE_PROJECTS = MOCK_PROJECT_INPUTS.filter((input) => input.ret
   .sort((a, b) => b.profit - a.profit);
 
 export const NEGATIVE_PROJECTS_TOTAL = NEGATIVE_PROJECTS.reduce((sum, project) => sum + project.profit, 0);
+
+/**
+ * The payload arrives ordered by return descending, and the projects section takes its default
+ * selection straight off the front of it. Derived here rather than listed, so reordering the
+ * fixture above cannot leave this silently describing the wrong five.
+ */
+export const PROJECTS_BY_RETURN = [...MOCK_PROJECT_INPUTS].sort((a, b) => b.return - a.return);
+
+export const DEFAULT_SELECTED_PROJECTS = PROJECTS_BY_RETURN.slice(0, PICKER_DEFAULT_COUNT);
+
+export const UNSELECTED_PROJECT = PROJECTS_BY_RETURN[PICKER_DEFAULT_COUNT];
+
+/**
+ * Several hundred projects, for paging the table and for the truncation disclosures the chart views
+ * show when "All" is selected. Returns descend with the index so the ordering is unambiguous.
+ */
+export const MANY_PROJECT_COUNT = 300;
+
+export const MANY_PROJECT_INPUTS = Array.from({ length: MANY_PROJECT_COUNT }, (unused, index) => ({
+  slug: `project-${String(index).padStart(3, '0')}`,
+  name: `Project ${String(index).padStart(3, '0')}`,
+  expenditure: 1_000_000 + (MANY_PROJECT_COUNT - index) * 1_000,
+  return: (MANY_PROJECT_COUNT - index) * 10_000_000,
+}));
+
+export const MANY_PROJECTS = {
+  method: 'logit',
+  rows: MANY_PROJECT_INPUTS.map((input) => projectRow(input.slug, input.name, input.expenditure, input.return)),
+};
+
+/**
+ * A project with no investment. The warehouse returns NULL — never zero — for a ratio it cannot
+ * divide, and the table must render that as the no-value indicator rather than as 0.
+ */
+export const NO_INVESTMENT_PROJECT = {
+  projectId: 'prj-unmeasured',
+  projectSlug: 'unmeasured',
+  projectName: 'Unmeasured Project',
+  totalExpenditure: 0,
+  totalReturn: 0,
+  profit: 0,
+  roi: null,
+  bcr: null,
+  breakevenMarkup: null,
+  categories: [],
+};
+
+export const PROJECTS_WITH_NULL_RATIOS = { method: 'logit', rows: [...MOCK_PROJECTS.rows, NO_INVESTMENT_PROJECT] };
 
 interface StubOptions {
   hasAccess?: boolean;

--- a/apps/lfx-one/e2e/helpers/org-roi.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-roi.helper.ts
@@ -4,20 +4,23 @@
 import { expect, Page, Route, test } from '@playwright/test';
 // Deep-imported, not from the `constants` barrel: the barrel pulls in modules that depend on
 // @angular/common and fail to load outside the app, the same trap the specs hit with `utils`.
-// Importing the real constants rather than restating their values means changing a ceiling or the
-// no-value indicator fails a test instead of silently diverging from what a viewer sees.
-import {
-  ORG_LENS_ROI_NO_VALUE,
-  ORG_LENS_ROI_PROJECT_BAR_MAX_ROWS,
-  ORG_LENS_ROI_PROJECT_BUBBLE_MAX_POINTS,
-  ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT,
-  ORG_LENS_ROI_PROJECT_SANKEY_MAX_PROJECTS,
-} from '@lfx-one/shared/constants/org-lens-roi.constants';
+import { ORG_LENS_ROI_NO_VALUE } from '@lfx-one/shared/constants/org-lens-roi.constants';
 
-export const PICKER_DEFAULT_COUNT = ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT;
-export const BAR_MAX_ROWS = ORG_LENS_ROI_PROJECT_BAR_MAX_ROWS;
-export const SANKEY_MAX_PROJECTS = ORG_LENS_ROI_PROJECT_SANKEY_MAX_PROJECTS;
-export const BUBBLE_MAX_POINTS = ORG_LENS_ROI_PROJECT_BUBBLE_MAX_POINTS;
+/**
+ * Written down here rather than imported from the component constants, deliberately.
+ *
+ * These four numbers are a product contract — how many projects each view promises to draw, and how
+ * many the default selection starts with. Importing them would make the assertions restate the
+ * implementation: changing the bar cap from 25 to 24 would move the component and the expectation
+ * together and the truncation test would still pass, having stopped testing anything. A silent
+ * change to any of these should fail here and make someone confirm it was intended.
+ */
+export const PICKER_DEFAULT_COUNT = 5;
+export const BAR_MAX_ROWS = 25;
+export const SANKEY_MAX_PROJECTS = 12;
+export const BUBBLE_MAX_POINTS = 250;
+
+/** Imported, unlike the ceilings above: a rendering detail rather than a promise to the viewer. */
 export const NO_VALUE = ORG_LENS_ROI_NO_VALUE;
 
 export const ORG_ROI_URL = '/org/roi';

--- a/apps/lfx-one/e2e/helpers/org-roi.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-roi.helper.ts
@@ -4,6 +4,8 @@
 import { expect, Page, Route, test } from '@playwright/test';
 // Deep-imported, not from the `constants` barrel: the barrel pulls in modules that depend on
 // @angular/common and fail to load outside the app, the same trap the specs hit with `utils`.
+import { ACCOUNT_COOKIE_KEY } from '@lfx-one/shared/constants/accounts.constants';
+import { FEATURE_FLAG_OVERRIDE_STORAGE_KEY, ORG_LENS_ROI_ENABLED_FLAG } from '@lfx-one/shared/constants/feature-flags.constants';
 import { ORG_LENS_ROI_NO_VALUE } from '@lfx-one/shared/constants/org-lens-roi.constants';
 
 /**
@@ -48,10 +50,17 @@ export function skipWhenAuthMissing(page: Page): void {
   }
 }
 
+/**
+ * Preselect the organization the ROI page reads.
+ *
+ * The cookie name comes from the shared constant rather than a literal. It was previously
+ * `lfx-selected-account`, which the app has never read — so no organization was ever selected, the
+ * page sat on its loading skeleton forever, and nothing caught it because the suite had never run.
+ */
 export async function seedSelectedOrgCookie(page: Page): Promise<void> {
   await page.context().addCookies([
     {
-      name: 'lfx-selected-account',
+      name: ACCOUNT_COOKIE_KEY,
       value: JSON.stringify({ uid: MOCK_ACCOUNT_ID }),
       domain: 'localhost',
       path: '/',
@@ -289,7 +298,26 @@ export async function stubOrgLensContext(page: Page, options: StubOptions = {}):
   );
 }
 
+/**
+ * Pin feature flags for this page, before any application code runs.
+ *
+ * Without this the ROI specs cannot run at all. `/org/roi` sits behind a `canMatch` guard, and the
+ * flag SDK evaluates twice — first against an anonymous context at bootstrap, then again once the
+ * authenticated user context is applied. A flag targeted at named users is false in that first
+ * window, so the guard can resolve against it and redirect before the real value arrives, leaving
+ * every case skipped or asserting against a page that has already navigated away.
+ *
+ * The override is read only by non-production builds; see `FEATURE_FLAG_OVERRIDE_STORAGE_KEY`.
+ */
+export async function stubFeatureFlags(page: Page, flags: Record<string, boolean>): Promise<void> {
+  await page.addInitScript(([key, value]) => window.localStorage.setItem(key as string, value as string), [
+    FEATURE_FLAG_OVERRIDE_STORAGE_KEY,
+    JSON.stringify(flags),
+  ] as const);
+}
+
 export async function gotoOrgRoiPage(page: Page): Promise<void> {
+  await stubFeatureFlags(page, { [ORG_LENS_ROI_ENABLED_FLAG]: true });
   await seedSelectedOrgCookie(page);
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
@@ -297,7 +325,9 @@ export async function gotoOrgRoiPage(page: Page): Promise<void> {
   await page.goto(ORG_ROI_URL, { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
   await expect(page).not.toHaveURL(/auth0\.com/);
-  if (!page.url().includes('/org/roi')) {
-    test.skip(true, 'org-lens-roi-enabled flag appears off — /org/roi redirected away');
-  }
+
+  // The guard redirects asynchronously, so arriving at the URL is not the same as staying on it —
+  // asserting immediately would pass against a page that is about to leave.
+  await expect(page).toHaveURL(/\/org\/roi/, { timeout: 15_000 });
+  await expect(page.getByTestId('org-roi-page')).toBeVisible({ timeout: 15_000 });
 }

--- a/apps/lfx-one/e2e/org-roi-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-projects.spec.ts
@@ -6,7 +6,26 @@ import { expect, test } from '@playwright/test';
 // in @angular/common and fails to load outside the Angular app with a JIT compiler error.
 import { formatCurrency } from '@lfx-one/shared/utils/number.utils';
 
-import { gotoOrgRoiPage, MOCK_PROJECT_INPUTS, MOCK_PROJECTS, NEGATIVE_PROJECTS, NEGATIVE_PROJECTS_TOTAL, stubOrgLensContext } from './helpers/org-roi.helper';
+import {
+  BAR_MAX_ROWS,
+  BUBBLE_MAX_POINTS,
+  DEFAULT_SELECTED_PROJECTS,
+  gotoOrgRoiPage,
+  MANY_PROJECT_COUNT,
+  MANY_PROJECT_INPUTS,
+  MANY_PROJECTS,
+  MOCK_PROJECT_INPUTS,
+  MOCK_PROJECTS,
+  NEGATIVE_PROJECTS,
+  NEGATIVE_PROJECTS_TOTAL,
+  NO_INVESTMENT_PROJECT,
+  NO_VALUE,
+  PICKER_DEFAULT_COUNT,
+  PROJECTS_WITH_NULL_RATIOS,
+  SANKEY_MAX_PROJECTS,
+  stubOrgLensContext,
+  UNSELECTED_PROJECT,
+} from './helpers/org-roi.helper';
 
 test.setTimeout(120_000);
 
@@ -143,8 +162,8 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
   });
 
   test('serves the complete project set rather than a capped subset', async ({ page }) => {
-    // The donut summarises, but the payload behind it must carry every project — the forthcoming
-    // projects section and its table read the same response.
+    // The donut summarises, but the payload behind it must carry every project — the projects
+    // section and its table read the same response.
     const payloads: { rows: unknown[] }[] = [];
     page.on('response', async (response) => {
       if (!/\/lens\/roi\/projects(\?|$)/.test(response.url())) return;
@@ -193,5 +212,346 @@ test.describe('Org Lens ROI Metrics — leading projects', () => {
 
     await expect(page.getByTestId('org-roi-projects-donut-error')).toBeVisible();
     await expect(page.getByTestId('org-roi-projects-donut-forbidden')).toHaveCount(0);
+  });
+});
+
+/**
+ * The projects section: four views over the same complete project set, three of them driven by one
+ * shared selection. Every expected string is derived from the fixture through the same formatter
+ * the components use.
+ */
+test.describe('Org Lens ROI Metrics — projects section', () => {
+  test('opens on the comparison view with the top projects by return already selected', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const section = page.getByTestId('org-roi-projects-section');
+    await expect(section).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-section-tab-bar')).toHaveAttribute('aria-pressed', 'true');
+    await expect(page.getByTestId('org-roi-projects-bar-chart')).toBeVisible();
+
+    const chips = page.getByTestId('org-roi-project-picker-chips');
+    for (const project of DEFAULT_SELECTED_PROJECTS) {
+      await expect(chips).toContainText(project.name);
+    }
+    // The sixth-ranked project is not selected by default, which is what makes the default a
+    // selection rather than just "everything".
+    await expect(chips).not.toContainText(UNSELECTED_PROJECT.name);
+  });
+
+  test('shares one selection across the comparison, flow and efficiency views', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const removed = DEFAULT_SELECTED_PROJECTS[0];
+    await page.getByTestId(`org-roi-project-picker-remove-prj-${removed.slug}`).click();
+    await expect(page.getByTestId('org-roi-project-picker-chips')).not.toContainText(removed.name);
+
+    // The selection belongs to the section, not to whichever view happened to change it.
+    await page.getByTestId('org-roi-projects-section-tab-sankey').click();
+    await expect(page.getByTestId('org-roi-project-picker-chips')).not.toContainText(removed.name);
+
+    await page.getByTestId('org-roi-projects-section-tab-bubble').click();
+    await expect(page.getByTestId('org-roi-project-picker-chips')).not.toContainText(removed.name);
+    await expect(page.getByTestId('org-roi-projects-bubble-table')).not.toContainText(removed.name);
+  });
+
+  test('applies the Top, All and None presets', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-project-picker-none').click();
+    await expect(page.getByTestId('org-roi-project-picker-empty')).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-bar-empty')).toBeVisible();
+
+    await page.getByTestId('org-roi-project-picker-all').click();
+    const chips = page.getByTestId('org-roi-project-picker-chips');
+    for (const project of MOCK_PROJECT_INPUTS) {
+      await expect(chips).toContainText(project.name);
+    }
+
+    await page.getByTestId('org-roi-project-picker-top').click();
+    await expect(chips).not.toContainText(UNSELECTED_PROJECT.name);
+  });
+
+  test('adds a project by search', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-project-picker-search').fill(UNSELECTED_PROJECT.name);
+    await expect(page.getByTestId('org-roi-project-picker-match-count')).toContainText('1 project matches.');
+
+    await page.getByTestId(`org-roi-project-picker-add-prj-${UNSELECTED_PROJECT.slug}`).click();
+    await expect(page.getByTestId('org-roi-project-picker-chips')).toContainText(UNSELECTED_PROJECT.name);
+    // Adding clears the query, so the box is ready for the next search rather than still filtered.
+    await expect(page.getByTestId('org-roi-project-picker-search')).toHaveValue('');
+  });
+
+  test('reports how many projects a search actually matched, not how many it drew', async ({ page }) => {
+    // The match list is capped for readability. Reporting the capped length told a viewer
+    // searching a large portfolio that 20 projects matched when hundreds did.
+    await stubOrgLensContext(page, { projects: MANY_PROJECTS });
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-project-picker-search').fill('Project');
+    const label = page.getByTestId('org-roi-project-picker-match-count');
+    // Every project bar the five already selected matches the shared prefix.
+    await expect(label).toContainText(`${(MANY_PROJECT_COUNT - PICKER_DEFAULT_COUNT).toLocaleString('en-US')} projects match`);
+    await expect(label).toContainText('showing the first');
+  });
+
+  test('keeps an emptied selection empty when the estimation method changes', async ({ page }) => {
+    // None is a choice. Restoring the default on the next payload treated it as an absence, so a
+    // method switch silently put five projects back onto a deliberately cleared chart.
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-project-picker-none').click();
+    await expect(page.getByTestId('org-roi-project-picker-empty')).toBeVisible();
+
+    await page.getByTestId('org-roi-assumptions-trigger').click();
+    await page.getByTestId('org-roi-assumptions-method-direct').click();
+
+    await expect(page.getByTestId('org-roi-project-picker-empty')).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-bar-empty')).toBeVisible();
+  });
+
+  test('renders projects after a failed read is retried under another method', async ({ page }) => {
+    // An end-to-end recovery path rather than a regression guard: the selection logic distinguishes
+    // "never chosen" from "emptied", so a failed read can no longer strand the charts blank by
+    // construction. Keyed on the method in the request rather than on a call count — the donut and
+    // the section both read this endpoint, and how many times either retries is not this test's
+    // business to predict.
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/projects*', (route) => {
+      const failed = new URL(route.request().url()).searchParams.get('method') === 'logit';
+      if (failed) {
+        return route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ code: 'UNAVAILABLE' }) });
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MOCK_PROJECTS) });
+    });
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-section-error')).toBeVisible();
+
+    // Switching method re-issues the read, which now succeeds.
+    await page.getByTestId('org-roi-assumptions-trigger').click();
+    await page.getByTestId('org-roi-assumptions-method-direct').click();
+
+    const chips = page.getByTestId('org-roi-project-picker-chips');
+    await expect(chips).toBeVisible();
+    await expect(chips).toContainText(DEFAULT_SELECTED_PROJECTS[0].name);
+    await expect(page.getByTestId('org-roi-projects-bar-chart')).toBeVisible();
+  });
+
+  test('does not offer an already-selected project as a search match', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const selected = DEFAULT_SELECTED_PROJECTS[0];
+    await page.getByTestId('org-roi-project-picker-search').fill(selected.name);
+    await expect(page.getByTestId('org-roi-project-picker-match-count')).toContainText('No unselected project matches that name.');
+  });
+
+  test('states that the comparison bars use separate scales and never rescales the stack', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-bar-scale-note')).toContainText('separate scales');
+
+    // Categories sum to their project's investment by construction, so this warning must be absent
+    // for a fixture whose parts add up — the fixture builder carries the balance in its last
+    // category precisely so this holds.
+    await expect(page.getByTestId('org-roi-projects-bar-reconciliation-warning')).toHaveCount(0);
+
+    const table = page.getByTestId('org-roi-projects-bar-table');
+    const leader = DEFAULT_SELECTED_PROJECTS[0];
+    await expect(table).toContainText(formatCurrency(leader.expenditure));
+    await expect(table).toContainText(formatCurrency(leader.return));
+  });
+
+  test('toggles the flow view between investment and return', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+    await page.getByTestId('org-roi-projects-section-tab-sankey').click();
+
+    await expect(page.getByTestId('org-roi-projects-sankey-measure-investment')).toHaveAttribute('aria-pressed', 'true');
+    const flows = page.getByTestId('org-roi-projects-sankey-table');
+    // Investment fans out through its categories, so the org node reaches a category, not a project.
+    await expect(flows).toContainText('Your organization');
+    await expect(flows).toContainText('Code Contribution');
+
+    await page.getByTestId('org-roi-projects-sankey-measure-return').click();
+    await expect(page.getByTestId('org-roi-projects-sankey-measure-return')).toHaveAttribute('aria-pressed', 'true');
+    await expect(flows).toContainText(formatCurrency(DEFAULT_SELECTED_PROJECTS[0].return));
+    // Return is not decomposed by category in the warehouse, so no category node may appear.
+    await expect(flows).not.toContainText('Code Contribution');
+  });
+
+  test('carries the modelled-cost disclosure on every view that shows an investment figure', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    const barNote = page.getByTestId('org-roi-projects-bar-modelled-cost-note');
+    await expect(barNote).toContainText('modelled cost');
+    await expect(barNote).toContainText('not actual or reported compensation');
+
+    await page.getByTestId('org-roi-projects-section-tab-sankey').click();
+    await expect(page.getByTestId('org-roi-projects-sankey-modelled-cost-note')).toContainText('modelled cost');
+    // The return flow is not derived from investment, so it does not owe the disclosure.
+    await page.getByTestId('org-roi-projects-sankey-measure-return').click();
+    await expect(page.getByTestId('org-roi-projects-sankey-modelled-cost-note')).toHaveCount(0);
+
+    await page.getByTestId('org-roi-projects-section-tab-bubble').click();
+    await expect(page.getByTestId('org-roi-projects-bubble-modelled-cost-note')).toContainText('modelled cost');
+
+    await page.getByTestId('org-roi-projects-section-tab-table').click();
+    await expect(page.getByTestId('org-roi-projects-table-modelled-cost-note')).toContainText('modelled cost');
+  });
+
+  test('names every chart for assistive technology and lists its values as text', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-bar-chart')).toHaveAttribute('aria-label', /bar chart comparing modelled investment/i);
+    await expect(page.getByTestId('org-roi-projects-bar-table')).toHaveCount(1);
+
+    await page.getByTestId('org-roi-projects-section-tab-sankey').click();
+    await expect(page.getByTestId('org-roi-projects-sankey-chart')).toHaveAttribute('aria-label', /flow diagram of modelled investment/i);
+    await expect(page.getByTestId('org-roi-projects-sankey-table')).toHaveCount(1);
+
+    await page.getByTestId('org-roi-projects-section-tab-bubble').click();
+    await expect(page.getByTestId('org-roi-projects-bubble-chart')).toHaveAttribute('aria-label', /logarithmic axes/i);
+    await expect(page.getByTestId('org-roi-projects-bubble-table')).toHaveCount(1);
+  });
+
+  test('explains the logarithmic axes on the efficiency view', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+    await page.getByTestId('org-roi-projects-section-tab-bubble').click();
+
+    await expect(page.getByTestId('org-roi-projects-bubble-scale-note')).toContainText('logarithmic');
+    // The fixture has no zero-valued project, so nothing is floored and the caveat must not appear.
+    await expect(page.getByTestId('org-roi-projects-bubble-floored-note')).toHaveCount(0);
+  });
+
+  test('discloses a project it had to draw at the axis floor', async ({ page }) => {
+    await stubOrgLensContext(page, { projects: PROJECTS_WITH_NULL_RATIOS });
+    await gotoOrgRoiPage(page);
+    await page.getByTestId('org-roi-projects-section-tab-bubble').click();
+    await page.getByTestId('org-roi-project-picker-all').click();
+
+    const note = page.getByTestId('org-roi-projects-bubble-floored-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText(NO_INVESTMENT_PROJECT.projectName);
+    // Its true figures are still reported, unfloored.
+    await expect(page.getByTestId('org-roi-projects-bubble-table')).toContainText(NO_INVESTMENT_PROJECT.projectName);
+  });
+
+  test('pages the table through the complete project set', async ({ page }) => {
+    await stubOrgLensContext(page, { projects: MANY_PROJECTS });
+    await gotoOrgRoiPage(page);
+    await page.getByTestId('org-roi-projects-section-tab-table').click();
+
+    await expect(page.getByTestId('org-roi-projects-table-count')).toContainText(`${MANY_PROJECT_COUNT.toLocaleString('en-US')} projects`);
+
+    // The payload arrives ordered by return descending, so the first page opens on the leader and
+    // the last project is nowhere near it.
+    const first = MANY_PROJECT_INPUTS[0];
+    const last = MANY_PROJECT_INPUTS[MANY_PROJECT_COUNT - 1];
+    await expect(page.getByTestId(`org-roi-projects-table-row-prj-${first.slug}`)).toBeVisible();
+    await expect(page.getByTestId(`org-roi-projects-table-row-prj-${last.slug}`)).toHaveCount(0);
+
+    // Reversing the sort must reach the other end of the same complete set — not of a capped one.
+    await page.getByTestId('org-roi-projects-table-sort-return').click();
+    await expect(page.getByTestId(`org-roi-projects-table-row-prj-${last.slug}`)).toBeVisible();
+    await expect(page.getByTestId(`org-roi-projects-table-row-prj-${first.slug}`)).toHaveCount(0);
+  });
+
+  test('sorts by a metric column and shows the direction', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+    await page.getByTestId('org-roi-projects-section-tab-table').click();
+
+    const cheapest = [...MOCK_PROJECT_INPUTS].sort((a, b) => a.expenditure - b.expenditure)[0];
+    await page.getByTestId('org-roi-projects-table-sort-investment').click();
+    // First click on a money column sorts largest-first, so the cheapest project is not the leader.
+    const rows = page.locator('[data-testid^="org-roi-projects-table-row-"]');
+    await expect(rows.first()).not.toContainText(cheapest.name);
+
+    await page.getByTestId('org-roi-projects-table-sort-investment').click();
+    await expect(rows.first()).toContainText(cheapest.name);
+  });
+
+  test('renders an undefined ratio as the no-value indicator, never as zero', async ({ page }) => {
+    await stubOrgLensContext(page, { projects: PROJECTS_WITH_NULL_RATIOS });
+    await gotoOrgRoiPage(page);
+    await page.getByTestId('org-roi-projects-section-tab-table').click();
+
+    const row = page.getByTestId(`org-roi-projects-table-row-${NO_INVESTMENT_PROJECT.projectId}`);
+    await expect(row).toBeVisible();
+    // A blank ROI means "there was no investment to divide by", not "it broke even".
+    await expect(row).toContainText(NO_VALUE);
+    await expect(row).not.toContainText('0.0%');
+  });
+
+  test('does not offer the picker on the table, which pages the complete set', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-project-picker')).toBeVisible();
+    await page.getByTestId('org-roi-projects-section-tab-table').click();
+    await expect(page.getByTestId('org-roi-project-picker')).toHaveCount(0);
+  });
+
+  test('discloses how many selected projects a chart could not draw', async ({ page }) => {
+    await stubOrgLensContext(page, { projects: MANY_PROJECTS });
+    await gotoOrgRoiPage(page);
+    await page.getByTestId('org-roi-project-picker-all').click();
+
+    // "All" is a legitimate selection on a portfolio this size, so the shortfall is disclosed
+    // rather than the selection being silently capped at the picker.
+    const barNote = page.getByTestId('org-roi-projects-bar-truncation-note');
+    await expect(barNote).toBeVisible();
+    await expect(barNote).toContainText(`${MANY_PROJECT_COUNT - BAR_MAX_ROWS} more`);
+
+    await page.getByTestId('org-roi-projects-section-tab-sankey').click();
+    const sankeyNote = page.getByTestId('org-roi-projects-sankey-truncation-note');
+    await expect(sankeyNote).toBeVisible();
+    await expect(sankeyNote).toContainText(`${MANY_PROJECT_COUNT - SANKEY_MAX_PROJECTS} more`);
+
+    // A scatter tolerates far more points than bars or flows, so its ceiling is higher — but the
+    // fixture still exceeds it, and it owes the same disclosure.
+    await page.getByTestId('org-roi-projects-section-tab-bubble').click();
+    const bubbleNote = page.getByTestId('org-roi-projects-bubble-truncation-note');
+    await expect(bubbleNote).toBeVisible();
+    await expect(bubbleNote).toContainText(`${MANY_PROJECT_COUNT - BUBBLE_MAX_POINTS} more`);
+  });
+
+  test('refuses an ungranted caller without rendering any project figure', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/projects*', (route) =>
+      route.fulfill({
+        status: 403,
+        contentType: 'application/json',
+        body: JSON.stringify({ code: 'FORBIDDEN', message: 'You do not have access to Org Lens data for this organization.' }),
+      })
+    );
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-section-forbidden')).toBeVisible();
+    await expect(page.getByTestId('org-roi-project-picker')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-projects-bar-chart')).toHaveCount(0);
+  });
+
+  test('distinguishes a 503 from a refusal in the projects section', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/projects*', (route) =>
+      route.fulfill({ status: 503, contentType: 'application/json', body: JSON.stringify({ code: 'ROLE_GRANTS_UNAVAILABLE' }) })
+    );
+    await gotoOrgRoiPage(page);
+
+    await expect(page.getByTestId('org-roi-projects-section-error')).toBeVisible();
+    await expect(page.getByTestId('org-roi-projects-section-forbidden')).toHaveCount(0);
   });
 });

--- a/apps/lfx-one/e2e/org-roi-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-projects.spec.ts
@@ -278,13 +278,13 @@ test.describe('Org Lens ROI Metrics — projects section', () => {
     await stubOrgLensContext(page);
     await gotoOrgRoiPage(page);
 
-    await page.getByTestId('org-roi-project-picker-search').fill(UNSELECTED_PROJECT.name);
+    await page.locator('[data-test="org-roi-project-picker-search"]').fill(UNSELECTED_PROJECT.name);
     await expect(page.getByTestId('org-roi-project-picker-match-count')).toContainText('1 project matches.');
 
     await page.getByTestId(`org-roi-project-picker-add-prj-${UNSELECTED_PROJECT.slug}`).click();
     await expect(page.getByTestId('org-roi-project-picker-chips')).toContainText(UNSELECTED_PROJECT.name);
     // Adding clears the query, so the box is ready for the next search rather than still filtered.
-    await expect(page.getByTestId('org-roi-project-picker-search')).toHaveValue('');
+    await expect(page.locator('[data-test="org-roi-project-picker-search"]')).toHaveValue('');
   });
 
   test('reports how many projects a search actually matched, not how many it drew', async ({ page }) => {
@@ -293,7 +293,7 @@ test.describe('Org Lens ROI Metrics — projects section', () => {
     await stubOrgLensContext(page, { projects: MANY_PROJECTS });
     await gotoOrgRoiPage(page);
 
-    await page.getByTestId('org-roi-project-picker-search').fill('Project');
+    await page.locator('[data-test="org-roi-project-picker-search"]').fill('Project');
     const label = page.getByTestId('org-roi-project-picker-match-count');
     // Every project bar the five already selected matches the shared prefix.
     await expect(label).toContainText(`${(MANY_PROJECT_COUNT - PICKER_DEFAULT_COUNT).toLocaleString('en-US')} projects match`);
@@ -349,7 +349,7 @@ test.describe('Org Lens ROI Metrics — projects section', () => {
     await gotoOrgRoiPage(page);
 
     const selected = DEFAULT_SELECTED_PROJECTS[0];
-    await page.getByTestId('org-roi-project-picker-search').fill(selected.name);
+    await page.locator('[data-test="org-roi-project-picker-search"]').fill(selected.name);
     await expect(page.getByTestId('org-roi-project-picker-match-count')).toContainText('No unselected project matches that name.');
   });
 

--- a/apps/lfx-one/package.json
+++ b/apps/lfx-one/package.json
@@ -69,6 +69,7 @@
     "@tiptap/pm": "^2",
     "@tiptap/starter-kit": "^2",
     "chart.js": "^4.5.1",
+    "chartjs-chart-sankey": "0.15.0",
     "compression": "^1.8.1",
     "express": "^4.18.2",
     "express-openid-connect": "^2.19.2",

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.html
@@ -1,0 +1,90 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3 rounded-md border border-gray-200 bg-gray-50 p-3" data-testid="org-roi-project-picker">
+  <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+    <h3 class="text-sm font-semibold text-gray-900">Projects shown</h3>
+
+    <div class="inline-flex self-start rounded-md border border-gray-200 bg-white p-0.5" role="group" aria-label="Project selection presets">
+      <button
+        type="button"
+        (click)="selectTop()"
+        class="rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50"
+        data-testid="org-roi-project-picker-top">
+        Top {{ defaultCount }}
+      </button>
+      <button
+        type="button"
+        (click)="selectAll()"
+        [disabled]="!canSelectAll()"
+        class="rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:text-gray-300"
+        data-testid="org-roi-project-picker-all">
+        All
+      </button>
+      <button
+        type="button"
+        (click)="selectNone()"
+        [disabled]="!hasSelection()"
+        class="rounded px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-50 disabled:cursor-not-allowed disabled:text-gray-300"
+        data-testid="org-roi-project-picker-none">
+        None
+      </button>
+    </div>
+  </div>
+
+  @if (hasSelection()) {
+    <ul class="flex flex-wrap gap-2" data-testid="org-roi-project-picker-chips">
+      @for (option of selectedOptions(); track option.projectId) {
+        <li class="inline-flex items-center gap-2 rounded-full border border-gray-300 bg-white py-1 pl-3 pr-1 text-xs text-gray-700">
+          <span>{{ option.projectName }}</span>
+          <button
+            type="button"
+            (click)="remove(option.projectId)"
+            class="flex h-5 w-5 items-center justify-center rounded-full text-gray-400 hover:bg-gray-100 hover:text-gray-700"
+            [attr.aria-label]="'Remove ' + option.projectName"
+            [attr.data-testid]="'org-roi-project-picker-remove-' + option.projectId">
+            <i class="fa-light fa-xmark text-xs" aria-hidden="true"></i>
+          </button>
+        </li>
+      }
+    </ul>
+  } @else {
+    <p class="text-xs text-gray-500" data-testid="org-roi-project-picker-empty">No projects selected. Choose a preset, or search for a project to add.</p>
+  }
+
+  <div class="flex flex-col gap-2">
+    <label class="flex flex-col gap-1 text-xs text-gray-600">
+      <span class="sr-only">Search projects to add</span>
+      <input
+        type="search"
+        [ngModel]="query()"
+        (ngModelChange)="query.set($event)"
+        placeholder="Add a project by name"
+        class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
+        data-testid="org-roi-project-picker-search" />
+    </label>
+
+    @if (hasQuery()) {
+      <!-- Announced rather than only drawn: a search that silently returns nothing is
+           indistinguishable from one that has not run yet. -->
+      <p class="text-xs text-gray-500" role="status" data-testid="org-roi-project-picker-match-count">{{ matchCountLabel() }}</p>
+
+      @if (matches().length > 0) {
+        <ul class="flex max-h-48 flex-col gap-1 overflow-y-auto" data-testid="org-roi-project-picker-matches">
+          @for (option of matches(); track option.projectId) {
+            <li>
+              <button
+                type="button"
+                (click)="add(option.projectId)"
+                class="flex w-full items-baseline justify-between gap-4 rounded px-2 py-1.5 text-left text-sm text-gray-700 hover:bg-white"
+                [attr.data-testid]="'org-roi-project-picker-add-' + option.projectId">
+                <span>{{ option.projectName }}</span>
+                <span class="text-xs font-medium text-gray-500">{{ option.amount }}</span>
+              </button>
+            </li>
+          }
+        </ul>
+      }
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.html
@@ -53,16 +53,15 @@
   }
 
   <div class="flex flex-col gap-2">
-    <label class="flex flex-col gap-1 text-xs text-gray-600">
-      <span class="sr-only">Search projects to add</span>
-      <input
-        type="search"
-        [ngModel]="query()"
-        (ngModelChange)="query.set($event)"
-        placeholder="Add a project by name"
-        class="w-full rounded-md border border-gray-300 px-3 py-2 text-sm text-gray-900 placeholder:text-gray-400 focus:border-blue-500 focus:outline-none"
-        data-testid="org-roi-project-picker-search" />
-    </label>
+    <lfx-input-text
+      [form]="searchForm"
+      control="query"
+      placeholder="Add a project by name"
+      icon="fa-light fa-search"
+      size="small"
+      styleClass="w-full"
+      autocomplete="off"
+      dataTest="org-roi-project-picker-search" />
 
     @if (hasQuery()) {
       <!-- Announced rather than only drawn: a search that silently returns nothing is

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.ts
@@ -1,8 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, output, Signal, signal } from '@angular/core';
-import { FormsModule } from '@angular/forms';
+import { Component, computed, input, output, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { InputTextComponent } from '@components/input-text/input-text.component';
 import { ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT, ORG_LENS_ROI_PROJECT_PICKER_MAX_MATCHES } from '@lfx-one/shared/constants';
 import type { OrgLensRoiProjectOption } from '@lfx-one/shared/interfaces';
 
@@ -15,7 +17,7 @@ import type { OrgLensRoiProjectOption } from '@lfx-one/shared/interfaces';
  */
 @Component({
   selector: 'lfx-org-roi-project-picker',
-  imports: [FormsModule],
+  imports: [InputTextComponent, ReactiveFormsModule],
   templateUrl: './org-roi-project-picker.component.html',
 })
 export class OrgRoiProjectPickerComponent {
@@ -33,7 +35,10 @@ export class OrgRoiProjectPickerComponent {
 
   protected readonly defaultCount = ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT;
 
-  protected readonly query = signal('');
+  /** The LFX input wrappers are reactive-forms only, so the search box is a control, not ngModel. */
+  protected readonly searchForm = new FormGroup({ query: new FormControl('', { nonNullable: true }) });
+
+  private readonly query: Signal<string> = toSignal(this.searchForm.controls.query.valueChanges, { initialValue: '' });
 
   private readonly optionsById: Signal<Map<string, OrgLensRoiProjectOption>> = computed(
     () => new Map(this.options().map((option) => [option.projectId, option]))
@@ -90,12 +95,12 @@ export class OrgRoiProjectPickerComponent {
         .slice(0, this.defaultCount)
         .map((option) => option.projectId)
     );
-    this.query.set('');
+    this.searchForm.controls.query.setValue('');
   }
 
   public selectAll(): void {
     this.selectionChange.emit(this.options().map((option) => option.projectId));
-    this.query.set('');
+    this.searchForm.controls.query.setValue('');
   }
 
   public selectNone(): void {
@@ -105,7 +110,7 @@ export class OrgRoiProjectPickerComponent {
   public add(projectId: string): void {
     if (this.selectedIds().includes(projectId)) return;
     this.selectionChange.emit([...this.selectedIds(), projectId]);
-    this.query.set('');
+    this.searchForm.controls.query.setValue('');
   }
 
   public remove(projectId: string): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-project-picker/org-roi-project-picker.component.ts
@@ -1,0 +1,114 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, output, Signal, signal } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import { ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT, ORG_LENS_ROI_PROJECT_PICKER_MAX_MATCHES } from '@lfx-one/shared/constants';
+import type { OrgLensRoiProjectOption } from '@lfx-one/shared/interfaces';
+
+/**
+ * The project selection shared by the comparison, flow and efficiency views.
+ *
+ * One component rather than one per view: the three views differ in how they draw a selection, not
+ * in how a selection is made, and three copies of this would drift the moment one of them gained a
+ * behaviour the others did not.
+ */
+@Component({
+  selector: 'lfx-org-roi-project-picker',
+  imports: [FormsModule],
+  templateUrl: './org-roi-project-picker.component.html',
+})
+export class OrgRoiProjectPickerComponent {
+  /** Every project, already ranked by return — the order the default selection is taken from. */
+  public readonly options = input.required<OrgLensRoiProjectOption[]>();
+
+  public readonly selectedIds = input.required<string[]>();
+
+  /**
+   * One-way in, events out, rather than a two-way `model`. The section distinguishes a selection
+   * the viewer emptied from one it has never set, and a `model` this component could write to
+   * would let it produce the first without saying so.
+   */
+  public readonly selectionChange = output<string[]>();
+
+  protected readonly defaultCount = ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT;
+
+  protected readonly query = signal('');
+
+  private readonly optionsById: Signal<Map<string, OrgLensRoiProjectOption>> = computed(
+    () => new Map(this.options().map((option) => [option.projectId, option]))
+  );
+
+  /**
+   * Chips follow the selection's own order, not the ranking. Reordering them under the viewer when
+   * a project is added would make the chip they just created appear somewhere they were not
+   * looking, and the set is what matters here — nothing downstream reads this order.
+   */
+  protected readonly selectedOptions: Signal<OrgLensRoiProjectOption[]> = computed(() => {
+    const byId = this.optionsById();
+    // An id with no option is dropped rather than rendered blank: the selection outlives a payload
+    // refresh, so a project can leave the set between one response and the next.
+    return this.selectedIds()
+      .map((id) => byId.get(id))
+      .filter((option): option is OrgLensRoiProjectOption => option !== undefined);
+  });
+
+  protected readonly hasSelection: Signal<boolean> = computed(() => this.selectedOptions().length > 0);
+
+  protected readonly canSelectAll: Signal<boolean> = computed(() => this.selectedIds().length < this.options().length);
+
+  /** Every unselected project matching the query. Counted here, before any cap is applied. */
+  private readonly allMatches: Signal<OrgLensRoiProjectOption[]> = computed(() => {
+    const query = this.query().trim().toLowerCase();
+    if (query === '') return [];
+    const selected = new Set(this.selectedIds());
+    return this.options().filter((option) => !selected.has(option.projectId) && option.projectName.toLowerCase().includes(query));
+  });
+
+  /** Capped for display — this finds one project, it does not browse. */
+  protected readonly matches: Signal<OrgLensRoiProjectOption[]> = computed(() => this.allMatches().slice(0, ORG_LENS_ROI_PROJECT_PICKER_MAX_MATCHES));
+
+  protected readonly hasQuery: Signal<boolean> = computed(() => this.query().trim() !== '');
+
+  /**
+   * Counts the matches that exist, not the ones drawn, and says so when those differ. Counting the
+   * capped list instead reported "20 projects match" to a viewer whose search actually found
+   * hundreds — an unqualified claim about data the component had withheld, which is the one thing
+   * every other truncation in this feature is careful not to do.
+   */
+  protected readonly matchCountLabel: Signal<string> = computed(() => {
+    const total = this.allMatches().length;
+    const shown = this.matches().length;
+    if (total === 0) return 'No unselected project matches that name.';
+    if (total > shown) return `${total.toLocaleString('en-US')} projects match; showing the first ${shown}. Narrow the search to find a specific project.`;
+    return total === 1 ? '1 project matches.' : `${total.toLocaleString('en-US')} projects match.`;
+  });
+
+  public selectTop(): void {
+    this.selectionChange.emit(
+      this.options()
+        .slice(0, this.defaultCount)
+        .map((option) => option.projectId)
+    );
+    this.query.set('');
+  }
+
+  public selectAll(): void {
+    this.selectionChange.emit(this.options().map((option) => option.projectId));
+    this.query.set('');
+  }
+
+  public selectNone(): void {
+    this.selectionChange.emit([]);
+  }
+
+  public add(projectId: string): void {
+    if (this.selectedIds().includes(projectId)) return;
+    this.selectionChange.emit([...this.selectedIds(), projectId]);
+    this.query.set('');
+  }
+
+  public remove(projectId: string): void {
+    this.selectionChange.emit(this.selectedIds().filter((id) => id !== projectId));
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.html
@@ -52,6 +52,9 @@
         <tr>
           <th scope="col">Project</th>
           <th scope="col">Investment</th>
+          @for (column of categoryColumns(); track column.type) {
+            <th scope="col">{{ column.label }}</th>
+          }
           <th scope="col">Return</th>
         </tr>
       </thead>
@@ -60,6 +63,9 @@
           <tr>
             <th scope="row">{{ row.projectName }}</th>
             <td>{{ row.investment }}</td>
+            @for (amount of row.categories; track $index) {
+              <td>{{ amount }}</td>
+            }
             <td>{{ row.return }}</td>
           </tr>
         }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.html
@@ -1,0 +1,71 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="org-roi-projects-bar">
+  @if (!hasProjects()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-bar-empty">
+      <i class="fa-light fa-chart-simple text-gray-400" aria-hidden="true"></i>
+      <span>Select at least one project to compare investment against return.</span>
+    </div>
+  } @else {
+    @if (hiddenCount() > 0) {
+      <p class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600" data-testid="org-roi-projects-bar-truncation-note">
+        <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span
+          >Showing the first {{ maxRows }} of the selected projects. {{ hiddenCount() }} more are selected but not drawn — a bar each would not be readable. Use
+          the table to see every project.</span
+        >
+      </p>
+    }
+
+    <div class="w-full" [style.height]="chartHeight()" role="img" [attr.aria-label]="chartSummaryLabel()" data-testid="org-roi-projects-bar-chart">
+      <lfx-chart type="bar" [data]="chartData()" [options]="chartOptions()" height="100%" />
+    </div>
+
+    <p class="text-xs text-gray-500" data-testid="org-roi-projects-bar-scale-note">
+      Investment and return are drawn on separate scales — return is typically tens of times larger, and on a shared scale the investment categories would be
+      invisible. Compare each bar's own composition, not the two bars' lengths.
+    </p>
+
+    @if (unreconciled().length > 0) {
+      <!-- Categories sum to a project's investment by construction. When they do not, that is a
+           defect in the metric layer, so it is reported rather than corrected here. -->
+      <div
+        class="flex flex-col gap-1 rounded-md border border-amber-200 bg-amber-50 px-3 py-2.5 text-xs text-amber-900"
+        data-testid="org-roi-projects-bar-reconciliation-warning">
+        <span class="font-medium">Some category breakdowns do not add up to their project's investment.</span>
+        <ul class="flex flex-col gap-0.5">
+          @for (entry of unreconciled(); track entry.projectName) {
+            <li>{{ entry.projectName }}: off by {{ entry.difference }}</li>
+          }
+        </ul>
+      </div>
+    }
+
+    <!-- The canvas is otherwise the only presentation of these values. `sr-only` keeps the table
+         out of the visual layout without hiding it from assistive technology. -->
+    <table class="sr-only" data-testid="org-roi-projects-bar-table">
+      <caption>
+        Investment and return by project
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">Project</th>
+          <th scope="col">Investment</th>
+          <th scope="col">Return</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (row of tableRows(); track row.projectId) {
+          <tr>
+            <th scope="row">{{ row.projectName }}</th>
+            <td>{{ row.investment }}</td>
+            <td>{{ row.return }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    <p class="text-xs text-gray-500" data-testid="org-roi-projects-bar-modelled-cost-note">{{ investmentExplanation }}</p>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.ts
@@ -1,0 +1,181 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal } from '@angular/core';
+import { ChartComponent } from '@components/chart/chart.component';
+import {
+  lfxColors,
+  ORG_LENS_ROI_CATEGORY_COLOR,
+  ORG_LENS_ROI_CONTRIBUTION_TYPES,
+  ORG_LENS_ROI_KPI_EXPLANATION,
+  ORG_LENS_ROI_PROJECT_BAR_MAX_ROWS,
+  ORG_LENS_ROI_RETURN_COLOR,
+} from '@lfx-one/shared/constants';
+import type { OrgLensRoiProjectBarRow, OrgLensRoiProjectBarSegment, OrgLensRoiProjectRow } from '@lfx-one/shared/interfaces';
+import { formatCurrency } from '@lfx-one/shared/utils';
+import type { ChartData, ChartOptions } from 'chart.js';
+
+/** Each project's investment, stacked by contribution category, against the return it is associated with. */
+@Component({
+  selector: 'lfx-org-roi-projects-bar',
+  imports: [ChartComponent],
+  templateUrl: './org-roi-projects-bar.component.html',
+})
+export class OrgRoiProjectsBarComponent {
+  /** The selected projects, in the order the picker ranked them. */
+  public readonly projects = input.required<OrgLensRoiProjectRow[]>();
+
+  /** The same wording the KPI band uses. This chart stacks investment, so it owes the disclosure. */
+  protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
+
+  protected readonly maxRows = ORG_LENS_ROI_PROJECT_BAR_MAX_ROWS;
+
+  protected readonly hasProjects: Signal<boolean> = computed(() => this.projects().length > 0);
+
+  /** Everything past the ceiling is dropped from the drawing and disclosed, never silently. */
+  protected readonly hiddenCount: Signal<number> = computed(() => Math.max(0, this.projects().length - this.maxRows));
+
+  protected readonly rows: Signal<OrgLensRoiProjectBarRow[]> = computed(() =>
+    this.projects()
+      .slice(0, this.maxRows)
+      .map((project) => ({
+        projectId: project.projectId,
+        projectName: project.projectName,
+        segments: this.toSegments(project),
+        totalExpenditure: project.totalExpenditure,
+        totalReturn: project.totalReturn,
+      }))
+  );
+
+  /**
+   * Categories sum to the project's own investment by warehouse construction — verified across all
+   * production project rows, worst difference under a billionth of a cent. Nothing here rescales
+   * them to fit: a stack that fails to reach its project's investment figure is a defect in the
+   * metric layer, and papering over it in the renderer would hide exactly the thing worth knowing.
+   * This surfaces the discrepancy instead.
+   */
+  protected readonly unreconciled: Signal<{ projectName: string; difference: string }[]> = computed(() =>
+    this.rows()
+      .map((row) => ({
+        projectName: row.projectName,
+        difference: row.segments.reduce((sum, segment) => sum + segment.expenditure, 0) - row.totalExpenditure,
+      }))
+      // A cent, not an epsilon: the payload carries currency rounded to the cent, so anything
+      // smaller is representation noise rather than a modelling disagreement.
+      .filter((entry) => Math.abs(entry.difference) >= 0.01)
+      .map((entry) => ({ projectName: entry.projectName, difference: formatCurrency(entry.difference) }))
+  );
+
+  /** Only the categories actually present, so an organization with no events gets no dead legend entry. */
+  private readonly presentTypes: Signal<OrgLensRoiProjectBarSegment[]> = computed(() => {
+    const byType = new Map<string, OrgLensRoiProjectBarSegment>();
+    for (const row of this.rows()) {
+      for (const segment of row.segments) {
+        if (segment.expenditure !== 0 && !byType.has(segment.type)) byType.set(segment.type, segment);
+      }
+    }
+    // Canonical order, not first-seen: the stack must read the same way on every project.
+    return ORG_LENS_ROI_CONTRIBUTION_TYPES.map((type) => byType.get(type)).filter((segment): segment is OrgLensRoiProjectBarSegment => segment !== undefined);
+  });
+
+  protected readonly chartHeight: Signal<string> = computed(() => `${Math.max(240, this.rows().length * 44 + 80)}px`);
+
+  protected readonly chartSummaryLabel: Signal<string> = computed(
+    () =>
+      `Horizontal bar chart comparing modelled investment, stacked by contribution category, against return for ${this.rows().length} projects. The same figures are listed in the table below.`
+  );
+
+  /** The accessible equivalent of the canvas: the same figures as real text. */
+  protected readonly tableRows: Signal<{ projectId: string; projectName: string; investment: string; return: string }[]> = computed(() =>
+    this.rows().map((row) => ({
+      projectId: row.projectId,
+      projectName: row.projectName,
+      investment: formatCurrency(row.totalExpenditure),
+      return: formatCurrency(row.totalReturn),
+    }))
+  );
+
+  protected readonly chartData: Signal<ChartData<'bar'>> = computed(() => {
+    const rows = this.rows();
+    const categoryDatasets = this.presentTypes().map((category) => ({
+      label: category.label,
+      // Stacked against each other, so each category contributes its own slice of the same bar.
+      stack: 'investment',
+      xAxisID: 'x',
+      backgroundColor: category.color,
+      borderWidth: 0,
+      data: rows.map((row) => row.segments.find((segment) => segment.type === category.type)?.expenditure ?? 0),
+    }));
+
+    return {
+      labels: rows.map((row) => row.projectName),
+      datasets: [
+        ...categoryDatasets,
+        {
+          label: 'Return',
+          // Its own stack, so it sits beside the investment bar rather than on top of it —
+          // return is not another kind of investment.
+          stack: 'return',
+          xAxisID: 'x2',
+          backgroundColor: ORG_LENS_ROI_RETURN_COLOR,
+          borderWidth: 0,
+          data: rows.map((row) => row.totalReturn),
+        },
+      ],
+    };
+  });
+
+  protected readonly chartOptions: Signal<ChartOptions<'bar'>> = computed(() => ({
+    indexAxis: 'y',
+    responsive: true,
+    maintainAspectRatio: false,
+    scales: {
+      // Two value axes, not one, and deliberately not a logarithmic one. Return runs 36-56x
+      // investment, so on a single shared linear axis the investment stack is a sliver and its
+      // categories are invisible — the thing this chart exists to show. A log axis would fix the
+      // range but break the stack: segments are positioned by cumulative total, so under log
+      // scaling a segment's length stops corresponding to its value and the small categories
+      // collapse regardless. Separate linear scales keep each bar internally truthful; the
+      // disclosure below states that the two are not comparable by length.
+      x: {
+        stacked: true,
+        position: 'bottom',
+        beginAtZero: true,
+        title: { display: true, text: 'Investment', font: { size: 11 } },
+        ticks: { callback: (value) => formatCurrency(Number(value)) },
+        grid: { color: lfxColors.gray[200] },
+      },
+      x2: {
+        stacked: true,
+        position: 'top',
+        beginAtZero: true,
+        title: { display: true, text: 'Return', font: { size: 11 } },
+        ticks: { callback: (value) => formatCurrency(Number(value)) },
+        grid: { display: false },
+      },
+      y: { stacked: true, grid: { display: false } },
+    },
+    plugins: {
+      legend: { position: 'bottom', labels: { boxWidth: 12, font: { size: 11 } } },
+      tooltip: {
+        backgroundColor: 'rgba(255, 255, 255, 0.98)',
+        titleColor: lfxColors.gray[900],
+        bodyColor: lfxColors.gray[600],
+        borderColor: lfxColors.gray[200],
+        borderWidth: 1,
+        padding: 10,
+        cornerRadius: 6,
+        callbacks: { label: (ctx) => ` ${ctx.dataset.label}: ${formatCurrency(Number(ctx.parsed.x))}` },
+      },
+    },
+  }));
+
+  private toSegments(project: OrgLensRoiProjectRow): OrgLensRoiProjectBarSegment[] {
+    return project.categories.map((category) => ({
+      type: category.type,
+      label: category.label,
+      expenditure: category.expenditure,
+      color: ORG_LENS_ROI_CATEGORY_COLOR[category.type] ?? lfxColors.gray[400],
+    }));
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.ts
@@ -74,8 +74,19 @@ export class OrgRoiProjectsBarComponent {
         if (segment.expenditure !== 0 && !byType.has(segment.type)) byType.set(segment.type, segment);
       }
     }
-    // Canonical order, not first-seen: the stack must read the same way on every project.
-    return ORG_LENS_ROI_CONTRIBUTION_TYPES.map((type) => byType.get(type)).filter((segment): segment is OrgLensRoiProjectBarSegment => segment !== undefined);
+    // Canonical order first, so the stack reads the same way on every project — then anything the
+    // warehouse sent that this constant does not know about yet, appended rather than dropped.
+    //
+    // Filtering to the known vocabulary would silently understate a project: the BFF deliberately
+    // forwards unrecognised contribution types (a seed can gain a ninth before this constant does),
+    // and `unreconciled` sums the payload's own segments, so a dropped category would leave the
+    // chart short of its project's investment with nothing to say so.
+    const known = new Set<string>(ORG_LENS_ROI_CONTRIBUTION_TYPES);
+    const canonical = ORG_LENS_ROI_CONTRIBUTION_TYPES.map((type) => byType.get(type)).filter(
+      (segment): segment is OrgLensRoiProjectBarSegment => segment !== undefined
+    );
+    const unknown = [...byType.values()].filter((segment) => !known.has(segment.type));
+    return [...canonical, ...unknown];
   });
 
   protected readonly chartHeight: Signal<string> = computed(() => `${Math.max(240, this.rows().length * 44 + 80)}px`);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bar/org-roi-projects-bar.component.ts
@@ -85,14 +85,31 @@ export class OrgRoiProjectsBarComponent {
       `Horizontal bar chart comparing modelled investment, stacked by contribution category, against return for ${this.rows().length} projects. The same figures are listed in the table below.`
   );
 
-  /** The accessible equivalent of the canvas: the same figures as real text. */
-  protected readonly tableRows: Signal<{ projectId: string; projectName: string; investment: string; return: string }[]> = computed(() =>
-    this.rows().map((row) => ({
-      projectId: row.projectId,
-      projectName: row.projectName,
-      investment: formatCurrency(row.totalExpenditure),
-      return: formatCurrency(row.totalReturn),
-    }))
+  /** Column headings for the accessible table: one per category actually drawn, in stack order. */
+  protected readonly categoryColumns: Signal<{ type: string; label: string }[]> = computed(() =>
+    this.presentTypes().map((category) => ({ type: category.type, label: category.label }))
+  );
+
+  /**
+   * The accessible equivalent of the canvas.
+   *
+   * Carries a cell per contribution category, not just the totals. The stack composition *is* what
+   * this chart shows — a text alternative giving only investment and return would describe a
+   * different, simpler chart, and leave a screen-reader user unable to read the one on the page.
+   */
+  protected readonly tableRows: Signal<{ projectId: string; projectName: string; investment: string; return: string; categories: string[] }[]> = computed(
+    () => {
+      const columns = this.presentTypes();
+      return this.rows().map((row) => ({
+        projectId: row.projectId,
+        projectName: row.projectName,
+        investment: formatCurrency(row.totalExpenditure),
+        return: formatCurrency(row.totalReturn),
+        // Absent categories render as a zero rather than a blank, so every row has the same shape
+        // and a missing category is stated rather than left to be inferred from an empty cell.
+        categories: columns.map((column) => formatCurrency(row.segments.find((segment) => segment.type === column.type)?.expenditure ?? 0)),
+      }));
+    }
   );
 
   protected readonly chartData: Signal<ChartData<'bar'>> = computed(() => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.html
@@ -19,18 +19,21 @@
       <lfx-chart type="bubble" [data]="chartData()" [options]="chartOptions()" height="100%" />
     </div>
 
+    <!-- Describes the encoding actually rendered. An earlier version pointed at a break-even
+         diagonal that is never drawn — and could not be, since the axes are scaled independently,
+         so the corner-to-corner line is not y = x. -->
     <p class="text-xs text-gray-500" data-testid="org-roi-projects-bubble-scale-note">
       Both axes are logarithmic: return spans several orders of magnitude across a portfolio, and on a linear scale every project but the largest would sit in
-      the corner. Each bubble's area is proportional to its net return, and an amber bubble lost money. Projects further above the diagonal returned more per
-      dollar invested.
+      the corner. Bubbles are sized by how large a project's net return is, and an amber bubble lost money. The further a project sits towards the top-left, the
+      more it returned per dollar invested.
     </p>
 
-    @if (flooredNames().length > 0) {
+    @if (hasFlooredPoints()) {
       <p class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600" data-testid="org-roi-projects-bubble-floored-note">
         <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
         <span
-          >A logarithmic axis has no zero, so these projects are drawn at the edge rather than at their true position: {{ flooredNames().join(', ') }}. Their
-          figures in the table below are exact.</span
+          >A logarithmic axis has no zero, so these projects are drawn at the edge rather than at their true position: {{ flooredLabel() }}. Their figures in
+          the table below are exact.</span
         >
       </p>
     }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.html
@@ -1,0 +1,66 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="org-roi-projects-bubble">
+  @if (!hasPoints()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-bubble-empty">
+      <i class="fa-light fa-chart-scatter text-gray-400" aria-hidden="true"></i>
+      <span>Select at least one project to plot its efficiency.</span>
+    </div>
+  } @else {
+    @if (hiddenCount() > 0) {
+      <p class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600" data-testid="org-roi-projects-bubble-truncation-note">
+        <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span>Showing the first {{ maxPoints }} of the selected projects. {{ hiddenCount() }} more are selected but not plotted.</span>
+      </p>
+    }
+
+    <div class="h-[420px] w-full" role="img" [attr.aria-label]="chartSummaryLabel()" data-testid="org-roi-projects-bubble-chart">
+      <lfx-chart type="bubble" [data]="chartData()" [options]="chartOptions()" height="100%" />
+    </div>
+
+    <p class="text-xs text-gray-500" data-testid="org-roi-projects-bubble-scale-note">
+      Both axes are logarithmic: return spans several orders of magnitude across a portfolio, and on a linear scale every project but the largest would sit in
+      the corner. Each bubble's area is proportional to its net return, and an amber bubble lost money. Projects further above the diagonal returned more per
+      dollar invested.
+    </p>
+
+    @if (flooredNames().length > 0) {
+      <p class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600" data-testid="org-roi-projects-bubble-floored-note">
+        <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span
+          >A logarithmic axis has no zero, so these projects are drawn at the edge rather than at their true position: {{ flooredNames().join(', ') }}. Their
+          figures in the table below are exact.</span
+        >
+      </p>
+    }
+
+    <!-- The canvas is otherwise the only presentation of these values, and it plots floored
+         coordinates — so this table carries the true figures rather than the plotted ones. -->
+    <table class="sr-only" data-testid="org-roi-projects-bubble-table">
+      <caption>
+        Investment, return and ROI by project
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">Project</th>
+          <th scope="col">Investment</th>
+          <th scope="col">Return</th>
+          <th scope="col">ROI</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (row of tableRows(); track row.projectId) {
+          <tr>
+            <th scope="row">{{ row.projectName }}</th>
+            <td>{{ row.investment }}</td>
+            <td>{{ row.return }}</td>
+            <td>{{ row.roi }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    <p class="text-xs text-gray-500" data-testid="org-roi-projects-bubble-modelled-cost-note">{{ investmentExplanation }}</p>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.ts
@@ -1,0 +1,158 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal } from '@angular/core';
+import { ChartComponent } from '@components/chart/chart.component';
+import {
+  lfxColors,
+  ORG_LENS_ROI_BUBBLE_FILL,
+  ORG_LENS_ROI_BUBBLE_LOG_FLOOR,
+  ORG_LENS_ROI_KPI_EXPLANATION,
+  ORG_LENS_ROI_NO_VALUE,
+  ORG_LENS_ROI_PROJECT_BUBBLE_MAX_POINTS,
+  ORG_LENS_ROI_RETURN_COLOR,
+} from '@lfx-one/shared/constants';
+import type { OrgLensRoiProjectBubblePoint, OrgLensRoiProjectRow } from '@lfx-one/shared/interfaces';
+import { formatCurrency, formatPercent } from '@lfx-one/shared/utils';
+import type { ChartData, ChartOptions } from 'chart.js';
+
+/** Investment against return on logarithmic axes, so the efficient outliers stay visible. */
+@Component({
+  selector: 'lfx-org-roi-projects-bubble',
+  imports: [ChartComponent],
+  templateUrl: './org-roi-projects-bubble.component.html',
+})
+export class OrgRoiProjectsBubbleComponent {
+  /** The selected projects, in the order the picker ranked them. */
+  public readonly projects = input.required<OrgLensRoiProjectRow[]>();
+
+  /** The same wording the KPI band uses. The x axis is investment, so this view owes the disclosure. */
+  protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
+
+  protected readonly maxPoints = ORG_LENS_ROI_PROJECT_BUBBLE_MAX_POINTS;
+
+  protected readonly hiddenCount: Signal<number> = computed(() => Math.max(0, this.projects().length - this.maxPoints));
+
+  private readonly drawnProjects: Signal<OrgLensRoiProjectRow[]> = computed(() => this.projects().slice(0, this.maxPoints));
+
+  /** The largest net return in the selection, which every bubble's radius is scaled against. */
+  private readonly maxProfitMagnitude: Signal<number> = computed(() =>
+    this.drawnProjects().reduce((largest, project) => Math.max(largest, Math.abs(project.profit)), 0)
+  );
+
+  protected readonly points: Signal<OrgLensRoiProjectBubblePoint[]> = computed(() => {
+    const largest = this.maxProfitMagnitude();
+    return this.drawnProjects().map((project) => {
+      const x = Math.max(project.totalExpenditure, ORG_LENS_ROI_BUBBLE_LOG_FLOOR);
+      const y = Math.max(project.totalReturn, ORG_LENS_ROI_BUBBLE_LOG_FLOOR);
+      // Square root, so a bubble's *area* is proportional to its net return. Scaling the radius
+      // directly would overstate the largest by the square of its lead.
+      const share = largest > 0 ? Math.sqrt(Math.abs(project.profit) / largest) : 0;
+      return {
+        projectId: project.projectId,
+        projectName: project.projectName,
+        x,
+        y,
+        r: 4 + share * 18,
+        // A logarithmic axis has no zero, so a project with no investment or no return cannot be
+        // placed truthfully. It is lifted to the floor and said so, rather than dropped — dropping
+        // it would make an unmeasured project indistinguishable from one that does not exist.
+        isFloored: project.totalExpenditure < ORG_LENS_ROI_BUBBLE_LOG_FLOOR || project.totalReturn < ORG_LENS_ROI_BUBBLE_LOG_FLOOR,
+      };
+    });
+  });
+
+  protected readonly hasPoints: Signal<boolean> = computed(() => this.points().length > 0);
+
+  protected readonly flooredNames: Signal<string[]> = computed(() =>
+    this.points()
+      .filter((point) => point.isFloored)
+      .map((point) => point.projectName)
+  );
+
+  protected readonly chartSummaryLabel: Signal<string> = computed(
+    () =>
+      `Bubble chart of ${this.points().length} projects, plotting modelled investment against modelled return on logarithmic axes, with each bubble sized by net return. The same figures are listed below.`
+  );
+
+  /** The accessible equivalent of the canvas, carrying the true unfloored figures. */
+  protected readonly tableRows: Signal<{ projectId: string; projectName: string; investment: string; return: string; roi: string }[]> = computed(() =>
+    this.drawnProjects().map((project) => ({
+      projectId: project.projectId,
+      projectName: project.projectName,
+      investment: formatCurrency(project.totalExpenditure),
+      return: formatCurrency(project.totalReturn),
+      // Read from the payload, never re-derived, and blank rather than zero when undefined.
+      roi: typeof project.roi === 'number' && Number.isFinite(project.roi) ? `${formatPercent(project.roi * 100)}%` : ORG_LENS_ROI_NO_VALUE,
+    }))
+  );
+
+  protected readonly chartData: Signal<ChartData<'bubble'>> = computed(() => {
+    const projects = this.drawnProjects();
+    return {
+      datasets: [
+        {
+          label: 'Projects',
+          data: this.points().map((point) => ({ x: point.x, y: point.y, r: point.r })),
+          // Loss-making projects are a mainline case here, not an anomaly, so they are coloured
+          // apart rather than left to be inferred from position.
+          backgroundColor: projects.map((project) => (project.profit < 0 ? ORG_LENS_ROI_BUBBLE_FILL.lossMaking : ORG_LENS_ROI_BUBBLE_FILL.profitable)),
+          borderColor: projects.map((project) => (project.profit < 0 ? lfxColors.amber[500] : ORG_LENS_ROI_RETURN_COLOR)),
+          borderWidth: 1,
+        },
+      ],
+    };
+  });
+
+  protected readonly chartOptions: Signal<ChartOptions<'bubble'>> = computed(() => {
+    const points = this.points();
+    const projects = this.drawnProjects();
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      scales: {
+        // Logarithmic on both axes. Portfolio ROI runs in the thousands of percent, so return spans
+        // four orders of magnitude across a portfolio and a linear axis presses every project
+        // except the largest into the corner — which is precisely where the efficient
+        // low-investment, high-return projects this view exists to find would be hidden.
+        x: {
+          type: 'logarithmic',
+          title: { display: true, text: 'Investment', font: { size: 11 } },
+          ticks: { callback: (value) => formatCurrency(Number(value)) },
+          grid: { color: lfxColors.gray[200] },
+        },
+        y: {
+          type: 'logarithmic',
+          title: { display: true, text: 'Return', font: { size: 11 } },
+          ticks: { callback: (value) => formatCurrency(Number(value)) },
+          grid: { color: lfxColors.gray[200] },
+        },
+      },
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(255, 255, 255, 0.98)',
+          titleColor: lfxColors.gray[900],
+          bodyColor: lfxColors.gray[600],
+          borderColor: lfxColors.gray[200],
+          borderWidth: 1,
+          padding: 10,
+          cornerRadius: 6,
+          callbacks: {
+            title: (items) => points[items[0]?.dataIndex ?? 0]?.projectName ?? '',
+            // The project's true figures, not the floored coordinates the bubble was placed at.
+            label: (ctx) => {
+              const project = projects[ctx.dataIndex];
+              if (project === undefined) return '';
+              return [
+                ` Investment: ${formatCurrency(project.totalExpenditure)}`,
+                ` Return: ${formatCurrency(project.totalReturn)}`,
+                ` Net return: ${formatCurrency(project.profit)}`,
+              ];
+            },
+          },
+        },
+      },
+    };
+  });
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-bubble/org-roi-projects-bubble.component.ts
@@ -64,11 +64,15 @@ export class OrgRoiProjectsBubbleComponent {
 
   protected readonly hasPoints: Signal<boolean> = computed(() => this.points().length > 0);
 
-  protected readonly flooredNames: Signal<string[]> = computed(() =>
+  private readonly flooredNames: Signal<string[]> = computed(() =>
     this.points()
       .filter((point) => point.isFloored)
       .map((point) => point.projectName)
   );
+
+  protected readonly hasFlooredPoints: Signal<boolean> = computed(() => this.flooredNames().length > 0);
+
+  protected readonly flooredLabel: Signal<string> = computed(() => this.flooredNames().join(', '));
 
   protected readonly chartSummaryLabel: Signal<string> = computed(
     () =>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.html
@@ -22,7 +22,7 @@
   @if (!hasLinks()) {
     <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-sankey-empty">
       <i class="fa-light fa-diagram-project text-gray-400" aria-hidden="true"></i>
-      <span>No {{ measureLabel().toLowerCase() }} flow to draw for the selected projects.</span>
+      <span>No {{ measureLabelLowercase() }} flow to draw for the selected projects.</span>
     </div>
   } @else {
     @if (hiddenCount() > 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.html
@@ -1,0 +1,72 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="org-roi-projects-sankey">
+  <div class="inline-flex self-start rounded-md border border-gray-200 p-0.5" role="group" aria-label="Flow measure">
+    @for (option of measures; track option) {
+      <button
+        type="button"
+        (click)="setMeasure(option)"
+        class="rounded px-3 py-1 text-xs font-medium"
+        [class.bg-blue-50]="option === measure()"
+        [class.text-blue-700]="option === measure()"
+        [class.text-gray-600]="option !== measure()"
+        [class.hover:bg-gray-50]="option !== measure()"
+        [attr.aria-pressed]="option === measure()"
+        [attr.data-testid]="'org-roi-projects-sankey-measure-' + option">
+        {{ measureLabels[option] }}
+      </button>
+    }
+  </div>
+
+  @if (!hasLinks()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-sankey-empty">
+      <i class="fa-light fa-diagram-project text-gray-400" aria-hidden="true"></i>
+      <span>No {{ measureLabel().toLowerCase() }} flow to draw for the selected projects.</span>
+    </div>
+  } @else {
+    @if (hiddenCount() > 0) {
+      <p class="flex items-start gap-2 rounded-md bg-gray-50 px-3 py-2.5 text-xs text-gray-600" data-testid="org-roi-projects-sankey-truncation-note">
+        <i class="fa-light fa-circle-info mt-0.5 text-gray-400" aria-hidden="true"></i>
+        <span
+          >Showing the first {{ maxProjects }} of the selected projects. {{ hiddenCount() }} more are selected but not drawn — a flow diagram crosses every link
+          against every other and stops being readable past that. Use the table to see every project.</span
+        >
+      </p>
+    }
+
+    <div class="w-full" [style.height]="chartHeight()" role="img" [attr.aria-label]="chartSummaryLabel()" data-testid="org-roi-projects-sankey-chart">
+      <lfx-chart type="sankey" [data]="chartData()" [options]="chartOptions()" height="100%" />
+    </div>
+
+    <!-- The canvas is otherwise the only presentation of these flows. -->
+    <table class="sr-only" data-testid="org-roi-projects-sankey-table">
+      <caption>
+        {{
+          measureLabel()
+        }}
+        flows
+      </caption>
+      <thead>
+        <tr>
+          <th scope="col">From</th>
+          <th scope="col">To</th>
+          <th scope="col">Amount</th>
+        </tr>
+      </thead>
+      <tbody>
+        @for (row of flowRows(); track row.key) {
+          <tr>
+            <th scope="row">{{ row.from }}</th>
+            <td>{{ row.to }}</td>
+            <td>{{ row.amount }}</td>
+          </tr>
+        }
+      </tbody>
+    </table>
+
+    @if (showsModelledCost()) {
+      <p class="text-xs text-gray-500" data-testid="org-roi-projects-sankey-modelled-cost-note">{{ investmentExplanation }}</p>
+    }
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
@@ -171,7 +171,11 @@ export class OrgRoiProjectsSankeyComponent {
   private nodeColor(node: string): string {
     if (node === ORG_LENS_ROI_SANKEY_ORG_NODE_KEY) return this.measure() === 'return' ? ORG_LENS_ROI_RETURN_COLOR : lfxColors.blue[600];
     const type = node.startsWith(ORG_LENS_ROI_SANKEY_CATEGORY_NODE_PREFIX) ? node.slice(ORG_LENS_ROI_SANKEY_CATEGORY_NODE_PREFIX.length) : '';
-    return ORG_LENS_ROI_CATEGORY_COLOR[type as OrgLensRoiContributionType] ?? lfxColors.gray[400];
+    // Looked up as a plain string, not asserted to be a known type. The payload can carry a
+    // contribution type this constant does not know yet, which is exactly what the fallback is
+    // for — asserting would suppress the check that keeps the fallback honest.
+    const colorsByType: Record<string, string> = ORG_LENS_ROI_CATEGORY_COLOR;
+    return colorsByType[type] ?? lfxColors.gray[400];
   }
 
   private projectNode(projectId: string): string {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
@@ -11,9 +11,12 @@ import {
   ORG_LENS_ROI_PROJECT_SANKEY_MEASURE_LABELS,
   ORG_LENS_ROI_PROJECT_SANKEY_MEASURES,
   ORG_LENS_ROI_RETURN_COLOR,
+  ORG_LENS_ROI_SANKEY_CATEGORY_NODE_PREFIX,
   ORG_LENS_ROI_SANKEY_ORG_NODE,
+  ORG_LENS_ROI_SANKEY_ORG_NODE_KEY,
+  ORG_LENS_ROI_SANKEY_PROJECT_NODE_PREFIX,
 } from '@lfx-one/shared/constants';
-import type { OrgLensRoiProjectFlowLink, OrgLensRoiProjectRow, OrgLensRoiProjectSankeyMeasure } from '@lfx-one/shared/interfaces';
+import type { OrgLensRoiContributionType, OrgLensRoiProjectFlowLink, OrgLensRoiProjectRow, OrgLensRoiProjectSankeyMeasure } from '@lfx-one/shared/interfaces';
 import { formatCurrency } from '@lfx-one/shared/utils';
 
 /** Where the money goes and where it comes back from, as a flow diagram. */
@@ -56,7 +59,7 @@ export class OrgRoiProjectsSankeyComponent {
     if (this.measure() === 'return') {
       return projects
         .filter((project) => project.totalReturn > 0)
-        .map((project) => ({ from: project.projectName, to: ORG_LENS_ROI_SANKEY_ORG_NODE, flow: project.totalReturn }));
+        .map((project) => ({ from: this.projectNode(project.projectId), to: ORG_LENS_ROI_SANKEY_ORG_NODE_KEY, flow: project.totalReturn }));
     }
 
     const categoryTotals = new Map<string, number>();
@@ -64,34 +67,38 @@ export class OrgRoiProjectsSankeyComponent {
     for (const project of projects) {
       for (const category of project.categories) {
         if (category.expenditure <= 0) continue;
-        categoryTotals.set(category.label, (categoryTotals.get(category.label) ?? 0) + category.expenditure);
-        categoryToProject.push({ from: category.label, to: project.projectName, flow: category.expenditure });
+        const node = this.categoryNode(category.type);
+        categoryTotals.set(node, (categoryTotals.get(node) ?? 0) + category.expenditure);
+        categoryToProject.push({ from: node, to: this.projectNode(project.projectId), flow: category.expenditure });
       }
     }
 
-    const orgToCategory = [...categoryTotals.entries()].map(([label, flow]) => ({ from: ORG_LENS_ROI_SANKEY_ORG_NODE, to: label, flow }));
+    const orgToCategory = [...categoryTotals.entries()].map(([node, flow]) => ({ from: ORG_LENS_ROI_SANKEY_ORG_NODE_KEY, to: node, flow }));
     return [...orgToCategory, ...categoryToProject];
+  });
+
+  /**
+   * Node keys are type-prefixed ids, not display names, and the labels below map them back for
+   * rendering. Sankey identifies a node by its key, so keying on the name merged two projects that
+   * happen to share one — and worse, a project named after a contribution category, or "Your
+   * organization", would have joined that node and produced a cycle.
+   */
+  protected readonly nodeLabels: Signal<Record<string, string>> = computed(() => {
+    const labels: Record<string, string> = { [ORG_LENS_ROI_SANKEY_ORG_NODE_KEY]: ORG_LENS_ROI_SANKEY_ORG_NODE };
+    for (const project of this.drawnProjects()) {
+      labels[this.projectNode(project.projectId)] = project.projectName;
+      for (const category of project.categories) {
+        labels[this.categoryNode(category.type)] = category.label;
+      }
+    }
+    return labels;
   });
 
   protected readonly hasLinks: Signal<boolean> = computed(() => this.links().length > 0);
 
-  /**
-   * Sankey identifies a node by its label, so the colour has to be looked up by the category's
-   * display label rather than its type code. The mapping comes from the payload, which carries
-   * both on every category row.
-   */
-  private readonly categoryColorByLabel: Signal<Map<string, string>> = computed(() => {
-    const byLabel = new Map<string, string>();
-    for (const project of this.drawnProjects()) {
-      for (const category of project.categories) {
-        const color = ORG_LENS_ROI_CATEGORY_COLOR[category.type];
-        if (color !== undefined) byLabel.set(category.label, color);
-      }
-    }
-    return byLabel;
-  });
-
   protected readonly measureLabel: Signal<string> = computed(() => this.measureLabels[this.measure()]);
+
+  protected readonly measureLabelLowercase: Signal<string> = computed(() => this.measureLabel().toLowerCase());
 
   protected readonly chartHeight: Signal<string> = computed(() => `${Math.max(280, this.drawnProjects().length * 46 + 120)}px`);
 
@@ -102,17 +109,16 @@ export class OrgRoiProjectsSankeyComponent {
     return `Flow diagram of modelled investment from your organization, through contribution categories, out to ${this.drawnProjects().length} projects. The same figures are listed below.`;
   });
 
-  /**
-   * The accessible equivalent of the canvas: every flow as real text.
-   *
-   * Keyed by position rather than by endpoint labels. Two projects can share a display name, which
-   * would give two distinct flows the same key and leave the rendered list one row short of the
-   * chart. (The chart itself still merges them — sankey identifies a node by its label — but that
-   * is the library's constraint, not one to reproduce here.)
-   */
-  protected readonly flowRows: Signal<{ key: string; from: string; to: string; amount: string }[]> = computed(() =>
-    this.links().map((link, index) => ({ key: `${index}|${link.from}|${link.to}`, from: link.from, to: link.to, amount: formatCurrency(link.flow) }))
-  );
+  /** The accessible equivalent of the canvas: every flow as real text, with nodes resolved to names. */
+  protected readonly flowRows: Signal<{ key: string; from: string; to: string; amount: string }[]> = computed(() => {
+    const labels = this.nodeLabels();
+    return this.links().map((link, index) => ({
+      key: `${index}|${link.from}|${link.to}`,
+      from: labels[link.from] ?? link.from,
+      to: labels[link.to] ?? link.to,
+      amount: formatCurrency(link.flow),
+    }));
+  });
 
   protected readonly chartData: Signal<unknown> = computed(() => ({
     datasets: [
@@ -123,6 +129,8 @@ export class OrgRoiProjectsSankeyComponent {
         colorTo: (context: { raw?: OrgLensRoiProjectFlowLink }) => this.nodeColor(context.raw?.to ?? ''),
         colorMode: 'gradient',
         borderWidth: 0,
+        // Maps the type-prefixed node keys back to the names a viewer reads.
+        labels: this.nodeLabels(),
         // Node heights are driven by the larger of a node's inbound and outbound totals, so a
         // category that feeds several projects is not drawn smaller than the flows leaving it.
         size: 'max',
@@ -130,26 +138,30 @@ export class OrgRoiProjectsSankeyComponent {
     ],
   }));
 
-  protected readonly chartOptions: Signal<unknown> = computed(() => ({
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: { display: false },
-      tooltip: {
-        backgroundColor: 'rgba(255, 255, 255, 0.98)',
-        titleColor: lfxColors.gray[900],
-        bodyColor: lfxColors.gray[600],
-        borderColor: lfxColors.gray[200],
-        borderWidth: 1,
-        padding: 10,
-        cornerRadius: 6,
-        callbacks: {
-          label: (ctx: { raw?: OrgLensRoiProjectFlowLink }) =>
-            ctx.raw === undefined ? '' : ` ${ctx.raw.from} → ${ctx.raw.to}: ${formatCurrency(ctx.raw.flow)}`,
+  protected readonly chartOptions: Signal<unknown> = computed(() => {
+    const labels = this.nodeLabels();
+    return {
+      responsive: true,
+      maintainAspectRatio: false,
+      plugins: {
+        legend: { display: false },
+        tooltip: {
+          backgroundColor: 'rgba(255, 255, 255, 0.98)',
+          titleColor: lfxColors.gray[900],
+          bodyColor: lfxColors.gray[600],
+          borderColor: lfxColors.gray[200],
+          borderWidth: 1,
+          padding: 10,
+          cornerRadius: 6,
+          callbacks: {
+            // Resolves the node keys to names, so the tooltip never shows `project:<id>`.
+            label: (ctx: { raw?: OrgLensRoiProjectFlowLink }) =>
+              ctx.raw === undefined ? '' : ` ${labels[ctx.raw.from] ?? ctx.raw.from} → ${labels[ctx.raw.to] ?? ctx.raw.to}: ${formatCurrency(ctx.raw.flow)}`,
+          },
         },
       },
-    },
-  }));
+    };
+  });
 
   public setMeasure(measure: OrgLensRoiProjectSankeyMeasure): void {
     this.measure.set(measure);
@@ -157,7 +169,16 @@ export class OrgRoiProjectsSankeyComponent {
 
   /** Categories keep the colour they carry on the comparison view; project nodes stay neutral. */
   private nodeColor(node: string): string {
-    if (node === ORG_LENS_ROI_SANKEY_ORG_NODE) return this.measure() === 'return' ? ORG_LENS_ROI_RETURN_COLOR : lfxColors.blue[600];
-    return this.categoryColorByLabel().get(node) ?? lfxColors.gray[400];
+    if (node === ORG_LENS_ROI_SANKEY_ORG_NODE_KEY) return this.measure() === 'return' ? ORG_LENS_ROI_RETURN_COLOR : lfxColors.blue[600];
+    const type = node.startsWith(ORG_LENS_ROI_SANKEY_CATEGORY_NODE_PREFIX) ? node.slice(ORG_LENS_ROI_SANKEY_CATEGORY_NODE_PREFIX.length) : '';
+    return ORG_LENS_ROI_CATEGORY_COLOR[type as OrgLensRoiContributionType] ?? lfxColors.gray[400];
+  }
+
+  private projectNode(projectId: string): string {
+    return `${ORG_LENS_ROI_SANKEY_PROJECT_NODE_PREFIX}${projectId}`;
+  }
+
+  private categoryNode(type: OrgLensRoiContributionType): string {
+    return `${ORG_LENS_ROI_SANKEY_CATEGORY_NODE_PREFIX}${type}`;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
@@ -1,0 +1,163 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal, signal } from '@angular/core';
+import { ChartComponent } from '@components/chart/chart.component';
+import {
+  lfxColors,
+  ORG_LENS_ROI_CATEGORY_COLOR,
+  ORG_LENS_ROI_KPI_EXPLANATION,
+  ORG_LENS_ROI_PROJECT_SANKEY_MAX_PROJECTS,
+  ORG_LENS_ROI_PROJECT_SANKEY_MEASURE_LABELS,
+  ORG_LENS_ROI_PROJECT_SANKEY_MEASURES,
+  ORG_LENS_ROI_RETURN_COLOR,
+  ORG_LENS_ROI_SANKEY_ORG_NODE,
+} from '@lfx-one/shared/constants';
+import type { OrgLensRoiProjectFlowLink, OrgLensRoiProjectRow, OrgLensRoiProjectSankeyMeasure } from '@lfx-one/shared/interfaces';
+import { formatCurrency } from '@lfx-one/shared/utils';
+
+/** Where the money goes and where it comes back from, as a flow diagram. */
+@Component({
+  selector: 'lfx-org-roi-projects-sankey',
+  imports: [ChartComponent],
+  templateUrl: './org-roi-projects-sankey.component.html',
+})
+export class OrgRoiProjectsSankeyComponent {
+  /** The selected projects, in the order the picker ranked them. */
+  public readonly projects = input.required<OrgLensRoiProjectRow[]>();
+
+  protected readonly measures = ORG_LENS_ROI_PROJECT_SANKEY_MEASURES;
+  protected readonly measureLabels = ORG_LENS_ROI_PROJECT_SANKEY_MEASURE_LABELS;
+  protected readonly maxProjects = ORG_LENS_ROI_PROJECT_SANKEY_MAX_PROJECTS;
+
+  /** The same wording the KPI band uses, carried only by the flow that is a modelled cost. */
+  protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
+
+  protected readonly measure = signal<OrgLensRoiProjectSankeyMeasure>('investment');
+
+  protected readonly showsModelledCost: Signal<boolean> = computed(() => this.measure() === 'investment');
+
+  protected readonly hiddenCount: Signal<number> = computed(() => Math.max(0, this.projects().length - this.maxProjects));
+
+  private readonly drawnProjects: Signal<OrgLensRoiProjectRow[]> = computed(() => this.projects().slice(0, this.maxProjects));
+
+  /**
+   * Investment fans out through its contribution categories; return comes straight back.
+   *
+   * The asymmetry is the data's, not a presentational choice: investment is decomposed by category
+   * in the warehouse and return is not, so an intermediate node on the return side would be
+   * invented rather than reported.
+   *
+   * A zero flow is dropped. A sankey link of zero width is not drawn but still contributes a node,
+   * leaving a labelled stub attached to nothing.
+   */
+  protected readonly links: Signal<OrgLensRoiProjectFlowLink[]> = computed(() => {
+    const projects = this.drawnProjects();
+    if (this.measure() === 'return') {
+      return projects
+        .filter((project) => project.totalReturn > 0)
+        .map((project) => ({ from: project.projectName, to: ORG_LENS_ROI_SANKEY_ORG_NODE, flow: project.totalReturn }));
+    }
+
+    const categoryTotals = new Map<string, number>();
+    const categoryToProject: OrgLensRoiProjectFlowLink[] = [];
+    for (const project of projects) {
+      for (const category of project.categories) {
+        if (category.expenditure <= 0) continue;
+        categoryTotals.set(category.label, (categoryTotals.get(category.label) ?? 0) + category.expenditure);
+        categoryToProject.push({ from: category.label, to: project.projectName, flow: category.expenditure });
+      }
+    }
+
+    const orgToCategory = [...categoryTotals.entries()].map(([label, flow]) => ({ from: ORG_LENS_ROI_SANKEY_ORG_NODE, to: label, flow }));
+    return [...orgToCategory, ...categoryToProject];
+  });
+
+  protected readonly hasLinks: Signal<boolean> = computed(() => this.links().length > 0);
+
+  /**
+   * Sankey identifies a node by its label, so the colour has to be looked up by the category's
+   * display label rather than its type code. The mapping comes from the payload, which carries
+   * both on every category row.
+   */
+  private readonly categoryColorByLabel: Signal<Map<string, string>> = computed(() => {
+    const byLabel = new Map<string, string>();
+    for (const project of this.drawnProjects()) {
+      for (const category of project.categories) {
+        const color = ORG_LENS_ROI_CATEGORY_COLOR[category.type];
+        if (color !== undefined) byLabel.set(category.label, color);
+      }
+    }
+    return byLabel;
+  });
+
+  protected readonly measureLabel: Signal<string> = computed(() => this.measureLabels[this.measure()]);
+
+  protected readonly chartHeight: Signal<string> = computed(() => `${Math.max(280, this.drawnProjects().length * 46 + 120)}px`);
+
+  protected readonly chartSummaryLabel: Signal<string> = computed(() => {
+    if (this.measure() === 'return') {
+      return `Flow diagram of modelled return from ${this.drawnProjects().length} projects back to your organization. The same figures are listed below.`;
+    }
+    return `Flow diagram of modelled investment from your organization, through contribution categories, out to ${this.drawnProjects().length} projects. The same figures are listed below.`;
+  });
+
+  /**
+   * The accessible equivalent of the canvas: every flow as real text.
+   *
+   * Keyed by position rather than by endpoint labels. Two projects can share a display name, which
+   * would give two distinct flows the same key and leave the rendered list one row short of the
+   * chart. (The chart itself still merges them — sankey identifies a node by its label — but that
+   * is the library's constraint, not one to reproduce here.)
+   */
+  protected readonly flowRows: Signal<{ key: string; from: string; to: string; amount: string }[]> = computed(() =>
+    this.links().map((link, index) => ({ key: `${index}|${link.from}|${link.to}`, from: link.from, to: link.to, amount: formatCurrency(link.flow) }))
+  );
+
+  protected readonly chartData: Signal<unknown> = computed(() => ({
+    datasets: [
+      {
+        label: this.measureLabel(),
+        data: this.links(),
+        colorFrom: (context: { raw?: OrgLensRoiProjectFlowLink }) => this.nodeColor(context.raw?.from ?? ''),
+        colorTo: (context: { raw?: OrgLensRoiProjectFlowLink }) => this.nodeColor(context.raw?.to ?? ''),
+        colorMode: 'gradient',
+        borderWidth: 0,
+        // Node heights are driven by the larger of a node's inbound and outbound totals, so a
+        // category that feeds several projects is not drawn smaller than the flows leaving it.
+        size: 'max',
+      },
+    ],
+  }));
+
+  protected readonly chartOptions: Signal<unknown> = computed(() => ({
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: 'rgba(255, 255, 255, 0.98)',
+        titleColor: lfxColors.gray[900],
+        bodyColor: lfxColors.gray[600],
+        borderColor: lfxColors.gray[200],
+        borderWidth: 1,
+        padding: 10,
+        cornerRadius: 6,
+        callbacks: {
+          label: (ctx: { raw?: OrgLensRoiProjectFlowLink }) =>
+            ctx.raw === undefined ? '' : ` ${ctx.raw.from} → ${ctx.raw.to}: ${formatCurrency(ctx.raw.flow)}`,
+        },
+      },
+    },
+  }));
+
+  public setMeasure(measure: OrgLensRoiProjectSankeyMeasure): void {
+    this.measure.set(measure);
+  }
+
+  /** Categories keep the colour they carry on the comparison view; project nodes stay neutral. */
+  private nodeColor(node: string): string {
+    if (node === ORG_LENS_ROI_SANKEY_ORG_NODE) return this.measure() === 'return' ? ORG_LENS_ROI_RETURN_COLOR : lfxColors.blue[600];
+    return this.categoryColorByLabel().get(node) ?? lfxColors.gray[400];
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-sankey/org-roi-projects-sankey.component.ts
@@ -16,7 +16,14 @@ import {
   ORG_LENS_ROI_SANKEY_ORG_NODE_KEY,
   ORG_LENS_ROI_SANKEY_PROJECT_NODE_PREFIX,
 } from '@lfx-one/shared/constants';
-import type { OrgLensRoiContributionType, OrgLensRoiProjectFlowLink, OrgLensRoiProjectRow, OrgLensRoiProjectSankeyMeasure } from '@lfx-one/shared/interfaces';
+import type {
+  OrgLensRoiContributionType,
+  OrgLensRoiProjectFlowLink,
+  OrgLensRoiProjectRow,
+  OrgLensRoiProjectSankeyMeasure,
+  OrgLensRoiSankeyChartData,
+  OrgLensRoiSankeyColorContext,
+} from '@lfx-one/shared/interfaces';
 import { formatCurrency } from '@lfx-one/shared/utils';
 
 /** Where the money goes and where it comes back from, as a flow diagram. */
@@ -120,13 +127,13 @@ export class OrgRoiProjectsSankeyComponent {
     }));
   });
 
-  protected readonly chartData: Signal<unknown> = computed(() => ({
+  protected readonly chartData: Signal<OrgLensRoiSankeyChartData> = computed(() => ({
     datasets: [
       {
         label: this.measureLabel(),
         data: this.links(),
-        colorFrom: (context: { raw?: OrgLensRoiProjectFlowLink }) => this.nodeColor(context.raw?.from ?? ''),
-        colorTo: (context: { raw?: OrgLensRoiProjectFlowLink }) => this.nodeColor(context.raw?.to ?? ''),
+        colorFrom: (context: OrgLensRoiSankeyColorContext) => this.nodeColor(context.raw?.from ?? ''),
+        colorTo: (context: OrgLensRoiSankeyColorContext) => this.nodeColor(context.raw?.to ?? ''),
         colorMode: 'gradient',
         borderWidth: 0,
         // Maps the type-prefixed node keys back to the names a viewer reads.
@@ -155,7 +162,7 @@ export class OrgRoiProjectsSankeyComponent {
           cornerRadius: 6,
           callbacks: {
             // Resolves the node keys to names, so the tooltip never shows `project:<id>`.
-            label: (ctx: { raw?: OrgLensRoiProjectFlowLink }) =>
+            label: (ctx: OrgLensRoiSankeyColorContext) =>
               ctx.raw === undefined ? '' : ` ${labels[ctx.raw.from] ?? ctx.raw.from} → ${labels[ctx.raw.to] ?? ctx.raw.to}: ${formatCurrency(ctx.raw.flow)}`,
           },
         },

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-section/org-roi-projects-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-section/org-roi-projects-section.component.html
@@ -1,0 +1,69 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<section class="flex flex-col gap-4 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-roi-projects-section">
+  <div class="flex flex-col gap-3">
+    <h2 class="text-base font-semibold text-gray-900">Projects</h2>
+
+    <!-- A button group, not `role="tablist"`. The full tab pattern also requires a matching
+         `tabpanel`, `aria-controls` pairing and roving-tabindex arrow-key navigation; declaring
+         the role without them announces "tab 1 of 4" and then leads a screen reader to no panel.
+         This is the same idiom the measure toggles on the sibling charts use. -->
+    <div class="inline-flex flex-wrap gap-0.5 self-start rounded-md border border-gray-200 p-0.5" role="group" aria-label="Project view">
+      @for (option of views; track option) {
+        <button
+          type="button"
+          (click)="setView(option)"
+          class="rounded px-3 py-1 text-xs font-medium"
+          [class.bg-blue-50]="option === view()"
+          [class.text-blue-700]="option === view()"
+          [class.text-gray-600]="option !== view()"
+          [class.hover:bg-gray-50]="option !== view()"
+          [attr.aria-pressed]="option === view()"
+          [attr.data-testid]="'org-roi-projects-section-tab-' + option">
+          {{ viewLabels[option] }}
+        </button>
+      }
+    </div>
+  </div>
+
+  @if (loading()) {
+    <div class="flex flex-col gap-2" data-testid="org-roi-projects-section-loading">
+      <p-skeleton width="100%" height="360px" />
+    </div>
+  } @else if (forbidden()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-section-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (failed()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-section-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>The projects breakdown couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (!hasRows()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-section-empty">
+      <i class="fa-light fa-folder-open text-gray-400" aria-hidden="true"></i>
+      <span>No projects are available for this organization.</span>
+    </div>
+  } @else {
+    @if (showsPicker()) {
+      <lfx-org-roi-project-picker [options]="options()" [selectedIds]="selectedIds()" (selectionChange)="setSelection($event)" />
+    }
+
+    @switch (view()) {
+      @case ('bar') {
+        <lfx-org-roi-projects-bar [projects]="selectedProjects()" />
+      }
+      @case ('sankey') {
+        <lfx-org-roi-projects-sankey [projects]="selectedProjects()" />
+      }
+      @case ('bubble') {
+        <lfx-org-roi-projects-bubble [projects]="selectedProjects()" />
+      }
+      @case ('table') {
+        <lfx-org-roi-projects-table [projects]="projectRows()" />
+      }
+    }
+  }
+</section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-section/org-roi-projects-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-section/org-roi-projects-section.component.ts
@@ -1,0 +1,155 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, linkedSignal, Signal, signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import {
+  ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT,
+  ORG_LENS_ROI_PROJECT_SELECTION_VIEWS,
+  ORG_LENS_ROI_PROJECT_VIEW_LABELS,
+  ORG_LENS_ROI_PROJECT_VIEWS,
+} from '@lfx-one/shared/constants';
+import type { OrgLensRoiMethod, OrgLensRoiProjectOption, OrgLensRoiProjectRow, OrgLensRoiProjectView } from '@lfx-one/shared/interfaces';
+import { formatCurrency } from '@lfx-one/shared/utils';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensRoiService } from '@services/org-lens-roi.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+
+import { OrgRoiProjectPickerComponent } from '../org-roi-project-picker/org-roi-project-picker.component';
+import { OrgRoiProjectsBarComponent } from '../org-roi-projects-bar/org-roi-projects-bar.component';
+import { OrgRoiProjectsBubbleComponent } from '../org-roi-projects-bubble/org-roi-projects-bubble.component';
+import { OrgRoiProjectsSankeyComponent } from '../org-roi-projects-sankey/org-roi-projects-sankey.component';
+import { OrgRoiProjectsTableComponent } from '../org-roi-projects-table/org-roi-projects-table.component';
+
+/** Four complementary views of the same project set, over one shared selection. */
+@Component({
+  selector: 'lfx-org-roi-projects-section',
+  imports: [
+    OrgRoiProjectPickerComponent,
+    OrgRoiProjectsBarComponent,
+    OrgRoiProjectsSankeyComponent,
+    OrgRoiProjectsBubbleComponent,
+    OrgRoiProjectsTableComponent,
+    SkeletonModule,
+  ],
+  templateUrl: './org-roi-projects-section.component.html',
+})
+export class OrgRoiProjectsSectionComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly roiService = inject(OrgLensRoiService);
+
+  public readonly method = input.required<OrgLensRoiMethod>();
+
+  protected readonly views = ORG_LENS_ROI_PROJECT_VIEWS;
+  protected readonly viewLabels = ORG_LENS_ROI_PROJECT_VIEW_LABELS;
+
+  protected readonly view = signal<OrgLensRoiProjectView>('bar');
+
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  protected readonly forbidden = signal(false);
+
+  /**
+   * The rows alone, not the whole response — nothing here reads the envelope's `method`, and
+   * holding it would mean inventing one for the pre-fetch sentinel.
+   */
+  protected readonly projectRows: Signal<OrgLensRoiProjectRow[]> = this.initProjectRows();
+
+  protected readonly hasRows: Signal<boolean> = computed(() => this.projectRows().length > 0);
+
+  /** Already ranked by return: the payload arrives ordered that way and nothing re-sorts it here. */
+  protected readonly options: Signal<OrgLensRoiProjectOption[]> = computed(() =>
+    this.projectRows().map((row) => ({ projectId: row.projectId, projectName: row.projectName, amount: formatCurrency(row.totalReturn) }))
+  );
+
+  /**
+   * The selection shared by the comparison, flow and efficiency views.
+   *
+   * `null` means the viewer has not chosen, so the default applies; `[]` means they chose nothing.
+   * Keeping those distinct is the whole point of the sentinel — collapsing both to an empty array
+   * made a failed read (which emits zero projects) indistinguishable from pressing None, so after a
+   * retry succeeded the charts stayed blank for the rest of the session.
+   *
+   * The cases, in the order they are tested:
+   *
+   * - **A different organization** — back to unchosen, so that org gets its own default.
+   * - **No options yet** — hold. A read that failed, was refused, or has not landed says nothing
+   *   about what the viewer wants, so it must not overwrite what they picked.
+   * - **Unchosen** — stay unchosen.
+   * - **Deliberately emptied** — stay empty, including across an estimation-method switch.
+   * - **A real selection** — keep whatever still exists. Switching method returns the same projects
+   *   with different figures, and discarding the selection would make the two impossible to
+   *   compare. If none survive, the ids are stale and the default applies.
+   */
+  private readonly selectionOverride = linkedSignal<{ orgUid: string; options: OrgLensRoiProjectOption[] }, string[] | null>({
+    source: computed(() => ({ orgUid: this.accountContext.selectedAccount()?.accountId ?? '', options: this.options() })),
+    computation: ({ orgUid, options }, previous) => {
+      if (previous === undefined || previous.source.orgUid !== orgUid) return null;
+      if (options.length === 0) return previous.value;
+      if (previous.value === null || previous.value.length === 0) return previous.value;
+
+      const available = new Set(options.map((option) => option.projectId));
+      const kept = previous.value.filter((id) => available.has(id));
+      return kept.length > 0 ? kept : null;
+    },
+  });
+
+  /** The default is derived, never stored, so it always reflects the options actually in hand. */
+  protected readonly selectedIds: Signal<string[]> = computed(
+    () =>
+      this.selectionOverride() ??
+      this.options()
+        .slice(0, ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT)
+        .map((option) => option.projectId)
+  );
+
+  /** Selection order follows the ranking, so every view draws the leading projects first. */
+  protected readonly selectedProjects: Signal<OrgLensRoiProjectRow[]> = computed(() => {
+    const selected = new Set(this.selectedIds());
+    return this.projectRows().filter((row) => selected.has(row.projectId));
+  });
+
+  /** The table pages the complete set, so it needs no picker; the other three views do. */
+  protected readonly showsPicker: Signal<boolean> = computed(() => (ORG_LENS_ROI_PROJECT_SELECTION_VIEWS as readonly string[]).includes(this.view()));
+
+  public setView(view: OrgLensRoiProjectView): void {
+    this.view.set(view);
+  }
+
+  public setSelection(projectIds: string[]): void {
+    this.selectionOverride.set(projectIds);
+  }
+
+  private initProjectRows(): Signal<OrgLensRoiProjectRow[]> {
+    // Keyed by string, not the account object: that object is rewritten in place and would retrigger the fetch.
+    const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.method()}`));
+
+    return toSignal(
+      requestKey$.pipe(
+        map((key) => key.split('|') as [string, OrgLensRoiMethod]),
+        filter(([orgUid]) => !!orgUid),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+        }),
+        switchMap(([orgUid, method]) =>
+          this.roiService.getProjects(orgUid, method).pipe(
+            tap(() => this.loading.set(false)),
+            map((projects) => projects.rows),
+            catchError((error: unknown) => {
+              console.error('Failed to load ROI projects section', error);
+              this.loading.set(false);
+              // Only a 403 may show the no-access message; a 503 must not.
+              if ((error as { status?: number })?.status === 403) this.forbidden.set(true);
+              else this.failed.set(true);
+              return of([] as OrgLensRoiProjectRow[]);
+            })
+          )
+        )
+      ),
+      { initialValue: [] as OrgLensRoiProjectRow[] }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-section/org-roi-projects-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-section/org-roi-projects-section.component.ts
@@ -14,7 +14,7 @@ import { formatCurrency } from '@lfx-one/shared/utils';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensRoiService } from '@services/org-lens-roi.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, filter, map, of, switchMap, tap } from 'rxjs';
+import { catchError, distinctUntilChanged, filter, map, of, switchMap, tap } from 'rxjs';
 
 import { OrgRoiProjectPickerComponent } from '../org-roi-project-picker/org-roi-project-picker.component';
 import { OrgRoiProjectsBarComponent } from '../org-roi-projects-bar/org-roi-projects-bar.component';
@@ -122,19 +122,24 @@ export class OrgRoiProjectsSectionComponent {
   }
 
   private initProjectRows(): Signal<OrgLensRoiProjectRow[]> {
-    // Keyed by string, not the account object: that object is rewritten in place and would retrigger the fetch.
-    const requestKey$ = toObservable(computed(() => `${this.accountContext.selectedAccount()?.accountId ?? ''}|${this.method()}`));
+    // A typed pair rather than a delimited string, so nothing has to be parsed back out or cast.
+    //
+    // The dedup the string gave for free has to be restored explicitly: the selected-account object
+    // is rewritten in place, so this recomputes on changes that leave both fields identical, and a
+    // fresh object reference would re-emit and refetch each time.
+    const request$ = toObservable(computed(() => ({ orgUid: this.accountContext.selectedAccount()?.accountId ?? '', method: this.method() }))).pipe(
+      distinctUntilChanged((previous, next) => previous.orgUid === next.orgUid && previous.method === next.method)
+    );
 
     return toSignal(
-      requestKey$.pipe(
-        map((key) => key.split('|') as [string, OrgLensRoiMethod]),
-        filter(([orgUid]) => !!orgUid),
+      request$.pipe(
+        filter(({ orgUid }) => !!orgUid),
         tap(() => {
           this.loading.set(true);
           this.failed.set(false);
           this.forbidden.set(false);
         }),
-        switchMap(([orgUid, method]) =>
+        switchMap(({ orgUid, method }) =>
           this.roiService.getProjects(orgUid, method).pipe(
             tap(() => this.loading.set(false)),
             map((projects) => projects.rows),

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
@@ -8,9 +8,7 @@
       <span>No projects are available for this organization.</span>
     </div>
   } @else {
-    <p class="text-xs text-gray-500" data-testid="org-roi-projects-table-count">
-      {{ totalRecords().toLocaleString('en-US') }} projects. Sorting and paging apply to this visit only.
-    </p>
+    <p class="text-xs text-gray-500" data-testid="org-roi-projects-table-count">{{ countLabel() }}. Sorting and paging apply to this visit only.</p>
 
     <lfx-table
       [value]="rows()"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
@@ -1,0 +1,62 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-3" data-testid="org-roi-projects-table">
+  @if (!hasRows()) {
+    <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-projects-table-empty">
+      <i class="fa-light fa-table text-gray-400" aria-hidden="true"></i>
+      <span>No projects are available for this organization.</span>
+    </div>
+  } @else {
+    <p class="text-xs text-gray-500" data-testid="org-roi-projects-table-count">
+      {{ totalRecords().toLocaleString('en-US') }} projects. Sorting and paging apply to this visit only.
+    </p>
+
+    <lfx-table
+      [value]="rows()"
+      dataKey="projectId"
+      [paginator]="totalRecords() > pageSize()"
+      [rows]="pageSize()"
+      [first]="pageFirst()"
+      [totalRecords]="totalRecords()"
+      [rowsPerPageOptions]="pageSizeOptions"
+      [alwaysShowPaginator]="false"
+      [showCurrentPageReport]="true"
+      currentPageReportTemplate="{first} - {last} of {totalRecords}"
+      [tableStyle]="{ 'table-layout': 'fixed', width: '100%' }"
+      (onPage)="onPage($event)"
+      ariaLabel="Projects by return on investment">
+      <ng-template #header>
+        <tr>
+          @for (field of sortFields; track field) {
+            <th [attr.aria-sort]="ariaSortMap()[field]" [class.text-right]="field !== 'name'">
+              <button
+                type="button"
+                class="flex items-center gap-1 whitespace-nowrap font-semibold"
+                [class.ml-auto]="field !== 'name'"
+                (click)="toggleSort(field)"
+                [attr.data-testid]="'org-roi-projects-table-sort-' + field">
+                {{ sortLabels[field] }}
+                <i class="text-xs" [class]="sortIconMap()[field]" aria-hidden="true"></i>
+              </button>
+            </th>
+          }
+        </tr>
+      </ng-template>
+
+      <ng-template #body let-row>
+        <tr [attr.data-testid]="'org-roi-projects-table-row-' + row.projectId">
+          <td class="truncate" [attr.title]="row.projectName">{{ row.projectName }}</td>
+          <td class="text-right tabular-nums">{{ row.investmentLabel }}</td>
+          <td class="text-right tabular-nums">{{ row.returnLabel }}</td>
+          <td class="text-right tabular-nums" [class.text-amber-700]="row.profit < 0">{{ row.profitLabel }}</td>
+          <td class="text-right tabular-nums">{{ row.roiLabel }}</td>
+          <td class="text-right tabular-nums">{{ row.bcrLabel }}</td>
+          <td class="text-right tabular-nums">{{ row.breakevenMarkupLabel }}</td>
+        </tr>
+      </ng-template>
+    </lfx-table>
+
+    <p class="text-xs text-gray-500" data-testid="org-roi-projects-table-modelled-cost-note">{{ investmentExplanation }}</p>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
@@ -1,0 +1,162 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input, Signal, signal } from '@angular/core';
+import { TableComponent } from '@components/table/table.component';
+import {
+  ORG_LENS_ROI_KPI_EXPLANATION,
+  ORG_LENS_ROI_NO_VALUE,
+  ORG_LENS_ROI_PROJECT_SORT_FIELDS,
+  ORG_LENS_ROI_PROJECT_SORT_LABELS,
+  ORG_LENS_ROI_PROJECTS_TABLE_DEFAULT_SORT,
+  ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE,
+  ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE_OPTIONS,
+} from '@lfx-one/shared/constants';
+import type {
+  OrgLensRoiProjectAriaSort,
+  OrgLensRoiProjectRow,
+  OrgLensRoiProjectSortField,
+  OrgLensRoiProjectTableRow,
+  SortDirection,
+} from '@lfx-one/shared/interfaces';
+import { formatCurrency, formatPercent } from '@lfx-one/shared/utils';
+
+/** Every project in the portfolio, sortable and paged. */
+@Component({
+  selector: 'lfx-org-roi-projects-table',
+  imports: [TableComponent],
+  templateUrl: './org-roi-projects-table.component.html',
+})
+export class OrgRoiProjectsTableComponent {
+  /** The complete, uncapped project set — this view pages it rather than summarising it. */
+  public readonly projects = input.required<OrgLensRoiProjectRow[]>();
+
+  protected readonly sortFields = ORG_LENS_ROI_PROJECT_SORT_FIELDS;
+  protected readonly sortLabels = ORG_LENS_ROI_PROJECT_SORT_LABELS;
+  protected readonly pageSizeOptions = [...ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE_OPTIONS];
+
+  /** The same wording the KPI band uses; the Investment column is a modelled cost. */
+  protected readonly investmentExplanation = ORG_LENS_ROI_KPI_EXPLANATION.totalExpenditure;
+
+  /**
+   * Sort and page live in signals, not the URL. Encoding them would make this view's transient
+   * state shareable and bookmarkable, which implies a durability the figures behind it do not
+   * have — they are re-estimated on every pipeline run.
+   */
+  protected readonly sortField = signal<OrgLensRoiProjectSortField>(ORG_LENS_ROI_PROJECTS_TABLE_DEFAULT_SORT);
+  protected readonly sortDir = signal<SortDirection>('desc');
+  protected readonly pageSize = signal(ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE);
+  protected readonly pageFirst = signal(0);
+
+  protected readonly totalRecords: Signal<number> = computed(() => this.projects().length);
+
+  protected readonly hasRows: Signal<boolean> = computed(() => this.totalRecords() > 0);
+
+  protected readonly rows: Signal<OrgLensRoiProjectTableRow[]> = computed(() => {
+    const field = this.sortField();
+    const direction = this.sortDir() === 'asc' ? 1 : -1;
+    return this.projects()
+      .map((project) => this.toTableRow(project))
+      .sort((a, b) => this.compareRows(a, b, direction, field));
+  });
+
+  protected readonly sortIconMap: Signal<Record<OrgLensRoiProjectSortField, string>> = computed(() => {
+    const field = this.sortField();
+    const active = this.sortDir() === 'asc' ? 'fa-solid fa-sort-up text-blue-500' : 'fa-solid fa-sort-down text-blue-500';
+    const inactive = 'fa-light fa-sort text-gray-300';
+    return this.mapOverFields((candidate) => (candidate === field ? active : inactive));
+  });
+
+  protected readonly ariaSortMap: Signal<Record<OrgLensRoiProjectSortField, OrgLensRoiProjectAriaSort>> = computed(() => {
+    const field = this.sortField();
+    const active: OrgLensRoiProjectAriaSort = this.sortDir() === 'asc' ? 'ascending' : 'descending';
+    return this.mapOverFields((candidate) => (candidate === field ? active : 'none'));
+  });
+
+  public toggleSort(field: OrgLensRoiProjectSortField): void {
+    if (this.sortField() === field) this.sortDir.set(this.sortDir() === 'desc' ? 'asc' : 'desc');
+    else {
+      this.sortField.set(field);
+      // A name sorts A-Z first; a money column is asked about largest-first.
+      this.sortDir.set(field === 'name' ? 'asc' : 'desc');
+    }
+    // Otherwise a viewer on page 12 re-sorts and lands somewhere arbitrary in the new order.
+    this.pageFirst.set(0);
+  }
+
+  public onPage(event: { first?: number; rows?: number }): void {
+    this.pageSize.set(event.rows ?? this.pageSize());
+    this.pageFirst.set(event.first ?? 0);
+  }
+
+  private mapOverFields<T>(valueFor: (field: OrgLensRoiProjectSortField) => T): Record<OrgLensRoiProjectSortField, T> {
+    return Object.fromEntries(this.sortFields.map((field) => [field, valueFor(field)])) as Record<OrgLensRoiProjectSortField, T>;
+  }
+
+  /**
+   * Codepoint order, deliberately not `localeCompare`. The tie-break key is an opaque warehouse id,
+   * so collation carries no meaning — and an unpinned locale would let Node and the browser order
+   * ties differently, which for an SSR-rendered table is a hydration mismatch.
+   */
+  private compareProjectIds(a: string, b: string): number {
+    return Number(a > b) - Number(a < b);
+  }
+
+  private compareRows(a: OrgLensRoiProjectTableRow, b: OrgLensRoiProjectTableRow, direction: number, field: OrgLensRoiProjectSortField): number {
+    const tieBreak = this.compareProjectIds(a.projectId, b.projectId);
+
+    if (field === 'name') {
+      // Codepoint order again, for the same SSR reason as the tie-break above.
+      return (Number(a.projectName > b.projectName) - Number(a.projectName < b.projectName)) * direction || tieBreak;
+    }
+
+    const left = this.sortValue(a, field);
+    const right = this.sortValue(b, field);
+    // A measure that has no value is not a small one. Nulls sort last in both directions, so
+    // reversing the order never promotes "unknown" to the top of the table — which is why this
+    // sits outside the direction multiply rather than inside it.
+    if (left === null && right === null) return tieBreak;
+    if (left === null) return 1;
+    if (right === null) return -1;
+    return (left - right) * direction || tieBreak;
+  }
+
+  private sortValue(row: OrgLensRoiProjectTableRow, field: OrgLensRoiProjectSortField): number | null {
+    if (field === 'investment') return row.totalExpenditure;
+    if (field === 'return') return row.totalReturn;
+    if (field === 'profit') return row.profit;
+    if (field === 'roi') return row.roi;
+    if (field === 'bcr') return row.bcr;
+    return row.breakevenMarkup;
+  }
+
+  /** Never re-derives roi, bcr or profit: they are defined once in the metric layer. */
+  private toTableRow(project: OrgLensRoiProjectRow): OrgLensRoiProjectTableRow {
+    return {
+      projectId: project.projectId,
+      projectSlug: project.projectSlug,
+      projectName: project.projectName,
+      totalExpenditure: project.totalExpenditure,
+      totalReturn: project.totalReturn,
+      profit: project.profit,
+      roi: project.roi,
+      bcr: project.bcr,
+      breakevenMarkup: project.breakevenMarkup,
+      investmentLabel: formatCurrency(project.totalExpenditure),
+      returnLabel: formatCurrency(project.totalReturn),
+      profitLabel: formatCurrency(project.profit),
+      roiLabel: this.isRenderable(project.roi) ? `${formatPercent(project.roi * 100)}%` : ORG_LENS_ROI_NO_VALUE,
+      bcrLabel: this.isRenderable(project.bcr) ? `${project.bcr.toFixed(1)}×` : ORG_LENS_ROI_NO_VALUE,
+      breakevenMarkupLabel: this.isRenderable(project.breakevenMarkup) ? project.breakevenMarkup.toFixed(3) : ORG_LENS_ROI_NO_VALUE,
+    };
+  }
+
+  /**
+   * A measure is renderable only if it is actually a finite number. `=== null` is not enough: an
+   * absent key is `undefined`, which slips past it and reaches `toFixed()`. These measures are
+   * nullable by design, so anything non-numeric renders as the no-value indicator, never as 0.
+   */
+  private isRenderable(value: number | null | undefined): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
@@ -52,6 +52,8 @@ export class OrgRoiProjectsTableComponent {
 
   protected readonly hasRows: Signal<boolean> = computed(() => this.totalRecords() > 0);
 
+  protected readonly countLabel: Signal<string> = computed(() => `${this.totalRecords().toLocaleString('en-US')} projects`);
+
   protected readonly rows: Signal<OrgLensRoiProjectTableRow[]> = computed(() => {
     const field = this.sortField();
     const direction = this.sortDir() === 'asc' ? 1 : -1;
@@ -106,8 +108,11 @@ export class OrgRoiProjectsTableComponent {
     const tieBreak = this.compareProjectIds(a.projectId, b.projectId);
 
     if (field === 'name') {
-      // Codepoint order again, for the same SSR reason as the tie-break above.
-      return (Number(a.projectName > b.projectName) - Number(a.projectName < b.projectName)) * direction || tieBreak;
+      // A locale comparison here, unlike the tie-break above. A project name is read by a person,
+      // and codepoint order sorts by ASCII value — every capitalised name ahead of every lowercase
+      // one, and accented names last. The locale is pinned so Node and the browser agree, which is
+      // the SSR hydration concern that makes an *unpinned* comparison unusable.
+      return a.projectName.localeCompare(b.projectName, 'en-US') * direction || tieBreak;
     }
 
     const left = this.sortValue(a, field);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -110,6 +110,11 @@
     <lfx-org-roi-category-donut />
 
     <lfx-org-roi-projects-donut [method]="method()" />
+
+    <!-- Same condition as the donuts, deliberately not a fourth guard of its own: the identity
+         check is what stops one organization's projects rendering under another's header, and a
+         separate condition here is how it would come to diverge. -->
+    <lfx-org-roi-projects-section [method]="method()" />
   }
 
   <!-- Mounted outside the branches above, on the same condition as its trigger. Inside the

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -22,6 +22,7 @@ import { OrgRoiCategoryDonutComponent } from './components/org-roi-category-donu
 import { OrgRoiEmptyStateComponent } from './components/org-roi-empty-state/org-roi-empty-state.component';
 import { OrgRoiKpiCardsComponent } from './components/org-roi-kpi-cards/org-roi-kpi-cards.component';
 import { OrgRoiProjectsDonutComponent } from './components/org-roi-projects-donut/org-roi-projects-donut.component';
+import { OrgRoiProjectsSectionComponent } from './components/org-roi-projects-section/org-roi-projects-section.component';
 
 const EMPTY_SUMMARY: OrgLensRoiSummary = {
   orgUid: '',
@@ -49,6 +50,7 @@ const EMPTY_COVERAGE: OrgLensRoiCoverage = { orgUid: '', hasData: false, coverag
     OrgRoiAnnualTrendComponent,
     OrgRoiCategoryDonutComponent,
     OrgRoiProjectsDonutComponent,
+    OrgRoiProjectsSectionComponent,
     OrgRoiAssumptionsDrawerComponent,
     OrgRoiEmptyStateComponent,
     EmptyStateComponent,

--- a/apps/lfx-one/src/app/shared/components/chart/chart.component.html
+++ b/apps/lfx-one/src/app/shared/components/chart/chart.component.html
@@ -1,4 +1,4 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<p-chart [type]="type()" [data]="data()" [options]="options()" [style]="style()" [width]="width()" [height]="height()"></p-chart>
+<p-chart [type]="primeChartType()" [data]="data()" [options]="options()" [style]="style()" [width]="width()" [height]="height()"></p-chart>

--- a/apps/lfx-one/src/app/shared/components/chart/chart.component.ts
+++ b/apps/lfx-one/src/app/shared/components/chart/chart.component.ts
@@ -1,12 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input } from '@angular/core';
+import { Component, computed, input, Signal } from '@angular/core';
 import { ChartModule } from 'primeng/chart';
 import { Chart } from 'chart.js';
+import { Flow, SankeyController } from 'chartjs-chart-sankey';
 import { ZERO_BAR_STUB_PLUGIN } from '@lfx-one/shared/constants';
 
-export type ChartType = 'bar' | 'line' | 'scatter' | 'bubble' | 'pie' | 'doughnut' | 'polarArea' | 'radar';
+export type ChartType = 'bar' | 'line' | 'scatter' | 'bubble' | 'pie' | 'doughnut' | 'polarArea' | 'radar' | 'sankey';
 
 @Component({
   selector: 'lfx-chart',
@@ -17,8 +18,11 @@ export class ChartComponent {
   // Register the zero-bar stub plugin once globally so any chart host (cards,
   // drawers) that opts a dataset in via `zeroStub: true` gets the 4px gray stub.
   // The plugin no-ops for datasets that don't opt in, so other charts are unaffected.
-  private static readonly zeroBarStubRegistered = (() => {
-    Chart.register(ZERO_BAR_STUB_PLUGIN);
+  // Sankey is registered alongside it: the controller and its Flow element come from
+  // chartjs-chart-sankey rather than chart.js core, so `type="sankey"` throws
+  // "sankey is not a registered controller" without this.
+  private static readonly chartExtensionsRegistered = (() => {
+    Chart.register(ZERO_BAR_STUB_PLUGIN, SankeyController, Flow);
     return true;
   })();
 
@@ -28,4 +32,13 @@ export class ChartComponent {
   public readonly style = input<any>();
   public readonly width = input<string>('100%');
   public readonly height = input<string>('100%');
+
+  /**
+   * PrimeNG types its own `type` input against a fixed union of core Chart.js types, so a type
+   * contributed by a registered plugin cannot be passed through it as-is. Only the compile-time
+   * union is narrow — at runtime PrimeNG forwards the string to Chart.js, which accepts any
+   * registered controller id. Widened here, at the one boundary that needs it, rather than by
+   * loosening the `ChartType` this component exposes to its callers.
+   */
+  protected readonly primeChartType: Signal<any> = computed(() => this.type());
 }

--- a/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
@@ -29,8 +29,18 @@ export const orgLensRoiEnabledGuard: CanMatchFn = async () => {
         catchError(() => of(false))
       )
     );
+    // Provider never became ready in time (LD slow / unreachable) → fail open, matching
+    // myClasEnabledGuard. Failing closed silently bounced viewers off a page they may well be
+    // entitled to, and the bounce is indistinguishable from the feature not existing.
+    //
+    // This flag is a dark launch rather than a fully-enabled one, so failing open can show an
+    // unfinished page to an Org Lens viewer when LaunchDarkly is slow. That is bounded: every ROI
+    // endpoint runs its own `assertOrgLensRead` regardless of any flag, so what leaks early is an
+    // incomplete view, never data the viewer could not already request. Logged so the frequency is
+    // visible rather than assumed.
     if (!ready) {
-      return router.parseUrl('/org/overview');
+      console.warn('orgLensRoiEnabledGuard: LD provider not ready after 5 s — failing open');
+      return true;
     }
   }
 

--- a/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/org-lens-roi-enabled.guard.ts
@@ -21,6 +21,14 @@ export const orgLensRoiEnabledGuard: CanMatchFn = async () => {
   const featureFlagService = inject(FeatureFlagService);
   const router = inject(Router);
 
+  // A locally pinned value decides on its own, before the provider is consulted at all — waiting
+  // first would let a readiness timeout answer for it, and a pinned `false` must never be
+  // overridden. Non-production builds only; see `FEATURE_FLAG_OVERRIDE_STORAGE_KEY`.
+  const override = featureFlagService.getFlagOverride(ORG_LENS_ROI_ENABLED_FLAG);
+  if (override !== undefined) {
+    return override ? true : router.parseUrl('/org/overview');
+  }
+
   if (!featureFlagService.providerReady()) {
     const ready = await firstValueFrom(
       toObservable(featureFlagService.providerReady).pipe(
@@ -29,18 +37,16 @@ export const orgLensRoiEnabledGuard: CanMatchFn = async () => {
         catchError(() => of(false))
       )
     );
-    // Provider never became ready in time (LD slow / unreachable) → fail open, matching
-    // myClasEnabledGuard. Failing closed silently bounced viewers off a page they may well be
-    // entitled to, and the bounce is indistinguishable from the feature not existing.
+    // Provider never became ready in time (LD slow / unreachable) → fail CLOSED, deliberately
+    // unlike `myClasEnabledGuard`, which fails open. That guard's flag is enabled for all
+    // production users, so allowing the route grants access they already have; this one is a dark
+    // launch, so the same behaviour would show an unfinished page to any Org Lens viewer whenever
+    // LaunchDarkly is slow — turning an outage into a release.
     //
-    // This flag is a dark launch rather than a fully-enabled one, so failing open can show an
-    // unfinished page to an Org Lens viewer when LaunchDarkly is slow. That is bounded: every ROI
-    // endpoint runs its own `assertOrgLensRead` regardless of any flag, so what leaks early is an
-    // incomplete view, never data the viewer could not already request. Logged so the frequency is
-    // visible rather than assumed.
+    // Revisit at GA: once the flag is on for everyone, failing open becomes the better trade and
+    // this should match its sibling.
     if (!ready) {
-      console.warn('orgLensRoiEnabledGuard: LD provider not ready after 5 s — failing open');
-      return true;
+      return router.parseUrl('/org/overview');
     }
   }
 

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
@@ -2,8 +2,36 @@
 // SPDX-License-Identifier: MIT
 
 import { computed, Injectable, Signal, signal } from '@angular/core';
-import { User } from '@lfx-one/shared';
+import { environment } from '@environments/environment';
+import { FEATURE_FLAG_OVERRIDE_STORAGE_KEY, User } from '@lfx-one/shared';
 import { Client, EvaluationContext, JsonValue, OpenFeature, ProviderEvents, ProviderStatus } from '@openfeature/web-sdk';
+
+/**
+ * A locally-forced value for one flag, or `undefined` when none is set.
+ *
+ * Exists so automated tests can pin a flag without reaching LaunchDarkly. Without it a flag-gated
+ * route cannot be tested at all: the SDK evaluates first against an anonymous context and only
+ * later against the authenticated user, so a flag targeted at named users reads false in that first
+ * window and a `canMatch` guard can redirect before the real value ever arrives. Intercepting the
+ * SDK at the network layer was tried and is not workable — aborting its stream stops the provider
+ * reaching READY, and serving one keeps it reconnecting.
+ *
+ * **Ignored entirely in production builds**, so it cannot be used to unlock a flag against a
+ * deployed environment.
+ */
+function readFlagOverride(key: string): boolean | undefined {
+  if (environment.production || typeof window === 'undefined') return undefined;
+
+  try {
+    const raw = window.localStorage.getItem(FEATURE_FLAG_OVERRIDE_STORAGE_KEY);
+    if (raw === null) return undefined;
+    const value = (JSON.parse(raw) as Record<string, unknown>)[key];
+    return typeof value === 'boolean' ? value : undefined;
+  } catch {
+    // Unreadable or malformed storage must never take a flag decision with it.
+    return undefined;
+  }
+}
 
 @Injectable({
   providedIn: 'root',
@@ -66,6 +94,11 @@ export class FeatureFlagService {
     return computed(() => {
       // Reactive dependency on context signal
       this.context();
+
+      const override = readFlagOverride(key);
+      if (override !== undefined) {
+        return override;
+      }
 
       if (!this.isInitialized() || !this.client) {
         return defaultValue;

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
@@ -87,10 +87,6 @@ export class FeatureFlagService {
   }
 
   /**
-   * Get a boolean feature flag as a signal
-   * Returns computed signal that updates automatically when flag changes
-   */
-  /**
    * A value pinned locally for this flag, or `undefined` when none is set.
    *
    * Exposed so a route guard can consult it *before* waiting on the provider. A guard that decides
@@ -101,6 +97,10 @@ export class FeatureFlagService {
     return readFlagOverride(key);
   }
 
+  /**
+   * Get a boolean feature flag as a signal
+   * Returns computed signal that updates automatically when flag changes
+   */
   public getBooleanFlag(key: string, defaultValue: boolean = false): Signal<boolean> {
     return computed(() => {
       // Reactive dependency on context signal

--- a/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
+++ b/apps/lfx-one/src/app/shared/services/feature-flag.service.ts
@@ -90,6 +90,17 @@ export class FeatureFlagService {
    * Get a boolean feature flag as a signal
    * Returns computed signal that updates automatically when flag changes
    */
+  /**
+   * A value pinned locally for this flag, or `undefined` when none is set.
+   *
+   * Exposed so a route guard can consult it *before* waiting on the provider. A guard that decides
+   * on a readiness timeout would otherwise ignore a pinned value entirely — including a pinned
+   * `false`, which is the case that must never be overridden.
+   */
+  public getFlagOverride(key: string): boolean | undefined {
+    return readFlagOverride(key);
+  }
+
   public getBooleanFlag(key: string, defaultValue: boolean = false): Signal<boolean> {
     return computed(() => {
       // Reactive dependency on context signal

--- a/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
@@ -46,6 +46,16 @@ export class OrgLensRoiService {
     return this.http.get<OrgLensRoiInvestmentBreakdown>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/investment-breakdown`);
   }
 
+  /**
+   * Two surfaces read this — the leading-projects donut and the projects section — so a page load
+   * issues it twice. Deliberate rather than overlooked, and cheaper than it looks: on hydration
+   * both are served from Angular's HTTP transfer cache, which serves a key repeatedly rather than
+   * consuming it, and after that the second is a BFF round-trip answered by the shared server-side
+   * cache rather than the warehouse. De-duplicating it client-side needs memoisation whose
+   * interaction with synchronous cache replay, subscription cancellation and completion semantics
+   * costs more in subtlety than the request it saves. The structural fix, if this ever becomes a
+   * real cost, is to fetch once in the page and pass the rows into both surfaces as inputs.
+   */
   public getProjects(orgUid: string, method: OrgLensRoiMethod): Observable<OrgLensRoiProjects> {
     return this.http.get<OrgLensRoiProjects>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/projects`, {
       params: new HttpParams().set('method', method),

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
   },
   "dependencies": {
     "@stripe/stripe-js": "^9.7.0",
-    "chart.js": "^4.5.1"
+    "chart.js": "^4.5.1",
+    "chartjs-chart-sankey": "0.15.0"
   }
 }

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -27,3 +27,14 @@ export const ORG_LENS_ROI_ENABLED_FLAG = 'org-lens-roi-enabled';
  * only this one hides/shows the UI without changing what a direct API caller can do.
  */
 export const WG_WEEKLY_BRIEF_SLACK_FLAG = 'wg-weekly-brief-slack';
+
+/**
+ * `localStorage` key holding a `Record<string, boolean>` of locally-forced flag values, read by
+ * `FeatureFlagService.getBooleanFlag` in **non-production builds only**.
+ *
+ * This is the supported way to pin a flag in an e2e run. Flag-gated routes are otherwise untestable
+ * — the SDK evaluates against an anonymous context before the authenticated one, so a flag targeted
+ * at named users reads false in that window and a route guard can redirect before the real value
+ * lands.
+ */
+export const FEATURE_FLAG_OVERRIDE_STORAGE_KEY = 'lfx-feature-flag-overrides';

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -101,3 +101,97 @@ export const ORG_LENS_ROI_KPI_EXPLANATION = {
   roi: 'Net return divided by investment, shown as a percentage. 100% means you got back your investment again on top of it. Blank when there is no investment to divide by.',
   bcr: 'Total return divided by investment. A benefit-cost ratio of 5× means every dollar of modelled investment is associated with five dollars of modelled return. Always exactly one more than ROI.',
 } as const;
+
+/** The four complementary views of the projects section, in tab order. */
+export const ORG_LENS_ROI_PROJECT_VIEWS = ['bar', 'sankey', 'bubble', 'table'] as const;
+
+export const ORG_LENS_ROI_PROJECT_VIEW_LABELS: Record<(typeof ORG_LENS_ROI_PROJECT_VIEWS)[number], string> = {
+  bar: 'Investment vs return',
+  sankey: 'Where it flows',
+  bubble: 'Efficiency',
+  table: 'All projects',
+};
+
+/** The three views driven by the shared project selection; the table always pages the complete set. */
+export const ORG_LENS_ROI_PROJECT_SELECTION_VIEWS = ['bar', 'sankey', 'bubble'] as const;
+
+/** How many projects the shared picker starts with, taken from the top by return. */
+export const ORG_LENS_ROI_PROJECT_PICKER_DEFAULT_COUNT = 5;
+
+/** Matches beyond this are not offered; the search box exists to find one project, not to browse. */
+export const ORG_LENS_ROI_PROJECT_PICKER_MAX_MATCHES = 20;
+
+/**
+ * Per-view drawing ceilings. "All" is a legitimate selection on an organization with hundreds of
+ * projects, and no view stays readable at that size — so each draws its leading N and discloses the
+ * shortfall, rather than the selection being silently capped at the picker. The three differ
+ * because legibility does: bars degrade by height, flows by link crossings, points barely at all.
+ */
+export const ORG_LENS_ROI_PROJECT_BAR_MAX_ROWS = 25;
+
+/** Lowest of the three: a flow diagram crosses every link against every other. */
+export const ORG_LENS_ROI_PROJECT_SANKEY_MAX_PROJECTS = 12;
+
+/** Highest of the three: a scatter plot stays legible far longer than bars or flows. */
+export const ORG_LENS_ROI_PROJECT_BUBBLE_MAX_POINTS = 250;
+
+export const ORG_LENS_ROI_PROJECT_SANKEY_MEASURES = ['investment', 'return'] as const;
+
+export const ORG_LENS_ROI_PROJECT_SANKEY_MEASURE_LABELS: Record<(typeof ORG_LENS_ROI_PROJECT_SANKEY_MEASURES)[number], string> = {
+  investment: 'Investment',
+  return: 'Return',
+};
+
+/** The single node every investment flow passes through, on its way out to the projects. */
+export const ORG_LENS_ROI_SANKEY_ORG_NODE = 'Your organization';
+
+export const ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE = 25;
+
+export const ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];
+
+export const ORG_LENS_ROI_PROJECT_SORT_FIELDS = ['name', 'investment', 'return', 'profit', 'roi', 'bcr', 'breakevenMarkup'] as const;
+
+/** Annotated so adding a sort field without a heading fails here rather than at the template. */
+export const ORG_LENS_ROI_PROJECT_SORT_LABELS: Record<(typeof ORG_LENS_ROI_PROJECT_SORT_FIELDS)[number], string> = {
+  name: 'Project',
+  investment: 'Investment',
+  return: 'Return',
+  profit: 'Net return',
+  roi: 'ROI',
+  bcr: 'BCR',
+  breakevenMarkup: 'Breakeven markup',
+};
+
+/** The table opens on the payload's own ordering, so the first page needs no client re-sort. */
+export const ORG_LENS_ROI_PROJECTS_TABLE_DEFAULT_SORT = 'return';
+
+/**
+ * Keyed by contribution type rather than by position, so a category keeps its colour as the stack
+ * order changes from project to project. Ordered against `ORG_LENS_ROI_CONTRIBUTION_TYPES`.
+ */
+export const ORG_LENS_ROI_CATEGORY_COLOR: Record<(typeof ORG_LENS_ROI_CONTRIBUTION_TYPES)[number], string> = {
+  code: lfxColors.blue[600],
+  community: lfxColors.emerald[500],
+  meetings: lfxColors.violet[500],
+  event_attendance: lfxColors.amber[500],
+  event_sponsorship: lfxColors.blue[400],
+  membership_project: lfxColors.emerald[400],
+  membership_tlf: lfxColors.violet[400],
+  educ_courses: lfxColors.amber[400],
+};
+
+/** Return is one series against the stacked investment categories, so it needs a colour of its own. */
+export const ORG_LENS_ROI_RETURN_COLOR = lfxColors.emerald[600];
+
+/** A log axis cannot plot zero, so non-positive values are lifted to this floor and disclosed. */
+export const ORG_LENS_ROI_BUBBLE_LOG_FLOOR = 1;
+
+/**
+ * Translucent fills for the efficiency plot, where bubbles overlap and an opaque one hides those
+ * behind it. These are the alpha forms of `emerald[600]` and `amber[500]`, which the same points
+ * use — at full opacity — for their borders.
+ */
+export const ORG_LENS_ROI_BUBBLE_FILL = {
+  profitable: 'rgba(0, 153, 102, 0.45)',
+  lossMaking: 'rgba(254, 154, 0, 0.55)',
+} as const;

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -1,6 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+// Deep import rather than the utils barrel: this is a constants module, and the barrel reaches
+// modules that depend on Angular. `color.utils` itself imports nothing, so there is no cycle.
+import { hexToRgba } from '../utils/color.utils';
 import { lfxColors } from './colors.constants';
 
 export const ORG_LENS_ROI_METHODS = ['logit', 'direct'] as const;
@@ -198,10 +201,10 @@ export const ORG_LENS_ROI_BUBBLE_LOG_FLOOR = 1;
 
 /**
  * Translucent fills for the efficiency plot, where bubbles overlap and an opaque one hides those
- * behind it. These are the alpha forms of `emerald[600]` and `amber[500]`, which the same points
- * use — at full opacity — for their borders.
+ * behind it. Derived from the same palette entries the points use — at full opacity — for their
+ * borders, so a palette change moves fill and border together instead of silently parting them.
  */
 export const ORG_LENS_ROI_BUBBLE_FILL = {
-  profitable: 'rgba(0, 153, 102, 0.45)',
-  lossMaking: 'rgba(254, 154, 0, 0.55)',
+  profitable: hexToRgba(lfxColors.emerald[600], 0.45),
+  lossMaking: hexToRgba(lfxColors.amber[500], 0.55),
 } as const;

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -145,6 +145,16 @@ export const ORG_LENS_ROI_PROJECT_SANKEY_MEASURE_LABELS: Record<(typeof ORG_LENS
 /** The single node every investment flow passes through, on its way out to the projects. */
 export const ORG_LENS_ROI_SANKEY_ORG_NODE = 'Your organization';
 
+/**
+ * Sankey identifies a node by its key, so the keys are type-prefixed ids and display names are
+ * supplied separately. Keying on the name alone merged two projects sharing one, and let a project
+ * named after a contribution category — or after the organization node — join that node and form a
+ * cycle.
+ */
+export const ORG_LENS_ROI_SANKEY_ORG_NODE_KEY = 'org';
+export const ORG_LENS_ROI_SANKEY_PROJECT_NODE_PREFIX = 'project:';
+export const ORG_LENS_ROI_SANKEY_CATEGORY_NODE_PREFIX = 'category:';
+
 export const ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE = 25;
 
 export const ORG_LENS_ROI_PROJECTS_TABLE_PAGE_SIZE_OPTIONS = [10, 25, 50, 100];

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -153,6 +153,34 @@ export interface OrgLensRoiProjectFlowLink {
   flow: number;
 }
 
+/** The context a sankey colour callback receives. Only `raw` is read. */
+export interface OrgLensRoiSankeyColorContext {
+  raw?: OrgLensRoiProjectFlowLink;
+}
+
+/**
+ * The sankey dataset this feature builds.
+ *
+ * Described here rather than as `ChartData<'sankey'>`: `chartjs-chart-sankey` exports its types but
+ * does **not** augment Chart.js's `ChartTypeRegistry`, so no `'sankey'` variant of the built-in
+ * chart types exists to reference.
+ */
+export interface OrgLensRoiSankeyDataset {
+  label: string;
+  data: OrgLensRoiProjectFlowLink[];
+  colorFrom: (context: OrgLensRoiSankeyColorContext) => string;
+  colorTo: (context: OrgLensRoiSankeyColorContext) => string;
+  colorMode: 'gradient';
+  borderWidth: number;
+  /** Maps the type-prefixed node keys to the names a viewer reads. */
+  labels: Record<string, string>;
+  size: 'max' | 'min';
+}
+
+export interface OrgLensRoiSankeyChartData {
+  datasets: OrgLensRoiSankeyDataset[];
+}
+
 /** One plotted project of the efficiency view. A view model — never serialized. */
 export interface OrgLensRoiProjectBubblePoint {
   projectId: string;

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -6,6 +6,9 @@ import type {
   ORG_LENS_ROI_COVERAGE_REASONS,
   ORG_LENS_ROI_METHODS,
   ORG_LENS_ROI_PROJECT_MEASURES,
+  ORG_LENS_ROI_PROJECT_SANKEY_MEASURES,
+  ORG_LENS_ROI_PROJECT_SORT_FIELDS,
+  ORG_LENS_ROI_PROJECT_VIEWS,
 } from '../constants/org-lens-roi.constants';
 
 export type OrgLensRoiMethod = (typeof ORG_LENS_ROI_METHODS)[number];
@@ -108,4 +111,79 @@ export interface OrgLensRoiProjectSlice {
   /** What the arc is sized by. Never negative, because an arc cannot be. */
   weight: number;
   color: string;
+}
+
+export type OrgLensRoiProjectView = (typeof ORG_LENS_ROI_PROJECT_VIEWS)[number];
+
+export type OrgLensRoiProjectSankeyMeasure = (typeof ORG_LENS_ROI_PROJECT_SANKEY_MEASURES)[number];
+
+export type OrgLensRoiProjectSortField = (typeof ORG_LENS_ROI_PROJECT_SORT_FIELDS)[number];
+
+export type OrgLensRoiProjectAriaSort = 'ascending' | 'descending' | 'none';
+
+/** One entry of the shared picker — both the chips already chosen and the search matches on offer. */
+export interface OrgLensRoiProjectOption {
+  projectId: string;
+  projectName: string;
+  /** The project's return, formatted. The picker ranks by return, so this is what it shows. */
+  amount: string;
+}
+
+/** One stacked investment category within a bar. Never rescaled: the parts sum to the whole already. */
+export interface OrgLensRoiProjectBarSegment {
+  type: OrgLensRoiContributionType;
+  label: string;
+  expenditure: number;
+  color: string;
+}
+
+/** One project's row of the comparison bar chart. A view model — never serialized. */
+export interface OrgLensRoiProjectBarRow {
+  projectId: string;
+  projectName: string;
+  segments: OrgLensRoiProjectBarSegment[];
+  totalExpenditure: number;
+  totalReturn: number;
+}
+
+/** One `{from, to, flow}` link of the sankey. A view model — never serialized. */
+export interface OrgLensRoiProjectFlowLink {
+  from: string;
+  to: string;
+  flow: number;
+}
+
+/** One plotted project of the efficiency view. A view model — never serialized. */
+export interface OrgLensRoiProjectBubblePoint {
+  projectId: string;
+  projectName: string;
+  /** Investment, lifted to the log floor when non-positive. */
+  x: number;
+  /** Return, lifted to the log floor when non-positive. */
+  y: number;
+  r: number;
+  /** True when either coordinate was lifted, so the point can be disclosed rather than trusted. */
+  isFloored: boolean;
+}
+
+/**
+ * One row of the projects table, carrying both the raw measures it sorts on and the strings it
+ * renders, so neither formatting nor null handling happens in the template.
+ */
+export interface OrgLensRoiProjectTableRow {
+  projectId: string;
+  projectSlug: string;
+  projectName: string;
+  totalExpenditure: number;
+  totalReturn: number;
+  profit: number;
+  roi: number | null;
+  bcr: number | null;
+  breakevenMarkup: number | null;
+  investmentLabel: string;
+  returnLabel: string;
+  profitLabel: string;
+  roiLabel: string;
+  bcrLabel: string;
+  breakevenMarkupLabel: string;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -10036,6 +10036,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chartjs-chart-sankey@npm:0.15.0":
+  version: 0.15.0
+  resolution: "chartjs-chart-sankey@npm:0.15.0"
+  peerDependencies:
+    chart.js: ">=3.3.0"
+  checksum: 10c0/bfc4c24634168547dc94f542cc85e818a5a435ea02c7bcf727076c6cd43b23f3d245bbe1ee38ca29faba099ea1f1f507b3ea21fa93c35d2c64e25829fdf09a78
+  languageName: node
+  linkType: hard
+
 "check-error@npm:^2.1.1":
   version: 2.1.3
   resolution: "check-error@npm:2.1.3"
@@ -14472,6 +14481,7 @@ __metadata:
     angular-eslint: "npm:21.0.1"
     autoprefixer: "npm:^10.4.21"
     chart.js: "npm:^4.5.1"
+    chartjs-chart-sankey: "npm:0.15.0"
     compression: "npm:^1.8.1"
     eslint: "npm:^9.39.1"
     express: "npm:^4.18.2"
@@ -14528,6 +14538,7 @@ __metadata:
     "@typescript-eslint/types": "npm:^8.39.1"
     "@typescript-eslint/utils": "npm:^8.39.1"
     chart.js: "npm:^4.5.1"
+    chartjs-chart-sankey: "npm:0.15.0"
     husky: "npm:^9.1.7"
     lint-staged: "npm:^16.2.7"
     prettier: "npm:^3.7.4"


### PR DESCRIPTION
User Story 5 of the Org Lens ROI feature ([LFXV2-2980](https://linuxfoundation.atlassian.net/browse/LFXV2-2980)). Follows #1352 (page shell + BFF) and #1384 (category and projects donuts).

## What this adds

Four complementary views over the **complete, uncapped** project set, under a shared selection, on the existing `/org/roi` page.

**No BFF work.** `GET /:orgUid/lens/roi/projects` already serves every project with its category breakdown in one payload — measured at 210 KiB for the largest organization (Red Hat, 408 projects) against the 1 MiB `VALKEY_CACHE.MAX_VALUE_BYTES` ceiling. All four views read it.

| View | What it shows |
|---|---|
| Investment vs return | Investment stacked by contribution category, against return |
| Where it flows | Sankey, with an Investment/Return toggle |
| Efficiency | Bubble plot on logarithmic axes, sized by net return |
| All projects | Sortable, paged table over every project |

One picker serves the three chart views, so the selection is shared structurally rather than duplicated per view.

## Decisions worth reviewing

**The bar chart uses two scales, and this is the one judgement call I'd like a second opinion on.** Return runs 36–56× investment, so on a shared linear axis the stacked categories — the entire content of the view — are invisible. A logarithmic axis is *wrong* for a stacked bar: segments are positioned by cumulative total, so under log scaling a segment's length stops corresponding to its value and the small categories collapse anyway. So investment and return are drawn on separate scales, with a note stating the two bars cannot be compared by length. This is the same open axis-scaling question already recorded against the annual trend; if that resolves differently, both should change together.

**The sankey is deliberately asymmetric.** Investment fans out `organization → category → project`; return comes straight back. Return is not decomposed by category in the warehouse, so an intermediate node on that side would be invented rather than reported.

**A log axis has no zero.** Projects with no investment or no return are drawn at the floor and named in a disclosure, rather than dropped — dropping them would make an unmeasured project indistinguishable from one that does not exist. The accompanying table carries their true figures.

**Truncation is disclosed, not silent.** "All" is a legitimate selection on a 408-project portfolio, and no view stays readable at that size, so each draws its leading N (bar 25, sankey 12, bubble 250) and says how many it could not draw. The ceilings differ because legibility does.

**No client-side rescaling.** Categories sum to their project's investment by construction — re-measured against production at a worst gap of 7.45e-09 across all 408 Red Hat projects. A discrepancy of a cent or more is surfaced as the metric-layer defect it would be, not corrected in the renderer. `roi`, `bcr` and `profit` are read from the payload and never re-derived; a null ratio renders as `—`, never `0`.

**One deliberate duplicate request.** The donut and the section both read the projects endpoint. Client-side de-duplication was implemented and then removed: it needed memoisation whose interaction with hydration's synchronous transfer-cache replay, subscription cancellation and completion semantics produced a defect in three consecutive review rounds, to save a request that the transfer cache and the server-side cache already make cheap. The reasoning and the structural alternative are recorded in a comment on `getProjects`.

## Also in this PR

- `chartjs-chart-sankey@0.15.0` — MIT, no runtime dependencies, ships its own types, pinned exactly because it is **pre-1.0**. Flagging for dependency-owner review rather than assuming approval. Exposure is one component and one registration line.
- PrimeNG types its chart `type` against a fixed union that no plugin can extend, so `lfx-chart` widens at that single binding; the `ChartType` it exposes to callers stays narrow.
- ~~The e2e workflow was enabled non-blocking.~~ **Removed during review** — handing AWS, Auth0 and Supabase credentials to a workflow that runs PR-controlled install/build/test scripts deserves its own review and should not ride along with a feature. Both workflow files are back to their `main` state; this will return as a separate PR. (The run triggered before the revert confirmed the exposure is real, not theoretical: it completed OIDC auth, pulled the credentials from AWS Secrets Manager, and went on to run PR-controlled `yarn install` and `yarn build`.)

## Not in this PR

Row-click navigation to the ROI project detail route (FR-034) is **deferred to US6**, which creates that route. Inventing the path or stubbing it would put a guessed URL into merged code that US6 then has to agree with.

## Test plan

- [x] `yarn format:check`, `yarn lint:check`, `yarn build`, `./check-headers.sh`
- [x] `yarn test` — 1,495 unit tests pass
- [x] `yarn playwright test --list` — 31 cases in the ROI projects spec (21 new), compiles and enumerates
- [x] Verified manually against production Red Hat data (408 projects) on a local dev build
- [x] **SC-003 performance measured**: time-to-usable-content 1.52–2.19 s across four runs against the 408-project payload, inside the 3 s threshold. Tab switches 40–127 ms; selecting all 408 projects redraws the bubble view in under 80 ms.
- [ ] ⚠️ **The e2e suite still has no CI gate.** The 31 cases are verified by compilation only. One real run did start on this PR before the CI change was reverted: the credential path, Playwright setup and build all succeeded and the suite began executing, so the pipeline works — but it had not finished when the enablement was pulled, so the cases remain unproven.

⚠️ Note on the performance figure: the client-side number is healthy, but the **uncached warehouse read is ~7 s** for the largest organization. That is upstream of this PR — the first viewer waits on it before anything can paint — and belongs against the caching strategy rather than this view.

Made with [Cursor](https://cursor.com)

[LFXV2-2980]: https://linuxfoundation.atlassian.net/browse/LFXV2-2980?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ