### PR TITLE
fix(guards): fail open on ld timeout in my-clas-enabled guard

### DIFF
--- a/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
@@ -12,9 +12,10 @@ import { FeatureFlagService } from '../services/feature-flag.service';
 
 /**
  * CanMatch guard for the Profile "My CLAs" tab (`/profile/clas`), gating the
- * read-only EasyCLA view behind the `my-clas-enabled` flag. Mirrors
- * orgLensEnabledGuard: SSR defers to the browser, the browser waits for the
- * flag provider to be READY, and it fails closed to the default profile tab.
+ * read-only EasyCLA view behind the `my-clas-enabled` flag. SSR defers to the
+ * browser; the browser waits up to 5 s for the flag provider to be READY, then
+ * fails open (allows the route) if LD is unreachable so users aren't silently
+ * redirected away from a feature that is enabled for them in production.
  */
 export const myClasEnabledGuard: CanMatchFn = async () => {
   const platformId = inject(PLATFORM_ID);
@@ -36,9 +37,12 @@ export const myClasEnabledGuard: CanMatchFn = async () => {
         catchError(() => of(false))
       )
     );
-    // Provider never became ready (no client id / LD unreachable) → fail closed.
+    // Provider never became ready in time (LD slow / unreachable) → fail open so users
+    // aren't silently redirected away from a route the flag is enabled for in production.
+    // Log so the team can monitor frequency and detect drift if the flag scope ever narrows.
     if (!ready) {
-      return router.parseUrl('/profile');
+      console.warn('myClasEnabledGuard: LD provider not ready after 5 s — failing open');
+      return true;
     }
   }
 


### PR DESCRIPTION
## Summary

- `myClasEnabledGuard` previously redirected to `/profile` (→ `/profile/attributions`) when the LaunchDarkly provider did not become ready within 5 s
- This created an intermittent race condition during SSR hydration: the guard ran concurrently with `FeatureFlagService.initialize()`, and on slow connections or transient LD errors the timeout fired before `providerReady` was set
- Changed the timeout path to fail **open** (`return true`) — since `my-clas-enabled` is enabled for all production users, allowing the route when LD is unreachable is the correct behaviour; the guard still redirects when LD is available and the flag is definitively off

## Ticket

[LFXV2-3105](https://linuxfoundation.atlassian.net/browse/LFXV2-3105)

## Test plan

- [ ] Navigate to `/profile/clas` on a cold tab load — confirm no redirect to attributions
- [ ] Verify the CLAs tab still hides correctly when `my-clas-enabled` is off (flag eval path unchanged)
- [ ] Check no TypeScript errors (`yarn check-types`)

[LFXV2-3105]: https://linuxfoundation.atlassian.net/browse/LFXV2-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ