### PR TITLE
fix(committees): exclude LF Staff seats from engagement classification

### DIFF
--- a/apps/lfx-one/e2e/committee-engagement-robust.spec.ts
+++ b/apps/lfx-one/e2e/committee-engagement-robust.spec.ts
@@ -50,6 +50,8 @@ test.describe('Committee engagement — structural contract (flag on)', () => {
     await expect(page.getByTestId('members-engagement-chip-m-high')).toBeVisible();
     await expect(page.getByTestId('members-engagement-meetings-m-emeritus')).toBeVisible();
     await expect(page.getByTestId('members-engagement-chip-m-emeritus')).toBeVisible();
+    await expect(page.getByTestId('members-engagement-meetings-m-lf-staff')).toBeVisible();
+    await expect(page.getByTestId('members-engagement-chip-m-lf-staff')).toBeVisible();
 
     // The At Risk chip joins the existing chip row's testid scheme.
     await expect(page.getByTestId('members-filter-chips').getByTestId('members-chip-atRisk')).toBeVisible();

--- a/apps/lfx-one/e2e/committee-engagement.spec.ts
+++ b/apps/lfx-one/e2e/committee-engagement.spec.ts
@@ -196,7 +196,8 @@ test.describe('Committee engagement — overview summary (flag on)', () => {
     test.skip(!flagOn, 'wg-engagement-metrics flag appears OFF for this test user — see file header for the LD precondition');
 
     await expect(summary.getByTestId('committee-engagement-summary-attendance-rate')).toContainText('78%', { timeout: ELEMENT_TIMEOUT });
-    await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('3/7');
+    // 3/5, not 3/7 — the denominator is eligible_count (roster minus Emeritus/LF Staff), not total_count.
+    await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('3/5');
     await expect(summary.getByTestId('committee-engagement-summary-at-risk')).toContainText('2');
     await expect(summary.getByTestId('committee-engagement-summary-freshness')).toHaveText('Updated daily');
   });

--- a/apps/lfx-one/e2e/committee-engagement.spec.ts
+++ b/apps/lfx-one/e2e/committee-engagement.spec.ts
@@ -87,8 +87,9 @@ test.describe('Committee engagement — members table (flag on)', () => {
     await expect(page.getByTestId('members-engagement-chip-m-medium')).toContainText('Medium');
     await expect(page.getByTestId('members-engagement-chip-m-low')).toContainText('Low');
     await expect(page.getByTestId('members-engagement-chip-m-inactive-invited')).toContainText('Inactive');
-    // Emeritus renders its own neutral tier — never Low/Inactive/at-risk styling.
+    // Emeritus and LF Staff both render their own neutral tier — never Low/Inactive/at-risk styling.
     await expect(page.getByTestId('members-engagement-chip-m-emeritus')).toContainText('Emeritus');
+    await expect(page.getByTestId('members-engagement-chip-m-lf-staff')).toContainText('LF Staff');
 
     // computed_at is null in the fixture → the daily-refresh freshness fallback.
     await expect(page.getByTestId('members-engagement-freshness')).toHaveText('Updated daily');
@@ -110,10 +111,11 @@ test.describe('Committee engagement — members table (flag on)', () => {
 
     await expect(page.getByText('Lee Lowturn')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
     await expect(page.getByText('Ira Skipsall')).toBeVisible();
-    // High / never-invited Inactive / Emeritus members are all filtered out.
+    // High / never-invited Inactive / Emeritus / LF Staff members are all filtered out.
     await expect(page.getByText('Harper Chairwood')).toHaveCount(0);
     await expect(page.getByText('Nova Neverasked')).toHaveCount(0);
     await expect(page.getByText('Evan Emeritus')).toHaveCount(0);
+    await expect(page.getByText('Sam Staffer')).toHaveCount(0);
   });
 
   test('switching the window refetches and re-renders the cells', async ({ page }) => {
@@ -194,7 +196,7 @@ test.describe('Committee engagement — overview summary (flag on)', () => {
     test.skip(!flagOn, 'wg-engagement-metrics flag appears OFF for this test user — see file header for the LD precondition');
 
     await expect(summary.getByTestId('committee-engagement-summary-attendance-rate')).toContainText('78%', { timeout: ELEMENT_TIMEOUT });
-    await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('3/6');
+    await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('3/7');
     await expect(summary.getByTestId('committee-engagement-summary-at-risk')).toContainText('2');
     await expect(summary.getByTestId('committee-engagement-summary-freshness')).toHaveText('Updated daily');
   });

--- a/apps/lfx-one/e2e/committee-engagement.spec.ts
+++ b/apps/lfx-one/e2e/committee-engagement.spec.ts
@@ -87,9 +87,13 @@ test.describe('Committee engagement — members table (flag on)', () => {
     await expect(page.getByTestId('members-engagement-chip-m-medium')).toContainText('Medium');
     await expect(page.getByTestId('members-engagement-chip-m-low')).toContainText('Low');
     await expect(page.getByTestId('members-engagement-chip-m-inactive-invited')).toContainText('Inactive');
-    // Emeritus and LF Staff both render their own neutral tier — never Low/Inactive/at-risk styling.
+    // Emeritus and LF Staff + Observer both render their own neutral tier — never
+    // Low/Inactive/at-risk styling.
     await expect(page.getByTestId('members-engagement-chip-m-emeritus')).toContainText('Emeritus');
     await expect(page.getByTestId('members-engagement-chip-m-lf-staff')).toContainText('LF Staff');
+    // An LF Staff member who is a real Voting Rep classifies on real attendance, NOT the neutral
+    // LF Staff tier (LFXV2-3101 follow-up, Jordan Evans review).
+    await expect(page.getByTestId('members-engagement-chip-m-lf-staff-rep')).toContainText('High');
 
     // computed_at is null in the fixture → the daily-refresh freshness fallback.
     await expect(page.getByTestId('members-engagement-freshness')).toHaveText('Updated daily');
@@ -116,6 +120,8 @@ test.describe('Committee engagement — members table (flag on)', () => {
     await expect(page.getByText('Nova Neverasked')).toHaveCount(0);
     await expect(page.getByText('Evan Emeritus')).toHaveCount(0);
     await expect(page.getByText('Sam Staffer')).toHaveCount(0);
+    // Real 80% attendance — not at-risk, filtered out same as any other well-engaged member.
+    await expect(page.getByText('Priya Repstaff')).toHaveCount(0);
   });
 
   test('switching the window refetches and re-renders the cells', async ({ page }) => {
@@ -196,8 +202,10 @@ test.describe('Committee engagement — overview summary (flag on)', () => {
     test.skip(!flagOn, 'wg-engagement-metrics flag appears OFF for this test user — see file header for the LD precondition');
 
     await expect(summary.getByTestId('committee-engagement-summary-attendance-rate')).toContainText('78%', { timeout: ELEMENT_TIMEOUT });
-    // 3/5, not 3/7 — the denominator is eligible_count (roster minus Emeritus/LF Staff), not total_count.
-    await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('3/5');
+    // 4/6, not 4/8 — the denominator is eligible_count (roster minus Emeritus/LF Staff+Observer),
+    // not total_count. active_count is 4 (m-high, m-medium, m-low, m-lf-staff-rep — the real Voting
+    // Rep LF Staff member counts like any other real member).
+    await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('4/6');
     await expect(summary.getByTestId('committee-engagement-summary-at-risk')).toContainText('2');
     await expect(summary.getByTestId('committee-engagement-summary-freshness')).toHaveText('Updated daily');
   });

--- a/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
+++ b/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
@@ -4,10 +4,13 @@
 /**
  * Shared fixtures/mocks for the committee engagement UI specs (LFXV2-1705).
  *
- * The engagement fixture exercises every classification tier the BFF can serve (High / Medium /
- * Low / Inactive-with-invites / Inactive-never-invited / Emeritus) over a roster whose uids match
- * the mocked `/members` response, so the Members-table join and the At-Risk filter behave exactly
- * as they would against the real endpoint. Specs mock the BFF over `page.route` and stay
+ * The engagement fixture exercises six of the seven classification tiers the BFF can serve (High /
+ * Medium / Low / Inactive-with-invites / Inactive-never-invited / Emeritus) over a roster whose
+ * uids match the mocked `/members` response, so the Members-table join and the At-Risk filter
+ * behave exactly as they would against the real endpoint. `LF Staff` (LFXV2-3101) has no fixture
+ * member here — the classifier's own boundary behavior for it is covered by
+ * `committee-engagement-classifier.utils.spec.ts` and `committee-engagement.service.spec.ts`; this
+ * suite doesn't currently assert on its UI rendering. Specs mock the BFF over `page.route` and stay
  * independent of the server's ENGAGEMENT_BACKEND mode.
  */
 

--- a/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
+++ b/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
@@ -111,9 +111,11 @@ export function buildRoster(): Record<string, unknown>[] {
  * One engagement response per window; the 90d numbers differ from 30d so a window switch is
  * observable in the UI, not just on the network. `at_risk_count: 2` = m-low (Low) +
  * m-inactive-invited (Inactive with invites); m-inactive-never, m-emeritus, and m-lf-staff are
- * excluded by rule. `active_count`/`at_risk_count`/`attendance_rate` are fixture literals, not
- * derived from `members[]` below — they don't need to recompute when a member's numbers change,
- * only to stay a plausible, internally-consistent snapshot.
+ * excluded by rule. `eligible_count: 5` = the 7-member roster minus m-emeritus and m-lf-staff (the
+ * active_count ratio's denominator, LFXV2-3101 review fix — NOT total_count, which stays the full
+ * roster size). `active_count`/`eligible_count`/`at_risk_count`/`attendance_rate` are fixture
+ * literals, not derived from `members[]` below — they don't need to recompute when a member's
+ * numbers change, only to stay a plausible, internally-consistent snapshot.
  */
 export function buildEngagementResponse(window: CommitteeEngagementWindow, overrides: Partial<CommitteeEngagementResponse> = {}): CommitteeEngagementResponse {
   const is90d = window === '90d';
@@ -163,7 +165,7 @@ export function buildEngagementResponse(window: CommitteeEngagementWindow, overr
         committee_meetings: 12,
       },
     ],
-    summary: { attendance_rate: 0.78, active_count: 3, total_count: 7, at_risk_count: 2 },
+    summary: { attendance_rate: 0.78, active_count: 3, eligible_count: 5, total_count: 7, at_risk_count: 2 },
     computed_at: null,
     data_available: true,
     data_source: 'live',
@@ -190,7 +192,9 @@ export function buildDegradedEngagementResponse(window: CommitteeEngagementWindo
       committee_meetings: 0,
       classification: degradedClassification(m),
     })),
-    summary: { attendance_rate: 0, active_count: 0, total_count: 7, at_risk_count: 0 },
+    // eligible_count stays 5 (not zeroed) — roster-known independent of engagement data, same as
+    // total_count. See CommitteeEngagementSummary.eligible_count's doc.
+    summary: { attendance_rate: 0, active_count: 0, eligible_count: 5, total_count: 7, at_risk_count: 0 },
     data_available: false,
   };
 }

--- a/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
+++ b/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
@@ -4,10 +4,11 @@
 /**
  * Shared fixtures/mocks for the committee engagement UI specs (LFXV2-1705).
  *
- * The engagement fixture exercises six of the seven classification tiers the BFF can serve (High /
- * Medium / Low / Inactive-with-invites / Inactive-never-invited / Emeritus) over a roster whose
- * uids match the mocked `/members` response, so the Members-table join and the At-Risk filter
- * behave exactly as they would against the real endpoint. `LF Staff` (LFXV2-3101) has no fixture
+ * The engagement fixture exercises five of the six classification tiers the BFF can serve (High /
+ * Medium / Low / Inactive / Emeritus) over six fixture scenarios (Inactive appears twice: with and
+ * without invites) on a roster whose uids match the mocked `/members` response, so the
+ * Members-table join and the At-Risk filter behave exactly as they would against the real endpoint.
+ * `LF Staff` (LFXV2-3101) has no fixture
  * member here — the classifier's own boundary behavior for it is covered by
  * `committee-engagement-classifier.utils.spec.ts` and `committee-engagement.service.spec.ts`; this
  * suite doesn't currently assert on its UI rendering. Specs mock the BFF over `page.route` and stay

--- a/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
+++ b/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
@@ -4,19 +4,16 @@
 /**
  * Shared fixtures/mocks for the committee engagement UI specs (LFXV2-1705).
  *
- * The engagement fixture exercises five of the six classification tiers the BFF can serve (High /
- * Medium / Low / Inactive / Emeritus) over six fixture scenarios (Inactive appears twice: with and
- * without invites) on a roster whose uids match the mocked `/members` response, so the
- * Members-table join and the At-Risk filter behave exactly as they would against the real endpoint.
- * `LF Staff` (LFXV2-3101) has no fixture
- * member here — the classifier's own boundary behavior for it is covered by
- * `committee-engagement-classifier.utils.spec.ts` and `committee-engagement.service.spec.ts`; this
- * suite doesn't currently assert on its UI rendering. Specs mock the BFF over `page.route` and stay
- * independent of the server's ENGAGEMENT_BACKEND mode.
+ * The engagement fixture exercises all six classification tiers the BFF can serve (High / Medium /
+ * Low / Inactive / Emeritus / LF Staff, LFXV2-3101) over seven fixture scenarios (Inactive appears
+ * twice: with and without invites) on a roster whose uids match the mocked `/members` response, so
+ * the Members-table join and the At-Risk filter behave exactly as they would against the real
+ * endpoint. Specs mock the BFF over `page.route` and stay independent of the server's
+ * ENGAGEMENT_BACKEND mode.
  */
 
 import { COMMITTEE_ENGAGEMENT_DEFAULT_WINDOW } from '@lfx-one/shared/constants';
-import type { CommitteeEngagementResponse, CommitteeEngagementWindow } from '@lfx-one/shared/interfaces';
+import type { CommitteeEngagementResponse, CommitteeEngagementWindow, CommitteeMemberEngagement } from '@lfx-one/shared/interfaces';
 import { expect, Locator, Page, test } from '@playwright/test';
 
 export const PAGE_LOAD_TIMEOUT = 30_000;
@@ -65,7 +62,7 @@ export function buildEngagementCommittee(): Record<string, unknown> {
     is_foundation: false,
     parent_uid: null,
     parent_project_uid: 'e2e-project-uid',
-    total_members: 6,
+    total_members: 7,
     created_at: '2025-01-15T00:00:00Z',
     updated_at: '2026-06-01T00:00:00Z',
     member_visibility: 'basic_profile',
@@ -91,6 +88,10 @@ const ROSTER: RosterSeed[] = [
   { uid: 'm-inactive-invited', first: 'Ira', last: 'Skipsall', role: 'None', votingStatus: 'Voting Rep' },
   { uid: 'm-inactive-never', first: 'Nova', last: 'Neverasked', role: 'None', votingStatus: 'Observer' },
   { uid: 'm-emeritus', first: 'Evan', last: 'Emeritus', role: 'None', votingStatus: 'Emeritus' },
+  // Mirrors the live bug the ticket was filed from (LFXV2-3101): an LF Staff seat added as an
+  // Observer with no real attendance expectation, which must render its own neutral tier, never
+  // Low/Inactive/at-risk styling.
+  { uid: 'm-lf-staff', first: 'Sam', last: 'Staffer', role: 'LF Staff', votingStatus: 'Observer' },
 ];
 
 export function buildRoster(): Record<string, unknown>[] {
@@ -109,7 +110,10 @@ export function buildRoster(): Record<string, unknown>[] {
 /**
  * One engagement response per window; the 90d numbers differ from 30d so a window switch is
  * observable in the UI, not just on the network. `at_risk_count: 2` = m-low (Low) +
- * m-inactive-invited (Inactive with invites); m-inactive-never and m-emeritus are excluded by rule.
+ * m-inactive-invited (Inactive with invites); m-inactive-never, m-emeritus, and m-lf-staff are
+ * excluded by rule. `active_count`/`at_risk_count`/`attendance_rate` are fixture literals, not
+ * derived from `members[]` below — they don't need to recompute when a member's numbers change,
+ * only to stay a plausible, internally-consistent snapshot.
  */
 export function buildEngagementResponse(window: CommitteeEngagementWindow, overrides: Partial<CommitteeEngagementResponse> = {}): CommitteeEngagementResponse {
   const is90d = window === '90d';
@@ -148,13 +152,30 @@ export function buildEngagementResponse(window: CommitteeEngagementWindow, overr
         committee_meetings: 12,
       },
       { uid: 'm-emeritus', attended: 1, invited: 10, rate: 0.1, classification: 'Emeritus', role: 'None', voting_status: 'Emeritus', committee_meetings: 12 },
+      {
+        uid: 'm-lf-staff',
+        attended: 0,
+        invited: 8,
+        rate: 0,
+        classification: 'LF Staff',
+        role: 'LF Staff',
+        voting_status: 'Observer',
+        committee_meetings: 12,
+      },
     ],
-    summary: { attendance_rate: 0.78, active_count: 3, total_count: 6, at_risk_count: 2 },
+    summary: { attendance_rate: 0.78, active_count: 3, total_count: 7, at_risk_count: 2 },
     computed_at: null,
     data_available: true,
     data_source: 'live',
     ...overrides,
   };
+}
+
+/** Degraded-path classification: role/voting_status stay populated (roster passthroughs) even when every count zeroes out, so the Emeritus/LF Staff seat-type short-circuits still apply — see `CommitteeEngagementResponse.data_available`'s doc. */
+function degradedClassification(member: { voting_status: string; role: string }): CommitteeMemberEngagement['classification'] {
+  if (member.voting_status === 'Emeritus') return 'Emeritus';
+  if (member.role === 'LF Staff') return 'LF Staff';
+  return 'Inactive';
 }
 
 export function buildDegradedEngagementResponse(window: CommitteeEngagementWindow): CommitteeEngagementResponse {
@@ -167,9 +188,9 @@ export function buildDegradedEngagementResponse(window: CommitteeEngagementWindo
       invited: 0,
       rate: 0,
       committee_meetings: 0,
-      classification: m.voting_status === 'Emeritus' ? 'Emeritus' : 'Inactive',
+      classification: degradedClassification(m),
     })),
-    summary: { attendance_rate: 0, active_count: 0, total_count: 6, at_risk_count: 0 },
+    summary: { attendance_rate: 0, active_count: 0, total_count: 7, at_risk_count: 0 },
     data_available: false,
   };
 }

--- a/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
+++ b/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
@@ -62,7 +62,7 @@ export function buildEngagementCommittee(): Record<string, unknown> {
     is_foundation: false,
     parent_uid: null,
     parent_project_uid: 'e2e-project-uid',
-    total_members: 7,
+    total_members: 8,
     created_at: '2025-01-15T00:00:00Z',
     updated_at: '2026-06-01T00:00:00Z',
     member_visibility: 'basic_profile',
@@ -92,6 +92,11 @@ const ROSTER: RosterSeed[] = [
   // Observer with no real attendance expectation, which must render its own neutral tier, never
   // Low/Inactive/at-risk styling.
   { uid: 'm-lf-staff', first: 'Sam', last: 'Staffer', role: 'LF Staff', votingStatus: 'Observer' },
+  // LFXV2-3101 follow-up (Jordan Evans review): an LF Staff member who is a real Voting Rep — an
+  // ED or staff member serving as a genuine board/committee voting representative — must classify
+  // and count normally, NOT as the neutral LF Staff tier. Only the Observer-status staff seat above
+  // is excluded.
+  { uid: 'm-lf-staff-rep', first: 'Priya', last: 'Repstaff', role: 'LF Staff', votingStatus: 'Voting Rep' },
 ];
 
 export function buildRoster(): Record<string, unknown>[] {
@@ -111,11 +116,12 @@ export function buildRoster(): Record<string, unknown>[] {
  * One engagement response per window; the 90d numbers differ from 30d so a window switch is
  * observable in the UI, not just on the network. `at_risk_count: 2` = m-low (Low) +
  * m-inactive-invited (Inactive with invites); m-inactive-never, m-emeritus, and m-lf-staff are
- * excluded by rule. `eligible_count: 5` = the 7-member roster minus m-emeritus and m-lf-staff (the
- * active_count ratio's denominator, LFXV2-3101 review fix — NOT total_count, which stays the full
- * roster size). `active_count`/`eligible_count`/`at_risk_count`/`attendance_rate` are fixture
- * literals, not derived from `members[]` below — they don't need to recompute when a member's
- * numbers change, only to stay a plausible, internally-consistent snapshot.
+ * excluded by rule — m-lf-staff-rep is NOT excluded (real Voting Rep, LFXV2-3101 follow-up) and
+ * counts like any other real member. `eligible_count: 6` = the 8-member roster minus m-emeritus and
+ * m-lf-staff (the active_count ratio's denominator, LFXV2-3101 review fix — NOT total_count, which
+ * stays the full roster size). `active_count`/`eligible_count`/`at_risk_count`/`attendance_rate` are
+ * fixture literals, not derived from `members[]` below — they don't need to recompute when a
+ * member's numbers change, only to stay a plausible, internally-consistent snapshot.
  */
 export function buildEngagementResponse(window: CommitteeEngagementWindow, overrides: Partial<CommitteeEngagementResponse> = {}): CommitteeEngagementResponse {
   const is90d = window === '90d';
@@ -164,8 +170,18 @@ export function buildEngagementResponse(window: CommitteeEngagementWindow, overr
         voting_status: 'Observer',
         committee_meetings: 12,
       },
+      {
+        uid: 'm-lf-staff-rep',
+        attended: 8,
+        invited: 10,
+        rate: 0.8,
+        classification: 'High',
+        role: 'LF Staff',
+        voting_status: 'Voting Rep',
+        committee_meetings: 12,
+      },
     ],
-    summary: { attendance_rate: 0.78, active_count: 3, eligible_count: 5, total_count: 7, at_risk_count: 2 },
+    summary: { attendance_rate: 0.78, active_count: 4, eligible_count: 6, total_count: 8, at_risk_count: 2 },
     computed_at: null,
     data_available: true,
     data_source: 'live',
@@ -173,10 +189,10 @@ export function buildEngagementResponse(window: CommitteeEngagementWindow, overr
   };
 }
 
-/** Degraded-path classification: role/voting_status stay populated (roster passthroughs) even when every count zeroes out, so the Emeritus/LF Staff seat-type short-circuits still apply — see `CommitteeEngagementResponse.data_available`'s doc. */
+/** Degraded-path classification: role/voting_status stay populated (roster passthroughs) even when every count zeroes out, so the Emeritus/LF Staff+Observer seat-type short-circuits still apply — see `CommitteeEngagementResponse.data_available`'s doc. LF Staff alone is NOT enough (LFXV2-3101 follow-up) — m-lf-staff-rep (Voting Rep) must still degrade to Inactive like any other real member. */
 function degradedClassification(member: { voting_status: string; role: string }): CommitteeMemberEngagement['classification'] {
   if (member.voting_status === 'Emeritus') return 'Emeritus';
-  if (member.role === 'LF Staff') return 'LF Staff';
+  if (member.role === 'LF Staff' && member.voting_status === 'Observer') return 'LF Staff';
   return 'Inactive';
 }
 
@@ -192,9 +208,9 @@ export function buildDegradedEngagementResponse(window: CommitteeEngagementWindo
       committee_meetings: 0,
       classification: degradedClassification(m),
     })),
-    // eligible_count stays 5 (not zeroed) — roster-known independent of engagement data, same as
+    // eligible_count stays 6 (not zeroed) — roster-known independent of engagement data, same as
     // total_count. See CommitteeEngagementSummary.eligible_count's doc.
-    summary: { attendance_rate: 0, active_count: 0, eligible_count: 5, total_count: 7, at_risk_count: 0 },
+    summary: { attendance_rate: 0, active_count: 0, eligible_count: 6, total_count: 8, at_risk_count: 0 },
     data_available: false,
   };
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.html
@@ -52,7 +52,7 @@
         </div>
         <div
           class="flex items-center gap-3 py-2.5"
-          pTooltip="Active count excludes Emeritus and LF Staff seats; total roster count includes them"
+          pTooltip="Both active count and the total shown here exclude Emeritus and LF Staff seats — see the committee roster for the full member count"
           tooltipPosition="top"
           tooltipEvent="both"
           tabindex="0"

--- a/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.html
@@ -39,7 +39,7 @@
       <div class="flex flex-col divide-y divide-gray-100">
         <div
           class="flex items-center gap-3 py-2.5"
-          pTooltip="Personal attendance across all invited roster members, including Emeritus seats"
+          pTooltip="Personal attendance across all invited roster members, including Emeritus seats but excluding LF Staff seats"
           tooltipPosition="top"
           tooltipEvent="both"
           tabindex="0"
@@ -52,7 +52,7 @@
         </div>
         <div
           class="flex items-center gap-3 py-2.5"
-          pTooltip="Active count excludes Emeritus seats; total roster count includes them"
+          pTooltip="Active count excludes Emeritus and LF Staff seats; total roster count includes them"
           tooltipPosition="top"
           tooltipEvent="both"
           tabindex="0"

--- a/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.ts
@@ -47,9 +47,13 @@ export class CommitteeEngagementSummaryComponent {
     const summary = this.engagement()?.summary;
     return summary ? formatCommitteeEngagementRatePercent(summary.attendance_rate) : '—';
   });
+  // Denominator is eligible_count, NOT total_count (LFXV2-3101 review fix) — total_count includes
+  // Emeritus/LF Staff seats that active_count's numerator always excludes, so active_count/
+  // total_count could never reach 100% for a committee that seats either. See
+  // CommitteeEngagementSummary.eligible_count's doc.
   public readonly activeMembersLabel: Signal<string> = computed(() => {
     const summary = this.engagement()?.summary;
-    return summary ? `${summary.active_count}/${summary.total_count}` : '—';
+    return summary ? `${summary.active_count}/${summary.eligible_count}` : '—';
   });
   public readonly atRiskCount: Signal<number> = computed(() => this.engagement()?.summary?.at_risk_count ?? 0);
   // Explicit aria-labels below embed the displayed value/window — a screen-reader user focusing
@@ -60,7 +64,7 @@ export class CommitteeEngagementSummaryComponent {
   );
   public readonly activeMembersAriaLabel: Signal<string> = computed(
     () =>
-      `Active Members (${this.windowLabel()}): ${this.activeMembersLabel()} — active count excludes Emeritus and LF Staff seats; total roster count includes them`
+      `Active Members (${this.windowLabel()}): ${this.activeMembersLabel()} — both active count and the denominator exclude Emeritus and LF Staff seats; the full roster count is shown separately elsewhere on the page`
   );
 
   public onWindowChange(windowId: string): void {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.ts
@@ -55,10 +55,12 @@ export class CommitteeEngagementSummaryComponent {
   // Explicit aria-labels below embed the displayed value/window — a screen-reader user focusing
   // the tooltip host must hear the metric itself, not just its explanation (LFXV2-1705 review).
   public readonly attendanceRateAriaLabel: Signal<string> = computed(
-    () => `Attendance Rate: ${this.attendanceRateLabel()} — personal attendance across all invited roster members, including Emeritus seats`
+    () =>
+      `Attendance Rate: ${this.attendanceRateLabel()} — personal attendance across all invited roster members, including Emeritus seats but excluding LF Staff seats`
   );
   public readonly activeMembersAriaLabel: Signal<string> = computed(
-    () => `Active Members (${this.windowLabel()}): ${this.activeMembersLabel()} — active count excludes Emeritus seats; total roster count includes them`
+    () =>
+      `Active Members (${this.windowLabel()}): ${this.activeMembersLabel()} — active count excludes Emeritus and LF Staff seats; total roster count includes them`
   );
 
   public onWindowChange(windowId: string): void {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -941,9 +941,11 @@ export class CommitteeMembersComponent implements OnInit {
   /**
    * Tooltip context for the engagement chip. Emeritus and LF Staff (LFXV2-3101) both get a neutral
    * explainer — neither renders with at-risk styling, and neither's classification is driven by
-   * their real attendance numbers, so a tooltip stating those numbers would be misleading. Chair /
-   * Vice Chair are called out so their (real) attendance reads with role context. Empty string
-   * disables the PrimeNG tooltip.
+   * their real attendance numbers, so this tooltip states the exclusion rather than the numbers
+   * themselves (the Meetings column still shows the real attended/invited count for every row,
+   * chip-neutral seats included — this tooltip only concerns the classification chip). Chair / Vice
+   * Chair are called out so their (real) attendance reads with role context. Empty string disables
+   * the PrimeNG tooltip.
    */
   private resolveEngagementContext(row: CommitteeMemberEngagement): string {
     if (row.voting_status === CommitteeMemberVotingStatus.EMERITUS) {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -939,15 +939,20 @@ export class CommitteeMembersComponent implements OnInit {
   }
 
   /**
-   * Tooltip context for the engagement chip. Emeritus gets the honorific explainer (it renders as
-   * a neutral state, never at-risk styling); Chair / Vice Chair / LF Staff seats are called out so
-   * their attendance reads with role context. Empty string disables the PrimeNG tooltip.
+   * Tooltip context for the engagement chip. Emeritus and LF Staff (LFXV2-3101) both get a neutral
+   * explainer — neither renders with at-risk styling, and neither's classification is driven by
+   * their real attendance numbers, so a tooltip stating those numbers would be misleading. Chair /
+   * Vice Chair are called out so their (real) attendance reads with role context. Empty string
+   * disables the PrimeNG tooltip.
    */
   private resolveEngagementContext(row: CommitteeMemberEngagement): string {
     if (row.voting_status === CommitteeMemberVotingStatus.EMERITUS) {
       return 'Emeritus seat — honorific status; attendance expectations do not apply';
     }
-    if (row.role === CommitteeMemberRole.CHAIR || row.role === CommitteeMemberRole.VICE_CHAIR || row.role === CommitteeMemberRole.LF_STAFF) {
+    if (row.role === CommitteeMemberRole.LF_STAFF) {
+      return 'LF Staff seat — excluded from engagement metrics; attendance expectations do not apply';
+    }
+    if (row.role === CommitteeMemberRole.CHAIR || row.role === CommitteeMemberRole.VICE_CHAIR) {
       return `${row.role} — attended ${row.attended} of ${row.invited} invited meetings`;
     }
     return '';

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -939,22 +939,24 @@ export class CommitteeMembersComponent implements OnInit {
   }
 
   /**
-   * Tooltip context for the engagement chip. Emeritus and LF Staff (LFXV2-3101) both get a neutral
-   * explainer — neither renders with at-risk styling, and neither's classification is driven by
-   * their real attendance numbers, so this tooltip states the exclusion rather than the numbers
-   * themselves (the Meetings column still shows the real attended/invited count for every row,
-   * chip-neutral seats included — this tooltip only concerns the classification chip). Chair / Vice
-   * Chair are called out so their (real) attendance reads with role context. Empty string disables
-   * the PrimeNG tooltip.
+   * Tooltip context for the engagement chip. Emeritus and LF Staff+Observer (LFXV2-3101, narrowed
+   * to this two-part condition in a follow-up review — an LF Staff member who is a real Voting Rep
+   * or Alternate Voting Rep is a genuine participant, not excluded) both get a neutral explainer —
+   * neither renders with at-risk styling, and neither's classification is driven by their real
+   * attendance numbers, so this tooltip states the exclusion rather than the numbers themselves
+   * (the Meetings column still shows the real attended/invited count for every row, chip-neutral
+   * seats included — this tooltip only concerns the classification chip). Chair / Vice Chair / a
+   * real (non-excluded) LF Staff seat are called out so their (real) attendance reads with role
+   * context. Empty string disables the PrimeNG tooltip.
    */
   private resolveEngagementContext(row: CommitteeMemberEngagement): string {
     if (row.voting_status === CommitteeMemberVotingStatus.EMERITUS) {
       return 'Emeritus seat — honorific status; attendance expectations do not apply';
     }
-    if (row.role === CommitteeMemberRole.LF_STAFF) {
+    if (row.role === CommitteeMemberRole.LF_STAFF && row.voting_status === CommitteeMemberVotingStatus.OBSERVER) {
       return 'LF Staff seat — excluded from engagement metrics; attendance expectations do not apply';
     }
-    if (row.role === CommitteeMemberRole.CHAIR || row.role === CommitteeMemberRole.VICE_CHAIR) {
+    if (row.role === CommitteeMemberRole.CHAIR || row.role === CommitteeMemberRole.VICE_CHAIR || row.role === CommitteeMemberRole.LF_STAFF) {
       return `${row.role} — attended ${row.attended} of ${row.invited} invited meetings`;
     }
     return '';

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
@@ -202,6 +202,41 @@ describe('generateMockEngagementRows', () => {
       expect(m1).toMatchObject({ INVITED_COUNT_30D: 5, ATTENDED_COUNT_30D: 5, MEMBER_JOINED_AT: secondMostRecentJoin });
     });
 
+    it('never assigns the Orlin case to a real LF Staff member, even if they are the most-recently-joined real member — a different eligible member takes it instead (LFXV2-3101)', () => {
+      // Regression: classifyCommitteeEngagement short-circuits LF Staff exactly like Emeritus, so an
+      // LF Staff candidate would silently absorb the Orlin slot without ever rendering forced counts.
+      // Mirrors the Emeritus test above.
+      const mostRecentJoin = new Date(Date.now() - 27 * 24 * 60 * 60 * 1000).toISOString();
+      const secondMostRecentJoin = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000).toISOString();
+      const roster = [
+        member('m0', { role: { name: 'LF Staff' } as never, created_at: mostRecentJoin }),
+        member('m1', { created_at: secondMostRecentJoin }),
+        ...ROSTER.slice(2),
+      ];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m0 = rows.find((r) => r.MEMBER_USER_ID === 'm0');
+      const m1 = rows.find((r) => r.MEMBER_USER_ID === 'm1');
+      expect(m0?.MEMBER_ROLE).toBe('LF Staff');
+      expect(m0?.INVITED_COUNT_30D).not.toBe(5);
+      expect(m1).toMatchObject({ INVITED_COUNT_30D: 5, ATTENDED_COUNT_30D: 5, MEMBER_JOINED_AT: secondMostRecentJoin });
+    });
+
+    it('never assigns a reserved Inactive/Low/Medium demo pattern to a real LF Staff member — a different eligible member takes it instead (LFXV2-3101)', () => {
+      // Reserved slot 2 is normally Inactive (see the top-level test above) — putting a real LF
+      // Staff member there must bump the Inactive pattern to the next eligible member instead of
+      // silently swallowing it, mirroring how the Orlin/Emeritus exclusions work.
+      const roster = [ROSTER[0], ROSTER[1], member('m2', { role: { name: 'LF Staff' } as never }), ...ROSTER.slice(3)];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m2 = rows.find((r) => r.MEMBER_USER_ID === 'm2');
+      const m3 = rows.find((r) => r.MEMBER_USER_ID === 'm3');
+      expect(m2?.MEMBER_ROLE).toBe('LF Staff');
+      // The Inactive pattern's shape (invited but never attends) is deterministic and
+      // committee-wide, independent of which uid holds it — so whichever member now holds it
+      // reproduces the exact numbers the unmodified-roster test above asserts for slot 2.
+      expect(m3?.INVITED_COUNT_30D).toBeGreaterThan(0);
+      expect(m3?.ATTENDED_COUNT_30D).toBe(0);
+    });
+
     it('does not force the literal Orlin counts on a real member whose tenure is too short to plausibly support them', () => {
       // A member who really joined yesterday cannot honestly show 5 real meetings attended,
       // regardless of the ticket's literal example — the forced counts must stay off unless real

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
@@ -179,6 +179,21 @@ describe('generateMockEngagementRows', () => {
       expect(rows.find((r) => r.MEMBER_USER_ID === 'm0')?.MEMBER_VOTING_STATUS).toBe('Voting Rep');
     });
 
+    it('never promotes a real LF Staff member to the fabricated Emeritus fallback — a different eligible member takes it instead (LFXV2-3101)', () => {
+      // Regression: without the exclusion, m0 (first index with no real voting status) would be
+      // promoted to a fabricated Emeritus profile — rendering the wrong chip (Emeritus instead of
+      // LF Staff) and, since Emeritus isn't rate-excluded, feeding its fabricated high-invite/
+      // near-zero-attendance numbers into attendance_rate, the exact depression this ticket exists
+      // to prevent.
+      const roster = [member('m0', { role: { name: 'LF Staff' } as never }), ...ROSTER.slice(1)];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m0 = rows.find((r) => r.MEMBER_USER_ID === 'm0');
+      expect(m0?.MEMBER_ROLE).toBe('LF Staff');
+      expect(m0?.MEMBER_VOTING_STATUS).not.toBe('Emeritus');
+      // Someone else on the roster still demonstrates the Emeritus scenario.
+      expect(rows.some((r) => r.MEMBER_VOTING_STATUS === 'Emeritus')).toBe(true);
+    });
+
     it('never assigns the Orlin case to a real Emeritus member, even if they are the most-recently-joined real member — a different eligible member takes it instead', () => {
       // Regression: buildAttendanceProfile checks isEmeritus before the Orlin slot, so an
       // Emeritus candidate would silently absorb the role without ever rendering forced counts —
@@ -210,14 +225,26 @@ describe('generateMockEngagementRows', () => {
       const secondMostRecentJoin = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000).toISOString();
       const roster = [
         member('m0', { role: { name: 'LF Staff' } as never, created_at: mostRecentJoin }),
-        member('m1', { created_at: secondMostRecentJoin }),
+        // Real (non-null) voting status so m1 isn't itself swept into the Emeritus fallback once
+        // m0 is excluded from it — this test is isolating the Orlin-slot exclusion, not that one.
+        member('m1', { voting: { status: 'Voting Rep' } as never, created_at: secondMostRecentJoin }),
         ...ROSTER.slice(2),
       ];
       const rows = generateMockEngagementRows('committee-1', roster);
       const m0 = rows.find((r) => r.MEMBER_USER_ID === 'm0');
       const m1 = rows.find((r) => r.MEMBER_USER_ID === 'm1');
       expect(m0?.MEMBER_ROLE).toBe('LF Staff');
-      expect(m0?.INVITED_COUNT_30D).not.toBe(5);
+      // A single window's organic count can coincidentally equal 5 (as it does for this seed) — the
+      // Orlin profile's real signature is the *same* forced 5/5 repeating across all three windows,
+      // which an organic (hash-derived, window-scaled) profile essentially never reproduces by chance.
+      expect(m0).not.toMatchObject({
+        INVITED_COUNT_30D: 5,
+        ATTENDED_COUNT_30D: 5,
+        INVITED_COUNT_90D: 5,
+        ATTENDED_COUNT_90D: 5,
+        INVITED_COUNT_YTD: 5,
+        ATTENDED_COUNT_YTD: 5,
+      });
       expect(m1).toMatchObject({ INVITED_COUNT_30D: 5, ATTENDED_COUNT_30D: 5, MEMBER_JOINED_AT: secondMostRecentJoin });
     });
 

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
@@ -259,9 +259,24 @@ describe('generateMockEngagementRows', () => {
       expect(m2?.MEMBER_ROLE).toBe('LF Staff');
       // The Inactive pattern's shape (invited but never attends) is deterministic and
       // committee-wide, independent of which uid holds it — so whichever member now holds it
-      // reproduces the exact numbers the unmodified-roster test above asserts for slot 2.
-      expect(m3?.INVITED_COUNT_30D).toBeGreaterThan(0);
-      expect(m3?.ATTENDED_COUNT_30D).toBe(0);
+      // reproduces the exact numbers the unmodified-roster test above asserts for slot 2, across
+      // EVERY window. Asserting only 30d isn't enough: an organic (hash-derived) member can hit
+      // attended === 0 for a single window by coincidence, same risk the Orlin test above guards
+      // against with its own all-windows check.
+      for (const suffix of ['30D', '90D', 'YTD'] as const) {
+        expect(m3?.[`INVITED_COUNT_${suffix}`]).toBeGreaterThan(0);
+        expect(m3?.[`ATTENDED_COUNT_${suffix}`]).toBe(0);
+      }
+      // And m2 itself must not coincidentally carry that same signature in every window — the real
+      // assertion is that the pattern moved, not merely that m2's 30d number happens to differ.
+      expect(m2).not.toMatchObject({
+        INVITED_COUNT_30D: m3?.INVITED_COUNT_30D,
+        ATTENDED_COUNT_30D: 0,
+        INVITED_COUNT_90D: m3?.INVITED_COUNT_90D,
+        ATTENDED_COUNT_90D: 0,
+        INVITED_COUNT_YTD: m3?.INVITED_COUNT_YTD,
+        ATTENDED_COUNT_YTD: 0,
+      });
     });
 
     it('does not force the literal Orlin counts on a real member whose tenure is too short to plausibly support them', () => {

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
@@ -179,13 +179,14 @@ describe('generateMockEngagementRows', () => {
       expect(rows.find((r) => r.MEMBER_USER_ID === 'm0')?.MEMBER_VOTING_STATUS).toBe('Voting Rep');
     });
 
-    it('never promotes a real LF Staff member to the fabricated Emeritus fallback — a different eligible member takes it instead (LFXV2-3101)', () => {
-      // Regression: without the exclusion, m0 (first index with no real voting status) would be
-      // promoted to a fabricated Emeritus profile — rendering the wrong chip (Emeritus instead of
-      // LF Staff) and, since Emeritus isn't rate-excluded, feeding its fabricated high-invite/
-      // near-zero-attendance numbers into attendance_rate, the exact depression this ticket exists
-      // to prevent.
-      const roster = [member('m0', { role: { name: 'LF Staff' } as never }), ...ROSTER.slice(1)];
+    it('never promotes a real LF Staff + Observer member to the fabricated Emeritus fallback — a different eligible member takes it instead (LFXV2-3101)', () => {
+      // Regression: without the exclusion, m0 would be promoted to a fabricated Emeritus profile —
+      // rendering the wrong chip (Emeritus instead of LF Staff) and, since Emeritus isn't
+      // rate-excluded, feeding its fabricated high-invite/near-zero-attendance numbers into
+      // attendance_rate, the exact depression this ticket exists to prevent. Real (Observer) voting
+      // status set explicitly so this doesn't depend on the organic hash-derived fallback landing
+      // on Observer by chance.
+      const roster = [member('m0', { role: { name: 'LF Staff' } as never, voting: { status: 'Observer' } as never }), ...ROSTER.slice(1)];
       const rows = generateMockEngagementRows('committee-1', roster);
       const m0 = rows.find((r) => r.MEMBER_USER_ID === 'm0');
       expect(m0?.MEMBER_ROLE).toBe('LF Staff');
@@ -217,14 +218,16 @@ describe('generateMockEngagementRows', () => {
       expect(m1).toMatchObject({ INVITED_COUNT_30D: 5, ATTENDED_COUNT_30D: 5, MEMBER_JOINED_AT: secondMostRecentJoin });
     });
 
-    it('never assigns the Orlin case to a real LF Staff member, even if they are the most-recently-joined real member — a different eligible member takes it instead (LFXV2-3101)', () => {
-      // Regression: classifyCommitteeEngagement short-circuits LF Staff exactly like Emeritus, so an
-      // LF Staff candidate would silently absorb the Orlin slot without ever rendering forced counts.
-      // Mirrors the Emeritus test above.
+    it('never assigns the Orlin case to a real LF Staff + Observer member, even if they are the most-recently-joined real member — a different eligible member takes it instead (LFXV2-3101)', () => {
+      // Regression: classifyCommitteeEngagement short-circuits LF Staff + Observer exactly like
+      // Emeritus, so an LF Staff + Observer candidate would silently absorb the Orlin slot without
+      // ever rendering forced counts. Mirrors the Emeritus test above. Real (Observer) voting
+      // status set explicitly so this doesn't depend on the organic hash-derived fallback landing
+      // on Observer by chance.
       const mostRecentJoin = new Date(Date.now() - 27 * 24 * 60 * 60 * 1000).toISOString();
       const secondMostRecentJoin = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000).toISOString();
       const roster = [
-        member('m0', { role: { name: 'LF Staff' } as never, created_at: mostRecentJoin }),
+        member('m0', { role: { name: 'LF Staff' } as never, voting: { status: 'Observer' } as never, created_at: mostRecentJoin }),
         // Real (non-null) voting status so m1 isn't itself swept into the Emeritus fallback once
         // m0 is excluded from it — this test is isolating the Orlin-slot exclusion, not that one.
         member('m1', { voting: { status: 'Voting Rep' } as never, created_at: secondMostRecentJoin }),
@@ -248,11 +251,35 @@ describe('generateMockEngagementRows', () => {
       expect(m1).toMatchObject({ INVITED_COUNT_30D: 5, ATTENDED_COUNT_30D: 5, MEMBER_JOINED_AT: secondMostRecentJoin });
     });
 
-    it('never assigns a reserved Inactive/Low/Medium demo pattern to a real LF Staff member — a different eligible member takes it instead (LFXV2-3101)', () => {
+    it('DOES assign the Orlin case to a real LF Staff + Voting Rep member — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
+      // A real Voting Rep who happens to be LF Staff never classifies 'LF Staff' under the
+      // narrowed rule, so they're eligible for the Orlin slot exactly like any other real member.
+      const mostRecentJoin = new Date(Date.now() - 27 * 24 * 60 * 60 * 1000).toISOString();
+      const roster = [
+        member('m0', { role: { name: 'LF Staff' } as never, voting: { status: 'Voting Rep' } as never, created_at: mostRecentJoin }),
+        ...ROSTER.slice(1),
+      ];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m0 = rows.find((r) => r.MEMBER_USER_ID === 'm0');
+      expect(m0?.MEMBER_ROLE).toBe('LF Staff');
+      expect(m0?.MEMBER_VOTING_STATUS).toBe('Voting Rep');
+      expect(m0).toMatchObject({
+        INVITED_COUNT_30D: 5,
+        ATTENDED_COUNT_30D: 5,
+        INVITED_COUNT_90D: 5,
+        ATTENDED_COUNT_90D: 5,
+        INVITED_COUNT_YTD: 5,
+        ATTENDED_COUNT_YTD: 5,
+      });
+    });
+
+    it('never assigns a reserved Inactive/Low/Medium demo pattern to a real LF Staff + Observer member — a different eligible member takes it instead (LFXV2-3101)', () => {
       // Reserved slot 2 is normally Inactive (see the top-level test above) — putting a real LF
-      // Staff member there must bump the Inactive pattern to the next eligible member instead of
-      // silently swallowing it, mirroring how the Orlin/Emeritus exclusions work.
-      const roster = [ROSTER[0], ROSTER[1], member('m2', { role: { name: 'LF Staff' } as never }), ...ROSTER.slice(3)];
+      // Staff + Observer member there must bump the Inactive pattern to the next eligible member
+      // instead of silently swallowing it, mirroring how the Orlin/Emeritus exclusions work. Real
+      // (Observer) voting status set explicitly so this doesn't depend on the organic hash-derived
+      // fallback landing on Observer by chance.
+      const roster = [ROSTER[0], ROSTER[1], member('m2', { role: { name: 'LF Staff' } as never, voting: { status: 'Observer' } as never }), ...ROSTER.slice(3)];
       const rows = generateMockEngagementRows('committee-1', roster);
       const m2 = rows.find((r) => r.MEMBER_USER_ID === 'm2');
       const m3 = rows.find((r) => r.MEMBER_USER_ID === 'm3');
@@ -277,6 +304,23 @@ describe('generateMockEngagementRows', () => {
         INVITED_COUNT_YTD: m3?.INVITED_COUNT_YTD,
         ATTENDED_COUNT_YTD: 0,
       });
+    });
+
+    it('DOES assign a reserved demo pattern to a real LF Staff + Voting Rep member at slot 2 — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
+      const roster = [
+        ROSTER[0],
+        ROSTER[1],
+        member('m2', { role: { name: 'LF Staff' } as never, voting: { status: 'Voting Rep' } as never }),
+        ...ROSTER.slice(3),
+      ];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m2 = rows.find((r) => r.MEMBER_USER_ID === 'm2');
+      expect(m2?.MEMBER_ROLE).toBe('LF Staff');
+      expect(m2?.MEMBER_VOTING_STATUS).toBe('Voting Rep');
+      for (const suffix of ['30D', '90D', 'YTD'] as const) {
+        expect(m2?.[`INVITED_COUNT_${suffix}`]).toBeGreaterThan(0);
+        expect(m2?.[`ATTENDED_COUNT_${suffix}`]).toBe(0);
+      }
     });
 
     it('does not force the literal Orlin counts on a real member whose tenure is too short to plausibly support them', () => {

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
@@ -34,8 +34,12 @@ const ORLIN_FORCED_COUNTS = { invited: 5, attended: 5 };
  * a member's numbers never imply meetings that happened before their shown join date.
  * `MEMBER_VOTING_STATUS` prefers the real `voting.status` too — including a real `'None'`, which is
  * itself a recorded status and never overwritten — falling back to a hash-derived placeholder only
- * for members with no usable real status (no `voting` recorded, or a blank/falsy `status`). Two
- * scenarios (`Emeritus`, "the Orlin case" — see below) are guaranteed visible somewhere in the
+ * for members with no usable real status (no `voting` recorded, or a blank/falsy `status`). Any
+ * real `role: 'LF Staff'` member (LFXV2-3101) is excluded from the Orlin-slot and reserved
+ * Inactive/Low/Medium demo-pattern eligibility pools, the same way a real (or promoted) `Emeritus`
+ * member is — both roster facts always short-circuit `classifyCommitteeEngagement` regardless of
+ * fabricated numbers, so assigning either role a reserved attendance pattern would silently swallow
+ * it rather than render it. Two scenarios (`Emeritus`, "the Orlin case" — see below) are guaranteed visible somewhere in the
  * roster whenever that's possible without
  * overriding a real, known value; when every member's real data already rules a scenario out
  * (e.g. every member has a real non-`Emeritus` status), that scenario simply isn't demonstrated
@@ -64,17 +68,17 @@ interface MemberIdentity {
 
 interface RosterPlan {
   identities: MemberIdentity[];
-  /** Sorted index of the member demonstrating the "Orlin case" (forced low-but-100%-rate counts); `null` when no member (excluding any `Emeritus`) can take the role without contradicting real tenure data. */
+  /** Sorted index of the member demonstrating the "Orlin case" (forced low-but-100%-rate counts); `null` when no member (excluding any `Emeritus` or real `LF Staff`, LFXV2-3101) can take the role without contradicting real tenure data. */
   orlinIndex: number | null;
   /** Tenure (days) to use for `orlinIndex` when that member has no real join date — computed per committee so the forced counts stay plausible against this committee's own real 30-day meeting cadence; unused when `orlinIndex` is `null` or has real tenure data. */
   orlinFallbackJoinedDaysAgo: number;
   /**
-   * Every sorted index except `orlinIndex` and any `Emeritus` member (real or promoted), in
-   * order — i.e. every member eligible for a reserved pattern. Only the first
-   * `DEMO_ATTENDANCE_PROFILES.length` of these actually receive one (Inactive/Low/Medium); the
-   * rest are organic. Kept as a plain eligibility list rather than pre-sliced so
-   * `buildAttendanceProfile` can compute the same boundary once, from `indexOf`, for both the
-   * tenure default and the pattern assignment.
+   * Every sorted index except `orlinIndex`, any `Emeritus` member (real or promoted), and any real
+   * `LF Staff` member (LFXV2-3101), in order — i.e. every member eligible for a reserved pattern.
+   * Only the first `DEMO_ATTENDANCE_PROFILES.length` of these actually receive one
+   * (Inactive/Low/Medium); the rest are organic. Kept as a plain eligibility list rather than
+   * pre-sliced so `buildAttendanceProfile` can compute the same boundary once, from `indexOf`, for
+   * both the tenure default and the pattern assignment.
    */
   demoAttendanceIndices: number[];
 }
@@ -93,9 +97,10 @@ interface RosterPlan {
  *   value (Emeritus is what proves the classifier's Emeritus short-circuit and the `active_count`
  *   exclusion) for the stronger guarantee of never relabeling a real, recorded status — the same
  *   trade this file makes for tenure data (see the "Known trade-off" note below).
- * - "The Orlin case": eligible candidates exclude every `Emeritus` member (real or promoted) — the
- *   Emeritus profile always takes precedence in `buildAttendanceProfile`, so an Emeritus candidate
- *   would silently swallow the slot without ever rendering it. Among the rest, the most-recently
+ * - "The Orlin case": eligible candidates exclude every `Emeritus` member (real or promoted) and
+ *   every real `LF Staff` member (LFXV2-3101) — the Emeritus and LF Staff profiles both always take
+ *   precedence in `classifyCommitteeEngagement`, so either candidate would silently swallow the
+ *   slot without ever rendering it as the intended demo tier. Among the rest, the most-recently
  *   real-joined member is used *only* if their tenure is at least `minOrlinTenureDays` *and* less
  *   than `WINDOW_30D_DAYS` — the upper bound keeps this specifically the "joined *recently*" case
  *   (the ticket's literal example) rather than any tenured member who happens to clear the lower
@@ -146,18 +151,25 @@ function planRosterIdentities(committeeUid: string, sortedMembers: CommitteeMemb
   }
 
   const isEmeritus = (index: number): boolean => votingStatuses[index] === CommitteeMemberVotingStatus.EMERITUS;
+  // `LF Staff` (LFXV2-3101) always classifies `LF Staff` regardless of attendance numbers, exactly
+  // like Emeritus always classifies `Emeritus` — an LF Staff member assigned the Orlin slot or a
+  // reserved Inactive/Low/Medium demo pattern would silently swallow it the same way an Emeritus
+  // member would, so it's excluded from both eligibility pools the same way. `MEMBER_ROLE` is
+  // always the roster's real role (see the module doc), so this is a real exclusion, not a
+  // hash-derived one.
+  const isLfStaff = (index: number): boolean => sortedMembers[index]?.role?.name === CommitteeMemberRole.LF_STAFF;
 
   let orlinIndex = realJoinedDaysAgo.reduce<number | null>((mostRecentIndex, days, index) => {
-    if (days === null || days < minOrlinTenureDays || days >= WINDOW_30D_DAYS || isEmeritus(index)) return mostRecentIndex;
+    if (days === null || days < minOrlinTenureDays || days >= WINDOW_30D_DAYS || isEmeritus(index) || isLfStaff(index)) return mostRecentIndex;
     if (mostRecentIndex === null || days < (realJoinedDaysAgo[mostRecentIndex] as number)) return index;
     return mostRecentIndex;
   }, null);
   if (orlinIndex === null) {
-    const fallbackIndex = realJoinedDaysAgo.findIndex((days, index) => days === null && !isEmeritus(index));
+    const fallbackIndex = realJoinedDaysAgo.findIndex((days, index) => days === null && !isEmeritus(index) && !isLfStaff(index));
     orlinIndex = fallbackIndex === -1 ? null : fallbackIndex;
   }
 
-  const demoAttendanceIndices = sortedMembers.map((_, index) => index).filter((index) => index !== orlinIndex && !isEmeritus(index));
+  const demoAttendanceIndices = sortedMembers.map((_, index) => index).filter((index) => index !== orlinIndex && !isEmeritus(index) && !isLfStaff(index));
 
   return {
     identities: sortedMembers.map((_, index) => ({

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
@@ -233,7 +233,8 @@ interface AttendanceProfile {
 /**
  * The three attendance *patterns* (never identity) demonstrating Inactive/Low/Medium, assigned in
  * `RosterPlan.demoAttendanceIndices` order (not fixed sorted positions — see `planRosterIdentities`
- * for why the assignable set excludes the Orlin and any real-Emeritus members).
+ * for why the assignable set excludes the Orlin slot, any real-Emeritus member, and any real
+ * `LF Staff` member).
  */
 const DEMO_ATTENDANCE_PROFILES: Omit<AttendanceProfile, 'joinedDaysAgo'>[] = [
   { invitationRate: 0.8, attendanceRateOverride: 0 }, // Inactive: invited but never attends.

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
@@ -35,15 +35,15 @@ const ORLIN_FORCED_COUNTS = { invited: 5, attended: 5 };
  * `MEMBER_VOTING_STATUS` prefers the real `voting.status` too — including a real `'None'`, which is
  * itself a recorded status and never overwritten — falling back to a hash-derived placeholder only
  * for members with no usable real status (no `voting` recorded, or a blank/falsy `status`). Any
- * real `role: 'LF Staff'` member (LFXV2-3101) is excluded from the Orlin-slot and reserved
- * Inactive/Low/Medium demo-pattern eligibility pools, the same way a real (or promoted) `Emeritus`
- * member is — both roster facts always short-circuit `classifyCommitteeEngagement` regardless of
- * fabricated numbers, so assigning either role a reserved attendance pattern would silently swallow
- * it rather than render it. Two scenarios (`Emeritus`, "the Orlin case" — see below) are guaranteed visible somewhere in the
- * roster whenever that's possible without
- * overriding a real, known value; when every member's real data already rules a scenario out
- * (e.g. every member has a real non-`Emeritus` status), that scenario simply isn't demonstrated
- * for this specific committee rather than being faked.
+ * real `role: 'LF Staff'` member (LFXV2-3101) is excluded from the Emeritus-fallback promotion, the
+ * Orlin slot, and the reserved Inactive/Low/Medium demo-pattern pool, the same way a real (or
+ * promoted) `Emeritus` member is excluded from the Orlin/demo pools — both roster facts always
+ * short-circuit `classifyCommitteeEngagement` regardless of fabricated numbers, so assigning either
+ * one a reserved slot would silently swallow it rather than render it. Two scenarios (`Emeritus`,
+ * "the Orlin case" — see below) are guaranteed visible somewhere in the roster whenever that's
+ * possible without overriding a real, known value; when every member's real data already rules a
+ * scenario out (e.g. every member has a real non-`Emeritus` status), that scenario simply isn't
+ * demonstrated for this specific committee rather than being faked.
  *
  * Every number is derived from stable inputs only — `committeeUid`, `member.uid`, `window`,
  * the member's real `created_at`/`voting.status` where present, the rest of the roster's identity

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
@@ -90,7 +90,11 @@ interface RosterPlan {
  * - `Emeritus`: real `voting.status` wins for every member — including a real `None`, which is a
  *   recorded status like any other, not an absence of one; if nothing on the roster is naturally
  *   `Emeritus`, the first member with no usable real status (no `voting` recorded, or a blank/falsy
- *   `status`) is promoted — but only that one case. If every member already has a real, known status
+ *   `status`) is promoted — but only that one case, and never a real `LF Staff` member (LFXV2-3101):
+ *   promoting one to a fabricated Emeritus profile would render the wrong chip (`Emeritus` instead
+ *   of `LF Staff`) and, since Emeritus is deliberately not rate-excluded, feed its fabricated
+ *   high-invite/near-zero-attendance numbers into `attendance_rate` — the exact depression the LF
+ *   Staff carve-out exists to prevent. If every member already has a real, known status
  *   (including a committee where everyone is `None` — the common case for a committee without
  *   voting enabled), no member is promoted;
  *   this committee's mock output just won't include an `Emeritus` row. This trades away some demo
@@ -140,24 +144,29 @@ function planRosterIdentities(committeeUid: string, sortedMembers: CommitteeMemb
   const votingStatuses = realVotingStatuses.map(
     (real, index) => real ?? organicVotingStatus(hashToUnitInterval(`${committeeUid}:${sortedMembers[index]?.uid}:voting-status`))
   );
+  // `LF Staff` (LFXV2-3101) always classifies `LF Staff` regardless of attendance numbers, exactly
+  // like Emeritus always classifies `Emeritus` — an LF Staff member assigned the Emeritus-fallback
+  // promotion, the Orlin slot, or a reserved Inactive/Low/Medium demo pattern would silently swallow
+  // whichever one it's assigned to (and, for the Emeritus promotion specifically, would also let a
+  // fabricated high-invite/near-zero-attendance Emeritus profile feed the rate sum, since Emeritus
+  // is deliberately NOT rate-excluded — the exact depression this ticket exists to prevent). Hoisted
+  // above the Emeritus-fallback block below so that block can exclude it too. `MEMBER_ROLE` is
+  // always the roster's real role (see the module doc), so this is a real exclusion, not a
+  // hash-derived one.
+  const isLfStaff = (index: number): boolean => sortedMembers[index]?.role?.name === CommitteeMemberRole.LF_STAFF;
+
   // The two fallback assignments below both prefer "the first member with no real data of the
   // relevant kind" — on a roster with no real data at all (e.g. a bare test fixture), that's the
   // same index for both, so the second fallback must skip whichever index the first one already
-  // claimed, or one member would need to simultaneously be Emeritus and the Orlin case.
+  // claimed, or one member would need to simultaneously be Emeritus and the Orlin case. Both also
+  // skip any real LF Staff member — see the comment on `isLfStaff` above.
   let emeritusFallbackIndex = -1;
   if (!votingStatuses.includes(CommitteeMemberVotingStatus.EMERITUS)) {
-    emeritusFallbackIndex = realVotingStatuses.findIndex((real) => real === null);
+    emeritusFallbackIndex = realVotingStatuses.findIndex((real, index) => real === null && !isLfStaff(index));
     if (emeritusFallbackIndex !== -1) votingStatuses[emeritusFallbackIndex] = CommitteeMemberVotingStatus.EMERITUS;
   }
 
   const isEmeritus = (index: number): boolean => votingStatuses[index] === CommitteeMemberVotingStatus.EMERITUS;
-  // `LF Staff` (LFXV2-3101) always classifies `LF Staff` regardless of attendance numbers, exactly
-  // like Emeritus always classifies `Emeritus` — an LF Staff member assigned the Orlin slot or a
-  // reserved Inactive/Low/Medium demo pattern would silently swallow it the same way an Emeritus
-  // member would, so it's excluded from both eligibility pools the same way. `MEMBER_ROLE` is
-  // always the roster's real role (see the module doc), so this is a real exclusion, not a
-  // hash-derived one.
-  const isLfStaff = (index: number): boolean => sortedMembers[index]?.role?.name === CommitteeMemberRole.LF_STAFF;
 
   let orlinIndex = realJoinedDaysAgo.reduce<number | null>((mostRecentIndex, days, index) => {
     if (days === null || days < minOrlinTenureDays || days >= WINDOW_30D_DAYS || isEmeritus(index) || isLfStaff(index)) return mostRecentIndex;

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
@@ -35,7 +35,7 @@ const ORLIN_FORCED_COUNTS = { invited: 5, attended: 5 };
  * `MEMBER_VOTING_STATUS` prefers the real `voting.status` too — including a real `'None'`, which is
  * itself a recorded status and never overwritten — falling back to a hash-derived placeholder only
  * for members with no usable real status (no `voting` recorded, or a blank/falsy `status`). Any
- * real `role: 'LF Staff'` member (LFXV2-3101) is excluded from the Emeritus-fallback promotion, the
+ * real `role: 'LF Staff'` member with `voting.status: 'Observer'` (LFXV2-3101) is excluded from the Emeritus-fallback promotion, the
  * Orlin slot, and the reserved Inactive/Low/Medium demo-pattern pool, the same way a real (or
  * promoted) `Emeritus` member is excluded from the Orlin/demo pools — both roster facts always
  * short-circuit `classifyCommitteeEngagement` regardless of fabricated numbers, so assigning either
@@ -68,13 +68,13 @@ interface MemberIdentity {
 
 interface RosterPlan {
   identities: MemberIdentity[];
-  /** Sorted index of the member demonstrating the "Orlin case" (forced low-but-100%-rate counts); `null` when no member (excluding any `Emeritus` or real `LF Staff`, LFXV2-3101) can take the role without contradicting real tenure data. */
+  /** Sorted index of the member demonstrating the "Orlin case" (forced low-but-100%-rate counts); `null` when no member (excluding any `Emeritus` or real `LF Staff` + `Observer`, LFXV2-3101) can take the role without contradicting real tenure data. */
   orlinIndex: number | null;
   /** Tenure (days) to use for `orlinIndex` when that member has no real join date — computed per committee so the forced counts stay plausible against this committee's own real 30-day meeting cadence; unused when `orlinIndex` is `null` or has real tenure data. */
   orlinFallbackJoinedDaysAgo: number;
   /**
    * Every sorted index except `orlinIndex`, any `Emeritus` member (real or promoted), and any real
-   * `LF Staff` member (LFXV2-3101), in order — i.e. every member eligible for a reserved pattern.
+   * `LF Staff` + `Observer` member (LFXV2-3101), in order — i.e. every member eligible for a reserved pattern.
    * Only the first `DEMO_ATTENDANCE_PROFILES.length` of these actually receive one
    * (Inactive/Low/Medium); the rest are organic. Kept as a plain eligibility list rather than
    * pre-sliced so `buildAttendanceProfile` can compute the same boundary once, from `indexOf`, for
@@ -90,22 +90,26 @@ interface RosterPlan {
  * - `Emeritus`: real `voting.status` wins for every member — including a real `None`, which is a
  *   recorded status like any other, not an absence of one; if nothing on the roster is naturally
  *   `Emeritus`, the first member with no usable real status (no `voting` recorded, or a blank/falsy
- *   `status`) is promoted — but only that one case, and never a real `LF Staff` member (LFXV2-3101):
- *   promoting one to a fabricated Emeritus profile would render the wrong chip (`Emeritus` instead
- *   of `LF Staff`) and, since Emeritus is deliberately not rate-excluded, feed its fabricated
- *   high-invite/near-zero-attendance numbers into `attendance_rate` — the exact depression the LF
- *   Staff carve-out exists to prevent. If every member already has a real, known status
- *   (including a committee where everyone is `None` — the common case for a committee without
- *   voting enabled), no member is promoted;
- *   this committee's mock output just won't include an `Emeritus` row. This trades away some demo
- *   value (Emeritus is what proves the classifier's Emeritus short-circuit and the `active_count`
- *   exclusion) for the stronger guarantee of never relabeling a real, recorded status — the same
- *   trade this file makes for tenure data (see the "Known trade-off" note below).
+ *   `status`) is promoted — but only that one case, and never a real `LF Staff` + `Observer` member
+ *   (LFXV2-3101, narrowed to this two-part condition in a follow-up review): promoting one to a
+ *   fabricated Emeritus profile would render the wrong chip (`Emeritus` instead of `LF Staff`) and,
+ *   since Emeritus is deliberately not rate-excluded, feed its fabricated high-invite/
+ *   near-zero-attendance numbers into `attendance_rate` — the exact depression the LF Staff
+ *   carve-out exists to prevent. (A real `LF Staff` member with no real voting status who gets
+ *   organically hash-assigned a non-`Observer` status — e.g. `Voting Rep` — is NOT excluded from
+ *   this promotion: they'd never have classified `LF Staff` anyway under the narrowed rule, so
+ *   nothing is silently swallowed by promoting them.) If every member already has a real, known
+ *   status (including a committee where everyone is `None` — the common case for a committee
+ *   without voting enabled), no member is promoted; this committee's mock output just won't
+ *   include an `Emeritus` row. This trades away some demo value (Emeritus is what proves the
+ *   classifier's Emeritus short-circuit and the `active_count` exclusion) for the stronger
+ *   guarantee of never relabeling a real, recorded status — the same trade this file makes for
+ *   tenure data (see the "Known trade-off" note below).
  * - "The Orlin case": eligible candidates exclude every `Emeritus` member (real or promoted) and
- *   every real `LF Staff` member (LFXV2-3101) — the Emeritus and LF Staff profiles both always take
- *   precedence in `classifyCommitteeEngagement`, so either candidate would silently swallow the
- *   slot without ever rendering it as the intended demo tier. Among the rest, the most-recently
- *   real-joined member is used *only* if their tenure is at least `minOrlinTenureDays` *and* less
+ *   every real `LF Staff` + `Observer` member (LFXV2-3101) — the Emeritus and LF Staff profiles
+ *   both always take precedence in `classifyCommitteeEngagement`, so either candidate would
+ *   silently swallow the slot without ever rendering it as the intended demo tier. Among the rest,
+ *   the most-recently real-joined member is used *only* if their tenure is at least `minOrlinTenureDays` *and* less
  *   than `WINDOW_30D_DAYS` — the upper bound keeps this specifically the "joined *recently*" case
  *   (the ticket's literal example) rather than any tenured member who happens to clear the lower
  *   bound; without it, nearly every real committee would show the scenario, but on whichever
@@ -144,41 +148,49 @@ function planRosterIdentities(committeeUid: string, sortedMembers: CommitteeMemb
   const votingStatuses = realVotingStatuses.map(
     (real, index) => real ?? organicVotingStatus(hashToUnitInterval(`${committeeUid}:${sortedMembers[index]?.uid}:voting-status`))
   );
-  // `LF Staff` (LFXV2-3101) always classifies `LF Staff` regardless of attendance numbers, exactly
-  // like Emeritus always classifies `Emeritus` — an LF Staff member assigned the Emeritus-fallback
-  // promotion, the Orlin slot, or a reserved Inactive/Low/Medium demo pattern would silently swallow
-  // whichever one it's assigned to (and, for the Emeritus promotion specifically, would also let a
-  // fabricated high-invite/near-zero-attendance Emeritus profile feed the rate sum, since Emeritus
-  // is deliberately NOT rate-excluded — the exact depression this ticket exists to prevent). Hoisted
-  // above the Emeritus-fallback block below so that block can exclude it too. `MEMBER_ROLE` is
-  // always the roster's real role (see the module doc), so this is a real exclusion, not a
-  // hash-derived one.
-  const isLfStaff = (index: number): boolean => sortedMembers[index]?.role?.name === CommitteeMemberRole.LF_STAFF;
+  // `LF Staff` + `Observer` voting status (LFXV2-3101, narrowed in a follow-up review per Jordan
+  // Evans — a real Voting Rep or Alternate Voting Rep who happens to be LF Staff is a genuine
+  // participant and must NOT be excluded here) always classifies `LF Staff` regardless of
+  // attendance numbers, exactly like Emeritus always classifies `Emeritus` — a matching member
+  // assigned the Emeritus-fallback promotion, the Orlin slot, or a reserved Inactive/Low/Medium
+  // demo pattern would silently swallow whichever one it's assigned to (and, for the Emeritus
+  // promotion specifically, would also let a fabricated high-invite/near-zero-attendance Emeritus
+  // profile feed the rate sum, since Emeritus is deliberately NOT rate-excluded — the exact
+  // depression this ticket exists to prevent). Hoisted above the Emeritus-fallback block below so
+  // that block can exclude it too. `MEMBER_ROLE` is always the roster's real role (see the module
+  // doc), so this is a real exclusion, not a hash-derived one — `votingStatuses[index]` may still
+  // be organic/hash-derived when the member has no real recorded status, exactly like the
+  // production check (`isLfStaffObserverSeat` in `committee-engagement-classifier.utils.ts`) treats
+  // a real-or-fallback `MEMBER_VOTING_STATUS` identically either way.
+  const isLfStaffObserver = (index: number): boolean =>
+    sortedMembers[index]?.role?.name === CommitteeMemberRole.LF_STAFF && votingStatuses[index] === CommitteeMemberVotingStatus.OBSERVER;
 
   // The two fallback assignments below both prefer "the first member with no real data of the
   // relevant kind" — on a roster with no real data at all (e.g. a bare test fixture), that's the
   // same index for both, so the second fallback must skip whichever index the first one already
   // claimed, or one member would need to simultaneously be Emeritus and the Orlin case. Both also
-  // skip any real LF Staff member — see the comment on `isLfStaff` above.
+  // skip any real LF Staff + Observer member — see the comment on `isLfStaffObserver` above.
   let emeritusFallbackIndex = -1;
   if (!votingStatuses.includes(CommitteeMemberVotingStatus.EMERITUS)) {
-    emeritusFallbackIndex = realVotingStatuses.findIndex((real, index) => real === null && !isLfStaff(index));
+    emeritusFallbackIndex = realVotingStatuses.findIndex((real, index) => real === null && !isLfStaffObserver(index));
     if (emeritusFallbackIndex !== -1) votingStatuses[emeritusFallbackIndex] = CommitteeMemberVotingStatus.EMERITUS;
   }
 
   const isEmeritus = (index: number): boolean => votingStatuses[index] === CommitteeMemberVotingStatus.EMERITUS;
 
   let orlinIndex = realJoinedDaysAgo.reduce<number | null>((mostRecentIndex, days, index) => {
-    if (days === null || days < minOrlinTenureDays || days >= WINDOW_30D_DAYS || isEmeritus(index) || isLfStaff(index)) return mostRecentIndex;
+    if (days === null || days < minOrlinTenureDays || days >= WINDOW_30D_DAYS || isEmeritus(index) || isLfStaffObserver(index)) return mostRecentIndex;
     if (mostRecentIndex === null || days < (realJoinedDaysAgo[mostRecentIndex] as number)) return index;
     return mostRecentIndex;
   }, null);
   if (orlinIndex === null) {
-    const fallbackIndex = realJoinedDaysAgo.findIndex((days, index) => days === null && !isEmeritus(index) && !isLfStaff(index));
+    const fallbackIndex = realJoinedDaysAgo.findIndex((days, index) => days === null && !isEmeritus(index) && !isLfStaffObserver(index));
     orlinIndex = fallbackIndex === -1 ? null : fallbackIndex;
   }
 
-  const demoAttendanceIndices = sortedMembers.map((_, index) => index).filter((index) => index !== orlinIndex && !isEmeritus(index) && !isLfStaff(index));
+  const demoAttendanceIndices = sortedMembers
+    .map((_, index) => index)
+    .filter((index) => index !== orlinIndex && !isEmeritus(index) && !isLfStaffObserver(index));
 
   return {
     identities: sortedMembers.map((_, index) => ({
@@ -234,7 +246,7 @@ interface AttendanceProfile {
  * The three attendance *patterns* (never identity) demonstrating Inactive/Low/Medium, assigned in
  * `RosterPlan.demoAttendanceIndices` order (not fixed sorted positions — see `planRosterIdentities`
  * for why the assignable set excludes the Orlin slot, any real-Emeritus member, and any real
- * `LF Staff` member).
+ * `LF Staff` + `Observer` member).
  */
 const DEMO_ATTENDANCE_PROFILES: Omit<AttendanceProfile, 'joinedDaysAgo'>[] = [
   { invitationRate: 0.8, attendanceRateOverride: 0 }, // Inactive: invited but never attends.

--- a/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
@@ -58,6 +58,7 @@ vi.mock('@lfx-one/shared/utils', async () => {
     classifyCommitteeEngagement: actual.classifyCommitteeEngagement,
     computeCommitteeEngagementRate: actual.computeCommitteeEngagementRate,
     isCommitteeMemberActive: actual.isCommitteeMemberActive,
+    isCommitteeMemberActiveEligible: actual.isCommitteeMemberActiveEligible,
     isCommitteeMemberAtRisk: actual.isCommitteeMemberAtRisk,
     isCommitteeMemberRateEligible: actual.isCommitteeMemberRateEligible,
     isJoinedWithinWindow: actual.isJoinedWithinWindow,
@@ -296,7 +297,26 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
 
       // Without the exclusion this would be 10/18 = 0.56; the LF Staff row must not depress it.
       expect(result.summary.attendance_rate).toBe(1);
-      expect(result.summary.total_count).toBe(2); // roster count is unaffected — only the rate/active/at-risk sums exclude LF Staff
+      expect(result.summary.total_count).toBe(2); // roster count is unaffected — only the rate/active/eligible/at-risk sums exclude LF Staff
+      // eligible_count (the active_count ratio denominator, LFXV2-3101 review fix) excludes the
+      // LF Staff member too — 1/1, not 1/2, so the ratio can read 100% for this committee.
+      expect(result.summary.eligible_count).toBe(1);
+    });
+
+    it("excludes an Emeritus member from eligible_count, the active_count ratio's denominator (LFXV2-3101 review fix)", async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1'), member('emeritus')]);
+      generateMockEngagementRows.mockReturnValueOnce([
+        row({ MEMBER_USER_ID: 'm1', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 10 }),
+        row({ MEMBER_USER_ID: 'emeritus', MEMBER_VOTING_STATUS: 'Emeritus', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 1 }),
+      ]);
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      // Without the exclusion this would read active_count 1 / total_count 2 — permanently capped
+      // below 100% for any committee that seats an Emeritus member, regardless of real participation.
+      expect(result.summary.active_count).toBe(1);
+      expect(result.summary.eligible_count).toBe(1);
+      expect(result.summary.total_count).toBe(2);
     });
 
     it('does not broaden the LF Staff exclusion to a non-staff Observer with low attendance', async () => {
@@ -462,7 +482,7 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
 
       expect(result).toEqual({
         members: [{ uid: 'm1', attended: 0, invited: 0, rate: 0, classification: 'Inactive', role: 'None', voting_status: 'None', committee_meetings: 0 }],
-        summary: { attendance_rate: 0, active_count: 0, total_count: 1, at_risk_count: 0 },
+        summary: { attendance_rate: 0, active_count: 0, eligible_count: 1, total_count: 1, at_risk_count: 0 },
         computed_at: null,
         data_available: false,
         data_source: 'live',
@@ -504,7 +524,7 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
 
       expect(result.members[0]).toMatchObject({ invited: 0, attended: 0, classification: 'Inactive' });
-      expect(result.summary).toEqual({ attendance_rate: 0, active_count: 0, total_count: 1, at_risk_count: 0 });
+      expect(result.summary).toEqual({ attendance_rate: 0, active_count: 0, eligible_count: 1, total_count: 1, at_risk_count: 0 });
     });
 
     it('returns a fully internally-consistent zeroed payload for a no-rows committee — no member classifies High or counts active, regardless of roster tenure', async () => {
@@ -524,7 +544,8 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       // Emeritus is a roster seat-type fact, independent of engagement data — still shown, but it
       // doesn't count toward active_count/at_risk_count either way (isCommitteeMemberActive excludes it).
       expect(result.members.find((m) => m.uid === 'emeritus-member')).toMatchObject({ classification: 'Emeritus' });
-      expect(result.summary).toEqual({ attendance_rate: 0, active_count: 0, total_count: 3, at_risk_count: 0 });
+      // eligible_count excludes the Emeritus member too (roster-known, unaffected by data_available).
+      expect(result.summary).toEqual({ attendance_rate: 0, active_count: 0, eligible_count: 2, total_count: 3, at_risk_count: 0 });
     });
 
     it('still tenure-graces a roster member added since the model refresh when the committee DOES have real data (data_available:true)', async () => {

--- a/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
@@ -510,6 +510,26 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       expect(result.summary.attendance_rate).toBe(0);
     });
 
+    it('prefers the live roster voting status over a conflicting/stale warehouse MEMBER_VOTING_STATUS for the LF Staff exclusion (Cursor Bugbot follow-up, LFXV2-3101)', async () => {
+      // The roster and the matched row disagree on voting status — a promotion from Observer to a
+      // real Voting Rep landed on the live roster before the dbt model's next refresh (still
+      // reporting the old 'Observer'). Roster must win, the same way it already does for role —
+      // otherwise this member stays incorrectly excluded (stale role-fresh + votingStatus-stale
+      // combination) until the warehouse catches up.
+      getCommitteeMembers.mockResolvedValueOnce([member('m1', { role: { name: 'LF Staff' } as never, voting: { status: 'Voting Rep' } as never })]);
+      execute.mockResolvedValueOnce({
+        rows: [row({ MEMBER_USER_ID: 'm1', MEMBER_VOTING_STATUS: 'Observer', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 8 })],
+      });
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      // Classifies on real attendance (8/10 = High), NOT the neutral LF Staff tier — the stale
+      // warehouse 'Observer' must not win over the roster's real 'Voting Rep'.
+      expect(result.members[0]).toMatchObject({ role: 'LF Staff', voting_status: 'Voting Rep', classification: 'High' });
+      expect(result.summary.active_count).toBe(1);
+      expect(result.summary.attendance_rate).toBe(0.8);
+    });
+
     it('degrades to a zeroed, data_available:false response when the engagement table is missing', async () => {
       getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
       execute.mockRejectedValueOnce(new Error('Snowflake query execution failed: Object does not exist or not authorized.'));

--- a/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
@@ -59,6 +59,7 @@ vi.mock('@lfx-one/shared/utils', async () => {
     computeCommitteeEngagementRate: actual.computeCommitteeEngagementRate,
     isCommitteeMemberActive: actual.isCommitteeMemberActive,
     isCommitteeMemberAtRisk: actual.isCommitteeMemberAtRisk,
+    isCommitteeMemberRateEligible: actual.isCommitteeMemberRateEligible,
     isJoinedWithinWindow: actual.isJoinedWithinWindow,
   };
 });
@@ -461,6 +462,17 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
 
       expect(result.members[0]).toMatchObject({ role: 'Chair', voting_status: 'Emeritus', classification: 'Emeritus' });
       expect(result.summary.at_risk_count).toBe(0);
+    });
+
+    it('falls back to the roster real role on a degraded (unmatched) member, so a real LF Staff member still short-circuits (LFXV2-3101)', async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1', { role: { name: 'LF Staff' } as never })]);
+      execute.mockRejectedValueOnce(new Error('Snowflake query execution failed: Object does not exist or not authorized.'));
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      expect(result.members[0]).toMatchObject({ role: 'LF Staff', classification: 'LF Staff' });
+      expect(result.summary.at_risk_count).toBe(0);
+      expect(result.summary.active_count).toBe(0);
     });
 
     it('does NOT tenure-grace a recently-joined member when the whole committee has no data — classifies Inactive, not High, on a genuinely empty read', async () => {

--- a/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
@@ -273,6 +273,44 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       expect(result.summary.active_count).toBe(0);
     });
 
+    it('classifies an LF Staff member as "LF Staff" regardless of a low real attendance rate, and never at-risk (LFXV2-3101)', async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
+      generateMockEngagementRows.mockReturnValueOnce([row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'LF Staff', INVITED_COUNT_30D: 8, ATTENDED_COUNT_30D: 0 })]);
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      expect(result.members[0]).toMatchObject({ classification: 'LF Staff', role: 'LF Staff' });
+      expect(result.summary.at_risk_count).toBe(0);
+      expect(result.summary.active_count).toBe(0);
+    });
+
+    it("excludes an LF Staff member's attended/invited counts from the aggregate attendance_rate (LFXV2-3101)", async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1'), member('staff')]);
+      generateMockEngagementRows.mockReturnValueOnce([
+        row({ MEMBER_USER_ID: 'm1', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 10 }), // High, real member
+        row({ MEMBER_USER_ID: 'staff', MEMBER_ROLE: 'LF Staff', INVITED_COUNT_30D: 8, ATTENDED_COUNT_30D: 0 }), // LF Staff, 0 real attendance
+      ]);
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      // Without the exclusion this would be 10/18 = 0.56; the LF Staff row must not depress it.
+      expect(result.summary.attendance_rate).toBe(1);
+      expect(result.summary.total_count).toBe(2); // roster count is unaffected — only the rate/active/at-risk sums exclude LF Staff
+    });
+
+    it('does not broaden the LF Staff exclusion to a non-staff Observer with low attendance', async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
+      generateMockEngagementRows.mockReturnValueOnce([
+        row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'None', MEMBER_VOTING_STATUS: 'Observer', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 2 }),
+      ]);
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      expect(result.members[0]?.classification).toBe('Low');
+      expect(result.summary.at_risk_count).toBe(1);
+      expect(result.summary.attendance_rate).toBe(0.2);
+    });
+
     it('the new active_count rule counts a Low-classified member (some real attendance) as active', async () => {
       getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
       generateMockEngagementRows.mockReturnValueOnce([row({ MEMBER_USER_ID: 'm1', INVITED_COUNT_30D: 100, ATTENDED_COUNT_30D: 10 })]);

--- a/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
@@ -275,9 +275,11 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       expect(result.summary.active_count).toBe(0);
     });
 
-    it('classifies an LF Staff member as "LF Staff" regardless of a low real attendance rate, and never at-risk (LFXV2-3101)', async () => {
+    it('classifies an LF Staff + Observer member as "LF Staff" regardless of a low real attendance rate, and never at-risk (LFXV2-3101)', async () => {
       getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
-      generateMockEngagementRows.mockReturnValueOnce([row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'LF Staff', INVITED_COUNT_30D: 8, ATTENDED_COUNT_30D: 0 })]);
+      generateMockEngagementRows.mockReturnValueOnce([
+        row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'LF Staff', MEMBER_VOTING_STATUS: 'Observer', INVITED_COUNT_30D: 8, ATTENDED_COUNT_30D: 0 }),
+      ]);
 
       const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
 
@@ -286,21 +288,53 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       expect(result.summary.active_count).toBe(0);
     });
 
-    it("excludes an LF Staff member's attended/invited counts from the aggregate attendance_rate (LFXV2-3101)", async () => {
+    it('does NOT classify an LF Staff + Voting Rep member as "LF Staff" — only Observer-status staff seats are excluded (LFXV2-3101 follow-up, Jordan Evans review)', async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
+      // row()'s default MEMBER_VOTING_STATUS is 'Voting Rep' — deliberately left unset here to
+      // exercise that default, not overridden to Observer.
+      generateMockEngagementRows.mockReturnValueOnce([row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'LF Staff', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 9 })]);
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      // Classifies on real attendance (9/10 = High), same as any other real Voting Rep — an ED or
+      // staff member serving as a real board/committee voting representative is a genuine
+      // participant, not a silenced staff-only seat.
+      expect(result.members[0]).toMatchObject({ classification: 'High', role: 'LF Staff' });
+      expect(result.summary.active_count).toBe(1);
+      expect(result.summary.eligible_count).toBe(1);
+    });
+
+    it("excludes an LF Staff + Observer member's attended/invited counts from the aggregate attendance_rate (LFXV2-3101)", async () => {
       getCommitteeMembers.mockResolvedValueOnce([member('m1'), member('staff')]);
       generateMockEngagementRows.mockReturnValueOnce([
         row({ MEMBER_USER_ID: 'm1', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 10 }), // High, real member
-        row({ MEMBER_USER_ID: 'staff', MEMBER_ROLE: 'LF Staff', INVITED_COUNT_30D: 8, ATTENDED_COUNT_30D: 0 }), // LF Staff, 0 real attendance
+        row({ MEMBER_USER_ID: 'staff', MEMBER_ROLE: 'LF Staff', MEMBER_VOTING_STATUS: 'Observer', INVITED_COUNT_30D: 8, ATTENDED_COUNT_30D: 0 }), // LF Staff + Observer, 0 real attendance
       ]);
 
       const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
 
-      // Without the exclusion this would be 10/18 = 0.56; the LF Staff row must not depress it.
+      // Without the exclusion this would be 10/18 = 0.56; the LF Staff + Observer row must not depress it.
       expect(result.summary.attendance_rate).toBe(1);
-      expect(result.summary.total_count).toBe(2); // roster count is unaffected — only the rate/active/eligible/at-risk sums exclude LF Staff
+      expect(result.summary.total_count).toBe(2); // roster count is unaffected — only the rate/active/eligible/at-risk sums exclude LF Staff + Observer
       // eligible_count (the active_count ratio denominator, LFXV2-3101 review fix) excludes the
-      // LF Staff member too — 1/1, not 1/2, so the ratio can read 100% for this committee.
+      // LF Staff + Observer member too — 1/1, not 1/2, so the ratio can read 100% for this committee.
       expect(result.summary.eligible_count).toBe(1);
+    });
+
+    it('does NOT exclude an LF Staff + Voting Rep member from attendance_rate or eligible_count (LFXV2-3101 follow-up)', async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1'), member('staff-rep')]);
+      generateMockEngagementRows.mockReturnValueOnce([
+        row({ MEMBER_USER_ID: 'm1', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 10 }),
+        row({ MEMBER_USER_ID: 'staff-rep', MEMBER_ROLE: 'LF Staff', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 0 }), // LF Staff + real Voting Rep (row() default)
+      ]);
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      // 10/20 = 0.5 — the LF Staff + Voting Rep member's real 0 attendance DOES count, unlike the
+      // Observer-status case above.
+      expect(result.summary.attendance_rate).toBe(0.5);
+      expect(result.summary.eligible_count).toBe(2);
+      expect(result.summary.total_count).toBe(2);
     });
 
     it("excludes an Emeritus member from eligible_count, the active_count ratio's denominator (LFXV2-3101 review fix)", async () => {
@@ -464,7 +498,9 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       // (LF Staff) before the dbt model's next refresh (still reporting the old 'None'). Roster
       // must win: this is exactly the scenario commit dfba24c02's precedence flip fixes.
       getCommitteeMembers.mockResolvedValueOnce([member('m1', { role: { name: 'LF Staff' } as never })]);
-      execute.mockResolvedValueOnce({ rows: [row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'None', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 8 })] });
+      execute.mockResolvedValueOnce({
+        rows: [row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'None', MEMBER_VOTING_STATUS: 'Observer', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 8 })],
+      });
 
       const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
 
@@ -499,8 +535,8 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       expect(result.summary.at_risk_count).toBe(0);
     });
 
-    it('falls back to the roster real role on a degraded (unmatched) member, so a real LF Staff member still short-circuits (LFXV2-3101)', async () => {
-      getCommitteeMembers.mockResolvedValueOnce([member('m1', { role: { name: 'LF Staff' } as never })]);
+    it('falls back to the roster real role/voting-status on a degraded (unmatched) member, so a real LF Staff + Observer member still short-circuits (LFXV2-3101)', async () => {
+      getCommitteeMembers.mockResolvedValueOnce([member('m1', { role: { name: 'LF Staff' } as never, voting: { status: 'Observer' } as never })]);
       execute.mockRejectedValueOnce(new Error('Snowflake query execution failed: Object does not exist or not authorized.'));
 
       const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');

--- a/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
@@ -439,6 +439,21 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       expect(sql).toContain('COMMITTEE_MEETINGS_YTD');
     });
 
+    it('prefers the live roster role over a conflicting/stale warehouse MEMBER_ROLE for the LF Staff exclusion (LFXV2-3101 review fix)', async () => {
+      // The roster and the matched row disagree on role — a role promoted onto the live roster
+      // (LF Staff) before the dbt model's next refresh (still reporting the old 'None'). Roster
+      // must win: this is exactly the scenario commit dfba24c02's precedence flip fixes.
+      getCommitteeMembers.mockResolvedValueOnce([member('m1', { role: { name: 'LF Staff' } as never })]);
+      execute.mockResolvedValueOnce({ rows: [row({ MEMBER_USER_ID: 'm1', MEMBER_ROLE: 'None', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 8 })] });
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      expect(result.members[0]).toMatchObject({ role: 'LF Staff', classification: 'LF Staff' });
+      expect(result.summary.active_count).toBe(0);
+      // This member's real 10/8 attendance is excluded from the rate sum once role wins LF Staff.
+      expect(result.summary.attendance_rate).toBe(0);
+    });
+
     it('degrades to a zeroed, data_available:false response when the engagement table is missing', async () => {
       getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
       execute.mockRejectedValueOnce(new Error('Snowflake query execution failed: Object does not exist or not authorized.'));

--- a/apps/lfx-one/src/server/services/committee-engagement.service.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.ts
@@ -374,9 +374,15 @@ export class CommitteeEngagementService {
       const joinedWithinWindow =
         isJoinedWithinWindow(effectiveRow?.MEMBER_JOINED_AT ?? null, windowStart) || (usableData && isJoinedWithinWindow(member.created_at, windowStart));
 
-      const classificationInput = { attended, invited: counts.invited, votingStatus, joinedWithinWindow };
-      totalAttended += attended;
-      totalInvited += counts.invited;
+      const classificationInput = { attended, invited: counts.invited, votingStatus, role, joinedWithinWindow };
+      // LF Staff seats are excluded from the rate sum (LFXV2-3101) — unlike Emeritus, which stays
+      // unconditionally included here (see `CommitteeEngagementSummary.attendance_rate`'s doc):
+      // a staff seat's real 0-attendance would otherwise drag down the whole committee's displayed
+      // rate for a member with no real attendance expectation in the first place.
+      if (role !== CommitteeMemberRole.LF_STAFF) {
+        totalAttended += attended;
+        totalInvited += counts.invited;
+      }
 
       const classification = classifyCommitteeEngagement(classificationInput);
       if (isCommitteeMemberActive(classificationInput)) activeCount++;

--- a/apps/lfx-one/src/server/services/committee-engagement.service.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.ts
@@ -16,6 +16,7 @@ import {
   computeCommitteeEngagementRate,
   isCommitteeMemberActive,
   isCommitteeMemberAtRisk,
+  isCommitteeMemberRateEligible,
   isJoinedWithinWindow,
 } from '@lfx-one/shared/utils';
 import type { Request } from 'express';
@@ -376,10 +377,10 @@ export class CommitteeEngagementService {
 
       const classificationInput = { attended, invited: counts.invited, votingStatus, role, joinedWithinWindow };
       // LF Staff seats are excluded from the rate sum (LFXV2-3101) — unlike Emeritus, which stays
-      // unconditionally included here (see `CommitteeEngagementSummary.attendance_rate`'s doc):
-      // a staff seat's real 0-attendance would otherwise drag down the whole committee's displayed
-      // rate for a member with no real attendance expectation in the first place.
-      if (role !== CommitteeMemberRole.LF_STAFF) {
+      // unconditionally included here (see `CommitteeEngagementSummary.attendance_rate`'s doc). See
+      // `isCommitteeMemberRateEligible`'s doc for why this is a named predicate rather than an
+      // inline check, and for the known role-freshness trade-off it documents.
+      if (isCommitteeMemberRateEligible(classificationInput)) {
         totalAttended += attended;
         totalInvited += counts.invited;
       }

--- a/apps/lfx-one/src/server/services/committee-engagement.service.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.ts
@@ -341,30 +341,38 @@ export class CommitteeEngagementService {
       // violated in practice (a mismatched grain assumption, a future live-read bug) rather than
       // assuming it's already broken — an unclamped value here would produce a >100% rate.
       const attended = Math.min(counts.attended, counts.invited);
-      // `votingStatus` falls back to the roster's own value (already in hand, not warehouse-sourced)
-      // rather than defaulting straight to 'None' when there's no matching row — otherwise a real,
-      // known Emeritus member would silently lose that short-circuit and classify Inactive on every
-      // unmatched/degraded response, even though the roster already knows better. `||`, not `??`,
+      // `votingStatus` prefers the LIVE roster value first, warehouse `MEMBER_VOTING_STATUS` as the
+      // fallback for the same "no matching row" reason both fields fall back to the roster below
+      // (Cursor Bugbot follow-up, LFXV2-3101: this used to be warehouse-first, but `role` just below
+      // is roster-first, and once `isLfStaffObserverSeat` — `committee-engagement-classifier.utils.
+      // ts` — started combining both fields into one exclusion condition, that asymmetry became a
+      // real bug: a member promoted from Observer to a real Voting/Alternate Rep on the live roster
+      // would keep `role`'s LF Staff value fresh but `votingStatus` could still read the stale
+      // pre-promotion `Observer` from the warehouse until the dbt model's next refresh, incorrectly
+      // keeping them in the neutral LF Staff tier). Matching `role`'s precedence direction here
+      // means both fields a combined exclusion check reads are equally fresh, closing that gap —
+      // and, as a side effect, an Emeritus promotion/demotion (which depends on this same field
+      // alone) now also reflects on the roster immediately rather than lagging a refresh, which was
+      // never a deliberate design choice to preserve, just the pre-ticket default. `||`, not `??`,
       // so a blank passthrough falls through too; the real enum value ('None' included) is always a
       // non-empty string. Last-resort default is the documented `None` sentinel rather than '' —
       // matching the mock generator's own voting-status posture, though its actual default differs
       // (`organicVotingStatus()` hash-derives a rep status, never `None`), since that's mock mode's
       // own no-real-data-fabrication concern, not a contract this live/degraded path needs to match.
-      const votingStatus = row?.MEMBER_VOTING_STATUS || member.voting?.status || CommitteeMemberVotingStatus.NONE;
-      // `role` prefers the LIVE roster value first, unlike `votingStatus` above — deliberately the
-      // opposite precedence (LFXV2-3101 review fix). Before this ticket `role` was pure passthrough
-      // display text, so precedence never mattered functionally; now it also decides the `LF Staff`
-      // exclusion (`isCommitteeMemberRateEligible` et al.), and a warehouse-first order would let a
-      // role promoted or demoted on the roster stay silently wrong here until the dbt model's next
-      // refresh — reintroducing, for `role`, exactly the display/chip contradiction this ticket
-      // exists to remove for `votingStatus`'s Emeritus case. `member.role?.name` is also a typed
+      const votingStatus = member.voting?.status || row?.MEMBER_VOTING_STATUS || CommitteeMemberVotingStatus.NONE;
+      // `role` also prefers the LIVE roster value first (LFXV2-3101 review fix). Before this ticket
+      // `role` was pure passthrough display text, so precedence never mattered functionally; now it
+      // also decides the `LF Staff` exclusion (`isCommitteeMemberRateEligible` et al.), and a
+      // warehouse-first order would let a role promoted or demoted on the roster stay silently wrong
+      // here until the dbt model's next refresh — reintroducing exactly the display/chip
+      // contradiction this ticket exists to remove. `member.role?.name` is also a typed
       // `CommitteeMemberRole`, unlike `row?.MEMBER_ROLE` (an untyped warehouse string) — preferring
       // it first means a live-mode `MEMBER_ROLE` spelling/casing mismatch degrades to the roster's
       // known-good value instead of silently defeating the LF Staff exclusion checks everywhere
       // `role` is used (see `isLfStaffObserverSeat` in `committee-engagement-classifier.utils.ts`
       // for the exact, narrower-than-role-alone condition, LFXV2-3101 follow-up). The warehouse
-      // value remains the fallback for the same "no matching
-      // row" reason `votingStatus` falls back to the roster above, just in the opposite direction.
+      // value remains the fallback for the same "no matching row" reason `votingStatus` falls back
+      // to the roster above.
       const role = member.role?.name || row?.MEMBER_ROLE || CommitteeMemberRole.NONE;
       // Same roster-fallback reasoning as role/voting-status above, but checked independently
       // rather than value-selected: a value-selection fallback (`row value || roster value`) would

--- a/apps/lfx-one/src/server/services/committee-engagement.service.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.ts
@@ -15,6 +15,7 @@ import {
   classifyCommitteeEngagement,
   computeCommitteeEngagementRate,
   isCommitteeMemberActive,
+  isCommitteeMemberActiveEligible,
   isCommitteeMemberAtRisk,
   isCommitteeMemberRateEligible,
   isJoinedWithinWindow,
@@ -313,6 +314,7 @@ export class CommitteeEngagementService {
     let totalAttended = 0;
     let totalInvited = 0;
     let activeCount = 0;
+    let eligibleCount = 0;
     let atRiskCount = 0;
     let matchedCount = 0;
 
@@ -398,6 +400,11 @@ export class CommitteeEngagementService {
 
       const classification = classifyCommitteeEngagement(classificationInput);
       if (isCommitteeMemberActive(classificationInput)) activeCount++;
+      // Attendance-independent (role/voting_status alone), so computed unconditionally like
+      // total_count — never gated on usableData/effectiveRow the way activeCount's attendance
+      // check is. See eligible_count's doc for why this, not total_count, is the correct
+      // active_count ratio denominator.
+      if (isCommitteeMemberActiveEligible(classificationInput)) eligibleCount++;
       if (isCommitteeMemberAtRisk(classificationInput)) atRiskCount++;
 
       return {
@@ -436,6 +443,7 @@ export class CommitteeEngagementService {
       summary: {
         attendance_rate: computeCommitteeEngagementRate(totalAttended, totalInvited),
         active_count: activeCount,
+        eligible_count: eligibleCount,
         total_count: members.length,
         at_risk_count: atRiskCount,
       },

--- a/apps/lfx-one/src/server/services/committee-engagement.service.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.ts
@@ -339,25 +339,36 @@ export class CommitteeEngagementService {
       // violated in practice (a mismatched grain assumption, a future live-read bug) rather than
       // assuming it's already broken — an unclamped value here would produce a >100% rate.
       const attended = Math.min(counts.attended, counts.invited);
-      // Falls back to the roster's own role/voting-status (already in hand, not warehouse-sourced)
+      // `votingStatus` falls back to the roster's own value (already in hand, not warehouse-sourced)
       // rather than defaulting straight to 'None' when there's no matching row — otherwise a real,
       // known Emeritus member would silently lose that short-circuit and classify Inactive on every
       // unmatched/degraded response, even though the roster already knows better. `||`, not `??`,
-      // so a blank passthrough falls through too; both fields' real enum values ('None' included)
-      // are always non-empty strings. Last-resort default is the documented `None` sentinel rather
-      // than '' — matching the mock generator's own role default
-      // (`member.role?.name ?? CommitteeMemberRole.NONE`); its voting-status default differs
-      // (`organicVotingStatus()` hash-derives a rep status, never `None`), but that's mock mode's
+      // so a blank passthrough falls through too; the real enum value ('None' included) is always a
+      // non-empty string. Last-resort default is the documented `None` sentinel rather than '' —
+      // matching the mock generator's own voting-status posture, though its actual default differs
+      // (`organicVotingStatus()` hash-derives a rep status, never `None`), since that's mock mode's
       // own no-real-data-fabrication concern, not a contract this live/degraded path needs to match.
       const votingStatus = row?.MEMBER_VOTING_STATUS || member.voting?.status || CommitteeMemberVotingStatus.NONE;
-      const role = row?.MEMBER_ROLE || member.role?.name || CommitteeMemberRole.NONE;
+      // `role` prefers the LIVE roster value first, unlike `votingStatus` above — deliberately the
+      // opposite precedence (LFXV2-3101 review fix). Before this ticket `role` was pure passthrough
+      // display text, so precedence never mattered functionally; now it also decides the `LF Staff`
+      // exclusion (`isCommitteeMemberRateEligible` et al.), and a warehouse-first order would let a
+      // role promoted or demoted on the roster stay silently wrong here until the dbt model's next
+      // refresh — reintroducing, for `role`, exactly the display/chip contradiction this ticket
+      // exists to remove for `votingStatus`'s Emeritus case. `member.role?.name` is also a typed
+      // `CommitteeMemberRole`, unlike `row?.MEMBER_ROLE` (an untyped warehouse string) — preferring
+      // it first means a live-mode `MEMBER_ROLE` spelling/casing mismatch degrades to the roster's
+      // known-good value instead of silently defeating the `=== CommitteeMemberRole.LF_STAFF` checks
+      // everywhere they're used. The warehouse value remains the fallback for the same "no matching
+      // row" reason `votingStatus` falls back to the roster above, just in the opposite direction.
+      const role = member.role?.name || row?.MEMBER_ROLE || CommitteeMemberRole.NONE;
       // Same roster-fallback reasoning as role/voting-status above, but checked independently
       // rather than value-selected: a value-selection fallback (`row value || roster value`) would
       // pick a present-but-unparseable row date over a perfectly good roster one, since both are
       // truthy — `isJoinedWithinWindow` can't tell "unparseable" from "valid but outside the
       // window" from the inside. Checking both and taking either `true` sidesteps that: `created_at`
       // is a required roster field, so it's always available to fall back to, and discarding it here
-      // would cost a recently-joined member their tenure grace (case 2 of the classifier's decision
+      // would cost a recently-joined member their tenure grace (case 3 of the classifier's decision
       // order) whenever the row's own date is missing, blank, or unparseable.
       //
       // The roster `created_at` fallback is gated on `usableData` (`dataAvailable && anyRowMatched`),

--- a/apps/lfx-one/src/server/services/committee-engagement.service.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.ts
@@ -360,8 +360,10 @@ export class CommitteeEngagementService {
       // exists to remove for `votingStatus`'s Emeritus case. `member.role?.name` is also a typed
       // `CommitteeMemberRole`, unlike `row?.MEMBER_ROLE` (an untyped warehouse string) — preferring
       // it first means a live-mode `MEMBER_ROLE` spelling/casing mismatch degrades to the roster's
-      // known-good value instead of silently defeating the `=== CommitteeMemberRole.LF_STAFF` checks
-      // everywhere they're used. The warehouse value remains the fallback for the same "no matching
+      // known-good value instead of silently defeating the LF Staff exclusion checks everywhere
+      // `role` is used (see `isLfStaffObserverSeat` in `committee-engagement-classifier.utils.ts`
+      // for the exact, narrower-than-role-alone condition, LFXV2-3101 follow-up). The warehouse
+      // value remains the fallback for the same "no matching
       // row" reason `votingStatus` falls back to the roster above, just in the opposite direction.
       const role = member.role?.name || row?.MEMBER_ROLE || CommitteeMemberRole.NONE;
       // Same roster-fallback reasoning as role/voting-status above, but checked independently

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -414,15 +414,35 @@ describe('GroupsEngagementStatsService', () => {
       expect(result.active_members).toBe(0);
     });
 
-    it('excludes an LF Staff member from active_members regardless of real attendance (LFXV2-3101)', async () => {
+    it('excludes an LF Staff + Observer member from active_members regardless of real attendance (LFXV2-3101)', async () => {
       getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
       execute.mockResolvedValueOnce({
-        rows: [activeMemberRow({ COMMITTEE_ID: 'committee-1', MEMBER_USER_ID: 'm1', ATTENDED_COUNT_30D: 10, MEMBER_ROLE: 'LF Staff' })],
+        rows: [
+          activeMemberRow({
+            COMMITTEE_ID: 'committee-1',
+            MEMBER_USER_ID: 'm1',
+            ATTENDED_COUNT_30D: 10,
+            MEMBER_ROLE: 'LF Staff',
+            MEMBER_VOTING_STATUS: 'Observer',
+          }),
+        ],
       });
 
       const result = await service.getEngagementStats(buildReq());
 
       expect(result.active_members).toBe(0);
+    });
+
+    it('does NOT exclude an LF Staff + Voting Rep member from active_members — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', async () => {
+      getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+      execute.mockResolvedValueOnce({
+        // MEMBER_VOTING_STATUS defaults to 'Voting Rep' — deliberately left unset here.
+        rows: [activeMemberRow({ COMMITTEE_ID: 'committee-1', MEMBER_USER_ID: 'm1', ATTENDED_COUNT_30D: 10, MEMBER_ROLE: 'LF Staff' })],
+      });
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(result.active_members).toBe(1);
     });
 
     it('does not count a veteran member with zero attendance and no tenure grace', async () => {

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -106,12 +106,14 @@ function activeMemberRow(overrides: {
   MEMBER_USER_ID: string;
   MEMBER_JOINED_AT?: string | null;
   MEMBER_VOTING_STATUS?: string;
+  MEMBER_ROLE?: string;
   INVITED_COUNT_30D?: number;
   ATTENDED_COUNT_30D?: number;
 }) {
   return {
     MEMBER_JOINED_AT: '2020-01-01T00:00:00.000Z',
     MEMBER_VOTING_STATUS: 'Voting Rep',
+    MEMBER_ROLE: 'None',
     INVITED_COUNT_30D: 999,
     ATTENDED_COUNT_30D: 0,
     ...overrides,
@@ -405,6 +407,17 @@ describe('GroupsEngagementStatsService', () => {
       getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
       execute.mockResolvedValueOnce({
         rows: [activeMemberRow({ COMMITTEE_ID: 'committee-1', MEMBER_USER_ID: 'm1', ATTENDED_COUNT_30D: 10, MEMBER_VOTING_STATUS: 'Emeritus' })],
+      });
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(result.active_members).toBe(0);
+    });
+
+    it('excludes an LF Staff member from active_members regardless of real attendance (LFXV2-3101)', async () => {
+      getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+      execute.mockResolvedValueOnce({
+        rows: [activeMemberRow({ COMMITTEE_ID: 'committee-1', MEMBER_USER_ID: 'm1', ATTENDED_COUNT_30D: 10, MEMBER_ROLE: 'LF Staff' })],
       });
 
       const result = await service.getEngagementStats(buildReq());

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -158,8 +158,8 @@ export class GroupsEngagementStatsService {
 
   /**
    * Counts distinct active members (attended >=1 meeting in the trailing 30 days, or joined within
-   * it, excluding Emeritus and LF Staff — `isCommitteeMemberActive`, the same function
-   * LFXV2-1705/LFXV2-3101 use) across the *covered* subset of committees the caller can see
+   * it, excluding Emeritus and LF Staff+Observer seats — `isCommitteeMemberActive`, the same
+   * function LFXV2-1705/LFXV2-3101 use) across the *covered* subset of committees the caller can see
    * (`getMyCommitteeUids` — "mine" semantics, no scope param, per LFXV2-1711). A member is counted
    * once even if active on multiple covered
    * committees — the model's grain is one row per `(committee_id, member_user_id)`, so a member on

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -77,16 +77,16 @@ function resolveBackend(): 'mock' | 'live' {
  * otherwise resolve via the roster's own `voting.status`; or a blank/unparseable `MEMBER_JOINED_AT`
  * the detail page would still resolve via the roster's own `created_at` (`buildResponse` ORs both
  * sources when the roster join has at least one match for that committee; this rollup only has the
- * warehouse row, never a roster fallback). An `LF Staff` seat (LFXV2-3101) is NOT one of these
- * divergences, despite superficially looking like the same shape: `MEMBER_ROLE` (unlike the roster
- * fallbacks above) is a column on this same `platinum_lfx_one_committee_meeting_attendance` table
- * `ActiveMemberRow` already reads, so selecting it costs nothing extra — no roster join, no N+1 —
- * and `classificationInput` here passes `role: row.MEMBER_ROLE` accordingly, so an LF Staff member
- * is excluded from `active_members` on this rollup exactly like the detail page excludes it from
- * `active_count`. This rollup has no live roster at all (see the class doc above), so unlike the
- * detail page's roster-first precedence (`committee-engagement.service.ts`'s `role` resolution,
- * LFXV2-3101 review fix), `MEMBER_ROLE` here is the *only* source — there's no live value to prefer
- * over it, and no staleness trade-off to make.
+ * warehouse row, never a roster fallback); or an `LF Staff` seat whose role changed on the live
+ * roster more recently than the dbt model's last refresh (LFXV2-3101) — `MEMBER_ROLE` (unlike the
+ * roster fallbacks above) IS a column on this same `platinum_lfx_one_committee_meeting_attendance`
+ * table `ActiveMemberRow` already reads, so selecting it and passing `role: row.MEMBER_ROLE` into
+ * `classificationInput` costs nothing extra (no roster join, no N+1) and closes the gap for the
+ * common case — but this rollup has no live roster at all to prefer, unlike the detail page's
+ * roster-first precedence (`committee-engagement.service.ts`'s `role` resolution, LFXV2-3101 review
+ * fix: `member.role?.name || row?.MEMBER_ROLE`). So a role promoted onto (or demoted off) the live
+ * roster lands on the detail page immediately but only reaches this rollup at the model's next
+ * refresh — a real, if narrow, divergence window, same family as the other three above.
  *
  * A larger case in the same family, deliberately NOT wired the same way: this rollup dedupes purely
  * on the warehouse's own `MEMBER_USER_ID` with no roster join at all, so a committee whose

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -23,7 +23,7 @@ const COMMITTEE_UID_CHUNK_SIZE = 100;
 
 type ActiveMemberRow = Pick<
   CommitteeEngagementWarehouseRow,
-  'MEMBER_USER_ID' | 'MEMBER_JOINED_AT' | 'MEMBER_VOTING_STATUS' | 'INVITED_COUNT_30D' | 'ATTENDED_COUNT_30D'
+  'MEMBER_USER_ID' | 'MEMBER_JOINED_AT' | 'MEMBER_VOTING_STATUS' | 'MEMBER_ROLE' | 'INVITED_COUNT_30D' | 'ATTENDED_COUNT_30D'
 > & { COMMITTEE_ID: string };
 
 /**
@@ -74,20 +74,19 @@ function resolveBackend(): 'mock' | 'live' {
  * roster join per visible committee, which would reintroduce the N+1 fetch this endpoint exists to
  * avoid), so it can still diverge from the per-committee detail page for: a roster member the model
  * hasn't picked up yet (a very recent join); a blank `MEMBER_VOTING_STATUS` the detail page would
- * otherwise resolve via the roster's own `voting.status`; a blank/unparseable `MEMBER_JOINED_AT`
+ * otherwise resolve via the roster's own `voting.status`; or a blank/unparseable `MEMBER_JOINED_AT`
  * the detail page would still resolve via the roster's own `created_at` (`buildResponse` ORs both
  * sources when the roster join has at least one match for that committee; this rollup only has the
- * warehouse row, never a roster fallback); or an `LF Staff` seat (LFXV2-3101) — the detail page's
- * `classificationInput` passes `role` (warehouse `MEMBER_ROLE`, falling back to the roster's own
- * `role.name` only when the row is missing) so an LF Staff member never counts as active there, but
- * `ActiveMemberRow` here deliberately doesn't select `MEMBER_ROLE` at all (kept minimal for this
- * rollup's no-roster-join design), so
- * `isCommitteeMemberActive`'s `role` check always sees `undefined` and an LF Staff member with real
- * attendance still counts as active on this rollup. Left undone here rather than adding the column:
- * this endpoint is a different feature (LFXV2-1711, the Groups dashboard) than the ticket that
- * introduced the LF Staff exclusion (LFXV2-3101, the committee detail page), and the two other
- * divergence sources above already establish that this rollup trades exact per-committee agreement
- * for avoiding the N+1 roster fetch — the same trade-off, one more cause.
+ * warehouse row, never a roster fallback). An `LF Staff` seat (LFXV2-3101) is NOT one of these
+ * divergences, despite superficially looking like the same shape: `MEMBER_ROLE` (unlike the roster
+ * fallbacks above) is a column on this same `platinum_lfx_one_committee_meeting_attendance` table
+ * `ActiveMemberRow` already reads, so selecting it costs nothing extra — no roster join, no N+1 —
+ * and `classificationInput` here passes `role: row.MEMBER_ROLE` accordingly, so an LF Staff member
+ * is excluded from `active_members` on this rollup exactly like the detail page excludes it from
+ * `active_count`. This rollup has no live roster at all (see the class doc above), so unlike the
+ * detail page's roster-first precedence (`committee-engagement.service.ts`'s `role` resolution,
+ * LFXV2-3101 review fix), `MEMBER_ROLE` here is the *only* source — there's no live value to prefer
+ * over it, and no staleness trade-off to make.
  *
  * A larger case in the same family, deliberately NOT wired the same way: this rollup dedupes purely
  * on the warehouse's own `MEMBER_USER_ID` with no roster join at all, so a committee whose
@@ -253,6 +252,7 @@ export class GroupsEngagementStatsService {
             attended: Math.min(Math.max(row.ATTENDED_COUNT_30D, 0), invited),
             invited, // unused by isCommitteeMemberActive; kept only for the clamp above
             votingStatus: row.MEMBER_VOTING_STATUS,
+            role: row.MEMBER_ROLE,
             joinedWithinWindow: isJoinedWithinWindow(row.MEMBER_JOINED_AT, windowStart),
           };
           if (isCommitteeMemberActive(classificationInput)) activeUids.add(row.MEMBER_USER_ID);
@@ -330,7 +330,7 @@ export class GroupsEngagementStatsService {
   private queryActiveMemberChunk(warehouseCommitteeIds: string[]): Promise<{ rows: ActiveMemberRow[] }> {
     const placeholders = warehouseCommitteeIds.map(() => '?').join(', ');
     const sql = `
-      SELECT COMMITTEE_ID, MEMBER_USER_ID, MEMBER_JOINED_AT, MEMBER_VOTING_STATUS, INVITED_COUNT_30D, ATTENDED_COUNT_30D
+      SELECT COMMITTEE_ID, MEMBER_USER_ID, MEMBER_JOINED_AT, MEMBER_VOTING_STATUS, MEMBER_ROLE, INVITED_COUNT_30D, ATTENDED_COUNT_30D
       FROM ${committeeEngagementTable()}
       WHERE COMMITTEE_ID IN (${placeholders})
     `;

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -78,9 +78,10 @@ function resolveBackend(): 'mock' | 'live' {
  * the detail page would still resolve via the roster's own `created_at` (`buildResponse` ORs both
  * sources when the roster join has at least one match for that committee; this rollup only has the
  * warehouse row, never a roster fallback); or an `LF Staff` seat (LFXV2-3101) — the detail page's
- * `classificationInput` passes `role` (from the roster, with a warehouse-`MEMBER_ROLE` fallback) so
- * an LF Staff member never counts as active there, but `ActiveMemberRow` here deliberately doesn't
- * select `MEMBER_ROLE` at all (kept minimal for this rollup's no-roster-join design), so
+ * `classificationInput` passes `role` (warehouse `MEMBER_ROLE`, falling back to the roster's own
+ * `role.name` only when the row is missing) so an LF Staff member never counts as active there, but
+ * `ActiveMemberRow` here deliberately doesn't select `MEMBER_ROLE` at all (kept minimal for this
+ * rollup's no-roster-join design), so
  * `isCommitteeMemberActive`'s `role` check always sees `undefined` and an LF Staff member with real
  * attendance still counts as active on this rollup. Left undone here rather than adding the column:
  * this endpoint is a different feature (LFXV2-1711, the Groups dashboard) than the ticket that

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -74,10 +74,19 @@ function resolveBackend(): 'mock' | 'live' {
  * roster join per visible committee, which would reintroduce the N+1 fetch this endpoint exists to
  * avoid), so it can still diverge from the per-committee detail page for: a roster member the model
  * hasn't picked up yet (a very recent join); a blank `MEMBER_VOTING_STATUS` the detail page would
- * otherwise resolve via the roster's own `voting.status`; or a blank/unparseable `MEMBER_JOINED_AT`
+ * otherwise resolve via the roster's own `voting.status`; a blank/unparseable `MEMBER_JOINED_AT`
  * the detail page would still resolve via the roster's own `created_at` (`buildResponse` ORs both
  * sources when the roster join has at least one match for that committee; this rollup only has the
- * warehouse row, never a roster fallback).
+ * warehouse row, never a roster fallback); or an `LF Staff` seat (LFXV2-3101) — the detail page's
+ * `classificationInput` passes `role` (from the roster, with a warehouse-`MEMBER_ROLE` fallback) so
+ * an LF Staff member never counts as active there, but `ActiveMemberRow` here deliberately doesn't
+ * select `MEMBER_ROLE` at all (kept minimal for this rollup's no-roster-join design), so
+ * `isCommitteeMemberActive`'s `role` check always sees `undefined` and an LF Staff member with real
+ * attendance still counts as active on this rollup. Left undone here rather than adding the column:
+ * this endpoint is a different feature (LFXV2-1711, the Groups dashboard) than the ticket that
+ * introduced the LF Staff exclusion (LFXV2-3101, the committee detail page), and the two other
+ * divergence sources above already establish that this rollup trades exact per-committee agreement
+ * for avoiding the N+1 roster fetch — the same trade-off, one more cause.
  *
  * A larger case in the same family, deliberately NOT wired the same way: this rollup dedupes purely
  * on the warehouse's own `MEMBER_USER_ID` with no roster join at all, so a committee whose

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -93,8 +93,8 @@ function resolveBackend(): 'mock' | 'live' {
  * `MEMBER_USER_ID` values don't key to any roster member still contributes its warehouse-classified
  * members to this count, while `committee-engagement.service.ts`'s detail page — which now resolves
  * member ids via `resolveMemberV2UidsToV1Ids` (a `committee_member.uid.<v2MemberUid>` NATS key on
- * `lfx.lookup_v1_mapping`, LFXV2-1705) — reports `data_available: false` and every non-Emeritus
- * member `Inactive` for that same committee. This is a real, currently-live divergence between the
+ * `lfx.lookup_v1_mapping`, LFXV2-1705) — reports `data_available: false` and every non-Emeritus,
+ * non-LF-Staff member `Inactive` for that same committee. This is a real, currently-live divergence between the
  * two surfaces, not just a theoretical one. It's intentionally not closed here: this rollup's count
  * only needs distinct warehouse ids, not v2 identity, so it's already correct regardless of id
  * space — resolving member ids here would require a roster fetch per visible committee, reintroducing
@@ -158,9 +158,10 @@ export class GroupsEngagementStatsService {
 
   /**
    * Counts distinct active members (attended >=1 meeting in the trailing 30 days, or joined within
-   * it, excluding Emeritus — `isCommitteeMemberActive`, the same function LFXV2-1705 uses) across
-   * the *covered* subset of committees the caller can see (`getMyCommitteeUids` — "mine" semantics,
-   * no scope param, per LFXV2-1711). A member is counted once even if active on multiple covered
+   * it, excluding Emeritus and LF Staff — `isCommitteeMemberActive`, the same function
+   * LFXV2-1705/LFXV2-3101 use) across the *covered* subset of committees the caller can see
+   * (`getMyCommitteeUids` — "mine" semantics, no scope param, per LFXV2-1711). A member is counted
+   * once even if active on multiple covered
    * committees — the model's grain is one row per `(committee_id, member_user_id)`, so a member on
    * N committees produces N rows; deduping by `MEMBER_USER_ID` is what makes this a *member* count
    * rather than a row count. `getMyCommitteeUids` returns v2 committee-service UUIDs; the model is

--- a/packages/shared/src/constants/committee-engagement.constants.ts
+++ b/packages/shared/src/constants/committee-engagement.constants.ts
@@ -20,8 +20,9 @@ export const COMMITTEE_ENGAGEMENT_DEFAULT_WINDOW = '30d';
  * Attendance-rate thresholds (attended / invited) for engagement classification, computed in the
  * BFF so they can be tuned without a dbt deploy once real distributions are observed. Applies once
  * a member has at least one real invite (`invited > 0`) — see
- * `committee-engagement-classifier.utils.ts`'s `classifyCommitteeEngagement` for the `Emeritus` and
- * tenure-clipping (`member_joined_at`) cases these thresholds don't cover.
+ * `committee-engagement-classifier.utils.ts`'s `classifyCommitteeEngagement` for the `Emeritus`,
+ * `LF Staff` (LFXV2-3101), and tenure-clipping (`member_joined_at`) cases these thresholds don't
+ * cover.
  *   rate <= 0            → Inactive (invited, but attended nothing)
  *   0 < rate < medium     → Low
  *   medium <= rate < high → Medium

--- a/packages/shared/src/constants/committee-engagement.constants.ts
+++ b/packages/shared/src/constants/committee-engagement.constants.ts
@@ -54,10 +54,11 @@ export const COMMITTEE_ENGAGEMENT_WINDOW_OPTIONS: FilterPillOption[] = COMMITTEE
 }));
 
 /**
- * Tag severity per engagement classification for the members-table chip. `Emeritus` is
- * deliberately neutral (`secondary`) — an honorific seat state, never at-risk styling — and
- * `Inactive` only reads as a danger signal on the chip; the actual At-Risk filter uses
- * `isCommitteeEngagementRowAtRisk` (Low, or Inactive with real invites), not this map.
+ * Tag severity per engagement classification for the members-table chip. `Emeritus` and
+ * `LF Staff` (LFXV2-3101) are both deliberately neutral (`secondary`) — seat states with no real
+ * attendance expectation, never at-risk styling — and `Inactive` only reads as a danger signal on
+ * the chip; the actual At-Risk filter uses `isCommitteeEngagementRowAtRisk` (Low, or Inactive with
+ * real invites), not this map.
  */
 export const COMMITTEE_ENGAGEMENT_CLASSIFICATION_TAG_SEVERITY: Record<CommitteeEngagementClassification, TagSeverity> = {
   High: 'success',
@@ -65,4 +66,5 @@ export const COMMITTEE_ENGAGEMENT_CLASSIFICATION_TAG_SEVERITY: Record<CommitteeE
   Low: 'warn',
   Inactive: 'danger',
   Emeritus: 'secondary',
+  'LF Staff': 'secondary',
 };

--- a/packages/shared/src/interfaces/committee-engagement.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.interface.ts
@@ -25,9 +25,13 @@ export type CommitteeEngagementClassification = 'High' | 'Medium' | 'Low' | 'Ina
  * short-circuits to a neutral tier), `role` (`CommitteeMemberRole.LF_STAFF` short-circuits to a
  * neutral tier, LFXV2-3101), and `joinedWithinWindow` (whether `member_joined_at` falls after the
  * requested window's start — tenure clipping, so a brand-new member's zero invites doesn't read as
- * disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role` is optional: the
- * only other consumer of this shape (`groups-engagement-stats.service.ts`, LFXV2-1705) doesn't
- * query role data and simply gets no LF Staff exclusion, matching its pre-LFXV2-3101 behavior.
+ * disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role` is optional only
+ * for shape-compatibility with any future minimal-column consumer that can't supply it — both
+ * current consumers populate it today: `committee-engagement.service.ts` resolves it roster-first,
+ * warehouse `MEMBER_ROLE` as a fallback (LFXV2-3101 review fix — see that call site's own comment
+ * for why); `groups-engagement-stats.service.ts` has no live roster to prefer, so it passes
+ * warehouse `MEMBER_ROLE` directly (see that class's own doc for the resulting freshness lag versus
+ * the roster-first detail page).
  */
 export interface CommitteeEngagementClassificationInput {
   attended: number;

--- a/packages/shared/src/interfaces/committee-engagement.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.interface.ts
@@ -14,21 +14,25 @@ export type CommitteeEngagementDataSource = 'mock' | 'live';
  * Engagement tier derived in the BFF from the member's personal attendance rate.
  * `Emeritus` and `LF Staff` are both seat-type overrides, not rate tiers — neither ever classifies
  * `Inactive`/`Low` regardless of real attendance: `Emeritus` members are on the roster for
- * legacy/honorific reasons, and `LF Staff` seats (LFXV2-3101) carry no real attendance expectation,
- * so treating either as disengaged would be noise, not signal.
+ * legacy/honorific reasons, and an LF Staff member with Observer voting status (LFXV2-3101) carries
+ * no real attendance expectation, so treating either as disengaged would be noise, not signal. An
+ * LF Staff member who is a real Voting Rep or Alternate Voting Rep is NOT covered by this
+ * override — see `isLfStaffObserverSeat` in `committee-engagement-classifier.utils.ts`.
  */
 export type CommitteeEngagementClassification = 'High' | 'Medium' | 'Low' | 'Inactive' | 'Emeritus' | 'LF Staff';
 
 /**
  * Classification inputs beyond the raw counts, per LFXV2-1705's finalized model semantics
  * (`platinum_lfx_one_committee_meeting_attendance`, `lf-dbt#2694`): `votingStatus` (`'Emeritus'`
- * short-circuits to a neutral tier), `role` (`CommitteeMemberRole.LF_STAFF` short-circuits to a
- * neutral tier, LFXV2-3101), and `joinedWithinWindow` (whether `member_joined_at` falls after the
- * requested window's start — tenure clipping, so a brand-new member's zero invites doesn't read as
- * disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role`'s key is required
- * (value may be `undefined`), not optional — a construction site that forgets it should get a
- * compile error, not silently reintroduce the bug this ticket fixes (an unmeasured LF Staff seat
- * counting toward the rate/active sums again). Both current consumers populate it today:
+ * short-circuits to a neutral tier), `role`+`votingStatus` together (LF Staff + Observer
+ * short-circuits to a neutral tier, LFXV2-3101 — see `isLfStaffObserverSeat`'s doc for why this is
+ * a two-part condition, not `role` alone), and `joinedWithinWindow` (whether `member_joined_at`
+ * falls after the requested window's start — tenure clipping, so a brand-new member's zero invites
+ * doesn't read as disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role`'s
+ * key is required (value may be `undefined`), not optional — a construction site that forgets it
+ * should get a compile error, not silently reintroduce the bug this ticket fixes (an unmeasured LF
+ * Staff+Observer seat counting toward the rate/active sums again). Both current consumers populate
+ * it today:
  * `committee-engagement.service.ts` resolves it roster-first, warehouse `MEMBER_ROLE` as a fallback
  * (LFXV2-3101 review fix — see that call site's own comment for why); `groups-engagement-stats.
  * service.ts` has no live roster to prefer, so it passes warehouse `MEMBER_ROLE` directly (see that
@@ -53,7 +57,7 @@ export interface CommitteeMemberEngagement {
   /** `attended / invited`, 0 when `invited` is 0, rounded to 2 decimal places. */
   rate: number;
   classification: CommitteeEngagementClassification;
-  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — passthrough for the UI to call out distinctly; also drives the `LF Staff` classification (LFXV2-3101) and its `attendance_rate`/`active_count` exclusion. */
+  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — passthrough for the UI to call out distinctly; also drives the `LF Staff` classification (LFXV2-3101, together with `voting_status === 'Observer'` — see `isLfStaffObserverSeat`) and its `attendance_rate`/`active_count` exclusion. */
   role: string;
   /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'` — passthrough, drives the `Emeritus` classification. */
   voting_status: string;
@@ -64,21 +68,23 @@ export interface CommitteeMemberEngagement {
 /** Aggregate stats for `GET /api/committees/:uid/engagement`. */
 export interface CommitteeEngagementSummary {
   /**
-   * `sum(attended) / sum(invited)` across the full committee roster, excluding `LF Staff` seats
-   * (LFXV2-3101 — a staff seat's real 0-attendance shouldn't depress a committee's rate), but NOT
-   * Emeritus-excluded — a committee with an Emeritus member (high invitation rate, low real
-   * attendance, by design) can still show a depressed rate here alongside an `active_count` that
-   * ignores that same member. A UI surfacing both side-by-side should call this out rather than
-   * let them appear to contradict. Known, accepted edge case: a roster made up entirely of `LF
-   * Staff` seats (no non-staff member ever invited) reports `0` here via the same `invited <= 0`
-   * sentinel an empty/never-invited roster already reports — indistinguishable from "no data yet"
-   * at this field alone. Not disambiguated by a separate value, consistent with how this field
-   * already overloads `0` for "nobody was invited" before this ticket.
+   * `sum(attended) / sum(invited)` across the full committee roster, excluding LF Staff+Observer
+   * seats (LFXV2-3101 — a staff seat with no real participation expectation shouldn't depress a
+   * committee's rate; an LF Staff member who is a real Voting Rep or Alternate Voting Rep is NOT
+   * excluded — see `isLfStaffObserverSeat`), but NOT Emeritus-excluded — a committee with an
+   * Emeritus member (high invitation rate, low real attendance, by design) can still show a
+   * depressed rate here alongside an `active_count` that ignores that same member. A UI surfacing
+   * both side-by-side should call this out rather than let them appear to contradict. Known,
+   * accepted edge case: a roster made up entirely of LF Staff+Observer seats (no non-excluded
+   * member ever invited) reports `0` here via the same `invited <= 0` sentinel an empty/
+   * never-invited roster already reports — indistinguishable from "no data yet" at this field
+   * alone. Not disambiguated by a separate value, consistent with how this field already overloads
+   * `0` for "nobody was invited" before this ticket.
    */
   attendance_rate: number;
   /**
-   * Count of non-Emeritus, non-LF-Staff members with real attendance this window, or who joined
-   * within it (active by definition of being newly on the roster) — broader than "classified
+   * Count of non-Emeritus, non-LF-Staff+Observer members with real attendance this window, or who
+   * joined within it (active by definition of being newly on the roster) — broader than "classified
    * High/Medium": a Low-classified member with some real attendance still counts here. See
    * `committee-engagement-classifier.utils.ts`'s `isCommitteeMemberActive`. The "joined within it"
    * clause only applies when `data_available` is `true` — on a zero-row committee, or one whose
@@ -88,19 +94,19 @@ export interface CommitteeEngagementSummary {
    */
   active_count: number;
   /**
-   * Roster members NOT excluded from `active_count`'s population — i.e. not Emeritus, not LF Staff
-   * (`isCommitteeMemberActiveEligible`, LFXV2-3101 review fix). The correct denominator for
-   * displaying `active_count` as a ratio: `total_count` includes Emeritus/LF Staff seats that
-   * `active_count`'s numerator always excludes, so `active_count / total_count` can never reach
-   * 100% for a committee that seats either, regardless of real participation — the same shape of
-   * bug this ticket fixed for the At-Risk filter, just showing up in the ratio instead.
-   * Attendance-independent, so — unlike `active_count`/`at_risk_count`/`attendance_rate` — this
-   * does NOT zero out when `data_available` is `false`: `role`/`voting_status` are roster
-   * passthroughs that stay populated regardless (see `data_available`'s doc), so this is
-   * roster-known the same way `total_count` is.
+   * Roster members NOT excluded from `active_count`'s population — i.e. not Emeritus, not LF
+   * Staff+Observer (`isCommitteeMemberActiveEligible`, LFXV2-3101 review fix). The correct
+   * denominator for displaying `active_count` as a ratio: `total_count` includes Emeritus/LF
+   * Staff+Observer seats that `active_count`'s numerator always excludes, so `active_count /
+   * total_count` can never reach 100% for a committee that seats either, regardless of real
+   * participation — the same shape of bug this ticket fixed for the At-Risk filter, just showing up
+   * in the ratio instead. Attendance-independent, so — unlike `active_count`/`at_risk_count`/
+   * `attendance_rate` — this does NOT zero out when `data_available` is `false`: `role`/
+   * `voting_status` are roster passthroughs that stay populated regardless (see `data_available`'s
+   * doc), so this is roster-known the same way `total_count` is.
    */
   eligible_count: number;
-  /** Full committee roster size (including members with no engagement data, and including Emeritus/LF Staff seats — use `eligible_count`, not this field, as the `active_count` ratio's denominator). */
+  /** Full committee roster size (including members with no engagement data, and including Emeritus/LF Staff+Observer seats — use `eligible_count`, not this field, as the `active_count` ratio's denominator). */
   total_count: number;
   /** Members classified Low, plus members invited within the window who attended nothing (badge reads Inactive, but there is signal to act on — unlike a member never invited). */
   at_risk_count: number;
@@ -127,8 +133,9 @@ export interface CommitteeEngagementResponse {
    * `CommitteeMember.uid` for this committee). All three degrade identically from the caller's point
    * of view. Every member then shows zeroed counts and classifies `Inactive` — except a roster
    * member with a real `Emeritus` voting status, which still classifies `Emeritus`, or a roster
-   * member with `role: 'LF Staff'` (LFXV2-3101), which still classifies `LF Staff` — both are
-   * seat-type facts independent of whether any engagement data exists. The tenure-grace `High`
+   * member with `role: 'LF Staff'` AND `voting_status: 'Observer'` (LFXV2-3101, both fields — see
+   * `isLfStaffObserverSeat`), which still classifies `LF Staff` — both are seat-type facts
+   * independent of whether any engagement data exists. The tenure-grace `High`
    * exception (a member who genuinely joined within the requested window, classified `High` instead
    * of `Inactive` off zero invites) does NOT apply when `data_available` is `false` — with no usable
    * data for the whole committee, there is no engagement data to correlate tenure against, so every

--- a/packages/shared/src/interfaces/committee-engagement.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.interface.ts
@@ -25,19 +25,20 @@ export type CommitteeEngagementClassification = 'High' | 'Medium' | 'Low' | 'Ina
  * short-circuits to a neutral tier), `role` (`CommitteeMemberRole.LF_STAFF` short-circuits to a
  * neutral tier, LFXV2-3101), and `joinedWithinWindow` (whether `member_joined_at` falls after the
  * requested window's start — tenure clipping, so a brand-new member's zero invites doesn't read as
- * disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role` is optional only
- * for shape-compatibility with any future minimal-column consumer that can't supply it — both
- * current consumers populate it today: `committee-engagement.service.ts` resolves it roster-first,
- * warehouse `MEMBER_ROLE` as a fallback (LFXV2-3101 review fix — see that call site's own comment
- * for why); `groups-engagement-stats.service.ts` has no live roster to prefer, so it passes
- * warehouse `MEMBER_ROLE` directly (see that class's own doc for the resulting freshness lag versus
- * the roster-first detail page).
+ * disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role`'s key is required
+ * (value may be `undefined`), not optional — a construction site that forgets it should get a
+ * compile error, not silently reintroduce the bug this ticket fixes (an unmeasured LF Staff seat
+ * counting toward the rate/active sums again). Both current consumers populate it today:
+ * `committee-engagement.service.ts` resolves it roster-first, warehouse `MEMBER_ROLE` as a fallback
+ * (LFXV2-3101 review fix — see that call site's own comment for why); `groups-engagement-stats.
+ * service.ts` has no live roster to prefer, so it passes warehouse `MEMBER_ROLE` directly (see that
+ * class's own doc for the resulting freshness lag versus the roster-first detail page).
  */
 export interface CommitteeEngagementClassificationInput {
   attended: number;
   invited: number;
   votingStatus: string;
-  role?: string;
+  role: string | undefined;
   joinedWithinWindow: boolean;
 }
 

--- a/packages/shared/src/interfaces/committee-engagement.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.interface.ts
@@ -48,7 +48,7 @@ export interface CommitteeMemberEngagement {
   /** `attended / invited`, 0 when `invited` is 0, rounded to 2 decimal places. */
   rate: number;
   classification: CommitteeEngagementClassification;
-  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — passthrough for the UI to call out distinctly. */
+  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — passthrough for the UI to call out distinctly; also drives the `LF Staff` classification (LFXV2-3101) and its `attendance_rate`/`active_count` exclusion. */
   role: string;
   /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'` — passthrough, drives the `Emeritus` classification. */
   voting_status: string;
@@ -64,7 +64,11 @@ export interface CommitteeEngagementSummary {
    * Emeritus-excluded — a committee with an Emeritus member (high invitation rate, low real
    * attendance, by design) can still show a depressed rate here alongside an `active_count` that
    * ignores that same member. A UI surfacing both side-by-side should call this out rather than
-   * let them appear to contradict.
+   * let them appear to contradict. Known, accepted edge case: a roster made up entirely of `LF
+   * Staff` seats (no non-staff member ever invited) reports `0` here via the same `invited <= 0`
+   * sentinel an empty/never-invited roster already reports — indistinguishable from "no data yet"
+   * at this field alone. Not disambiguated by a separate value, consistent with how this field
+   * already overloads `0` for "nobody was invited" before this ticket.
    */
   attendance_rate: number;
   /**
@@ -103,12 +107,13 @@ export interface CommitteeEngagementResponse {
    * all (a total join-key mismatch — the warehouse's `MEMBER_USER_ID` values don't correspond to any
    * `CommitteeMember.uid` for this committee). All three degrade identically from the caller's point
    * of view. Every member then shows zeroed counts and classifies `Inactive` — except a roster
-   * member with a real `Emeritus` voting status, which still classifies `Emeritus` (a seat-type
-   * fact independent of whether any engagement data exists). The tenure-grace `High` exception
-   * (a member who genuinely joined within the requested window, classified `High` instead of
-   * `Inactive` off zero invites) does NOT apply when `data_available` is `false` — with no usable
+   * member with a real `Emeritus` voting status, which still classifies `Emeritus`, or a roster
+   * member with `role: 'LF Staff'` (LFXV2-3101), which still classifies `LF Staff` — both are
+   * seat-type facts independent of whether any engagement data exists. The tenure-grace `High`
+   * exception (a member who genuinely joined within the requested window, classified `High` instead
+   * of `Inactive` off zero invites) does NOT apply when `data_available` is `false` — with no usable
    * data for the whole committee, there is no engagement data to correlate tenure against, so every
-   * non-Emeritus member classifies `Inactive` and `summary`'s computed fields (`attendance_rate`,
+   * non-Emeritus, non-LF-Staff member classifies `Inactive` and `summary`'s computed fields (`attendance_rate`,
    * `active_count`, `at_risk_count`) are all `0` — `total_count` still reflects the full roster size
    * regardless, since that's roster-known independent of engagement data. Asserting `High` (or a
    * nonzero `active_count`) on literal 0/0 counts would contradict `data_available: false` and
@@ -129,8 +134,8 @@ export interface CommitteeEngagementResponse {
    *
    * The UI should key its "no data available" placeholder state off this flag rather than inferring
    * it from all-zero numbers — `members[]` is roster-complete either way, with `role`/`voting_status`
-   * always populated and counts zeroed on `false` (see above for the roster-Emeritus exception, and
-   * the tenure-grace exception's `data_available:true`-only condition).
+   * always populated and counts zeroed on `false` (see above for the roster-Emeritus and roster-LF-
+   * Staff exceptions, and the tenure-grace exception's `data_available:true`-only condition).
    */
   data_available: boolean;
   /**

--- a/packages/shared/src/interfaces/committee-engagement.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.interface.ts
@@ -12,23 +12,28 @@ export type CommitteeEngagementDataSource = 'mock' | 'live';
 
 /**
  * Engagement tier derived in the BFF from the member's personal attendance rate.
- * `Emeritus` is a seat-type override, not a rate tier — Emeritus members never classify
- * `Inactive`/`Low` regardless of their real attendance, since they're on the roster for
- * legacy/honorific reasons rather than active participation.
+ * `Emeritus` and `LF Staff` are both seat-type overrides, not rate tiers — neither ever classifies
+ * `Inactive`/`Low` regardless of real attendance: `Emeritus` members are on the roster for
+ * legacy/honorific reasons, and `LF Staff` seats (LFXV2-3101) carry no real attendance expectation,
+ * so treating either as disengaged would be noise, not signal.
  */
-export type CommitteeEngagementClassification = 'High' | 'Medium' | 'Low' | 'Inactive' | 'Emeritus';
+export type CommitteeEngagementClassification = 'High' | 'Medium' | 'Low' | 'Inactive' | 'Emeritus' | 'LF Staff';
 
 /**
  * Classification inputs beyond the raw counts, per LFXV2-1705's finalized model semantics
  * (`platinum_lfx_one_committee_meeting_attendance`, `lf-dbt#2694`): `votingStatus` (`'Emeritus'`
- * short-circuits to a neutral tier) and `joinedWithinWindow` (whether `member_joined_at` falls
- * after the requested window's start — tenure clipping, so a brand-new member's zero invites
- * doesn't read as disengagement). Consumed by `committee-engagement-classifier.utils.ts`.
+ * short-circuits to a neutral tier), `role` (`CommitteeMemberRole.LF_STAFF` short-circuits to a
+ * neutral tier, LFXV2-3101), and `joinedWithinWindow` (whether `member_joined_at` falls after the
+ * requested window's start — tenure clipping, so a brand-new member's zero invites doesn't read as
+ * disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role` is optional: the
+ * only other consumer of this shape (`groups-engagement-stats.service.ts`, LFXV2-1705) doesn't
+ * query role data and simply gets no LF Staff exclusion, matching its pre-LFXV2-3101 behavior.
  */
 export interface CommitteeEngagementClassificationInput {
   attended: number;
   invited: number;
   votingStatus: string;
+  role?: string;
   joinedWithinWindow: boolean;
 }
 
@@ -54,17 +59,18 @@ export interface CommitteeMemberEngagement {
 /** Aggregate stats for `GET /api/committees/:uid/engagement`. */
 export interface CommitteeEngagementSummary {
   /**
-   * `sum(attended) / sum(invited)` across the full committee roster, 0 when nobody was invited.
-   * Unlike `active_count`/`at_risk_count`, this is NOT Emeritus-excluded — a committee with an
-   * Emeritus member (high invitation rate, low real attendance, by design) can show a
-   * depressed rate here alongside an `active_count` that ignores that same member. A UI
-   * surfacing both side-by-side should call this out rather than let them appear to contradict.
+   * `sum(attended) / sum(invited)` across the full committee roster, excluding `LF Staff` seats
+   * (LFXV2-3101 — a staff seat's real 0-attendance shouldn't depress a committee's rate), but NOT
+   * Emeritus-excluded — a committee with an Emeritus member (high invitation rate, low real
+   * attendance, by design) can still show a depressed rate here alongside an `active_count` that
+   * ignores that same member. A UI surfacing both side-by-side should call this out rather than
+   * let them appear to contradict.
    */
   attendance_rate: number;
   /**
-   * Count of non-Emeritus members with real attendance this window, or who joined within it
-   * (active by definition of being newly on the roster) — broader than "classified High/Medium":
-   * a Low-classified member with some real attendance still counts here. See
+   * Count of non-Emeritus, non-LF-Staff members with real attendance this window, or who joined
+   * within it (active by definition of being newly on the roster) — broader than "classified
+   * High/Medium": a Low-classified member with some real attendance still counts here. See
    * `committee-engagement-classifier.utils.ts`'s `isCommitteeMemberActive`. The "joined within it"
    * clause only applies when `data_available` is `true` — on a zero-row committee, or one whose
    * rows exist but don't join to any roster member, tenure alone can't imply active (see

--- a/packages/shared/src/interfaces/committee-engagement.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.interface.ts
@@ -83,10 +83,24 @@ export interface CommitteeEngagementSummary {
    * `committee-engagement-classifier.utils.ts`'s `isCommitteeMemberActive`. The "joined within it"
    * clause only applies when `data_available` is `true` — on a zero-row committee, or one whose
    * rows exist but don't join to any roster member, tenure alone can't imply active (see
-   * `data_available`'s doc), so this is `0` there regardless of roster join dates.
+   * `data_available`'s doc), so this is `0` there regardless of roster join dates. Display this as
+   * a ratio against `eligible_count`, NOT `total_count` — see `eligible_count`'s doc for why.
    */
   active_count: number;
-  /** Full committee roster size (including members with no engagement data). */
+  /**
+   * Roster members NOT excluded from `active_count`'s population — i.e. not Emeritus, not LF Staff
+   * (`isCommitteeMemberActiveEligible`, LFXV2-3101 review fix). The correct denominator for
+   * displaying `active_count` as a ratio: `total_count` includes Emeritus/LF Staff seats that
+   * `active_count`'s numerator always excludes, so `active_count / total_count` can never reach
+   * 100% for a committee that seats either, regardless of real participation — the same shape of
+   * bug this ticket fixed for the At-Risk filter, just showing up in the ratio instead.
+   * Attendance-independent, so — unlike `active_count`/`at_risk_count`/`attendance_rate` — this
+   * does NOT zero out when `data_available` is `false`: `role`/`voting_status` are roster
+   * passthroughs that stay populated regardless (see `data_available`'s doc), so this is
+   * roster-known the same way `total_count` is.
+   */
+  eligible_count: number;
+  /** Full committee roster size (including members with no engagement data, and including Emeritus/LF Staff seats — use `eligible_count`, not this field, as the `active_count` ratio's denominator). */
   total_count: number;
   /** Members classified Low, plus members invited within the window who attended nothing (badge reads Inactive, but there is signal to act on — unlike a member never invited). */
   at_risk_count: number;
@@ -119,8 +133,8 @@ export interface CommitteeEngagementResponse {
    * of `Inactive` off zero invites) does NOT apply when `data_available` is `false` — with no usable
    * data for the whole committee, there is no engagement data to correlate tenure against, so every
    * non-Emeritus, non-LF-Staff member classifies `Inactive` and `summary`'s computed fields (`attendance_rate`,
-   * `active_count`, `at_risk_count`) are all `0` — `total_count` still reflects the full roster size
-   * regardless, since that's roster-known independent of engagement data. Asserting `High` (or a
+   * `active_count`, `at_risk_count`) are all `0` — `total_count` and `eligible_count` still reflect
+   * the roster regardless, since both are roster-known independent of engagement data. Asserting `High` (or a
    * nonzero `active_count`) on literal 0/0 counts would contradict `data_available: false` and
    * `attendance_rate: 0` in the same payload. The tenure-grace exception only fires when
    * `data_available` is `true` — i.e. the committee has rows AND at least one roster member matched

--- a/packages/shared/src/interfaces/committee-engagement.internal.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.internal.interface.ts
@@ -26,7 +26,7 @@ export interface CommitteeEngagementWarehouseRow {
   MEMBER_USER_ID: string;
   /** When the member joined the committee roster — used for tenure clipping (see the classifier). */
   MEMBER_JOINED_AT: string | Date | null;
-  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — passthrough, informational. */
+  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — `'LF Staff'` short-circuits classification and excludes the row from the rate/active sums (LFXV2-3101). */
   MEMBER_ROLE: string;
   /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'` — `'Emeritus'` short-circuits classification. */
   MEMBER_VOTING_STATUS: string;

--- a/packages/shared/src/interfaces/committee-engagement.internal.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.internal.interface.ts
@@ -26,7 +26,7 @@ export interface CommitteeEngagementWarehouseRow {
   MEMBER_USER_ID: string;
   /** When the member joined the committee roster — used for tenure clipping (see the classifier). */
   MEMBER_JOINED_AT: string | Date | null;
-  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — `'LF Staff'` short-circuits classification and excludes the row from the rate/active sums (LFXV2-3101). */
+  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — `'LF Staff'` together with `MEMBER_VOTING_STATUS === 'Observer'` short-circuits classification and excludes the row from the rate/active sums (LFXV2-3101; `role` alone is not enough — a real Voting Rep who happens to be LF Staff is not excluded). */
   MEMBER_ROLE: string;
   /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'` — `'Emeritus'` short-circuits classification. */
   MEMBER_VOTING_STATUS: string;

--- a/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
+++ b/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
@@ -20,8 +20,9 @@
 export interface GroupsEngagementStats {
   /**
    * Distinct members active on any *covered* visible committee — attended >=1 meeting in the
-   * trailing 30 days, or joined within it (tenure grace), excluding Emeritus and LF Staff seats
-   * (`isCommitteeMemberActive`, the same rule LFXV2-1705/LFXV2-3101 use). A member active on multiple visible
+   * trailing 30 days, or joined within it (tenure grace), excluding Emeritus and LF Staff+Observer
+   * seats (`isCommitteeMemberActive`, the same rule LFXV2-1705/LFXV2-3101 use — an LF Staff member
+   * who is a real Voting Rep or Alternate Voting Rep is NOT excluded). A member active on multiple visible
    * committees is counted once, not once per committee. `null` only when `coverage.covered` is `0`
    * or the computation failed — see this interface's doc comment for exactly which cases that
    * covers.

--- a/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
+++ b/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
@@ -20,8 +20,8 @@
 export interface GroupsEngagementStats {
   /**
    * Distinct members active on any *covered* visible committee — attended >=1 meeting in the
-   * trailing 30 days, or joined within it (tenure grace), excluding Emeritus
-   * (`isCommitteeMemberActive`, the same rule LFXV2-1705 uses). A member active on multiple visible
+   * trailing 30 days, or joined within it (tenure grace), excluding Emeritus and LF Staff seats
+   * (`isCommitteeMemberActive`, the same rule LFXV2-1705/LFXV2-3101 use). A member active on multiple visible
    * committees is counted once, not once per committee. `null` only when `coverage.covered` is `0`
    * or the computation failed — see this interface's doc comment for exactly which cases that
    * covers.

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
@@ -8,6 +8,7 @@ import {
   classifyCommitteeEngagement,
   computeCommitteeEngagementRate,
   isCommitteeMemberActive,
+  isCommitteeMemberActiveEligible,
   isCommitteeMemberAtRisk,
   isCommitteeMemberRateEligible,
   isJoinedWithinWindow,
@@ -181,6 +182,25 @@ describe('isCommitteeMemberActive', () => {
 
   it('is always false for LF Staff, even with real attendance or a fresh join (LFXV2-3101)', () => {
     expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: true })).toBe(false);
+  });
+});
+
+describe('isCommitteeMemberActiveEligible (LFXV2-3101 review fix — the active_count/eligible_count denominator)', () => {
+  it('is false for Emeritus, so an Emeritus-heavy committee is not permanently capped below 100% active', () => {
+    expect(isCommitteeMemberActiveEligible({ votingStatus: EMERITUS, role: undefined })).toBe(false);
+  });
+
+  it('is false for LF Staff, for the same reason', () => {
+    expect(isCommitteeMemberActiveEligible({ votingStatus: OBSERVER, role: LF_STAFF })).toBe(false);
+  });
+
+  it('is true for a real member regardless of attendance — eligibility is attendance-independent, unlike isCommitteeMemberActive', () => {
+    expect(isCommitteeMemberActiveEligible({ votingStatus: VOTING_REP, role: CHAIR })).toBe(true);
+    expect(isCommitteeMemberActiveEligible({ votingStatus: VOTING_REP, role: undefined })).toBe(true);
+  });
+
+  it('is true for a non-staff Observer (the carve-out is role-based, not voting-status-based)', () => {
+    expect(isCommitteeMemberActiveEligible({ votingStatus: OBSERVER, role: undefined })).toBe(true);
   });
 });
 

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
@@ -9,6 +9,7 @@ import {
   computeCommitteeEngagementRate,
   isCommitteeMemberActive,
   isCommitteeMemberAtRisk,
+  isCommitteeMemberRateEligible,
   isJoinedWithinWindow,
 } from './committee-engagement-classifier.utils';
 
@@ -180,6 +181,24 @@ describe('isCommitteeMemberActive', () => {
 
   it('is always false for LF Staff, even with real attendance or a fresh join (LFXV2-3101)', () => {
     expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: true })).toBe(false);
+  });
+});
+
+describe('isCommitteeMemberRateEligible (LFXV2-3101)', () => {
+  it('is false for LF Staff, regardless of real attendance', () => {
+    expect(isCommitteeMemberRateEligible({ attended: 8, invited: 8, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(false);
+  });
+
+  it('is true for Emeritus — unlike every other rule in this file, Emeritus is NOT rate-excluded', () => {
+    expect(isCommitteeMemberRateEligible({ attended: 1, invited: 20, votingStatus: EMERITUS, joinedWithinWindow: false })).toBe(true);
+  });
+
+  it('is true for a real Chair with zero attendance (the carve-out is role-based, not a broad exclusion)', () => {
+    expect(isCommitteeMemberRateEligible({ attended: 0, invited: 3, votingStatus: VOTING_REP, role: CHAIR, joinedWithinWindow: false })).toBe(true);
+  });
+
+  it('is true for a member with no role set at all (undefined, not LF Staff)', () => {
+    expect(isCommitteeMemberRateEligible({ attended: 5, invited: 10, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe(true);
   });
 });
 

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
@@ -15,6 +15,7 @@ import {
 } from './committee-engagement-classifier.utils';
 
 const VOTING_REP = CommitteeMemberVotingStatus.VOTING_REP;
+const ALTERNATE_VOTING_REP = CommitteeMemberVotingStatus.ALTERNATE_VOTING_REP;
 const OBSERVER = CommitteeMemberVotingStatus.OBSERVER;
 const EMERITUS = CommitteeMemberVotingStatus.EMERITUS;
 const CHAIR = CommitteeMemberRole.CHAIR;
@@ -52,13 +53,13 @@ describe('classifyCommitteeEngagement — decision table', () => {
     expect(classifyCommitteeEngagement({ attended: 10, invited: 10, votingStatus: EMERITUS, joinedWithinWindow: false })).toBe('Emeritus');
   });
 
-  // Row 2 (LFXV2-3101): LF Staff role always wins too, regardless of real numbers.
-  it('classifies LF Staff regardless of a low real attendance rate (0/0)', () => {
+  // Row 2 (LFXV2-3101): LF Staff + Observer wins too, regardless of real numbers.
+  it('classifies LF Staff regardless of a low real attendance rate (0/0), when voting status is Observer', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 0, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
   });
 
-  it('classifies LF Staff even for real attendance', () => {
-    expect(classifyCommitteeEngagement({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
+  it('classifies LF Staff even for real attendance, when voting status is Observer', () => {
+    expect(classifyCommitteeEngagement({ attended: 5, invited: 5, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
   });
 
   it('does not broaden the LF Staff carve-out to non-staff Observers', () => {
@@ -67,6 +68,20 @@ describe('classifyCommitteeEngagement — decision table', () => {
 
   it('does not broaden the LF Staff carve-out to a real Chair with zero attendance', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 3, votingStatus: VOTING_REP, role: CHAIR, joinedWithinWindow: false })).toBe('Inactive');
+  });
+
+  // LFXV2-3101 follow-up (Jordan Evans review): an LF Staff member who is also a real Voting Rep
+  // or Alternate Voting Rep (an ED or staff member serving as a board/committee representative)
+  // is a genuine participant and must classify/count normally — only the Observer-status staff
+  // seat is excluded, not every LF Staff member regardless of their real voting role.
+  it('does NOT classify LF Staff for a real Voting Rep who happens to be LF Staff — classifies on real attendance instead', () => {
+    expect(classifyCommitteeEngagement({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe('High');
+  });
+
+  it('does NOT classify LF Staff for a real Alternate Voting Rep who happens to be LF Staff', () => {
+    expect(classifyCommitteeEngagement({ attended: 0, invited: 5, votingStatus: ALTERNATE_VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(
+      'Inactive'
+    );
   });
 
   // Row 3: no invites yet, joined within window — "the Orlin case", but the invited=0 variant.
@@ -180,8 +195,12 @@ describe('isCommitteeMemberActive', () => {
     expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: EMERITUS, joinedWithinWindow: true })).toBe(false);
   });
 
-  it('is always false for LF Staff, even with real attendance or a fresh join (LFXV2-3101)', () => {
-    expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: true })).toBe(false);
+  it('is always false for LF Staff + Observer, even with real attendance or a fresh join (LFXV2-3101)', () => {
+    expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: true })).toBe(false);
+  });
+
+  it('is true for a real Voting Rep who happens to be LF Staff — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
+    expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(true);
   });
 });
 
@@ -205,8 +224,12 @@ describe('isCommitteeMemberActiveEligible (LFXV2-3101 review fix — the active_
 });
 
 describe('isCommitteeMemberRateEligible (LFXV2-3101)', () => {
-  it('is false for LF Staff, regardless of real attendance', () => {
-    expect(isCommitteeMemberRateEligible({ attended: 8, invited: 8, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(false);
+  it('is false for LF Staff + Observer, regardless of real attendance', () => {
+    expect(isCommitteeMemberRateEligible({ attended: 8, invited: 8, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe(false);
+  });
+
+  it('is true for a real Voting Rep who happens to be LF Staff — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
+    expect(isCommitteeMemberRateEligible({ attended: 8, invited: 8, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(true);
   });
 
   it('is true for Emeritus — unlike every other rule in this file, Emeritus is NOT rate-excluded', () => {
@@ -221,10 +244,15 @@ describe('isCommitteeMemberRateEligible (LFXV2-3101)', () => {
     expect(isCommitteeMemberRateEligible({ attended: 5, invited: 10, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe(true);
   });
 
-  it('is false for a member who is BOTH Emeritus and LF Staff, even though they classify Emeritus (the exclusion is role-based, independent of the reported tier)', () => {
+  it('is true for a member who is BOTH Emeritus and LF Staff — the LF Staff rate exclusion is scoped to Observer voting status specifically, and Emeritus is never voting-status Observer', () => {
+    // LFXV2-3101 follow-up: the LF Staff exclusion only fires for role === LF_STAFF &&
+    // votingStatus === Observer. An Emeritus+LF-Staff member's votingStatus is Emeritus, not
+    // Observer, so isLfStaffObserverSeat is false here — they classify Emeritus (voting status
+    // wins first in the classifier) and are rate-eligible via the ordinary Emeritus-inclusion rule,
+    // not excluded a second way by role.
     const input = { attended: 1, invited: 20, votingStatus: EMERITUS, role: LF_STAFF, joinedWithinWindow: false };
     expect(classifyCommitteeEngagement(input)).toBe('Emeritus');
-    expect(isCommitteeMemberRateEligible(input)).toBe(false);
+    expect(isCommitteeMemberRateEligible(input)).toBe(true);
   });
 });
 

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
@@ -200,6 +200,12 @@ describe('isCommitteeMemberRateEligible (LFXV2-3101)', () => {
   it('is true for a member with no role set at all (undefined, not LF Staff)', () => {
     expect(isCommitteeMemberRateEligible({ attended: 5, invited: 10, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe(true);
   });
+
+  it('is false for a member who is BOTH Emeritus and LF Staff, even though they classify Emeritus (the exclusion is role-based, independent of the reported tier)', () => {
+    const input = { attended: 1, invited: 20, votingStatus: EMERITUS, role: LF_STAFF, joinedWithinWindow: false };
+    expect(classifyCommitteeEngagement(input)).toBe('Emeritus');
+    expect(isCommitteeMemberRateEligible(input)).toBe(false);
+  });
 });
 
 describe('isJoinedWithinWindow', () => {

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { CommitteeMemberVotingStatus } from '../enums';
+import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums';
 import {
   classifyCommitteeEngagement,
   computeCommitteeEngagementRate,
@@ -13,7 +13,10 @@ import {
 } from './committee-engagement-classifier.utils';
 
 const VOTING_REP = CommitteeMemberVotingStatus.VOTING_REP;
+const OBSERVER = CommitteeMemberVotingStatus.OBSERVER;
 const EMERITUS = CommitteeMemberVotingStatus.EMERITUS;
+const CHAIR = CommitteeMemberRole.CHAIR;
+const LF_STAFF = CommitteeMemberRole.LF_STAFF;
 
 describe('computeCommitteeEngagementRate', () => {
   it('returns 0 when invited is 0', () => {
@@ -47,17 +50,34 @@ describe('classifyCommitteeEngagement — decision table', () => {
     expect(classifyCommitteeEngagement({ attended: 10, invited: 10, votingStatus: EMERITUS, joinedWithinWindow: false })).toBe('Emeritus');
   });
 
-  // Row 2: no invites yet, joined within window — "the Orlin case", but the invited=0 variant.
+  // Row 2 (LFXV2-3101): LF Staff role always wins too, regardless of real numbers.
+  it('classifies LF Staff regardless of a low real attendance rate (0/0)', () => {
+    expect(classifyCommitteeEngagement({ attended: 0, invited: 0, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
+  });
+
+  it('classifies LF Staff even for real attendance', () => {
+    expect(classifyCommitteeEngagement({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
+  });
+
+  it('does not broaden the LF Staff carve-out to non-staff Observers', () => {
+    expect(classifyCommitteeEngagement({ attended: 2, invited: 10, votingStatus: OBSERVER, joinedWithinWindow: false })).toBe('Low');
+  });
+
+  it('does not broaden the LF Staff carve-out to a real Chair with zero attendance', () => {
+    expect(classifyCommitteeEngagement({ attended: 0, invited: 3, votingStatus: VOTING_REP, role: CHAIR, joinedWithinWindow: false })).toBe('Inactive');
+  });
+
+  // Row 3: no invites yet, joined within window — "the Orlin case", but the invited=0 variant.
   it('classifies High (not Inactive) for a member with zero invites who joined within the window', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 0, votingStatus: VOTING_REP, joinedWithinWindow: true })).toBe('High');
   });
 
-  // Row 3: no invites, been a member the whole window — unchanged from the original rule.
+  // Row 4: no invites, been a member the whole window — unchanged from the original rule.
   it('classifies Inactive for a never-invited member who has been on the roster the whole window', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 0, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe('Inactive');
   });
 
-  // Rows 4-6: threshold on the real rate, unchanged boundaries.
+  // Rows 5-7: threshold on the real rate, unchanged boundaries.
   it('classifies a rate just below the medium threshold as Low', () => {
     expect(classifyCommitteeEngagement({ attended: 39, invited: 100, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe('Low');
   });
@@ -85,7 +105,7 @@ describe('classifyCommitteeEngagement — decision table', () => {
     expect(classifyCommitteeEngagement({ attended: 395, invited: 1000, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe('Low');
   });
 
-  // Row 7: invited at least once, attended nothing — a real signal, tenure does not protect it.
+  // Row 8: invited at least once, attended nothing — a real signal, tenure does not protect it.
   it('classifies Inactive for a member invited at least once who attended nothing, even if joined within the window', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 3, votingStatus: VOTING_REP, joinedWithinWindow: true })).toBe('Inactive');
     expect(classifyCommitteeEngagement({ attended: 0, invited: 3, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe('Inactive');
@@ -125,6 +145,14 @@ describe('isCommitteeMemberAtRisk', () => {
   it('is never true for an Emeritus member, regardless of real attendance', () => {
     expect(isCommitteeMemberAtRisk({ attended: 0, invited: 20, votingStatus: EMERITUS, joinedWithinWindow: false })).toBe(false);
   });
+
+  it('is never true for an LF Staff member, regardless of real attendance (LFXV2-3101)', () => {
+    expect(isCommitteeMemberAtRisk({ attended: 0, invited: 20, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe(false);
+  });
+
+  it('is still true for a non-staff Observer with a low real rate (the carve-out is role-based, not voting-status-based)', () => {
+    expect(isCommitteeMemberAtRisk({ attended: 10, invited: 100, votingStatus: OBSERVER, joinedWithinWindow: false })).toBe(true);
+  });
 });
 
 describe('isCommitteeMemberActive', () => {
@@ -148,6 +176,10 @@ describe('isCommitteeMemberActive', () => {
 
   it('is always false for Emeritus, even with real attendance or a fresh join', () => {
     expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: EMERITUS, joinedWithinWindow: true })).toBe(false);
+  });
+
+  it('is always false for LF Staff, even with real attendance or a fresh join (LFXV2-3101)', () => {
+    expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: true })).toBe(false);
   });
 });
 

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -144,13 +144,16 @@ export function isCommitteeMemberActiveEligible(input: Pick<CommitteeEngagementC
  * usually also an active staff seat) but not undefined behavior: the check simply doesn't care
  * what tier the member displayed as.
  *
- * `input.role`'s value is whatever the caller resolved — for `committee-engagement.service.ts`
- * today that's the live roster's `role.name` first, falling back to warehouse `MEMBER_ROLE` only
- * when the roster value is missing (deliberately the OPPOSITE precedence `votingStatus` uses for
- * the Emeritus check, which stays warehouse-first — see that call site's own comment for why: this
- * exclusion needs to reflect a role change the moment it lands on the roster, not lag until the
- * dbt model's next refresh, and the roster's typed `CommitteeMemberRole` is also a safer match
- * target than the warehouse's untyped string).
+ * `input.role`'s and `input.votingStatus`'s values are whatever the caller resolved — for
+ * `committee-engagement.service.ts` today that's the live roster's value first for BOTH fields,
+ * warehouse `MEMBER_ROLE`/`MEMBER_VOTING_STATUS` only as the fallback when the roster value is
+ * missing (Cursor Bugbot follow-up, LFXV2-3101: `votingStatus` used to stay warehouse-first even
+ * after `role` was flipped roster-first, which meant a member promoted from Observer to a real
+ * Voting/Alternate Rep could keep a stale warehouse `Observer` and stay incorrectly excluded here
+ * until the next dbt refresh — this predicate combines both fields into one condition via
+ * `isLfStaffObserverSeat`, so both need equally fresh precedence or the combination itself goes
+ * stale even when each field individually wouldn't). The roster's typed `CommitteeMemberRole`/
+ * `CommitteeMemberVotingStatus` are also safer match targets than the warehouse's untyped strings.
  */
 export function isCommitteeMemberRateEligible(input: CommitteeEngagementClassificationInput): boolean {
   return !isLfStaffObserverSeat(input);

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -96,6 +96,27 @@ export function isCommitteeMemberActive(input: CommitteeEngagementClassification
 }
 
 /**
+ * Whether a member's `attended`/`invited` counts should feed the committee-wide `attendance_rate`
+ * sum (LFXV2-3101) — `LF Staff` seats are excluded, Emeritus seats deliberately are NOT (see
+ * `CommitteeEngagementSummary.attendance_rate`'s doc for why the two aren't symmetric here, unlike
+ * every other rule in this file). Exported as its own named predicate, not left as an inline check
+ * at the one call site, so this asymmetry is stated once in the module that owns every other
+ * classification rule, rather than risking a second, easily-missed copy.
+ *
+ * `input.role`'s value is whatever the caller resolved — for `committee-engagement.service.ts`
+ * today that's warehouse `MEMBER_ROLE` first, falling back to the live roster's `role.name` only
+ * when the warehouse row is missing (same precedence `votingStatus` already used for the Emeritus
+ * check, chosen there for a different reason — rescuing a missing row, not freshness). A known,
+ * accepted consequence: a member's role change on the live roster (promoted off LF Staff, or newly
+ * assigned to it) doesn't affect this exclusion until the warehouse model's next refresh — this
+ * predicate reports what the measured attendance snapshot says the seat was, not necessarily what
+ * the roster says it is right now.
+ */
+export function isCommitteeMemberRateEligible(input: CommitteeEngagementClassificationInput): boolean {
+  return input.role !== CommitteeMemberRole.LF_STAFF;
+}
+
+/**
  * `false` (fail-safe: no tenure protection) for a missing or unparseable join date. Shared between
  * `committee-engagement.service.ts` (per-member tenure clipping for `GET /:uid/engagement`) and
  * `groups-engagement-stats.service.ts` (the `active_members` rollup for `GET /engagement-stats`) so

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -34,14 +34,29 @@ export function computeCommitteeEngagementRate(attended: number, invited: number
 }
 
 /**
+ * Whether a member is an LF Staff seat with Observer voting status specifically — the actual
+ * exclusion condition every "LF Staff" rule in this file keys on, not `role === LF_STAFF` alone
+ * (LFXV2-3101 follow-up review fix). Staff seats are typically added as an Observer with no real
+ * meeting-attendance expectation, which is what the exclusion exists to protect — but an LF Staff
+ * member who is a Voting Rep or Alternate Voting Rep (e.g. an ED or staff member serving as a real
+ * board/committee voting representative) is a genuine participant and should classify/count
+ * normally, the same as any other member. Excluding them anyway would silence real engagement
+ * signal for exactly the population — real participants — every rule in this file exists to
+ * measure. Scoped to `role`+`Observer` specifically, not broadened to every Observer regardless of
+ * role: a non-staff Observer can still have real engagement expectations depending on the
+ * community, so excluding all Observers would hide genuine disengagement signal in the other
+ * direction.
+ */
+function isLfStaffObserverSeat(input: Pick<CommitteeEngagementClassificationInput, 'role' | 'votingStatus'>): boolean {
+  return input.role === CommitteeMemberRole.LF_STAFF && input.votingStatus === CommitteeMemberVotingStatus.OBSERVER;
+}
+
+/**
  * Decision order (see the ticket's Jira thread for the full rationale):
  * 1. `Emeritus` voting status always wins — on the roster for legacy/honorific reasons, real
  *    attendance (often ~5%, per the model's real observed data) shouldn't read as disengagement.
- * 2. `LF Staff` role wins next (LFXV2-3101) — staff seats are typically added as an Observer with
- *    no real meeting-attendance expectation, so their real (often 0%) attendance shouldn't read as
- *    disengagement either. Deliberately keyed on `role`, not `votingStatus === Observer`: a
- *    non-staff Observer can have real engagement expectations depending on the community, so
- *    broadening this to all Observers would hide genuine disengagement signal.
+ * 2. `LF Staff` + `Observer` wins next (LFXV2-3101) — see `isLfStaffObserverSeat`'s doc for exactly
+ *    why it's this two-part condition and not `role` alone.
  * 3. No invites yet, but joined within the window: no real opportunity has existed, so this can't
  *    be `Inactive` — tenure, not disengagement. Classified `High` (active by definition) rather
  *    than a new tier, since the ticket's classification set is fixed.
@@ -53,9 +68,9 @@ export function computeCommitteeEngagementRate(attended: number, invited: number
  *    not protect this case.
  */
 export function classifyCommitteeEngagement(input: CommitteeEngagementClassificationInput): CommitteeEngagementClassification {
-  const { attended, invited, votingStatus, role, joinedWithinWindow } = input;
+  const { attended, invited, votingStatus, joinedWithinWindow } = input;
   if (votingStatus === CommitteeMemberVotingStatus.EMERITUS) return 'Emeritus';
-  if (role === CommitteeMemberRole.LF_STAFF) return 'LF Staff';
+  if (isLfStaffObserverSeat(input)) return 'LF Staff';
   if (invited <= 0) return joinedWithinWindow ? 'High' : 'Inactive';
 
   const rate = rawCommitteeEngagementRate(attended, invited);
@@ -72,8 +87,9 @@ export function classifyCommitteeEngagement(input: CommitteeEngagementClassifica
  * `Low` members are at risk by definition. A member invited within the window who attended
  * nothing is at risk too, even though `classifyCommitteeEngagement` also calls them `Inactive` —
  * that tier's other member (never invited at all) has no signal to act on, but this one does.
- * `Emeritus`, `LF Staff` (LFXV2-3101), and the tenure-grace `High` (case 3 above) are never
- * at-risk — none of them match `Low` or `Inactive`, so no extra exclusion logic is needed here.
+ * `Emeritus`, `LF Staff`+`Observer` (LFXV2-3101), and the tenure-grace `High` (case 3 above) are
+ * never at-risk — none of them match `Low` or `Inactive`, so no extra exclusion logic is needed
+ * here.
  */
 export function isCommitteeMemberAtRisk(input: CommitteeEngagementClassificationInput): boolean {
   const classification = classifyCommitteeEngagement(input);
@@ -84,14 +100,15 @@ export function isCommitteeMemberAtRisk(input: CommitteeEngagementClassification
  * The "Active Members x/y" summary rule — deliberately broader than "classified High/Medium":
  * per the ticket, the numerator is members with *any* real attendance this window, plus members
  * who joined within it (active by definition of being newly on the roster), excluding Emeritus
- * and LF Staff (LFXV2-3101). This function doesn't delegate to `classifyCommitteeEngagement`, so
- * both exclusions need their own explicit check here, same as the classifier's. A `Low`-classified
- * member (some attendance, just under the Medium threshold) still counts here — this is a distinct
- * rule from `classifyCommitteeEngagement`, not a rollup of its tiers.
+ * and LF Staff+Observer seats (LFXV2-3101, see `isLfStaffObserverSeat`'s doc for the two-part
+ * condition). This function doesn't delegate to `classifyCommitteeEngagement`, so both exclusions
+ * need their own explicit check here, same as the classifier's. A `Low`-classified member (some
+ * attendance, just under the Medium threshold) still counts here — this is a distinct rule from
+ * `classifyCommitteeEngagement`, not a rollup of its tiers.
  */
 export function isCommitteeMemberActive(input: CommitteeEngagementClassificationInput): boolean {
   if (input.votingStatus === CommitteeMemberVotingStatus.EMERITUS) return false;
-  if (input.role === CommitteeMemberRole.LF_STAFF) return false;
+  if (isLfStaffObserverSeat(input)) return false;
   return input.attended > 0 || input.joinedWithinWindow;
 }
 
@@ -100,32 +117,32 @@ export function isCommitteeMemberActive(input: CommitteeEngagementClassification
  * could ever contribute to it, independent of whether *this* member happens to be active right
  * now. This is `CommitteeEngagementSummary.eligible_count`'s per-member rule, the correct
  * denominator for displaying `active_count` as a ratio (LFXV2-3101 review fix): counting Emeritus
- * and LF Staff seats in the denominator while `isCommitteeMemberActive` always excludes them from
- * the numerator means a committee that seats either could never read 100% active regardless of
- * real participation — the same shape of bug the ticket fixed for the At-Risk filter, just showing
- * up in the ratio instead. Attendance-independent by design (unlike `isCommitteeMemberActive`,
- * which mixes the exclusion with an attendance check) — a never-attended non-Emeritus/non-staff
- * member is still eligible, just not active.
+ * and LF Staff+Observer seats in the denominator while `isCommitteeMemberActive` always excludes
+ * them from the numerator means a committee that seats either could never read 100% active
+ * regardless of real participation — the same shape of bug the ticket fixed for the At-Risk
+ * filter, just showing up in the ratio instead. Attendance-independent by design (unlike
+ * `isCommitteeMemberActive`, which mixes the exclusion with an attendance check) — a
+ * never-attended non-Emeritus/non-staff member is still eligible, just not active.
  */
 export function isCommitteeMemberActiveEligible(input: Pick<CommitteeEngagementClassificationInput, 'votingStatus' | 'role'>): boolean {
-  return input.votingStatus !== CommitteeMemberVotingStatus.EMERITUS && input.role !== CommitteeMemberRole.LF_STAFF;
+  return input.votingStatus !== CommitteeMemberVotingStatus.EMERITUS && !isLfStaffObserverSeat(input);
 }
 
 /**
  * Whether a member's `attended`/`invited` counts should feed the committee-wide `attendance_rate`
- * sum (LFXV2-3101) — `LF Staff` seats are excluded, Emeritus seats deliberately are NOT (see
- * `CommitteeEngagementSummary.attendance_rate`'s doc for why the two aren't symmetric here, unlike
- * every other rule in this file). Exported as its own named predicate, not left as an inline check
- * at the one call site, so this asymmetry is stated once in the module that owns every other
- * classification rule, rather than risking a second, easily-missed copy.
+ * sum (LFXV2-3101) — `LF Staff`+`Observer` seats are excluded, Emeritus seats deliberately are NOT
+ * (see `CommitteeEngagementSummary.attendance_rate`'s doc for why the two aren't symmetric here,
+ * unlike every other rule in this file). Exported as its own named predicate, not left as an
+ * inline check at the one call site, so this asymmetry is stated once in the module that owns
+ * every other classification rule, rather than risking a second, easily-missed copy.
  *
- * Keyed on `input.role` alone, independent of `classifyCommitteeEngagement`'s tier — a member who
- * is BOTH a real Emeritus (`votingStatus`) and a real LF Staff seat (`role`) classifies `Emeritus`
- * (voting status wins first in the classifier's decision order) and renders the Emeritus chip, but
- * is still excluded from the rate sum here, since the exclusion is deliberately role-based, not
- * classification-based. Rare in practice (an honorific legacy seat is not usually also an active
- * staff seat) but not undefined behavior: the role check simply doesn't care what tier the member
- * displayed as.
+ * Delegates to `isLfStaffObserverSeat`, independent of `classifyCommitteeEngagement`'s tier — a
+ * member who is BOTH a real Emeritus (`votingStatus`) and a real LF Staff+Observer seat classifies
+ * `Emeritus` (voting status wins first in the classifier's decision order) and renders the
+ * Emeritus chip, but is still excluded from the rate sum here, since the exclusion is deliberately
+ * seat-type-based, not classification-based. Rare in practice (an honorific legacy seat is not
+ * usually also an active staff seat) but not undefined behavior: the check simply doesn't care
+ * what tier the member displayed as.
  *
  * `input.role`'s value is whatever the caller resolved — for `committee-engagement.service.ts`
  * today that's the live roster's `role.name` first, falling back to warehouse `MEMBER_ROLE` only
@@ -136,7 +153,7 @@ export function isCommitteeMemberActiveEligible(input: Pick<CommitteeEngagementC
  * target than the warehouse's untyped string).
  */
 export function isCommitteeMemberRateEligible(input: CommitteeEngagementClassificationInput): boolean {
-  return input.role !== CommitteeMemberRole.LF_STAFF;
+  return !isLfStaffObserverSeat(input);
 }
 
 /**

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -104,13 +104,12 @@ export function isCommitteeMemberActive(input: CommitteeEngagementClassification
  * classification rule, rather than risking a second, easily-missed copy.
  *
  * `input.role`'s value is whatever the caller resolved — for `committee-engagement.service.ts`
- * today that's warehouse `MEMBER_ROLE` first, falling back to the live roster's `role.name` only
- * when the warehouse row is missing (same precedence `votingStatus` already used for the Emeritus
- * check, chosen there for a different reason — rescuing a missing row, not freshness). A known,
- * accepted consequence: a member's role change on the live roster (promoted off LF Staff, or newly
- * assigned to it) doesn't affect this exclusion until the warehouse model's next refresh — this
- * predicate reports what the measured attendance snapshot says the seat was, not necessarily what
- * the roster says it is right now.
+ * today that's the live roster's `role.name` first, falling back to warehouse `MEMBER_ROLE` only
+ * when the roster value is missing (deliberately the OPPOSITE precedence `votingStatus` uses for
+ * the Emeritus check, which stays warehouse-first — see that call site's own comment for why: this
+ * exclusion needs to reflect a role change the moment it lands on the roster, not lag until the
+ * dbt model's next refresh, and the roster's typed `CommitteeMemberRole` is also a safer match
+ * target than the warehouse's untyped string).
  */
 export function isCommitteeMemberRateEligible(input: CommitteeEngagementClassificationInput): boolean {
   return input.role !== CommitteeMemberRole.LF_STAFF;

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -96,6 +96,22 @@ export function isCommitteeMemberActive(input: CommitteeEngagementClassification
 }
 
 /**
+ * Whether a member belongs to the population `active_count` is measured over — i.e. whether they
+ * could ever contribute to it, independent of whether *this* member happens to be active right
+ * now. This is `CommitteeEngagementSummary.eligible_count`'s per-member rule, the correct
+ * denominator for displaying `active_count` as a ratio (LFXV2-3101 review fix): counting Emeritus
+ * and LF Staff seats in the denominator while `isCommitteeMemberActive` always excludes them from
+ * the numerator means a committee that seats either could never read 100% active regardless of
+ * real participation — the same shape of bug the ticket fixed for the At-Risk filter, just showing
+ * up in the ratio instead. Attendance-independent by design (unlike `isCommitteeMemberActive`,
+ * which mixes the exclusion with an attendance check) — a never-attended non-Emeritus/non-staff
+ * member is still eligible, just not active.
+ */
+export function isCommitteeMemberActiveEligible(input: Pick<CommitteeEngagementClassificationInput, 'votingStatus' | 'role'>): boolean {
+  return input.votingStatus !== CommitteeMemberVotingStatus.EMERITUS && input.role !== CommitteeMemberRole.LF_STAFF;
+}
+
+/**
  * Whether a member's `attended`/`invited` counts should feed the committee-wide `attendance_rate`
  * sum (LFXV2-3101) — `LF Staff` seats are excluded, Emeritus seats deliberately are NOT (see
  * `CommitteeEngagementSummary.attendance_rate`'s doc for why the two aren't symmetric here, unlike

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -103,6 +103,14 @@ export function isCommitteeMemberActive(input: CommitteeEngagementClassification
  * at the one call site, so this asymmetry is stated once in the module that owns every other
  * classification rule, rather than risking a second, easily-missed copy.
  *
+ * Keyed on `input.role` alone, independent of `classifyCommitteeEngagement`'s tier — a member who
+ * is BOTH a real Emeritus (`votingStatus`) and a real LF Staff seat (`role`) classifies `Emeritus`
+ * (voting status wins first in the classifier's decision order) and renders the Emeritus chip, but
+ * is still excluded from the rate sum here, since the exclusion is deliberately role-based, not
+ * classification-based. Rare in practice (an honorific legacy seat is not usually also an active
+ * staff seat) but not undefined behavior: the role check simply doesn't care what tier the member
+ * displayed as.
+ *
  * `input.role`'s value is whatever the caller resolved — for `committee-engagement.service.ts`
  * today that's the live roster's `role.name` first, falling back to warehouse `MEMBER_ROLE` only
  * when the roster value is missing (deliberately the OPPOSITE precedence `votingStatus` uses for

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { COMMITTEE_ENGAGEMENT_RATE_THRESHOLDS } from '../constants/committee-engagement.constants';
-import { CommitteeMemberVotingStatus } from '../enums';
+import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums';
 import type { CommitteeEngagementClassification, CommitteeEngagementClassificationInput } from '../interfaces/committee-engagement.interface';
 
 /**
@@ -37,19 +37,25 @@ export function computeCommitteeEngagementRate(attended: number, invited: number
  * Decision order (see the ticket's Jira thread for the full rationale):
  * 1. `Emeritus` voting status always wins — on the roster for legacy/honorific reasons, real
  *    attendance (often ~5%, per the model's real observed data) shouldn't read as disengagement.
- * 2. No invites yet, but joined within the window: no real opportunity has existed, so this can't
+ * 2. `LF Staff` role wins next (LFXV2-3101) — staff seats are typically added as an Observer with
+ *    no real meeting-attendance expectation, so their real (often 0%) attendance shouldn't read as
+ *    disengagement either. Deliberately keyed on `role`, not `votingStatus === Observer`: a
+ *    non-staff Observer can have real engagement expectations depending on the community, so
+ *    broadening this to all Observers would hide genuine disengagement signal.
+ * 3. No invites yet, but joined within the window: no real opportunity has existed, so this can't
  *    be `Inactive` — tenure, not disengagement. Classified `High` (active by definition) rather
  *    than a new tier, since the ticket's classification set is fixed.
- * 3. No invites, and been a member the whole window: a genuine no-signal veteran — unchanged from
+ * 4. No invites, and been a member the whole window: a genuine no-signal veteran — unchanged from
  *    the original rule.
- * 4-6. Invited at least once: threshold on the real (unrounded) rate as before.
- * 7. Invited at least once, attended nothing: a real disengagement signal regardless of tenure —
- *    unlike case 2, they had an actual opportunity and skipped every one of them, so tenure does
+ * 5-7. Invited at least once: threshold on the real (unrounded) rate as before.
+ * 8. Invited at least once, attended nothing: a real disengagement signal regardless of tenure —
+ *    unlike case 3, they had an actual opportunity and skipped every one of them, so tenure does
  *    not protect this case.
  */
 export function classifyCommitteeEngagement(input: CommitteeEngagementClassificationInput): CommitteeEngagementClassification {
-  const { attended, invited, votingStatus, joinedWithinWindow } = input;
+  const { attended, invited, votingStatus, role, joinedWithinWindow } = input;
   if (votingStatus === CommitteeMemberVotingStatus.EMERITUS) return 'Emeritus';
+  if (role === CommitteeMemberRole.LF_STAFF) return 'LF Staff';
   if (invited <= 0) return joinedWithinWindow ? 'High' : 'Inactive';
 
   const rate = rawCommitteeEngagementRate(attended, invited);
@@ -66,8 +72,8 @@ export function classifyCommitteeEngagement(input: CommitteeEngagementClassifica
  * `Low` members are at risk by definition. A member invited within the window who attended
  * nothing is at risk too, even though `classifyCommitteeEngagement` also calls them `Inactive` —
  * that tier's other member (never invited at all) has no signal to act on, but this one does.
- * `Emeritus` and the tenure-grace `High` (case 2 above) are never at-risk — neither matches `Low`
- * or `Inactive`, so no extra exclusion logic is needed here.
+ * `Emeritus`, `LF Staff` (LFXV2-3101), and the tenure-grace `High` (case 3 above) are never
+ * at-risk — none of them match `Low` or `Inactive`, so no extra exclusion logic is needed here.
  */
 export function isCommitteeMemberAtRisk(input: CommitteeEngagementClassificationInput): boolean {
   const classification = classifyCommitteeEngagement(input);
@@ -77,12 +83,15 @@ export function isCommitteeMemberAtRisk(input: CommitteeEngagementClassification
 /**
  * The "Active Members x/y" summary rule — deliberately broader than "classified High/Medium":
  * per the ticket, the numerator is members with *any* real attendance this window, plus members
- * who joined within it (active by definition of being newly on the roster), excluding Emeritus.
- * A `Low`-classified member (some attendance, just under the Medium threshold) still counts here —
- * this is a distinct rule from `classifyCommitteeEngagement`, not a rollup of its tiers.
+ * who joined within it (active by definition of being newly on the roster), excluding Emeritus
+ * and LF Staff (LFXV2-3101). This function doesn't delegate to `classifyCommitteeEngagement`, so
+ * both exclusions need their own explicit check here, same as the classifier's. A `Low`-classified
+ * member (some attendance, just under the Medium threshold) still counts here — this is a distinct
+ * rule from `classifyCommitteeEngagement`, not a rollup of its tiers.
  */
 export function isCommitteeMemberActive(input: CommitteeEngagementClassificationInput): boolean {
   if (input.votingStatus === CommitteeMemberVotingStatus.EMERITUS) return false;
+  if (input.role === CommitteeMemberRole.LF_STAFF) return false;
   return input.attended > 0 || input.joinedWithinWindow;
 }
 

--- a/packages/shared/src/utils/committee-engagement-display.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-display.utils.ts
@@ -19,10 +19,11 @@ export function toCommitteeEngagementWindow(windowId: string): CommitteeEngageme
  * (there is signal to act on, unlike a never-invited member) — but operates on the already-classified
  * response row rather than re-deriving the tier client-side. Re-deriving from the response's rounded
  * `rate` would disagree with the server at threshold boundaries (e.g. 0.395 displays as 0.40 but
- * classifies `Low`), so the served `classification` is authoritative. `Emeritus` and the
- * tenure-grace `High` can never match. Rows from a degraded response (`data_available: false`) are
- * zeroed with `invited: 0` and classify `Inactive` — or `Emeritus` / tenure-grace `High` for the
- * roster exceptions the response contract documents — so they never read as at-risk here.
+ * classifies `Low`), so the served `classification` is authoritative. `Emeritus`, `LF Staff`
+ * (LFXV2-3101), and the tenure-grace `High` can never match. Rows from a degraded response
+ * (`data_available: false`) are zeroed with `invited: 0` and classify `Inactive` — or `Emeritus` /
+ * tenure-grace `High` for the roster exceptions the response contract documents — so they never
+ * read as at-risk here.
  */
 export function isCommitteeEngagementRowAtRisk(row: CommitteeMemberEngagement): boolean {
   return row.classification === 'Low' || (row.classification === 'Inactive' && row.invited > 0);


### PR DESCRIPTION
## Summary

Fixes [LFXV2-3101](https://linuxfoundation.atlassian.net/browse/LFXV2-3101). The committee Engagement card (Attendance Rate %, Active Members x/y, At Risk count) and the Members-tab At-Risk filter counted `role: LF Staff` seats identically to real community voting reps. LF Staff seats are typically added as an Observer with no real meeting-attendance expectation, so they were classified `Inactive`, surfaced as At Risk, and dragged down the top-line Attendance Rate % / Active Members numbers purely because they never attend.

**Found live on WG Identity & Trust**: the "At Risk (4)" filter showed 3 of 4 flagged members as `role: LF Staff` / `voting_status: Observer` / 0/8 meetings — only 1 of 4 was a genuine at-risk signal.

## Scope decision

Carve-out is keyed on `role === CommitteeMemberRole.LF_STAFF` specifically, **not** `votingStatus === Observer` — non-staff Observers can have real engagement expectations depending on the community, so broadening to all Observers would hide genuine disengagement signal. Guarded by tests: a non-staff Observer with low attendance and a real Chair/Vice-Chair/voting rep with zero attendance both still classify normally.

LF Staff gets its **own classification tier** (`'LF Staff'`, neutral `secondary` severity) rather than reusing `'Emeritus'` — reusing Emeritus would literally print the word "Emeritus" on a staff member's chip, which is wrong.

## Two design decisions made during implementation

1. **Attendance Rate % sum**: unlike Emeritus (which stays included in the rate sum by long-standing design — see `CommitteeEngagementSummary.attendance_rate`'s doc), LF Staff seats are **excluded** from `attendance_rate`'s numerator/denominator, not just from Active/At-Risk. The ticket explicitly named Attendance Rate % as an affected metric, so mirroring Emeritus's non-exclusion there would have left that specific complaint unfixed.
2. **`groups-engagement-stats.service.ts`** (the Groups dashboard "Active Members" rollup, a different feature/ticket, LFXV2-1711) now also excludes LF Staff — this turned out to be a one-column `SELECT` addition (no roster join needed), not the N+1-avoidance trade-off it looked like at first.

## Known, deliberately undone

- **All-LF-Staff-roster edge case**: a committee whose only invited members are all LF Staff reports `attendance_rate: 0`, indistinguishable from "nobody was invited" (documented in `CommitteeEngagementSummary.attendance_rate`'s doc). Considered a frontend heuristic (`render '—' when active_count === 0 && total_count > 0`) but rejected it — it would also suppress genuine "everyone is a real member and genuinely at 0% engagement" signal, which is a worse trade than the rare all-staff-roster case it would fix. A real fix needs an API contract change (nullable `attendance_rate`) that felt out of scope for this pass.
- **Branch name**: `fix/LFXV2-3101-engagement-exclude-lf-staff` includes a descriptive suffix beyond the repo's strict `<type>/LFXV2-<number>` branch-naming convention (flagged by `/lfx-self-serve-pr-readiness` as SHOULD_FIX). Kept as-is rather than renamed after push.
- 4 of 8 commit subjects run 73–83 chars (over the 72-char team-style target, under the 100-char commitlint hard limit) — left as-is rather than rewriting history for a cosmetic nit.

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass (1564 unit tests across `packages/shared` + `apps/lfx-one` server + component specs)
- [x] New unit coverage: classifier decision-table cases (LF Staff at 0/0 and with real attendance, non-broadening to Observer/Chair, Emeritus∩LF-Staff overlap), `isCommitteeMemberActive`, `isCommitteeMemberAtRisk`, new `isCommitteeMemberRateEligible` predicate, service-level aggregate exclusion from `attendance_rate`/`active_count`, degraded-path role fallback, mock-generator demo-slot/Orlin/Emeritus-fallback exclusions, Groups-rollup exclusion
- [x] E2E fixture (`committee-engagement.helper.ts`) extended with an `m-lf-staff` roster member; both `committee-engagement.spec.ts` and `committee-engagement-robust.spec.ts` updated — chip label, neutral severity, At-Risk-filter exclusion. Verified via `playwright test --list` (loads/compiles cleanly); not run live in this session (no dev server / LaunchDarkly-flagged test user available here — the specs skip gracefully without `TEST_USERNAME`/`TEST_PASSWORD`, per their existing gating)
- [ ] Manual spot-check on WG Identity & Trust once deployed: LF Staff member's chip reads "LF Staff" (neutral), tooltip reflects the exclusion, no longer appears under At Risk, Attendance Rate %/Active Members shift as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[LFXV2-3101]: https://linuxfoundation.atlassian.net/browse/LFXV2-3101?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ