### PR TITLE
feat(dashboards): add per-event detail drawer to roster

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
@@ -1,0 +1,120 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  styleClass="xl:!w-[45%] lg:!w-[55%] md:!w-[70%] sm:!w-[90%] !w-full"
+  [showCloseIcon]="true"
+  [dismissible]="true"
+  data-testid="event-detail-drawer">
+  <ng-template #header>
+    <div class="flex flex-col gap-0.5">
+      <h3 class="text-base font-semibold text-gray-900">{{ detail()?.eventName || 'Event detail' }}</h3>
+      @if (detail()) {
+        <p class="text-xs text-gray-500">
+          {{ dateLabel() }}
+          @if (detail()?.country) {
+            · {{ detail()?.country }}
+          }
+        </p>
+      }
+    </div>
+  </ng-template>
+
+  @if (loading()) {
+    <div class="flex flex-col gap-4" data-testid="event-detail-skeleton">
+      <div class="h-20 animate-pulse rounded-lg bg-gray-100"></div>
+      <div class="h-20 animate-pulse rounded-lg bg-gray-100"></div>
+      <div class="h-40 animate-pulse rounded-lg bg-gray-100"></div>
+    </div>
+  } @else if (detail(); as d) {
+    <div class="flex flex-col gap-5">
+      <!-- Registrations vs goal -->
+      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-registrations">
+        <div class="flex items-baseline justify-between">
+          <span class="text-xs font-medium text-gray-500">Registrations</span>
+          @if (vsLastYearLabel(); as vs) {
+            <span class="text-[11px] font-medium text-gray-400">{{ vs }}</span>
+          }
+        </div>
+        <div class="flex items-baseline gap-2">
+          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ num(d.registrations.actual) }}</span>
+          @if (d.registrations.goal > 0) {
+            <span class="text-sm text-gray-400 tabular-nums">/ {{ num(d.registrations.goal) }} goal</span>
+          }
+        </div>
+        @if (regProgress() !== null) {
+          <div class="mt-1 h-2 overflow-hidden rounded-full bg-gray-100">
+            <div
+              class="h-full rounded-full"
+              [ngClass]="{
+                'bg-emerald-500': regProgress()! >= 80,
+                'bg-amber-500': regProgress()! >= 50 && regProgress()! < 80,
+                'bg-red-400': regProgress()! < 50,
+              }"
+              [style.width.%]="regProgress()"></div>
+          </div>
+        }
+      </div>
+
+      <!-- Sponsorship vs goal -->
+      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-sponsorship">
+        <span class="text-xs font-medium text-gray-500">Sponsorship revenue</span>
+        <div class="flex items-baseline gap-2">
+          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ money(d.sponsorshipRevenue.actual) }}</span>
+          @if (d.sponsorshipRevenue.goal > 0) {
+            <span class="text-sm text-gray-400 tabular-nums">/ {{ money(d.sponsorshipRevenue.goal) }} goal</span>
+          }
+        </div>
+        @if (sponProgress() !== null) {
+          <div class="mt-1 h-2 overflow-hidden rounded-full bg-gray-100">
+            <div
+              class="h-full rounded-full"
+              [ngClass]="{
+                'bg-emerald-500': sponProgress()! >= 80,
+                'bg-amber-500': sponProgress()! >= 50 && sponProgress()! < 80,
+                'bg-red-400': sponProgress()! < 50,
+              }"
+              [style.width.%]="sponProgress()"></div>
+          </div>
+        }
+      </div>
+
+      <!-- Sponsorship by tier -->
+      @if (d.sponsorshipTiers.length) {
+        <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-tiers">
+          <span class="text-xs font-medium text-gray-500">Sponsorship by tier</span>
+          <div class="flex flex-col gap-2.5">
+            @for (tier of d.sponsorshipTiers; track tier.tier) {
+              <div class="flex items-center justify-between gap-3" [attr.data-testid]="'event-detail-tier-' + tier.tier">
+                <span class="truncate text-xs font-medium text-gray-700">{{ tier.tier || 'Other' }}</span>
+                <div class="flex items-baseline gap-3">
+                  <span class="text-[11px] text-gray-400">{{ tier.sponsorCount }} sponsor{{ tier.sponsorCount === 1 ? '' : 's' }}</span>
+                  <span class="w-20 text-right text-xs font-semibold text-gray-900 tabular-nums">{{ money(tier.revenue) }}</span>
+                </div>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Pacing lives in PCC (prediction service); deep-link out -->
+      @if (d.eventUrl) {
+        <a
+          [href]="d.eventUrl"
+          target="_blank"
+          rel="noopener noreferrer"
+          class="flex items-center justify-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-xs font-semibold text-blue-700 hover:bg-blue-100"
+          data-testid="event-detail-pcc-link">
+          <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+          View registration pacing &amp; prediction in PCC
+        </a>
+      }
+    </div>
+  } @else {
+    <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="event-detail-empty">
+      <p class="text-sm text-gray-500">No detail available for this event.</p>
+    </div>
+  }
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
@@ -13,7 +13,10 @@
       <h3 class="text-base font-semibold text-gray-900">{{ detail()?.eventName || 'Event detail' }}</h3>
       @if (detail()) {
         <p class="text-xs text-gray-500">
-          {{ dateLabel() }}
+          <!-- &nbsp; not a plain space: preserveWhitespaces is off, so a whitespace-only text
+               node between the interpolation and the @if block is stripped and the date would
+               run straight into the country separator. -->
+          {{ view()?.dateLabel }}
           @if (detail()?.country) {
             · {{ detail()?.country }}
           }
@@ -24,9 +27,9 @@
 
   @if (loading()) {
     <div class="flex flex-col gap-4" data-testid="event-detail-skeleton">
-      <div class="h-20 animate-pulse rounded-lg bg-gray-100"></div>
-      <div class="h-20 animate-pulse rounded-lg bg-gray-100"></div>
-      <div class="h-40 animate-pulse rounded-lg bg-gray-100"></div>
+      <p-skeleton width="100%" height="5rem" borderRadius="8px" />
+      <p-skeleton width="100%" height="5rem" borderRadius="8px" />
+      <p-skeleton width="100%" height="10rem" borderRadius="8px" />
     </div>
   } @else if (detail(); as d) {
     <div class="flex flex-col gap-5">
@@ -34,14 +37,14 @@
       <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-registrations">
         <div class="flex items-baseline justify-between">
           <span class="text-xs font-medium text-gray-500">Registrations</span>
-          @if (vsLastYearLabel(); as vs) {
+          @if (view()?.vsLastYearLabel; as vs) {
             <span class="text-[11px] font-medium text-gray-400">{{ vs }}</span>
           }
         </div>
         <div class="flex items-baseline gap-2">
-          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ num(d.registrations.actual) }}</span>
+          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ view()?.registrationsActual }}</span>
           @if (d.registrations.goal > 0) {
-            <span class="text-sm text-gray-400 tabular-nums">/ {{ num(d.registrations.goal) }} goal</span>
+            <span class="text-sm text-gray-400 tabular-nums">/ {{ view()?.registrationsGoal }} goal</span>
           }
         </div>
         @if (regProgress() !== null) {
@@ -62,9 +65,9 @@
       <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-sponsorship">
         <span class="text-xs font-medium text-gray-500">Sponsorship revenue</span>
         <div class="flex items-baseline gap-2">
-          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ money(d.sponsorshipRevenue.actual) }}</span>
+          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ view()?.sponsorshipActual }}</span>
           @if (d.sponsorshipRevenue.goal > 0) {
-            <span class="text-sm text-gray-400 tabular-nums">/ {{ money(d.sponsorshipRevenue.goal) }} goal</span>
+            <span class="text-sm text-gray-400 tabular-nums">/ {{ view()?.sponsorshipGoal }} goal</span>
           }
         </div>
         @if (sponProgress() !== null) {
@@ -86,12 +89,12 @@
         <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-tiers">
           <span class="text-xs font-medium text-gray-500">Sponsorship by tier</span>
           <div class="flex flex-col gap-2.5">
-            @for (tier of d.sponsorshipTiers; track tier.tier) {
+            @for (tier of view()?.tiers ?? []; track tier.tier) {
               <div class="flex items-center justify-between gap-3" [attr.data-testid]="'event-detail-tier-' + tier.tier">
-                <span class="truncate text-xs font-medium text-gray-700">{{ tier.tier || 'Other' }}</span>
+                <span class="truncate text-xs font-medium text-gray-700">{{ tier.label }}</span>
                 <div class="flex items-baseline gap-3">
                   <span class="text-[11px] text-gray-400">{{ tier.sponsorCount }} sponsor{{ tier.sponsorCount === 1 ? '' : 's' }}</span>
-                  <span class="w-20 text-right text-xs font-semibold text-gray-900 tabular-nums">{{ money(tier.revenue) }}</span>
+                  <span class="w-20 text-right text-xs font-semibold text-gray-900 tabular-nums">{{ tier.revenue }}</span>
                 </div>
               </div>
             }
@@ -111,6 +114,11 @@
           View registration pacing &amp; prediction in PCC
         </a>
       }
+    </div>
+  } @else if (failed()) {
+    <div class="flex flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-red-200 bg-red-50 p-8" data-testid="event-detail-error">
+      <p class="text-sm font-medium text-red-700">We couldn't load this event's detail.</p>
+      <p class="text-xs text-red-600">Close the panel and try again.</p>
     </div>
   } @else {
     <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="event-detail-empty">

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.spec.ts
@@ -1,0 +1,155 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { AnalyticsService } from '@services/analytics.service';
+import { of, throwError } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { EventDetailDrawerComponent } from './event-detail-drawer.component';
+
+import type { EventDetailResponse } from '@lfx-one/shared/interfaces';
+
+describe('EventDetailDrawerComponent', () => {
+  const detail = (overrides: Partial<EventDetailResponse> = {}): EventDetailResponse => ({
+    eventId: 'evt-1',
+    eventName: 'KubeCon NA',
+    startDate: '2026-11-10',
+    country: 'United States',
+    eventUrl: 'https://events.example.org/kubecon',
+    registrations: { actual: 900, goal: 1000 },
+    sponsorshipRevenue: { actual: 500000, goal: 1000000 },
+    vsLastYear: 1.1,
+    compScore: 'high',
+    cfpStatus: 'Review Complete',
+    sponsorshipTiers: [
+      { tier: 'Diamond', revenue: 300000, sponsorCount: 2 },
+      { tier: 'Gold', revenue: 200000, sponsorCount: 4 },
+    ],
+    ...overrides,
+  });
+
+  let fixture: ComponentFixture<EventDetailDrawerComponent>;
+  let getEventDetail: ReturnType<typeof vi.fn>;
+
+  async function setup(impl: ReturnType<typeof vi.fn>): Promise<void> {
+    getEventDetail = impl;
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [EventDetailDrawerComponent],
+      // p-drawer uses synthetic animations; without a noop animations provider every render
+      // through the drawer throws NG05105 before any assertion runs.
+      providers: [{ provide: AnalyticsService, useValue: { getEventDetail } }, provideNoopAnimations()],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(EventDetailDrawerComponent);
+  }
+
+  /** Mirrors the parent: two separate signal writes per open, eventId first. */
+  async function open(eventId: string, slug = 'tlf'): Promise<void> {
+    fixture.componentRef.setInput('eventId', eventId);
+    fixture.componentRef.setInput('foundationSlug', slug);
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function text(): string {
+    return document.body.textContent ?? '';
+  }
+
+  it('does not fetch until the drawer is opened', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail())));
+
+    fixture.componentRef.setInput('eventId', 'evt-1');
+    fixture.componentRef.setInput('foundationSlug', 'tlf');
+    await fixture.whenStable();
+
+    expect(getEventDetail).not.toHaveBeenCalled();
+  });
+
+  it('loads the event on open and passes the foundation slug', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail())));
+
+    await open('evt-1');
+
+    expect(getEventDetail).toHaveBeenCalledWith('evt-1', 'tlf');
+    expect(text()).toContain('KubeCon NA');
+  });
+
+  // The parent sets eventId and visible in two separate writes; without deduping the pair
+  // one open would fire two identical requests.
+  it('issues a single request per open', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail())));
+
+    await open('evt-1');
+
+    expect(getEventDetail).toHaveBeenCalledTimes(1);
+  });
+
+  // The drawer stays open while the user clicks a different roster row. Reacting only to
+  // `visible` left the previous event's numbers on screen under the new event's name.
+  it('reloads when a different event is selected while already open', async () => {
+    await setup(vi.fn().mockImplementation((id: string) => of(detail({ eventId: id, eventName: id === 'evt-1' ? 'KubeCon NA' : 'Open Source Summit' }))));
+
+    await open('evt-1');
+    expect(text()).toContain('KubeCon NA');
+
+    fixture.componentRef.setInput('eventId', 'evt-2');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getEventDetail).toHaveBeenLastCalledWith('evt-2', 'tlf');
+    expect(text()).toContain('Open Source Summit');
+    expect(text()).not.toContain('KubeCon NA');
+  });
+
+  it('renders the empty state when the event genuinely has no detail', async () => {
+    await setup(vi.fn().mockReturnValue(of(null)));
+
+    await open('evt-1');
+
+    expect(document.querySelector('[data-testid="event-detail-empty"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="event-detail-error"]')).toBeNull();
+  });
+
+  // A failure and a genuine no-detail both leave detail() null; only one should tell the user
+  // something went wrong, otherwise an outage reads as "this event has no data".
+  it('distinguishes a load failure from a missing event', async () => {
+    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await open('evt-1');
+
+    expect(document.querySelector('[data-testid="event-detail-error"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="event-detail-empty"]')).toBeNull();
+  });
+
+  it('clears the skeleton after a failed load', async () => {
+    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+
+    await open('evt-1');
+
+    expect(document.querySelector('[data-testid="event-detail-skeleton"]')).toBeNull();
+  });
+
+  it('renders the sponsorship tier breakdown', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail())));
+
+    await open('evt-1');
+
+    expect(document.querySelector('[data-testid="event-detail-tier-Diamond"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="event-detail-tier-Gold"]')).toBeTruthy();
+  });
+
+  it('labels an unnamed tier rather than rendering a blank row', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail({ sponsorshipTiers: [{ tier: '', revenue: 1000, sponsorCount: 1 }] }))));
+
+    await open('evt-1');
+
+    expect(text()).toContain('Other');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
@@ -1,0 +1,93 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
+import { AnalyticsService } from '@services/analytics.service';
+import { DrawerModule } from 'primeng/drawer';
+import { finalize, of, skip, switchMap } from 'rxjs';
+
+import type { EventDetailResponse } from '@lfx-one/shared/interfaces';
+
+@Component({
+  selector: 'lfx-event-detail-drawer',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+  imports: [NgClass, DrawerModule],
+  templateUrl: './event-detail-drawer.component.html',
+})
+export class EventDetailDrawerComponent {
+  private readonly analyticsService = inject(AnalyticsService);
+
+  // === Model Signals (two-way binding) ===
+  public readonly visible = model<boolean>(false);
+
+  // === Inputs ===
+  /** Event id to load when the drawer opens. */
+  public readonly eventId = input<string | null>(null);
+
+  // === Computed Signals ===
+  protected readonly detail: Signal<EventDetailResponse | null> = this.initDetail();
+  protected readonly loading = computed(() => this.visible() && this.detail() === null && this.eventId() !== null);
+
+  // Registration progress (0–100) when a real goal exists.
+  protected readonly regProgress = computed(() => {
+    const d = this.detail();
+    if (!d || d.registrations.goal <= 0) return null;
+    return Math.min(100, Math.round((d.registrations.actual / d.registrations.goal) * 100));
+  });
+  // Sponsorship progress (0–100) when a real goal exists.
+  protected readonly sponProgress = computed(() => {
+    const d = this.detail();
+    if (!d || d.sponsorshipRevenue.goal <= 0) return null;
+    return Math.min(100, Math.round((d.sponsorshipRevenue.actual / d.sponsorshipRevenue.goal) * 100));
+  });
+
+  // === Protected Helpers (template) ===
+  protected num(value: number): string {
+    return formatNumber(value);
+  }
+
+  protected money(value: number): string {
+    return formatCurrency(value);
+  }
+
+  /** Registration pace vs last year as a signed percent string, or null when no baseline. */
+  protected vsLastYearLabel(): string | null {
+    const d = this.detail();
+    if (!d || d.vsLastYear === null) return null;
+    const pct = Math.round((d.vsLastYear - 1) * 100);
+    if (pct > 0) return `+${pct}% vs last year`;
+    if (pct < 0) return `${pct}% vs last year`;
+    return 'On par with last year';
+  }
+
+  protected dateLabel(): string {
+    const iso = this.detail()?.startDate ?? '';
+    const [year, month, day] = iso.split('-').map(Number);
+    if (!year || !month || !day) return iso;
+    return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
+    });
+  }
+
+  // === Private Initializers ===
+  private initDetail(): Signal<EventDetailResponse | null> {
+    // Lazy-load on open: react to visibility flipping true (skip the initial value).
+    return toSignal(
+      toObservable(this.visible).pipe(
+        skip(1),
+        switchMap((open) => {
+          const id = this.eventId();
+          if (!open || !id) return of(null);
+          return this.analyticsService.getEventDetail(id).pipe(finalize(() => undefined));
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
@@ -7,14 +7,15 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { DrawerModule } from 'primeng/drawer';
-import { finalize, of, skip, switchMap } from 'rxjs';
+import { Skeleton } from 'primeng/skeleton';
+import { catchError, combineLatest, distinctUntilChanged, finalize, of, switchMap } from 'rxjs';
 
 import type { EventDetailResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-event-detail-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass, DrawerModule],
+  imports: [NgClass, DrawerModule, Skeleton],
   templateUrl: './event-detail-drawer.component.html',
 })
 export class EventDetailDrawerComponent {
@@ -26,14 +27,20 @@ export class EventDetailDrawerComponent {
   // === Inputs ===
   /** Event id to load when the drawer opens. */
   public readonly eventId = input<string | null>(null);
+  /** Foundation the event belongs to; required by the server to scope the read. */
+  public readonly foundationSlug = input<string | undefined>();
 
   // === WritableSignals ===
   /**
-   * Set by the detail stream rather than derived from `detail() === null`. The request emits
-   * `null` on failure, so a derived flag would leave the skeleton up forever on an error
-   * instead of falling through to the empty state.
+   * Set by the detail stream rather than derived from `detail() === null`. The request can end in
+   * an error, so a derived flag would leave the skeleton up forever instead of falling through.
    */
   protected readonly loading = signal(false);
+  /**
+   * Distinguishes "we could not load this" from "this event has no detail" — both leave `detail()`
+   * null, but only one of them should tell the user something went wrong.
+   */
+  protected readonly failed = signal(false);
 
   // === Computed Signals ===
   protected readonly detail: Signal<EventDetailResponse | null> = this.initDetail();
@@ -51,30 +58,49 @@ export class EventDetailDrawerComponent {
     return Math.min(100, Math.round((d.sponsorshipRevenue.actual / d.sponsorshipRevenue.goal) * 100));
   });
 
-  // === Protected Helpers (template) ===
-  protected num(value: number): string {
-    return formatNumber(value);
-  }
-
-  protected money(value: number): string {
-    return formatCurrency(value);
-  }
-
-  /** Registration pace vs last year as a signed percent string, or null when no baseline. */
-  protected vsLastYearLabel(): string | null {
+  /**
+   * Everything the template renders as text, formatted once per detail change. The template used
+   * to call formatting helpers directly, which re-ran locale/currency formatting on every
+   * change-detection pass; per the frontend checklist templates read computed values instead.
+   */
+  protected readonly view = computed(() => {
     const d = this.detail();
-    if (!d || d.vsLastYear === null) return null;
-    const pct = Math.round((d.vsLastYear - 1) * 100);
+    if (!d) return null;
+    return {
+      dateLabel: this.formatDate(d.startDate),
+      vsLastYearLabel: this.formatVsLastYear(d.vsLastYear),
+      registrationsActual: formatNumber(d.registrations.actual),
+      registrationsGoal: formatNumber(d.registrations.goal),
+      sponsorshipActual: formatCurrency(d.sponsorshipRevenue.actual),
+      sponsorshipGoal: formatCurrency(d.sponsorshipRevenue.goal),
+      tiers: d.sponsorshipTiers.map((tier) => ({
+        tier: tier.tier,
+        label: tier.tier || 'Other',
+        sponsorCount: tier.sponsorCount,
+        revenue: formatCurrency(tier.revenue),
+      })),
+    };
+  });
+
+  // === Private Helpers ===
+  /** Registration pace vs last year as a signed percent string, or null when no baseline. */
+  private formatVsLastYear(vsLastYear: number | null): string | null {
+    if (vsLastYear === null) return null;
+    const pct = Math.round((vsLastYear - 1) * 100);
     if (pct > 0) return `+${pct}% vs last year`;
     if (pct < 0) return `${pct}% vs last year`;
     return 'On par with last year';
   }
 
-  protected dateLabel(): string {
-    const iso = this.detail()?.startDate ?? '';
+  private formatDate(iso: string): string {
     const [year, month, day] = iso.split('-').map(Number);
     if (!year || !month || !day) return iso;
-    return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString('en-US', {
+    // Range-check before Date.UTC: it rolls out-of-range parts over silently (month=13 becomes
+    // January of the next year), rendering a confidently wrong date instead of the raw value.
+    if (month < 1 || month > 12 || day < 1 || day > 31) return iso;
+    const parsed = new Date(Date.UTC(year, month - 1, day));
+    if (parsed.getUTCMonth() !== month - 1 || parsed.getUTCDate() !== day) return iso;
+    return parsed.toLocaleDateString('en-US', {
       month: 'short',
       day: 'numeric',
       year: 'numeric',
@@ -84,20 +110,32 @@ export class EventDetailDrawerComponent {
 
   // === Private Initializers ===
   private initDetail(): Signal<EventDetailResponse | null> {
-    // Lazy-load on open: react to visibility flipping true (skip the initial value).
+    // Lazy-load on open, and reload when the selected event changes. Both are triggers: the
+    // drawer stays open while the user clicks a different roster row, so watching `visible`
+    // alone would leave the previous event's numbers on screen under the new event's name.
     return toSignal(
-      toObservable(this.visible).pipe(
-        skip(1),
-        switchMap((open) => {
-          const id = this.eventId();
-          if (!open || !id) {
+      combineLatest([toObservable(this.visible), toObservable(this.eventId), toObservable(this.foundationSlug)]).pipe(
+        // The parent sets eventId and visible in two separate writes, so one open produces two
+        // emissions; dedupe the triple so that lands as a single fetch rather than a duplicate.
+        distinctUntilChanged(([prevOpen, prevId, prevSlug], [open, id, slug]) => prevOpen === open && prevId === id && prevSlug === slug),
+        switchMap(([open, id, slug]) => {
+          if (!open || !id || !slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
-          // finalize, not a tap on the value — the request emits null on error, and that
-          // still has to clear the skeleton.
-          return this.analyticsService.getEventDetail(id).pipe(finalize(() => this.loading.set(false)));
+          this.failed.set(false);
+          // finalize, not a tap on the value — the stream can end in an error, and that still
+          // has to clear the skeleton. The error is caught here rather than in the service so a
+          // failure renders "couldn't load" instead of the "no detail" empty state.
+          return this.analyticsService.getEventDetail(id, slug).pipe(
+            catchError((error: unknown) => {
+              console.error('[analytics] event-detail failed', { eventId: id, foundationSlug: slug, error });
+              this.failed.set(true);
+              return of(null);
+            }),
+            finalize(() => this.loading.set(false))
+          );
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { ChangeDetectionStrategy, Component, computed, inject, input, model, Signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, input, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
@@ -27,9 +27,16 @@ export class EventDetailDrawerComponent {
   /** Event id to load when the drawer opens. */
   public readonly eventId = input<string | null>(null);
 
+  // === WritableSignals ===
+  /**
+   * Set by the detail stream rather than derived from `detail() === null`. The request emits
+   * `null` on failure, so a derived flag would leave the skeleton up forever on an error
+   * instead of falling through to the empty state.
+   */
+  protected readonly loading = signal(false);
+
   // === Computed Signals ===
   protected readonly detail: Signal<EventDetailResponse | null> = this.initDetail();
-  protected readonly loading = computed(() => this.visible() && this.detail() === null && this.eventId() !== null);
 
   // Registration progress (0–100) when a real goal exists.
   protected readonly regProgress = computed(() => {
@@ -83,8 +90,14 @@ export class EventDetailDrawerComponent {
         skip(1),
         switchMap((open) => {
           const id = this.eventId();
-          if (!open || !id) return of(null);
-          return this.analyticsService.getEventDetail(id).pipe(finalize(() => undefined));
+          if (!open || !id) {
+            this.loading.set(false);
+            return of(null);
+          }
+          this.loading.set(true);
+          // finalize, not a tap on the value — the request emits null on error, and that
+          // still has to clear the skeleton.
+          return this.analyticsService.getEventDetail(id).pipe(finalize(() => this.loading.set(false)));
         })
       ),
       { initialValue: null }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
@@ -65,17 +65,18 @@
 
       <!-- Rows -->
       @for (row of rows(); track row.eventId) {
-        <div class="flex items-center gap-4 border-b border-gray-100 py-3" role="row" [attr.data-testid]="'event-roster-row-' + row.eventId">
+        <div
+          class="flex cursor-pointer items-center gap-4 border-b border-gray-100 py-3 transition-colors hover:bg-blue-50/40"
+          role="row"
+          tabindex="0"
+          (click)="openEvent(row.eventId)"
+          (keydown.enter)="openEvent(row.eventId)"
+          (keydown.space)="openEvent(row.eventId)"
+          [attr.data-testid]="'event-roster-row-' + row.eventId">
           <span class="w-24 text-xs text-gray-500 tabular-nums" role="cell">{{ row.dateLabel }}</span>
 
           <div class="flex flex-1 min-w-[180px] items-center gap-2" role="cell">
-            @if (row.eventUrl) {
-              <a [href]="row.eventUrl" target="_blank" rel="noopener noreferrer" class="truncate text-xs font-semibold text-blue-600 hover:underline">{{
-                row.eventName
-              }}</a>
-            } @else {
-              <span class="truncate text-xs font-semibold text-gray-700">{{ row.eventName }}</span>
-            }
+            <span class="truncate text-xs font-semibold text-blue-600">{{ row.eventName }}</span>
             @if (row.atRisk) {
               <i class="fa-solid fa-circle-exclamation text-xs text-red-500" aria-label="Behind registration goal" title="Behind registration goal"></i>
             }
@@ -135,3 +136,5 @@
     </div>
   }
 </div>
+
+<lfx-event-detail-drawer [(visible)]="drawerVisible" [eventId]="selectedEventId()" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.html
@@ -71,7 +71,8 @@
           tabindex="0"
           (click)="openEvent(row.eventId)"
           (keydown.enter)="openEvent(row.eventId)"
-          (keydown.space)="openEvent(row.eventId)"
+          (keydown.space)="$event.preventDefault(); openEvent(row.eventId)"
+          [attr.aria-label]="'View detail for ' + row.eventName"
           [attr.data-testid]="'event-roster-row-' + row.eventId">
           <span class="w-24 text-xs text-gray-500 tabular-nums" role="cell">{{ row.dateLabel }}</span>
 
@@ -137,4 +138,4 @@
   }
 </div>
 
-<lfx-event-detail-drawer [(visible)]="drawerVisible" [eventId]="selectedEventId()" />
+<lfx-event-detail-drawer [(visible)]="drawerVisible" [eventId]="selectedEventId()" [foundationSlug]="foundationSlug()" />

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
@@ -11,9 +11,11 @@ import { combineLatest, finalize, of, startWith, switchMap } from 'rxjs';
 
 import type { EventRosterBar, EventRosterResponse, EventRosterRow, EventRosterRowView } from '@lfx-one/shared/interfaces';
 
+import { EventDetailDrawerComponent } from '../event-detail-drawer/event-detail-drawer.component';
+
 @Component({
   selector: 'lfx-event-roster-section',
-  imports: [NgClass, ReactiveFormsModule],
+  imports: [NgClass, ReactiveFormsModule, EventDetailDrawerComponent],
   templateUrl: './event-roster-section.component.html',
 })
 export class EventRosterSectionComponent {
@@ -30,6 +32,8 @@ export class EventRosterSectionComponent {
   protected readonly loading = signal(false);
   protected readonly includePast = signal(false);
   protected readonly skeletons: readonly number[] = [0, 1, 2, 3, 4];
+  protected readonly drawerVisible = signal(false);
+  protected readonly selectedEventId = signal<string | null>(null);
 
   // === Computed Signals ===
   protected readonly roster: Signal<EventRosterResponse> = this.initRoster();
@@ -49,6 +53,11 @@ export class EventRosterSectionComponent {
   // === Protected Methods ===
   protected toggleIncludePast(includePast: boolean): void {
     this.includePast.set(includePast);
+  }
+
+  protected openEvent(eventId: string): void {
+    this.selectedEventId.set(eventId);
+    this.drawerVisible.set(true);
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -57,6 +57,7 @@ import {
   MembershipChurnPerTierSummaryResponse,
   NpsSummaryResponse,
   OutstandingBalanceSummaryResponse,
+  EventDetailResponse,
   EventRosterResponse,
   EventsOverviewSummaryResponse,
   EventsSummaryResponse,
@@ -1175,6 +1176,14 @@ export class AnalyticsService {
       this.eventRosterCache.set(key, req$);
     }
     return this.eventRosterCache.get(key)!;
+  }
+
+  /**
+   * Per-event detail for the roster drawer (meta, actual-vs-goal, sponsorship-by-tier).
+   * Emits null on error so the drawer shows its empty state.
+   */
+  public getEventDetail(eventId: string): Observable<EventDetailResponse | null> {
+    return this.http.get<EventDetailResponse>('/api/analytics/event-detail', { params: { eventId } }).pipe(catchError(() => of(null)));
   }
 
   public getTrainingCertificationSummary(foundationSlug: string, range: string = 'YTD'): Observable<TrainingCertificationSummaryResponse> {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1182,8 +1182,14 @@ export class AnalyticsService {
    * Per-event detail for the roster drawer (meta, actual-vs-goal, sponsorship-by-tier).
    * Emits null on error so the drawer shows its empty state.
    */
-  public getEventDetail(eventId: string): Observable<EventDetailResponse | null> {
-    return this.http.get<EventDetailResponse>('/api/analytics/event-detail', { params: { eventId } }).pipe(catchError(() => of(null)));
+  /**
+   * Event detail for one event. `foundationSlug` is required and server-enforced: the event id
+   * alone carries no ownership, so the query is scoped to the foundation rather than trusting it.
+   * Resolves to `null` for a genuinely missing event and throws on transport/authorization
+   * failures, so the drawer can tell "no such event" apart from "we could not load it".
+   */
+  public getEventDetail(eventId: string, foundationSlug: string): Observable<EventDetailResponse | null> {
+    return this.http.get<EventDetailResponse>('/api/analytics/event-detail', { params: { eventId, foundationSlug } });
   }
 
   public getTrainingCertificationSummary(foundationSlug: string, range: string = 'YTD'): Observable<TrainingCertificationSummaryResponse> {

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2817,6 +2817,41 @@ export class AnalyticsController {
   }
 
   /**
+   * GET /api/analytics/event-detail
+   * Per-event detail for the roster drawer (meta, actual-vs-goal, sponsorship-by-tier).
+   */
+  public async getEventDetail(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_event_detail');
+
+    try {
+      const eventId = getStringQueryParam(req, 'eventId');
+
+      if (!eventId) {
+        throw ServiceValidationError.forField('eventId', 'eventId query parameter is required', {
+          operation: 'get_event_detail',
+        });
+      }
+
+      if (!/^[A-Za-z0-9_-]{1,64}$/.test(eventId)) {
+        throw ServiceValidationError.forField('eventId', 'Invalid eventId format', {
+          operation: 'get_event_detail',
+        });
+      }
+
+      const response = await this.projectService.getEventDetail(eventId);
+
+      logger.success(req, 'get_event_detail', startTime, {
+        event_id: eventId,
+        found: response !== null,
+      });
+
+      res.json(response);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  /**
    * GET /api/analytics/brand-reach
    * Get brand reach metrics (total digital reach across social + owned sites)
    */

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2824,6 +2824,22 @@ export class AnalyticsController {
     const startTime = logger.startOperation(req, 'get_event_detail');
 
     try {
+      const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+      // Required alongside eventId: a bare event id would let any ED read another foundation's
+      // sponsorship revenue and goals, since the id alone carries no ownership information.
+      if (!foundationSlug) {
+        throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', {
+          operation: 'get_event_detail',
+        });
+      }
+
+      if (!SLUG_PATTERN.test(foundationSlug)) {
+        throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', {
+          operation: 'get_event_detail',
+        });
+      }
+
       const eventId = getStringQueryParam(req, 'eventId');
 
       if (!eventId) {
@@ -2838,10 +2854,11 @@ export class AnalyticsController {
         });
       }
 
-      const response = await this.projectService.getEventDetail(eventId);
+      const response = await this.projectService.getEventDetail(eventId, foundationSlug);
 
       logger.success(req, 'get_event_detail', startTime, {
         event_id: eventId,
+        foundation_slug: foundationSlug,
         found: response !== null,
       });
 

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -192,6 +192,7 @@ router.get('/board-meeting-participation-summary', (req, res, next) => analytics
 router.get('/event-growth', (req, res, next) => analyticsController.getEventGrowth(req, res, next));
 router.get('/events-overview-summary', (req, res, next) => analyticsController.getEventsOverviewSummary(req, res, next));
 router.get('/event-roster', (req, res, next) => analyticsController.getEventRoster(req, res, next));
+router.get('/event-detail', (req, res, next) => analyticsController.getEventDetail(req, res, next));
 router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
 router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
 router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -286,6 +286,73 @@ describe('ProjectService — Snowflake-backed marketing reads', () => {
       await expect(service.getSocialReach('tlf', undefined, { start: '2026-01-01', end: '2026-07-01', label: 'test' } as any)).rejects.toBe(failure);
     });
   });
+
+  describe('getEventDetail', () => {
+    const eventRow = {
+      EVENT_ID: 'evt-1',
+      EVENT_NAME: 'KubeCon NA',
+      START_DATE: '2026-11-10',
+      EVENT_COUNTRY: 'United States',
+      EVENT_URL: 'https://events.example.org/kubecon',
+      REG_ACTUAL: 900,
+      REG_GOAL: 1000,
+      SPON_GOAL: 1000000,
+      VS_LY: 1.1,
+      COMP_SCORE: 'high',
+      CFP_STATUS: 'Review Complete',
+    };
+
+    // Ordered mock: the event query resolves first, the tier query second.
+    function mockReads(event: unknown[], tiers: unknown[]): void {
+      execute.mockResolvedValueOnce({ rows: event }).mockResolvedValueOnce({ rows: tiers });
+    }
+
+    it('maps the event and its tier breakdown', async () => {
+      mockReads(
+        [eventRow],
+        [
+          { SPONSORSHIP_TIER: 'Diamond', REVENUE: 300000, SPONSOR_COUNT: 2 },
+          { SPONSORSHIP_TIER: 'Gold', REVENUE: 200000, SPONSOR_COUNT: 4 },
+        ]
+      );
+
+      const result = await service.getEventDetail('evt-1', 'tlf');
+
+      expect(result?.eventName).toBe('KubeCon NA');
+      // Sponsorship actual is summed from the tier rows, not read from the event row.
+      expect(result?.sponsorshipRevenue).toEqual({ actual: 500000, goal: 1000000 });
+      expect(result?.sponsorshipTiers).toHaveLength(2);
+    });
+
+    // Both queries are scoped by foundation: the event id alone carries no ownership, so an ED
+    // could otherwise read another foundation's sponsorship revenue by guessing an id.
+    it('binds the foundation slug ahead of the event id in both reads', async () => {
+      mockReads([eventRow], []);
+
+      await service.getEventDetail('evt-1', 'tlf');
+
+      expect(execute).toHaveBeenCalledTimes(2);
+      for (const [sql, binds] of execute.mock.calls) {
+        expect(sql).toContain('slug_resolve');
+        expect(binds).toEqual(['tlf', 'evt-1']);
+      }
+    });
+
+    // An event outside the caller's foundation is filtered out by the slug_resolve join, so it
+    // is indistinguishable from a nonexistent one — no existence oracle for other foundations.
+    it('returns null when the event is not in the caller’s foundation', async () => {
+      mockReads([], []);
+
+      await expect(service.getEventDetail('evt-1', 'other-foundation')).resolves.toBeNull();
+    });
+
+    it('propagates Snowflake failures rather than resolving a partial event', async () => {
+      const failure = new Error('snowflake timeout');
+      execute.mockRejectedValue(failure);
+
+      await expect(service.getEventDetail('evt-1', 'tlf')).rejects.toBe(failure);
+    });
+  });
 });
 
 describe('ProjectService — paid ads compatibility', () => {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -5154,8 +5154,11 @@ export class ProjectService {
    * from MARKETING_EVENT_SPONSORSHIPS_BY_TIER. No daily-pacing time-series exists in these
    * tables (that is PCC's prediction service); the drawer deep-links to eventUrl for pacing.
    */
-  public async getEventDetail(eventId: string): Promise<EventDetailResponse | null> {
-    logger.debug(undefined, 'get_event_detail', 'Fetching event detail from Snowflake', { event_id: eventId });
+  public async getEventDetail(eventId: string, foundationSlug: string): Promise<EventDetailResponse | null> {
+    logger.debug(undefined, 'get_event_detail', 'Fetching event detail from Snowflake', {
+      event_id: eventId,
+      foundation_slug: foundationSlug,
+    });
 
     interface EventRow {
       EVENT_ID: string;
@@ -5177,38 +5180,59 @@ export class ProjectService {
       SPONSOR_COUNT: number;
     }
 
+    // Scoped by foundation as well as event id: the id alone carries no ownership, so without the
+    // slug_resolve join any ED could read another foundation's event by guessing its id. A caller
+    // asking for an event outside their foundation gets the same null as a nonexistent one.
     const eventQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
       SELECT
-        EVENT_ID,
-        EVENT_NAME,
-        TO_CHAR(EVENT_START_DATE, 'YYYY-MM-DD') AS START_DATE,
-        EVENT_COUNTRY,
-        EVENT_URL,
-        COUNT_REGISTRATIONS_ALL_TIME AS REG_ACTUAL,
-        EVENT_REGISTRATIONS_GOAL AS REG_GOAL,
-        EVENT_SPONSORSHIP_REVENUE_GOAL AS SPON_GOAL,
-        PERCENT_COMPARISON_TO_PREV_YEAR AS VS_LY,
-        COMP_SCORE,
-        CFP_STATUS
-      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS
-      WHERE EVENT_ID = ?
+        r.EVENT_ID,
+        r.EVENT_NAME,
+        TO_CHAR(r.EVENT_START_DATE, 'YYYY-MM-DD') AS START_DATE,
+        r.EVENT_COUNTRY,
+        r.EVENT_URL,
+        r.COUNT_REGISTRATIONS_ALL_TIME AS REG_ACTUAL,
+        r.EVENT_REGISTRATIONS_GOAL AS REG_GOAL,
+        r.EVENT_SPONSORSHIP_REVENUE_GOAL AS SPON_GOAL,
+        r.PERCENT_COMPARISON_TO_PREV_YEAR AS VS_LY,
+        r.COMP_SCORE,
+        r.CFP_STATUS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS r
+      INNER JOIN slug_resolve sr ON r.PROJECT_ID = sr.project_id
+      WHERE r.EVENT_ID = ?
       LIMIT 1
     `;
 
+    // SPONSORSHIP_TIER is free text, so NULL and '' both occur and would group separately while
+    // mapping to the same client-side tier name — two rows with an identical track key, one of
+    // which Angular drops. Collapse both to 'Other' before the GROUP BY so they sum into one row.
+    // Scoped by foundation for the same reason as the event query — the tier breakdown is the
+    // sponsorship revenue detail, so leaving it unscoped would leak the numbers the join above
+    // protects.
     const tierQuery = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
       SELECT
-        SPONSORSHIP_TIER,
-        SUM(IFNULL(SPONSORSHIP_REV_ALL_TIME, 0)) AS REVENUE,
-        SUM(IFNULL(SPONSORSHIP_COUNT_ALL_TIME, 0)) AS SPONSOR_COUNT
-      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_SPONSORSHIPS_BY_TIER
-      WHERE EVENT_ID = ?
-      GROUP BY SPONSORSHIP_TIER
+        COALESCE(NULLIF(TRIM(t.SPONSORSHIP_TIER), ''), 'Other') AS SPONSORSHIP_TIER,
+        SUM(IFNULL(t.SPONSORSHIP_REV_ALL_TIME, 0)) AS REVENUE,
+        SUM(IFNULL(t.SPONSORSHIP_COUNT_ALL_TIME, 0)) AS SPONSOR_COUNT
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_SPONSORSHIPS_BY_TIER t
+      INNER JOIN slug_resolve sr ON t.PROJECT_ID = sr.project_id
+      WHERE t.EVENT_ID = ?
+      GROUP BY COALESCE(NULLIF(TRIM(t.SPONSORSHIP_TIER), ''), 'Other')
       ORDER BY REVENUE DESC
     `;
 
     const [eventResult, tierResult] = await Promise.all([
-      this.snowflakeService.execute<EventRow>(eventQuery, [eventId]),
-      this.snowflakeService.execute<TierRow>(tierQuery, [eventId]),
+      this.snowflakeService.execute<EventRow>(eventQuery, [foundationSlug, eventId]),
+      this.snowflakeService.execute<TierRow>(tierQuery, [foundationSlug, eventId]),
     ]);
 
     const row = eventResult.rows?.[0];

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -28,6 +28,7 @@ import {
   EmailCtrResponse,
   EngagedCommunitySizeResponse,
   EventCompScore,
+  EventDetailResponse,
   EventGrowthResponse,
   EventGrowthTopEvent,
   EventRosterResponse,
@@ -5143,6 +5144,103 @@ export class ProjectService {
     }));
 
     return { projectId: '', events };
+  }
+
+  /**
+   * Get per-event detail for the roster drawer — event meta, registration/sponsorship
+   * actual-vs-goal, comparison rating, and a sponsorship-by-tier breakdown.
+   *
+   * Meta comes from MARKETING_EVENT_REGISTRATIONS (one row per event) and the tier breakdown
+   * from MARKETING_EVENT_SPONSORSHIPS_BY_TIER. No daily-pacing time-series exists in these
+   * tables (that is PCC's prediction service); the drawer deep-links to eventUrl for pacing.
+   */
+  public async getEventDetail(eventId: string): Promise<EventDetailResponse | null> {
+    logger.debug(undefined, 'get_event_detail', 'Fetching event detail from Snowflake', { event_id: eventId });
+
+    interface EventRow {
+      EVENT_ID: string;
+      EVENT_NAME: string;
+      START_DATE: string;
+      EVENT_COUNTRY: string | null;
+      EVENT_URL: string | null;
+      REG_ACTUAL: number | null;
+      REG_GOAL: number | null;
+      SPON_GOAL: number | null;
+      VS_LY: number | null;
+      COMP_SCORE: string | null;
+      CFP_STATUS: string | null;
+    }
+
+    interface TierRow {
+      SPONSORSHIP_TIER: string | null;
+      REVENUE: number;
+      SPONSOR_COUNT: number;
+    }
+
+    const eventQuery = `
+      SELECT
+        EVENT_ID,
+        EVENT_NAME,
+        TO_CHAR(EVENT_START_DATE, 'YYYY-MM-DD') AS START_DATE,
+        EVENT_COUNTRY,
+        EVENT_URL,
+        COUNT_REGISTRATIONS_ALL_TIME AS REG_ACTUAL,
+        EVENT_REGISTRATIONS_GOAL AS REG_GOAL,
+        EVENT_SPONSORSHIP_REVENUE_GOAL AS SPON_GOAL,
+        PERCENT_COMPARISON_TO_PREV_YEAR AS VS_LY,
+        COMP_SCORE,
+        CFP_STATUS
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS
+      WHERE EVENT_ID = ?
+      LIMIT 1
+    `;
+
+    const tierQuery = `
+      SELECT
+        SPONSORSHIP_TIER,
+        SUM(IFNULL(SPONSORSHIP_REV_ALL_TIME, 0)) AS REVENUE,
+        SUM(IFNULL(SPONSORSHIP_COUNT_ALL_TIME, 0)) AS SPONSOR_COUNT
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_SPONSORSHIPS_BY_TIER
+      WHERE EVENT_ID = ?
+      GROUP BY SPONSORSHIP_TIER
+      ORDER BY REVENUE DESC
+    `;
+
+    const [eventResult, tierResult] = await Promise.all([
+      this.snowflakeService.execute<EventRow>(eventQuery, [eventId]),
+      this.snowflakeService.execute<TierRow>(tierQuery, [eventId]),
+    ]);
+
+    const row = eventResult.rows?.[0];
+    if (!row) {
+      logger.warning(undefined, 'get_event_detail', 'No event row for id', { event_id: eventId });
+      return null;
+    }
+
+    const normalizeScore = (score: string | null): EventCompScore => {
+      const s = (score ?? '').toLowerCase();
+      return s === 'high' || s === 'medium' || s === 'low' ? s : 'unknown';
+    };
+
+    const sponsorshipActual = tierResult.rows.reduce((sum, t) => sum + (t.REVENUE ?? 0), 0);
+
+    return {
+      eventId: row.EVENT_ID,
+      eventName: row.EVENT_NAME,
+      startDate: row.START_DATE,
+      country: row.EVENT_COUNTRY ?? '',
+      eventUrl: row.EVENT_URL ?? '',
+      registrations: { actual: row.REG_ACTUAL ?? 0, goal: row.REG_GOAL ?? 0 },
+      sponsorshipRevenue: { actual: sponsorshipActual, goal: row.SPON_GOAL ?? 0 },
+      vsLastYear: row.VS_LY,
+      compScore: normalizeScore(row.COMP_SCORE),
+      cfpStatus: row.CFP_STATUS ?? '',
+      sponsorshipTiers: tierResult.rows.map((t) => ({
+        tier: t.SPONSORSHIP_TIER ?? '',
+        revenue: t.REVENUE ?? 0,
+        sponsorCount: t.SPONSOR_COUNT ?? 0,
+      })),
+    };
   }
 
   /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -674,6 +674,37 @@ export interface EventRosterResponse {
   events: EventRosterRow[];
 }
 
+/** One sponsorship tier row for the per-event detail drawer. */
+export interface EventSponsorshipTier {
+  /** Tier name (Diamond, Gold, Platinum, …); '' when unlabeled. */
+  tier: string;
+  /** Sponsorship revenue in dollars for this tier at this event. */
+  revenue: number;
+  /** Number of sponsors in this tier. */
+  sponsorCount: number;
+}
+
+/**
+ * Per-event detail for the roster drawer, sourced from
+ * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS (event meta + goals) and
+ * MARKETING_EVENT_SPONSORSHIPS_BY_TIER (tier breakdown). No daily-pacing time-series is
+ * available in these tables — that lives in PCC's prediction service, linked via eventUrl.
+ */
+export interface EventDetailResponse {
+  eventId: string;
+  eventName: string;
+  startDate: string;
+  country: string;
+  eventUrl: string;
+  registrations: { actual: number; goal: number };
+  sponsorshipRevenue: { actual: number; goal: number };
+  /** Ratio of this year's registrations to last year's (1.0 = on par); null when no baseline. */
+  vsLastYear: number | null;
+  compScore: EventCompScore;
+  cfpStatus: string;
+  sponsorshipTiers: EventSponsorshipTier[];
+}
+
 /**
  * Foundation-wide events summary for the Marketing Impact Overview tab, sourced from
  * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW (per-project, pre-computed period


### PR DESCRIPTION
Adds the per-event detail drawer opened from a roster row, with the b2c/b2b focus split.

**Stacked on** `feat/LFXV2-2768-event-roster-goals`.

LFXV2-2768