### PR TITLE
feat(dashboards): expand event drawer into a full deep-dive

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
@@ -4,107 +4,227 @@
 <p-drawer
   [(visible)]="visible"
   position="right"
-  styleClass="xl:!w-[45%] lg:!w-[55%] md:!w-[70%] sm:!w-[90%] !w-full"
-  [showCloseIcon]="true"
-  [dismissible]="true"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
   data-testid="event-detail-drawer">
+  <!-- Header -->
   <ng-template #header>
-    <div class="flex flex-col gap-0.5">
-      <h3 class="text-base font-semibold text-gray-900">{{ detail()?.eventName || 'Event detail' }}</h3>
-      @if (detail()) {
-        <p class="text-xs text-gray-500">
-          <!-- &nbsp; not a plain space: preserveWhitespaces is off, so a whitespace-only text
-               node between the interpolation and the @if block is stripped and the date would
-               run straight into the country separator. -->
-          {{ view()?.dateLabel }}
-          @if (detail()?.country) {
-            <span>&nbsp;· {{ detail()?.country }}</span>
-          }
-        </p>
-      }
-    </div>
-  </ng-template>
-
-  @if (loading()) {
-    <div class="flex flex-col gap-4" data-testid="event-detail-skeleton">
-      <p-skeleton width="100%" height="5rem" borderRadius="8px" />
-      <p-skeleton width="100%" height="5rem" borderRadius="8px" />
-      <p-skeleton width="100%" height="10rem" borderRadius="8px" />
-    </div>
-  } @else if (detail(); as d) {
-    <div class="flex flex-col gap-5">
-      <!-- Registrations vs goal -->
-      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-registrations">
-        <div class="flex items-baseline justify-between">
-          <span class="text-xs font-medium text-gray-500">Registrations</span>
-          @if (view()?.vsLastYearLabel; as vs) {
-            <span class="text-[11px] font-medium text-gray-400">{{ vs }}</span>
-          }
-        </div>
-        <div class="flex items-baseline gap-2">
-          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ view()?.registrationsActual }}</span>
-          @if (d.registrations.goal > 0) {
-            <span class="text-sm text-gray-400 tabular-nums">/ {{ view()?.registrationsGoal }} goal</span>
-          }
-        </div>
-        @if (regProgress() !== null) {
-          <div class="mt-1 h-2 overflow-hidden rounded-full bg-gray-100">
-            <div
-              class="h-full rounded-full"
-              role="progressbar"
-              [attr.aria-valuenow]="regProgress()"
-              aria-valuemin="0"
-              aria-valuemax="100"
-              [attr.aria-label]="'Registrations: ' + view()?.registrationsActual + ' of ' + view()?.registrationsGoal + ' goal'"
-              [ngClass]="{
-                'bg-emerald-500': view()?.registrationsTone === 'good',
-                'bg-amber-500': view()?.registrationsTone === 'warn',
-                'bg-red-400': view()?.registrationsTone === 'critical',
-              }"
-              [style.width.%]="regProgress()"></div>
+    <div class="flex w-full items-start justify-between gap-4" data-testid="event-detail-drawer-header">
+      <div class="flex min-w-0 flex-1 flex-col gap-1">
+        <h2 class="text-lg font-semibold text-gray-900" data-testid="event-detail-drawer-title">{{ detail()?.eventName || 'Event detail' }}</h2>
+        @if (detail(); as d) {
+          <div class="flex flex-wrap items-center gap-x-2 gap-y-0.5 text-sm text-gray-500">
+            <span>{{ dateLabel() }}</span>
+            @if (locationLabel()) {
+              <span aria-hidden="true">·</span>
+              <span><i class="fa-light fa-location-dot mr-1" aria-hidden="true"></i>{{ locationLabel() }}</span>
+            }
+            @if (d.status) {
+              <span aria-hidden="true">·</span>
+              <span>{{ d.status }}</span>
+            }
           </div>
         }
       </div>
+      <lfx-button
+        icon="fa-light fa-xmark"
+        [text]="true"
+        [rounded]="true"
+        severity="secondary"
+        ariaLabel="Close panel"
+        (onClick)="onClose()"
+        data-testid="event-detail-drawer-close" />
+    </div>
+  </ng-template>
 
-      <!-- Sponsorship vs goal -->
-      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-sponsorship">
-        <span class="text-xs font-medium text-gray-500">Sponsorship revenue</span>
-        <div class="flex items-baseline gap-2">
-          <span class="text-2xl font-semibold text-gray-900 tabular-nums">{{ view()?.sponsorshipActual }}</span>
-          @if (d.sponsorshipRevenue.goal > 0) {
-            <span class="text-sm text-gray-400 tabular-nums">/ {{ view()?.sponsorshipGoal }} goal</span>
-          }
+  <!-- Content -->
+  @if (loading()) {
+    <div class="flex flex-col gap-6 pb-2" data-testid="event-detail-skeleton">
+      <p-skeleton width="100%" height="7rem" borderRadius="8px" />
+      <p-skeleton width="100%" height="6rem" borderRadius="8px" />
+      <p-skeleton width="100%" height="10rem" borderRadius="8px" />
+    </div>
+  } @else if (detail(); as d) {
+    <div class="flex flex-col gap-6 pb-2" data-testid="event-detail-drawer-content">
+      <!-- Headline stats -->
+      <div class="flex flex-col gap-4 sm:flex-row" data-testid="event-detail-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Registrations</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ num(d.registrations.actual) }}</span>
+            @if (d.registrations.goal > 0) {
+              <span class="text-xs text-gray-400">of {{ num(d.registrations.goal) }} goal</span>
+            } @else {
+              <span class="text-xs text-gray-400">no goal set</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Sponsorship revenue</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ money(d.sponsorshipRevenue.actual) }}</span>
+            @if (d.sponsorshipRevenue.goal > 0) {
+              <span class="text-xs text-gray-400">of {{ money(d.sponsorshipRevenue.goal) }} goal</span>
+            } @else {
+              <span class="text-xs text-gray-400">no goal set</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">vs Last year</span>
+            @if (vsLastYearLabel(); as vs) {
+              <span
+                class="text-2xl font-semibold"
+                [class.text-green-600]="(d.vsLastYear ?? 1) > 1"
+                [class.text-red-600]="(d.vsLastYear ?? 1) < 1"
+                [class.text-gray-900]="(d.vsLastYear ?? 1) === 1"
+                >{{ vs }}</span
+              >
+              <span class="text-xs text-gray-400">registration pace</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+              <span class="text-xs text-gray-400">no prior year</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+
+      <!-- Registration pacing -->
+      <div class="flex flex-col gap-4 rounded-lg border border-gray-200 p-4" data-testid="event-detail-pacing">
+        <div class="flex items-center justify-between gap-3">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-semibold text-gray-900">Registration pacing</h3>
+            @if (behindGoalLabel(); as behind) {
+              <p class="text-sm text-gray-600">{{ behind }}</p>
+            }
+          </div>
+          <lfx-tag [value]="paceRatingLabel()" [severity]="paceSeverity()" [rounded]="true" />
         </div>
-        @if (sponProgress() !== null) {
-          <div class="mt-1 h-2 overflow-hidden rounded-full bg-gray-100">
-            <div
-              class="h-full rounded-full"
-              role="progressbar"
-              [attr.aria-valuenow]="sponProgress()"
-              aria-valuemin="0"
-              aria-valuemax="100"
-              [attr.aria-label]="'Sponsorship revenue: ' + view()?.sponsorshipActual + ' of ' + view()?.sponsorshipGoal + ' goal'"
-              [ngClass]="{
-                'bg-emerald-500': view()?.sponsorshipTone === 'good',
-                'bg-amber-500': view()?.sponsorshipTone === 'warn',
-                'bg-red-400': view()?.sponsorshipTone === 'critical',
-              }"
-              [style.width.%]="sponProgress()"></div>
+
+        @if (d.registrations.goal > 0 && regProgress() !== null) {
+          <div class="flex flex-col gap-1.5">
+            <div class="flex items-baseline justify-between text-sm">
+              <span class="font-semibold text-gray-900">{{ num(d.registrations.actual) }}</span>
+              <span class="text-gray-400">{{ num(d.registrations.goal) }} goal</span>
+            </div>
+            <div class="h-2.5 overflow-hidden rounded-full bg-gray-100">
+              <div
+                class="h-full rounded-full"
+                role="progressbar"
+                [attr.aria-valuenow]="regProgress()"
+                aria-valuemin="0"
+                aria-valuemax="100"
+                [attr.aria-label]="'Registrations: ' + num(d.registrations.actual) + ' of ' + num(d.registrations.goal) + ' goal'"
+                [ngClass]="{
+                  'bg-emerald-500': regProgress()! >= 80,
+                  'bg-amber-500': regProgress()! >= 50 && regProgress()! < 80,
+                  'bg-red-400': regProgress()! < 50,
+                }"
+                [style.width.%]="regProgress()"></div>
+            </div>
           </div>
         }
+
+        @if (d.pacing.available) {
+          <!-- Headline: current / last year / predicted, mirroring PCC -->
+          <div class="flex flex-wrap gap-8">
+            <div class="flex flex-col">
+              <span class="text-xl font-semibold text-blue-600">{{ d.pacing.current !== null ? num(d.pacing.current) : '—' }}</span>
+              <span class="text-xs text-gray-400">Current</span>
+            </div>
+            @if (d.hasPriorYear) {
+              <div class="flex flex-col">
+                <span class="text-xl font-semibold text-gray-500">{{ d.pacing.priorYear !== null ? num(d.pacing.priorYear) : '—' }}</span>
+                <span class="text-xs text-gray-400">Last year</span>
+              </div>
+            }
+            <div class="flex flex-col">
+              <span class="text-xl font-semibold text-violet-600">{{ d.pacing.predictedAvg !== null ? num(d.pacing.predictedAvg) : '—' }}</span>
+              <span class="text-xs text-gray-400">
+                Predicted
+                @if (d.pacing.predictedLow !== null && d.pacing.predictedHigh !== null) {
+                  <span class="text-gray-400">({{ num(d.pacing.predictedLow) }}–{{ num(d.pacing.predictedHigh) }})</span>
+                }
+              </span>
+            </div>
+            <!-- DAYS_LEFT_FROM_YESTERDAY keeps counting down past the event, so a past event
+                 yields a negative. "Days left" is meaningless then — drop the whole block. -->
+            @if (d.pacing.daysLeft !== null && d.pacing.daysLeft > 0) {
+              <div class="ml-auto flex flex-col text-right">
+                <span class="text-xl font-semibold text-gray-900">{{ num(d.pacing.daysLeft) }}</span>
+                <span class="text-xs text-gray-400">Days left</span>
+              </div>
+            }
+          </div>
+
+          <!-- Daily cumulative registration curve -->
+          @if (hasPacingChart()) {
+            <div class="h-[240px]" data-testid="event-detail-pacing-chart">
+              <lfx-chart type="line" [data]="pacingChartData()" [options]="pacingChartOptions" height="100%" />
+            </div>
+          }
+        } @else {
+          <p class="text-sm text-gray-500">Day-by-day pacing prediction is coming to this view.</p>
+        }
+
+        @if (d.eventUrl) {
+          <a
+            [href]="d.eventUrl"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="flex w-fit items-center gap-1.5 text-sm font-semibold text-blue-600 hover:underline"
+            data-testid="event-detail-event-link">
+            <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+            View event page
+          </a>
+        }
+      </div>
+
+      <!-- Revenue detail -->
+      <div class="flex flex-col gap-4 rounded-lg border border-gray-200 p-4" data-testid="event-detail-revenue">
+        <h3 class="text-sm font-semibold text-gray-900">Revenue</h3>
+        <div class="flex flex-col gap-4 sm:flex-row">
+          <div class="flex flex-1 flex-col gap-1">
+            <span class="text-sm text-gray-500">Registration revenue</span>
+            @if (d.registrationRevenue.actual !== null) {
+              <span class="text-xl font-semibold text-gray-900">{{ money(d.registrationRevenue.actual) }}</span>
+            } @else {
+              <span class="text-xl font-semibold text-gray-300">—</span>
+            }
+            @if (d.registrationRevenue.goal > 0) {
+              <span class="text-xs text-gray-400">Goal {{ money(d.registrationRevenue.goal) }}</span>
+            }
+          </div>
+          <div class="flex flex-1 flex-col gap-1">
+            <span class="text-sm text-gray-500">Sponsorship revenue</span>
+            <span class="text-xl font-semibold text-gray-900">{{ money(d.sponsorshipRevenue.actual) }}</span>
+            <div class="flex items-center gap-2">
+              @if (d.sponsorshipRevenue.goal > 0) {
+                <span class="text-xs text-gray-400">Goal {{ money(d.sponsorshipRevenue.goal) }}</span>
+              }
+              @if (sponProgress() !== null) {
+                <span class="text-xs font-medium text-gray-500">{{ sponProgress() }}%</span>
+              }
+            </div>
+          </div>
+        </div>
       </div>
 
       <!-- Sponsorship by tier -->
       @if (d.sponsorshipTiers.length) {
-        <div class="flex flex-col gap-2 rounded-lg border border-gray-200 p-4" data-testid="event-detail-tiers">
-          <span class="text-xs font-medium text-gray-500">Sponsorship by tier</span>
-          <div class="flex flex-col gap-2.5">
-            @for (tier of view()?.tiers ?? []; track tier.tier) {
-              <div class="flex items-center justify-between gap-3" [attr.data-testid]="'event-detail-tier-' + tier.tier">
-                <span class="truncate text-xs font-medium text-gray-700">{{ tier.label }}</span>
-                <div class="flex items-baseline gap-3">
-                  <span class="text-[11px] text-gray-400">{{ tier.sponsorCount }} sponsor{{ tier.sponsorCount === 1 ? '' : 's' }}</span>
-                  <span class="w-20 text-right text-xs font-semibold text-gray-900 tabular-nums">{{ tier.revenue }}</span>
+        <div class="flex flex-col gap-3 rounded-lg border border-gray-200 p-4" data-testid="event-detail-tiers">
+          <h3 class="text-sm font-semibold text-gray-900">Sponsorship by tier</h3>
+          <div class="flex flex-col gap-0">
+            @for (tier of d.sponsorshipTiers; track tier.tier) {
+              <div
+                class="flex items-center justify-between gap-3 border-b border-gray-100 py-2.5 last:border-b-0"
+                [attr.data-testid]="'event-detail-tier-' + tier.tier">
+                <span class="truncate text-sm font-medium text-gray-700">{{ tier.tier || 'Other' }}</span>
+                <div class="flex items-baseline gap-4">
+                  <span class="text-xs text-gray-400">{{ tier.sponsorCount }} sponsor{{ tier.sponsorCount === 1 ? '' : 's' }}</span>
+                  <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ money(tier.revenue) }}</span>
                 </div>
               </div>
             }
@@ -112,20 +232,32 @@
         </div>
       }
 
-      <!-- eventUrl is the public event page (Cvent / events.linuxfoundation.org), not a PCC
-           prediction view — there is no PCC event deep-link in this app to point at, so the
-           label describes where the link actually goes. -->
-      @if (d.eventUrl) {
-        <a
-          [href]="d.eventUrl"
-          target="_blank"
-          rel="noopener noreferrer"
-          class="flex items-center justify-center gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-xs font-semibold text-blue-700 hover:bg-blue-100"
-          data-testid="event-detail-event-link">
-          <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
-          View event page
-        </a>
-      }
+      <!-- Where registrations come from -->
+      <div class="flex flex-col gap-3 rounded-lg border border-gray-200 p-4" data-testid="event-detail-channels">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Where registrations come from</h3>
+          <p class="text-sm text-gray-600">Web traffic attributed to each marketing channel.</p>
+        </div>
+        @if (d.channels.length) {
+          <div class="flex flex-col gap-3">
+            @for (channel of d.channels; track channel.channel) {
+              <div class="flex items-center gap-3" [attr.data-testid]="'event-detail-channel-' + channel.channel">
+                <span class="w-36 truncate text-sm font-medium text-gray-700">{{ channel.channel }}</span>
+                <div class="h-2 flex-1 overflow-hidden rounded-full bg-gray-100">
+                  <div class="h-full rounded-full bg-blue-500" [style.width.%]="channel.sharePercent"></div>
+                </div>
+                <span class="w-16 text-right text-sm font-semibold text-gray-900">{{ num(channel.sessions) }}</span>
+                <span class="w-12 text-right text-xs text-gray-400">{{ channel.sharePercent }}%</span>
+              </div>
+            }
+          </div>
+        } @else {
+          <p class="text-sm text-gray-500">
+            No tracked registration traffic yet.
+            <span class="font-medium text-gray-700">Email and paid are the fastest levers to drive early registrations.</span>
+          </p>
+        }
+      </div>
     </div>
   } @else if (failed()) {
     <div class="flex flex-col items-center justify-center gap-1 rounded-lg border border-dashed border-red-200 bg-red-50 p-8" data-testid="event-detail-error">

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.html
@@ -85,7 +85,10 @@
               <span class="text-xs text-gray-400">registration pace</span>
             } @else {
               <span class="text-2xl font-semibold text-gray-400">—</span>
-              <span class="text-xs text-gray-400">no prior year</span>
+              <!-- hasPriorYear and vsLastYear are separate facts: a prior edition can exist while
+                   the comparison ratio is still missing. Saying "no prior year" in that case
+                   contradicts the pacing block below, which shows a Last year figure. -->
+              <span class="text-xs text-gray-400">{{ d.hasPriorYear ? 'no comparison available' : 'no prior year' }}</span>
             }
           </div>
         </lfx-card>
@@ -118,9 +121,9 @@
                 aria-valuemax="100"
                 [attr.aria-label]="'Registrations: ' + num(d.registrations.actual) + ' of ' + num(d.registrations.goal) + ' goal'"
                 [ngClass]="{
-                  'bg-emerald-500': regProgress()! >= 80,
-                  'bg-amber-500': regProgress()! >= 50 && regProgress()! < 80,
-                  'bg-red-400': regProgress()! < 50,
+                  'bg-emerald-500': registrationsTone() === 'good',
+                  'bg-amber-500': registrationsTone() === 'warn',
+                  'bg-red-400': registrationsTone() === 'critical',
                 }"
                 [style.width.%]="regProgress()"></div>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.spec.ts
@@ -3,6 +3,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
 import { AnalyticsService } from '@services/analytics.service';
 import { of, throwError } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
@@ -16,17 +17,25 @@ describe('EventDetailDrawerComponent', () => {
     eventId: 'evt-1',
     eventName: 'KubeCon NA',
     startDate: '2026-11-10',
+    isPast: false,
+    location: 'Salt Palace Convention Center',
+    city: 'Salt Lake City',
     country: 'United States',
+    status: 'Active',
     eventUrl: 'https://events.example.org/kubecon',
     registrations: { actual: 900, goal: 1000 },
+    registrationRevenue: { actual: null, goal: 0 },
     sponsorshipRevenue: { actual: 500000, goal: 1000000 },
     vsLastYear: 1.1,
+    hasPriorYear: true,
     compScore: 'high',
     cfpStatus: 'Review Complete',
     sponsorshipTiers: [
       { tier: 'Diamond', revenue: 300000, sponsorCount: 2 },
       { tier: 'Gold', revenue: 200000, sponsorCount: 4 },
     ],
+    channels: [],
+    pacing: { available: false, daysLeft: null, current: null, priorYear: null, predictedAvg: null, predictedLow: null, predictedHigh: null, points: [] },
     ...overrides,
   });
 
@@ -41,7 +50,7 @@ describe('EventDetailDrawerComponent', () => {
       imports: [EventDetailDrawerComponent],
       // p-drawer uses synthetic animations; without a noop animations provider every render
       // through the drawer throws NG05105 before any assertion runs.
-      providers: [{ provide: AnalyticsService, useValue: { getEventDetail } }, provideNoopAnimations()],
+      providers: [{ provide: AnalyticsService, useValue: { getEventDetail } }, provideNoopAnimations(), provideRouter([])],
     }).compileComponents();
 
     fixture = TestBed.createComponent(EventDetailDrawerComponent);
@@ -138,34 +147,36 @@ describe('EventDetailDrawerComponent', () => {
 
   // The roster's bars already expose progressbar semantics; the drawer shows the same metrics
   // and must not be the one place AT can't read completion.
-  it('exposes both goal bars to assistive technology', async () => {
+  it('exposes the registration goal bar to assistive technology', async () => {
     await setup(vi.fn().mockReturnValue(of(detail())));
 
     await open('evt-1');
 
+    // Only registrations renders as a bar in this layout; sponsorship is a figure, not a meter.
     const bars = document.querySelectorAll('[role="progressbar"]');
-    expect(bars).toHaveLength(2);
-    // 900/1000 registrations, 500000/1000000 sponsorship.
+    expect(bars).toHaveLength(1);
     expect(bars[0].getAttribute('aria-valuenow')).toBe('90');
-    expect(bars[1].getAttribute('aria-valuenow')).toBe('50');
-    for (const bar of Array.from(bars)) {
-      expect(bar.getAttribute('aria-valuemin')).toBe('0');
-      expect(bar.getAttribute('aria-valuemax')).toBe('100');
-      expect(bar.getAttribute('aria-label')).toBeTruthy();
-    }
+    expect(bars[0].getAttribute('aria-valuemin')).toBe('0');
+    expect(bars[0].getAttribute('aria-valuemax')).toBe('100');
+    expect(bars[0].getAttribute('aria-label')).toBeTruthy();
   });
 
   // The bar colours read the same shared thresholds as the roster's bar and at-risk icon, so
   // tuning either constant moves both views together instead of letting them disagree.
-  it('colours the goal bars from the shared thresholds', async () => {
-    // 800/1000 = 80%, exactly the on-track boundary; 400/1000 = 40%, below the behind-goal one.
-    await setup(vi.fn().mockReturnValue(of(detail({ registrations: { actual: 800, goal: 1000 }, sponsorshipRevenue: { actual: 400000, goal: 1000000 } }))));
+  it('colours the goal bar green at exactly the on-track threshold', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail({ registrations: { actual: 800, goal: 1000 } }))));
 
     await open('evt-1');
 
-    const bars = document.querySelectorAll('[role="progressbar"]');
-    expect(bars[0].classList.contains('bg-emerald-500')).toBe(true);
-    expect(bars[1].classList.contains('bg-red-400')).toBe(true);
+    expect(document.querySelector('[role="progressbar"]')?.classList.contains('bg-emerald-500')).toBe(true);
+  });
+
+  it('colours the goal bar red below the behind-goal threshold', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail({ registrations: { actual: 400, goal: 1000 } }))));
+
+    await open('evt-1');
+
+    expect(document.querySelector('[role="progressbar"]')?.classList.contains('bg-red-400')).toBe(true);
   });
 
   it('renders the sponsorship tier breakdown', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.spec.ts
@@ -179,6 +179,25 @@ describe('EventDetailDrawerComponent', () => {
     expect(document.querySelector('[role="progressbar"]')?.classList.contains('bg-red-400')).toBe(true);
   });
 
+  // hasPriorYear and vsLastYear are separate facts. Claiming "no prior year" when a prior edition
+  // exists contradicts the pacing block below, which shows a Last year figure for the same event.
+  it('says no comparison rather than no prior year when the ratio is missing', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail({ vsLastYear: null, hasPriorYear: true }))));
+
+    await open('evt-1');
+
+    expect(text()).toContain('no comparison available');
+    expect(text()).not.toContain('no prior year');
+  });
+
+  it('says no prior year when there genuinely was no prior edition', async () => {
+    await setup(vi.fn().mockReturnValue(of(detail({ vsLastYear: null, hasPriorYear: false }))));
+
+    await open('evt-1');
+
+    expect(text()).toContain('no prior year');
+  });
+
   it('renders the sponsorship tier breakdown', async () => {
     await setup(vi.fn().mockReturnValue(of(detail())));
 

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
@@ -4,19 +4,24 @@
 import { NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, input, model, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { BEHIND_GOAL_PERCENT_THRESHOLD, ON_TRACK_PERCENT_THRESHOLD } from '@lfx-one/shared/constants';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { lfxColors } from '@lfx-one/shared/constants';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { DrawerModule } from 'primeng/drawer';
 import { Skeleton } from 'primeng/skeleton';
 import { catchError, combineLatest, distinctUntilChanged, finalize, of, switchMap } from 'rxjs';
 
+import type { ChartData, ChartOptions } from 'chart.js';
 import type { EventDetailResponse } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-event-detail-drawer',
   changeDetection: ChangeDetectionStrategy.OnPush,
-  imports: [NgClass, DrawerModule, Skeleton],
+  imports: [NgClass, DrawerModule, Skeleton, ButtonComponent, CardComponent, TagComponent, ChartComponent],
   templateUrl: './event-detail-drawer.component.html',
 })
 export class EventDetailDrawerComponent {
@@ -59,42 +64,99 @@ export class EventDetailDrawerComponent {
     return Math.min(100, Math.round((d.sponsorshipRevenue.actual / d.sponsorshipRevenue.goal) * 100));
   });
 
+  // Whether we have a daily curve to plot (needs the drilldown prediction data).
+  protected readonly hasPacingChart = computed(() => (this.detail()?.pacing.points.length ?? 0) > 0);
+
+  // Registration-pacing line chart: current-year + last-year + predicted, over days-to-event.
+  protected readonly pacingChartData: Signal<ChartData<'line'>> = computed(() => this.buildPacingChart());
+
+  protected readonly pacingChartOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    interaction: { mode: 'index', intersect: false },
+    plugins: {
+      legend: { display: true, position: 'bottom', labels: { boxWidth: 10, boxHeight: 10, color: lfxColors.gray[500], font: { size: 11 } } },
+      tooltip: { enabled: true },
+    },
+    scales: {
+      x: {
+        // No `reverse` here. This is a category axis, so points render in array order, and the
+        // query already returns DAYS_TO_EVENT descending — the event (0) lands on the right.
+        // Reversing as well would flip it back and run the timeline backwards.
+        title: { display: true, text: 'Days to event', color: lfxColors.gray[400], font: { size: 10 } },
+        grid: { display: false },
+        ticks: { color: lfxColors.gray[500], font: { size: 10 }, maxTicksLimit: 8 },
+      },
+      y: {
+        beginAtZero: true,
+        grid: { color: lfxColors.gray[200] },
+        border: { display: false },
+        ticks: { color: lfxColors.gray[500], font: { size: 10 } },
+      },
+    },
+    elements: { point: { radius: 0, hitRadius: 8 }, line: { tension: 0.3, borderWidth: 2 } },
+  };
+
   /**
-   * Everything the template renders as text, formatted once per detail change. The template used
-   * to call formatting helpers directly, which re-ran locale/currency formatting on every
-   * change-detection pass; per the frontend checklist templates read computed values instead.
+   * Everything the template renders as a derived label, computed once per detail change rather
+   * than called from the template — these do locale, number and string formatting, which a
+   * template invocation would re-run on every change-detection pass (frontend-checklist.md §4).
    */
-  protected readonly view = computed(() => {
+  protected readonly dateLabel = computed(() => this.formatDate(this.detail()?.startDate ?? ''));
+  protected readonly vsLastYearLabel = computed(() => this.formatVsLastYear(this.detail()?.vsLastYear ?? null));
+  protected readonly locationLabel = computed(() => {
     const d = this.detail();
-    if (!d) return null;
-    return {
-      dateLabel: this.formatDate(d.startDate),
-      vsLastYearLabel: this.formatVsLastYear(d.vsLastYear),
-      registrationsActual: formatNumber(d.registrations.actual),
-      registrationsGoal: formatNumber(d.registrations.goal),
-      sponsorshipActual: formatCurrency(d.sponsorshipRevenue.actual),
-      sponsorshipGoal: formatCurrency(d.sponsorshipRevenue.goal),
-      registrationsTone: this.barTone(this.regProgress()),
-      sponsorshipTone: this.barTone(this.sponProgress()),
-      tiers: d.sponsorshipTiers.map((tier) => ({
-        tier: tier.tier,
-        label: tier.tier || 'Other',
-        sponsorCount: tier.sponsorCount,
-        revenue: formatCurrency(tier.revenue),
-      })),
-    };
+    if (!d) return '';
+    return [d.location, d.city, d.country].filter((part) => part && part.length).join(', ');
+  });
+  /** Human label for the comparison pace rating. */
+  protected readonly paceRatingLabel = computed(() => {
+    switch (this.detail()?.compScore) {
+      case 'high':
+        return 'Pacing ahead';
+      case 'medium':
+        return 'On pace';
+      case 'low':
+        return 'Pacing behind';
+      default:
+        return 'No pace signal';
+    }
+  });
+  /** "N registrations behind goal" when there is a real, unmet goal; otherwise null. */
+  protected readonly behindGoalLabel = computed(() => {
+    const d = this.detail();
+    if (!d || d.registrations.goal <= 0) return null;
+    const gap = d.registrations.goal - d.registrations.actual;
+    if (gap <= 0) return 'Registration goal met';
+    return `${formatNumber(gap)} registrations behind goal`;
   });
 
-  // === Private Helpers ===
-  /**
-   * Goal-bar tone from the shared thresholds rather than literals, so the drawer's colours and the
-   * roster's bar + at-risk icon move together when either threshold is tuned.
-   */
-  private barTone(percent: number | null): 'good' | 'warn' | 'critical' | null {
-    if (percent === null) return null;
-    if (percent >= ON_TRACK_PERCENT_THRESHOLD) return 'good';
-    if (percent >= BEHIND_GOAL_PERCENT_THRESHOLD) return 'warn';
-    return 'critical';
+  // === Protected Methods ===
+  protected onClose(): void {
+    this.visible.set(false);
+  }
+
+  // === Protected Helpers (template) ===
+  protected num(value: number): string {
+    return formatNumber(value);
+  }
+
+  /** lfx-tag severity for the registration-pace rating. */
+  protected paceSeverity(): 'success' | 'warn' | 'danger' | 'secondary' {
+    switch (this.detail()?.compScore) {
+      case 'high':
+        return 'success';
+      case 'medium':
+        return 'warn';
+      case 'low':
+        return 'danger';
+      default:
+        return 'secondary';
+    }
+  }
+
+  protected money(value: number): string {
+    return formatCurrency(value);
   }
 
   /** Registration pace vs last year as a signed percent string, or null when no baseline. */
@@ -120,6 +182,45 @@ export class EventDetailDrawerComponent {
       year: 'numeric',
       timeZone: 'UTC',
     });
+  }
+
+  /** Full venue + city + country line for the header; '' when nothing is known. */
+  // === Private Helpers ===
+  private buildPacingChart(): ChartData<'line'> {
+    const points = this.detail()?.pacing.points ?? [];
+    const labels = points.map((point) => point.daysToEvent);
+    return {
+      labels,
+      datasets: [
+        {
+          label: 'Current year',
+          data: points.map((point) => point.current),
+          borderColor: lfxColors.blue[500],
+          backgroundColor: 'transparent',
+          spanGaps: false,
+        },
+        // Only when a prior-year edition exists — the headline already gates on hasPriorYear, and
+        // an all-null series would otherwise render as a legend entry with no line behind it.
+        ...(this.detail()?.hasPriorYear
+          ? [
+              {
+                label: 'Last year',
+                data: points.map((point) => point.priorYear),
+                borderColor: lfxColors.gray[400],
+                backgroundColor: 'transparent',
+                borderDash: [4, 4],
+              },
+            ]
+          : []),
+        {
+          label: 'Predicted',
+          data: points.map((point) => point.predictedAvg),
+          borderColor: lfxColors.violet[500],
+          backgroundColor: 'transparent',
+          borderDash: [6, 4],
+        },
+      ],
+    };
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-detail-drawer/event-detail-drawer.component.ts
@@ -8,7 +8,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { lfxColors } from '@lfx-one/shared/constants';
+import { BEHIND_GOAL_PERCENT_THRESHOLD, lfxColors, ON_TRACK_PERCENT_THRESHOLD } from '@lfx-one/shared/constants';
 import { formatCurrency, formatNumber } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { DrawerModule } from 'primeng/drawer';
@@ -109,6 +109,18 @@ export class EventDetailDrawerComponent {
     if (!d) return '';
     return [d.location, d.city, d.country].filter((part) => part && part.length).join(', ');
   });
+  /**
+   * Goal-bar tone from the shared thresholds rather than literals, so this bar and the roster's
+   * bar + at-risk icon move together when either constant is tuned.
+   */
+  protected readonly registrationsTone = computed(() => {
+    const percent = this.regProgress();
+    if (percent === null) return null;
+    if (percent >= ON_TRACK_PERCENT_THRESHOLD) return 'good';
+    if (percent >= BEHIND_GOAL_PERCENT_THRESHOLD) return 'warn';
+    return 'critical';
+  });
+
   /** Human label for the comparison pace rating. */
   protected readonly paceRatingLabel = computed(() => {
     switch (this.detail()?.compScore) {

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -1,47 +1,12 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!-- The events sections each render their own card; without a wrapper they sit flush against
+     one another. -->
 <div class="flex flex-col gap-6" data-testid="overview-tab">
   <lfx-events-attention-section [foundationSlug]="foundationSlug()" data-testid="overview-tab-events-attention" />
 
   <lfx-events-summary-section [foundationSlug]="foundationSlug()" [foundationName]="foundationName()" data-testid="overview-tab-events-summary" />
 
   <lfx-event-roster-section [foundationSlug]="foundationSlug()" data-testid="overview-tab-event-roster" />
-
-  <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-5" data-testid="overview-tab-summary-header">
-    <div class="flex flex-col gap-0.5">
-      <h3 class="text-base font-semibold text-gray-900">{{ summaryTitle() }}</h3>
-      <p class="text-xs text-gray-500">{{ summarySubtitle() }}</p>
-    </div>
-
-    <div class="grid grid-cols-1 gap-4 pt-3 sm:grid-cols-2 lg:grid-cols-4" data-testid="overview-tab-kpi-grid">
-      @if (loading()) {
-        @for (i of [1, 2, 3, 4]; track i) {
-          <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="overview-tab-kpi-skeleton">
-            <div class="h-4 w-24 animate-pulse rounded bg-gray-200"></div>
-            <div class="h-8 w-32 animate-pulse rounded bg-gray-200"></div>
-            <div class="h-3 w-40 animate-pulse rounded bg-gray-200"></div>
-            <div class="h-3 w-36 animate-pulse rounded bg-gray-200"></div>
-          </div>
-        }
-      } @else {
-        @for (kpi of performanceSummaryKpis(); track kpi.id) {
-          <lfx-sparkline-kpi-card [kpi]="kpi" section="overview" />
-        } @empty {
-          <div class="col-span-full text-center py-8 text-sm text-gray-500" data-testid="overview-tab-kpi-empty">
-            No performance data available for this period.
-          </div>
-        }
-      }
-    </div>
-  </div>
-
-  <lfx-attribution-section
-    [foundationSlug]="foundationSlug()"
-    [selectedPeriod]="selectedPeriod()"
-    [foundationName]="foundationName()"
-    [focusProgram]="focusProgram()"
-    [attributionOverride]="overviewKpiData().attribution"
-    [loadingOverride]="loading()"
-    data-testid="overview-tab-attribution-section" />
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.ts
@@ -1,240 +1,29 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, signal, Signal } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
-import { formatChangePct, formatCurrency, formatNumber, isPeriodMonth, resolvePeriodRange, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
-import { AnalyticsService } from '@services/analytics.service';
-import { catchError, combineLatest, finalize, forkJoin, of, switchMap } from 'rxjs';
+import { Component, input } from '@angular/core';
 
-import type { MarketingImpactFocusProgram, OverviewKpiData, PerformanceSummaryKpi } from '@lfx-one/shared/interfaces';
+import type { MarketingImpactFocusProgram } from '@lfx-one/shared/interfaces';
 
-import { AttributionSectionComponent } from '../attribution-section/attribution-section.component';
 import { EventRosterSectionComponent } from '../event-roster-section/event-roster-section.component';
 import { EventsAttentionSectionComponent } from '../events-attention-section/events-attention-section.component';
 import { EventsSummarySectionComponent } from '../events-summary-section/events-summary-section.component';
-import { SparklineKpiCardComponent } from '../sparkline-kpi-card/sparkline-kpi-card.component';
 
+/**
+ * Marketing Impact overview tab — the LF Events story: at-risk events, the events summary,
+ * and the event roster (with the per-event deep-dive drawer).
+ */
 @Component({
   selector: 'lfx-overview-tab',
-  imports: [
-    SparklineKpiCardComponent,
-    AttributionSectionComponent,
-    EventsSummarySectionComponent,
-    EventRosterSectionComponent,
-    EventsAttentionSectionComponent,
-  ],
+  imports: [EventsSummarySectionComponent, EventRosterSectionComponent, EventsAttentionSectionComponent],
   templateUrl: './overview-tab.component.html',
 })
 export class OverviewTabComponent {
-  // === Services ===
-  private readonly analyticsService = inject(AnalyticsService);
-
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
-  public readonly selectedPeriod = input<string>('');
   public readonly foundationName = input<string>('');
+  // Accepted from the parent page for API symmetry; the events sections are YTD-scoped and
+  // foundation-scoped, so they are not consumed here.
+  public readonly selectedPeriod = input<string>('');
   public readonly focusProgram = input<MarketingImpactFocusProgram>('all');
-
-  // === WritableSignals ===
-  protected readonly loading = signal(false);
-
-  // === Computed Signals ===
-  protected readonly overviewKpiData: Signal<OverviewKpiData> = this.initOverviewKpiData();
-  protected readonly performanceSummaryKpis: Signal<PerformanceSummaryKpi[]> = this.initPerformanceSummaryKpis();
-  protected readonly summaryTitle: Signal<string> = this.initSummaryTitle();
-  protected readonly summarySubtitle: Signal<string> = this.initSummarySubtitle();
-
-  // === Private Initializers ===
-  private initOverviewKpiData(): Signal<OverviewKpiData> {
-    const slug$ = toObservable(this.foundationSlug);
-    const focus$ = toObservable(this.focusProgram);
-    const period$ = toObservable(this.selectedPeriod);
-
-    return toSignal(
-      combineLatest([slug$, focus$, period$]).pipe(
-        switchMap(([slug, focus, period]) => {
-          if (!slug) {
-            this.loading.set(false);
-            return of({ revenueImpact: null, brandReach: null, emailCtr: null, attribution: null });
-          }
-          this.loading.set(true);
-          const classification = FOCUS_TO_CLASSIFICATION[focus];
-          return forkJoin({
-            revenueImpact: this.analyticsService.getRevenueImpact(slug, classification, period || undefined).pipe(catchError(() => of(null))),
-            // getBrandReach uses pre-computed _30D columns that cannot be period-filtered
-            brandReach: this.analyticsService.getBrandReach(slug, classification).pipe(catchError(() => of(null))),
-            emailCtr: this.analyticsService.getEmailCtr(slug, classification, period || undefined).pipe(catchError(() => of(null))),
-            // Attributed Revenue KPI reports Linear attribution to match the
-            // "Marketing attribution" table below (same source, same model),
-            // not pipeline-won CRM revenue which is a different metric.
-            // No catchError here: getMarketingAttribution already swallows HTTP
-            // errors and emits { channels: [], projects: [] }, which the card
-            // renders as a dash — a component-level handler would be unreachable.
-            attribution: this.analyticsService.getMarketingAttribution(slug, classification, period || undefined),
-          }).pipe(finalize(() => this.loading.set(false)));
-        })
-      ),
-      { initialValue: { revenueImpact: null, brandReach: null, emailCtr: null, attribution: null } }
-    );
-  }
-
-  private initPerformanceSummaryKpis(): Signal<PerformanceSummaryKpi[]> {
-    return computed(() => {
-      const data = this.overviewKpiData();
-      const isMonth = isPeriodMonth(this.selectedPeriod());
-      const changeSuffix: 'MoM' | 'Period' = isMonth ? 'MoM' : 'Period';
-      const cards: PerformanceSummaryKpi[] = [];
-
-      // Attributed Revenue is driven by the attribution response, not revenueImpact
-      // (they are fetched independently and can diverge), so this card is guarded on
-      // data.attribution. An empty/unavailable channel list renders as a dash —
-      // matching the "No attribution data available" state of the table below —
-      // rather than a misleading $0.
-      if (data.attribution) {
-        const channels = data.attribution.channels ?? [];
-        // Linear-attributed revenue from the same source as the "Marketing
-        // attribution" table, so the headline agrees with that table. The
-        // attribution response carries no time dimension, so there is no honest
-        // period delta to show here.
-        const attributedRevenue = channels.reduce((sum, ch) => sum + (ch.linearRevenue ?? 0), 0);
-        cards.push({
-          id: 'attributed-revenue',
-          label: 'Attributed Revenue',
-          icon: 'fa-light fa-dollar-sign',
-          iconClass: 'bg-green-100 text-green-600',
-          value: channels.length ? formatCurrency(attributedRevenue) : '—',
-          momChange: null,
-          momTrend: 'neutral',
-          momTrendClass: 'text-gray-500',
-          yoyChange: null,
-          yoyTrend: 'neutral',
-          yoyTrendClass: 'text-gray-500',
-        });
-      }
-
-      if (data.revenueImpact) {
-        const ri = data.revenueImpact;
-        cards.push({
-          id: 'roas',
-          label: 'Return on Ad Spend',
-          icon: 'fa-light fa-chart-line-up',
-          iconClass: 'bg-blue-100 text-blue-600',
-          value: `${(ri.paidMedia?.roas ?? 0).toFixed(2)}x`,
-          // No MoM delta: paid spend is lumpy and event-driven, so a
-          // month-over-month ROAS swing mostly reflects a change in campaign
-          // volume/mix (e.g. fewer campaigns when events wind down), not a
-          // change in ad efficiency. Showing it as a performance delta
-          // misrepresents a volume shift as a decline.
-          momChange: null,
-          momTrend: 'neutral',
-          momTrendClass: 'text-gray-500',
-          yoyChange: null,
-          yoyTrend: 'neutral',
-          yoyTrendClass: 'text-gray-500',
-        });
-      }
-
-      if (data.brandReach) {
-        const br = data.brandReach;
-        // sessionMomChangePct is 0 both for a genuine flat month AND when there is
-        // no valid comparison (the server needs >= 8 weeks of trend AND a positive
-        // prior-4-week total — it leaves the pct at 0 on a zero prior window to
-        // avoid divide-by-zero). Replicate both server conditions so a 0 is only
-        // shown when it is a real "0.0% MoM"; otherwise suppress the delta.
-        const trend = br.weeklyTrend ?? [];
-        const priorWindowSessions = trend.length >= 8 ? trend.slice(-8, -4).reduce((sum, d) => sum + (d.sessions ?? 0), 0) : 0;
-        const hasComparison = priorWindowSessions > 0;
-        const momPct = hasComparison ? br.sessionMomChangePct : null;
-        cards.push({
-          id: 'web-sessions',
-          label: 'Total Web Sessions',
-          icon: 'fa-light fa-globe',
-          iconClass: 'bg-violet-100 text-violet-600',
-          value: formatNumber(br.totalMonthlySessions),
-          momChange: formatChangePct(momPct, 'MoM'),
-          momTrend: trendDirection(momPct),
-          momTrendClass: trendColorClass(momPct),
-          yoyChange: null,
-          yoyTrend: 'neutral',
-          yoyTrendClass: 'text-gray-500',
-        });
-      }
-
-      if (data.emailCtr) {
-        const ec = data.emailCtr;
-        // No sends in scope means CTR is undefined, not 0% — a 0.00% reads as
-        // poor performance rather than "no sends", so suppress the value in that
-        // case. What "in scope" means depends on the selection: the series is
-        // calendar zero-filled, so for a single-month view only the trailing
-        // (current) month counts, but for a preset range (last-3, YTD) currentCtr
-        // is a period aggregate that is valid if ANY month in the range had sends.
-        const sends = ec.monthlySends ?? [];
-        const lastSends = sends.length > 0 ? sends[sends.length - 1] : undefined;
-        const lastMonthActive = lastSends !== undefined && lastSends > 0;
-        const hasSends = isMonth ? lastMonthActive : sends.some((s) => s > 0);
-        // The MoM delta only applies to the single-month view: momChangePercentage
-        // always compares the trailing two months, so pairing it with a range's
-        // period-aggregate value would place a monthly delta beside a period value
-        // — the exact metric mismatch this refinement removes. Show it only for a
-        // month selection with an active trailing month; suppress it for ranges.
-        const momPct = isMonth && lastMonthActive ? ec.momChangePercentage : null;
-        cards.push({
-          id: 'email-ctr',
-          label: 'Email CTR',
-          icon: 'fa-light fa-envelope-open',
-          iconClass: 'bg-amber-100 text-amber-600',
-          value: hasSends ? `${(ec.currentCtr ?? 0).toFixed(2)}%` : '—',
-          momChange: formatChangePct(momPct, changeSuffix),
-          momTrend: trendDirection(momPct),
-          momTrendClass: trendColorClass(momPct),
-          yoyChange: null,
-          yoyTrend: 'neutral',
-          yoyTrendClass: 'text-gray-500',
-          badge: momPct != null && momPct < 0 ? 'Needs review' : undefined,
-        });
-      }
-
-      return cards;
-    });
-  }
-
-  private initSummaryTitle(): Signal<string> {
-    return computed(() => {
-      const periodValue = this.selectedPeriod();
-      if (!isPeriodMonth(periodValue)) {
-        const resolved = resolvePeriodRange(periodValue);
-        return resolved ? `${resolved.label} performance summary` : 'Performance summary';
-      }
-      const [year, month] = periodValue.split('-').map(Number);
-      if (!year || !month) return 'Performance summary';
-      const monthName = new Date(Date.UTC(year, month - 1, 1)).toLocaleDateString('en-US', { month: 'long', timeZone: 'UTC' });
-      return `${monthName} performance summary`;
-    });
-  }
-
-  private initSummarySubtitle(): Signal<string> {
-    return computed(() => {
-      const periodValue = this.selectedPeriod();
-      if (!isPeriodMonth(periodValue)) {
-        const resolved = resolvePeriodRange(periodValue);
-        const name = this.foundationName();
-        const foundation = name || 'all LF projects';
-        return resolved ? `${resolved.label} · Linear attribution · ${foundation}` : '';
-      }
-      const [year, month] = periodValue.split('-').map(Number);
-      if (!year || !month) return '';
-      const date = new Date(Date.UTC(year, month - 1, 1));
-      const priorMonth = new Date(Date.UTC(date.getUTCFullYear(), date.getUTCMonth() - 1, 1));
-      const priorYear = new Date(Date.UTC(date.getUTCFullYear() - 1, date.getUTCMonth(), 1));
-
-      const momLabel = priorMonth.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
-      const yoyLabel = priorYear.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
-
-      const name = this.foundationName();
-      const foundation = name || 'all LF projects';
-      return `vs. ${momLabel} (MoM) · vs. ${yoyLabel} (YoY) · Linear attribution · ${foundation}`;
-    });
-  }
 }

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -375,9 +375,15 @@ describe('ProjectService — Snowflake-backed marketing reads', () => {
       CFP_STATUS: 'Review Complete',
     };
 
-    // Ordered mock: the event query resolves first, the tier query second.
-    function mockReads(event: unknown[], tiers: unknown[]): void {
-      execute.mockResolvedValueOnce({ rows: event }).mockResolvedValueOnce({ rows: tiers });
+    // Ordered mock for the first three reads (event, tier, channel attribution). getEventDetail
+    // also awaits getEventPacing, which issues two more — defaulted to empty rather than counted,
+    // so adding a query to that path doesn't break these cases.
+    function mockReads(event: unknown[], tiers: unknown[], channels: unknown[] = []): void {
+      execute
+        .mockResolvedValueOnce({ rows: event })
+        .mockResolvedValueOnce({ rows: tiers })
+        .mockResolvedValueOnce({ rows: channels })
+        .mockResolvedValue({ rows: [] });
     }
 
     it('maps the event and its tier breakdown', async () => {
@@ -404,8 +410,13 @@ describe('ProjectService — Snowflake-backed marketing reads', () => {
 
       await service.getEventDetail('evt-1', 'tlf');
 
-      expect(execute).toHaveBeenCalledTimes(2);
-      for (const [sql, binds] of execute.mock.calls) {
+      // Identified by content, not call order: getEventDetail also drives the channel and pacing
+      // reads, and a positional assertion would silently pass if a scoped query were reordered.
+      const scoped = execute.mock.calls.filter(
+        ([sql]) => String(sql).includes('MARKETING_EVENT_REGISTRATIONS r') || String(sql).includes('SPONSORSHIPS_BY_TIER t')
+      );
+      expect(scoped).toHaveLength(2);
+      for (const [sql, binds] of scoped) {
         expect(sql).toContain('slug_resolve');
         expect(binds).toEqual(['tlf', 'evt-1']);
       }
@@ -417,6 +428,31 @@ describe('ProjectService — Snowflake-backed marketing reads', () => {
       mockReads([], []);
 
       await expect(service.getEventDetail('evt-1', 'other-foundation')).resolves.toBeNull();
+    });
+
+    // Same contract as the getSocialReach guard above: a real failure must not be laundered into
+    // a legitimate-looking "no data yet" state. Only an unmaterialized table is unavailable.
+    it('propagates a pacing query failure rather than reporting pacing unavailable', async () => {
+      const failure = new Error('SQL compilation error: invalid identifier FOO');
+      execute
+        .mockResolvedValueOnce({ rows: [eventRow] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockRejectedValue(failure);
+
+      await expect(service.getEventDetail('evt-1', 'tlf')).rejects.toBe(failure);
+    });
+
+    it('reports pacing unavailable when the prediction table is not materialized', async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [eventRow] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockResolvedValueOnce({ rows: [] })
+        .mockRejectedValue(new Error("Object 'MARKETING_EVENT_REGISTRATION_PREDICTIONS' does not exist or not authorized."));
+
+      const result = await service.getEventDetail('evt-1', 'tlf');
+
+      expect(result?.pacing.available).toBe(false);
     });
 
     it('propagates Snowflake failures rather than resolving a partial event', async () => {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -27,9 +27,11 @@ import {
   CreateProjectDocumentRequest,
   EmailCtrResponse,
   EngagedCommunitySizeResponse,
+  EventChannelAttribution,
   EventCompScore,
   EventDetailResponse,
   EventGrowthResponse,
+  EventPacing,
   EventGrowthTopEvent,
   EventRosterResponse,
   EventRosterRow,
@@ -5175,12 +5177,18 @@ export class ProjectService {
       EVENT_ID: string;
       EVENT_NAME: string;
       START_DATE: string;
+      EVENT_IS_PAST: boolean;
+      EVENT_LOCATION: string | null;
+      EVENT_CITY: string | null;
       EVENT_COUNTRY: string | null;
+      EVENT_STATUS: string | null;
       EVENT_URL: string | null;
       REG_ACTUAL: number | null;
       REG_GOAL: number | null;
+      REGREV_GOAL: number | null;
       SPON_GOAL: number | null;
       VS_LY: number | null;
+      CREATED_LAST_YEAR: boolean | null;
       COMP_SCORE: string | null;
       CFP_STATUS: string | null;
     }
@@ -5189,6 +5197,13 @@ export class ProjectService {
       SPONSORSHIP_TIER: string | null;
       REVENUE: number;
       SPONSOR_COUNT: number;
+    }
+
+    interface ChannelRow {
+      CHANNEL: string | null;
+      SESSIONS: number;
+      UNIQUE_VISITORS: number;
+      REVENUE: number;
     }
 
     // Scoped by foundation as well as event id: the id alone carries no ownership, so without the
@@ -5204,12 +5219,18 @@ export class ProjectService {
         r.EVENT_ID,
         r.EVENT_NAME,
         TO_CHAR(r.EVENT_START_DATE, 'YYYY-MM-DD') AS START_DATE,
+        r.EVENT_IS_PAST,
+        r.EVENT_LOCATION,
+        r.EVENT_CITY,
         r.EVENT_COUNTRY,
+        r.EVENT_STATUS,
         r.EVENT_URL,
         r.COUNT_REGISTRATIONS_ALL_TIME AS REG_ACTUAL,
         r.EVENT_REGISTRATIONS_GOAL AS REG_GOAL,
+        r.EVENT_REGISTRATION_REVENUE_GOAL AS REGREV_GOAL,
         r.EVENT_SPONSORSHIP_REVENUE_GOAL AS SPON_GOAL,
         r.PERCENT_COMPARISON_TO_PREV_YEAR AS VS_LY,
+        r.EVENT_CREATED_LAST_YEAR AS CREATED_LAST_YEAR,
         r.COMP_SCORE,
         r.CFP_STATUS
       FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS r
@@ -5241,9 +5262,23 @@ export class ProjectService {
       ORDER BY REVENUE DESC
     `;
 
-    const [eventResult, tierResult] = await Promise.all([
+    // Marketing-channel attribution for this event (rolled up across the monthly rows).
+    const channelQuery = `
+      SELECT
+        CHANNEL,
+        SUM(IFNULL(SESSIONS, 0)) AS SESSIONS,
+        SUM(IFNULL(UNIQUE_VISITORS, 0)) AS UNIQUE_VISITORS,
+        SUM(IFNULL(LINEAR_REVENUE, 0)) AS REVENUE
+      FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATION_ATTRIBUTION
+      WHERE RESOLVED_EVENT_ID = ?
+      GROUP BY CHANNEL
+      ORDER BY SESSIONS DESC
+    `;
+
+    const [eventResult, tierResult, channelResult] = await Promise.all([
       this.snowflakeService.execute<EventRow>(eventQuery, [foundationSlug, eventId]),
       this.snowflakeService.execute<TierRow>(tierQuery, [foundationSlug, eventId]),
+      this.snowflakeService.execute<ChannelRow>(channelQuery, [eventId]),
     ]);
 
     const row = eventResult.rows?.[0];
@@ -5258,18 +5293,34 @@ export class ProjectService {
     };
 
     const sponsorshipActual = tierResult.rows.reduce((sum, t) => sum + (t.REVENUE ?? 0), 0);
+    const totalSessions = channelResult.rows.reduce((sum, ch) => sum + (ch.SESSIONS ?? 0), 0);
+
+    const channels: EventChannelAttribution[] = channelResult.rows.map((ch) => ({
+      channel: ch.CHANNEL ?? 'Unknown',
+      sessions: ch.SESSIONS ?? 0,
+      uniqueVisitors: ch.UNIQUE_VISITORS ?? 0,
+      revenue: ch.REVENUE ?? 0,
+      sharePercent: totalSessions > 0 ? Math.round(((ch.SESSIONS ?? 0) / totalSessions) * 1000) / 10 : 0,
+    }));
 
     return {
       eventId: row.EVENT_ID,
       eventName: row.EVENT_NAME,
       startDate: row.START_DATE,
+      isPast: row.EVENT_IS_PAST,
+      location: row.EVENT_LOCATION ?? '',
+      city: row.EVENT_CITY ?? '',
       country: row.EVENT_COUNTRY ?? '',
+      status: row.EVENT_STATUS ?? '',
       // Same normalization as the roster read above: a scheme-less warehouse URL bound to [href]
       // would resolve as a relative LFX One path rather than failing safely.
       eventUrl: normalizeToUrl(row.EVENT_URL ?? '') ?? '',
       registrations: { actual: row.REG_ACTUAL ?? 0, goal: row.REG_GOAL ?? 0 },
+      // No per-event registration-revenue actual is modeled yet (only the goal).
+      registrationRevenue: { actual: null, goal: row.REGREV_GOAL ?? 0 },
       sponsorshipRevenue: { actual: sponsorshipActual, goal: row.SPON_GOAL ?? 0 },
       vsLastYear: row.VS_LY,
+      hasPriorYear: row.CREATED_LAST_YEAR === true,
       compScore: normalizeScore(row.COMP_SCORE),
       cfpStatus: row.CFP_STATUS ?? '',
       sponsorshipTiers: tierResult.rows.map((t) => ({
@@ -5277,6 +5328,8 @@ export class ProjectService {
         revenue: t.REVENUE ?? 0,
         sponsorCount: t.SPONSOR_COUNT ?? 0,
       })),
+      channels,
+      pacing: await this.getEventPacing(eventId),
     };
   }
 
@@ -7497,5 +7550,115 @@ export class ProjectService {
     const coordinatorChecks: AccessCheckRequest[] = nonWriters.map((p) => ({ resource: 'project', id: p.uid, access: 'meeting_coordinator' }));
     const coordinatorResults = await this.accessCheckService.checkAccess(req, coordinatorChecks);
     return writerChecked.filter((p) => p.writer === true || coordinatorResults.get(`${p.uid}#meeting_coordinator`) === true);
+  }
+
+  /**
+   * Get the per-event registration-pacing summary + daily curve from the prediction models
+   * (MARKETING_EVENT_REGISTRATION_PREDICTIONS + _DRILLDOWN). These are mirrored from PCC and may
+   * not exist yet; any failure (missing table, no rows) resolves to an unavailable pacing block
+   * so the drawer degrades to its placeholder + PCC link rather than erroring.
+   */
+  private async getEventPacing(eventId: string): Promise<EventPacing> {
+    const unavailable: EventPacing = {
+      available: false,
+      daysLeft: null,
+      current: null,
+      priorYear: null,
+      predictedAvg: null,
+      predictedLow: null,
+      predictedHigh: null,
+      points: [],
+    };
+
+    interface HeadRow {
+      DAYS_LEFT: number | null;
+      CURRENT: number | null;
+      PRIOR: number | null;
+      PRED_AVG: number | null;
+      PRED_LOW: number | null;
+      PRED_HIGH: number | null;
+    }
+    interface PointRow {
+      DAYS_TO_EVENT: number;
+      CURRENT: number | null;
+      PRIOR: number | null;
+      PRED_AVG: number | null;
+      PRED_LOW: number | null;
+      PRED_HIGH: number | null;
+    }
+
+    const headQuery = `
+      SELECT
+        DAYS_LEFT_FROM_YESTERDAY AS DAYS_LEFT,
+        FINAL_CURRENT_CUMULATIVE_REGISTRATIONS AS CURRENT,
+        FINAL_PRIOR_CUMULATIVE_REGISTRATIONS AS PRIOR,
+        FINAL_CUMULATIVE_AVG_PREDICTED_REGISTRATIONS AS PRED_AVG,
+        FINAL_CUMULATIVE_LOW_PREDICTED_REGISTRATIONS AS PRED_LOW,
+        FINAL_CUMULATIVE_HIGH_PREDICTED_REGISTRATIONS AS PRED_HIGH
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATION_PREDICTIONS
+      WHERE EVENT_ID = ?
+      LIMIT 1
+    `;
+
+    const pointsQuery = `
+      SELECT
+        DAYS_TO_EVENT,
+        CURRENT_EVENT_CUMULATIVE_REGISTRATIONS AS CURRENT,
+        PRIOR_EVENT_CUMULATIVE_REGISTRATIONS AS PRIOR,
+        CUMULATIVE_AVG_PREDICTED_REGISTRATIONS AS PRED_AVG,
+        CUMULATIVE_LOW_PREDICTED_REGISTRATIONS AS PRED_LOW,
+        CUMULATIVE_HIGH_PREDICTED_REGISTRATIONS AS PRED_HIGH
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATION_PREDICTIONS_DRILLDOWN
+      WHERE EVENT_ID = ?
+      ORDER BY DAYS_TO_EVENT DESC
+    `;
+
+    try {
+      const [headResult, pointsResult] = await Promise.all([
+        this.snowflakeService.execute<HeadRow>(headQuery, [eventId]),
+        this.snowflakeService.execute<PointRow>(pointsQuery, [eventId]),
+      ]);
+
+      const head = headResult.rows?.[0];
+      if (!head) return unavailable;
+
+      return {
+        available: true,
+        daysLeft: head.DAYS_LEFT,
+        current: head.CURRENT,
+        priorYear: head.PRIOR,
+        predictedAvg: head.PRED_AVG,
+        predictedLow: head.PRED_LOW,
+        predictedHigh: head.PRED_HIGH,
+        points: pointsResult.rows.map((p) => ({
+          daysToEvent: p.DAYS_TO_EVENT,
+          current: p.CURRENT,
+          priorYear: p.PRIOR,
+          predictedAvg: p.PRED_AVG,
+          predictedLow: p.PRED_LOW,
+          predictedHigh: p.PRED_HIGH,
+        })),
+      };
+    } catch (error) {
+      // Narrowed to the missing-table case only. project.service.spec.ts regression-tests the
+      // opposite contract for getSocialReach: swallowing a Snowflake failure and resolving a
+      // defaults object reached the dashboard as a 200 and rendered as a genuine measurement.
+      // A timeout, a permission error or a renamed column must surface rather than read as
+      // "no pacing data yet"; only an unmaterialized table is a legitimate unavailable state.
+      const message = error instanceof Error ? error.message : String(error);
+      const isMissingTable = /does not exist or not authorized|Object .* does not exist/i.test(message);
+      if (!isMissingTable) {
+        logger.warning(undefined, 'get_event_pacing', 'Pacing query failed, propagating', {
+          event_id: eventId,
+          error: message,
+        });
+        throw error;
+      }
+      logger.warning(undefined, 'get_event_pacing', 'Pacing prediction tables not materialized yet', {
+        event_id: eventId,
+        error: message,
+      });
+      return unavailable;
+    }
   }
 }

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -683,6 +683,51 @@ export interface EventSponsorshipTier {
   sponsorCount: number;
 }
 
+/** One marketing-channel row for an event: how registrations/traffic are attributed. */
+export interface EventChannelAttribution {
+  /** Consolidated channel label (Organic Search, Email / HubSpot, Social, …). */
+  channel: string;
+  sessions: number;
+  uniqueVisitors: number;
+  /** Linear-attributed revenue in dollars. */
+  revenue: number;
+  /** Share of the event's total sessions, 0–100. */
+  sharePercent: number;
+}
+
+/**
+ * One point on the registration-pacing curve, keyed by days-to-event (x-axis).
+ * Mirrors PCC's EventPredictionDrilldown grain.
+ */
+export interface EventPacingPoint {
+  daysToEvent: number;
+  /** Current-year cumulative registrations (null for future days not yet reached). */
+  current: number | null;
+  /** Prior-year cumulative registrations aligned by days-to-event. */
+  priorYear: number | null;
+  predictedAvg: number | null;
+  predictedLow: number | null;
+  predictedHigh: number | null;
+}
+
+/**
+ * Per-event registration-pacing summary + daily curve. Populated once the pacing prediction
+ * models land (MARKETING_EVENT_REGISTRATION_PREDICTIONS[_DRILLDOWN]); until then `available` is
+ * false, `points` is empty, and the UI shows a placeholder that links to PCC. Headline numbers
+ * mirror PCC's EventPrediction; `points` mirrors EventPredictionDrilldown.
+ */
+export interface EventPacing {
+  available: boolean;
+  daysLeft: number | null;
+  current: number | null;
+  priorYear: number | null;
+  predictedAvg: number | null;
+  predictedLow: number | null;
+  predictedHigh: number | null;
+  /** The day-by-day cumulative curve; empty until the drilldown model lands. */
+  points: EventPacingPoint[];
+}
+
 /**
  * Per-event detail for the roster drawer, sourced from
  * ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS (event meta + goals) and
@@ -693,15 +738,27 @@ export interface EventDetailResponse {
   eventId: string;
   eventName: string;
   startDate: string;
+  isPast: boolean;
+  /** Full venue string, e.g. "InterContinental Grand Seoul Parnas"; '' when unknown. */
+  location: string;
+  city: string;
   country: string;
+  /** Event lifecycle status from the source (Active, Archived, …). */
+  status: string;
   eventUrl: string;
   registrations: { actual: number; goal: number };
+  /** Registration revenue; actual is null until the source exposes it (goal is known). */
+  registrationRevenue: { actual: number | null; goal: number };
   sponsorshipRevenue: { actual: number; goal: number };
   /** Ratio of this year's registrations to last year's (1.0 = on par); null when no baseline. */
   vsLastYear: number | null;
+  /** Whether a prior-year edition of this event exists to compare against. */
+  hasPriorYear: boolean;
   compScore: EventCompScore;
   cfpStatus: string;
   sponsorshipTiers: EventSponsorshipTier[];
+  channels: EventChannelAttribution[];
+  pacing: EventPacing;
 }
 
 /**


### PR DESCRIPTION
Expands the per-event drawer into a full deep-dive with the registration pacing chart and supporting breakdowns.

**Stacked on** `feat/LFXV2-2768-events-attention`.

LFXV2-2768