### PR TITLE
feat(dashboards): scope events summary and roster to the period

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/event-roster-section/event-roster-section.component.ts
@@ -24,6 +24,7 @@ export class EventRosterSectionComponent {
 
   // === Inputs ===
   public readonly foundationSlug = input<string | undefined>();
+  public readonly selectedPeriod = input<string>('');
 
   // === Controls ===
   protected readonly search = new FormControl('', { nonNullable: true });
@@ -64,16 +65,17 @@ export class EventRosterSectionComponent {
   private initRoster(): Signal<EventRosterResponse> {
     const slug$ = toObservable(this.foundationSlug);
     const past$ = toObservable(this.includePast);
+    const period$ = toObservable(this.selectedPeriod);
 
     return toSignal(
-      combineLatest([slug$, past$]).pipe(
-        switchMap(([slug, includePast]) => {
+      combineLatest([slug$, past$, period$]).pipe(
+        switchMap(([slug, includePast, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of({ projectId: '', events: [] });
           }
           this.loading.set(true);
-          return this.analyticsService.getEventRoster(slug, includePast).pipe(finalize(() => this.loading.set(false)));
+          return this.analyticsService.getEventRoster(slug, includePast, period || undefined).pipe(finalize(() => this.loading.set(false)));
         })
       ),
       { initialValue: { projectId: '', events: [] } }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-summary-section/events-summary-section.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/events-summary-section/events-summary-section.component.ts
@@ -66,17 +66,19 @@ export class EventsSummarySectionComponent {
 
     return toSignal(
       combineLatest([slug$, period$]).pipe(
-        switchMap(([slug]) => {
+        switchMap(([slug, period]) => {
           if (!slug) {
             this.loading.set(false);
             return of(null);
           }
           this.loading.set(true);
-          // All 7 tiles come from a single YTD-scoped endpoint over
-          // PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW + MARKETING_EVENT_SPONSORSHIPS. Each
-          // metric carries its value and a YoY change fraction (null when no prior baseline);
-          // a null response falls the whole block back to dashes.
-          return this.analyticsService.getEventsOverviewSummary(slug).pipe(
+          // The default (YTD/trailing) period reads all 7 tiles from
+          // PLATINUM_LFX_ONE.MARKETING_EVENT_OVERVIEW + MARKETING_EVENT_SPONSORSHIPS. A single
+          // month re-aggregates events/registrations/speakers per event instead and returns null
+          // for the four metrics that only exist as YTD rollups. Each metric carries its value
+          // and a YoY change fraction (null when no prior baseline); a null response falls the
+          // whole block back to dashes.
+          return this.analyticsService.getEventsOverviewSummary(slug, period || undefined).pipe(
             map((data) =>
               data === null
                 ? null
@@ -103,8 +105,10 @@ export class EventsSummarySectionComponent {
       const data = this.summary();
       return EventsSummarySectionComponent.tiles.map((tile) => {
         const metric = data ? data[tile.key] : null;
+        // A null value means the metric isn't derivable for the selected period (the YTD-only
+        // rollups under a month filter), so it stays a dash rather than rendering as zero.
         let value = '—';
-        if (metric) {
+        if (metric && metric.value !== null) {
           value = tile.format === 'currency' ? formatCurrency(metric.value) : formatNumber(metric.value);
         }
 

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/overview-tab/overview-tab.component.html
@@ -12,5 +12,5 @@
     [selectedPeriod]="selectedPeriod()"
     data-testid="overview-tab-events-summary" />
 
-  <lfx-event-roster-section [foundationSlug]="foundationSlug()" data-testid="overview-tab-event-roster" />
+  <lfx-event-roster-section [foundationSlug]="foundationSlug()" [selectedPeriod]="selectedPeriod()" data-testid="overview-tab-event-roster" />
 </div>

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1147,9 +1147,11 @@ export class AnalyticsService {
    * Foundation-wide Events Summary tiles for the Marketing Impact Overview tab.
    * Emits null on error so the tiles fall back to dashes rather than measured zeros.
    */
-  public getEventsOverviewSummary(foundationSlug: string): Observable<EventsOverviewSummaryResponse | null> {
+  public getEventsOverviewSummary(foundationSlug: string, period?: string): Observable<EventsOverviewSummaryResponse | null> {
     return this.http
-      .get<EventsOverviewSummaryResponse>('/api/analytics/events-overview-summary', { params: { foundationSlug } })
+      .get<EventsOverviewSummaryResponse>('/api/analytics/events-overview-summary', {
+        params: this.buildFoundationParams(foundationSlug, undefined, period),
+      })
       .pipe(catchError(() => of(null)));
   }
 
@@ -1157,10 +1159,12 @@ export class AnalyticsService {
    * Foundation event roster (upcoming by default; pass includePast for the full history).
    * Emits an empty roster on error so the table shows its empty state rather than breaking.
    */
-  public getEventRoster(foundationSlug: string, includePast = false): Observable<EventRosterResponse> {
-    const key = `${foundationSlug}|${includePast}`;
+  public getEventRoster(foundationSlug: string, includePast = false, period?: string): Observable<EventRosterResponse> {
+    // Every argument that changes the response belongs in the key — the period included, or a
+    // period switch would replay the previous period's roster.
+    const key = `${foundationSlug}|${includePast}|${period ?? ''}`;
     if (!this.eventRosterCache.has(key)) {
-      const params: Record<string, string> = { foundationSlug };
+      const params = this.buildFoundationParams(foundationSlug, undefined, period);
       if (includePast) {
         params['includePast'] = 'true';
       }

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -2763,11 +2763,13 @@ export class AnalyticsController {
         });
       }
 
-      const response = await this.projectService.getEventsOverviewSummary(foundationSlug);
+      const period = getValidatedPeriod(req, 'get_events_overview_summary');
+      const response = await this.projectService.getEventsOverviewSummary(foundationSlug, period);
 
       logger.success(req, 'get_events_overview_summary', startTime, {
         foundation_slug: foundationSlug,
         project_id: response.projectId,
+        period: period?.label,
       });
 
       res.json(response);
@@ -2802,11 +2804,13 @@ export class AnalyticsController {
 
       const includePast = getStringQueryParam(req, 'includePast') === 'true';
 
-      const response = await this.projectService.getEventRoster(foundationSlug, includePast);
+      const period = getValidatedPeriod(req, 'get_event_roster');
+      const response = await this.projectService.getEventRoster(foundationSlug, includePast, period);
 
       logger.success(req, 'get_event_roster', startTime, {
         foundation_slug: foundationSlug,
         include_past: includePast,
+        period: period?.label,
         event_count: response.events.length,
       });
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -4957,13 +4957,30 @@ export class ProjectService {
    * for the sponsorship dollar total. The foundation rollup (children included) is baked into
    * the project spine, so a single row keyed on the resolved PROJECT_ID covers the foundation.
    *
-   * Only YTD is modeled here (the table has no monthly grain); the *_PERCENT_CHANGE_YTD columns
-   * carry the YoY deltas as fractions (0.52 = +52%), surfaced unchanged as changeFraction.
+   * The *_PERCENT_CHANGE_YTD columns carry the YoY deltas as fractions (0.52 = +52%), surfaced
+   * unchanged as changeFraction.
+   *
+   * MARKETING_EVENT_OVERVIEW has no monthly grain, so a month-scoped period takes a different
+   * path: events, registrations, and speakers are re-aggregated per event from
+   * MARKETING_EVENT_REGISTRATIONS (which carries EVENT_START_DATE), and the metrics with no
+   * per-event column — attendees, countries, organizations, sponsorship — come back null so the
+   * UI dashes them instead of labelling a YTD rollup as a single month.
    */
-  public async getEventsOverviewSummary(foundationSlug: string): Promise<EventsOverviewSummaryResponse> {
+  public async getEventsOverviewSummary(foundationSlug: string, period?: ResolvedPeriodRange): Promise<EventsOverviewSummaryResponse> {
     logger.debug(undefined, 'get_events_overview_summary', 'Fetching events overview summary from Snowflake', {
       foundation_slug: foundationSlug,
+      period: period?.label,
     });
+
+    // Only a month re-aggregates. YTD and trailing ranges fall through to MARKETING_EVENT_OVERVIEW,
+    // whose columns are pre-aggregated year-to-date rollups with no date grain to filter on — a
+    // trailing range cannot narrow them. Re-aggregating trailing from MARKETING_EVENT_REGISTRATIONS
+    // would scope events/registrations/speakers but drop attendees, countries, organizations, and
+    // sponsorship to dashes, and 'last-6' is the default period, so the default view would lose four
+    // of seven tiles. Serving the YTD rollup is the better trade until those metrics have a date grain.
+    if (period && period.type === 'month') {
+      return this.getEventsOverviewSummaryForMonth(foundationSlug, period);
+    }
 
     interface OverviewRow {
       PROJECT_ID: string;
@@ -5062,11 +5079,16 @@ export class ProjectService {
    * joined to sponsorship actuals aggregated from MARKETING_EVENT_SPONSORSHIPS_BY_TIER. A goal
    * of 0 means "no goal required" for that event (the UI renders no progress bar). Defaults to
    * upcoming events only; pass includePast to return the full history.
+   *
+   * When a period is supplied the roster is scoped to events *starting* inside it, so the
+   * dashboard's month selector narrows this list the same way it narrows the paid and email
+   * sections. Without one it falls back to the dashboard's default month range.
    */
-  public async getEventRoster(foundationSlug: string, includePast = false): Promise<EventRosterResponse> {
+  public async getEventRoster(foundationSlug: string, includePast = false, period?: ResolvedPeriodRange): Promise<EventRosterResponse> {
     logger.debug(undefined, 'get_event_roster', 'Fetching event roster from Snowflake', {
       foundation_slug: foundationSlug,
       include_past: includePast,
+      period: period?.label,
     });
 
     interface RosterRow {
@@ -5088,6 +5110,16 @@ export class ProjectService {
     }
 
     const pastFilter = includePast ? '' : 'AND r.EVENT_IS_PAST = FALSE';
+
+    // The period only scopes history. Every month the picker offers is already over, so applying
+    // a month range to the upcoming-events view (EVENT_IS_PAST = FALSE) could only ever return
+    // nothing — upcoming events are forward-looking by definition and aren't "in" a past month.
+    // Narrowing therefore applies solely when the caller asked for past events.
+    // Half-open range so an event starting on the first of the next month belongs to that month.
+    // Binds come after the slug because slug_resolve holds the first placeholder.
+    const applyPeriod = Boolean(period) && includePast;
+    const periodFilter = applyPeriod ? 'AND r.EVENT_START_DATE >= TO_DATE(?) AND r.EVENT_START_DATE < TO_DATE(?)' : '';
+    const periodParams = applyPeriod && period ? [period.startDate, period.endDate] : [];
 
     const query = `
       WITH slug_resolve AS (
@@ -5119,11 +5151,11 @@ export class ProjectService {
       FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS r
       INNER JOIN slug_resolve sr ON r.PROJECT_ID = sr.project_id
       LEFT JOIN sponsorship sp ON r.EVENT_ID = sp.EVENT_ID
-      WHERE 1 = 1 ${pastFilter}
+      WHERE 1 = 1 ${pastFilter} ${periodFilter}
       ORDER BY r.EVENT_START_DATE
     `;
 
-    const result = await this.snowflakeService.execute<RosterRow>(query, [foundationSlug]);
+    const result = await this.snowflakeService.execute<RosterRow>(query, [foundationSlug, ...periodParams]);
 
     const normalizeScore = (score: string | null): EventCompScore => {
       const s = (score ?? '').toLowerCase();
@@ -7513,6 +7545,59 @@ export class ProjectService {
     const coordinatorChecks: AccessCheckRequest[] = nonWriters.map((p) => ({ resource: 'project', id: p.uid, access: 'meeting_coordinator' }));
     const coordinatorResults = await this.accessCheckService.checkAccess(req, coordinatorChecks);
     return writerChecked.filter((p) => p.writer === true || coordinatorResults.get(`${p.uid}#meeting_coordinator`) === true);
+  }
+
+  /**
+   * Month-scoped Events Summary, re-aggregated from MARKETING_EVENT_REGISTRATIONS (one row per
+   * event, carrying EVENT_START_DATE) for events starting inside the month.
+   *
+   * Only the three metrics with a per-event column are derivable this way. Attendees, countries,
+   * organizations, and sponsorship revenue exist solely as pre-aggregated YTD rollups on
+   * MARKETING_EVENT_OVERVIEW / MARKETING_EVENT_SPONSORSHIPS and have no monthly grain anywhere
+   * in the Platinum layer, so they return null. There is likewise no monthly YoY baseline
+   * modeled, so every changeFraction is null.
+   */
+  private async getEventsOverviewSummaryForMonth(foundationSlug: string, period: ResolvedPeriodRange): Promise<EventsOverviewSummaryResponse> {
+    interface MonthRow {
+      PROJECT_ID: string;
+      EVENT_COUNT: number;
+      REGISTRATIONS_COUNT: number;
+      SPEAKERS_COUNT: number;
+    }
+
+    // Speakers uses accepted proposals — a nominated-but-unaccepted proposal is not a speaker.
+    const query = `
+      WITH slug_resolve AS (
+        SELECT DISTINCT project_id
+        FROM ANALYTICS.PLATINUM.ENGAGEMENT_SCORES_BY_CLASSIFICATION
+        WHERE project_slug = ?
+      )
+      SELECT
+        MAX(r.PROJECT_ID) AS PROJECT_ID,
+        COUNT(DISTINCT r.EVENT_ID) AS EVENT_COUNT,
+        IFNULL(SUM(r.COUNT_REGISTRATIONS_ALL_TIME), 0) AS REGISTRATIONS_COUNT,
+        IFNULL(SUM(r.ACCEPTED_SPEAKER_PROPOSALS_ALL_TIME), 0) AS SPEAKERS_COUNT
+      FROM ANALYTICS.PLATINUM_LFX_ONE.MARKETING_EVENT_REGISTRATIONS r
+      INNER JOIN slug_resolve sr ON r.PROJECT_ID = sr.project_id
+      WHERE r.EVENT_START_DATE >= TO_DATE(?)
+        AND r.EVENT_START_DATE < TO_DATE(?)
+    `;
+
+    const result = await this.snowflakeService.execute<MonthRow>(query, [foundationSlug, period.startDate, period.endDate]);
+    const row = result.rows?.[0];
+
+    const unavailable: EventsOverviewMetric = { value: null, changeFraction: null };
+
+    return {
+      projectId: row?.PROJECT_ID ?? '',
+      events: { value: row?.EVENT_COUNT ?? 0, changeFraction: null },
+      registrations: { value: row?.REGISTRATIONS_COUNT ?? 0, changeFraction: null },
+      speakers: { value: row?.SPEAKERS_COUNT ?? 0, changeFraction: null },
+      attendees: unavailable,
+      countries: unavailable,
+      organizations: unavailable,
+      sponsorship: unavailable,
+    };
   }
 
   /**

--- a/packages/shared/src/interfaces/dashboard-metric.interface.ts
+++ b/packages/shared/src/interfaces/dashboard-metric.interface.ts
@@ -636,7 +636,13 @@ export interface EventsSummaryResponse {
  * there is no prior-period baseline to compare against.
  */
 export interface EventsOverviewMetric {
-  value: number;
+  /**
+   * The metric's value, or null when it isn't derivable for the requested period. Attendee,
+   * country, organization, and sponsorship counts only exist as pre-aggregated YTD rollups in
+   * Snowflake, so a month-scoped request returns null for them rather than passing off a
+   * year-to-date figure as a monthly one.
+   */
+  value: number | null;
   changeFraction: number | null;
 }
 


### PR DESCRIPTION
Scopes the events summary and roster to the picker's selected period. A month-grain request re-aggregates from `MARKETING_EVENT_REGISTRATIONS`; the four metrics that only exist as YTD rollups return null and render as a dash rather than passing off a year-to-date figure as a monthly one.

The period narrows the roster only for past events — upcoming events are forward-looking, so a past month range could only ever return nothing.

**Stacked on** `feat/LFXV2-2768-campaign-impact-shell`.

LFXV2-2768