### PR TITLE
feat(dashboards): scope email sends to period and add send date

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -69,8 +69,15 @@
       </div>
 
       @if (hasTopCampaigns()) {
-        <!-- Unbounded row count — scrolls within the card so the page doesn't grow without limit. -->
-        <div class="flex max-h-[32rem] flex-col gap-0 overflow-y-auto" role="table" aria-label="Email sends" data-testid="email-campaigns-table">
+        <!-- Unbounded row count — scrolls within the card so the page doesn't grow without limit.
+             tabindex="0" so keyboard-only users can focus the region and scroll to the rows below
+             the fold; without it the overflow is reachable by pointer only. -->
+        <div
+          class="flex max-h-[32rem] flex-col gap-0 overflow-y-auto focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-500"
+          tabindex="0"
+          role="table"
+          aria-label="Email sends"
+          data-testid="email-campaigns-table">
           <!-- Table header -->
           <div class="sticky top-0 z-10 flex items-center gap-3 border-b border-gray-200 bg-white pb-2" role="row">
             <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGN</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -61,16 +61,21 @@
       }
     </div>
 
-    <!-- Top campaigns table -->
+    <!-- Email sends table -->
     <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-5" data-testid="email-top-campaigns">
-      <h4 class="text-sm font-semibold text-gray-900">Top campaigns by sends</h4>
+      <div class="flex items-baseline justify-between gap-3">
+        <h4 class="text-sm font-semibold text-gray-900">Email sends</h4>
+        <span class="text-[11px] text-gray-500" data-testid="email-campaigns-count">{{ topCampaignsCountLabel() }}</span>
+      </div>
 
       @if (hasTopCampaigns()) {
-        <div class="flex flex-col gap-0" role="table" aria-label="Top campaigns by sends" data-testid="email-campaigns-table">
+        <!-- Unbounded row count — scrolls within the card so the page doesn't grow without limit. -->
+        <div class="flex max-h-[32rem] flex-col gap-0 overflow-y-auto" role="table" aria-label="Email sends" data-testid="email-campaigns-table">
           <!-- Table header -->
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+          <div class="sticky top-0 z-10 flex items-center gap-3 border-b border-gray-200 bg-white pb-2" role="row">
             <span class="flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">CAMPAIGN</span>
             <span class="w-24 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">TYPE</span>
+            <span class="w-24 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SEND DATE</span>
             <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SENDS</span>
             <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPENS</span>
             <span class="w-20 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">OPEN RATE</span>
@@ -78,10 +83,11 @@
           </div>
 
           <!-- Rows -->
-          @for (row of topCampaigns(); track row.type + '|' + row.name; let idx = $index) {
+          @for (row of topCampaigns(); track row.type + '|' + row.name + '|' + row.sendDate; let idx = $index) {
             <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + idx">
-              <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell">{{ row.name }}</span>
+              <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell" [title]="row.name">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500" role="cell">{{ row.type }}</span>
+              <span class="w-24 text-xs text-gray-500" role="cell">{{ row.sendDate }}</span>
               <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
               <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
               <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>
@@ -91,7 +97,7 @@
         </div>
       } @else {
         <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="email-campaigns-empty">
-          <p class="text-sm text-gray-500">No campaign data available.</p>
+          <p class="text-sm text-gray-500">No email sends in this period.</p>
         </div>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.html
@@ -94,7 +94,9 @@
             <div class="flex items-center gap-3 border-b border-gray-100 py-2.5" role="row" [attr.data-testid]="'email-campaign-row-' + idx">
               <span class="flex-1 truncate text-xs font-medium text-gray-700" role="cell" [title]="row.name">{{ row.name }}</span>
               <span class="w-24 truncate text-[11px] text-gray-500" role="cell">{{ row.type }}</span>
-              <span class="w-24 text-xs text-gray-500" role="cell">{{ row.sendDate }}</span>
+              <!-- An em dash, not the raw value: sendDate is null for source rows with no usable
+                   publish date, and binding it directly renders the string "null". -->
+              <span class="w-24 text-xs text-gray-500" role="cell">{{ row.sendDate || '—' }}</span>
               <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.sends }}</span>
               <span class="w-20 text-right text-xs text-gray-900" role="cell">{{ row.opens }}</span>
               <span class="w-20 text-right text-xs text-gray-500" role="cell">{{ row.openRate }}</span>

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -195,7 +195,9 @@ export class EmailTabComponent {
             // Codepoint comparison, not localeCompare: these are opaque YYYY-MM-DD identifiers,
             // and a locale-sensitive collation could order them differently on the server than in
             // the browser — which would make the SSR-rendered list reshuffle on hydration.
-            return b.sendDate < a.sendDate ? -1 : b.sendDate > a.sendDate ? 1 : 0;
+            if (b.sendDate < a.sendDate) return -1;
+            if (b.sendDate > a.sendDate) return 1;
+            return 0;
           }
           return b.sends - a.sends;
         })

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -3,7 +3,7 @@
 
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { computeMomPct, formatChangePct, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import { computeMomPct, formatChangePct, formatNumber, formatPercent, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
 import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
@@ -38,6 +38,10 @@ export class EmailTabComponent {
   protected readonly hasEmailTypes = computed(() => this.emailTypeRows().length > 0);
   protected readonly topCampaigns: Signal<TopCampaignRow[]> = this.initTopCampaigns();
   protected readonly hasTopCampaigns = computed(() => this.topCampaigns().length > 0);
+  protected readonly topCampaignsCountLabel = computed(() => {
+    const count = this.topCampaigns().length;
+    return `${formatNumber(count)} ${count === 1 ? 'send' : 'sends'}`;
+  });
 
   // === Private Initializers ===
   private initEmailData(): Signal<EmailCtrResponse | null> {
@@ -144,7 +148,7 @@ export class EmailTabComponent {
           label: 'Click-Through Rate',
           icon: 'fa-light fa-arrow-pointer',
           iconClass: 'bg-violet-100 text-violet-600',
-          value: `${(data.currentCtr ?? 0).toFixed(2)}%`,
+          value: `${formatPercent(data.currentCtr ?? 0)}%`,
           momChange: formatChangePct(changePct, 'MoM'),
           momTrend: trendDirection(changePct),
           momTrendClass: trendColorClass(changePct),
@@ -169,7 +173,7 @@ export class EmailTabComponent {
           sends: formatNumber(et.totalSends),
           opens: formatNumber(et.totalOpens),
           openRate: `${et.openRate.toFixed(1)}%`,
-          ctr: `${et.ctr.toFixed(2)}%`,
+          ctr: `${formatPercent(et.ctr)}%`,
         })
       );
     });
@@ -180,20 +184,41 @@ export class EmailTabComponent {
       const data = this.emailData();
       if (!data?.emailTypeBreakdown?.length) return [];
 
+      // Every send in the selected period, newest first — deliberately uncapped so the table is a
+      // complete listing rather than a top-N. Undated rows sort last so they can't head the table.
       const allCampaigns = data.emailTypeBreakdown.flatMap((et) => et.campaigns ?? []);
       return allCampaigns
-        .sort((a, b) => b.sends - a.sends)
-        .slice(0, 5)
+        .sort((a, b) => {
+          if (a.sendDate !== b.sendDate) {
+            if (!a.sendDate) return 1;
+            if (!b.sendDate) return -1;
+            return b.sendDate.localeCompare(a.sendDate);
+          }
+          return b.sends - a.sends;
+        })
         .map(
           (c): TopCampaignRow => ({
             name: c.campaignName,
             type: c.emailType,
+            sendDate: c.sendDate ? this.formatSendDate(c.sendDate) : '—',
             sends: formatNumber(c.sends),
             opens: formatNumber(c.opens),
             openRate: `${c.openRate.toFixed(1)}%`,
-            ctr: `${c.ctr.toFixed(2)}%`,
+            ctr: `${formatPercent(c.ctr)}%`,
           })
         );
+    });
+  }
+
+  /** Formats a YYYY-MM-DD send date as "Jul 14, 2026", parsing parts explicitly to avoid TZ drift. */
+  private formatSendDate(iso: string): string {
+    const [year, month, day] = iso.split('-').map(Number);
+    if (!year || !month || !day) return iso;
+    return new Date(Date.UTC(year, month - 1, day)).toLocaleDateString('en-US', {
+      month: 'short',
+      day: 'numeric',
+      year: 'numeric',
+      timeZone: 'UTC',
     });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/email-tab/email-tab.component.ts
@@ -192,7 +192,10 @@ export class EmailTabComponent {
           if (a.sendDate !== b.sendDate) {
             if (!a.sendDate) return 1;
             if (!b.sendDate) return -1;
-            return b.sendDate.localeCompare(a.sendDate);
+            // Codepoint comparison, not localeCompare: these are opaque YYYY-MM-DD identifiers,
+            // and a locale-sensitive collation could order them differently on the server than in
+            // the browser — which would make the SSR-rendered list reshuffle on hydration.
+            return b.sendDate < a.sendDate ? -1 : b.sendDate > a.sendDate ? 1 : 0;
           }
           return b.sends - a.sends;
         })

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2890,6 +2890,8 @@ export interface EmailCtrCampaignGroup {
 export interface EmailCampaignPerformance {
   campaignName: string;
   emailType: string;
+  /** Day-level publish/send date as YYYY-MM-DD, or null when the source row carries no usable date. */
+  sendDate: string | null;
   sends: number;
   opens: number;
   clicks: number;

--- a/packages/shared/src/interfaces/marketing-impact.interface.ts
+++ b/packages/shared/src/interfaces/marketing-impact.interface.ts
@@ -213,10 +213,12 @@ export interface EmailTypeRow {
   ctr: string;
 }
 
-/** View-model row for the top campaigns table. */
+/** View-model row for the email sends table. */
 export interface TopCampaignRow {
   name: string;
   type: string;
+  /** Formatted send date (e.g. "Jul 14, 2026"), or an em dash when the source row has no date. */
+  sendDate: string;
   sends: string;
   opens: string;
   openRate: string;

--- a/packages/shared/src/utils/marketing-impact.utils.ts
+++ b/packages/shared/src/utils/marketing-impact.utils.ts
@@ -5,9 +5,6 @@ import { BEHIND_GOAL_PERCENT_THRESHOLD } from '../constants/marketing-impact.con
 
 import type { MarketingImpactPeriodOption, ResolvedPeriodRange } from '../interfaces/marketing-impact.interface';
 
-/** Number of past months to show in the Marketing Impact period picker. */
-const MONTH_COUNT = 12;
-
 /** Returns the default reporting month (previous calendar month, UTC). */
 export function getDefaultMarketingImpactMonth(): string {
   const now = new Date();
@@ -82,37 +79,31 @@ export function computeMomPct(arr: number[] | undefined): number | null {
 const PERIOD_PRESETS = ['ytd', 'last-3', 'last-6'] as const;
 const MONTH_REGEX = /^\d{4}-(0[1-9]|1[0-2])$/;
 
-/** Builds grouped period options: presets first, then individual months. */
+/**
+ * Builds the period options: trailing-range presets only. Individual months were removed from the
+ * picker — resolvePeriodRange still accepts a YYYY-MM value so existing deep links and any stored
+ * month period keep resolving instead of failing closed.
+ */
 export function buildMarketingImpactPeriodOptions(): MarketingImpactPeriodOption[] {
-  const now = new Date();
-  const currentYear = now.getUTCFullYear();
-  const presets: MarketingImpactPeriodOption[] = [
+  const currentYear = new Date().getUTCFullYear();
+  return [
     { label: `Year to Date (${currentYear})`, value: 'ytd' },
     { label: 'Last 3 months', value: 'last-3' },
     { label: 'Last 6 months', value: 'last-6' },
   ];
-
-  const months: MarketingImpactPeriodOption[] = [];
-  for (let i = 1; i <= MONTH_COUNT; i++) {
-    const date = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth() - i, 1));
-    const label = date.toLocaleDateString('en-US', { month: 'long', year: 'numeric', timeZone: 'UTC' });
-    const value = `${date.getUTCFullYear()}-${String(date.getUTCMonth() + 1).padStart(2, '0')}`;
-    months.push({ label, value });
-  }
-
-  return [...presets, ...months];
 }
 
 /**
- * Returns the default period value, which is 'ytd' — not a calendar month. Month periods
- * re-aggregate from the event-grained tables and can only supply events/registrations/speakers,
- * so defaulting to one dashed four of the seven summary tiles on the landing view.
+ * Returns the default period value: 'ytd', the widest preset the picker offers.
+ *
+ * A month is deliberately not the default. Month periods re-aggregate from the event-grained
+ * tables and can only supply events/registrations/speakers — attendees, countries, organizations
+ * and sponsorship come back null — so defaulting to one dashed four of the seven summary tiles on
+ * the landing view. Months are no longer in the picker at all (see
+ * buildMarketingImpactPeriodOptions), though resolvePeriodRange still accepts a YYYY-MM value so
+ * existing deep links keep working.
  */
 export function getDefaultMarketingImpactPeriod(): string {
-  // YTD, not the previous month: month periods re-aggregate from the event-grained tables, which
-  // can only supply events/registrations/speakers — attendees, countries, organizations and
-  // sponsorship come back null. Defaulting to a month therefore dashed four of the seven summary
-  // tiles on the landing view. Month stays selectable for the three metrics that support it.
   return 'ytd';
 }
 


### PR DESCRIPTION
Three related changes:
- The email sends table now covers the picker's full date range and gains a SEND DATE column.
- The period picker drops individual month options, leaving presets only.
- The Overview tab's events sections show a coming-soon placeholder under Campaign Type = All; the Events tab is unchanged.

**Stacked on** `feat/LFXV2-2768-events-split-views`.

LFXV2-2768