### PR TITLE
style(dashboards): align paid performance table columns

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -36,12 +36,13 @@
         <div class="flex flex-col gap-0" role="table" aria-label="Campaign performance by project" data-testid="performance-marketing-table">
           <!-- Table header -->
           <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
-            <span class="w-40 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SPEND</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
-            <span class="w-16 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ROAS</span>
-            <span class="w-24 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
-            <span class="flex-1 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PERF.</span>
+            <!-- Name takes the slack; the metric columns stay fixed so they line up down the table. -->
+            <span class="min-w-0 flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>
+            <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SPEND</span>
+            <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
+            <span class="w-16 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ROAS</span>
+            <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
+            <span class="w-20 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PERF.</span>
           </div>
 
           <!-- Rows -->
@@ -59,19 +60,22 @@
               (keydown.enter)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
               (keydown.space)="$event.preventDefault(); row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
               [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
-              <div class="flex w-40 items-center gap-1.5" role="cell">
+              <div class="flex min-w-0 flex-1 items-center gap-1.5" role="cell">
                 @if (row.campaigns.length > 0) {
-                  <i class="fa-solid fa-chevron-right text-[9px] text-gray-400 transition-transform" [class.rotate-90]="projectExpanded" aria-hidden="true"></i>
+                  <i
+                    class="fa-solid fa-chevron-right shrink-0 text-[9px] text-gray-400 transition-transform"
+                    [class.rotate-90]="projectExpanded"
+                    aria-hidden="true"></i>
                 } @else {
-                  <span class="w-[9px]"></span>
+                  <span class="w-[9px] shrink-0"></span>
                 }
-                <span class="truncate text-xs font-medium text-gray-700">{{ row.name }}</span>
+                <span class="truncate text-xs font-medium text-gray-700" [title]="row.name">{{ row.name }}</span>
               </div>
-              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.spend }}</span>
-              <span class="w-24 text-right text-xs text-gray-900" role="cell">{{ row.revenue }}</span>
-              <span class="w-16 text-right text-xs font-medium text-gray-900" role="cell">{{ row.roas }}</span>
-              <span class="w-24 text-right text-xs text-gray-500" role="cell">{{ row.impressions }}</span>
-              <div class="flex flex-1 justify-end" role="cell">
+              <span class="w-24 shrink-0 text-right text-xs text-gray-900 tabular-nums" role="cell">{{ row.spend }}</span>
+              <span class="w-24 shrink-0 text-right text-xs text-gray-900 tabular-nums" role="cell">{{ row.revenue }}</span>
+              <span class="w-16 shrink-0 text-right text-xs font-medium text-gray-900 tabular-nums" role="cell">{{ row.roas }}</span>
+              <span class="w-24 shrink-0 text-right text-xs text-gray-500 tabular-nums" role="cell">{{ row.impressions }}</span>
+              <div class="flex w-20 shrink-0 justify-end" role="cell">
                 <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
                   {{ row.performance }}
                 </span>
@@ -85,13 +89,13 @@
                   class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
                   role="row"
                   [attr.data-testid]="'campaign-row-' + projectKey + '-' + $index">
-                  <!-- w-40 (parent) minus pl-6 (indent) = 8.5rem -->
-                  <span class="w-[8.5rem] truncate text-[11px] text-gray-500" role="cell">{{ campaign.campaignName }}</span>
-                  <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.spend }}</span>
-                  <span class="w-24 text-right text-[11px] text-gray-500" role="cell">{{ campaign.revenue }}</span>
-                  <span class="w-16 text-right text-[11px] text-gray-500" role="cell">{{ campaign.roas }}</span>
-                  <span class="w-24 text-right text-[11px] text-gray-400" role="cell">{{ campaign.impressions }}</span>
-                  <div class="flex-1" role="cell"></div>
+                  <!-- Flexes with the parent name column; pl-6 supplies the indent. -->
+                  <span class="min-w-0 flex-1 truncate text-[11px] text-gray-500" [title]="campaign.campaignName" role="cell">{{ campaign.campaignName }}</span>
+                  <span class="w-24 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.spend }}</span>
+                  <span class="w-24 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.revenue }}</span>
+                  <span class="w-16 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.roas }}</span>
+                  <span class="w-24 shrink-0 text-right text-[11px] text-gray-400 tabular-nums" role="cell">{{ campaign.impressions }}</span>
+                  <div class="w-20 shrink-0" role="cell"></div>
                 </div>
               }
             }

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.html
@@ -33,73 +33,82 @@
       <h4 class="text-sm font-semibold text-gray-900">Campaign performance by project</h4>
 
       @if (hasProjects()) {
-        <div class="flex flex-col gap-0" role="table" aria-label="Campaign performance by project" data-testid="performance-marketing-table">
-          <!-- Table header -->
-          <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
-            <!-- Name takes the slack; the metric columns stay fixed so they line up down the table. -->
-            <span class="min-w-0 flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>
-            <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SPEND</span>
-            <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
-            <span class="w-16 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ROAS</span>
-            <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
-            <span class="w-20 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PERF.</span>
-          </div>
-
-          <!-- Rows -->
-          @for (row of projectRows(); track row.name) {
-            @let projectKey = row.name;
-            @let projectExpanded = expandedProjects().has(projectKey);
-            <div
-              class="flex items-center gap-3 border-b border-gray-100 py-2.5 transition-colors"
-              [class.cursor-pointer]="row.campaigns.length > 0"
-              [class.hover:bg-gray-50]="row.campaigns.length > 0"
-              role="row"
-              [attr.data-testid]="'performance-marketing-row-' + row.name"
-              [attr.aria-expanded]="row.campaigns.length > 0 ? projectExpanded : null"
-              (click)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
-              (keydown.enter)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
-              (keydown.space)="$event.preventDefault(); row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
-              [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
-              <div class="flex min-w-0 flex-1 items-center gap-1.5" role="cell">
-                @if (row.campaigns.length > 0) {
-                  <i
-                    class="fa-solid fa-chevron-right shrink-0 text-[9px] text-gray-400 transition-transform"
-                    [class.rotate-90]="projectExpanded"
-                    aria-hidden="true"></i>
-                } @else {
-                  <span class="w-[9px] shrink-0"></span>
-                }
-                <span class="truncate text-xs font-medium text-gray-700" [title]="row.name">{{ row.name }}</span>
+        <!-- The five metric columns are fixed-width and total ~492px with their gaps, so on a
+             narrow viewport the flexible project column would shrink to nothing and the metrics
+             would overflow the card. Scroll horizontally instead, matching the platform table. -->
+        <div class="overflow-x-auto">
+          <div class="min-w-[720px]">
+            <div class="flex flex-col gap-0" role="table" aria-label="Campaign performance by project" data-testid="performance-marketing-table">
+              <!-- Table header -->
+              <div class="flex items-center gap-3 border-b border-gray-200 pb-2" role="row">
+                <!-- Name takes the slack; the metric columns stay fixed so they line up down the table. -->
+                <span class="min-w-0 flex-1 text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PROJECT</span>
+                <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">SPEND</span>
+                <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">REVENUE</span>
+                <span class="w-16 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">ROAS</span>
+                <span class="w-24 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">IMPRESSIONS</span>
+                <span class="w-20 shrink-0 text-right text-[11px] font-semibold tracking-wide text-gray-400" role="columnheader">PERF.</span>
               </div>
-              <span class="w-24 shrink-0 text-right text-xs text-gray-900 tabular-nums" role="cell">{{ row.spend }}</span>
-              <span class="w-24 shrink-0 text-right text-xs text-gray-900 tabular-nums" role="cell">{{ row.revenue }}</span>
-              <span class="w-16 shrink-0 text-right text-xs font-medium text-gray-900 tabular-nums" role="cell">{{ row.roas }}</span>
-              <span class="w-24 shrink-0 text-right text-xs text-gray-500 tabular-nums" role="cell">{{ row.impressions }}</span>
-              <div class="flex w-20 shrink-0 justify-end" role="cell">
-                <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
-                  {{ row.performance }}
-                </span>
-              </div>
-            </div>
 
-            <!-- Expanded campaign rows -->
-            @if (projectExpanded) {
-              @for (campaign of row.campaigns; track $index) {
+              <!-- Rows -->
+              @for (row of projectRows(); track row.name) {
+                @let projectKey = row.name;
+                @let projectExpanded = expandedProjects().has(projectKey);
                 <div
-                  class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
+                  class="flex items-center gap-3 border-b border-gray-100 py-2.5 transition-colors"
+                  [class.cursor-pointer]="row.campaigns.length > 0"
+                  [class.hover:bg-gray-50]="row.campaigns.length > 0"
                   role="row"
-                  [attr.data-testid]="'campaign-row-' + projectKey + '-' + $index">
-                  <!-- Flexes with the parent name column; pl-6 supplies the indent. -->
-                  <span class="min-w-0 flex-1 truncate text-[11px] text-gray-500" [title]="campaign.campaignName" role="cell">{{ campaign.campaignName }}</span>
-                  <span class="w-24 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.spend }}</span>
-                  <span class="w-24 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.revenue }}</span>
-                  <span class="w-16 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.roas }}</span>
-                  <span class="w-24 shrink-0 text-right text-[11px] text-gray-400 tabular-nums" role="cell">{{ campaign.impressions }}</span>
-                  <div class="w-20 shrink-0" role="cell"></div>
+                  [attr.data-testid]="'performance-marketing-row-' + row.name"
+                  [attr.aria-expanded]="row.campaigns.length > 0 ? projectExpanded : null"
+                  (click)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
+                  (keydown.enter)="row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
+                  (keydown.space)="$event.preventDefault(); row.campaigns.length > 0 && toggleProjectExpand(projectKey)"
+                  [attr.tabindex]="row.campaigns.length > 0 ? 0 : null">
+                  <div class="flex min-w-0 flex-1 items-center gap-1.5" role="cell">
+                    @if (row.campaigns.length > 0) {
+                      <i
+                        class="fa-solid fa-chevron-right shrink-0 text-[9px] text-gray-400 transition-transform"
+                        [class.rotate-90]="projectExpanded"
+                        aria-hidden="true"></i>
+                    } @else {
+                      <span class="w-[9px] shrink-0"></span>
+                    }
+                    <span class="truncate text-xs font-medium text-gray-700" [title]="row.name">{{ row.name }}</span>
+                  </div>
+                  <span class="w-24 shrink-0 text-right text-xs text-gray-900 tabular-nums" role="cell">{{ row.spend }}</span>
+                  <span class="w-24 shrink-0 text-right text-xs text-gray-900 tabular-nums" role="cell">{{ row.revenue }}</span>
+                  <span class="w-16 shrink-0 text-right text-xs font-medium text-gray-900 tabular-nums" role="cell">{{ row.roas }}</span>
+                  <span class="w-24 shrink-0 text-right text-xs text-gray-500 tabular-nums" role="cell">{{ row.impressions }}</span>
+                  <div class="flex w-20 shrink-0 justify-end" role="cell">
+                    <span class="rounded px-1.5 py-0.5 text-[10px] font-medium" [class]="row.performanceClass">
+                      {{ row.performance }}
+                    </span>
+                  </div>
                 </div>
+
+                <!-- Expanded campaign rows -->
+                @if (projectExpanded) {
+                  @for (campaign of row.campaigns; track $index) {
+                    <div
+                      class="flex items-center gap-3 border-b border-gray-50 bg-gray-50/50 py-2 pl-6"
+                      role="row"
+                      [attr.data-testid]="'campaign-row-' + projectKey + '-' + $index">
+                      <!-- Flexes with the parent name column; pl-6 supplies the indent. -->
+                      <span class="min-w-0 flex-1 truncate text-[11px] text-gray-500" [title]="campaign.campaignName" role="cell">{{
+                        campaign.campaignName
+                      }}</span>
+                      <span class="w-24 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.spend }}</span>
+                      <span class="w-24 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.revenue }}</span>
+                      <span class="w-16 shrink-0 text-right text-[11px] text-gray-500 tabular-nums" role="cell">{{ campaign.roas }}</span>
+                      <span class="w-24 shrink-0 text-right text-[11px] text-gray-400 tabular-nums" role="cell">{{ campaign.impressions }}</span>
+                      <div class="w-20 shrink-0" role="cell"></div>
+                    </div>
+                  }
+                }
               }
-            }
-          }
+            </div>
+          </div>
         </div>
       } @else {
         <div class="flex items-center justify-center rounded-lg border border-dashed border-gray-300 bg-gray-50 p-8" data-testid="performance-marketing-empty">

--- a/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/marketing-impact/components/performance-marketing-tab/performance-marketing-tab.component.ts
@@ -4,7 +4,7 @@
 import { Component, computed, inject, input, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FOCUS_TO_CLASSIFICATION } from '@lfx-one/shared/constants';
-import { computeMomPct, formatChangePct, formatCurrency, formatNumber, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
+import { computeMomPct, formatChangePct, formatCurrency, formatNumber, formatPercent, trendColorClass, trendDirection } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { catchError, combineLatest, finalize, of, switchMap } from 'rxjs';
 
@@ -254,9 +254,9 @@ export class PerformanceMarketingTabComponent {
           roas: `${(p.roas ?? 0).toFixed(2)}x`,
           clicks: formatNumber(p.clicks),
           impressions: formatNumber(p.impressions),
-          ctr: `${(p.ctr ?? 0).toFixed(2)}%`,
+          ctr: `${formatPercent(p.ctr ?? 0)}%`,
           cpc: formatCurrency(p.cpc),
-          convRate: `${(p.convRate ?? 0).toFixed(2)}%`,
+          convRate: `${formatPercent(p.convRate ?? 0)}%`,
           conversions: formatNumber(p.conversions),
           performance: perf,
           performanceClass: this.getPerformanceClass(perf),
@@ -296,9 +296,9 @@ export class PerformanceMarketingTabComponent {
         roas: `${totalRoas.toFixed(2)}x`,
         clicks: formatNumber(totals.clicks),
         impressions: formatNumber(totals.impressions),
-        ctr: `${totalCtr.toFixed(2)}%`,
+        ctr: `${formatPercent(totalCtr)}%`,
         cpc: formatCurrency(totalCpc),
-        convRate: `${totalConvRate.toFixed(2)}%`,
+        convRate: `${formatPercent(totalConvRate)}%`,
         conversions: formatNumber(totals.conversions),
         performance: totalPerf,
         performanceClass: this.getPerformanceClass(totalPerf),
@@ -346,10 +346,10 @@ export class PerformanceMarketingTabComponent {
           clicks: formatNumber(k.clicks),
           spend: formatCurrency(k.spend),
           impressions: formatNumber(k.impressions),
-          ctr: `${(k.ctr ?? 0).toFixed(2)}%`,
+          ctr: `${formatPercent(k.ctr ?? 0)}%`,
           cpc: formatCurrency(k.cpc),
           conversions: formatNumber(k.conversions),
-          convRate: `${(k.conversionRate ?? 0).toFixed(2)}%`,
+          convRate: `${formatPercent(k.conversionRate ?? 0)}%`,
           revenue: formatCurrency(k.attributedRevenue),
           roas: `${(k.roas ?? 0).toFixed(2)}x`,
           searchTerms: (k.searchTerms ?? []).map(
@@ -359,7 +359,7 @@ export class PerformanceMarketingTabComponent {
               clicks: formatNumber(st.clicks),
               spend: formatCurrency(st.spend),
               impressions: formatNumber(st.impressions),
-              ctr: `${(st.ctr ?? 0).toFixed(2)}%`,
+              ctr: `${formatPercent(st.ctr ?? 0)}%`,
               cpc: formatCurrency(st.cpc),
               conversions: st.conversions == null ? '—' : formatNumber(st.conversions),
             })


### PR DESCRIPTION
Fixes the paid performance table so the metric columns stay fixed-width and line up down the table, with the project name taking the remaining slack.

**Stacked on** `feat/LFXV2-2768-email-sends-and-period`.

LFXV2-2768