### PR TITLE
fix(server): externalize @aws-sdk/client-s3 from the ssr bundle

### DIFF
--- a/apps/lfx-one/angular.json
+++ b/apps/lfx-one/angular.json
@@ -64,7 +64,7 @@
               "lodash.isempty",
               "quill-delta"
             ],
-            "externalDependencies": ["snowflake-sdk", "@opentelemetry/api", "@opentelemetry/semantic-conventions", "pdfkit", "google-ads-api"]
+            "externalDependencies": ["snowflake-sdk", "@opentelemetry/api", "@opentelemetry/semantic-conventions", "pdfkit", "google-ads-api", "@aws-sdk/client-s3"]
           },
           "configurations": {
             "production": {

--- a/apps/lfx-one/angular.json
+++ b/apps/lfx-one/angular.json
@@ -64,7 +64,14 @@
               "lodash.isempty",
               "quill-delta"
             ],
-            "externalDependencies": ["snowflake-sdk", "@opentelemetry/api", "@opentelemetry/semantic-conventions", "pdfkit", "google-ads-api", "@aws-sdk/client-s3"]
+            "externalDependencies": [
+              "snowflake-sdk",
+              "@opentelemetry/api",
+              "@opentelemetry/semantic-conventions",
+              "pdfkit",
+              "google-ads-api",
+              "@aws-sdk/client-s3"
+            ]
           },
           "configurations": {
             "production": {


### PR DESCRIPTION
## Summary

Avatar upload on dev (`app.dev.lfx.dev`) 500s on every attempt. Pod logs in the `ui` namespace show the failure on the very first S3 call, `HeadBucketCommand` inside `ensureBucket()`:

```
{"level":"ERROR","operation":"object_store_ensure_bucket","err":{"type":"TypeError","message":"p is not a function"}}
```

**Root cause:** the Angular SSR build (`apps/lfx-one/angular.json`) bundles and minifies everything imported by the server entrypoint via esbuild, unless the package is listed in `externalDependencies`. `@aws-sdk/client-s3` (built on `@smithy/*` internals) relies on patterns — function references passed through config objects, `instanceof` checks across what the bundler treats as separate modules — that don't reliably survive identifier-mangling minification. That's what threw `p is not a function` on the very first SDK call.

This repo already knows about this exact failure class — `snowflake-sdk`, `pdfkit`, and `google-ads-api` are already excluded from the bundle for the same reason. `@aws-sdk/client-s3` was never added to that list when the avatar upload feature (#1282) landed. It went undetected because:
- Unit tests (`object-store.service.spec.ts`) mock the S3 client entirely, so they never execute the real SDK code.
- Local dev (`ng serve`) never runs the production esbuild/minify path — this class of bug is only reachable by actually running `ng build` and executing the resulting `dist/lfx-one/server/server.mjs`.

**Ruled out first:** IRSA/credentials were the initial suspect, but `pcc-sa` in the `ui` namespace already carries the correct `eks.amazonaws.com/role-arn` annotation (confirmed via `kubectl get sa pcc-sa -n ui`), provisioned out-of-band via terraform. This is a pure bundling bug, not a permissions gap.

**Fix:** add `@aws-sdk/client-s3` to `externalDependencies`. Verified the built `server.mjs` now has a plain `import ... from "@aws-sdk/client-s3"` instead of inlined/minified code. `node_modules` is preserved in the runtime container image (single-stage Dockerfile, no prune), so this resolves correctly via the module loader at runtime.

## Test plan

- [x] `yarn workspace lfx-one-ui build:development` succeeds
- [x] Confirmed `dist/lfx-one/server/server.mjs` imports `@aws-sdk/client-s3` rather than inlining it
- [x] `yarn --cwd apps/lfx-one lint` clean (one pre-existing unrelated warning)
- [ ] Re-test avatar upload against dev once this deploys

LFXV2-2628