### PR TITLE
fix(public-profile): harden training/cert projection follow-ups

### DIFF
--- a/apps/lfx-one/src/server/constants/public-profile.constants.ts
+++ b/apps/lfx-one/src/server/constants/public-profile.constants.ts
@@ -32,6 +32,6 @@ export const PUBLIC_PROFILE_TRAINING_STATUS_ALLOWLIST: ReadonlySet<string> = new
 /** Certification `Status` values kept on the public certifications list — completed only (myprofile parity). */
 export const PUBLIC_PROFILE_CERTIFICATION_STATUS_ALLOWLIST: ReadonlySet<string> = new Set(['Completed']);
 
-// Epoch-zero placeholder the artifact writes for a missing date. Training dates matching it are blanked
-// to ''; certifications with such a StartDate are dropped (myprofile's `!StartDate.includes('1970')`).
+// Epoch-zero placeholder for a missing date, matched with `startsWith` (tighter than myprofile's
+// `includes`). Training dates are blanked to ''; certifications drop such a StartDate (and absent ones).
 export const PUBLIC_PROFILE_EPOCH_PLACEHOLDER = '1970';

--- a/apps/lfx-one/src/server/constants/public-profile.constants.ts
+++ b/apps/lfx-one/src/server/constants/public-profile.constants.ts
@@ -26,6 +26,10 @@ export const PUBLIC_PROFILE_USERNAME_PATTERN = /^[A-Za-z0-9._-]{1,100}$/;
 // dropped from trainings; completed certifications surface via `certification_activities`.
 export const PUBLIC_PROFILE_TRAINING_TYPE_ALLOWLIST: ReadonlySet<string> = new Set(['E-Learning', 'Instructor-Led', 'edX']);
 
+// Training `Type` values deliberately dropped but recognized as normal (exam/subscription/bundle);
+// kept out of the allow-list so the drift signal fires only for a genuinely unrecognized Type, not these.
+export const PUBLIC_PROFILE_TRAINING_TYPE_KNOWN_EXCLUDED: ReadonlySet<string> = new Set(['Certification Exam', 'Subscription', 'Bundle']);
+
 /** Enrollment `Status` values kept on the public trainings list (myprofile parity). */
 export const PUBLIC_PROFILE_TRAINING_STATUS_ALLOWLIST: ReadonlySet<string> = new Set(['Enrolled', 'Completed', 'Started', 'Not started']);
 

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -376,7 +376,7 @@ describe('projectPublicProfile — training_activities allow-list projection', (
       req
     );
 
-    expect(logger.debug).toHaveBeenCalledWith(req, 'project_public_profile', expect.stringContaining('unrecognized Type'), { dropped_for_unknown_type: 2 });
+    expect(logger.warning).toHaveBeenCalledWith(req, 'project_public_profile', expect.stringContaining('unrecognized Type'), { dropped_for_unknown_type: 2 });
   });
 
   it('does not emit the drift signal when every dropped row also fails the Status allow-list', () => {
@@ -390,7 +390,7 @@ describe('projectPublicProfile — training_activities allow-list projection', (
       req
     );
 
-    expect(logger.debug).not.toHaveBeenCalled();
+    expect(logger.warning).not.toHaveBeenCalled();
   });
 
   it('scrubs only a leading epoch year, leaving a value that merely contains 1970 intact (startsWith, not includes)', () => {

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -363,19 +363,21 @@ describe('projectPublicProfile — training_activities allow-list projection', (
     expect(projectPublicProfile({ training_activities: { Name: 'A' } }).training_activities).toBeUndefined();
   });
 
-  it('emits a drift debug signal counting rows dropped for an unrecognized Type despite an allow-listed Status', () => {
+  it('emits a drift warning signal counting rows dropped for an unrecognized Type despite an allow-listed Status', () => {
     projectPublicProfile(
       {
         training_activities: [
           { Name: 'Kept', Type: 'E-Learning', Status: 'Completed' },
           { Name: 'Renamed type', Type: 'eLearning', Status: 'Completed' },
           { Name: 'Another renamed type', Type: 'Self-Paced', Status: 'Enrolled' },
+          { Name: 'Known excluded, not drift', Type: 'Bundle', Status: 'Completed' },
           { Name: 'Dropped for status, not type', Type: 'Bundle', Status: 'Cancelled' },
         ],
       },
       req
     );
 
+    // Only the two genuinely-unrecognized Types count; the Completed Bundle is a known excluded type.
     expect(logger.warning).toHaveBeenCalledWith(req, 'project_public_profile', expect.stringContaining('unrecognized Type'), { dropped_for_unknown_type: 2 });
   });
 
@@ -385,6 +387,22 @@ describe('projectPublicProfile — training_activities allow-list projection', (
         training_activities: [
           { Name: 'Kept', Type: 'E-Learning', Status: 'Completed' },
           { Name: 'Bad type and status', Type: 'Bundle', Status: 'Cancelled' },
+        ],
+      },
+      req
+    );
+
+    expect(logger.warning).not.toHaveBeenCalled();
+  });
+
+  it('does not emit the drift signal for a known excluded Type with an allow-listed Status', () => {
+    projectPublicProfile(
+      {
+        training_activities: [
+          { Name: 'Kept', Type: 'E-Learning', Status: 'Completed' },
+          { Name: 'Exam', Type: 'Certification Exam', Status: 'Completed' },
+          { Name: 'Sub', Type: 'Subscription', Status: 'Enrolled' },
+          { Name: 'Bundle', Type: 'Bundle', Status: 'Completed' },
         ],
       },
       req

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -10,6 +10,7 @@ vi.mock('./logger.service', () => ({
 import type { Request } from 'express';
 
 import { MicroserviceError } from '../errors';
+import { logger } from './logger.service';
 import { getPublicProfilesBucketUrl, projectPublicProfile, PublicProfileService, resolvePublicFlag } from './public-profile.service';
 
 const req = {} as unknown as Request;
@@ -361,6 +362,45 @@ describe('projectPublicProfile — training_activities allow-list projection', (
     expect(projectPublicProfile({ training_activities: 'nope' }).training_activities).toBeUndefined();
     expect(projectPublicProfile({ training_activities: { Name: 'A' } }).training_activities).toBeUndefined();
   });
+
+  it('emits a drift debug signal counting rows dropped for an unrecognized Type despite an allow-listed Status', () => {
+    projectPublicProfile(
+      {
+        training_activities: [
+          { Name: 'Kept', Type: 'E-Learning', Status: 'Completed' },
+          { Name: 'Renamed type', Type: 'eLearning', Status: 'Completed' },
+          { Name: 'Another renamed type', Type: 'Self-Paced', Status: 'Enrolled' },
+          { Name: 'Dropped for status, not type', Type: 'Bundle', Status: 'Cancelled' },
+        ],
+      },
+      req
+    );
+
+    expect(logger.debug).toHaveBeenCalledWith(req, 'project_public_profile', expect.stringContaining('unrecognized Type'), { dropped_for_unknown_type: 2 });
+  });
+
+  it('does not emit the drift signal when every dropped row also fails the Status allow-list', () => {
+    projectPublicProfile(
+      {
+        training_activities: [
+          { Name: 'Kept', Type: 'E-Learning', Status: 'Completed' },
+          { Name: 'Bad type and status', Type: 'Bundle', Status: 'Cancelled' },
+        ],
+      },
+      req
+    );
+
+    expect(logger.debug).not.toHaveBeenCalled();
+  });
+
+  it('scrubs only a leading epoch year, leaving a value that merely contains 1970 intact (startsWith, not includes)', () => {
+    const projected = projectPublicProfile({
+      training_activities: [{ Name: 'A', Type: 'E-Learning', Status: 'Completed', StartDate: '11970000000', EndDate: '1970-01-01T00:00:00Z' }],
+    });
+
+    // StartDate contains "1970" but does not start with it — kept; EndDate is a leading epoch placeholder — blanked.
+    expect(projected.training_activities?.[0]).toEqual({ Name: 'A', Type: 'E-Learning', StartDate: '11970000000', EndDate: '' });
+  });
 });
 
 describe('projectPublicProfile — certification_activities allow-list projection', () => {
@@ -403,6 +443,26 @@ describe('projectPublicProfile — certification_activities allow-list projectio
       EndDate: '2028-01-02T00:00:00Z',
     });
     expect(projected.certification_activities?.[0]).not.toHaveProperty('Status');
+  });
+
+  it('sorts the kept certifications by Name ascending (matching the trainings rail)', () => {
+    const projected = projectPublicProfile({
+      certification_activities: [
+        { Name: 'Zeta', Status: 'Completed', StartDate: '2025-01-02T00:00:00Z' },
+        { Name: 'Alpha', Status: 'Completed', StartDate: '2025-01-02T00:00:00Z' },
+        { Name: 'Mango', Status: 'Completed', StartDate: '2025-01-02T00:00:00Z' },
+      ],
+    });
+
+    expect(projected.certification_activities?.map((c) => c.Name)).toEqual(['Alpha', 'Mango', 'Zeta']);
+  });
+
+  it('keeps a StartDate that merely contains 1970 but does not start with it (startsWith, not includes)', () => {
+    const projected = projectPublicProfile({
+      certification_activities: [{ Name: 'Contains 1970', Status: 'Completed', StartDate: '11970000000' }],
+    });
+
+    expect(projected.certification_activities?.map((c) => c.Name)).toEqual(['Contains 1970']);
   });
 
   it('returns undefined when certification_activities is missing or not an array', () => {

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -141,7 +141,7 @@ function projectTrainingActivities(value: unknown, req?: Request): PublicProfile
     return statusAllowed && typeAllowed;
   });
   if (droppedForUnknownType > 0) {
-    logger.debug(req, 'project_public_profile', 'Dropped training rows with an unrecognized Type', {
+    logger.warning(req, 'project_public_profile', 'Dropped training rows with an unrecognized Type', {
       dropped_for_unknown_type: droppedForUnknownType,
     });
   }

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -18,6 +18,7 @@ import {
   PUBLIC_PROFILE_SERVICE_NAME,
   PUBLIC_PROFILE_TRAINING_STATUS_ALLOWLIST,
   PUBLIC_PROFILE_TRAINING_TYPE_ALLOWLIST,
+  PUBLIC_PROFILE_TRAINING_TYPE_KNOWN_EXCLUDED,
   PUBLIC_PROFILE_USERNAME_PATTERN,
   PUBLIC_PROFILES_BUCKET_URL_ENV,
 } from '../constants';
@@ -133,9 +134,9 @@ function projectTrainingActivities(value: unknown, req?: Request): PublicProfile
     const type = pickString(activity['Type']);
     const statusAllowed = status !== undefined && PUBLIC_PROFILE_TRAINING_STATUS_ALLOWLIST.has(status);
     const typeAllowed = type !== undefined && PUBLIC_PROFILE_TRAINING_TYPE_ALLOWLIST.has(type);
-    // Drift signal: an allow-listed Status with an unrecognized Type means the myprofile Type
-    // vocabulary likely drifted (allow-list duplicated here, no shared contract) — count it for Datadog.
-    if (statusAllowed && !typeAllowed) {
+    // Drift signal: an allow-listed Status with a Type that's neither allow-listed nor a known
+    // excluded type (exam/subscription/bundle) means the myprofile vocabulary likely drifted — count it.
+    if (statusAllowed && type !== undefined && !typeAllowed && !PUBLIC_PROFILE_TRAINING_TYPE_KNOWN_EXCLUDED.has(type)) {
       droppedForUnknownType++;
     }
     return statusAllowed && typeAllowed;

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -109,29 +109,43 @@ function projectTechnicalContribution(value: unknown): PublicProfileTechnicalCon
   return { projects };
 }
 
-/** Blanks the epoch-zero placeholder date the artifact writes for "no date"; passes other values through. */
+/**
+ * Blanks the epoch-zero placeholder date, passing other values through. Uses `startsWith('1970')`
+ * (tighter than myprofile's `includes`) so only a leading epoch year counts as the placeholder.
+ */
 function scrubEpochDate(value: unknown): string | undefined {
   const date = pickString(value);
   if (date === undefined) {
     return undefined;
   }
-  return date.includes(PUBLIC_PROFILE_EPOCH_PLACEHOLDER) ? '' : date;
+  return date.startsWith(PUBLIC_PROFILE_EPOCH_PLACEHOLDER) ? '' : date;
 }
 
 // Public trainings, myprofile parity: keep allow-listed statuses + types, blank epoch dates, sort by
 // name. Raw `Status` drives the filter only and is never projected to the client.
-function projectTrainingActivities(value: unknown): PublicProfileTraining[] | undefined {
+function projectTrainingActivities(value: unknown, req?: Request): PublicProfileTraining[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
   }
-  return asRecordArray(value)
-    .filter((activity) => {
-      const status = pickString(activity['Status']);
-      const type = pickString(activity['Type']);
-      return (
-        status !== undefined && PUBLIC_PROFILE_TRAINING_STATUS_ALLOWLIST.has(status) && type !== undefined && PUBLIC_PROFILE_TRAINING_TYPE_ALLOWLIST.has(type)
-      );
-    })
+  let droppedForUnknownType = 0;
+  const kept = asRecordArray(value).filter((activity) => {
+    const status = pickString(activity['Status']);
+    const type = pickString(activity['Type']);
+    const statusAllowed = status !== undefined && PUBLIC_PROFILE_TRAINING_STATUS_ALLOWLIST.has(status);
+    const typeAllowed = type !== undefined && PUBLIC_PROFILE_TRAINING_TYPE_ALLOWLIST.has(type);
+    // Drift signal: an allow-listed Status with an unrecognized Type means the myprofile Type
+    // vocabulary likely drifted (allow-list duplicated here, no shared contract) — count it for Datadog.
+    if (statusAllowed && !typeAllowed) {
+      droppedForUnknownType++;
+    }
+    return statusAllowed && typeAllowed;
+  });
+  if (droppedForUnknownType > 0) {
+    logger.debug(req, 'project_public_profile', 'Dropped training rows with an unrecognized Type', {
+      dropped_for_unknown_type: droppedForUnknownType,
+    });
+  }
+  return kept
     .map((activity) => ({
       Name: pickString(activity['Name']),
       Type: pickString(activity['Type']),
@@ -141,8 +155,8 @@ function projectTrainingActivities(value: unknown): PublicProfileTraining[] | un
     .sort((a, b) => (a.Name ?? '').localeCompare(b.Name ?? ''));
 }
 
-// Public certifications, myprofile parity: completed only, drop epoch/absent StartDate. Raw `Status`
-// drives the filter only and is never projected to the client.
+// Public certifications: completed only, sorted by name. Stricter than myprofile parity — also drops
+// an absent StartDate and matches the epoch date with `startsWith`. Raw `Status` is never projected.
 function projectCertificationActivities(value: unknown): PublicProfileCertification[] | undefined {
   if (!Array.isArray(value)) {
     return undefined;
@@ -155,7 +169,7 @@ function projectCertificationActivities(value: unknown): PublicProfileCertificat
         status !== undefined &&
         PUBLIC_PROFILE_CERTIFICATION_STATUS_ALLOWLIST.has(status) &&
         startDate !== undefined &&
-        !startDate.includes(PUBLIC_PROFILE_EPOCH_PLACEHOLDER)
+        !startDate.startsWith(PUBLIC_PROFILE_EPOCH_PLACEHOLDER)
       );
     })
     .map((activity) => ({
@@ -163,7 +177,8 @@ function projectCertificationActivities(value: unknown): PublicProfileCertificat
       Type: pickString(activity['Type']),
       StartDate: pickString(activity['StartDate']),
       EndDate: pickString(activity['EndDate']),
-    }));
+    }))
+    .sort((a, b) => (a.Name ?? '').localeCompare(b.Name ?? ''));
 }
 
 function projectBadges(value: unknown): PublicProfileBadge[] | undefined {
@@ -180,14 +195,14 @@ function projectBadges(value: unknown): PublicProfileBadge[] | undefined {
  * Projects the raw S3 artifact down to the render-only allowlist — fail closed, so any field not
  * listed here never reaches the client. This is the sole PII boundary for the anonymous endpoint.
  */
-export function projectPublicProfile(record: Record<string, unknown>): PublicProfile {
+export function projectPublicProfile(record: Record<string, unknown>, req?: Request): PublicProfile {
   return {
     isPublic: resolvePublicFlag(record),
     basic: projectBasic(record['basic']),
     About: pickString(record['About']),
     technical_contribution: projectTechnicalContribution(record['technical_contribution']),
     certification_activities: projectCertificationActivities(record['certification_activities']),
-    training_activities: projectTrainingActivities(record['training_activities']),
+    training_activities: projectTrainingActivities(record['training_activities'], req),
     badges: projectBadges(record['badges']),
   };
 }
@@ -335,6 +350,6 @@ export class PublicProfileService {
     }
 
     const record = parsed as Record<string, unknown>;
-    return projectPublicProfile(record);
+    return projectPublicProfile(record, req);
   }
 }


### PR DESCRIPTION
## Summary

Non-blocking follow-ups from #1354 (public profile training/certification allow-list), hardening the S3 artifact projection:

- **Drift signal** — `projectTrainingActivities` now counts rows with an allow-listed Status but an unrecognized Type and logs a `logger.warning` (`dropped_for_unknown_type`), so an upstream myprofile vocabulary rename surfaces in Datadog instead of silently emptying the trainings rail. The allow-list is duplicated from myprofile with no shared contract, so this is our only drift signal.
- **Tighter epoch match** — the epoch-placeholder date guard now uses `startsWith('1970')` instead of `includes('1970')`, so a value that merely contains `1970` is no longer treated as the placeholder.
- **Documented certification divergences** — the certification filter's stricter-than-parity rules (drops an absent StartDate; `startsWith` epoch match) are now spelled out on the filter and the `PUBLIC_PROFILE_EPOCH_PLACEHOLDER` constant.
- **Consistent sort** — the certifications rail now sorts by Name to match the adjacent trainings rail.

Unit tests cover the drift signal (fires with the correct count / stays silent when drops are status-driven), the `startsWith` precision on both rails, and the certification Name sort.

Refs LFXV2-2933