### PR TITLE
fix(meetings): call self-register endpoint for authenticated users

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -346,7 +346,7 @@
           }
         } @else if (!pastMeeting()) {
           <!-- Show RSVP Selection for authenticated invited non-organizers (upcoming meetings only) -->
-          @if (isInvited()) {
+          @if (effectivelyInvited()) {
             @defer (on viewport) {
               <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="occurrence()?.occurrence_id"> </lfx-rsvp-button-group>
             } @placeholder {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -78,7 +78,7 @@ import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DrawerModule } from 'primeng/drawer';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, combineLatest, filter, map, of, pairwise, switchMap, take, tap, timer } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, distinctUntilChanged, filter, map, of, pairwise, skip, switchMap, take, tap, timer } from 'rxjs';
 
 import { CancelOccurrenceConfirmationComponent } from '../../components/cancel-occurrence-confirmation/cancel-occurrence-confirmation.component';
 import { MeetingMaterialsDrawerComponent } from '../meeting-materials-drawer/meeting-materials-drawer.component';
@@ -263,6 +263,11 @@ export class MeetingCardComponent implements OnInit {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe(() => this.refreshAttachments$.next());
+
+    // Reset post-registration flag if this card instance is reused for a different meeting.
+    toObservable(this.meetingInput)
+      .pipe(map((m) => m?.id), distinctUntilChanged(), skip(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.registeredInSession.set(false));
   }
 
   public ngOnInit(): void {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -266,7 +266,12 @@ export class MeetingCardComponent implements OnInit {
 
     // Reset post-registration flag if this card instance is reused for a different meeting.
     toObservable(this.meetingInput)
-      .pipe(map((m) => m?.id), distinctUntilChanged(), skip(1), takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        map((m) => m?.id),
+        distinctUntilChanged(),
+        skip(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
       .subscribe(() => this.registeredInSession.set(false));
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -178,8 +178,11 @@ export class MeetingCardComponent implements OnInit {
 
   // Computed signals for invited/registration status to ensure reactivity after registration
   public readonly isInvited: Signal<boolean> = computed(() => this.meeting().invited ?? false);
+  // True when the user is invited OR has just registered in this session (optimistic, before the
+  // meeting refetch settles invited:true). Used to show RSVP options immediately after registration.
+  public readonly effectivelyInvited: Signal<boolean> = computed(() => this.isInvited() || this.registeredInSession());
   public readonly canRegisterForMeeting: Signal<boolean> = computed(
-    () => this.authenticated() && !this.isInvited() && !this.registeredInSession() && !this.meeting().restricted && this.meeting().visibility === 'public'
+    () => this.authenticated() && !this.effectivelyInvited() && !this.meeting().restricted && this.meeting().visibility === 'public'
   );
   // Computed signal to check if user can toggle between RSVP Details and RSVP Button Group
   // True when user is both an organizer AND invited to the meeting (for non-past meetings)

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -140,6 +140,7 @@ export class MeetingCardComponent implements OnInit {
   public transcript: WritableSignal<PastMeetingTranscript | null> = signal(null);
   public additionalRegistrantsCount: WritableSignal<number> = signal(0);
   public drawerGuestCount: WritableSignal<number> = signal(0);
+  private readonly registeredInSession: WritableSignal<boolean> = signal(false);
   // Host-flagged people surfaced by the registrants drawer, fed to the organizer chip so it
   // resolves the same organizer set the drawer badges (see resolvedHostsChange).
   public drawerHosts: WritableSignal<MeetingHostCandidate[]> = signal<MeetingHostCandidate[]>([]);
@@ -178,7 +179,7 @@ export class MeetingCardComponent implements OnInit {
   // Computed signals for invited/registration status to ensure reactivity after registration
   public readonly isInvited: Signal<boolean> = computed(() => this.meeting().invited ?? false);
   public readonly canRegisterForMeeting: Signal<boolean> = computed(
-    () => this.authenticated() && !this.isInvited() && !this.meeting().restricted && this.meeting().visibility === 'public'
+    () => this.authenticated() && !this.isInvited() && !this.registeredInSession() && !this.meeting().restricted && this.meeting().visibility === 'public'
   );
   // Computed signal to check if user can toggle between RSVP Details and RSVP Button Group
   // True when user is both an organizer AND invited to the meeting (for non-past meetings)
@@ -327,6 +328,7 @@ export class MeetingCardComponent implements OnInit {
 
     dialogRef.onClose.pipe(take(1)).subscribe((result: { registered: boolean } | undefined) => {
       if (result?.registered) {
+        this.registeredInSession.set(true);
         this.additionalRegistrantsCount.set(this.additionalRegistrantsCount() + 1);
         this.refreshMeeting();
       }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -140,7 +140,7 @@ export class MeetingCardComponent implements OnInit {
   public transcript: WritableSignal<PastMeetingTranscript | null> = signal(null);
   public additionalRegistrantsCount: WritableSignal<number> = signal(0);
   public drawerGuestCount: WritableSignal<number> = signal(0);
-  private readonly registeredInSession: WritableSignal<boolean> = signal(false);
+  private readonly optimisticInvited: WritableSignal<boolean> = signal(false);
   // Host-flagged people surfaced by the registrants drawer, fed to the organizer chip so it
   // resolves the same organizer set the drawer badges (see resolvedHostsChange).
   public drawerHosts: WritableSignal<MeetingHostCandidate[]> = signal<MeetingHostCandidate[]>([]);
@@ -180,7 +180,7 @@ export class MeetingCardComponent implements OnInit {
   public readonly isInvited: Signal<boolean> = computed(() => this.meeting().invited ?? false);
   // True when the user is invited OR has just registered in this session (optimistic, before the
   // meeting refetch settles invited:true). Used to show RSVP options immediately after registration.
-  public readonly effectivelyInvited: Signal<boolean> = computed(() => this.isInvited() || this.registeredInSession());
+  public readonly effectivelyInvited: Signal<boolean> = computed(() => this.isInvited() || this.optimisticInvited());
   public readonly canRegisterForMeeting: Signal<boolean> = computed(
     () => this.authenticated() && !this.effectivelyInvited() && !this.meeting().restricted && this.meeting().visibility === 'public'
   );
@@ -275,7 +275,7 @@ export class MeetingCardComponent implements OnInit {
         skip(1),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe(() => this.registeredInSession.set(false));
+      .subscribe(() => this.optimisticInvited.set(false));
   }
 
   public ngOnInit(): void {
@@ -341,7 +341,7 @@ export class MeetingCardComponent implements OnInit {
 
     dialogRef.onClose.pipe(take(1)).subscribe((result: { registered: boolean } | undefined) => {
       if (result?.registered) {
-        this.registeredInSession.set(true);
+        this.optimisticInvited.set(true);
         this.additionalRegistrantsCount.set(this.additionalRegistrantsCount() + 1);
         this.refreshMeeting();
       }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -178,7 +178,7 @@ export class MeetingCardComponent implements OnInit {
   // Computed signals for invited/registration status to ensure reactivity after registration
   public readonly isInvited: Signal<boolean> = computed(() => this.meeting().invited ?? false);
   public readonly canRegisterForMeeting: Signal<boolean> = computed(
-    () => !this.isInvited() && !this.meeting().restricted && this.meeting().visibility === 'public'
+    () => this.authenticated() && !this.isInvited() && !this.meeting().restricted && this.meeting().visibility === 'public'
   );
   // Computed signal to check if user can toggle between RSVP Details and RSVP Button Group
   // True when user is both an organizer AND invited to the meeting (for non-past meetings)

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -462,7 +462,7 @@
               } @else if (authenticated() && !isPastMeeting()) {
                 <!-- RSVP Container - Future Meeting (Authenticated Non-Organizers) -->
                 <div class="w-full md:w-[296px]">
-                  @if (isInvited()) {
+                  @if (effectivelyInvited()) {
                     @defer (when meeting()) {
                       <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id"> </lfx-rsvp-button-group>
                     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -355,8 +355,15 @@ export class MeetingJoinComponent implements OnInit {
 
     // Reset post-registration optimistic flag when navigating to a different meeting so a
     // previous registration doesn't grant registrant-list access for an unrelated meeting.
+    // Use getMeetingSeriesUid (not meeting.id) because past-occurrence composite ids differ
+    // from the live-series uid — occurrence navigation must not clear the flag.
     toObservable(this.meeting)
-      .pipe(map((m) => m?.id), distinctUntilChanged(), skip(1), takeUntilDestroyed(this.destroyRef))
+      .pipe(
+        map((m) => (m ? getMeetingSeriesUid(m) : undefined)),
+        distinctUntilChanged(),
+        skip(1),
+        takeUntilDestroyed(this.destroyRef)
+      )
       .subscribe(() => this.optimisticInvited.set(false));
 
     this.primaryRecordingUrl = this.initializePrimaryRecordingUrl();

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -208,6 +208,9 @@ export class MeetingJoinComponent implements OnInit {
   protected pastMeetingFullAccess = signal(false);
   private refreshTrigger$ = new BehaviorSubject<void>(undefined);
   private pastMeetingAttachmentsRefresh$ = new BehaviorSubject<void>(undefined);
+  // Set immediately on self-registration success so the UI responds before the meeting refetch
+  // settles the invited flag (query-service indexing lag).
+  private optimisticInvited = signal(false);
   private readonly optimisticDeletedUids = signal(new Set<string>());
   private readonly optimisticAddedAttachments = signal<PastMeetingAttachment[]>([]);
   public emailError: Signal<boolean>;
@@ -447,7 +450,7 @@ export class MeetingJoinComponent implements OnInit {
 
   public onRegistrantsToggle(): void {
     const meeting = this.meeting();
-    if (!meeting.organizer && !meeting.invited) {
+    if (!meeting.organizer && !meeting.invited && !this.optimisticInvited()) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Show Members is not enabled',
@@ -565,7 +568,8 @@ export class MeetingJoinComponent implements OnInit {
 
     dialogRef.onClose.pipe(take(1)).subscribe((result: { registered: boolean } | undefined) => {
       if (result?.registered) {
-        // Trigger refresh to update meeting data with invitation status
+        this.optimisticInvited.set(true);
+        this.registrantsRefresh$.next();
         this.refreshTrigger$.next();
       }
     });
@@ -1097,7 +1101,7 @@ export class MeetingJoinComponent implements OnInit {
   private initializeCanRegisterForMeeting(): Signal<boolean> {
     return computed(() => {
       const meeting = this.meeting();
-      return !this.isInvited() && !meeting?.restricted && meeting?.visibility === 'public';
+      return !this.isInvited() && !this.optimisticInvited() && !meeting?.restricted && meeting?.visibility === 'public';
     });
   }
 
@@ -1394,9 +1398,10 @@ export class MeetingJoinComponent implements OnInit {
         toObservable(this.currentOccurrence).pipe(distinctUntilChanged((a, b) => a?.occurrence_id === b?.occurrence_id)),
         toObservable(this.authenticated),
         this.registrantsRefresh$,
+        toObservable(this.optimisticInvited),
       ]).pipe(
-        switchMap(([meeting, occurrence, authenticated]) => {
-          if (!meeting?.id || !authenticated || !(meeting.organizer || meeting.invited) || this.isPastMeeting()) {
+        switchMap(([meeting, occurrence, authenticated, , optimisticInvited]) => {
+          if (!meeting?.id || !authenticated || !(meeting.organizer || meeting.invited || optimisticInvited) || this.isPastMeeting()) {
             return of([] as MeetingRegistrant[]);
           }
           this.registrantsLoading.set(true);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -288,6 +288,7 @@ export class MeetingJoinComponent implements OnInit {
   protected hasAttendanceData = computed(() => this.isPastMeeting() && this.participantCount() > 0);
   // Computed signals for invited/registration status
   public isInvited: Signal<boolean>;
+  public effectivelyInvited: Signal<boolean>;
   public canRegisterForMeeting: Signal<boolean>;
   public canToggleRsvpView: Signal<boolean>;
   public showMyRsvp: WritableSignal<boolean> = signal<boolean>(false);
@@ -372,6 +373,7 @@ export class MeetingJoinComponent implements OnInit {
 
     // Initialize invited/registration signals
     this.isInvited = this.initializeIsInvited();
+    this.effectivelyInvited = computed(() => this.isInvited() || this.optimisticInvited());
     this.canRegisterForMeeting = this.initializeCanRegisterForMeeting();
     this.canToggleRsvpView = this.initializeCanToggleRsvpView();
     this.currentUserRsvp = this.initializeCurrentUserRsvp();

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -353,6 +353,12 @@ export class MeetingJoinComponent implements OnInit {
         this.optimisticAddedAttachments.set([]);
       });
 
+    // Reset post-registration optimistic flag when navigating to a different meeting so a
+    // previous registration doesn't grant registrant-list access for an unrelated meeting.
+    toObservable(this.meeting)
+      .pipe(map((m) => m?.id), distinctUntilChanged(), skip(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.optimisticInvited.set(false));
+
     this.primaryRecordingUrl = this.initializePrimaryRecordingUrl();
     this.transcriptUrl = this.initializeTranscriptUrl();
     this.pastMeetingParticipants = this.initializePastMeetingParticipants();

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -446,6 +446,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     controller = new PublicMeetingController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.addMeetingRegistrantSelf.mockResolvedValue({ uid: 'reg-1' });
   });
@@ -461,17 +462,23 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(res.json).toHaveBeenCalledWith({ uid: 'reg-1' });
   });
 
-  it('passes user bearer token unchanged to addMeetingRegistrantSelf', async () => {
+  it('fetches meeting with M2M token then restores user token for self-register', async () => {
     const { req, res, next } = buildRegisterReq(true);
-    let tokenAtCallTime: string | undefined;
+    let tokenAtMeetingFetch: string | undefined;
+    let tokenAtSelfRegister: string | undefined;
+    meetingSvc.getMeetingById.mockImplementation((r: any) => {
+      tokenAtMeetingFetch = r.bearerToken;
+      return Promise.resolve(buildMeeting());
+    });
     meetingSvc.addMeetingRegistrantSelf.mockImplementation((r: any) => {
-      tokenAtCallTime = r.bearerToken;
+      tokenAtSelfRegister = r.bearerToken;
       return Promise.resolve({ uid: 'reg-1' });
     });
 
     await controller.registerForPublicMeeting(req, res, next);
 
-    expect(tokenAtCallTime).toBe('user-token');
+    expect(tokenAtMeetingFetch).toBe('m2m-token');
+    expect(tokenAtSelfRegister).toBe('user-token');
   });
 
   it('unauthenticated request returns 401 without calling the service', async () => {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -17,6 +17,7 @@ const {
   getEffectiveEmailMock,
   getEffectiveUsernameMock,
   validatePasswordMock,
+  validateUidParameterMock,
   meetingSvc,
   projectSvc,
   addInvitedStatusToMeetingMock,
@@ -27,6 +28,7 @@ const {
   getEffectiveEmailMock: vi.fn(),
   getEffectiveUsernameMock: vi.fn(),
   validatePasswordMock: vi.fn(),
+  validateUidParameterMock: vi.fn<(uid: unknown, req: unknown, next: (err: unknown) => void) => boolean>(() => true),
   meetingSvc: {
     getMeetingById: vi.fn(),
     getMeetingRegistrants: vi.fn(),
@@ -51,7 +53,7 @@ vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => n
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.
 vi.mock('@lfx-one/shared/constants', () => ({ HOST_KEY_EARLY_MINUTES: 70, HOST_KEY_LATE_MINUTES: 40, MEETING_PASSWORD_HEADER: 'x-meeting-password' }));
-vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
+vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: validateUidParameterMock }));
 
 vi.mock('../services/meeting.service', () => ({
   MeetingService: vi.fn(function () {
@@ -521,6 +523,10 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
 
   it('missing meeting_id returns validation error', async () => {
     const { req, res, next } = buildRegisterReq(true, { meeting_id: '' });
+    validateUidParameterMock.mockImplementationOnce((_uid, _req, nextFn) => {
+      nextFn(new Error('Meeting ID is required'));
+      return false;
+    });
 
     await controller.registerForPublicMeeting(req, res, next);
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -527,4 +527,14 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(next).toHaveBeenCalledTimes(1);
     expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
   });
+
+  it('restores user token when getMeetingById throws', async () => {
+    const { req, res, next } = buildRegisterReq(true);
+    meetingSvc.getMeetingById.mockRejectedValue(new Error('upstream error'));
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(req.bearerToken).toBe('user-token');
+    expect(next).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -35,6 +35,8 @@ const {
     resolveCreatedByForMeetings: vi.fn().mockResolvedValue(new Map()),
     getMeetingHostKey: vi.fn(),
     getPastOccurrencesForMeeting: vi.fn(),
+    addMeetingRegistrantSelf: vi.fn(),
+    addMeetingRegistrantWithM2M: vi.fn(),
   },
   projectSvc: { getProjectById: vi.fn() },
   addInvitedStatusToMeetingMock: vi.fn(),
@@ -422,5 +424,116 @@ describe('PublicMeetingController.getMeetingOccurrences', () => {
 
     expect(generateM2MTokenMock).toHaveBeenCalledTimes(1);
     expect(req.bearerToken).toBe('m2m-token');
+  });
+});
+
+describe('PublicMeetingController.registerForPublicMeeting', () => {
+  let controller: PublicMeetingController;
+
+  function buildRegisterReq(authenticated: boolean, body: Record<string, any> = {}, hasUserToken = true) {
+    const req = {
+      body: { meeting_id: MEETING_ID, first_name: 'Alice', last_name: 'Liddell', email: 'alice@example.com', ...body },
+      headers: {},
+      bearerToken: hasUserToken ? 'user-token' : undefined,
+      oidc: { isAuthenticated: () => authenticated },
+      path: '/public/api/meetings/register',
+      log: {},
+    } as any;
+    const res = { json: vi.fn(), status: vi.fn().mockReturnThis() } as any;
+    const next = vi.fn();
+    return { req, res, next };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicMeetingController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    meetingSvc.addMeetingRegistrantSelf.mockResolvedValue({ uid: 'reg-1' });
+    meetingSvc.addMeetingRegistrantWithM2M.mockResolvedValue({ uid: 'reg-1' });
+  });
+
+  it('authenticated path — calls addMeetingRegistrantSelf and returns 201', async () => {
+    const { req, res, next } = buildRegisterReq(true);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf).toHaveBeenCalledWith(req, MEETING_ID, req.body);
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ uid: 'reg-1' });
+  });
+
+  it('authenticated path — restores user bearer token before calling self-register', async () => {
+    const { req, res, next } = buildRegisterReq(true);
+    let tokenAtCallTime: string | undefined;
+    meetingSvc.addMeetingRegistrantSelf.mockImplementation((r: any) => {
+      tokenAtCallTime = r.bearerToken;
+      return Promise.resolve({ uid: 'reg-1' });
+    });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(tokenAtCallTime).toBe('user-token');
+  });
+
+  it('authenticated path — missing first_name returns validation error without calling the service', async () => {
+    const { req, res, next } = buildRegisterReq(true, { first_name: '' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+  });
+
+  it('authenticated path — non-public meeting returns authorization error', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE }));
+    const { req, res, next } = buildRegisterReq(true);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+  });
+
+  it('authenticated path — restricted meeting returns authorization error', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ restricted: true }));
+    const { req, res, next } = buildRegisterReq(true);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+  });
+
+  it('anonymous path — calls addMeetingRegistrantWithM2M and returns 201', async () => {
+    const { req, res, next } = buildRegisterReq(false);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantWithM2M).toHaveBeenCalledWith(req, req.body, 'm2m-token');
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  it('anonymous path — missing email returns validation error', async () => {
+    const { req, res, next } = buildRegisterReq(false, { email: '' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+  });
+
+  it('missing meeting_id returns validation error for both paths', async () => {
+    const { req, res, next } = buildRegisterReq(false, { meeting_id: '' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -36,7 +36,6 @@ const {
     getMeetingHostKey: vi.fn(),
     getPastOccurrencesForMeeting: vi.fn(),
     addMeetingRegistrantSelf: vi.fn(),
-    addMeetingRegistrantWithM2M: vi.fn(),
   },
   projectSvc: { getProjectById: vi.fn() },
   addInvitedStatusToMeetingMock: vi.fn(),
@@ -432,7 +431,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
 
   function buildRegisterReq(authenticated: boolean, body: Record<string, any> = {}, hasUserToken = true) {
     const req = {
-      body: { meeting_id: MEETING_ID, first_name: 'Alice', last_name: 'Liddell', email: 'alice@example.com', ...body },
+      body: { meeting_id: MEETING_ID, first_name: 'Alice', last_name: 'Liddell', ...body },
       headers: {},
       bearerToken: hasUserToken ? 'user-token' : undefined,
       oidc: { isAuthenticated: () => authenticated },
@@ -447,25 +446,22 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     controller = new PublicMeetingController();
-    generateM2MTokenMock.mockResolvedValue('m2m-token');
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.addMeetingRegistrantSelf.mockResolvedValue({ uid: 'reg-1' });
-    meetingSvc.addMeetingRegistrantWithM2M.mockResolvedValue({ uid: 'reg-1' });
   });
 
-  it('authenticated path — calls addMeetingRegistrantSelf and returns 201', async () => {
+  it('calls addMeetingRegistrantSelf with user token and returns 201', async () => {
     const { req, res, next } = buildRegisterReq(true);
 
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
     expect(meetingSvc.addMeetingRegistrantSelf).toHaveBeenCalledWith(req, MEETING_ID, req.body);
-    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
     expect(res.status).toHaveBeenCalledWith(201);
     expect(res.json).toHaveBeenCalledWith({ uid: 'reg-1' });
   });
 
-  it('authenticated path — restores user bearer token before calling self-register', async () => {
+  it('passes user bearer token unchanged to addMeetingRegistrantSelf', async () => {
     const { req, res, next } = buildRegisterReq(true);
     let tokenAtCallTime: string | undefined;
     meetingSvc.addMeetingRegistrantSelf.mockImplementation((r: any) => {
@@ -478,7 +474,16 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(tokenAtCallTime).toBe('user-token');
   });
 
-  it('authenticated path — missing first_name returns validation error without calling the service', async () => {
+  it('unauthenticated request returns 401 without calling the service', async () => {
+    const { req, res, next } = buildRegisterReq(false);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
+  });
+
+  it('missing first_name returns validation error without calling the service', async () => {
     const { req, res, next } = buildRegisterReq(true, { first_name: '' });
 
     await controller.registerForPublicMeeting(req, res, next);
@@ -487,7 +492,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
   });
 
-  it('authenticated path — non-public meeting returns authorization error', async () => {
+  it('non-public meeting returns authorization error', async () => {
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE }));
     const { req, res, next } = buildRegisterReq(true);
 
@@ -497,7 +502,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
   });
 
-  it('authenticated path — restricted meeting returns authorization error', async () => {
+  it('restricted meeting returns authorization error', async () => {
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ restricted: true }));
     const { req, res, next } = buildRegisterReq(true);
 
@@ -507,33 +512,12 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
   });
 
-  it('anonymous path — calls addMeetingRegistrantWithM2M and returns 201', async () => {
-    const { req, res, next } = buildRegisterReq(false);
-
-    await controller.registerForPublicMeeting(req, res, next);
-
-    expect(next).not.toHaveBeenCalled();
-    expect(meetingSvc.addMeetingRegistrantWithM2M).toHaveBeenCalledWith(req, req.body, 'm2m-token');
-    expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
-    expect(res.status).toHaveBeenCalledWith(201);
-  });
-
-  it('anonymous path — missing email returns validation error', async () => {
-    const { req, res, next } = buildRegisterReq(false, { email: '' });
+  it('missing meeting_id returns validation error', async () => {
+    const { req, res, next } = buildRegisterReq(true, { meeting_id: '' });
 
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).toHaveBeenCalledTimes(1);
-    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
-  });
-
-  it('missing meeting_id returns validation error for both paths', async () => {
-    const { req, res, next } = buildRegisterReq(false, { meeting_id: '' });
-
-    await controller.registerForPublicMeeting(req, res, next);
-
-    expect(next).toHaveBeenCalledTimes(1);
-    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
     expect(meetingSvc.addMeetingRegistrantSelf).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -502,9 +502,11 @@ export class PublicMeetingController {
    * POST /public/api/meetings/register
    * Registers an authenticated user to a public, non-restricted meeting.
    *
-   * Calls POST /itx/meetings/{id}/registrants/self with the user's bearer token. Email and
-   * username are sourced from the caller's JWT by the meeting service — the body email field
-   * is not forwarded. Authentication is required; unauthenticated requests receive 401.
+   * Meeting validation (public + non-restricted check) uses M2M so the GET endpoint's viewer
+   * FGA check doesn't block users who aren't yet registered. The user's bearer token is then
+   * restored before calling POST /itx/meetings/{id}/registrants/self so the meeting service
+   * sources identity from the caller's JWT. Authentication is required; unauthenticated
+   * requests receive 401.
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
     const registrantData: CreateMeetingRegistrantRequest = req.body;
@@ -536,6 +538,8 @@ export class PublicMeetingController {
         );
       }
 
+      const userToken = req.bearerToken;
+
       if (!registrantData.first_name || !registrantData.last_name) {
         return next(
           ServiceValidationError.fromFieldErrors(
@@ -553,6 +557,7 @@ export class PublicMeetingController {
         );
       }
 
+      await this.setupM2MToken(req);
       const meeting = await this.meetingService.getMeetingById(req, meetingId, 'v1_meeting', false);
 
       if (!meeting) {
@@ -566,6 +571,7 @@ export class PublicMeetingController {
       const authError = this.checkMeetingIsPublicAndNotRestricted(req, meeting);
       if (authError) return next(authError);
 
+      req.bearerToken = userToken;
       const newRegistrant = await this.meetingService.addMeetingRegistrantSelf(req, meetingId, registrantData);
 
       logger.success(req, 'register_for_public_meeting', startTime, {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -8,7 +8,7 @@ import { CreateMeetingRegistrantRequest, MeetingOccurrenceSummary, MeetingRegist
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
-import { AuthorizationError } from '../errors/authentication.error';
+import { AuthenticationError, AuthorizationError } from '../errors/authentication.error';
 import {
   addInvitedStatusToMeeting,
   applyHostKeyVisibility,
@@ -530,14 +530,19 @@ export class PublicMeetingController {
         return next(validationError);
       }
 
-      const originalToken = req.bearerToken;
-      const isAuthenticated = req.oidc?.isAuthenticated() && originalToken !== undefined;
+      if (!req.oidc?.isAuthenticated() || !req.bearerToken) {
+        return next(
+          new AuthenticationError('Authentication required to register for a meeting', {
+            operation: 'register_for_public_meeting',
+            service: 'public_meeting_controller',
+            path: req.path,
+          })
+        );
+      }
 
-      if (isAuthenticated) {
-        // Authenticated path: validate name fields only (email comes from JWT), then use the
-        // self-register endpoint so the meeting service enforces identity and public-only access.
-        if (!registrantData.first_name || !registrantData.last_name) {
-          const validationError = ServiceValidationError.fromFieldErrors(
+      if (!registrantData.first_name || !registrantData.last_name) {
+        return next(
+          ServiceValidationError.fromFieldErrors(
             {
               first_name: !registrantData.first_name ? 'First name is required' : [],
               last_name: !registrantData.last_name ? 'Last name is required' : [],
@@ -548,64 +553,10 @@ export class PublicMeetingController {
               service: 'public_meeting_controller',
               path: req.path,
             }
-          );
-
-          return next(validationError);
-        }
-
-        // Fetch the meeting with M2M to enforce public + non-restricted at the BFF layer,
-        // then restore the user's token before forwarding to the self-register endpoint.
-        await this.setupM2MToken(req);
-        const meeting = await this.meetingService.getMeetingById(req, meetingId, 'v1_meeting', false);
-
-        if (!meeting) {
-          throw new ResourceNotFoundError('Meeting', meetingId, {
-            operation: 'register_for_public_meeting',
-            service: 'public_meeting_controller',
-            path: `/itx/meetings/${meetingId}`,
-          });
-        }
-
-        const authError = this.checkMeetingIsPublicAndNotRestricted(req, meeting);
-        if (authError) return next(authError);
-
-        // Restore user's bearer token before calling self-register so the meeting service
-        // can source the identity from the user's JWT rather than the application identity.
-        req.bearerToken = originalToken;
-
-        const newRegistrant = await this.meetingService.addMeetingRegistrantSelf(req, meetingId, registrantData);
-
-        logger.success(req, 'register_for_public_meeting', startTime, {
-          meeting_id: meetingId,
-          registrant_uid: newRegistrant.uid,
-        });
-
-        return void res.status(201).json(newRegistrant);
-      }
-
-      // Anonymous path: email is required in the body. Use M2M token for the full registrant flow.
-      if (!registrantData.email || !registrantData.first_name || !registrantData.last_name) {
-        const validationError = ServiceValidationError.fromFieldErrors(
-          {
-            email: !registrantData.email ? 'Email is required' : [],
-            first_name: !registrantData.first_name ? 'First name is required' : [],
-            last_name: !registrantData.last_name ? 'Last name is required' : [],
-          },
-          'Registration data validation failed',
-          {
-            operation: 'register_for_public_meeting',
-            service: 'public_meeting_controller',
-            path: req.path,
-          }
+          )
         );
-
-        return next(validationError);
       }
 
-      // Generate M2M token
-      const m2mToken = await this.setupM2MToken(req);
-
-      // Fetch the meeting to validate it's public and non-restricted
       const meeting = await this.meetingService.getMeetingById(req, meetingId, 'v1_meeting', false);
 
       if (!meeting) {
@@ -619,8 +570,7 @@ export class PublicMeetingController {
       const authError = this.checkMeetingIsPublicAndNotRestricted(req, meeting);
       if (authError) return next(authError);
 
-      // Add the registrant using M2M token
-      const newRegistrant = await this.meetingService.addMeetingRegistrantWithM2M(req, registrantData, m2mToken);
+      const newRegistrant = await this.meetingService.addMeetingRegistrantSelf(req, meetingId, registrantData);
 
       logger.success(req, 'register_for_public_meeting', startTime, {
         meeting_id: meetingId,

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -500,7 +500,15 @@ export class PublicMeetingController {
 
   /**
    * POST /public/api/meetings/register
-   * Registers a user to a public, non-restricted meeting
+   * Registers a user to a public, non-restricted meeting.
+   *
+   * Authenticated users: calls POST /itx/meetings/{id}/registrants/self with the user's
+   * bearer token. Email is sourced from the user's JWT by the meeting service — the body
+   * email field is ignored. The meeting service enforces the public-only constraint.
+   *
+   * Anonymous users: falls back to the M2M path (POST /itx/meetings/{id}/registrants).
+   * Email must be provided in the request body. The BFF validates public and non-restricted
+   * constraints before forwarding.
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
     const registrantData: CreateMeetingRegistrantRequest = req.body;
@@ -522,7 +530,77 @@ export class PublicMeetingController {
         return next(validationError);
       }
 
-      // Validate required fields
+      const originalToken = req.bearerToken;
+      const isAuthenticated = req.oidc?.isAuthenticated() && originalToken !== undefined;
+
+      if (isAuthenticated) {
+        // Authenticated path: validate name fields only (email comes from JWT), then use the
+        // self-register endpoint so the meeting service enforces identity and public-only access.
+        if (!registrantData.first_name || !registrantData.last_name) {
+          const validationError = ServiceValidationError.fromFieldErrors(
+            {
+              first_name: !registrantData.first_name ? 'First name is required' : [],
+              last_name: !registrantData.last_name ? 'Last name is required' : [],
+            },
+            'Registration data validation failed',
+            {
+              operation: 'register_for_public_meeting',
+              service: 'public_meeting_controller',
+              path: req.path,
+            }
+          );
+
+          return next(validationError);
+        }
+
+        // Fetch the meeting with M2M to enforce public + non-restricted at the BFF layer,
+        // then restore the user's token before forwarding to the self-register endpoint.
+        await this.setupM2MToken(req);
+        const meeting = await this.meetingService.getMeetingById(req, meetingId, 'v1_meeting', false);
+
+        if (!meeting) {
+          throw new ResourceNotFoundError('Meeting', meetingId, {
+            operation: 'register_for_public_meeting',
+            service: 'public_meeting_controller',
+            path: `/itx/meetings/${meetingId}`,
+          });
+        }
+
+        if (meeting.visibility !== MeetingVisibility.PUBLIC) {
+          return next(
+            new AuthorizationError('Registration is not allowed for non-public meetings', {
+              operation: 'register_for_public_meeting',
+              service: 'public_meeting_controller',
+              path: req.path,
+            })
+          );
+        }
+
+        if (meeting.restricted) {
+          return next(
+            new AuthorizationError('Registration is not allowed for restricted meetings', {
+              operation: 'register_for_public_meeting',
+              service: 'public_meeting_controller',
+              path: req.path,
+            })
+          );
+        }
+
+        // Restore user's bearer token before calling self-register so the meeting service
+        // can source the identity from the user's JWT rather than the application identity.
+        req.bearerToken = originalToken;
+
+        const newRegistrant = await this.meetingService.addMeetingRegistrantSelf(req, meetingId, registrantData);
+
+        logger.success(req, 'register_for_public_meeting', startTime, {
+          meeting_id: meetingId,
+          registrant_uid: newRegistrant.uid,
+        });
+
+        return void res.status(201).json(newRegistrant);
+      }
+
+      // Anonymous path: email is required in the body. Use M2M token for the full registrant flow.
       if (!registrantData.email || !registrantData.first_name || !registrantData.last_name) {
         const validationError = ServiceValidationError.fromFieldErrors(
           {
@@ -557,24 +635,24 @@ export class PublicMeetingController {
 
       // Validate the meeting is public
       if (meeting.visibility !== MeetingVisibility.PUBLIC) {
-        const authError = new AuthorizationError('Registration is not allowed for non-public meetings', {
-          operation: 'register_for_public_meeting',
-          service: 'public_meeting_controller',
-          path: req.path,
-        });
-
-        return next(authError);
+        return next(
+          new AuthorizationError('Registration is not allowed for non-public meetings', {
+            operation: 'register_for_public_meeting',
+            service: 'public_meeting_controller',
+            path: req.path,
+          })
+        );
       }
 
       // Validate the meeting is not restricted
       if (meeting.restricted) {
-        const authError = new AuthorizationError('Registration is not allowed for restricted meetings', {
-          operation: 'register_for_public_meeting',
-          service: 'public_meeting_controller',
-          path: req.path,
-        });
-
-        return next(authError);
+        return next(
+          new AuthorizationError('Registration is not allowed for restricted meetings', {
+            operation: 'register_for_public_meeting',
+            service: 'public_meeting_controller',
+            path: req.path,
+          })
+        );
       }
 
       // Add the registrant using M2M token

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -517,15 +517,8 @@ export class PublicMeetingController {
     });
 
     try {
-      // Validate the meeting ID is provided
-      if (!meetingId) {
-        const validationError = ServiceValidationError.forField('meeting_id', 'Meeting ID is required', {
-          operation: 'register_for_public_meeting',
-          service: 'public_meeting_controller',
-          path: req.path,
-        });
-
-        return next(validationError);
+      if (!this.validateMeetingId(meetingId, 'register_for_public_meeting', req, next)) {
+        return;
       }
 
       if (!req.oidc?.isAuthenticated() || !req.bearerToken) {
@@ -618,7 +611,6 @@ export class PublicMeetingController {
 
   /**
    * Returns an AuthorizationError if the meeting is non-public or restricted, or null if valid.
-   * Both the authenticated and anonymous registration paths enforce the same constraints.
    */
   private checkMeetingIsPublicAndNotRestricted(req: Request, meeting: Pick<Meeting, 'visibility' | 'restricted'>): AuthorizationError | null {
     if (meeting.visibility !== MeetingVisibility.PUBLIC) {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -500,15 +500,11 @@ export class PublicMeetingController {
 
   /**
    * POST /public/api/meetings/register
-   * Registers a user to a public, non-restricted meeting.
+   * Registers an authenticated user to a public, non-restricted meeting.
    *
-   * Authenticated users: calls POST /itx/meetings/{id}/registrants/self with the user's
-   * bearer token. Email is sourced from the user's JWT by the meeting service — the body
-   * email field is ignored. The meeting service enforces the public-only constraint.
-   *
-   * Anonymous users: falls back to the M2M path (POST /itx/meetings/{id}/registrants).
-   * Email must be provided in the request body. The BFF validates public and non-restricted
-   * constraints before forwarding.
+   * Calls POST /itx/meetings/{id}/registrants/self with the user's bearer token. Email and
+   * username are sourced from the caller's JWT by the meeting service — the body email field
+   * is not forwarded. Authentication is required; unauthenticated requests receive 401.
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
     const registrantData: CreateMeetingRegistrantRequest = req.body;

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -566,25 +566,8 @@ export class PublicMeetingController {
           });
         }
 
-        if (meeting.visibility !== MeetingVisibility.PUBLIC) {
-          return next(
-            new AuthorizationError('Registration is not allowed for non-public meetings', {
-              operation: 'register_for_public_meeting',
-              service: 'public_meeting_controller',
-              path: req.path,
-            })
-          );
-        }
-
-        if (meeting.restricted) {
-          return next(
-            new AuthorizationError('Registration is not allowed for restricted meetings', {
-              operation: 'register_for_public_meeting',
-              service: 'public_meeting_controller',
-              path: req.path,
-            })
-          );
-        }
+        const authError = this.checkMeetingIsPublicAndNotRestricted(req, meeting);
+        if (authError) return next(authError);
 
         // Restore user's bearer token before calling self-register so the meeting service
         // can source the identity from the user's JWT rather than the application identity.
@@ -633,27 +616,8 @@ export class PublicMeetingController {
         });
       }
 
-      // Validate the meeting is public
-      if (meeting.visibility !== MeetingVisibility.PUBLIC) {
-        return next(
-          new AuthorizationError('Registration is not allowed for non-public meetings', {
-            operation: 'register_for_public_meeting',
-            service: 'public_meeting_controller',
-            path: req.path,
-          })
-        );
-      }
-
-      // Validate the meeting is not restricted
-      if (meeting.restricted) {
-        return next(
-          new AuthorizationError('Registration is not allowed for restricted meetings', {
-            operation: 'register_for_public_meeting',
-            service: 'public_meeting_controller',
-            path: req.path,
-          })
-        );
-      }
+      const authError = this.checkMeetingIsPublicAndNotRestricted(req, meeting);
+      if (authError) return next(authError);
 
       // Add the registrant using M2M token
       const newRegistrant = await this.meetingService.addMeetingRegistrantWithM2M(req, registrantData, m2mToken);
@@ -694,6 +658,28 @@ export class PublicMeetingController {
       operation,
       service: 'public_meeting_controller',
     });
+  }
+
+  /**
+   * Returns an AuthorizationError if the meeting is non-public or restricted, or null if valid.
+   * Both the authenticated and anonymous registration paths enforce the same constraints.
+   */
+  private checkMeetingIsPublicAndNotRestricted(req: Request, meeting: Pick<Meeting, 'visibility' | 'restricted'>): AuthorizationError | null {
+    if (meeting.visibility !== MeetingVisibility.PUBLIC) {
+      return new AuthorizationError('Registration is not allowed for non-public meetings', {
+        operation: 'register_for_public_meeting',
+        service: 'public_meeting_controller',
+        path: req.path,
+      });
+    }
+    if (meeting.restricted) {
+      return new AuthorizationError('Registration is not allowed for restricted meetings', {
+        operation: 'register_for_public_meeting',
+        service: 'public_meeting_controller',
+        path: req.path,
+      });
+    }
+    return null;
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -557,8 +557,13 @@ export class PublicMeetingController {
         );
       }
 
-      await this.setupM2MToken(req);
-      const meeting = await this.meetingService.getMeetingById(req, meetingId, 'v1_meeting', false);
+      let meeting: Awaited<ReturnType<typeof this.meetingService.getMeetingById>>;
+      try {
+        await this.setupM2MToken(req);
+        meeting = await this.meetingService.getMeetingById(req, meetingId, 'v1_meeting', false);
+      } finally {
+        req.bearerToken = userToken;
+      }
 
       if (!meeting) {
         throw new ResourceNotFoundError('Meeting', meetingId, {
@@ -571,7 +576,6 @@ export class PublicMeetingController {
       const authError = this.checkMeetingIsPublicAndNotRestricted(req, meeting);
       if (authError) return next(authError);
 
-      req.bearerToken = userToken;
       const newRegistrant = await this.meetingService.addMeetingRegistrantSelf(req, meetingId, registrantData);
 
       logger.success(req, 'register_for_public_meeting', startTime, {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -303,6 +303,8 @@ describe('MeetingService.addMeetingRegistrantSelf', () => {
     expect(path).toBe('/itx/meetings/mtg-1/registrants/self');
     expect(method).toBe('POST');
     expect(body).toMatchObject({ first_name: 'Alice', last_name: 'Liddell' });
+    expect(body).not.toHaveProperty('email');
+    expect(body).not.toHaveProperty('username');
     expect(result).toEqual(registrant);
   });
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -299,12 +299,13 @@ describe('MeetingService.addMeetingRegistrantSelf', () => {
     });
 
     expect(proxyRequest).toHaveBeenCalledTimes(1);
-    const [, , path, method, , body] = proxyRequest.mock.calls[0];
+    const [, , path, method, , body, headers] = proxyRequest.mock.calls[0];
     expect(path).toBe('/itx/meetings/mtg-1/registrants/self');
     expect(method).toBe('POST');
     expect(body).toMatchObject({ first_name: 'Alice', last_name: 'Liddell' });
     expect(body).not.toHaveProperty('email');
     expect(body).not.toHaveProperty('username');
+    expect(headers).toEqual({ 'X-Sync': 'true' });
     expect(result).toEqual(registrant);
   });
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -278,3 +278,66 @@ describe('MeetingService.getPastOccurrencesForMeeting', () => {
     expect(result).toEqual([]);
   });
 });
+
+describe('MeetingService.addMeetingRegistrantSelf', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('posts to the self-register endpoint with required fields and returns the new registrant', async () => {
+    const registrant = { uid: 'reg-abc', email: 'alice@example.com' };
+    proxyRequest.mockResolvedValueOnce(registrant);
+
+    const result = await service.addMeetingRegistrantSelf(req, 'mtg-1', {
+      meeting_id: 'mtg-1',
+      first_name: 'Alice',
+      last_name: 'Liddell',
+      email: 'alice@example.com',
+    });
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    const [, , path, method, , body] = proxyRequest.mock.calls[0];
+    expect(path).toBe('/itx/meetings/mtg-1/registrants/self');
+    expect(method).toBe('POST');
+    expect(body).toMatchObject({ first_name: 'Alice', last_name: 'Liddell' });
+    expect(result).toEqual(registrant);
+  });
+
+  it('omits optional fields when they are absent from the request', async () => {
+    proxyRequest.mockResolvedValueOnce({ uid: 'reg-1' });
+
+    await service.addMeetingRegistrantSelf(req, 'mtg-1', {
+      meeting_id: 'mtg-1',
+      first_name: 'Alice',
+      last_name: 'Liddell',
+      email: 'alice@example.com',
+    });
+
+    const [, , , , , body] = proxyRequest.mock.calls[0];
+    expect(body).not.toHaveProperty('org');
+    expect(body).not.toHaveProperty('job_title');
+    expect(body).not.toHaveProperty('occurrence');
+  });
+
+  it('maps org_name to org and occurrence_id to occurrence when provided', async () => {
+    proxyRequest.mockResolvedValueOnce({ uid: 'reg-1' });
+
+    await service.addMeetingRegistrantSelf(req, 'mtg-1', {
+      meeting_id: 'mtg-1',
+      first_name: 'Alice',
+      last_name: 'Liddell',
+      email: 'alice@example.com',
+      org_name: 'Linux Foundation',
+      job_title: 'Engineer',
+      occurrence_id: 'occ-42',
+    });
+
+    const [, , , , , body] = proxyRequest.mock.calls[0];
+    expect(body).toMatchObject({ org: 'Linux Foundation', job_title: 'Engineer', occurrence: 'occ-42' });
+    expect(body).not.toHaveProperty('org_name');
+    expect(body).not.toHaveProperty('occurrence_id');
+  });
+});

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1673,6 +1673,42 @@ export class MeetingService {
     return newRegistrant;
   }
 
+  /**
+   * Registers the authenticated user as a meeting registrant using their bearer token.
+   * Email and username are sourced from the user's JWT by the meeting service — they must
+   * not be included in the payload. Only public meetings are supported; private meetings
+   * return 403.
+   */
+  public async addMeetingRegistrantSelf(req: Request, meetingId: string, registrantData: CreateMeetingRegistrantRequest): Promise<MeetingRegistrant> {
+    const startTime = logger.startOperation(req, 'add_meeting_registrant_self', { meeting_id: meetingId });
+
+    logger.debug(req, 'add_meeting_registrant_self', 'Self-registering authenticated user for meeting', { meeting_id: meetingId });
+
+    const payload = {
+      first_name: registrantData.first_name,
+      last_name: registrantData.last_name,
+      ...(registrantData.org_name && { org: registrantData.org_name }),
+      ...(registrantData.job_title && { job_title: registrantData.job_title }),
+      ...(registrantData.occurrence_id && { occurrence: registrantData.occurrence_id }),
+    };
+
+    const newRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
+      req,
+      'LFX_V2_SERVICE',
+      `/itx/meetings/${meetingId}/registrants/self`,
+      'POST',
+      undefined,
+      payload,
+    );
+
+    logger.success(req, 'add_meeting_registrant_self', startTime, {
+      meeting_id: meetingId,
+      registrant_uid: newRegistrant.uid,
+    });
+
+    return newRegistrant;
+  }
+
   public async getMeetingProjectName<T extends Meeting>(req: Request, meetings: T[]): Promise<T[]> {
     return this.projectService.enrichWithProjectData(req, meetings) as Promise<T[]>;
   }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1642,38 +1642,6 @@ export class MeetingService {
   }
 
   /**
-   * Creates a new meeting registrant using M2M token (for public endpoints)
-   * @param req - Express request object
-   * @param registrantData - Registrant data to create
-   * @param m2mToken - M2M token for authentication
-   * @returns The created meeting registrant
-   */
-  public async addMeetingRegistrantWithM2M(req: Request, registrantData: CreateMeetingRegistrantRequest, m2mToken: string): Promise<MeetingRegistrant> {
-    const startTime = logger.startOperation(req, 'add_meeting_registrant_with_m2m', { meeting_id: registrantData.meeting_id });
-
-    const sanitizedPayload = logger.sanitize({ registrantData });
-    logger.debug(req, 'add_meeting_registrant_with_m2m', 'Creating meeting registrant with M2M token', sanitizedPayload);
-
-    const newRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
-      req,
-      'LFX_V2_SERVICE',
-      `/itx/meetings/${registrantData.meeting_id}/registrants`,
-      'POST',
-      undefined,
-      registrantData,
-      { Authorization: `Bearer ${m2mToken}`, ['X-Sync']: 'true' }
-    );
-
-    logger.success(req, 'add_meeting_registrant_with_m2m', startTime, {
-      meeting_id: registrantData.meeting_id,
-      registrant_uid: newRegistrant.uid,
-      host: registrantData.host || false,
-    });
-
-    return newRegistrant;
-  }
-
-  /**
    * Registers the authenticated user as a meeting registrant using their bearer token.
    * Email and username are sourced from the user's JWT by the meeting service — they must
    * not be included in the payload. Only public meetings are supported; private meetings
@@ -1698,7 +1666,8 @@ export class MeetingService {
       `/itx/meetings/${meetingId}/registrants/self`,
       'POST',
       undefined,
-      payload
+      payload,
+      { 'X-Sync': 'true' }
     );
 
     logger.success(req, 'add_meeting_registrant_self', startTime, {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1698,7 +1698,7 @@ export class MeetingService {
       `/itx/meetings/${meetingId}/registrants/self`,
       'POST',
       undefined,
-      payload,
+      payload
     );
 
     logger.success(req, 'add_meeting_registrant_self', startTime, {


### PR DESCRIPTION
## Summary

- When a user is authenticated, \`POST /public/api/meetings/register\` now calls \`POST /itx/meetings/{id}/registrants/self\` with the user's own bearer token. Email and username are sourced from the user's JWT by the meeting service, fixing the 403 error caused by M2M tokens with no FGA viewer grants on the meeting.
- **Authentication is now required** to register for a meeting. The previous anonymous M2M path has been removed — the new upstream endpoint (\`/itx/meetings/{id}/registrants/self\`) requires a user JWT to source identity, so an M2M fallback is not possible. Unauthenticated users are directed to sign in before registering.
- The BFF still validates public + non-restricted constraints before forwarding.
- Extracted shared \`checkMeetingIsPublicAndNotRestricted\` private helper to eliminate duplicate validation logic.
- Added comprehensive \`registerForPublicMeeting\` test suite (8 cases) and \`addMeetingRegistrantSelf\` service unit tests (3 cases).
- After successful self-registration the meeting card immediately shows RSVP options (register button hidden, RSVP button group shown) via optimistic \`registeredInSession\` / \`effectivelyInvited\` signals, without waiting for the query-service index to settle.
- After successful self-registration on the meeting join page the registrants drawer immediately fetches and shows the user's entry via optimistic \`optimisticInvited\` signal.

## Ticket

[LFXV2-3105](https://linuxfoundation.atlassian.net/browse/LFXV2-3105)

## Upstream dependency

**This PR must not be merged before [lfx-v2-meeting-service PR #243](https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/243) is merged and deployed.** That PR adds the \`POST /itx/meetings/{id}/registrants/self\` endpoint consumed here.

## Related PRs

- [lfx-v2-meeting-service #243](https://github.com/linuxfoundation/lfx-v2-meeting-service/pull/243) — upstream self-register endpoint

## Test plan

- [ ] Authenticated user clicking "Register for Meeting" on a public meeting registers successfully with their identity
- [ ] After registration the register button disappears and RSVP options appear immediately (before meeting refetch settles)
- [ ] After registration on the join page clicking "Show Members" shows the user in the list immediately
- [ ] Unauthenticated user attempting to register receives 401 and is prompted to sign in
- [ ] Authenticated user attempting to register for a private meeting receives 403
- [ ] Authenticated user attempting to register for a restricted meeting receives 403
- [ ] \`yarn check-types\` passes
- [ ] \`yarn lint:check\` passes (0 new errors)
- [ ] Unit tests pass

## Notes

Branch name includes \`-self-register-bff\` descriptor because \`fix/LFXV2-3105\` is already taken by another open PR on this ticket in this repo.

🤖 Generated with [Claude Code](https://claude.ai/code)

[LFXV2-3105]: https://linuxfoundation.atlassian.net/browse/LFXV2-3105?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ