### PR TITLE
refactor(cla): remove interim identity-query padding stopgap

### DIFF
--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -303,7 +303,7 @@ describe('ClaService.getMyClas', () => {
     expect(calledUrl).toContain('githubUsername=octocat');
   });
 
-  it('duplicates single-valued github keys when email is multi-valued, to survive the gateway multi-value strip (lfx-gateway#114)', async () => {
+  it('FR-011 guard: a multi-email caller reaches the gateway with its GitHub keys present', async () => {
     getEffectiveUsername.mockReturnValue('alice');
     getEffectiveEmail.mockReturnValue('alice@x.org');
     getEffectiveSub.mockReturnValue('auth0|abc');
@@ -321,41 +321,8 @@ describe('ClaService.getMyClas', () => {
 
     const calledUrl = gatewayFetch.mock.calls[0][1] as string;
     const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
-    // 3 verified emails -> email is multi-valued, so the lone github keys are padded to 2 so the
-    // gateway keeps them (it forwards only multi-valued params once any param repeats); the backend de-dupes.
-    expect(params.getAll('email').length).toBeGreaterThan(1);
-    expect(params.getAll('githubId')).toEqual(['13434323', '13434323']);
-    expect(params.getAll('githubUsername')).toEqual(['octocat', 'octocat']);
-    // lfUsername stays single-valued (harmless: the backend derives the principal from the X-USERNAME header).
-    expect(params.getAll('lfUsername')).toEqual(['alice']);
-    // The padded values are byte-identical (a repeated single value, not two distinct ids), so the
-    // backend collapses them via pre-authorization de-dupe — no double-count (FR-003, BFF half).
-    expect(new Set(params.getAll('githubId')).size).toBe(1);
-    expect(new Set(params.getAll('githubUsername')).size).toBe(1);
-  });
-
-  it('FR-011 guard: a multi-email caller reaches the gateway with its GitHub keys present (survives the strip)', async () => {
-    getEffectiveUsername.mockReturnValue('alice');
-    getEffectiveEmail.mockReturnValue('alice@x.org');
-    getEffectiveSub.mockReturnValue('auth0|abc');
-    getUserEmails.mockResolvedValueOnce({
-      primary_email: 'alice@x.org',
-      alternate_emails: [
-        { email: 'alice@work.com', verified: true },
-        { email: 'alice@personal.com', verified: true },
-      ],
-    });
-    getUserIdentities.mockResolvedValueOnce([{ provider: 'github', user_id: 'github|13434323', connection: 'github', profileData: { nickname: 'octocat' } }]);
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1'], clas: [] });
-
-    await new ClaService().getMyClas(req);
-
-    const calledUrl = gatewayFetch.mock.calls[0][1] as string;
-    const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
-    // Invariant, NOT the padding mechanism: a multi-email caller's github keys must reach the backend.
-    // Stays true after the #114 padding is removed and the gateway stops stripping single-value params.
-    expect(params.getAll('githubId')).toContain('13434323');
-    expect(params.getAll('githubUsername')).toContain('octocat');
+    expect(params.getAll('githubId')).toEqual(['13434323']);
+    expect(params.getAll('githubUsername')).toEqual(['octocat']);
   });
 
   it('does not duplicate github keys on the single-email path (no-regression, FR-002)', async () => {
@@ -369,13 +336,12 @@ describe('ClaService.getMyClas', () => {
 
     const calledUrl = gatewayFetch.mock.calls[0][1] as string;
     const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
-    // One email -> nothing is multi-valued -> no padding: byte-for-byte the pre-#114 query.
     expect(params.getAll('email')).toEqual(['alice@x.org']);
     expect(params.getAll('githubId')).toEqual(['13434323']);
     expect(params.getAll('githubUsername')).toEqual(['octocat']);
   });
 
-  it('under impersonation, pads and forwards the TARGET user github keys with the target token (FR-009)', async () => {
+  it('under impersonation, forwards the TARGET user github keys with the target token (FR-009)', async () => {
     isImpersonating.mockReturnValue(true);
     // getEffective* return the *target* identity during impersonation.
     getEffectiveUsername.mockReturnValue('alice');
@@ -396,7 +362,7 @@ describe('ClaService.getMyClas', () => {
 
     const [, calledUrl, opts] = gatewayFetch.mock.calls[0] as [unknown, string, { bearerToken?: string }];
     const params = new URLSearchParams(calledUrl.slice(calledUrl.indexOf('?') + 1));
-    expect(params.getAll('githubId')).toContain('13434323'); // target's key, padded, present
+    expect(params.getAll('githubId')).toContain('13434323');
     expect(params.getAll('githubUsername')).toContain('octocat');
     expect(opts.bearerToken).toBe('target-token'); // runs under the target's token, not the impersonator's
   });

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -301,40 +301,20 @@ export class ClaService {
    * `lfUsername` defaults to the authenticated principal upstream when omitted,
    * but is sent explicitly for clarity. GitHub id and username are both sent (see
    * resolveIdentity).
-   *
-   * STOPGAP (lfx-gateway#114): the platform API gateway's awslambda middleware
-   * forwards ONLY multi-valued query params when ANY param is repeated, silently
-   * dropping every single-valued one. With 2+ verified emails that strips the
-   * single `githubId`/`githubUsername`, so GitHub-only CLAs disappear. Pad each
-   * array key to length >= 2 (duplicate the lone value) whenever any key is
-   * already multi-valued, so it survives the gateway; EasyCLA de-dupes each
-   * identity list before authorizing, so the duplicate is a no-op server-side.
-   * `lfUsername` is intentionally NOT padded - the backend derives the principal
-   * from the X-USERNAME header, so its loss is harmless. Remove once #114 ships.
    */
   private identityQuery(identity: ResolvedClaIdentity): URLSearchParams {
     const params = new URLSearchParams();
 
-    const anyMulti = identity.emails.length > 1 || identity.githubIds.length > 1 || identity.githubUsernames.length > 1;
-
-    const appendKeepAlive = (key: string, values: string[]): void => {
-      if (values.length === 0) {
-        return;
-      }
-      if (anyMulti && values.length === 1) {
-        params.append(key, values[0]);
-        params.append(key, values[0]);
-        return;
-      }
-      for (const value of values) {
-        params.append(key, value);
-      }
-    };
-
     if (identity.lfUsername) params.set('lfUsername', identity.lfUsername);
-    appendKeepAlive('email', identity.emails);
-    appendKeepAlive('githubId', identity.githubIds);
-    appendKeepAlive('githubUsername', identity.githubUsernames);
+    for (const email of identity.emails) {
+      params.append('email', email);
+    }
+    for (const githubId of identity.githubIds) {
+      params.append('githubId', githubId);
+    }
+    for (const githubUsername of identity.githubUsernames) {
+      params.append('githubUsername', githubUsername);
+    }
     return params;
   }
 }


### PR DESCRIPTION
Closes #1413. Removes the interim BFF workaround from #1339 now that the durable gateway fix is deployed.

## Why

The platform API gateway's `awslambda` middleware dropped every single-valued query param whenever any param was repeated (linuxfoundation/lfx-gateway#114). Once a contributor had 2+ verified emails, `email` became multi-valued and `githubId` / `githubUsername` were silently stripped in transit, so GitHub-only CLAs disappeared from My CLAs (#1314). The BFF padded those keys to length 2 to survive the strip.

The root cause is now fixed (`linuxfoundation/traefik#8`) and deployed, so the padding is dead weight.

## What changed

- `identityQuery` in `apps/lfx-one/src/server/services/cla.service.ts`: dropped `anyMulti` and `appendKeepAlive`, restored a plain `params.append` per value, removed the `STOPGAP (lfx-gateway#114)` comment block. `lfUsername` still uses `params.set`; emission order is unchanged.
- Removed the padding-specific unit test and the now-stale comments describing the padding mechanism.
- **Tightened the FR-011 guard from `toContain` to `toEqual`.** As written it asserted `toContain('13434323')`, which is satisfied by a padded `['13434323','13434323']` just as well as by an unpadded `['13434323']` — so with the padding-specific test deleted, nothing in the suite would have failed if the padding were reintroduced. Verified by reintroducing the padding as a temporary mutant and confirming the guard now fails on it.

## Verification that the gateway fix is live

`/cla-service/v4/ops/health` is a public route that traverses the *same* `route-to-cla-service-lambda` middleware, so it can be probed unauthenticated. I sent a deliberately mixed query string — one single-valued param plus two multi-valued ones to force the failure condition — and read what the Lambda actually received:

```
GET /cla-service/v4/ops/health?probe=<tag>&probe=<tag>&scalar=SCALARSENTINEL&multi=1&multi=2
```

| Env | Query string as received by the CLA Lambda | Single-valued `scalar` |
|---|---|---|
| dev | `scalar=SCALARSENTINEL&multi=1&multi=2&probe=…&probe=…` | survived |
| staging | `scalar=SCALARSENTINEL&multi=1&multi=2&probe=…&probe=…` | survived |
| prod | `multi=1&multi=2&probe=…&probe=…&scalar=SCALARSENTINEL` | survived |

Under the old `valuesToMultiMap`, `scalar` would have been dropped in all three, because `multi` and `probe` made the multi-value map non-empty and the receiver then ignores the single-value map entirely. This satisfies the FR-010 removal gate.

Independently, a production My CLAs load for a contributor with 3 verified emails now reaches the backend with `lfUsername` intact alongside the repeated `email` params — meaningful because the stopgap never padded `lfUsername`, so its arrival can only be explained by the gateway forwarding single-valued params again.

> Note: the `lfx-gateway` deploy that carried this fix shows as failed overall, which is misleading — the only failing tests were `Security Service Health Check` (502 dev / 500 staging), with 17 passing. The Deploy Development, Deploy Staging, and Deploy Production jobs all succeeded, and the probe above independently confirms the middleware behaviour per environment.

## Test plan

- [x] `npx vitest run src/server/services/cla.service.spec.ts` — 37/37
- [x] `yarn test` (root) — 810/810
- [x] `./check-headers.sh`, `yarn format:check`, `yarn lint:check`, `yarn check-types`
- [x] `tsc --noEmit -p apps/lfx-one/tsconfig.json` (the documented `check-types` only covers `packages/shared`)
