### PR TITLE
fix(votes): stop empty table on uncached page jumps (LFXV2-3199)

### DIFF
--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -15,7 +15,7 @@ import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, catchError, combineLatest, finalize, map, of, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, finalize, map, Observable, of, switchMap, tap } from 'rxjs';
 
 import { VoteCastDrawerComponent } from '../components/vote-cast-drawer/vote-cast-drawer.component';
 import { VoteResultsDrawerComponent } from '../components/vote-results-drawer/vote-results-drawer.component';
@@ -100,7 +100,7 @@ export class VotesDashboardComponent {
   });
 
   // Lens-change pagination reset is independent of the data-fetch pipelines so it fires for every lens emission, not just Me-lens loads.
-  // fetch$.next() forces initVotes() to re-run after the reset — field-init order means it would otherwise see stale currentFirst and stop at the page-token guard.
+  // fetch$.next() forces initVotes() to re-run after the reset — field-init order means it would otherwise see stale currentFirst and walk from a stale page index.
   public constructor() {
     toObservable(this.lensService.activeLens)
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -271,38 +271,63 @@ export class VotesDashboardComponent {
           }
 
           const rows = this.rowsPerPage();
-          const first = this.currentFirst();
-          const pageIndex = first / rows;
-          const pageToken = pageIndex > 0 ? this.pageTokens[pageIndex - 1] : undefined;
-
-          if (pageIndex > 0 && !pageToken) {
-            this.currentFirst.set(0);
-            this.loading.set(false);
-            return of([]);
-          }
-
+          const pageIndex = this.currentFirst() / rows;
           const searchName = this.searchQuery();
           const queryFilters = this.buildFilters();
 
-          return this.voteService
-            .getVotesByProjectPaginated(project.uid, rows, pageToken, searchName || undefined, queryFilters.length ? queryFilters : undefined)
-            .pipe(
-              tap((response: PaginatedResponse<Vote>) => {
-                if (response.page_token) {
-                  this.pageTokens[pageIndex] = response.page_token;
-                }
-                this.loading.set(false);
-              }),
-              map((response: PaginatedResponse<Vote>) => response.data),
-              catchError(() => {
-                this.loading.set(false);
-                return of([]);
-              })
-            );
+          return this.fetchVotePage(project.uid, rows, pageIndex, searchName || undefined, queryFilters.length ? queryFilters : undefined).pipe(
+            tap(() => this.loading.set(false)),
+            map((response: PaginatedResponse<Vote>) => response.data),
+            catchError(() => {
+              this.loading.set(false);
+              return of([]);
+            })
+          );
         })
       ),
       { initialValue: [] }
     );
+  }
+
+  /**
+   * Fetches one page of votes. Cursor pagination only returns the *next* page's token, so a direct jump to a page whose
+   * token hasn't been collected yet walks forward from the nearest cached token, caching intermediate tokens along the way.
+   * If the cursor exhausts before the target (stale totalRecords, e.g. votes deleted after the count fetch), falls back to page 1.
+   */
+  private fetchVotePage(projectUid: string, rows: number, pageIndex: number, searchName?: string, filters?: string[]): Observable<PaginatedResponse<Vote>> {
+    const fetchSingle = (index: number): Observable<PaginatedResponse<Vote>> =>
+      this.voteService.getVotesByProjectPaginated(projectUid, rows, index > 0 ? this.pageTokens[index - 1] : undefined, searchName, filters).pipe(
+        tap((response: PaginatedResponse<Vote>) => {
+          if (response.page_token) {
+            this.pageTokens[index] = response.page_token;
+          }
+        })
+      );
+
+    const walk = (index: number): Observable<PaginatedResponse<Vote>> =>
+      fetchSingle(index).pipe(
+        switchMap((response: PaginatedResponse<Vote>) => {
+          if (index === pageIndex) {
+            return of(response);
+          }
+          if (!response.page_token) {
+            this.currentFirst.set(0);
+            return index === 0 ? of(response) : fetchSingle(0);
+          }
+          return walk(index + 1);
+        })
+      );
+
+    // Nearest page fetchable directly: page 0 needs no token; page p needs pageTokens[p - 1].
+    let startIndex = 0;
+    for (let i = pageIndex; i > 0; i--) {
+      if (this.pageTokens[i - 1]) {
+        startIndex = i;
+        break;
+      }
+    }
+
+    return walk(startIndex);
   }
 
   private initSelectedListVote(): Signal<Vote | null> {

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -307,10 +307,18 @@ export class VotesDashboardComponent {
     const walk = (index: number): Observable<PaginatedResponse<Vote>> =>
       fetchSingle(index).pipe(
         switchMap((response: PaginatedResponse<Vote>) => {
+          // A directly fetched target page that is empty with no next token means the cached cursor was stale (data shrank
+          // after the token was cached) — treat as exhaustion and fall back to page 1 with a fresh token chain.
           if (index === pageIndex) {
+            if (index > 0 && !response.page_token && !response.data.length) {
+              this.pageTokens = [];
+              this.currentFirst.set(0);
+              return fetchSingle(0);
+            }
             return of(response);
           }
           if (!response.page_token) {
+            this.pageTokens = [];
             this.currentFirst.set(0);
             return index === 0 ? of(response) : fetchSingle(0);
           }

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -7,15 +7,16 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
-import { PollStatus, VOTE_LABEL, VoteResponseStatus } from '@lfx-one/shared';
+import { PollStatus, VOTE_LABEL, VOTES_PAGE_WALK_LIMIT, VoteResponseStatus } from '@lfx-one/shared';
 import { Committee, PaginatedResponse, ProjectContext, Vote, VoteFilterState } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { LensService } from '@services/lens.service';
 import { PersonaService } from '@services/persona.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { VoteService } from '@services/vote.service';
+import { findCursorWalkStartIndex, recordPageToken, resolveCursorWalkOutcome } from '@lfx-one/shared/utils';
 import { SkeletonModule } from 'primeng/skeleton';
-import { BehaviorSubject, catchError, combineLatest, finalize, map, Observable, of, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, catchError, combineLatest, EMPTY, expand, finalize, last, map, Observable, of, switchMap, take, tap } from 'rxjs';
 
 import { VoteCastDrawerComponent } from '../components/vote-cast-drawer/vote-cast-drawer.component';
 import { VoteResultsDrawerComponent } from '../components/vote-results-drawer/vote-results-drawer.component';
@@ -292,53 +293,51 @@ export class VotesDashboardComponent {
   /**
    * Fetches one page of votes. Cursor pagination only returns the *next* page's token, so a direct jump to a page whose
    * token hasn't been collected yet walks forward from the nearest cached token, caching intermediate tokens along the way.
-   * If the cursor exhausts before the target (stale totalRecords, e.g. votes deleted after the count fetch), falls back to page 1.
+   * The walk is bounded (VOTES_PAGE_WALK_LIMIT, matching the meetings-dashboard cursor walk): on overflow the paginator
+   * clamps to the last reached page; on cursor exhaustion (data shrank after tokens were cached) it restarts from page 1
+   * with a fresh token chain. HTTP errors propagate to the caller so a failed request is never mistaken for exhaustion.
    */
   private fetchVotePage(projectUid: string, rows: number, pageIndex: number, searchName?: string, filters?: string[]): Observable<PaginatedResponse<Vote>> {
+    const startIndex = findCursorWalkStartIndex(this.pageTokens, pageIndex);
+
+    // Index of the last successfully fetched page — fetchSingle's tap runs before expand's projector sees each response.
+    let fetchedIndex = startIndex;
+
     const fetchSingle = (index: number): Observable<PaginatedResponse<Vote>> =>
       this.voteService.getVotesByProjectPaginated(projectUid, rows, index > 0 ? this.pageTokens[index - 1] : undefined, searchName, filters).pipe(
         tap((response: PaginatedResponse<Vote>) => {
-          if (response.page_token) {
-            this.pageTokens[index] = response.page_token;
-          } else {
-            // No next page — drop any stale tokens cached for pages beyond this one (e.g. after data shrank).
-            this.pageTokens.length = index;
-          }
+          fetchedIndex = index;
+          // Cache the next-page cursor; when the cursor exhausts, stale tokens beyond this page are dropped.
+          this.pageTokens = recordPageToken(this.pageTokens, index, response.page_token);
         })
       );
 
-    const walk = (index: number): Observable<PaginatedResponse<Vote>> =>
-      fetchSingle(index).pipe(
-        switchMap((response: PaginatedResponse<Vote>) => {
-          // A directly fetched target page that is empty with no next token means the cached cursor was stale (data shrank
-          // after the token was cached) — treat as exhaustion and fall back to page 1 with a fresh token chain.
-          if (index === pageIndex) {
-            if (index > 0 && !response.page_token && !response.data.length) {
-              this.pageTokens = [];
-              this.currentFirst.set(0);
-              return fetchSingle(0);
-            }
-            return of(response);
-          }
-          if (!response.page_token) {
-            this.pageTokens = [];
-            this.currentFirst.set(0);
-            return index === 0 ? of(response) : fetchSingle(0);
-          }
-          return walk(index + 1);
-        })
-      );
+    return fetchSingle(startIndex).pipe(
+      // Walk forward one page per request until the target page is fetched or the cursor exhausts.
+      expand((response: PaginatedResponse<Vote>) => (fetchedIndex === pageIndex || !response.page_token ? EMPTY : fetchSingle(fetchedIndex + 1))),
+      // Hard request ceiling: the start page plus VOTES_PAGE_WALK_LIMIT hops (matches the meetings-dashboard walk bound).
+      take(VOTES_PAGE_WALK_LIMIT + 1),
+      // Only the final page's response reaches the subscriber — intermediate walk pages just cache tokens. Terminal
+      // handling lives after take() because expand's projector never runs for the emission take() cuts off at.
+      last(),
+      switchMap((response: PaginatedResponse<Vote>) => {
+        const outcome = resolveCursorWalkOutcome(response, fetchedIndex, pageIndex);
 
-    // Nearest page fetchable directly: page 0 needs no token; page p needs pageTokens[p - 1].
-    let startIndex = 0;
-    for (let i = pageIndex; i > 0; i--) {
-      if (this.pageTokens[i - 1]) {
-        startIndex = i;
-        break;
-      }
-    }
+        // Data shrank after tokens were cached (empty target page or exhausted cursor) — restart from
+        // page 1 with a fresh token chain instead of showing an empty table.
+        if (outcome.action === 'restart') {
+          this.pageTokens = [];
+          this.currentFirst.set(0);
+          return outcome.refetch ? fetchSingle(0) : of(response);
+        }
 
-    return walk(startIndex);
+        // take() truncated the walk before the target — clamp the paginator to the last reached page.
+        if (outcome.action === 'clamp') {
+          this.currentFirst.set(outcome.clampIndex * rows);
+        }
+        return of(response);
+      })
+    );
   }
 
   private initSelectedListVote(): Signal<Vote | null> {

--- a/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts
@@ -300,6 +300,9 @@ export class VotesDashboardComponent {
         tap((response: PaginatedResponse<Vote>) => {
           if (response.page_token) {
             this.pageTokens[index] = response.page_token;
+          } else {
+            // No next page — drop any stale tokens cached for pages beyond this one (e.g. after data shrank).
+            this.pageTokens.length = index;
           }
         })
       );

--- a/apps/lfx-one/src/app/shared/services/vote.service.ts
+++ b/apps/lfx-one/src/app/shared/services/vote.service.ts
@@ -74,7 +74,9 @@ export class VoteService {
       }
     }
 
-    return this.getVotes(params);
+    // Deliberately bypasses getVotes' catchError fallback: the votes dashboard's cursor walk must distinguish a
+    // failed request from cursor exhaustion (empty result with no token), so HTTP errors propagate to the caller.
+    return this.http.get<PaginatedResponse<Vote>>('/api/votes', { params });
   }
 
   public getVotesCountByProject(projectUid: string, searchName?: string, filters?: string[]): Observable<number> {

--- a/packages/shared/src/constants/poll.constants.ts
+++ b/packages/shared/src/constants/poll.constants.ts
@@ -21,6 +21,14 @@ export const VOTE_LABEL = {
 } as const;
 
 /**
+ * Max sequential page requests when walking cursor tokens for a direct page jump in the votes dashboard
+ * @description Cursor pagination only returns the *next* page's token, so an uncached page jump (e.g. clicking
+ * "last page" on a cold token cache) walks forward one request per page. This bound caps that serial walk — on
+ * overflow the paginator clamps to the last reached page. Matches the meetings-dashboard cursor-walk bound.
+ */
+export const VOTES_PAGE_WALK_LIMIT = 10;
+
+/**
  * Poll status display labels
  * @description Human-readable labels for poll statuses
  */

--- a/packages/shared/src/interfaces/poll.interface.ts
+++ b/packages/shared/src/interfaces/poll.interface.ts
@@ -1,8 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { IndexedVoteResponseStatus, IndividualVoteStatus, PollStatus, PollType, VoteResponseStatus } from '../enums/poll.enum';
-import { CommitteeReference } from './committee.interface';
+import type { IndexedVoteResponseStatus, IndividualVoteStatus, PollStatus, PollType, VoteResponseStatus } from '../enums/poll.enum';
+import type { CommitteeReference } from './committee.interface';
 
 /**
  * Filter state for the votes dashboard table
@@ -705,3 +705,13 @@ export interface RankedQuestionView {
   choiceDistributions: RankedChoiceDistribution[];
   hasRoundSummary: boolean;
 }
+
+/**
+ * Terminal decision for a cursor-pagination page-jump walk
+ * @description Discriminated union returned by resolveCursorWalkOutcome:
+ * - `show`: the target page was reached — render the response as-is
+ * - `restart`: the cursor exhausted or the target came back empty — reset the token chain and drop to page 1
+ *   (`refetch` is false when the walk never left page 1, so its response is already the page-1 payload)
+ * - `clamp`: the walk hit its request ceiling before the target — clamp the paginator to `clampIndex`, the last fetched page
+ */
+export type CursorWalkOutcome = { action: 'show' } | { action: 'restart'; refetch: boolean } | { action: 'clamp'; clampIndex: number };

--- a/packages/shared/src/utils/vote.utils.ts
+++ b/packages/shared/src/utils/vote.utils.ts
@@ -4,8 +4,18 @@
 import { addDays } from 'date-fns';
 import { DRAFT_VOTE_DEFAULT_DURATION_DAYS, DRAFT_VOTE_PLACEHOLDER_QUESTION } from '../constants/poll.constants';
 import { CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { CommitteeReference } from '../interfaces/committee.interface';
-import { CreatePollQuestion, CreateVoteRequest, PollQuestion, QuestionFormValue, UpdateVoteRequest, Vote, VoteFormValue } from '../interfaces/poll.interface';
+import type { PaginatedResponse } from '../interfaces/api.interface';
+import type { CommitteeReference } from '../interfaces/committee.interface';
+import type {
+  CreatePollQuestion,
+  CreateVoteRequest,
+  CursorWalkOutcome,
+  PollQuestion,
+  QuestionFormValue,
+  UpdateVoteRequest,
+  Vote,
+  VoteFormValue,
+} from '../interfaces/poll.interface';
 
 /**
  * Maps UI eligibility value to API committee_filters
@@ -208,4 +218,68 @@ export function buildDraftUpdateVoteRequest(formValue: VoteFormValue, projectUid
     committee_filters: mapEligibilityToFilters(formValue.eligible_participants),
     poll_questions,
   };
+}
+
+/**
+ * Records a page's cursor in the token chain, preserving the invariant that index `i` holds the token for page `i + 1`
+ * @description When the fetched page has a next token, stores it at `pageTokens[fetchedIndex]`; when the cursor is
+ * exhausted (no next token), truncates the chain so stale tokens for pages beyond `fetchedIndex` are dropped.
+ * Returns a new array rather than mutating in place.
+ * @param pageTokens - Current cached cursor chain
+ * @param fetchedIndex - Index of the page whose response produced (or lacked) the token
+ * @param pageToken - Next-page cursor from the response, or undefined when the cursor is exhausted
+ * @returns The updated token chain
+ */
+export function recordPageToken(pageTokens: readonly string[], fetchedIndex: number, pageToken: string | undefined): string[] {
+  if (pageToken) {
+    const next = pageTokens.slice();
+    next[fetchedIndex] = pageToken;
+    return next;
+  }
+  return pageTokens.slice(0, fetchedIndex);
+}
+
+/**
+ * Finds the nearest page fetchable directly from the cached cursor chain
+ * @description Cursor pagination only returns the *next* page's token, so page 0 needs no token and page `p`
+ * needs `pageTokens[p - 1]` (index `i` holds the token for page `i + 1`). Scans back from the target and
+ * returns the closest page whose token is cached, or 0 when none is.
+ * @param pageTokens - Cached cursor chain (index `i` = token for page `i + 1`)
+ * @param pageIndex - Target page the paginator wants
+ * @returns Page index to start the forward walk from
+ */
+export function findCursorWalkStartIndex(pageTokens: readonly string[], pageIndex: number): number {
+  for (let i = pageIndex; i > 0; i--) {
+    if (pageTokens[i - 1]) {
+      return i;
+    }
+  }
+  return 0;
+}
+
+/**
+ * Resolves the terminal action once a cursor walk stops (target reached, cursor exhausted, or request ceiling hit)
+ * @description Pure decision for the page-jump walk: an empty target page with no next token or an exhausted cursor
+ * both mean the data shrank after tokens were cached, so the walk restarts from page 1 with a fresh chain; a live
+ * cursor short of the target means the ceiling truncated the walk, so the paginator clamps to the last fetched page.
+ * @param response - Final page response emitted by the walk
+ * @param fetchedIndex - Index of the last successfully fetched page
+ * @param pageIndex - Target page the paginator wanted
+ * @returns CursorWalkOutcome telling the caller to show, restart, or clamp
+ */
+export function resolveCursorWalkOutcome<T>(response: PaginatedResponse<T>, fetchedIndex: number, pageIndex: number): CursorWalkOutcome {
+  const exhausted = !response.page_token;
+
+  if (fetchedIndex === pageIndex) {
+    if (pageIndex > 0 && exhausted && !response.data.length) {
+      return { action: 'restart', refetch: true };
+    }
+    return { action: 'show' };
+  }
+
+  if (exhausted) {
+    return { action: 'restart', refetch: fetchedIndex > 0 };
+  }
+
+  return { action: 'clamp', clampIndex: fetchedIndex };
 }


### PR DESCRIPTION
## Summary

The votes dashboard uses cursor-based pagination, where the API only ever returns the token for the *next* page. Previously, jumping directly to a page whose token had not yet been collected rendered an empty table and silently reset the pager to page 1. This PR replaces that guard with a forward walk from the nearest cached token, so direct page jumps work at any depth.

Resolves LFXV2-3199

## Behavior changes

| Before | After |
|---|---|
| Clicking a page number in the votes table that had never been visited (e.g. jumping from page 1 straight to page 5) showed an empty table and snapped the pager back to page 1, with no way to reach that page except clicking "next" repeatedly. | Jumping to any page walks forward through the cursor chain behind the scenes and displays the requested page. If the data has shrunk since the page count was fetched (e.g. votes were deleted), the pager gracefully falls back to page 1 instead of showing an empty table. |

## Technical changes

`apps/lfx-one/src/app/modules/votes/votes-dashboard/votes-dashboard.component.ts` — Votes dashboard pagination
- Replaces the page-token guard (which reset `currentFirst` to 0 and returned an empty list for uncached pages) with a new private `fetchVotePage()` method.
- `fetchVotePage()` finds the nearest page fetchable directly (page 0 needs no token; page p needs `pageTokens[p - 1]`) and recursively walks forward via `switchMap`, caching each intermediate page token so later jumps are cheaper.
- Handles stale `totalRecords` (cursor exhausts before the target page): falls back to page 1, reusing the already-fetched page-0 response when the walk started there to avoid a duplicate request.
- The `initVotes()` pipeline now delegates to `fetchVotePage()` and maps the response to `response.data`; loading/error handling is unchanged.
- Updates the constructor comment on the lens-change pagination reset to reference the walk instead of the removed guard.