### PR TITLE
feat(chart): add pod scheduling passthrough

### DIFF
--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -125,6 +125,8 @@ environment:
 | `priorityClassName`              | PriorityClass for preemption ordering. A nonexistent class blocks scheduling.                                  | `""`                                                                          |
 | `topologySpreadConstraints`      | Spread replicas across failure domains                                                                         | `[]`                                                                          |
 
+`tolerations` only lets a pod land on a tainted node pool; it does not require it. Set `nodeSelector` too if the pod must land there.
+
 ### Environment Variables
 
 #### Application Configuration

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -119,6 +119,11 @@ environment:
 | `image.tag`                      | Image tag                                                                                                      | `"latest"`                                                                    |
 | `image.pullPolicy`               | Image pull policy                                                                                              | `IfNotPresent`                                                                |
 | `imagePullSecrets`               | Image pull secrets                                                                                             | `[]`                                                                          |
+| `nodeSelector`                   | Node labels required for scheduling                                                                            | `{}`                                                                          |
+| `tolerations`                    | Taints the pod tolerates. Pair with `nodeSelector` to target a tainted node pool.                              | `[]`                                                                          |
+| `affinity`                       | Node/pod affinity rules. Prefer `topologySpreadConstraints` for simple spreading.                              | `{}`                                                                          |
+| `priorityClassName`              | PriorityClass for preemption ordering. A nonexistent class blocks scheduling.                                  | `""`                                                                          |
+| `topologySpreadConstraints`      | Spread replicas across failure domains                                                                         | `[]`                                                                          |
 
 ### Environment Variables
 

--- a/charts/lfx-self-serve/templates/deployment.yaml
+++ b/charts/lfx-self-serve/templates/deployment.yaml
@@ -62,7 +62,7 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       {{- with .Values.priorityClassName }}
-      priorityClassName: {{ . }}
+      priorityClassName: {{ . | quote }}
       {{- end }}
       containers:
         - name: {{ .Chart.Name }}

--- a/charts/lfx-self-serve/templates/deployment.yaml
+++ b/charts/lfx-self-serve/templates/deployment.yaml
@@ -49,6 +49,21 @@ spec:
       topologySpreadConstraints:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: {{ include "lfx-self-serve.image" . }}

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -156,6 +156,19 @@ serviceAccount:
 podAnnotations: {}
 podLabels: {}
 
+# Pod scheduling. All default to empty and render nothing when unset.
+# nodeSelector + tolerations are the pair needed to target a tainted node pool.
+nodeSelector: {}
+tolerations: []
+affinity: {}
+# priorityClassName affects preemption order. Leave empty unless the cluster
+# defines priority classes; a nonexistent class blocks scheduling entirely.
+priorityClassName: ""
+
+# Spread replicas across failure domains. Consumed by the deployment template;
+# previously undeclared here.
+topologySpreadConstraints: []
+
 service:
   type: ClusterIP
   port: 80


### PR DESCRIPTION
## Summary
- Adds `nodeSelector`, `tolerations`, `affinity`, and `priorityClassName` passthrough to the `lfx-self-serve` chart's Deployment template, plus documents the previously-undeclared `topologySpreadConstraints` value.
- Purely additive: every field is guarded by `with`, so unset keys render nothing and existing deployments are byte-identical. Verified via a no-op `helm template` diff against real prod values (only chart-version metadata differed) and a positive-rendering test with all five fields set.

## Context
Surfaced while investigating prod rollout churn (lfx-self-serve#1375 / LFXV2-3086): the chart currently has no way to target a tainted/dedicated node pool, which blocks that option from being pursued. This is enabling work only — no deployed behavior changes, and no `lfx-v2-argocd`/`lfx-v2-opentofu` values are set to use these fields yet.

Issue: LFXV2-3086

🤖 Generated with [Claude Code](https://claude.com/claude-code)