### PR TITLE
feat(newsletters): add click metrics to newsletter analytics

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
@@ -75,6 +75,10 @@
             <th>Engagement</th>
             <th>Opens</th>
             <th>Last opened</th>
+            @if (showClicks()) {
+              <th data-testid="newsletter-recipient-engagement-header-clicks">Clicks</th>
+              <th data-testid="newsletter-recipient-engagement-header-last-clicked">Last clicked</th>
+            }
           </tr>
         </ng-template>
 
@@ -82,13 +86,13 @@
         <ng-template #body let-row>
           <tr [attr.data-testid]="'newsletter-recipient-engagement-row-' + row.email">
             <td class="w-8">
-              @if (row.open_count > 0) {
+              @if (row.open_count > 0 || row.click_count > 0) {
                 <button
                   type="button"
                   class="text-gray-400 hover:text-gray-600"
                   (click)="toggleTimeline(row.email)"
                   [attr.aria-expanded]="expandedEmails().has(row.email)"
-                  [attr.aria-label]="(expandedEmails().has(row.email) ? 'Collapse' : 'Expand') + ' open timeline for ' + row.displayName"
+                  [attr.aria-label]="(expandedEmails().has(row.email) ? 'Collapse' : 'Expand') + ' engagement timeline for ' + row.displayName"
                   [attr.data-testid]="'newsletter-recipient-engagement-expand-' + row.email">
                   <i class="fa-light" [class.fa-chevron-down]="expandedEmails().has(row.email)" [class.fa-chevron-right]="!expandedEmails().has(row.email)"></i>
                 </button>
@@ -131,22 +135,53 @@
                 <span class="text-sm text-gray-400">—</span>
               }
             </td>
+            @if (showClicks()) {
+              <td data-testid="newsletter-recipient-engagement-cell-clicks">
+                <lfx-badge [value]="row.click_count" severity="info" />
+              </td>
+              <td data-testid="newsletter-recipient-engagement-cell-last-clicked">
+                @if (row.last_clicked_at) {
+                  <span class="text-sm text-gray-700" [title]="row.last_clicked_at | date: 'MMM d, y, h:mm a'">{{ row.lastClickedRelative }}</span>
+                } @else {
+                  <span class="text-sm text-gray-400">—</span>
+                }
+              </td>
+            }
           </tr>
           @if (expandedEmails().has(row.email)) {
             <tr [attr.data-testid]="'newsletter-recipient-engagement-timeline-' + row.email">
               <td></td>
-              <td colspan="5" class="bg-gray-50 py-3">
-                <div class="flex flex-col gap-1 pl-2">
-                  <span class="text-xs uppercase tracking-wide text-gray-500">Open timeline</span>
-                  <ul class="flex flex-col gap-1">
-                    <!-- track $index, not the value: opened_at_list is second-precision (upstream SendGrid),
-                         so two opens in the same second collide on value and throw NG0955. -->
-                    @for (openedAt of row.opened_at_list; track $index) {
-                      <li class="text-sm text-gray-700">{{ openedAt | date: 'MMM d, y, h:mm a' }}</li>
+              <td [attr.colspan]="timelineColspan()" class="bg-gray-50 py-3">
+                <div class="flex flex-col gap-3 pl-2">
+                  <div class="flex flex-col gap-1">
+                    <span class="text-xs uppercase tracking-wide text-gray-500">Open timeline</span>
+                    <ul class="flex flex-col gap-1">
+                      <!-- track $index, not the value: opened_at_list is second-precision (upstream SendGrid),
+                           so two opens in the same second collide on value and throw NG0955. -->
+                      @for (openedAt of row.opened_at_list; track $index) {
+                        <li class="text-sm text-gray-700">{{ openedAt | date: 'MMM d, y, h:mm a' }}</li>
+                      }
+                    </ul>
+                    @if (row.open_count > row.opened_at_list.length) {
+                      <span class="text-xs text-gray-400">+{{ row.open_count - row.opened_at_list.length }} earlier opens</span>
                     }
-                  </ul>
-                  @if (row.open_count > row.opened_at_list.length) {
-                    <span class="text-xs text-gray-400">+{{ row.open_count - row.opened_at_list.length }} earlier opens</span>
+                  </div>
+                  @if (showClicks()) {
+                    <div class="flex flex-col gap-1" data-testid="newsletter-recipient-engagement-click-timeline">
+                      <span class="text-xs uppercase tracking-wide text-gray-500">Click timeline</span>
+                      <ul class="flex flex-col gap-1">
+                        <!-- track $index, not the value: clicked_at_list is second-precision (upstream
+                             SendGrid), so two clicks in the same second collide on value and throw NG0955. -->
+                        @for (clickedAt of row.clicked_at_list; track $index) {
+                          <li class="text-sm text-gray-700">{{ clickedAt | date: 'MMM d, y, h:mm a' }}</li>
+                        } @empty {
+                          <li class="text-sm text-gray-400">No clicks recorded</li>
+                        }
+                      </ul>
+                      @if (row.click_count > row.clicked_at_list.length) {
+                        <span class="text-xs text-gray-400">+{{ row.click_count - row.clicked_at_list.length }} earlier clicks</span>
+                      }
+                    </div>
                   }
                 </div>
               </td>
@@ -157,7 +192,7 @@
         <!-- Empty Message Template -->
         <ng-template #emptymessage>
           <tr>
-            <td colspan="6" class="text-center py-8">
+            <td [attr.colspan]="columnCount()" class="text-center py-8">
               <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2"></i>
               <p class="text-sm text-gray-500">No recipients match this filter</p>
             </td>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.html
@@ -130,7 +130,16 @@
             </td>
             <td>
               @if (row.last_opened_at) {
-                <span class="text-sm text-gray-700" [title]="row.last_opened_at | date: 'MMM d, y, h:mm a'">{{ row.lastOpenedRelative }}</span>
+                <span
+                  class="text-sm text-gray-700"
+                  role="note"
+                  tabindex="0"
+                  [pTooltip]="(row.last_opened_at | date: 'MMM d, y, h:mm a') ?? ''"
+                  tooltipPosition="top"
+                  tooltipEvent="both"
+                  [attr.aria-label]="'Last opened ' + ((row.last_opened_at | date: 'MMM d, y, h:mm a') ?? '')">
+                  {{ row.lastOpenedRelative }}
+                </span>
               } @else {
                 <span class="text-sm text-gray-400">—</span>
               }
@@ -141,7 +150,16 @@
               </td>
               <td data-testid="newsletter-recipient-engagement-cell-last-clicked">
                 @if (row.last_clicked_at) {
-                  <span class="text-sm text-gray-700" [title]="row.last_clicked_at | date: 'MMM d, y, h:mm a'">{{ row.lastClickedRelative }}</span>
+                  <span
+                    class="text-sm text-gray-700"
+                    role="note"
+                    tabindex="0"
+                    [pTooltip]="(row.last_clicked_at | date: 'MMM d, y, h:mm a') ?? ''"
+                    tooltipPosition="top"
+                    tooltipEvent="both"
+                    [attr.aria-label]="'Last clicked ' + ((row.last_clicked_at | date: 'MMM d, y, h:mm a') ?? '')">
+                    {{ row.lastClickedRelative }}
+                  </span>
                 } @else {
                   <span class="text-sm text-gray-400">—</span>
                 }
@@ -160,6 +178,8 @@
                            so two opens in the same second collide on value and throw NG0955. -->
                       @for (openedAt of row.opened_at_list; track $index) {
                         <li class="text-sm text-gray-700">{{ openedAt | date: 'MMM d, y, h:mm a' }}</li>
+                      } @empty {
+                        <li class="text-sm text-gray-400">No opens recorded</li>
                       }
                     </ul>
                     @if (row.open_count > row.opened_at_list.length) {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
@@ -336,6 +336,26 @@ describe('NewsletterRecipientEngagementComponent', () => {
       expect(clickTimeline?.textContent).toContain('+1 earlier clicks');
     });
 
+    // Regression: showClicks() can be true from the parent's aggregate rollup
+    // (analyticsHasClicks) while this specific row has zero clicks of its own —
+    // e.g. an opened-but-not-clicked recipient on a newsletter where other
+    // recipients did click. The click section must still render, with the
+    // `@empty` fallback text rather than an empty list.
+    it('shows the empty-state message in the click timeline for a recipient with no clicks', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+      await createComponent();
+      fixture.componentRef.setInput('analyticsHasClicks', true);
+      await fixture.whenStable();
+
+      const expandButton = card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement;
+      expandButton.click();
+      await fixture.whenStable();
+
+      const clickTimeline = card('newsletter-recipient-engagement-click-timeline');
+      expect(clickTimeline).not.toBeNull();
+      expect(clickTimeline?.textContent).toContain('No clicks recorded');
+    });
+
     it('falls back to unfiltered rows when a latched Clicked selection is no longer reachable', async () => {
       newsletterService.getRecipientEngagement.mockReturnValue(of(CLICK_RESPONSE));
       await createComponent();

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.spec.ts
@@ -124,19 +124,19 @@ describe('NewsletterRecipientEngagementComponent', () => {
 
     expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).toBeNull();
     const expandButton = card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement;
-    expect(expandButton.getAttribute('aria-label')).toBe('Expand open timeline for Jane Doe');
+    expect(expandButton.getAttribute('aria-label')).toBe('Expand engagement timeline for Jane Doe');
 
     expandButton.click();
     await fixture.whenStable();
 
     expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).not.toBeNull();
-    expect(expandButton.getAttribute('aria-label')).toBe('Collapse open timeline for Jane Doe');
+    expect(expandButton.getAttribute('aria-label')).toBe('Collapse engagement timeline for Jane Doe');
 
     expandButton.click();
     await fixture.whenStable();
 
     expect(card('newsletter-recipient-engagement-timeline-jane@acme.io')).toBeNull();
-    expect(expandButton.getAttribute('aria-label')).toBe('Expand open timeline for Jane Doe');
+    expect(expandButton.getAttribute('aria-label')).toBe('Expand engagement timeline for Jane Doe');
   });
 
   // bob@acme.io has no `name` — displayName falls back to email, and the
@@ -162,13 +162,13 @@ describe('NewsletterRecipientEngagementComponent', () => {
     await createComponent();
 
     const expandButton = card('newsletter-recipient-engagement-expand-noname@acme.io') as HTMLButtonElement;
-    expect(expandButton.getAttribute('aria-label')).toBe('Expand open timeline for noname@acme.io');
+    expect(expandButton.getAttribute('aria-label')).toBe('Expand engagement timeline for noname@acme.io');
 
     expandButton.click();
     await fixture.whenStable();
 
     expect(card('newsletter-recipient-engagement-timeline-noname@acme.io')).not.toBeNull();
-    expect(expandButton.getAttribute('aria-label')).toBe('Collapse open timeline for noname@acme.io');
+    expect(expandButton.getAttribute('aria-label')).toBe('Collapse engagement timeline for noname@acme.io');
   });
 
   // Regression: a recipient who opened before later bouncing/being marked spam
@@ -233,5 +233,126 @@ describe('NewsletterRecipientEngagementComponent', () => {
 
     expect(card('newsletter-recipient-engagement')).not.toBeNull();
     expect(card('newsletter-recipient-engagement-partial-note')?.textContent).toContain('0 of 10');
+  });
+
+  describe('click metrics', () => {
+    // Jane is both opened and clicked — proves the Clicked chip count overlaps
+    // Opened rather than being mutually exclusive with it, per
+    // NewsletterRecipientEngagementChipKey's documented design.
+    const CLICK_RESPONSE: NewsletterRecipientEngagementResponse = {
+      ...RESPONSE,
+      recipients: [
+        {
+          ...RESPONSE.recipients[0],
+          clicked: true,
+          click_count: 3,
+          last_clicked_at: '2026-08-09T11:00:00Z',
+          clicked_at_list: ['2026-08-08T11:00:00Z', '2026-08-09T11:00:00Z'],
+        },
+        RESPONSE.recipients[1],
+        RESPONSE.recipients[2],
+      ],
+    };
+
+    it('hides click columns and the Clicked chip when no recipient has click data and the parent reports none', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+      await createComponent();
+      fixture.componentRef.setInput('analyticsHasClicks', false);
+      await fixture.whenStable();
+
+      expect(card('newsletter-recipient-engagement-header-clicks')).toBeNull();
+      expect(card('newsletter-recipient-engagement-segment-clicked')).toBeNull();
+      expect(card('newsletter-recipient-engagement-cell-clicks')).toBeNull();
+    });
+
+    it('shows click columns and an overlapping Clicked chip count when recipients have click data', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(of(CLICK_RESPONSE));
+      await createComponent();
+
+      expect(card('newsletter-recipient-engagement-header-clicks')).not.toBeNull();
+      expect(card('newsletter-recipient-engagement-segment-clicked')?.textContent?.trim()).toBe('Clicked (1)');
+      expect(card('newsletter-recipient-engagement-segment-opened')?.textContent?.trim()).toBe('Opened (1)');
+    });
+
+    it('shows click columns when the parent reports click data even if this endpoint has none yet', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+      await createComponent();
+      fixture.componentRef.setInput('analyticsHasClicks', true);
+      await fixture.whenStable();
+
+      expect(card('newsletter-recipient-engagement-header-clicks')).not.toBeNull();
+      expect(card('newsletter-recipient-engagement-segment-clicked')?.textContent?.trim()).toBe('Clicked (0)');
+    });
+
+    it('filters rows to the Clicked chip', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(of(CLICK_RESPONSE));
+      await createComponent();
+
+      (card('newsletter-recipient-engagement-segment-clicked') as HTMLButtonElement).click();
+      await fixture.whenStable();
+
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]');
+      expect(rows).toHaveLength(1);
+      expect(rows[0].getAttribute('data-testid')).toBe('newsletter-recipient-engagement-row-jane@acme.io');
+    });
+
+    it('sorts a click-only recipient (no opens) ahead of silent, unengaged recipients and gives it an expand chevron', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(
+        of({
+          ...RESPONSE,
+          recipients: [
+            { email: 'not-opened@acme.io', delivered: true, failed: false, opened: false, open_count: 0, opened_at_list: [] },
+            {
+              email: 'click-only@acme.io',
+              delivered: true,
+              failed: false,
+              opened: false,
+              open_count: 0,
+              opened_at_list: [],
+              clicked: true,
+              click_count: 1,
+              clicked_at_list: ['2026-08-09T11:00:00Z'],
+            },
+          ],
+        })
+      );
+      await createComponent();
+
+      const rows = fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]');
+      expect(rows[0].getAttribute('data-testid')).toBe('newsletter-recipient-engagement-row-click-only@acme.io');
+      expect(card('newsletter-recipient-engagement-expand-click-only@acme.io')).not.toBeNull();
+    });
+
+    it('renders the click timeline inside the expanded row', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(of(CLICK_RESPONSE));
+      await createComponent();
+
+      const expandButton = card('newsletter-recipient-engagement-expand-jane@acme.io') as HTMLButtonElement;
+      expandButton.click();
+      await fixture.whenStable();
+
+      const clickTimeline = card('newsletter-recipient-engagement-click-timeline');
+      expect(clickTimeline).not.toBeNull();
+      expect(clickTimeline?.textContent).toContain('+1 earlier clicks');
+    });
+
+    it('falls back to unfiltered rows when a latched Clicked selection is no longer reachable', async () => {
+      newsletterService.getRecipientEngagement.mockReturnValue(of(CLICK_RESPONSE));
+      await createComponent();
+
+      (card('newsletter-recipient-engagement-segment-clicked') as HTMLButtonElement).click();
+      await fixture.whenStable();
+      expect(fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]')).toHaveLength(1);
+
+      // Click data disappears on a refetch (e.g. the parent's own analytics call
+      // races ahead and reports no clicks) while 'clicked' is still the active chip.
+      newsletterService.getRecipientEngagement.mockReturnValue(of(RESPONSE));
+      fixture.componentRef.setInput('status', 'sending');
+      await fixture.whenStable();
+      fixture.componentRef.setInput('status', 'sent');
+      await fixture.whenStable();
+
+      expect(fixture.nativeElement.querySelectorAll('[data-testid^="newsletter-recipient-engagement-row-"]')).toHaveLength(3);
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
@@ -23,6 +23,7 @@ import {
 } from '@lfx-one/shared/interfaces';
 import { formatRelativeTime } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, of, startWith, switchMap } from 'rxjs';
 
 /**
@@ -35,7 +36,17 @@ import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize
  */
 @Component({
   selector: 'lfx-newsletter-recipient-engagement',
-  imports: [DatePipe, ReactiveFormsModule, CardComponent, TableComponent, InputTextComponent, PersonAvatarComponent, TagComponent, BadgeComponent],
+  imports: [
+    DatePipe,
+    ReactiveFormsModule,
+    CardComponent,
+    TableComponent,
+    InputTextComponent,
+    PersonAvatarComponent,
+    TagComponent,
+    BadgeComponent,
+    TooltipModule,
+  ],
   templateUrl: './newsletter-recipient-engagement.component.html',
 })
 export class NewsletterRecipientEngagementComponent {

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-recipient-engagement/newsletter-recipient-engagement.component.ts
@@ -46,6 +46,9 @@ export class NewsletterRecipientEngagementComponent {
   public readonly projectUid = input.required<string>();
   public readonly newsletterUid = input.required<string>();
   public readonly status = input.required<NewsletterStatus>();
+  // Set by the parent from its own NewsletterAnalytics.hasClickData. See `showClicks`
+  // for why this is OR-ed with, not replaced by, this component's own rows.
+  public readonly analyticsHasClicks = input<boolean>(false);
 
   // Filter form
   public readonly filterForm: FormGroup;
@@ -67,6 +70,22 @@ export class NewsletterRecipientEngagementComponent {
   public readonly chipConfig: Signal<NewsletterRecipientEngagementChipConfig[]> = this.initChipConfig();
   public readonly filteredRows: Signal<NewsletterRecipientRow[]> = this.initFilteredRows();
   public readonly showCompletenessNote = computed(() => this.response()?.complete === false);
+  /**
+   * Click columns/chip/timeline show when EITHER the parent's aggregate analytics
+   * or this component's own rows say clicks exist. The two endpoints are fetched
+   * independently and can legitimately disagree: this one is gated on the stricter
+   * `auditor` relation (vs. the aggregate's `viewer` gate), the aggregate rollup can
+   * lag the per-recipient records in either direction, and this response can be
+   * `complete: false`. OR-ing means a real click is never hidden, and `false` only
+   * when both sources agree there's nothing to show.
+   */
+  public readonly showClicks = computed(() => this.analyticsHasClicks() || this.rows().some((row) => row.clicked || row.click_count > 0));
+  // 6 base columns (chevron, Recipient, Delivery, Engagement, Opens, Last opened)
+  // plus Clicks + Last clicked. Bound rather than hard-coded so the timeline and
+  // empty-message rows can never drift from the header when clicks are hidden.
+  public readonly columnCount = computed(() => (this.showClicks() ? 8 : 6));
+  // The timeline row renders its own empty chevron cell, so it spans one fewer.
+  public readonly timelineColspan = computed(() => this.columnCount() - 1);
 
   public constructor() {
     this.filterForm = this.initializeFilterForm();
@@ -148,9 +167,24 @@ export class NewsletterRecipientEngagementComponent {
           displayName: recipient.name || recipient.email,
           segment: this.classifySegment(recipient),
           lastOpenedRelative: recipient.last_opened_at ? formatRelativeTime(new Date(recipient.last_opened_at)) : null,
+          // Normalized here (never undefined) so the template never needs optional
+          // chaining on these — the raw upstream fields are optional for
+          // pre-deploy truthfulness, but a built row always has concrete values.
+          clicked: recipient.clicked ?? false,
+          click_count: recipient.click_count ?? 0,
+          clicked_at_list: recipient.clicked_at_list ?? [],
+          lastClickedRelative: recipient.last_clicked_at ? formatRelativeTime(new Date(recipient.last_clicked_at)) : null,
         }))
         .sort((a, b) => {
-          if (a.opened !== b.opened) return a.opened ? -1 : 1;
+          // A click can be recorded without an open (e.g. an image-blocked client),
+          // so keying on `opened` alone would bury the most-engaged recipient below
+          // silent openers. This is a strict superset of the previous comparator:
+          // with no click data every `clicked` is false and `click_count` is 0, so
+          // `aEngaged === a.opened` and the click tiebreak is always a tie.
+          const aEngaged = a.opened || a.clicked;
+          const bEngaged = b.opened || b.clicked;
+          if (aEngaged !== bEngaged) return aEngaged ? -1 : 1;
+          if (b.click_count !== a.click_count) return b.click_count - a.click_count;
           return b.open_count - a.open_count;
         });
     });
@@ -162,12 +196,18 @@ export class NewsletterRecipientEngagementComponent {
       const openedCount = rows.filter((row) => row.segment === 'opened').length;
       const notOpenedCount = rows.filter((row) => row.segment === 'not-opened').length;
       const failedCount = rows.filter((row) => row.segment === 'failed').length;
-      return [
+      const chips: NewsletterRecipientEngagementChipConfig[] = [
         { key: 'all', label: 'All', count: rows.length },
         { key: 'opened', label: 'Opened', count: openedCount },
-        { key: 'not-opened', label: 'Not opened', count: notOpenedCount },
-        { key: 'failed', label: 'Failed', count: failedCount },
       ];
+      // Overlaps 'opened' by design (see NewsletterRecipientEngagementChipKey) —
+      // inserted next to it so the two engagement chips read as a pair, ahead of
+      // the negative buckets.
+      if (this.showClicks()) {
+        chips.push({ key: 'clicked', label: 'Clicked', count: rows.filter((row) => row.clicked).length });
+      }
+      chips.push({ key: 'not-opened', label: 'Not opened', count: notOpenedCount }, { key: 'failed', label: 'Failed', count: failedCount });
+      return chips;
     });
   }
 
@@ -176,7 +216,12 @@ export class NewsletterRecipientEngagementComponent {
       let filtered = this.rows();
 
       const chip = this.activeChip();
-      if (chip !== 'all') {
+      // Guarded on showClicks() so a latched 'clicked' selection (from before click
+      // data disappeared, e.g. a refetch) falls back to unfiltered instead of
+      // filtering against an unreachable chip.
+      if (chip === 'clicked' && this.showClicks()) {
+        filtered = filtered.filter((row) => row.clicked);
+      } else if (chip !== 'all' && chip !== 'clicked') {
         filtered = filtered.filter((row) => row.segment === chip);
       }
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
@@ -174,12 +174,23 @@
                           target="_blank"
                           rel="noopener noreferrer nofollow external"
                           class="block truncate text-sm text-blue-600 hover:underline"
-                          [title]="link.url"
+                          [pTooltip]="link.url"
+                          tooltipPosition="top"
+                          tooltipEvent="both"
                           [attr.data-testid]="'newsletter-analytics-top-link-' + i">
                           {{ link.url }}
                         </a>
                       } @else {
-                        <span class="block truncate text-sm text-gray-500" [title]="link.url">{{ link.url }}</span>
+                        <span
+                          class="block truncate text-sm text-gray-500"
+                          role="note"
+                          tabindex="0"
+                          [pTooltip]="link.url"
+                          tooltipPosition="top"
+                          tooltipEvent="both"
+                          [attr.aria-label]="link.url">
+                          {{ link.url }}
+                        </span>
                       }
                     </td>
                     <td class="text-sm text-gray-900">{{ link.clicks }}</td>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.html
@@ -73,6 +73,38 @@
             <span class="text-xs text-gray-500">of delivered emails</span>
           </div>
         </lfx-card>
+        @if (hasClickData()) {
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+            <div class="flex flex-col gap-1 p-4 bg-gray-50 rounded-lg">
+              <span class="text-xs uppercase tracking-wide text-gray-500">Unique clicks</span>
+              <span class="text-2xl font-medium text-violet-600" data-testid="newsletter-analytics-unique-clicks">{{ a.unique_clicks ?? 0 }}</span>
+              <span class="text-xs text-gray-500">distinct recipients</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+            <div class="flex flex-col gap-1 p-4 bg-gray-50 rounded-lg">
+              <span class="text-xs uppercase tracking-wide text-gray-500">Total clicks</span>
+              <span class="text-2xl font-medium text-gray-900" data-testid="newsletter-analytics-total-clicks">{{ a.total_clicks ?? 0 }}</span>
+              <span class="text-xs text-gray-500">includes repeat clicks</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+            <div class="flex flex-col gap-1 p-4 bg-gray-50 rounded-lg">
+              <span class="text-xs uppercase tracking-wide text-gray-500">Click rate</span>
+              <span class="text-2xl font-medium text-violet-600" data-testid="newsletter-analytics-click-rate">{{ clickRatePercent() ?? 0 }}%</span>
+              <span class="text-xs text-gray-500">of delivered emails</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0">
+            <div class="flex flex-col gap-1 p-4 bg-gray-50 rounded-lg">
+              <span class="text-xs uppercase tracking-wide text-gray-500">Click-to-open rate</span>
+              <span class="text-2xl font-medium text-violet-600" data-testid="newsletter-analytics-click-to-open-rate"
+                >{{ clickToOpenRatePercent() ?? 0 }}%</span
+              >
+              <span class="text-xs text-gray-500">of unique opens</span>
+            </div>
+          </lfx-card>
+        }
       </div>
 
       <lfx-card>
@@ -96,7 +128,75 @@
         </div>
       </lfx-card>
 
-      <lfx-newsletter-recipient-engagement [projectUid]="projectUid()" [newsletterUid]="newsletterId()" [status]="a.status" />
+      @if (hasClickData()) {
+        <lfx-card data-testid="newsletter-analytics-clicks-chart">
+          <div class="flex flex-col gap-3 p-2">
+            <h2 class="text-base font-semibold text-gray-900">Clicks over time</h2>
+            @if (!hasDailyClickBreakdown()) {
+              <div class="flex flex-col items-center justify-center py-12 gap-2 text-gray-500">
+                <i class="fa-light fa-chart-line text-3xl"></i>
+                <span class="text-sm">Daily breakdown not available yet. Check back shortly.</span>
+              </div>
+            } @else if (canRenderChart() && clickChartData()) {
+              <div class="h-80">
+                <lfx-chart type="line" [data]="clickChartData()" [options]="chartOptions()" height="320px"></lfx-chart>
+              </div>
+            }
+          </div>
+        </lfx-card>
+
+        <lfx-card data-testid="newsletter-analytics-top-links">
+          <div class="flex flex-col gap-3 p-2">
+            <div class="flex flex-col gap-1">
+              <h2 class="text-base font-semibold text-gray-900">Top clicked links</h2>
+              <p class="text-xs text-gray-500">Top {{ topLinksLimit }} links by clicks</p>
+            </div>
+            @if (topLinkRows().length === 0) {
+              <div class="flex flex-col items-center justify-center py-12 gap-2 text-gray-500">
+                <i class="fa-light fa-link text-3xl"></i>
+                <span class="text-sm">No link clicks recorded yet.</span>
+              </div>
+            } @else {
+              <lfx-table [value]="topLinkRows()" styleClass="p-datatable-sm" dataKey="url" data-testid="newsletter-analytics-top-links-table">
+                <ng-template #header>
+                  <tr>
+                    <th>Link</th>
+                    <th>Clicks</th>
+                    <th>Unique clicks</th>
+                  </tr>
+                </ng-template>
+                <ng-template #body let-link let-i="rowIndex">
+                  <tr [attr.data-testid]="'newsletter-analytics-top-link-row-' + i">
+                    <td class="max-w-0">
+                      @if (link.href) {
+                        <a
+                          [href]="link.href"
+                          target="_blank"
+                          rel="noopener noreferrer nofollow external"
+                          class="block truncate text-sm text-blue-600 hover:underline"
+                          [title]="link.url"
+                          [attr.data-testid]="'newsletter-analytics-top-link-' + i">
+                          {{ link.url }}
+                        </a>
+                      } @else {
+                        <span class="block truncate text-sm text-gray-500" [title]="link.url">{{ link.url }}</span>
+                      }
+                    </td>
+                    <td class="text-sm text-gray-900">{{ link.clicks }}</td>
+                    <td class="text-sm text-gray-700">{{ link.unique_clicks }}</td>
+                  </tr>
+                </ng-template>
+              </lfx-table>
+            }
+          </div>
+        </lfx-card>
+      }
+
+      <lfx-newsletter-recipient-engagement
+        [projectUid]="projectUid()"
+        [newsletterUid]="newsletterId()"
+        [status]="a.status"
+        [analyticsHasClicks]="hasClickData()" />
 
       <lfx-newsletter-failed-recipients-drawer [(visible)]="failedDrawerVisible" [failedRecipients]="a.failed_recipients ?? []" [failedCount]="a.failed" />
     </div>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
@@ -9,8 +9,10 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
-import { lfxColors } from '@lfx-one/shared/constants';
-import { NewsletterAnalytics, NewsletterChartData } from '@lfx-one/shared/interfaces';
+import { TableComponent } from '@components/table/table.component';
+import { lfxColors, NEWSLETTER_TOP_LINKS_LIMIT } from '@lfx-one/shared/constants';
+import { NewsletterAnalytics, NewsletterChartData, NewsletterLinkRow } from '@lfx-one/shared/interfaces';
+import { normalizeToUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
@@ -26,6 +28,7 @@ import { NewsletterRecipientEngagementComponent } from '../components/newsletter
     CardComponent,
     ChartComponent,
     EmptyStateComponent,
+    TableComponent,
     SkeletonModule,
     NewsletterFailedRecipientsDrawerComponent,
     NewsletterRecipientEngagementComponent,
@@ -59,7 +62,30 @@ export class NewsletterAnalyticsComponent {
   // chart on real per-day data so we never render an empty axis with no series.
   protected readonly hasDailyBreakdown = computed(() => (this.analytics()?.daily_opens?.length ?? 0) > 0);
   protected readonly chartData: Signal<NewsletterChartData | null> = this.initChartData();
+  // Shared by both the opens and clicks charts — the config closes over nothing
+  // chart-specific (legend, tooltip mode, zero-based y-axis), so a single computed
+  // keeps the two visually identical instead of letting a duplicate drift.
   protected readonly chartOptions: Signal<Record<string, unknown>> = this.initChartOptions();
+
+  // Click metrics (lfx-v2-newsletter-service PR #76) are SendGrid-only: an
+  // email-service (SES) newsletter always reports zeros/empty arrays, and
+  // `send_provider` isn't exposed on any public DTO, so we can't distinguish
+  // "unmeasurable" from "zero clicks". Every click UI element is gated on this
+  // single rule so the page looks identical to today whenever it's false.
+  protected readonly hasClickData = computed(() => {
+    const a = this.analytics();
+    if (!a) return false;
+    return (a.total_clicks ?? 0) > 0 || (a.unique_clicks ?? 0) > 0 || (a.daily_clicks?.length ?? 0) > 0 || (a.top_links?.length ?? 0) > 0;
+  });
+  protected readonly clickRatePercent: Signal<number | null> = this.initClickRatePercent();
+  protected readonly clickToOpenRatePercent: Signal<number | null> = this.initClickToOpenRatePercent();
+  // Distinct from hasDailyBreakdown: upstream derives daily_clicks from a separate
+  // event query than daily_opens, so a day present in one series can be absent
+  // from the other. Reusing hasDailyBreakdown would render an empty clicks axis.
+  protected readonly hasDailyClickBreakdown = computed(() => (this.analytics()?.daily_clicks?.length ?? 0) > 0);
+  protected readonly clickChartData: Signal<NewsletterChartData | null> = this.initClickChartData();
+  protected readonly topLinkRows: Signal<NewsletterLinkRow[]> = this.initTopLinkRows();
+  protected readonly topLinksLimit = NEWSLETTER_TOP_LINKS_LIMIT;
 
   public constructor() {
     // Lazy chart rendering on the browser only — Chart.js touches `window` on init.
@@ -166,6 +192,71 @@ export class NewsletterAnalyticsComponent {
         y: { beginAtZero: true, ticks: { precision: 0 } },
       },
     }));
+  }
+
+  private initClickRatePercent(): Signal<number | null> {
+    return computed(() => {
+      const a = this.analytics();
+      if (!a) return null;
+      return Math.round((a.click_rate ?? 0) * 100);
+    });
+  }
+
+  private initClickToOpenRatePercent(): Signal<number | null> {
+    return computed(() => {
+      const a = this.analytics();
+      if (!a) return null;
+      // Clamp client-side too: upstream clamps click_to_open_rate to 1.0, but a
+      // stale/partial rollup can still report a raw value above 1 (clicks recorded
+      // before the matching opens land), which would otherwise render e.g. "112%".
+      return Math.round(Math.min(a.click_to_open_rate ?? 0, 1) * 100);
+    });
+  }
+
+  private initClickChartData(): Signal<NewsletterChartData | null> {
+    return computed(() => {
+      const a = this.analytics();
+      if (!a || !this.canRenderChart()) return null;
+      // Own labels, never index-aligned with the opens chart's daily_opens: upstream
+      // builds daily_clicks from a separate event query, so a day present in one
+      // series can be absent from the other (e.g. an image-blocked clicker produces
+      // a click-only day with no matching open bucket).
+      const daily = a.daily_clicks ?? [];
+      return {
+        labels: daily.map((d) => d.date),
+        datasets: [
+          {
+            label: 'Total clicks',
+            data: daily.map((d) => d.clicks),
+            borderColor: lfxColors.violet[600],
+            backgroundColor: this.alpha(lfxColors.violet[500], 0.1),
+            tension: 0.3,
+            fill: true,
+          },
+          {
+            label: 'Unique clicks',
+            data: daily.map((d) => d.unique_clicks),
+            borderColor: lfxColors.amber[500],
+            backgroundColor: this.alpha(lfxColors.amber[500], 0.1),
+            tension: 0.3,
+            fill: true,
+          },
+        ],
+      };
+    });
+  }
+
+  private initTopLinkRows(): Signal<NewsletterLinkRow[]> {
+    return computed(() => {
+      const links = this.analytics()?.top_links ?? [];
+      // Defensive slice: upstream already caps at NEWSLETTER_TOP_LINKS_LIMIT, but
+      // mirroring the cap here keeps the display note and the rendered rows from
+      // ever drifting apart if that upstream guarantee ever changes.
+      return links.slice(0, NEWSLETTER_TOP_LINKS_LIMIT).map((link) => ({
+        ...link,
+        href: normalizeToUrl(link.url),
+      }));
+    });
   }
 
   // Chart.js expects an rgba string for area fills; lfxColors entries are #RRGGBB.

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-analytics/newsletter-analytics.component.ts
@@ -16,6 +16,7 @@ import { normalizeToUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, finalize, of, switchMap, take } from 'rxjs';
 
 import { NewsletterFailedRecipientsDrawerComponent } from '../components/newsletter-failed-recipients-drawer/newsletter-failed-recipients-drawer.component';
@@ -30,6 +31,7 @@ import { NewsletterRecipientEngagementComponent } from '../components/newsletter
     EmptyStateComponent,
     TableComponent,
     SkeletonModule,
+    TooltipModule,
     NewsletterFailedRecipientsDrawerComponent,
     NewsletterRecipientEngagementComponent,
   ],

--- a/packages/shared/src/constants/newsletter.constants.ts
+++ b/packages/shared/src/constants/newsletter.constants.ts
@@ -39,6 +39,12 @@ export const NEWSLETTER_AI_MAX_TOKENS = 12_000;
 // global one.
 export const NEWSLETTER_ANALYTICS_FETCH_CONCURRENCY = 5;
 
+// Upstream caps the `top_links` click-analytics breakdown at the 20 highest-click
+// links (lfx-v2-newsletter-service PR #76). Mirrored here so the "Top clicked
+// links" card's display note and defensive display slice can't drift from
+// upstream or from each other.
+export const NEWSLETTER_TOP_LINKS_LIMIT = 20;
+
 // Per-request timeout for the send endpoint, overriding the API client's 30s
 // default. The new upstream accepts sends in well under a second (202 +
 // background fan-out), but while a pre-async newsletter-service is deployed

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -258,6 +258,25 @@ export interface NewsletterDailyOpens {
   unique_opens: number;
 }
 
+export interface NewsletterDailyClicks {
+  date: string;
+  clicks: number;
+  unique_clicks: number;
+}
+
+/**
+ * One row of the aggregate `top_links` breakdown (lfx-v2-newsletter-service PR
+ * #76). Capped upstream at the 20 highest-`clicks` URLs and already sorted by
+ * `clicks` descending — clients should not re-sort. Compliance-footer links
+ * (Unsubscribe, My Newsletters) are excluded upstream, so this reflects
+ * author content only.
+ */
+export interface NewsletterLinkClicks {
+  url: string;
+  clicks: number;
+  unique_clicks: number;
+}
+
 export interface NewsletterAnalytics {
   newsletter_id: string;
   subject: string;
@@ -275,6 +294,22 @@ export interface NewsletterAnalytics {
   open_rate: number;
   daily_opens: NewsletterDailyOpens[];
   last_event_at?: string;
+  // Click metrics (lfx-v2-newsletter-service PR #76). Non-pointer upstream — always
+  // present once deployed, arrays never null — but optional here so the interface
+  // stays truthful against a pre-deploy newsletter-service. CRITICAL: these are
+  // SendGrid-only. A newsletter sent via email-service (SES) always reports zeros /
+  // empty arrays here, and `send_provider` is not exposed on any public DTO, so a
+  // client cannot distinguish "clicks unmeasurable" from "zero clicks". Every click
+  // UI element must therefore be gated on a single derived "has click data" rule
+  // rather than rendering a misleading 0%.
+  total_clicks?: number;
+  unique_clicks?: number;
+  /** 0-1 fraction of delivered emails (same denominator as `open_rate`); multiply by 100 for display. */
+  click_rate?: number;
+  /** 0-1 fraction of unique opens, clamped to 1.0 upstream; `0` when there are no opens. */
+  click_to_open_rate?: number;
+  daily_clicks?: NewsletterDailyClicks[];
+  top_links?: NewsletterLinkClicks[];
 }
 
 /**
@@ -299,6 +334,14 @@ export interface NewsletterRecipientEngagement {
   // Every recorded open timestamp, ascending. Always present (empty array when
   // the recipient never opened); capped at the 500 most recent opens.
   opened_at_list: string[];
+  // Click fields (lfx-v2-newsletter-service PR #76). Same shape and 500-entry cap
+  // as the open fields above. SendGrid-only: on an email-service (SES) newsletter
+  // these are always `false` / `0` / omitted / `[]`. Optional for the same
+  // pre-deploy-truthfulness reason as NewsletterAnalytics' click fields.
+  clicked?: boolean;
+  click_count?: number;
+  last_clicked_at?: string;
+  clicked_at_list?: string[];
 }
 
 /**
@@ -335,10 +378,25 @@ export interface NewsletterRecipientRow extends NewsletterRecipientEngagement {
   // Precomputed so the template never calls a component method for formatting
   // (re-runs every CD cycle) — null when there's no last_opened_at to format.
   lastOpenedRelative: string | null;
+  // Click fields narrowed to required and normalized (`?? false` / `?? 0` / `?? []`)
+  // at row-build time, so the template never needs optional chaining on them.
+  clicked: boolean;
+  click_count: number;
+  clicked_at_list: string[];
+  /** Mirrors `lastOpenedRelative` for `last_clicked_at`; null when absent. */
+  lastClickedRelative: string | null;
 }
 
-/** Filter chip key for the recipient engagement table — `'all'` plus every `NewsletterRecipientEngagementSegment`. */
-export type NewsletterRecipientEngagementChipKey = 'all' | NewsletterRecipientEngagementSegment;
+/**
+ * Filter chip key for the recipient engagement table — `'all'` plus every
+ * `NewsletterRecipientEngagementSegment`, plus `'clicked'`. `'clicked'` is
+ * deliberately NOT a `NewsletterRecipientEngagementSegment`: clicking is
+ * orthogonal to the mutually-exclusive opened/not-opened/failed bucket (a
+ * clicker is usually also an opener, and an image-blocked clicker can still be
+ * 'not-opened'), so the Clicked chip's count overlaps 'Opened' and the chip
+ * counts do not sum to the 'all' count.
+ */
+export type NewsletterRecipientEngagementChipKey = 'all' | NewsletterRecipientEngagementSegment | 'clicked';
 
 /** One filter chip above the recipient engagement table, with its live count. */
 export interface NewsletterRecipientEngagementChipConfig {
@@ -376,6 +434,17 @@ export interface NewsletterChartDataset {
 export interface NewsletterChartData {
   labels: string[];
   datasets: NewsletterChartDataset[];
+}
+
+/**
+ * UI row for the "Top clicked links" table. `href` is the result of running
+ * the untrusted upstream `url` through `normalizeToUrl`, precomputed so the
+ * template neither calls a method nor re-validates on every CD cycle; `null`
+ * when the URL fails validation, in which case the raw string renders as
+ * unlinked text instead of an anchor.
+ */
+export interface NewsletterLinkRow extends NewsletterLinkClicks {
+  href: string | null;
 }
 
 export interface NewsletterOptOut {


### PR DESCRIPTION
## Summary

Adds SendGrid link-click tracking to the per-newsletter analytics page, per [lfx-v2-newsletter-service PR #76](https://github.com/linuxfoundation/lfx-v2-newsletter-service/pull/76) (merged upstream). No backend changes needed in this repo — the Express layer is a pure passthrough to the two existing analytics endpoints, which gained click fields additively.

### Metrics added

1. **Four tiles** (mirroring the opens tiles): Unique clicks, Total clicks, Click rate, Click-to-open rate.
2. **"Clicks over time"** — its own chart card below "Opens over time" (own date axis; upstream derives `daily_clicks` from a separate query than `daily_opens`, so the two can't be index-aligned).
3. **"Top clicked links"** — table of URL / Clicks / Unique clicks, top 20 by clicks (matches the upstream cap).
4. **Recipient engagement table** — Clicks + Last clicked columns, a "Clicked" filter chip (overlaps "Opened" by design — a click can be recorded without an open, e.g. an image-blocked client), and a per-recipient click timeline in the existing expandable row.

### Zero-data gating (backend capability confirmed)

Click fields are **SendGrid-only** — an SES-sent newsletter always reports zeros/empty arrays, and `send_provider` isn't exposed on any public DTO, so the frontend can't distinguish "unmeasurable" from "zero clicks." One rule covers every click UI element:

```ts
hasClickData = (total_clicks ?? 0) > 0 || (unique_clicks ?? 0) > 0
            || (daily_clicks?.length ?? 0) > 0 || (top_links?.length ?? 0) > 0
```

When false, nothing click-related renders — no tiles, no chart card, no links card, no click columns/chip. The page looks identical to today.

Note for whoever validates in a deployed environment: click metrics stay at zero unless **Clicked** is enabled in SendGrid Mail Settings → Event Webhook per environment. A zero-click staging newsletter may be config, not code.

### Out of scope

A Click Rate column on the Sent list — deferred as a separate ask, consistent with the previously-deferred sender column.

### Known pre-existing patterns not touched by this PR

- `newsletter-recipient-engagement.component.html`'s new "Last clicked" cell mirrors the existing "Last opened" cell's tooltip-on-non-focusable-`<span>` pattern (keyboard users can't trigger the native `title` tooltip on either). Left both as-is for consistency rather than fixing only the new cell; worth a follow-up a11y pass across the table.
- `newsletter-analytics.component.ts`'s pre-existing `failedDrawerVisible` signal uses `signal()` with `[(visible)]` two-way binding where `model()` is the repo convention. Predates this branch (#1004); not touched here to keep the diff scoped to click metrics.

## Test plan

- [x] `yarn lint:check` — clean
- [x] `yarn build` — SSR bundle builds successfully
- [x] `yarn test` (recipient-engagement spec) — 20/20 passing, including new click-metric cases and the click-timeline empty-state case
- [ ] Manual, SendGrid-sent newsletter with recorded clicks: tiles populate, clicks chart renders, top-links table lists real URLs, recipient rows show Clicks/Last clicked, Clicked chip and expanded timeline work
- [ ] Manual, SES-sent or zero-click newsletter: page renders identically to today (no click tiles/chart/links card/columns/chip)

Ref: LFXV2-3218

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added newsletter click analytics, including unique and total clicks, click rates, click-to-open rates, and clicks-over-time reporting.
  * Added a top-clicked-links table with safe link handling and empty states.
  * Enhanced recipient engagement tables with Clicked and Last clicked details, click timelines, filtering, sorting, and expandable activity.
  * Added accessible tooltips for engagement timestamps.
* **Bug Fixes**
  * Improved handling when click data is unavailable or changes during refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->