### PR TITLE
feat(org-lens): add ROI project detail view

### DIFF
--- a/apps/lfx-one/e2e/helpers/org-roi.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-roi.helper.ts
@@ -241,6 +241,40 @@ export const NO_INVESTMENT_PROJECT = {
 
 export const PROJECTS_WITH_NULL_RATIOS = { method: 'logit', rows: [...MOCK_PROJECTS.rows, NO_INVESTMENT_PROJECT] };
 
+/** The project the detail specs drill into — the top of the fixture by return. */
+export const DETAIL_PROJECT = PROJECTS_BY_RETURN[0];
+
+/** A loss-making one, so the detail view's negative net return is exercised as the mainline it is. */
+export const DETAIL_LOSS_PROJECT = MOCK_PROJECT_INPUTS.find((input) => input.return < input.expenditure) as (typeof MOCK_PROJECT_INPUTS)[number];
+
+export function orgRoiProjectDetailUrl(slug: string): string {
+  return `/org/roi/projects/${slug}`;
+}
+
+/**
+ * The detail payload for one of the fixture's projects, wrapping the same row shape `/projects`
+ * serves. Built from `MOCK_PROJECTS` rather than typed out again, so the drill-down and the table
+ * it is reached from cannot disagree about a project's figures.
+ */
+export function mockProjectDetail(slug: string, hasOrgLensProject = true): unknown {
+  const project = (MOCK_PROJECTS.rows as { projectSlug: string }[]).find((row) => row.projectSlug === slug);
+  return { orgUid: MOCK_ACCOUNT_ID, method: 'logit', project, hasOrgLensProject };
+}
+
+/**
+ * A project's yearly distribution. `efficiencyConstant` is always true in the contract — per-year
+ * ROI and BCR cancel to the lifetime figure — and the disclosure is driven by it, so a case can
+ * flip it to prove the copy is not hardcoded.
+ */
+export function mockProjectAnnual(slug: string, efficiencyConstant = true, apportioned = true): unknown {
+  const rows = [
+    annualRow(CURRENT_YEAR - 2, 1_200_000_000, 30_000_000),
+    annualRow(CURRENT_YEAR - 1, 1_300_000_000, 20_000_000),
+    annualRow(CURRENT_YEAR, 500_000_000, 10_000_000),
+  ];
+  return { method: 'logit', projectSlug: slug, rows, apportioned, efficiencyConstant };
+}
+
 interface StubOptions {
   hasAccess?: boolean;
   summary?: unknown;
@@ -248,6 +282,10 @@ interface StubOptions {
   annual?: unknown;
   investmentBreakdown?: unknown;
   projects?: unknown;
+  /** Status to answer both project-detail routes with; 200 uses the payloads below. */
+  projectDetailStatus?: number;
+  projectDetail?: unknown;
+  projectAnnual?: unknown;
 }
 
 export async function stubOrgLensContext(page: Page, options: StubOptions = {}): Promise<void> {
@@ -258,6 +296,21 @@ export async function stubOrgLensContext(page: Page, options: StubOptions = {}):
   await page.route('**/api/orgs/*/lens/roi/annual*', (route) => fulfillJson(route, options.annual ?? MOCK_ANNUAL));
   await page.route('**/api/orgs/*/lens/roi/investment-breakdown*', (route) => fulfillJson(route, options.investmentBreakdown ?? MOCK_INVESTMENT_BREAKDOWN));
   await page.route('**/api/orgs/*/lens/roi/projects*', (route) => fulfillJson(route, options.projects ?? MOCK_PROJECTS));
+
+  // These three globs cannot overlap: `*` does not cross a `/`, so the collection route above
+  // cannot capture `/projects/{slug}`, and neither can capture `/projects/{slug}/annual`. That
+  // mirrors the server, where the same distinction is made by registration order instead.
+  await page.route('**/api/orgs/*/lens/roi/projects/*', (route) => {
+    const status = options.projectDetailStatus ?? 200;
+    if (status !== 200) return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ message: 'stubbed' }) });
+    return fulfillJson(route, options.projectDetail ?? mockProjectDetail(DETAIL_PROJECT.slug));
+  });
+
+  await page.route('**/api/orgs/*/lens/roi/projects/*/annual*', (route) => {
+    const status = options.projectDetailStatus ?? 200;
+    if (status !== 200) return route.fulfill({ status, contentType: 'application/json', body: JSON.stringify({ message: 'stubbed' }) });
+    return fulfillJson(route, options.projectAnnual ?? mockProjectAnnual(DETAIL_PROJECT.slug));
+  });
 
   await page.route('**/api/user/personas*', (route) =>
     fulfillJson(route, {
@@ -317,17 +370,29 @@ export async function stubFeatureFlags(page: Page, flags: Record<string, boolean
 }
 
 export async function gotoOrgRoiPage(page: Page): Promise<void> {
+  await gotoRoiRoute(page, ORG_ROI_URL, 'org-roi-page');
+}
+
+/**
+ * The project detail route. It is a child of `/org/roi`, so it is matched by the same fail-closed
+ * dark-launch guard — the flag override below is what lets it resolve at all.
+ */
+export async function gotoOrgRoiProjectDetail(page: Page, slug: string): Promise<void> {
+  await gotoRoiRoute(page, orgRoiProjectDetailUrl(slug), 'org-roi-project-detail-page');
+}
+
+async function gotoRoiRoute(page: Page, url: string, testId: string): Promise<void> {
   await stubFeatureFlags(page, { [ORG_LENS_ROI_ENABLED_FLAG]: true });
   await seedSelectedOrgCookie(page);
   await page.goto('/', { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
   await page.reload({ waitUntil: 'domcontentloaded' });
-  await page.goto(ORG_ROI_URL, { waitUntil: 'domcontentloaded' });
+  await page.goto(url, { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
   await expect(page).not.toHaveURL(/auth0\.com/);
 
   // The guard redirects asynchronously, so arriving at the URL is not the same as staying on it —
   // asserting immediately would pass against a page that is about to leave.
   await expect(page).toHaveURL(/\/org\/roi/, { timeout: 15_000 });
-  await expect(page.getByTestId('org-roi-page')).toBeVisible({ timeout: 15_000 });
+  await expect(page.getByTestId(testId)).toBeVisible({ timeout: 15_000 });
 }

--- a/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
@@ -4,6 +4,7 @@
 import { expect, test } from '@playwright/test';
 // Imported from the module, not the `utils` barrel: the barrel re-exports form.utils, which pulls
 // in @angular/common and fails to load outside the Angular app with a JIT compiler error.
+import { ORG_LENS_ROI_METHOD_STORAGE_KEY } from '@lfx-one/shared/constants/org-lens-roi.constants';
 import { formatCurrency, formatPercent } from '@lfx-one/shared/utils/number.utils';
 
 import {
@@ -88,6 +89,20 @@ test.describe('Org Lens ROI project detail — figures', () => {
     const loss = DETAIL_LOSS_PROJECT.return - DETAIL_LOSS_PROJECT.expenditure;
     await expect(page.getByTestId('org-roi-project-detail-kpi-cards')).toContainText(formatCurrency(loss));
     await expect(page.getByTestId('org-roi-project-detail-loss-note')).toBeVisible();
+  });
+
+  test('withholds figures whose estimation method is not the one in effect', async ({ page }) => {
+    // The stored preference is restored after the first render, so a viewer on `direct` issues a
+    // `logit` request first. If that payload were rendered, the heading would read "Direct markup"
+    // over logit return and ratios — and because investment is method-invariant, only some of the
+    // figures would be wrong, which is harder to notice than all of them.
+    await stubOrgLensContext(page, { projectDetail: { ...(mockProjectDetail(DETAIL_PROJECT.slug) as object), method: 'logit' } });
+    await page.addInitScript((key) => window.localStorage.setItem(key as string, 'direct'), ORG_LENS_ROI_METHOD_STORAGE_KEY);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-subtitle')).toContainText('Direct markup');
+    await expect(page.getByTestId('org-roi-project-detail-kpi-cards')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-project-detail-page')).not.toContainText(formatCurrency(DETAIL_PROJECT.expenditure));
   });
 
   test('carries an explanation for every one of the five figures', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
@@ -1,0 +1,264 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, test } from '@playwright/test';
+// Imported from the module, not the `utils` barrel: the barrel re-exports form.utils, which pulls
+// in @angular/common and fails to load outside the Angular app with a JIT compiler error.
+import { formatCurrency, formatPercent } from '@lfx-one/shared/utils/number.utils';
+
+import {
+  CURRENT_YEAR,
+  DETAIL_LOSS_PROJECT,
+  DETAIL_PROJECT,
+  gotoOrgRoiPage,
+  gotoOrgRoiProjectDetail,
+  MOCK_ACCOUNT_ID,
+  mockProjectAnnual,
+  mockProjectDetail,
+  NO_VALUE,
+  orgRoiProjectDetailUrl,
+  stubOrgLensContext,
+} from './helpers/org-roi.helper';
+
+test.setTimeout(120_000);
+
+/**
+ * Every expected string is derived from the fixture through the same formatter the component uses.
+ * The detail payload is built from the same `MOCK_PROJECTS` rows the table renders, so a figure
+ * that differs between the table and the drill-down fails here rather than reaching a viewer.
+ */
+const PROFIT = DETAIL_PROJECT.return - DETAIL_PROJECT.expenditure;
+const ROI = PROFIT / DETAIL_PROJECT.expenditure;
+const BCR = DETAIL_PROJECT.return / DETAIL_PROJECT.expenditure;
+
+/** A project with no investment: the warehouse returns NULL, never zero, for a ratio it cannot divide. */
+const NO_INVESTMENT_DETAIL = {
+  orgUid: MOCK_ACCOUNT_ID,
+  method: 'logit',
+  project: {
+    projectId: 'prj-unmeasured',
+    projectSlug: 'unmeasured',
+    projectName: 'Unmeasured Project',
+    totalExpenditure: 0,
+    totalReturn: 0,
+    profit: 0,
+    roi: null,
+    bcr: null,
+    breakevenMarkup: null,
+    categories: [],
+  },
+  hasOrgLensProject: true,
+};
+
+test.describe('Org Lens ROI project detail — figures', () => {
+  test('shows all five figures for the project, read from the payload', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(DETAIL_PROJECT.name);
+
+    const cards = page.getByTestId('org-roi-project-detail-kpi-cards');
+    await expect(cards).toContainText(formatCurrency(DETAIL_PROJECT.expenditure));
+    await expect(cards).toContainText(formatCurrency(DETAIL_PROJECT.return));
+    await expect(cards).toContainText(formatCurrency(PROFIT));
+    await expect(cards).toContainText(`${formatPercent(ROI * 100)}%`);
+    await expect(cards).toContainText(`${BCR.toFixed(1)}×`);
+  });
+
+  test('renders a null ratio as the no-value indicator, never as zero', async ({ page }) => {
+    await stubOrgLensContext(page, { projectDetail: NO_INVESTMENT_DETAIL, projectAnnual: mockProjectAnnual('unmeasured') });
+    await gotoOrgRoiProjectDetail(page, 'unmeasured');
+
+    const cards = page.getByTestId('org-roi-project-detail-kpi-cards');
+    await expect(cards).toContainText(NO_VALUE);
+    // The distinction that matters: "we could not compute this" must not render as "broke even".
+    await expect(cards).not.toContainText('0.0%');
+    await expect(cards).not.toContainText('0.0×');
+  });
+
+  test('states a negative net return rather than leaving it to be inferred', async ({ page }) => {
+    await stubOrgLensContext(page, {
+      projectDetail: mockProjectDetail(DETAIL_LOSS_PROJECT.slug),
+      projectAnnual: mockProjectAnnual(DETAIL_LOSS_PROJECT.slug),
+    });
+    await gotoOrgRoiProjectDetail(page, DETAIL_LOSS_PROJECT.slug);
+
+    const loss = DETAIL_LOSS_PROJECT.return - DETAIL_LOSS_PROJECT.expenditure;
+    await expect(page.getByTestId('org-roi-project-detail-kpi-cards')).toContainText(formatCurrency(loss));
+    await expect(page.getByTestId('org-roi-project-detail-loss-note')).toBeVisible();
+  });
+
+  test('carries an explanation for every one of the five figures', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    for (const metric of ['total-expenditure', 'total-return', 'profit', 'roi', 'bcr']) {
+      await expect(page.getByTestId(`org-roi-project-detail-explanation-${metric}`)).toHaveCount(1);
+    }
+  });
+
+  test('carries the modelled-cost disclosure verbatim on the investment figure', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    // Each clause asserted separately, so shortening the copy to fit a layout fails a test rather
+    // than quietly weakening the disclosure.
+    const investment = page.getByTestId('org-roi-project-detail-explanation-total-expenditure');
+    await expect(investment).toContainText('modelled cost');
+    await expect(investment).toContainText('not actual or reported compensation');
+    await expect(investment).toContainText('standard rates that are the same for every organization');
+    await expect(investment).toContainText('No salary, payroll, or invoice data is used.');
+  });
+});
+
+test.describe('Org Lens ROI project detail — investment by year', () => {
+  test('renders the yearly distribution and its text equivalent', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-annual-chart')).toHaveAttribute('role', 'img');
+
+    const table = page.getByTestId('org-roi-project-detail-annual-table');
+    await expect(table).toContainText(formatCurrency(30_000_000));
+    await expect(table).toContainText(formatCurrency(1_200_000_000));
+    // Only the year still in progress is marked partial; an earlier final year is complete.
+    await expect(table).toContainText(`${CURRENT_YEAR} (partial year)`);
+    await expect(table).not.toContainText(`${CURRENT_YEAR - 1} (partial year)`);
+  });
+
+  test('discloses that per-year efficiency is constant, and plots no efficiency series', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    const note = page.getByTestId('org-roi-project-detail-efficiency-constant-note');
+    await expect(note).toBeVisible();
+    await expect(note).toContainText('same in every year');
+    // The chart carries investment alone; a per-year ROI or BCR series would contradict the note.
+    await expect(page.getByTestId('org-roi-project-detail-annual-chart')).not.toContainText('Benefit-Cost');
+  });
+
+  test('drives the constancy disclosure from the payload flag, not from hardcoded copy', async ({ page }) => {
+    await stubOrgLensContext(page, { projectAnnual: mockProjectAnnual(DETAIL_PROJECT.slug, false) });
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-annual-table')).toBeVisible();
+    await expect(page.getByTestId('org-roi-project-detail-efficiency-constant-note')).toHaveCount(0);
+  });
+
+  test('drives the apportionment note from the payload flag', async ({ page }) => {
+    await stubOrgLensContext(page, { projectAnnual: mockProjectAnnual(DETAIL_PROJECT.slug, true, false) });
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-apportionment-note')).toHaveCount(0);
+  });
+
+  test('shows an explanation, not an empty chart, when the project has no yearly breakdown', async ({ page }) => {
+    await stubOrgLensContext(page, {
+      projectAnnual: { method: 'logit', projectSlug: DETAIL_PROJECT.slug, rows: [], apportioned: true, efficiencyConstant: true },
+    });
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-annual-empty')).toBeVisible();
+    await expect(page.getByTestId('org-roi-project-detail-annual-chart')).toHaveCount(0);
+    // A project with no yearly split still has lifetime figures — this is a 200, not a 404.
+    await expect(page.getByTestId('org-roi-project-detail-kpi-cards')).toBeVisible();
+  });
+});
+
+test.describe('Org Lens ROI project detail — onward link', () => {
+  test('links into Org Lens when the project has a catalog entry', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    const link = page.getByTestId('org-roi-project-detail-onward-link');
+    await expect(link).toHaveAttribute('href', `/org/projects/${DETAIL_PROJECT.slug}`);
+    await expect(page.getByTestId('org-roi-project-detail-onward-unavailable')).toHaveCount(0);
+  });
+
+  test('explains the absence instead of rendering a link that would 404', async ({ page }) => {
+    // Measured 2026-08-05: 32.4% of ROI organization-project pairs have no Org Lens catalog row,
+    // so this is a routine outcome and the link must not be rendered unconditionally.
+    await stubOrgLensContext(page, { projectDetail: mockProjectDetail(DETAIL_PROJECT.slug, false) });
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-onward-unavailable')).toBeVisible();
+    await expect(page.getByTestId('org-roi-project-detail-onward-link')).toHaveCount(0);
+  });
+});
+
+test.describe('Org Lens ROI project detail — refusals and absence', () => {
+  test('shows a not-found state, not zeros, when the slug names no project of this organization', async ({ page }) => {
+    await stubOrgLensContext(page, { projectDetailStatus: 404 });
+    await gotoOrgRoiProjectDetail(page, 'someone-elses-project');
+
+    await expect(page.getByTestId('org-roi-project-detail-not-found')).toBeVisible();
+    await expect(page.getByTestId('org-roi-project-detail-kpi-cards')).toHaveCount(0);
+    // The distinction the 404 exists to preserve: no figure may appear for a project this
+    // organization has no measured relationship with.
+    await expect(page.getByTestId('org-roi-project-detail-page')).not.toContainText('$0');
+  });
+
+  test('distinguishes a refusal from an outage', async ({ page }) => {
+    await stubOrgLensContext(page, { projectDetailStatus: 403 });
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-forbidden')).toBeVisible();
+    await expect(page.getByTestId('org-roi-project-detail-error')).toHaveCount(0);
+    await expect(page.getByTestId('org-roi-project-detail-not-found')).toHaveCount(0);
+  });
+
+  test('shows a retryable error for a 503, never a permissions message', async ({ page }) => {
+    await stubOrgLensContext(page, { projectDetailStatus: 503 });
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+
+    await expect(page.getByTestId('org-roi-project-detail-error')).toBeVisible();
+    await expect(page.getByTestId('org-roi-project-detail-forbidden')).toHaveCount(0);
+  });
+
+  test('leaks no ROI figure in any response on the refused path', async ({ page }) => {
+    // Asserting only that the UI hides the figures would pass against a handler that refused and
+    // leaked at the same time, so this reads the response bodies.
+    const bodies: string[] = [];
+    page.on('response', (response) => {
+      if (!response.url().includes('/lens/roi/')) return;
+      void response
+        .text()
+        .then((text) => bodies.push(text))
+        .catch(() => undefined);
+    });
+
+    await stubOrgLensContext(page, { projectDetailStatus: 403 });
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+    await expect(page.getByTestId('org-roi-project-detail-forbidden')).toBeVisible();
+
+    for (const body of bodies) {
+      expect(body).not.toContain('totalExpenditure');
+      expect(body).not.toContain('totalReturn');
+    }
+  });
+});
+
+test.describe('Org Lens ROI projects table — navigation to detail', () => {
+  test('navigates to the project detail route when a row is selected', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-projects-section-tab-table').click();
+    await page.getByTestId(`org-roi-projects-table-link-prj-${DETAIL_PROJECT.slug}`).click();
+
+    await expect(page).toHaveURL(new RegExp(`${orgRoiProjectDetailUrl(DETAIL_PROJECT.slug)}$`));
+    await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(DETAIL_PROJECT.name);
+  });
+
+  test('reaches the same project the table row named', async ({ page }) => {
+    await stubOrgLensContext(page);
+    await gotoOrgRoiPage(page);
+
+    await page.getByTestId('org-roi-projects-section-tab-table').click();
+    const row = page.getByTestId(`org-roi-projects-table-row-prj-${DETAIL_PROJECT.slug}`);
+    await expect(row).toContainText(formatCurrency(DETAIL_PROJECT.expenditure));
+
+    await row.click();
+    await expect(page).toHaveURL(new RegExp(`${orgRoiProjectDetailUrl(DETAIL_PROJECT.slug)}$`));
+  });
+});

--- a/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
@@ -12,10 +12,8 @@ import {
   DETAIL_LOSS_PROJECT,
   DETAIL_PROJECT,
   gotoOrgRoiPage,
-  fulfillJson,
   gotoOrgRoiProjectDetail,
   MOCK_ACCOUNT_ID,
-  MOCK_PROJECT_INPUTS,
   mockProjectAnnual,
   mockProjectDetail,
   NO_VALUE,
@@ -235,20 +233,24 @@ test.describe('Org Lens ROI project detail — refusals and absence', () => {
   test('leaks no ROI figure in any response on the refused path', async ({ page }) => {
     // Asserting only that the UI hides the figures would pass against a handler that refused and
     // leaked at the same time, so this reads the response bodies.
-    const bodies: string[] = [];
+    //
+    // The body promises are collected and awaited rather than pushed from a floating `.then()`:
+    // reading a bare array can run before any body has resolved, and a loop over an empty array
+    // passes having inspected nothing — the assertion would report success precisely when it had
+    // checked the least. The count assertion below is the second half of that guard.
+    const bodies: Promise<string>[] = [];
     page.on('response', (response) => {
       if (!response.url().includes('/lens/roi/')) return;
-      void response
-        .text()
-        .then((text) => bodies.push(text))
-        .catch(() => undefined);
+      bodies.push(response.text().catch(() => ''));
     });
 
     await stubOrgLensContext(page, { projectDetailStatus: 403 });
     await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
     await expect(page.getByTestId('org-roi-project-detail-forbidden')).toBeVisible();
 
-    for (const body of bodies) {
+    const settled = await Promise.all(bodies);
+    expect(settled.length).toBeGreaterThan(0);
+    for (const body of settled) {
       expect(body).not.toContain('totalExpenditure');
       expect(body).not.toContain('totalReturn');
     }
@@ -267,28 +269,13 @@ test.describe('Org Lens ROI projects table — navigation to detail', () => {
     await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(DETAIL_PROJECT.name);
   });
 
-  test("never shows one project's figures under another's name while switching between them", async ({ page }) => {
-    // The component instance is reused across a project-to-project navigation and the payload keeps
-    // its previous value until the next response lands, so without an identity check on the slug
-    // the previous project's investment and ROI render under the new project's URL.
-    const second = MOCK_PROJECT_INPUTS.find((input) => input.slug !== DETAIL_PROJECT.slug) as (typeof MOCK_PROJECT_INPUTS)[number];
-
-    await stubOrgLensContext(page);
-    await page.route('**/api/orgs/*/lens/roi/projects/*', async (route) => {
-      const slug = new URL(route.request().url()).pathname.split('/').pop() ?? '';
-      // The second project answers slowly, which is the window the check has to survive.
-      if (slug === second.slug) await new Promise((resolve) => setTimeout(resolve, 1_500));
-      return fulfillJson(route, mockProjectDetail(slug));
-    });
-
-    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
-    await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(DETAIL_PROJECT.name);
-
-    await page.goto(orgRoiProjectDetailUrl(second.slug), { waitUntil: 'domcontentloaded' });
-    // The first project's figures must never appear on the second project's URL, at any point.
-    await expect(page.getByTestId('org-roi-project-detail-page')).not.toContainText(formatCurrency(DETAIL_PROJECT.expenditure));
-    await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(second.name, { timeout: 15_000 });
-  });
+  // There is deliberately no case here for a project-to-project navigation reusing the component.
+  // Nothing in the product links one project detail to another — every route in comes from the
+  // table and the only way out is back to it — so that navigation cannot be driven through the UI,
+  // and a `page.goto()` between two detail URLs is a full document load that rebuilds the component
+  // rather than reusing it. A test written that way asserts nothing about the race it names. The
+  // identity guard still checks the slug, because a URL edit or a history entry can reach it, and
+  // the estimation-method case above exercises that same guard through a path the UI does produce.
 
   test('reaches the same project the table row named', async ({ page }) => {
     await stubOrgLensContext(page);

--- a/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
@@ -66,6 +66,17 @@ test.describe('Org Lens ROI project detail — figures', () => {
     await expect(cards).toContainText(`${BCR.toFixed(1)}×`);
   });
 
+  test('resolves a mixed-case deep link rather than holding the skeleton', async ({ page }) => {
+    // The warehouse stores slugs lowercase and the server normalizes before querying, so the
+    // payload comes back lowercase. If the route param were compared raw, the identity guard would
+    // never match and this page would skeleton forever on a URL the server answered correctly.
+    await stubOrgLensContext(page);
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug.toUpperCase());
+
+    await expect(page.getByTestId('org-roi-project-detail-kpi-cards')).toContainText(formatCurrency(DETAIL_PROJECT.expenditure));
+    await expect(page.getByTestId('org-roi-project-detail-loading')).toHaveCount(0);
+  });
+
   test('renders a null ratio as the no-value indicator, never as zero', async ({ page }) => {
     await stubOrgLensContext(page, { projectDetail: NO_INVESTMENT_DETAIL, projectAnnual: mockProjectAnnual('unmeasured') });
     await gotoOrgRoiProjectDetail(page, 'unmeasured');

--- a/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-project-detail.spec.ts
@@ -11,8 +11,10 @@ import {
   DETAIL_LOSS_PROJECT,
   DETAIL_PROJECT,
   gotoOrgRoiPage,
+  fulfillJson,
   gotoOrgRoiProjectDetail,
   MOCK_ACCOUNT_ID,
+  MOCK_PROJECT_INPUTS,
   mockProjectAnnual,
   mockProjectDetail,
   NO_VALUE,
@@ -248,6 +250,29 @@ test.describe('Org Lens ROI projects table — navigation to detail', () => {
 
     await expect(page).toHaveURL(new RegExp(`${orgRoiProjectDetailUrl(DETAIL_PROJECT.slug)}$`));
     await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(DETAIL_PROJECT.name);
+  });
+
+  test("never shows one project's figures under another's name while switching between them", async ({ page }) => {
+    // The component instance is reused across a project-to-project navigation and the payload keeps
+    // its previous value until the next response lands, so without an identity check on the slug
+    // the previous project's investment and ROI render under the new project's URL.
+    const second = MOCK_PROJECT_INPUTS.find((input) => input.slug !== DETAIL_PROJECT.slug) as (typeof MOCK_PROJECT_INPUTS)[number];
+
+    await stubOrgLensContext(page);
+    await page.route('**/api/orgs/*/lens/roi/projects/*', async (route) => {
+      const slug = new URL(route.request().url()).pathname.split('/').pop() ?? '';
+      // The second project answers slowly, which is the window the check has to survive.
+      if (slug === second.slug) await new Promise((resolve) => setTimeout(resolve, 1_500));
+      return fulfillJson(route, mockProjectDetail(slug));
+    });
+
+    await gotoOrgRoiProjectDetail(page, DETAIL_PROJECT.slug);
+    await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(DETAIL_PROJECT.name);
+
+    await page.goto(orgRoiProjectDetailUrl(second.slug), { waitUntil: 'domcontentloaded' });
+    // The first project's figures must never appear on the second project's URL, at any point.
+    await expect(page.getByTestId('org-roi-project-detail-page')).not.toContainText(formatCurrency(DETAIL_PROJECT.expenditure));
+    await expect(page.getByTestId('org-roi-project-detail-title')).toHaveText(second.name, { timeout: 15_000 });
   });
 
   test('reaches the same project the table row named', async ({ page }) => {

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -128,6 +128,9 @@ export const routes: Routes = [
             loadComponent: () => import('./modules/dashboards/org/org-project-detail/org-project-detail.component').then((m) => m.OrgProjectDetailComponent),
           },
           {
+            // Componentless parent, so the dark-launch guard is declared once and the project
+            // detail child is matched by it rather than by a second guard of its own. A looser
+            // copy would be a way into the unfinished feature while the flag is off.
             path: 'roi',
             canMatch: [orgLensRoiEnabledGuard],
             data: {
@@ -136,7 +139,20 @@ export const routes: Routes = [
               description: "Modelled return on your organization's open source investment.",
               icon: 'fa-light fa-chart-mixed-up-circle-dollar',
             },
-            loadComponent: () => import('./modules/dashboards/org/org-roi/org-roi.component').then((m) => m.OrgRoiComponent),
+            children: [
+              {
+                path: '',
+                loadComponent: () => import('./modules/dashboards/org/org-roi/org-roi.component').then((m) => m.OrgRoiComponent),
+              },
+              {
+                path: 'projects/:projectSlug',
+                data: { title: 'Project ROI Detail', description: "Modelled return on your organization's investment in one project." },
+                loadComponent: () =>
+                  import('./modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component').then(
+                    (m) => m.OrgRoiProjectDetailComponent
+                  ),
+              },
+            ],
           },
           {
             // INFO: Future Epic implementation — the Governance page is hidden; deep links

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
@@ -43,8 +43,23 @@
       </ng-template>
 
       <ng-template #body let-row>
-        <tr [attr.data-testid]="'org-roi-projects-table-row-' + row.projectId">
-          <td class="truncate" [attr.title]="row.projectName">{{ row.projectName }}</td>
+        <!-- The whole row navigates, but the accessible target is the link in the first cell: a
+             click handler on `tr` is unreachable by keyboard, and a row is not a control. The
+             handler ignores clicks that originate inside the anchor so the link is not followed
+             twice. A row whose slug is missing stays inert rather than routing to a dead URL. -->
+        <tr class="cursor-pointer hover:bg-gray-50" [attr.data-testid]="'org-roi-projects-table-row-' + row.projectId" (click)="openProject(row, $event)">
+          <td class="truncate" [attr.title]="row.projectName">
+            @if (row.projectSlug) {
+              <a
+                [routerLink]="['/org/roi/projects', row.projectSlug]"
+                class="text-blue-600 hover:text-blue-700 hover:underline"
+                [attr.data-testid]="'org-roi-projects-table-link-' + row.projectId">
+                {{ row.projectName }}
+              </a>
+            } @else {
+              {{ row.projectName }}
+            }
+          </td>
           <td class="text-right tabular-nums">{{ row.investmentLabel }}</td>
           <td class="text-right tabular-nums">{{ row.returnLabel }}</td>
           <td class="text-right tabular-nums" [class.text-amber-700]="row.profit < 0">{{ row.profitLabel }}</td>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.html
@@ -45,9 +45,14 @@
       <ng-template #body let-row>
         <!-- The whole row navigates, but the accessible target is the link in the first cell: a
              click handler on `tr` is unreachable by keyboard, and a row is not a control. The
-             handler ignores clicks that originate inside the anchor so the link is not followed
-             twice. A row whose slug is missing stays inert rather than routing to a dead URL. -->
-        <tr class="cursor-pointer hover:bg-gray-50" [attr.data-testid]="'org-roi-projects-table-row-' + row.projectId" (click)="openProject(row, $event)">
+             handler ignores clicks that originate inside the anchor, and modifier-clicks anywhere,
+             so neither is handled twice or robbed of "open in a new tab". A row whose slug is
+             missing stays inert, and does not advertise itself as clickable either. -->
+        <tr
+          [class.cursor-pointer]="row.projectSlug"
+          [class.hover:bg-gray-50]="row.projectSlug"
+          [attr.data-testid]="'org-roi-projects-table-row-' + row.projectId"
+          (click)="openProject(row, $event)">
           <td class="truncate" [attr.title]="row.projectName">
             @if (row.projectSlug) {
               <a

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input, Signal, signal } from '@angular/core';
+import { Component, computed, inject, input, Signal, signal } from '@angular/core';
+import { Router, RouterLink } from '@angular/router';
 import { TableComponent } from '@components/table/table.component';
 import {
   ORG_LENS_ROI_KPI_EXPLANATION,
@@ -24,10 +25,12 @@ import { formatCurrency, formatPercent } from '@lfx-one/shared/utils';
 /** Every project in the portfolio, sortable and paged. */
 @Component({
   selector: 'lfx-org-roi-projects-table',
-  imports: [TableComponent],
+  imports: [TableComponent, RouterLink],
   templateUrl: './org-roi-projects-table.component.html',
 })
 export class OrgRoiProjectsTableComponent {
+  private readonly router = inject(Router);
+
   /** The complete, uncapped project set — this view pages it rather than summarising it. */
   public readonly projects = input.required<OrgLensRoiProjectRow[]>();
 
@@ -74,6 +77,20 @@ export class OrgRoiProjectsTableComponent {
     const active: OrgLensRoiProjectAriaSort = this.sortDir() === 'asc' ? 'ascending' : 'descending';
     return this.mapOverFields((candidate) => (candidate === field ? active : 'none'));
   });
+
+  /**
+   * Row click navigates to the project's ROI detail.
+   *
+   * Clicks inside the first cell's anchor are left alone — the router already handles those, and
+   * intercepting them would navigate twice and defeat modifier-clicks that open a new tab. A row
+   * with no slug does nothing: the slug is the route parameter, and routing without one would land
+   * on a URL that cannot resolve.
+   */
+  public openProject(row: OrgLensRoiProjectTableRow, event: Event): void {
+    if (!row.projectSlug) return;
+    if ((event.target as HTMLElement | null)?.closest('a') !== null) return;
+    void this.router.navigate(['/org/roi/projects', row.projectSlug]);
+  }
 
   public toggleSort(field: OrgLensRoiProjectSortField): void {
     if (this.sortField() === field) this.sortDir.set(this.sortDir() === 'desc' ? 'asc' : 'desc');

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
@@ -79,13 +79,11 @@ export class OrgRoiProjectsTableComponent {
   });
 
   /**
-   * Row click navigates to the project's ROI detail.
-   *
    * Clicks inside the first cell's anchor are left alone — the router already handles those, and
    * intercepting them would navigate twice. A modifier-click anywhere in the row is left alone for
-   * the same reason the anchor is: it means "open elsewhere", and routing the current tab would
-   * take away a choice the viewer just made. A row with no slug does nothing, since the slug is the
-   * route parameter and routing without one would land on a URL that cannot resolve.
+   * the same reason: it means "open elsewhere", and routing the current tab would take away a
+   * choice the viewer just made. A row with no slug does nothing, since the slug is the route
+   * parameter and routing without one would land on a URL that cannot resolve.
    */
   public openProject(row: OrgLensRoiProjectTableRow, event: MouseEvent): void {
     if (!row.projectSlug) return;

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-projects-table/org-roi-projects-table.component.ts
@@ -82,13 +82,16 @@ export class OrgRoiProjectsTableComponent {
    * Row click navigates to the project's ROI detail.
    *
    * Clicks inside the first cell's anchor are left alone — the router already handles those, and
-   * intercepting them would navigate twice and defeat modifier-clicks that open a new tab. A row
-   * with no slug does nothing: the slug is the route parameter, and routing without one would land
-   * on a URL that cannot resolve.
+   * intercepting them would navigate twice. A modifier-click anywhere in the row is left alone for
+   * the same reason the anchor is: it means "open elsewhere", and routing the current tab would
+   * take away a choice the viewer just made. A row with no slug does nothing, since the slug is the
+   * route parameter and routing without one would land on a URL that cannot resolve.
    */
-  public openProject(row: OrgLensRoiProjectTableRow, event: Event): void {
+  public openProject(row: OrgLensRoiProjectTableRow, event: MouseEvent): void {
     if (!row.projectSlug) return;
-    if ((event.target as HTMLElement | null)?.closest('a') !== null) return;
+    if (event.ctrlKey || event.metaKey || event.shiftKey || event.button !== 0) return;
+    const target = event.target as HTMLElement | null;
+    if (target?.closest('a')) return;
     void this.router.navigate(['/org/roi/projects', row.projectSlug]);
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.html
@@ -61,10 +61,10 @@
       <span>This project's ROI couldn't be loaded. Please try again.</span>
     </div>
   } @else if (loading() || !showsFigures()) {
-    <!-- The org-identity check belongs in the loading condition, not only on the figures below: the
+    <!-- The identity check belongs in the loading condition, not only on the figures below: the
          payload keeps its previous value until the next response lands, so without it this branch
-         loses to the populated one for that window, putting one organization's amounts under
-         another's name. -->
+         loses to the populated one for that window — showing the previous organization, project or
+         estimation method's amounts under the current one's heading. -->
     <section class="flex flex-col gap-4" data-testid="org-roi-project-detail-loading">
       <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
         @for (i of [1, 2, 3, 4, 5]; track i) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.html
@@ -1,0 +1,205 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<main class="container mx-auto flex flex-col gap-6 px-4 sm:px-6 lg:px-8" data-testid="org-roi-project-detail-page">
+  <header class="flex flex-col gap-2" data-testid="org-roi-project-detail-header">
+    <a routerLink="/org/roi" class="inline-flex w-fit items-center gap-2 text-sm text-gray-500 hover:text-gray-700" data-testid="org-roi-project-detail-back">
+      <i class="fa-light fa-arrow-left" aria-hidden="true"></i>
+      Back to ROI Metrics
+    </a>
+    <h1 class="font-display font-light text-2xl" data-testid="org-roi-project-detail-title">{{ projectName() }}</h1>
+    <p class="text-sm text-gray-500" data-testid="org-roi-project-detail-subtitle">
+      What your organization invested in this project and what came back, priced with the {{ methodLabel() }} estimate.
+    </p>
+  </header>
+
+  @if (!hasAnalyticsId()) {
+    <!-- Ahead of the loading branch, and for a stronger reason than the failure branches: with no
+         analytics id no request is ever issued, so the skeleton below would never resolve. -->
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-roi-project-detail-no-analytics-id">
+      <i class="fa-light fa-building text-gray-400" aria-hidden="true"></i>
+      <span>Select a company to view ROI metrics for one of its projects.</span>
+    </div>
+  } @else if (forbidden()) {
+    <!-- Both failure branches and the not-found one sit ahead of the loading branch. A failed
+         request clears the payload, which leaves it not matching the selected organization, so a
+         loading condition tested first would swallow every 403, 404 and 503 into a permanent
+         skeleton. Each new request resets these flags, so ordering them first cannot strand a
+         stale error over a fresh load. -->
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-roi-project-detail-forbidden">
+      <i class="fa-light fa-lock text-gray-400" aria-hidden="true"></i>
+      <span>You do not have Org Lens access for this organization.</span>
+    </div>
+  } @else if (missing()) {
+    <!-- A 404, not an empty state with zeros: the slug is not a project this organization has ROI
+         for, and showing zeros would assert a measurement that was never made. -->
+    <section
+      class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-300 bg-white py-16 text-center"
+      data-testid="org-roi-project-detail-not-found">
+      <div class="flex h-12 w-12 items-center justify-center rounded-full bg-gray-100 text-gray-500">
+        <i class="fa-light fa-circle-question text-2xl" aria-hidden="true"></i>
+      </div>
+      <h2 class="text-base font-semibold text-gray-900" data-testid="org-roi-project-detail-not-found-title">No ROI figures for this project</h2>
+      <p class="max-w-md text-sm text-gray-600" data-testid="org-roi-project-detail-not-found-description">
+        This project isn't one your organization has modelled ROI for. It may belong to a different organization, or your organization may have no measured
+        contribution activity on it.
+      </p>
+      <a routerLink="/org/roi" class="text-sm font-medium text-blue-600 hover:text-blue-700" data-testid="org-roi-project-detail-not-found-back">
+        Back to ROI Metrics
+      </a>
+    </section>
+  } @else if (failed()) {
+    <!-- Separate from the forbidden branch: a 503 must not read as a permissions message. -->
+    <div
+      class="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 bg-white px-4 py-6 text-sm text-gray-600"
+      data-testid="org-roi-project-detail-error">
+      <i class="fa-light fa-triangle-exclamation text-gray-400" aria-hidden="true"></i>
+      <span>This project's ROI couldn't be loaded. Please try again.</span>
+    </div>
+  } @else if (loading() || !showsFigures()) {
+    <!-- The org-identity check belongs in the loading condition, not only on the figures below: the
+         payload keeps its previous value until the next response lands, so without it this branch
+         loses to the populated one for that window, putting one organization's amounts under
+         another's name. -->
+    <section class="flex flex-col gap-4" data-testid="org-roi-project-detail-loading">
+      <div class="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-5">
+        @for (i of [1, 2, 3, 4, 5]; track i) {
+          <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4">
+            <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
+            <p-skeleton width="4rem" height="1.75rem" />
+            <p-skeleton width="80%" height="0.75rem" />
+          </div>
+        }
+      </div>
+      <p-skeleton width="100%" height="280px" />
+    </section>
+  } @else {
+    <div class="flex flex-col gap-3" data-testid="org-roi-project-detail-kpi-cards">
+      <lfx-stat-card-grid [cards]="cards()" [columns]="5" />
+
+      @if (isLossMaking()) {
+        <p class="text-xs text-amber-700" data-testid="org-roi-project-detail-loss-note">
+          This project's modelled return is less than its modelled investment. That is a real outcome for a meaningful share of projects, not a gap in the data.
+        </p>
+      }
+
+      <details class="group rounded-lg border border-gray-200 bg-white" data-testid="org-roi-project-detail-explanations">
+        <summary
+          class="flex cursor-pointer list-none items-center gap-2 px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50"
+          data-testid="org-roi-project-detail-explanations-toggle">
+          <i class="fa-light fa-circle-info text-gray-400" aria-hidden="true"></i>
+          How these figures are calculated
+          <i class="fa-light fa-chevron-down ml-auto text-gray-400 transition-transform group-open:rotate-180" aria-hidden="true"></i>
+        </summary>
+        <!-- The same wording the portfolio band uses, rendered from the shared constant rather than
+             paraphrased, so the two surfaces cannot drift apart when either is edited. -->
+        <dl class="flex flex-col gap-4 border-t border-gray-200 px-4 py-4">
+          <div class="flex flex-col gap-1" data-testid="org-roi-project-detail-explanation-total-expenditure">
+            <dt class="text-sm font-semibold text-gray-900">Investment</dt>
+            <dd class="text-sm text-gray-600">{{ explanation.totalExpenditure }}</dd>
+          </div>
+          <div class="flex flex-col gap-1" data-testid="org-roi-project-detail-explanation-total-return">
+            <dt class="text-sm font-semibold text-gray-900">Return</dt>
+            <dd class="text-sm text-gray-600">{{ explanation.totalReturn }}</dd>
+          </div>
+          <div class="flex flex-col gap-1" data-testid="org-roi-project-detail-explanation-profit">
+            <dt class="text-sm font-semibold text-gray-900">Net Return</dt>
+            <dd class="text-sm text-gray-600">{{ explanation.profit }}</dd>
+          </div>
+          <div class="flex flex-col gap-1" data-testid="org-roi-project-detail-explanation-roi">
+            <dt class="text-sm font-semibold text-gray-900">ROI</dt>
+            <dd class="text-sm text-gray-600">{{ explanation.roi }}</dd>
+          </div>
+          <div class="flex flex-col gap-1" data-testid="org-roi-project-detail-explanation-bcr">
+            <dt class="text-sm font-semibold text-gray-900">Benefit-Cost Ratio</dt>
+            <dd class="text-sm text-gray-600">{{ explanation.bcr }}</dd>
+          </div>
+        </dl>
+      </details>
+    </div>
+
+    <section class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-roi-project-detail-annual">
+      <h2 class="text-base font-semibold text-gray-900">Investment by year</h2>
+
+      @if (!hasYearRows()) {
+        <div class="flex items-center gap-2 py-6 text-sm text-gray-600" data-testid="org-roi-project-detail-annual-empty">
+          <i class="fa-light fa-chart-column text-gray-400" aria-hidden="true"></i>
+          <span>No yearly breakdown is available for this project.</span>
+        </div>
+      } @else {
+        <div class="h-[280px]" role="img" [attr.aria-label]="chartSummaryLabel()" data-testid="org-roi-project-detail-annual-chart">
+          <lfx-chart type="bar" [data]="chartData()" [options]="chartOptions" height="100%" />
+        </div>
+
+        <!-- The canvas is otherwise the only presentation of these values, so it is unreadable to a
+             screen reader. This table carries them, plus the per-year return the single-series
+             chart deliberately leaves out. -->
+        <table class="sr-only" data-testid="org-roi-project-detail-annual-table">
+          <caption>
+            Investment and return by year
+          </caption>
+          <thead>
+            <tr>
+              <th scope="col">Year</th>
+              <th scope="col">Investment</th>
+              <th scope="col">Return</th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (row of yearRows(); track row.year) {
+              <tr>
+                <th scope="row">{{ row.year }}{{ row.isPartial ? ' (partial year)' : '' }}</th>
+                <td>{{ row.investmentLabel }}</td>
+                <td>{{ row.returnLabel }}</td>
+              </tr>
+            }
+          </tbody>
+        </table>
+
+        <div class="flex flex-col gap-1 border-t border-gray-100 pt-3">
+          @if (apportioned()) {
+            <p class="text-xs text-gray-500" data-testid="org-roi-project-detail-apportionment-note">
+              Yearly figures are apportioned from this project's lifetime totals by each year's share of investment — they are not measured independently for
+              each year, so movement between years reflects when the activity happened rather than a change in performance.
+            </p>
+          }
+          @if (efficiencyConstant()) {
+            <!-- Driven by the payload's flag rather than stated as copy: per-project ROI and
+                 benefit-cost ratio are identical in every year because the apportionment share
+                 cancels out of both, so no per-year efficiency series is drawn anywhere on this
+                 page and the constancy is stated instead of left to be inferred. -->
+            <p class="text-xs text-gray-500" data-testid="org-roi-project-detail-efficiency-constant-note">
+              This project's ROI and benefit-cost ratio are the same in every year by construction — the yearly split divides investment and return in the same
+              proportion. A year-by-year efficiency figure would not show improvement or decline, so none is shown.
+            </p>
+          }
+        </div>
+      }
+    </section>
+
+    <section class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-roi-project-detail-onward">
+      @if (hasOrgLensProject()) {
+        <a
+          [routerLink]="orgProjectLink()"
+          class="inline-flex w-fit items-center gap-2 text-sm font-medium text-blue-600 hover:text-blue-700"
+          data-testid="org-roi-project-detail-onward-link">
+          <i class="fa-light fa-arrow-up-right-from-square" aria-hidden="true"></i>
+          View this project in Org Lens
+        </a>
+        <p class="text-xs text-gray-500">Participation, influence and people for this project, alongside the economics shown here.</p>
+      } @else {
+        <!-- Not rendered as a disabled link: measured 2026-08-05, 32.4% of ROI
+             organization-project pairs have no Org Lens catalog row, so this is a routine outcome
+             and a link that 404s would be worse than none. -->
+        <p class="text-xs text-gray-500" data-testid="org-roi-project-detail-onward-unavailable">
+          This project doesn't have an Org Lens project page for your organization, so there is no wider view to link to. ROI covers every project your
+          organization contributed to, which is a broader set than the projects tracked in Org Lens.
+        </p>
+      }
+    </section>
+  }
+</main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
@@ -50,9 +50,16 @@ export class OrgRoiProjectDetailComponent {
 
   protected readonly methodLabel: Signal<string> = computed(() => ORG_LENS_ROI_METHOD_LABELS[this.method()]);
 
-  protected readonly projectSlug: Signal<string> = toSignal(this.activatedRoute.paramMap.pipe(map((params) => params.get('projectSlug') ?? '')), {
-    initialValue: '',
-  });
+  /**
+   * Normalized the same way the server normalizes it before querying. The warehouse stores slugs
+   * lowercase, so the payload comes back lowercase; comparing a raw mixed-case route param against
+   * it in `payloadMatchesRoute` would never match, and the page would hold its skeleton forever on
+   * a deep link the server had answered perfectly well.
+   */
+  protected readonly projectSlug: Signal<string> = toSignal(
+    this.activatedRoute.paramMap.pipe(map((params) => (params.get('projectSlug') ?? '').trim().toLowerCase())),
+    { initialValue: '' }
+  );
 
   /**
    * No analytics id means no request is ever issued, so without a branch of its own this page would

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
@@ -73,21 +73,33 @@ export class OrgRoiProjectDetailComponent {
   private readonly annual: Signal<OrgLensRoiProjectAnnual | null> = computed(() => this.payload().annual);
 
   /**
-   * Whether the payload in hand describes the organization now selected.
+   * Whether the payload in hand describes **both** the organization now selected and the project
+   * now in the URL.
    *
-   * The same check the portfolio page makes on its summary, and for the same reason: a request in
-   * flight during an organization switch leaves the previous organization's figures on screen under
-   * the new one's header. Comparing the payload's own `orgUid` to the selected account is a
-   * synchronous signal read, so it flips in the same change-detection pass as the switch.
+   * The organization half is the check the portfolio page makes on its summary, for the same
+   * reason: a request in flight during a switch leaves the previous figures on screen under the new
+   * name. The project half matters at least as much here and has no analogue there. This route is
+   * navigated project-to-project — from a table row, from the browser's history — and Angular reuses
+   * the component instance across that, so the payload keeps the previous project until the next
+   * response lands. Checking the organization alone would pass, because it has not changed, and one
+   * project's investment and ROI would render under another's name.
+   *
+   * Both are synchronous signal reads, so they flip in the same change-detection pass as the
+   * navigation, unlike the `toObservable`-driven loading flag which settles one effect flush later.
    */
-  private readonly detailMatchesSelectedOrg: Signal<boolean> = computed(() => {
+  private readonly payloadMatchesRoute: Signal<boolean> = computed(() => {
     const selected = this.accountContext.selectedAccount()?.accountId ?? '';
-    return selected !== '' && this.detail()?.orgUid === selected;
+    const detail = this.detail();
+    if (detail === null || selected === '') return false;
+    return detail.orgUid === selected && detail.project.projectSlug === this.projectSlug();
   });
 
-  protected readonly showsFigures: Signal<boolean> = computed(() => !this.forbidden() && !this.failed() && !this.missing() && this.detailMatchesSelectedOrg());
+  protected readonly showsFigures: Signal<boolean> = computed(() => !this.forbidden() && !this.failed() && !this.missing() && this.payloadMatchesRoute());
 
-  protected readonly projectName: Signal<string> = computed(() => this.detail()?.project.projectName ?? this.projectSlug());
+  /** Falls back to the slug rather than the stale payload's name, for the same window. */
+  protected readonly projectName: Signal<string> = computed(
+    () => (this.payloadMatchesRoute() ? this.detail()?.project.projectName : null) ?? this.projectSlug()
+  );
 
   /**
    * Whether `/org/projects/{slug}` has anything to show.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
@@ -1,0 +1,307 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterNextRender, Component, computed, inject, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ChartComponent } from '@components/chart/chart.component';
+import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
+import {
+  lfxColors,
+  ORG_LENS_ROI_DEFAULT_METHOD,
+  ORG_LENS_ROI_KPI_EXPLANATION,
+  ORG_LENS_ROI_KPI_ICON_CLASS,
+  ORG_LENS_ROI_METHOD_LABELS,
+  ORG_LENS_ROI_NO_VALUE,
+} from '@lfx-one/shared/constants';
+import type { OrgLensRoiMethod, OrgLensRoiProjectAnnual, OrgLensRoiProjectDetail, OrgLensRoiProjectYearRow, StatCardItem } from '@lfx-one/shared/interfaces';
+import { formatCurrency, formatPercent } from '@lfx-one/shared/utils';
+import { AccountContextService } from '@services/account-context.service';
+import { OrgLensRoiMethodPreferenceService } from '@services/org-lens-roi-method-preference.service';
+import { OrgLensRoiService } from '@services/org-lens-roi.service';
+import type { ChartData, ChartOptions } from 'chart.js';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, combineLatest, distinctUntilChanged, filter, map, of, switchMap, tap } from 'rxjs';
+
+/** Pre-fetch sentinel. `null` distinguishes "nothing in hand" from a payload describing no project. */
+const EMPTY_DETAIL: { detail: OrgLensRoiProjectDetail | null; annual: OrgLensRoiProjectAnnual | null } = { detail: null, annual: null };
+
+/** One project's ROI, reached from the projects table (LFXV2-2980). */
+@Component({
+  selector: 'lfx-org-roi-project-detail',
+  imports: [ChartComponent, StatCardGridComponent, RouterLink, SkeletonModule],
+  templateUrl: './org-roi-project-detail.component.html',
+})
+export class OrgRoiProjectDetailComponent {
+  private readonly accountContext = inject(AccountContextService);
+  private readonly activatedRoute = inject(ActivatedRoute);
+  private readonly roiService = inject(OrgLensRoiService);
+  private readonly methodPreference = inject(OrgLensRoiMethodPreferenceService);
+
+  protected readonly noValue = ORG_LENS_ROI_NO_VALUE;
+  protected readonly explanation = ORG_LENS_ROI_KPI_EXPLANATION;
+
+  /**
+   * Honoured, not offered. The estimation method control lives in the portfolio page's assumptions
+   * drawer; arriving here on `direct` and being shown `logit` figures would change the basis of the
+   * numbers without saying so.
+   */
+  protected readonly method = signal<OrgLensRoiMethod>(ORG_LENS_ROI_DEFAULT_METHOD);
+
+  protected readonly methodLabel: Signal<string> = computed(() => ORG_LENS_ROI_METHOD_LABELS[this.method()]);
+
+  protected readonly projectSlug: Signal<string> = toSignal(this.activatedRoute.paramMap.pipe(map((params) => params.get('projectSlug') ?? '')), {
+    initialValue: '',
+  });
+
+  /**
+   * No analytics id means no request is ever issued, so without a branch of its own this page would
+   * hold its loading skeleton forever. Reachable by deep link — arriving from the portfolio page
+   * always has an organization selected, but a bookmarked or shared URL need not.
+   */
+  protected readonly hasAnalyticsId: Signal<boolean> = computed(() => !!this.accountContext.selectedAccount()?.accountId);
+
+  protected readonly loading = signal(true);
+  protected readonly failed = signal(false);
+  protected readonly forbidden = signal(false);
+  /** The 404 path: this organization has no ROI row for the slug. Distinct from a failed read. */
+  protected readonly missing = signal(false);
+
+  private readonly payload = this.initPayload();
+
+  private readonly detail: Signal<OrgLensRoiProjectDetail | null> = computed(() => this.payload().detail);
+  private readonly annual: Signal<OrgLensRoiProjectAnnual | null> = computed(() => this.payload().annual);
+
+  /**
+   * Whether the payload in hand describes the organization now selected.
+   *
+   * The same check the portfolio page makes on its summary, and for the same reason: a request in
+   * flight during an organization switch leaves the previous organization's figures on screen under
+   * the new one's header. Comparing the payload's own `orgUid` to the selected account is a
+   * synchronous signal read, so it flips in the same change-detection pass as the switch.
+   */
+  private readonly detailMatchesSelectedOrg: Signal<boolean> = computed(() => {
+    const selected = this.accountContext.selectedAccount()?.accountId ?? '';
+    return selected !== '' && this.detail()?.orgUid === selected;
+  });
+
+  protected readonly showsFigures: Signal<boolean> = computed(() => !this.forbidden() && !this.failed() && !this.missing() && this.detailMatchesSelectedOrg());
+
+  protected readonly projectName: Signal<string> = computed(() => this.detail()?.project.projectName ?? this.projectSlug());
+
+  /**
+   * Whether `/org/projects/{slug}` has anything to show.
+   *
+   * Measured 2026-08-05, 32.4% of ROI organization-project pairs have no Org Lens catalog row, so
+   * the link cannot be rendered unconditionally — the spec's original "always resolves" assumption
+   * is false and an unconditional link would send a third of viewers to a dead page.
+   */
+  protected readonly hasOrgLensProject: Signal<boolean> = computed(() => this.detail()?.hasOrgLensProject === true);
+
+  protected readonly orgProjectLink: Signal<string> = computed(() => `/org/projects/${this.detail()?.project.projectSlug ?? this.projectSlug()}`);
+
+  /** Five figures, read from the payload — roi, bcr and profit are defined once in the metric layer. */
+  protected readonly cards: Signal<StatCardItem[]> = computed(() => {
+    const project = this.detail()?.project;
+    return [
+      {
+        label: 'Investment',
+        value: this.money(project?.totalExpenditure),
+        subLine: 'Modelled cost',
+        icon: 'fa-light fa-hand-holding-dollar',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.totalExpenditure,
+      },
+      {
+        label: 'Return',
+        value: this.money(project?.totalReturn),
+        icon: 'fa-light fa-arrow-trend-up',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.totalReturn,
+      },
+      {
+        label: 'Net Return',
+        value: this.money(project?.profit),
+        icon: 'fa-light fa-scale-unbalanced',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.profit,
+      },
+      {
+        label: 'ROI',
+        value: this.ratioAsPercent(project?.roi),
+        icon: 'fa-light fa-percent',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.roi,
+      },
+      {
+        label: 'Benefit-Cost Ratio',
+        value: this.multiple(project?.bcr),
+        icon: 'fa-light fa-scale-balanced',
+        iconContainerClass: ORG_LENS_ROI_KPI_ICON_CLASS.bcr,
+      },
+    ];
+  });
+
+  /** A loss is a real outcome for 6.45% of production project rows, so it is stated, not implied. */
+  protected readonly isLossMaking: Signal<boolean> = computed(() => (this.detail()?.project.profit ?? 0) < 0);
+
+  protected readonly apportioned: Signal<boolean> = computed(() => this.annual()?.apportioned === true);
+
+  /** Drives the constancy disclosure from the contract rather than from a template literal. */
+  protected readonly efficiencyConstant: Signal<boolean> = computed(() => this.annual()?.efficiencyConstant === true);
+
+  protected readonly hasYearRows: Signal<boolean> = computed(() => this.yearRows().length > 0);
+
+  // Only the calendar year still in progress is partial. A project whose activity stopped earlier
+  // has a complete final year, and marking it "still accruing" would misexplain a real decline.
+  private readonly partialYear: Signal<number | null> = computed(() => {
+    const lastYear = this.annual()?.rows.at(-1)?.year ?? null;
+    return lastYear !== null && lastYear === new Date().getFullYear() ? lastYear : null;
+  });
+
+  protected readonly yearRows: Signal<OrgLensRoiProjectYearRow[]> = computed(() => {
+    const partial = this.partialYear();
+    return (this.annual()?.rows ?? []).map((row) => ({
+      year: row.year,
+      expenditure: row.expenditure,
+      investmentLabel: formatCurrency(row.expenditure),
+      returnLabel: formatCurrency(row.totalReturn),
+      isPartial: row.year === partial,
+    }));
+  });
+
+  protected readonly chartSummaryLabel: Signal<string> = computed(() => {
+    const rows = this.yearRows();
+    if (rows.length === 0) return 'Investment by year';
+    return `Bar chart of investment by year, ${rows[0].year} to ${rows[rows.length - 1].year}. The same figures follow in a table.`;
+  });
+
+  /**
+   * Investment only — one series, deliberately.
+   *
+   * Return runs tens of times investment on these projects, so plotting both on one linear axis
+   * flattens investment to the baseline, which is the unresolved scaling problem the portfolio
+   * trend and the comparison bar both record. This figure answers "when was the investment made",
+   * so a single series sidesteps that rather than inheriting it, and the table beside it carries
+   * the per-year return for anyone who wants both.
+   */
+  protected readonly chartData: Signal<ChartData<'bar'>> = computed(() => {
+    const rows = this.yearRows();
+    return {
+      labels: rows.map((row) => `${row.year}`),
+      datasets: [
+        {
+          label: 'Investment',
+          data: rows.map((row) => row.expenditure),
+          backgroundColor: lfxColors.blue[500],
+          borderColor: lfxColors.blue[500],
+        },
+      ],
+    };
+  });
+
+  protected readonly chartOptions: ChartOptions<'bar'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+      tooltip: {
+        backgroundColor: 'rgba(255, 255, 255, 0.98)',
+        titleColor: lfxColors.gray[900],
+        bodyColor: lfxColors.gray[600],
+        borderColor: lfxColors.gray[200],
+        borderWidth: 1,
+        padding: 10,
+        cornerRadius: 6,
+        callbacks: {
+          label: (ctx) => ` Investment: ${formatCurrency(ctx.parsed.y as number)}`,
+        },
+      },
+    },
+    scales: {
+      x: {
+        grid: { display: false },
+        border: { display: true, color: lfxColors.gray[400], width: 1 },
+        ticks: { color: lfxColors.gray[500], font: { size: 12 }, maxRotation: 0 },
+      },
+      y: {
+        grid: { color: lfxColors.gray[200], lineWidth: 1 },
+        border: { display: true, color: lfxColors.gray[400], width: 1, dash: [3, 3] },
+        ticks: { color: lfxColors.gray[500], font: { size: 12 }, callback: (v) => formatCurrency(v as number) },
+        beginAtZero: true,
+      },
+    },
+  };
+
+  public constructor() {
+    // Must stay in afterNextRender — restoring the stored method earlier causes a hydration mismatch.
+    afterNextRender(() => this.restoreMethod());
+  }
+
+  private initPayload(): Signal<{ detail: OrgLensRoiProjectDetail | null; annual: OrgLensRoiProjectAnnual | null }> {
+    // A typed triple rather than a delimited string, so nothing has to be parsed back out or cast.
+    // The dedup a string key gave for free is restored explicitly: the selected-account object is
+    // rewritten in place, so this recomputes on changes that leave every field identical.
+    const request$ = toObservable(
+      computed(() => ({ orgUid: this.accountContext.selectedAccount()?.accountId ?? '', projectSlug: this.projectSlug(), method: this.method() }))
+    ).pipe(
+      distinctUntilChanged((previous, next) => previous.orgUid === next.orgUid && previous.projectSlug === next.projectSlug && previous.method === next.method)
+    );
+
+    return toSignal(
+      request$.pipe(
+        filter(({ orgUid, projectSlug }) => !!orgUid && !!projectSlug),
+        tap(() => {
+          this.loading.set(true);
+          this.failed.set(false);
+          this.forbidden.set(false);
+          this.missing.set(false);
+        }),
+        switchMap(({ orgUid, projectSlug, method }) =>
+          combineLatest({
+            detail: this.roiService.getProjectDetail(orgUid, projectSlug, method),
+            annual: this.roiService.getProjectAnnual(orgUid, projectSlug, method),
+          }).pipe(
+            tap(() => this.loading.set(false)),
+            catchError((error: unknown) => {
+              console.error('Failed to load ROI project detail', error);
+              this.loading.set(false);
+              const status = (error as { status?: number })?.status;
+              // Three outcomes, kept apart: no grant, no such project for this organization, and
+              // everything else. Collapsing the 404 into the error state would tell a viewer to
+              // retry a request that cannot succeed.
+              if (status === 403) this.forbidden.set(true);
+              else if (status === 404) this.missing.set(true);
+              else this.failed.set(true);
+              return of(EMPTY_DETAIL);
+            })
+          )
+        )
+      ),
+      { initialValue: EMPTY_DETAIL }
+    );
+  }
+
+  private restoreMethod(): void {
+    const stored = this.methodPreference.read();
+    if (stored !== null) this.method.set(stored);
+  }
+
+  /**
+   * A measure is renderable only if it is actually a finite number. `=== null` is not enough: an
+   * absent key is `undefined`, which slips past it and reaches `toFixed()`. These measures are
+   * nullable by design, so anything non-numeric renders as the no-value indicator, never as 0.
+   */
+  private isRenderable(value: number | null | undefined): value is number {
+    return typeof value === 'number' && Number.isFinite(value);
+  }
+
+  private money(value: number | null | undefined): string {
+    return this.isRenderable(value) ? formatCurrency(value) : ORG_LENS_ROI_NO_VALUE;
+  }
+
+  private ratioAsPercent(value: number | null | undefined): string {
+    return this.isRenderable(value) ? `${formatPercent(value * 100)}%` : ORG_LENS_ROI_NO_VALUE;
+  }
+
+  /** A ratio, not a percentage, so it does not go through the percentage formatter. */
+  private multiple(value: number | null | undefined): string {
+    return this.isRenderable(value) ? `${value.toFixed(1)}×` : ORG_LENS_ROI_NO_VALUE;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
@@ -76,13 +76,12 @@ export class OrgRoiProjectDetailComponent {
    * Whether the payload in hand describes **both** the organization now selected and the project
    * now in the URL.
    *
-   * The organization half is the check the portfolio page makes on its summary, for the same
-   * reason: a request in flight during a switch leaves the previous figures on screen under the new
-   * name. The project half matters at least as much here and has no analogue there. This route is
-   * navigated project-to-project — from a table row, from the browser's history — and Angular reuses
-   * the component instance across that, so the payload keeps the previous project until the next
-   * response lands. Checking the organization alone would pass, because it has not changed, and one
-   * project's investment and ROI would render under another's name.
+   * The organization half is the check the portfolio page makes on its summary: a request in flight
+   * during a switch leaves the previous figures on screen under the new name. The project half has
+   * no analogue there. This route is navigated project-to-project and Angular reuses the component
+   * instance across that, so the payload keeps the previous project until the next response lands.
+   * Checking the organization alone would pass, because it has not changed, and one project's
+   * investment and ROI would render under another's name.
    *
    * Both are synchronous signal reads, so they flip in the same change-detection pass as the
    * navigation, unlike the `toObservable`-driven loading flag which settles one effect flush later.
@@ -105,8 +104,8 @@ export class OrgRoiProjectDetailComponent {
    * Whether `/org/projects/{slug}` has anything to show.
    *
    * Measured 2026-08-05, 32.4% of ROI organization-project pairs have no Org Lens catalog row, so
-   * the link cannot be rendered unconditionally — the spec's original "always resolves" assumption
-   * is false and an unconditional link would send a third of viewers to a dead page.
+   * the link cannot be rendered unconditionally — it does not always resolve, and an unconditional
+   * link would send a third of viewers to a dead page.
    */
   protected readonly hasOrgLensProject: Signal<boolean> = computed(() => this.detail()?.hasOrgLensProject === true);
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi-project-detail/org-roi-project-detail.component.ts
@@ -73,24 +73,30 @@ export class OrgRoiProjectDetailComponent {
   private readonly annual: Signal<OrgLensRoiProjectAnnual | null> = computed(() => this.payload().annual);
 
   /**
-   * Whether the payload in hand describes **both** the organization now selected and the project
-   * now in the URL.
+   * Whether the payload in hand describes the organization now selected, the project now in the
+   * URL, **and** the estimation method now in effect. All three, because all three can change
+   * under a payload that has already landed.
    *
    * The organization half is the check the portfolio page makes on its summary: a request in flight
    * during a switch leaves the previous figures on screen under the new name. The project half has
-   * no analogue there. This route is navigated project-to-project and Angular reuses the component
-   * instance across that, so the payload keeps the previous project until the next response lands.
-   * Checking the organization alone would pass, because it has not changed, and one project's
-   * investment and ROI would render under another's name.
+   * no analogue there — this route is navigated project-to-project and Angular reuses the component
+   * instance across that, so checking the organization alone would pass, because it has not
+   * changed, and one project's figures would render under another's name.
    *
-   * Both are synchronous signal reads, so they flip in the same change-detection pass as the
-   * navigation, unlike the `toObservable`-driven loading flag which settles one effect flush later.
+   * The method half covers the first load specifically. The stored preference is restored in
+   * `afterNextRender`, so a viewer who chose `direct` issues a `logit` request first; if that lands
+   * before the restore, the heading already reads "Direct markup" over logit return and ratios.
+   * Investment is method-invariant, so only some of the figures would be wrong — which is worse
+   * than all of them, being harder to notice.
+   *
+   * All three are synchronous signal reads, so they flip in the same change-detection pass as the
+   * change, unlike the `toObservable`-driven loading flag which settles one effect flush later.
    */
   private readonly payloadMatchesRoute: Signal<boolean> = computed(() => {
     const selected = this.accountContext.selectedAccount()?.accountId ?? '';
     const detail = this.detail();
     if (detail === null || selected === '') return false;
-    return detail.orgUid === selected && detail.project.projectSlug === this.projectSlug();
+    return detail.orgUid === selected && detail.project.projectSlug === this.projectSlug() && detail.method === this.method();
   });
 
   protected readonly showsFigures: Signal<boolean> = computed(() => !this.forbidden() && !this.failed() && !this.missing() && this.payloadMatchesRoute());

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -1,12 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
-import { afterNextRender, Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { afterNextRender, Component, computed, inject, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ORG_LENS_ROI_DEFAULT_METHOD, ORG_LENS_ROI_METHOD_STORAGE_KEY, ORG_LENS_ROI_METHODS } from '@lfx-one/shared/constants';
+import { ORG_LENS_ROI_DEFAULT_METHOD } from '@lfx-one/shared/constants';
 import type { OrgLensRoiCoverage, OrgLensRoiMethod, OrgLensRoiSummary } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
+import { OrgLensRoiMethodPreferenceService } from '@services/org-lens-roi-method-preference.service';
 import { OrgLensRoiService } from '@services/org-lens-roi.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
@@ -64,7 +64,7 @@ export class OrgRoiComponent {
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
   private readonly roiService = inject(OrgLensRoiService);
-  private readonly platformId = inject(PLATFORM_ID);
+  private readonly methodPreference = inject(OrgLensRoiMethodPreferenceService);
 
   protected readonly method = signal<OrgLensRoiMethod>(ORG_LENS_ROI_DEFAULT_METHOD);
   protected readonly drawerVisible = signal(false);
@@ -209,23 +209,11 @@ export class OrgRoiComponent {
   }
 
   private restoreMethod(): void {
-    if (!isPlatformBrowser(this.platformId)) return;
-    try {
-      const stored = localStorage.getItem(ORG_LENS_ROI_METHOD_STORAGE_KEY);
-      if (stored !== null && (ORG_LENS_ROI_METHODS as readonly string[]).includes(stored)) {
-        this.method.set(stored as OrgLensRoiMethod);
-      }
-    } catch {
-      // Ignore unavailable storage.
-    }
+    const stored = this.methodPreference.read();
+    if (stored !== null) this.method.set(stored);
   }
 
   private persistMethod(method: OrgLensRoiMethod): void {
-    if (!isPlatformBrowser(this.platformId)) return;
-    try {
-      localStorage.setItem(ORG_LENS_ROI_METHOD_STORAGE_KEY, method);
-    } catch {
-      // Ignore unavailable storage.
-    }
+    this.methodPreference.write(method);
   }
 }

--- a/apps/lfx-one/src/app/shared/services/org-lens-roi-method-preference.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-roi-method-preference.service.ts
@@ -1,0 +1,46 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { isPlatformBrowser } from '@angular/common';
+import { inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { ORG_LENS_ROI_METHOD_STORAGE_KEY, ORG_LENS_ROI_METHODS } from '@lfx-one/shared/constants';
+import type { OrgLensRoiMethod } from '@lfx-one/shared/interfaces';
+
+/**
+ * The viewer's chosen estimation method, persisted across visits.
+ *
+ * Shared by the ROI portfolio page, which offers the control, and the project detail view, which
+ * only honours it — a drill-down that silently reverted to the default would show the viewer a
+ * project priced on a different basis than the portfolio they arrived from, with nothing on screen
+ * saying so.
+ *
+ * Callers must read this in `afterNextRender` rather than a constructor: the server has no stored
+ * value, so restoring one during construction changes the first render and breaks hydration.
+ */
+@Injectable({ providedIn: 'root' })
+export class OrgLensRoiMethodPreferenceService {
+  private readonly platformId = inject(PLATFORM_ID);
+
+  /** Null when nothing is stored, storage is unavailable, or the stored value is not a known method. */
+  public read(): OrgLensRoiMethod | null {
+    if (!isPlatformBrowser(this.platformId)) return null;
+    try {
+      const stored = localStorage.getItem(ORG_LENS_ROI_METHOD_STORAGE_KEY);
+      if (stored !== null && (ORG_LENS_ROI_METHODS as readonly string[]).includes(stored)) {
+        return stored as OrgLensRoiMethod;
+      }
+    } catch {
+      // Ignore unavailable storage.
+    }
+    return null;
+  }
+
+  public write(method: OrgLensRoiMethod): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    try {
+      localStorage.setItem(ORG_LENS_ROI_METHOD_STORAGE_KEY, method);
+    } catch {
+      // Ignore unavailable storage.
+    }
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/app/shared/services/org-lens-roi.service.ts
@@ -8,6 +8,8 @@ import type {
   OrgLensRoiCoverage,
   OrgLensRoiInvestmentBreakdown,
   OrgLensRoiMethod,
+  OrgLensRoiProjectAnnual,
+  OrgLensRoiProjectDetail,
   OrgLensRoiProjects,
   OrgLensRoiSummary,
 } from '@lfx-one/shared/interfaces';
@@ -58,6 +60,19 @@ export class OrgLensRoiService {
    */
   public getProjects(orgUid: string, method: OrgLensRoiMethod): Observable<OrgLensRoiProjects> {
     return this.http.get<OrgLensRoiProjects>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/projects`, {
+      params: new HttpParams().set('method', method),
+    });
+  }
+
+  /** 404s when the slug names no project of this organization — never an empty 200. */
+  public getProjectDetail(orgUid: string, projectSlug: string, method: OrgLensRoiMethod): Observable<OrgLensRoiProjectDetail> {
+    return this.http.get<OrgLensRoiProjectDetail>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/projects/${encodeURIComponent(projectSlug)}`, {
+      params: new HttpParams().set('method', method),
+    });
+  }
+
+  public getProjectAnnual(orgUid: string, projectSlug: string, method: OrgLensRoiMethod): Observable<OrgLensRoiProjectAnnual> {
+    return this.http.get<OrgLensRoiProjectAnnual>(`/api/orgs/${encodeURIComponent(orgUid)}/lens/roi/projects/${encodeURIComponent(projectSlug)}/annual`, {
       params: new HttpParams().set('method', method),
     });
   }

--- a/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
@@ -5,23 +5,38 @@ import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { assertOrgUid, assertOrgLensRead, parseOrgLensRoiMethod, getSummary, getCoverage, getAnnual, getInvestmentBreakdown, getProjects, logger } = vi.hoisted(
-  () => ({
-    assertOrgUid: vi.fn(),
-    assertOrgLensRead: vi.fn(),
-    parseOrgLensRoiMethod: vi.fn(),
-    getSummary: vi.fn(),
-    getCoverage: vi.fn(),
-    getAnnual: vi.fn(),
-    getInvestmentBreakdown: vi.fn(),
-    getProjects: vi.fn(),
-    logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
-  })
-);
+const {
+  assertOrgUid,
+  assertOrgLensRead,
+  assertOrgLensRoiProjectSlug,
+  parseOrgLensRoiMethod,
+  getSummary,
+  getCoverage,
+  getAnnual,
+  getInvestmentBreakdown,
+  getProjects,
+  getProjectDetail,
+  getProjectAnnual,
+  logger,
+} = vi.hoisted(() => ({
+  assertOrgUid: vi.fn(),
+  assertOrgLensRead: vi.fn(),
+  assertOrgLensRoiProjectSlug: vi.fn(),
+  parseOrgLensRoiMethod: vi.fn(),
+  getSummary: vi.fn(),
+  getCoverage: vi.fn(),
+  getAnnual: vi.fn(),
+  getInvestmentBreakdown: vi.fn(),
+  getProjects: vi.fn(),
+  getProjectDetail: vi.fn(),
+  getProjectAnnual: vi.fn(),
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
 
 vi.mock('../helpers/org-uid.helper', () => ({ assertOrgUid }));
 vi.mock('../helpers/org-lens-read-access.helper', () => ({ assertOrgLensRead }));
 vi.mock('../helpers/org-lens-roi-method.helper', () => ({ parseOrgLensRoiMethod }));
+vi.mock('../helpers/org-lens-roi-project-slug.helper', () => ({ assertOrgLensRoiProjectSlug }));
 vi.mock('../services/org-lens-roi.service', () => ({
   OrgLensRoiService: class {
     public getSummary = getSummary;
@@ -29,6 +44,8 @@ vi.mock('../services/org-lens-roi.service', () => ({
     public getAnnual = getAnnual;
     public getInvestmentBreakdown = getInvestmentBreakdown;
     public getProjects = getProjects;
+    public getProjectDetail = getProjectDetail;
+    public getProjectAnnual = getProjectAnnual;
   },
 }));
 vi.mock('../services/logger.service', () => ({ logger }));
@@ -36,9 +53,10 @@ vi.mock('../services/logger.service', () => ({ logger }));
 import { OrgLensRoiController } from './org-lens-roi.controller';
 
 const ORG_UID = '001410000000000AAA';
+const PROJECT_SLUG = 'kubernetes';
 
 function buildReq(query: Record<string, unknown> = {}): Request {
-  return { params: { orgUid: ORG_UID }, query, path: '/test' } as unknown as Request;
+  return { params: { orgUid: ORG_UID, projectSlug: PROJECT_SLUG }, query, path: '/test' } as unknown as Request;
 }
 
 function buildRes(): Response {
@@ -67,6 +85,7 @@ describe('OrgLensRoiController — authorization gate', () => {
     controller = new OrgLensRoiController();
     next = vi.fn();
     assertOrgUid.mockReturnValue(undefined);
+    assertOrgLensRoiProjectSlug.mockReturnValue(undefined);
     parseOrgLensRoiMethod.mockReturnValue('logit');
     assertOrgLensRead.mockResolvedValue(undefined);
     getSummary.mockResolvedValue({ hasData: false });
@@ -74,6 +93,8 @@ describe('OrgLensRoiController — authorization gate', () => {
     getAnnual.mockResolvedValue({ rows: [] });
     getInvestmentBreakdown.mockResolvedValue({ rows: [], total: 0 });
     getProjects.mockResolvedValue({ method: 'logit', rows: [] });
+    getProjectDetail.mockResolvedValue({ orgUid: ORG_UID, method: 'logit', project: { projectSlug: PROJECT_SLUG }, hasOrgLensProject: true });
+    getProjectAnnual.mockResolvedValue({ method: 'logit', projectSlug: PROJECT_SLUG, rows: [], apportioned: true, efficiencyConstant: true });
   });
 
   // Every handler on the controller belongs here. A new endpoint added without a row is silently
@@ -85,6 +106,14 @@ describe('OrgLensRoiController — authorization gate', () => {
     { name: 'getAnnual', operation: 'get_org_lens_roi_annual', service: getAnnual },
     { name: 'getInvestmentBreakdown', operation: 'get_org_lens_roi_investment_breakdown', service: getInvestmentBreakdown },
     { name: 'getProjects', operation: 'get_org_lens_roi_projects', service: getProjects },
+    { name: 'getProjectDetail', operation: 'get_org_lens_roi_project_detail', service: getProjectDetail },
+    { name: 'getProjectAnnual', operation: 'get_org_lens_roi_project_annual', service: getProjectAnnual },
+  ] as const;
+
+  /** The two handlers that take a `:projectSlug`, and so carry a fourth validation and a 404 path. */
+  const projectHandlers = [
+    { name: 'getProjectDetail', operation: 'get_org_lens_roi_project_detail', service: getProjectDetail },
+    { name: 'getProjectAnnual', operation: 'get_org_lens_roi_project_annual', service: getProjectAnnual },
   ] as const;
 
   it('covers every request handler the controller exposes', () => {
@@ -188,6 +217,47 @@ describe('OrgLensRoiController — authorization gate', () => {
 
       expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
       expect(res.json).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe.each(projectHandlers)('$name — project slug', ({ name, operation, service }) => {
+    it('validates the slug before checking access or reading data', async () => {
+      const res = buildRes();
+
+      await controller[name](buildReq({ method: 'logit' }), res, next);
+
+      expect(assertOrgLensRoiProjectSlug).toHaveBeenCalledWith(PROJECT_SLUG, operation);
+      // The slug reaches a cache sub-resource key, which `buildOrgCacheKey` does not validate, so
+      // this has to resolve before anything builds one.
+      expect(assertOrgLensRoiProjectSlug.mock.invocationCallOrder[0]).toBeLessThan(assertOrgLensRead.mock.invocationCallOrder[0]);
+      expect(assertOrgLensRoiProjectSlug.mock.invocationCallOrder[0]).toBeLessThan(service.mock.invocationCallOrder[0]);
+    });
+
+    it('rejects a malformed slug without checking access or reading data', async () => {
+      const invalid = Object.assign(new Error('invalid projectSlug'), { statusCode: 400 });
+      assertOrgLensRoiProjectSlug.mockImplementationOnce(() => {
+        throw invalid;
+      });
+      const res = buildRes();
+
+      await controller[name](buildReq(), res, next);
+
+      expect(assertOrgLensRead).not.toHaveBeenCalled();
+      expect(service).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(invalid);
+    });
+
+    it('forwards a 404 — never an empty 200 — when the slug names no project of this organization', async () => {
+      // The distinction this asserts is a product requirement, not a formality: answering 200 with
+      // an empty payload would let another organization's project read as "measured, no data".
+      service.mockResolvedValueOnce(null);
+      const res = buildRes();
+
+      await controller[name](buildReq(), res, next);
+
+      expect(res.json).not.toHaveBeenCalled();
+      const error = vi.mocked(next).mock.calls[0][0] as { statusCode?: number };
+      expect(error.statusCode).toBe(404);
     });
   });
 });

--- a/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-roi.controller.spec.ts
@@ -110,7 +110,7 @@ describe('OrgLensRoiController — authorization gate', () => {
     { name: 'getProjectAnnual', operation: 'get_org_lens_roi_project_annual', service: getProjectAnnual },
   ] as const;
 
-  /** The two handlers that take a `:projectSlug`, and so carry a fourth validation and a 404 path. */
+  /** Subset of the handlers above: those taking a `:projectSlug`, which adds a validation and a 404 path. */
   const projectHandlers = [
     { name: 'getProjectDetail', operation: 'get_org_lens_roi_project_detail', service: getProjectDetail },
     { name: 'getProjectAnnual', operation: 'get_org_lens_roi_project_annual', service: getProjectAnnual },

--- a/apps/lfx-one/src/server/controllers/org-lens-roi.controller.ts
+++ b/apps/lfx-one/src/server/controllers/org-lens-roi.controller.ts
@@ -3,8 +3,10 @@
 
 import type { NextFunction, Request, Response } from 'express';
 
+import { ResourceNotFoundError } from '../errors';
 import { assertOrgLensRead } from '../helpers/org-lens-read-access.helper';
 import { parseOrgLensRoiMethod } from '../helpers/org-lens-roi-method.helper';
+import { assertOrgLensRoiProjectSlug } from '../helpers/org-lens-roi-project-slug.helper';
 import { assertOrgUid } from '../helpers/org-uid.helper';
 import { logger } from '../services/logger.service';
 import { OrgLensRoiService } from '../services/org-lens-roi.service';
@@ -101,6 +103,53 @@ export class OrgLensRoiController {
       const projects = await this.service.getProjects(req, orgUid, method);
       logger.success(req, operation, startTime, { org_uid: orgUid, method, rows: projects.rows.length });
       this.send(res, projects);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getProjectDetail(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_roi_project_detail';
+    const orgUid = req.params['orgUid'];
+    const projectSlug = req.params['projectSlug'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid, project_slug: projectSlug });
+    try {
+      assertOrgUid(orgUid, operation);
+      assertOrgLensRoiProjectSlug(projectSlug, operation);
+      const method = parseOrgLensRoiMethod(req.query['method'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const detail = await this.service.getProjectDetail(req, orgUid, projectSlug, method);
+      // 404, deliberately not an empty 200. A slug this organization has no ROI row for is either
+      // another organization's project or none at all, and answering "no data" would let the
+      // viewer read an absence of measurement into a project they cannot see.
+      if (detail === null) throw new ResourceNotFoundError('ROI project', projectSlug, { operation });
+
+      logger.success(req, operation, startTime, { org_uid: orgUid, project_slug: projectSlug, method, has_org_lens_project: detail.hasOrgLensProject });
+      this.send(res, detail);
+    } catch (error) {
+      return next(error);
+    }
+  }
+
+  public async getProjectAnnual(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_org_lens_roi_project_annual';
+    const orgUid = req.params['orgUid'];
+    const projectSlug = req.params['projectSlug'];
+    const startTime = logger.startOperation(req, operation, { org_uid: orgUid, project_slug: projectSlug });
+    try {
+      assertOrgUid(orgUid, operation);
+      assertOrgLensRoiProjectSlug(projectSlug, operation);
+      const method = parseOrgLensRoiMethod(req.query['method'], operation);
+      await assertOrgLensRead(req, orgUid, operation);
+
+      const annual = await this.service.getProjectAnnual(req, orgUid, projectSlug, method);
+      // Same distinction the read preserves: no rows for an existing project is a 200 with an empty
+      // distribution; a project that is not this organization's is a 404.
+      if (annual === null) throw new ResourceNotFoundError('ROI project', projectSlug, { operation });
+
+      logger.success(req, operation, startTime, { org_uid: orgUid, project_slug: projectSlug, method, rows: annual.rows.length });
+      this.send(res, annual);
     } catch (error) {
       return next(error);
     }

--- a/apps/lfx-one/src/server/helpers/org-lens-roi-project-slug.helper.ts
+++ b/apps/lfx-one/src/server/helpers/org-lens-roi-project-slug.helper.ts
@@ -1,0 +1,27 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { FOUNDATION_ID_PATTERN } from '@lfx-one/shared/constants';
+
+import { ServiceValidationError } from '../errors';
+
+/**
+ * Validates the ROI project slug path parameter.
+ *
+ * The same pattern the Org Lens project detail routes validate against, and the same pattern for a
+ * reason: ROI project identity comes from `silver_dim_projects`, the dimension behind
+ * `ORG_LENS_PROJECTS.PROJECT_SLUG`, so the two surfaces address the same slug space and disagreeing
+ * about which slugs are addressable would make the onward link between them unreliable.
+ *
+ * This also has to run before the slug reaches a cache key. The sub-resource a caller supplies to
+ * `buildOrgCacheKey` is not validated there, and the key is `:`-delimited, so an unconstrained slug
+ * could reshape it.
+ */
+export function assertOrgLensRoiProjectSlug(projectSlug: string | undefined, operation: string): asserts projectSlug is string {
+  if (!projectSlug || typeof projectSlug !== 'string') {
+    throw ServiceValidationError.forField('projectSlug', 'projectSlug path parameter is required', { operation });
+  }
+  if (!FOUNDATION_ID_PATTERN.test(projectSlug)) {
+    throw ServiceValidationError.forField('projectSlug', 'Invalid projectSlug format', { operation });
+  }
+}

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -142,8 +142,7 @@ function buildOrgsRouter(): Router {
   router.get('/:orgUid/lens/roi/investment-breakdown', (req, res, next) => orgLensRoiController.getInvestmentBreakdown(req, res, next));
   router.get('/:orgUid/lens/roi/projects', (req, res, next) => orgLensRoiController.getProjects(req, res, next));
   // Parameterized, so it stays below every literal above — `investment-breakdown` would otherwise
-  // be captured as a project slug. The `/annual` sub-path is a literal under the parameter and can
-  // sit either side of its sibling; it is registered first for symmetry with the rule above.
+  // be captured as a project slug.
   router.get('/:orgUid/lens/roi/projects/:projectSlug/annual', (req, res, next) => orgLensRoiController.getProjectAnnual(req, res, next));
   router.get('/:orgUid/lens/roi/projects/:projectSlug', (req, res, next) => orgLensRoiController.getProjectDetail(req, res, next));
 

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -141,6 +141,11 @@ function buildOrgsRouter(): Router {
   router.get('/:orgUid/lens/roi/annual', (req, res, next) => orgLensRoiController.getAnnual(req, res, next));
   router.get('/:orgUid/lens/roi/investment-breakdown', (req, res, next) => orgLensRoiController.getInvestmentBreakdown(req, res, next));
   router.get('/:orgUid/lens/roi/projects', (req, res, next) => orgLensRoiController.getProjects(req, res, next));
+  // Parameterized, so it stays below every literal above — `investment-breakdown` would otherwise
+  // be captured as a project slug. The `/annual` sub-path is a literal under the parameter and can
+  // sit either side of its sibling; it is registered first for symmetry with the rule above.
+  router.get('/:orgUid/lens/roi/projects/:projectSlug/annual', (req, res, next) => orgLensRoiController.getProjectAnnual(req, res, next));
+  router.get('/:orgUid/lens/roi/projects/:projectSlug', (req, res, next) => orgLensRoiController.getProjectDetail(req, res, next));
 
   // LFXV2-1894 — Org Lens Code Contributions page (KPI strip + repositories table + commits feed).
   router.get('/:orgUid/lens/contributions', (req, res, next) => orgLensContributionsController.getContributions(req, res, next));

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -232,14 +232,15 @@ export class OrgLensRoiService {
    * guessed at in the template or discovered by the viewer hitting a dead page.
    */
   public async getProjectDetail(req: Request, accountId: string, projectSlug: string, method: OrgLensRoiMethod): Promise<OrgLensRoiProjectDetail | null> {
+    const slug = this.normalizeSlug(projectSlug);
     return this.withNullableOrgCache(
       accountId,
-      `${ORG_LENS_ROI_CACHE_KEY.projectDetail}:${method}:${encodeURIComponent(projectSlug)}`,
+      `${ORG_LENS_ROI_CACHE_KEY.projectDetail}:${method}:${encodeURIComponent(slug)}`,
       OrgLensRoiService.isProjectDetail,
       async () => {
         logger.debug(req, 'get_org_lens_roi_project_detail', 'Cache miss; querying Snowflake', {
           account_id: accountId,
-          project_slug: projectSlug,
+          project_slug: slug,
           method,
         });
         const sql = `
@@ -270,12 +271,12 @@ export class OrgLensRoiService {
         -- one this endpoint answers with, rather than leaving that to the warehouse's row order.
         ORDER BY p.PROJECT_ID, b.DISPLAY_ORDER
       `;
-        const result = await this.snowflakeService.execute<OrgLensRoiProjectDetailWarehouseRow>(sql, [accountId, projectSlug, method]);
+        const result = await this.snowflakeService.execute<OrgLensRoiProjectDetailWarehouseRow>(sql, [accountId, slug, method]);
         const projects = this.groupProjectRows(result.rows);
         if (projects.length > 1) {
           logger.warning(req, 'get_org_lens_roi_project_detail', 'Expected at most one project for the slug', {
             account_id: accountId,
-            project_slug: projectSlug,
+            project_slug: slug,
             method,
             projects: projects.length,
           });
@@ -300,19 +301,31 @@ export class OrgLensRoiService {
    * and "your project, no yearly breakdown" stay distinguishable. Reading the annual table alone
    * would collapse both into zero rows, and the first must be a 404 while the second is a 200 with
    * an empty distribution. The unmatched side of the join carries a null YEAR and is dropped.
+   *
+   * The projects side is narrowed to a single `PROJECT_ID` — the same one `getProjectDetail`
+   * resolves, by the same `MIN()` ordering. Were a slug ever to map to two ids, the detail endpoint
+   * would describe one project while this one merged both and emitted a year twice, so the chart
+   * would contradict the figures printed above it.
    */
   public async getProjectAnnual(req: Request, accountId: string, projectSlug: string, method: OrgLensRoiMethod): Promise<OrgLensRoiProjectAnnual | null> {
+    const slug = this.normalizeSlug(projectSlug);
     return this.withNullableOrgCache(
       accountId,
-      `${ORG_LENS_ROI_CACHE_KEY.projectAnnual}:${method}:${encodeURIComponent(projectSlug)}`,
+      `${ORG_LENS_ROI_CACHE_KEY.projectAnnual}:${method}:${encodeURIComponent(slug)}`,
       OrgLensRoiService.isProjectAnnual,
       async () => {
         logger.debug(req, 'get_org_lens_roi_project_annual', 'Cache miss; querying Snowflake', {
           account_id: accountId,
-          project_slug: projectSlug,
+          project_slug: slug,
           method,
         });
         const sql = `
+        WITH project AS (
+          SELECT MIN(PROJECT_ID) AS PROJECT_ID
+          FROM ${this.projectsTable()}
+          WHERE ACCOUNT_ID = ? AND PROJECT_SLUG = ? AND MARKUP_METHOD = ?
+          HAVING COUNT(*) > 0
+        )
         SELECT
           a.YEAR,
           a.TOTAL_RETURN,
@@ -320,17 +333,16 @@ export class OrgLensRoiService {
           a.PROFIT,
           a.ROI,
           a.BCR
-        FROM ${this.projectsTable()} p
+        FROM project p
         LEFT JOIN ${this.projectAnnualTable()} a
-          ON a.ACCOUNT_ID = p.ACCOUNT_ID AND a.PROJECT_ID = p.PROJECT_ID AND a.MARKUP_METHOD = p.MARKUP_METHOD
-        WHERE p.ACCOUNT_ID = ? AND p.PROJECT_SLUG = ? AND p.MARKUP_METHOD = ?
+          ON a.ACCOUNT_ID = ? AND a.PROJECT_ID = p.PROJECT_ID AND a.MARKUP_METHOD = ?
         ORDER BY a.YEAR
       `;
-        const result = await this.snowflakeService.execute<OrgLensRoiProjectAnnualWarehouseRow>(sql, [accountId, projectSlug, method]);
+        const result = await this.snowflakeService.execute<OrgLensRoiProjectAnnualWarehouseRow>(sql, [accountId, slug, method, accountId, method]);
         if (result.rows.length === 0) return null;
         return {
           method,
-          projectSlug,
+          projectSlug: slug,
           rows: result.rows
             .filter((row): row is OrgLensRoiAnnualWarehouseRow => row.YEAR !== null && row.YEAR !== undefined)
             .map((row) => this.mapAnnualRow(row)),
@@ -630,6 +642,16 @@ export class OrgLensRoiService {
   private toNullableCount(value: unknown): number | null {
     const parsed = this.toNullableNumber(value);
     return parsed === null ? null : Math.round(parsed);
+  }
+
+  /**
+   * Project slugs are stored lowercase, and `org-lens-project-detail.service.ts` normalizes the same
+   * way before querying. Without this a mixed-case deep link would 404 here while resolving under
+   * `/org/projects/{slug}` — the two surfaces would disagree about which URLs exist, which is
+   * exactly the slug-space parity the onward link between them depends on.
+   */
+  private normalizeSlug(projectSlug: string): string {
+    return projectSlug.trim().toLowerCase();
   }
 
   private toNullableLabel(value: unknown): string | null {

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -13,6 +13,10 @@ import type {
   OrgLensRoiInvestmentBreakdown,
   OrgLensRoiInvestmentBreakdownWarehouseRow,
   OrgLensRoiMethod,
+  OrgLensRoiProjectAnnual,
+  OrgLensRoiProjectAnnualWarehouseRow,
+  OrgLensRoiProjectDetail,
+  OrgLensRoiProjectDetailWarehouseRow,
   OrgLensRoiProjectRow,
   OrgLensRoiProjects,
   OrgLensRoiProjectWarehouseRow,
@@ -25,7 +29,7 @@ import { resolveLfxOnePlatinumSchema } from '../helpers/snowflake-schema.helper'
 
 import { logger } from './logger.service';
 import { SnowflakeService } from './snowflake.service';
-import { withOrgCache } from './valkey.service';
+import { buildOrgCacheKey, valkeyService, withOrgCache } from './valkey.service';
 
 export class OrgLensRoiService {
   /**
@@ -213,6 +217,148 @@ export class OrgLensRoiService {
       },
       OrgLensRoiService.isProjects
     );
+  }
+
+  /**
+   * One project's ROI figures, or null when the slug names no project of **this** organization.
+   *
+   * Null becomes a 404 rather than an empty payload: a slug belonging to some other organization
+   * must not read as "this project has no data", which would invite the viewer to conclude
+   * something about a project their organization has no measured relationship with.
+   *
+   * The onward-link target is resolved in the same round-trip. `/org/projects/{slug}` is served
+   * from `ORG_LENS_PROJECTS`, and a measured 32.4% of ROI organization-project pairs have no row
+   * there, so whether the link resolves is a fact about the data and is answered here rather than
+   * guessed at in the template or discovered by the viewer hitting a dead page.
+   */
+  public async getProjectDetail(req: Request, accountId: string, projectSlug: string, method: OrgLensRoiMethod): Promise<OrgLensRoiProjectDetail | null> {
+    return this.withNullableOrgCache(
+      accountId,
+      `${ORG_LENS_ROI_CACHE_KEY.projectDetail}:${method}:${encodeURIComponent(projectSlug)}`,
+      OrgLensRoiService.isProjectDetail,
+      async () => {
+        logger.debug(req, 'get_org_lens_roi_project_detail', 'Cache miss; querying Snowflake', {
+          account_id: accountId,
+          project_slug: projectSlug,
+          method,
+        });
+        const sql = `
+        SELECT
+          p.PROJECT_ID,
+          p.PROJECT_SLUG,
+          p.PROJECT_NAME,
+          p.TOTAL_EXPENDITURE,
+          p.TOTAL_RETURN,
+          p.PROFIT,
+          p.ROI,
+          p.BCR,
+          p.BREAKEVEN_MARKUP,
+          b.CONTRIBUTION_TYPE,
+          b.CONTRIBUTION_LABEL,
+          b.EXPENDITURE AS CATEGORY_EXPENDITURE,
+          (
+            SELECT COUNT(*)
+            FROM ${this.orgLensProjectsTable()} c
+            WHERE c.ACCOUNT_ID = p.ACCOUNT_ID AND c.PROJECT_SLUG = p.PROJECT_SLUG
+          ) AS CATALOG_ROWS
+        FROM ${this.projectsTable()} p
+        LEFT JOIN ${this.projectsBreakdownTable()} b
+          ON b.ACCOUNT_ID = p.ACCOUNT_ID AND b.PROJECT_ID = p.PROJECT_ID
+        WHERE p.ACCOUNT_ID = ? AND p.PROJECT_SLUG = ? AND p.MARKUP_METHOD = ?
+        ORDER BY b.DISPLAY_ORDER
+      `;
+        const result = await this.snowflakeService.execute<OrgLensRoiProjectDetailWarehouseRow>(sql, [accountId, projectSlug, method]);
+        const project = this.groupProjectRows(result.rows).at(0) ?? null;
+        if (project === null) return null;
+        return {
+          orgUid: accountId,
+          method,
+          project,
+          hasOrgLensProject: this.toCount(result.rows.at(0)?.CATALOG_ROWS) > 0,
+        };
+      }
+    );
+  }
+
+  /**
+   * One project's investment distribution across years, or null when the slug names no project of
+   * this organization.
+   *
+   * Driven from the projects table rather than straight from the annual one, so "not your project"
+   * and "your project, no yearly breakdown" stay distinguishable. Reading the annual table alone
+   * would collapse both into zero rows, and the first must be a 404 while the second is a 200 with
+   * an empty distribution. The unmatched side of the join carries a null YEAR and is dropped.
+   */
+  public async getProjectAnnual(req: Request, accountId: string, projectSlug: string, method: OrgLensRoiMethod): Promise<OrgLensRoiProjectAnnual | null> {
+    return this.withNullableOrgCache(
+      accountId,
+      `${ORG_LENS_ROI_CACHE_KEY.projectAnnual}:${method}:${encodeURIComponent(projectSlug)}`,
+      OrgLensRoiService.isProjectAnnual,
+      async () => {
+        logger.debug(req, 'get_org_lens_roi_project_annual', 'Cache miss; querying Snowflake', {
+          account_id: accountId,
+          project_slug: projectSlug,
+          method,
+        });
+        const sql = `
+        SELECT
+          a.YEAR,
+          a.TOTAL_RETURN,
+          a.EXPENDITURE,
+          a.PROFIT,
+          a.ROI,
+          a.BCR
+        FROM ${this.projectsTable()} p
+        LEFT JOIN ${this.projectAnnualTable()} a
+          ON a.ACCOUNT_ID = p.ACCOUNT_ID AND a.PROJECT_ID = p.PROJECT_ID AND a.MARKUP_METHOD = p.MARKUP_METHOD
+        WHERE p.ACCOUNT_ID = ? AND p.PROJECT_SLUG = ? AND p.MARKUP_METHOD = ?
+        ORDER BY a.YEAR
+      `;
+        const result = await this.snowflakeService.execute<OrgLensRoiProjectAnnualWarehouseRow>(sql, [accountId, projectSlug, method]);
+        if (result.rows.length === 0) return null;
+        return {
+          method,
+          projectSlug,
+          rows: result.rows
+            .filter((row): row is OrgLensRoiAnnualWarehouseRow => row.YEAR !== null && row.YEAR !== undefined)
+            .map((row) => this.mapAnnualRow(row)),
+          apportioned: true,
+          // Constant by construction, not measured: the apportionment share cancels out of both
+          // ratios. Carried in the payload so the client's disclosure is driven by the contract.
+          efficiencyConstant: true,
+        };
+      }
+    );
+  }
+
+  /**
+   * Read-through cache for the two per-slug reads, which `withOrgCache` cannot serve.
+   *
+   * That helper treats a `null` fetch result as a value and writes it, and `getJson` then reads it
+   * back as a miss — so every unmatched slug would re-query the warehouse *and* leave a permanently
+   * useless entry behind, at a cardinality any authorized caller controls. Skipping the write on a
+   * miss follows `org-lens-project-detail.service.ts`, the repo's existing per-slug org-scoped read.
+   *
+   * A null key means the account id is not filter-safe, which `buildOrgCacheKey` fails closed on;
+   * the fetch still runs, uncached.
+   */
+  private async withNullableOrgCache<T>(
+    accountId: string,
+    subResource: string,
+    accept: (value: unknown) => boolean,
+    fetcher: () => Promise<T | null>
+  ): Promise<T | null> {
+    const key = buildOrgCacheKey(accountId, subResource);
+    if (key !== null) {
+      const cached = await valkeyService.getJson<T>(key, accept);
+      if (cached !== null) return cached;
+    }
+
+    const result = await fetcher();
+    if (result !== null && key !== null) {
+      await valkeyService.setJson(key, result, VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS);
+    }
+    return result;
   }
 
   /** Collapses the fanned-out join back to one entry per project, preserving the SQL ordering. */
@@ -430,6 +576,29 @@ export class OrgLensRoiService {
     });
   }
 
+  /**
+   * Reuses the projects guard on a one-element array, so the single-project payload is held to
+   * exactly the same per-row checks — including the category reconciliation — as the set it is
+   * drawn from. Two hand-written guards over one row shape would be free to drift.
+   */
+  private static isProjectDetail(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const detail = value as Record<string, unknown>;
+    if (typeof detail['orgUid'] !== 'string' || detail['orgUid'].length === 0) return false;
+    if (typeof detail['hasOrgLensProject'] !== 'boolean') return false;
+    return OrgLensRoiService.isProjects({ method: detail['method'], rows: [detail['project']] });
+  }
+
+  private static isProjectAnnual(value: unknown): boolean {
+    if (value === null || typeof value !== 'object' || Array.isArray(value)) return false;
+    const annual = value as Record<string, unknown>;
+    if (typeof annual['projectSlug'] !== 'string' || annual['projectSlug'].length === 0) return false;
+    // Always true on the write path, so a stored `false` is a corrupt entry rather than a variant —
+    // and one that would suppress the disclosure the constancy requires.
+    if (annual['efficiencyConstant'] !== true) return false;
+    return OrgLensRoiService.isAnnual(annual);
+  }
+
   private toFiniteNumber(value: unknown): number {
     const parsed = Number(value);
     return Number.isFinite(parsed) ? parsed : 0;
@@ -473,6 +642,15 @@ export class OrgLensRoiService {
 
   private projectsBreakdownTable(): string {
     return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_PROJECTS_BREAKDOWN`;
+  }
+
+  private projectAnnualTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_ROI_PROJECT_ANNUAL`;
+  }
+
+  /** The Org Lens projects catalog — read only to learn whether the onward link has a target. */
+  private orgLensProjectsTable(): string {
+    return `${resolveLfxOnePlatinumSchema()}.ORG_LENS_PROJECTS`;
   }
 
   private mappingTable(): string {

--- a/apps/lfx-one/src/server/services/org-lens-roi.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-roi.service.ts
@@ -265,10 +265,22 @@ export class OrgLensRoiService {
         LEFT JOIN ${this.projectsBreakdownTable()} b
           ON b.ACCOUNT_ID = p.ACCOUNT_ID AND b.PROJECT_ID = p.PROJECT_ID
         WHERE p.ACCOUNT_ID = ? AND p.PROJECT_SLUG = ? AND p.MARKUP_METHOD = ?
-        ORDER BY b.DISPLAY_ORDER
+        -- PROJECT_ID leads for the same reason it does in the set read: it keeps a project's
+        -- category rows contiguous, and if a slug ever mapped to two project ids it decides which
+        -- one this endpoint answers with, rather than leaving that to the warehouse's row order.
+        ORDER BY p.PROJECT_ID, b.DISPLAY_ORDER
       `;
         const result = await this.snowflakeService.execute<OrgLensRoiProjectDetailWarehouseRow>(sql, [accountId, projectSlug, method]);
-        const project = this.groupProjectRows(result.rows).at(0) ?? null;
+        const projects = this.groupProjectRows(result.rows);
+        if (projects.length > 1) {
+          logger.warning(req, 'get_org_lens_roi_project_detail', 'Expected at most one project for the slug', {
+            account_id: accountId,
+            project_slug: projectSlug,
+            method,
+            projects: projects.length,
+          });
+        }
+        const project = projects.at(0) ?? null;
         if (project === null) return null;
         return {
           orgUid: accountId,

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -105,7 +105,6 @@ export const ORG_LENS_ROI_KPI_EXPLANATION = {
     'A modelled cost, not actual or reported compensation. We count your organization’s public contribution activity — commits, community participation, meetings, events, memberships, and training — and price it at standard rates that are the same for every organization. No salary, payroll, or invoice data is used.',
   totalReturn:
     'The modelled economic value your organization received back from the projects it contributed to, estimated from the wider project ecosystem rather than measured from your own systems.',
-  /** Added for the project detail band, which shows five figures where the portfolio band shows four. */
   profit:
     'Total return less investment — what the modelled return is worth after the modelled cost of earning it. Negative for a project that returned less than it cost, which is a real and reasonably common outcome rather than a data problem.',
   roi: 'Net return divided by investment, shown as a percentage. 100% means you got back your investment again on top of it. Blank when there is no investment to divide by.',

--- a/packages/shared/src/constants/org-lens-roi.constants.ts
+++ b/packages/shared/src/constants/org-lens-roi.constants.ts
@@ -31,6 +31,9 @@ export const ORG_LENS_ROI_CACHE_KEY = {
   /** Unlike its siblings this key carries no method suffix — see the read in `org-lens-roi.service.ts`. */
   investmentBreakdown: 'roi-investment-breakdown:v1',
   projects: 'roi-projects:v1',
+  /** Both are additionally keyed by the project slug — see the reads in `org-lens-roi.service.ts`. */
+  projectDetail: 'roi-project-detail:v1',
+  projectAnnual: 'roi-project-annual:v1',
 } as const;
 
 /** Order must match the warehouse seed's display order. */
@@ -55,6 +58,7 @@ export const ORG_LENS_ROI_GLOBAL_ASSUMPTIONS = {
 export const ORG_LENS_ROI_KPI_ICON_CLASS = {
   totalExpenditure: 'bg-blue-100 text-blue-600',
   totalReturn: 'bg-emerald-100 text-emerald-600',
+  profit: 'bg-teal-100 text-teal-600',
   roi: 'bg-violet-100 text-violet-600',
   bcr: 'bg-amber-100 text-amber-600',
 } as const;
@@ -101,6 +105,9 @@ export const ORG_LENS_ROI_KPI_EXPLANATION = {
     'A modelled cost, not actual or reported compensation. We count your organization’s public contribution activity — commits, community participation, meetings, events, memberships, and training — and price it at standard rates that are the same for every organization. No salary, payroll, or invoice data is used.',
   totalReturn:
     'The modelled economic value your organization received back from the projects it contributed to, estimated from the wider project ecosystem rather than measured from your own systems.',
+  /** Added for the project detail band, which shows five figures where the portfolio band shows four. */
+  profit:
+    'Total return less investment — what the modelled return is worth after the modelled cost of earning it. Negative for a project that returned less than it cost, which is a real and reasonably common outcome rather than a data problem.',
   roi: 'Net return divided by investment, shown as a percentage. 100% means you got back your investment again on top of it. Blank when there is no investment to divide by.',
   bcr: 'Total return divided by investment. A benefit-cost ratio of 5× means every dollar of modelled investment is associated with five dollars of modelled return. Always exactly one more than ROI.',
 } as const;

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -93,6 +93,47 @@ export interface OrgLensRoiProjects {
   rows: OrgLensRoiProjectRow[];
 }
 
+/**
+ * One project's ROI detail. The project itself is the same shape `/projects` serves, singular.
+ *
+ * `orgUid` travels with it so the detail page can check the payload in hand actually describes the
+ * organization now selected, the way the portfolio page checks its summary — a request in flight
+ * during an organization switch would otherwise render one company's figures under another's name.
+ */
+export interface OrgLensRoiProjectDetail {
+  orgUid: string;
+  method: OrgLensRoiMethod;
+  project: OrgLensRoiProjectRow;
+  /**
+   * Whether this project also has an Org Lens catalog row for this organization, and therefore
+   * whether `/org/projects/{projectSlug}` resolves. False for a measured 32.4% of ROI
+   * organization-project pairs, so the onward link is conditional rather than assumed.
+   */
+  hasOrgLensProject: boolean;
+}
+
+export interface OrgLensRoiProjectAnnual {
+  method: OrgLensRoiMethod;
+  projectSlug: string;
+  rows: OrgLensRoiAnnualRow[];
+  apportioned: boolean;
+  /**
+   * Always true. Per-project ROI and BCR are identical in every year — the apportionment share
+   * scales numerator and denominator alike and cancels — so the flag tells the client to disclose
+   * the constancy and never to draw them as a trend.
+   */
+  efficiencyConstant: boolean;
+}
+
+/** One year of a project's investment distribution, pre-formatted for both the chart and its table. */
+export interface OrgLensRoiProjectYearRow {
+  year: number;
+  expenditure: number;
+  investmentLabel: string;
+  returnLabel: string;
+  isPartial: boolean;
+}
+
 /** One rendered arc of the category donut. A view model — never serialized, never a wire contract. */
 export interface OrgLensRoiCategorySlice {
   key: string;

--- a/packages/shared/src/interfaces/org-lens-roi.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.interface.ts
@@ -96,9 +96,11 @@ export interface OrgLensRoiProjects {
 /**
  * One project's ROI detail. The project itself is the same shape `/projects` serves, singular.
  *
- * `orgUid` travels with it so the detail page can check the payload in hand actually describes the
- * organization now selected, the way the portfolio page checks its summary — a request in flight
- * during an organization switch would otherwise render one company's figures under another's name.
+ * `orgUid` and `method` travel with it, alongside the project's own slug, so the detail page can
+ * check the payload in hand describes the organization, project and estimation method currently in
+ * effect — the way the portfolio page checks its summary against the selected organization. Any of
+ * the three can change while a request is in flight, and the payload holds its previous value until
+ * the next response lands.
  */
 export interface OrgLensRoiProjectDetail {
   orgUid: string;

--- a/packages/shared/src/interfaces/org-lens-roi.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-roi.internal.interface.ts
@@ -25,6 +25,15 @@ export interface OrgLensRoiAnnualWarehouseRow {
   BCR: number | null;
 }
 
+/**
+ * The per-project annual read, driven from `ORG_LENS_ROI_PROJECTS` so an existing project with no
+ * yearly breakdown stays distinguishable from a slug that is not this organization's project at
+ * all. `YEAR` is null on the join's unmatched side — the first case — and those rows are dropped.
+ */
+export interface OrgLensRoiProjectAnnualWarehouseRow extends Omit<OrgLensRoiAnnualWarehouseRow, 'YEAR'> {
+  YEAR: number | null;
+}
+
 export interface OrgLensRoiCoverageWarehouseRow {
   HAS_ROI: number;
   IS_MAPPED: number;
@@ -55,4 +64,13 @@ export interface OrgLensRoiProjectWarehouseRow {
   CONTRIBUTION_TYPE: string | null;
   CONTRIBUTION_LABEL: string | null;
   CATEGORY_EXPENDITURE: number | null;
+}
+
+/**
+ * The single-project read: the same shape, plus a count of the project's `ORG_LENS_PROJECTS` rows
+ * for this organization. Zero means `/org/projects/{slug}` has nothing to show, which is the case
+ * for a measured 32.4% of ROI organization-project pairs.
+ */
+export interface OrgLensRoiProjectDetailWarehouseRow extends OrgLensRoiProjectWarehouseRow {
+  CATALOG_ROWS: number;
 }


### PR DESCRIPTION
## Summary

Adds the dedicated per-project ROI view under `/org/roi`, reached from the projects table, closing
out User Story 6 of the Org Lens ROI Metrics feature (LFXV2-2980). Also lands the row-click
navigation that was deliberately deferred from the previous PR (#1389) because this route did not
exist yet.

Two new BFF endpoints, both behind the same org-lens read gate as their five siblings:

- `GET /:orgUid/lens/roi/projects/:projectSlug`
- `GET /:orgUid/lens/roi/projects/:projectSlug/annual`

## Decisions worth reviewing

- **404, not an empty 200.** A slug that is not this organization's project must not read as
  "measured, no data". The annual read is driven from `ORG_LENS_ROI_PROJECTS` left-joined to the
  annual table specifically so "not your project" (404) stays distinguishable from "your project,
  no yearly rows" (200 with an empty distribution).
- **Neither read uses `withOrgCache`.** That helper writes a `null` result which `getJson` then
  reads back as a miss, so every unmatched slug would re-query the warehouse *and* leave a dead
  entry, at a cardinality the caller controls. A private helper skips the write on a miss,
  following `org-lens-project-detail.service.ts`.
- **`roi` became a componentless parent route** so the detail child inherits the existing
  fail-closed dark-launch guard rather than declaring a second, looser copy of it.
- **The onward link into Org Lens is conditional.** Measured 2026-08-05, 32.4% of ROI
  organization-project pairs have no Org Lens catalog row, so the detail read resolves the link
  target in its own round-trip and the view explains the absence instead of rendering a link that
  404s. Verified live against Red Hat: LF Edge is one such project.
- **The yearly chart plots investment alone.** Return runs tens of times investment, so a shared
  linear axis flattens investment to the baseline — the open scaling question the portfolio trend
  and the comparison bar both record. One series sidesteps it; the `sr-only` table carries the
  per-year return.
- **Per-year ROI and BCR are constant by construction**, so the payload's `efficiencyConstant` flag
  drives a disclosure and no per-year efficiency series is drawn anywhere on the page.

## Testing

- `yarn format:check`, `yarn lint:check`, `yarn build`, `./check-headers.sh`, `./check-headers.sh`,
  and `yarn test` (1,827 unit tests) all pass. The controller spec grew 31 → 49 cases; deleting the
  read gate from one new handler fails 8 of them.
- `e2e/org-roi-project-detail.spec.ts` adds 19 cases. **They have not been executed** — the ROI e2e
  suite has never run in CI or locally past its harness blockers, unchanged since US2. Verified only
  by `yarn playwright test --list`.
- **Verified by hand in a browser against production Red Hat data** (408 projects, $144.9M
  investment): the drill-down's five figures are identical to the table row it came from, the
  onward link resolves for OpenStack and is correctly absent for LF Edge, and an unknown slug shows
  the explanatory state with no currency figure anywhere on the page.

## Review history

Bugbot, a general defect review and a security review were run pre-PR and are clean. Two defects
they found are fixed here rather than left for review: the identity guard originally checked only the
organization, so navigating between two projects — or landing before the stored estimation method was
restored — could render one context's figures under another's heading.

A cross-commit sweep was also run, and it is worth being precise about it: the first attempt **failed
partway through** (the agent exhausted its budget). It surfaced two stale comments, fixed here, but
never reached a verdict. A re-run is in progress and anything it finds will be posted as a review
comment on this PR.

One further caveat on process: the reviewer trio this repo documents (`lfx-skills:*`) was not
available in the environment this branch was prepared in, so the equivalent lanes above were used
instead. Worth a maintainer running the documented trio if that substitution is not acceptable.


Made with [Cursor](https://cursor.com)
