### PR TITLE
feat(social-listening): snowflake-backed REST endpoints (LFXV2-3015)

### DIFF
--- a/apps/lfx-one/src/server/controllers/social-listening.controller.ts
+++ b/apps/lfx-one/src/server/controllers/social-listening.controller.ts
@@ -1,0 +1,330 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import {
+  parseFoundationSlug,
+  parseSocialListeningAuthorFilters,
+  parseSocialListeningFilters,
+  parseSocialListeningLimit,
+  parseSocialListeningPagination,
+  parseSocialListeningScope,
+} from '../helpers/social-listening-params.helper';
+import { logger } from '../services/logger.service';
+import { SocialListeningService } from '../services/social-listening.service';
+
+/**
+ * Social Listening HTTP boundary (LFXV2-3002). Every handler validates its query params through
+ * `social-listening-params.helper` before touching the service, logs the HTTP operation, and defers
+ * error logging to `apiErrorHandler` via a bare `next(error)`.
+ *
+ * The ED gate is enforced by route middleware, not here — see `social-listening.route.ts`.
+ */
+export class SocialListeningController {
+  private readonly socialListeningService: SocialListeningService;
+
+  public constructor() {
+    this.socialListeningService = new SocialListeningService();
+  }
+
+  /**
+   * GET /api/social-listening/mentions-feed
+   * One page of mentions for a foundation, newest first.
+   * Query params: foundationSlug (required), period, source_project_id, platform, limit, offset, feed filters
+   */
+  public async getMentionsFeed(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_feed';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const { limit, offset } = parseSocialListeningPagination(req, operation);
+
+      const response = await this.socialListeningService.getMentionsFeed(req, {
+        ...scope,
+        ...parseSocialListeningFilters(req, operation),
+        limit,
+        offset,
+      });
+
+      logger.success(req, operation, startTime, {
+        foundation_slug: scope.foundationSlug,
+        limit,
+        offset,
+        returned_count: response.mentions.length,
+      });
+
+      res.json(response);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/mentions-count
+   * Total mentions matching the same scope + filters as the feed, for the paginator.
+   * Query params: foundationSlug (required), period, source_project_id, platform, feed filters
+   */
+  public async getMentionsCount(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_count';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+
+      const total = await this.socialListeningService.getMentionsCount(req, {
+        ...scope,
+        ...parseSocialListeningFilters(req, operation),
+      });
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, total });
+
+      res.json({ total });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/mentions-projects
+   * Sub-project options for the scope select. Spans the foundation's whole history (no period).
+   * Query params: foundationSlug (required)
+   */
+  public async getMentionsProjects(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_projects';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const foundationSlug = parseFoundationSlug(req, operation);
+      const projects = await this.socialListeningService.getMentionsProjects(req, { foundationSlug });
+
+      logger.success(req, operation, startTime, { foundation_slug: foundationSlug, project_count: projects.length });
+
+      res.json(projects);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/mentions-platforms
+   * Platform options for the scope select. Also period-independent.
+   * Query params: foundationSlug (required)
+   */
+  public async getMentionsPlatforms(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_platforms';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const foundationSlug = parseFoundationSlug(req, operation);
+      const platforms = await this.socialListeningService.getMentionsPlatforms(req, { foundationSlug });
+
+      logger.success(req, operation, startTime, { foundation_slug: foundationSlug, platform_count: platforms.length });
+
+      res.json(platforms);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/mentions-languages
+   * Distinct languages within the current scope + window.
+   * Query params: foundationSlug (required), period, source_project_id, platform
+   */
+  public async getMentionsLanguages(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_languages';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const languages = await this.socialListeningService.getMentionsLanguages(req, scope);
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, language_count: languages.length });
+
+      res.json(languages);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/mentions-keywords
+   * Distinct tracked keywords within the current scope + window.
+   * Query params: foundationSlug (required), period, source_project_id, platform
+   */
+  public async getMentionsKeywords(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_keywords';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const keywords = await this.socialListeningService.getMentionsKeywords(req, scope);
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, keyword_count: keywords.length });
+
+      res.json(keywords);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/mentions-tags
+   * Tags with their mention volume, highest first. Serves both the tag filter and the analytics
+   * top-tags panel — the filter re-sorts alphabetically client-side.
+   * Query params: foundationSlug (required), period, source_project_id, platform, limit
+   */
+  public async getMentionsTags(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_tags';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const limit = parseSocialListeningLimit(req, operation);
+      const tags = await this.socialListeningService.getMentionsTags(req, { ...scope, limit });
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, tag_count: tags.length });
+
+      res.json(tags);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/mentions-authors
+   * Author options, cascading off every other active filter so the list narrows with the feed.
+   * Query params: foundationSlug (required), period, source_project_id, platform, feed filters
+   * except `authors` / `mention_ids`
+   */
+  public async getMentionsAuthors(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_mentions_authors';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+
+      const authors = await this.socialListeningService.getMentionsAuthors(req, {
+        ...scope,
+        ...parseSocialListeningAuthorFilters(req, operation),
+      });
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, author_count: authors.length });
+
+      res.json(authors);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/analytics-overview
+   * Headline KPIs plus change against the immediately preceding, equal-length window.
+   * Query params: foundationSlug (required), period, source_project_id, platform
+   */
+  public async getAnalyticsOverview(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_analytics_overview';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const overview = await this.socialListeningService.getAnalyticsOverview(req, scope);
+
+      logger.success(req, operation, startTime, {
+        foundation_slug: scope.foundationSlug,
+        total_mentions: overview.TOTAL_MENTIONS,
+      });
+
+      res.json(overview);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/analytics-over-time
+   * Mention volume bucketed by day (windows up to ~2 months) or month (anything longer).
+   * Query params: foundationSlug (required), period, source_project_id, platform
+   */
+  public async getAnalyticsOverTime(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_analytics_over_time';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const points = await this.socialListeningService.getAnalyticsOverTime(req, scope);
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, data_points: points.length });
+
+      res.json(points);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/analytics-platform-distribution
+   * Mention share per platform within the current scope + window.
+   * Query params: foundationSlug (required), period, source_project_id, platform
+   */
+  public async getAnalyticsPlatformDistribution(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_analytics_platform_distribution';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const distribution = await this.socialListeningService.getAnalyticsPlatformDistribution(req, scope);
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, platform_count: distribution.length });
+
+      res.json(distribution);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/analytics-sentiment-distribution
+   * Mention share per sentiment bucket within the current scope + window.
+   * Query params: foundationSlug (required), period, source_project_id, platform
+   */
+  public async getAnalyticsSentimentDistribution(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_analytics_sentiment_distribution';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const distribution = await this.socialListeningService.getAnalyticsSentimentDistribution(req, scope);
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, bucket_count: distribution.length });
+
+      res.json(distribution);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /api/social-listening/analytics-top-projects
+   * Sub-projects ranked by mention volume.
+   * Query params: foundationSlug (required), period, source_project_id, platform, limit
+   */
+  public async getAnalyticsTopProjects(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const operation = 'get_social_listening_analytics_top_projects';
+    const startTime = logger.startOperation(req, operation);
+
+    try {
+      const scope = parseSocialListeningScope(req, operation);
+      const limit = parseSocialListeningLimit(req, operation);
+      const projects = await this.socialListeningService.getAnalyticsTopProjects(req, { ...scope, limit });
+
+      logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, project_count: projects.length });
+
+      res.json(projects);
+    } catch (error) {
+      next(error);
+    }
+  }
+}

--- a/apps/lfx-one/src/server/controllers/social-listening.controller.ts
+++ b/apps/lfx-one/src/server/controllers/social-listening.controller.ts
@@ -195,6 +195,8 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/mentions-authors
    * Author options, cascading off every other active filter so the list narrows with the feed.
+   * Caveat: authors arrive comma-joined, so an author name containing a comma can't be re-selected
+   * as a filter value (accepted limitation of the 3016 client codec).
    * Query params: foundationSlug (required), period, sourceProjectId, platform, feed filters
    * except `authors` / `mentionIds`
    */

--- a/apps/lfx-one/src/server/controllers/social-listening.controller.ts
+++ b/apps/lfx-one/src/server/controllers/social-listening.controller.ts
@@ -31,7 +31,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/mentions-feed
    * One page of mentions for a foundation, newest first.
-   * Query params: foundationSlug (required), period, source_project_id, platform, limit, offset, feed filters
+   * Query params: foundationSlug (required), period, sourceProjectId, platform, limit, offset, feed filters
    */
   public async getMentionsFeed(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_mentions_feed';
@@ -64,7 +64,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/mentions-count
    * Total mentions matching the same scope + filters as the feed, for the paginator.
-   * Query params: foundationSlug (required), period, source_project_id, platform, feed filters
+   * Query params: foundationSlug (required), period, sourceProjectId, platform, feed filters
    */
   public async getMentionsCount(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_mentions_count';
@@ -131,7 +131,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/mentions-languages
    * Distinct languages within the current scope + window.
-   * Query params: foundationSlug (required), period, source_project_id, platform
+   * Query params: foundationSlug (required), period, sourceProjectId, platform
    */
   public async getMentionsLanguages(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_mentions_languages';
@@ -152,7 +152,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/mentions-keywords
    * Distinct tracked keywords within the current scope + window.
-   * Query params: foundationSlug (required), period, source_project_id, platform
+   * Query params: foundationSlug (required), period, sourceProjectId, platform
    */
   public async getMentionsKeywords(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_mentions_keywords';
@@ -173,8 +173,8 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/mentions-tags
    * Tags with their mention volume, highest first. Serves both the tag filter and the analytics
-   * top-tags panel — the filter re-sorts alphabetically client-side.
-   * Query params: foundationSlug (required), period, source_project_id, platform, limit
+   * top-tags panel — the filter re-sorts alphabetically client-side. Capped at MENTION_TOP_TAGS_LIMIT.
+   * Query params: foundationSlug (required), period, sourceProjectId, platform
    */
   public async getMentionsTags(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_mentions_tags';
@@ -182,8 +182,7 @@ export class SocialListeningController {
 
     try {
       const scope = parseSocialListeningScope(req, operation);
-      const limit = parseSocialListeningLimit(req, operation);
-      const tags = await this.socialListeningService.getMentionsTags(req, { ...scope, limit });
+      const tags = await this.socialListeningService.getMentionsTags(req, scope);
 
       logger.success(req, operation, startTime, { foundation_slug: scope.foundationSlug, tag_count: tags.length });
 
@@ -196,8 +195,8 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/mentions-authors
    * Author options, cascading off every other active filter so the list narrows with the feed.
-   * Query params: foundationSlug (required), period, source_project_id, platform, feed filters
-   * except `authors` / `mention_ids`
+   * Query params: foundationSlug (required), period, sourceProjectId, platform, feed filters
+   * except `authors` / `mentionIds`
    */
   public async getMentionsAuthors(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_mentions_authors';
@@ -222,7 +221,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/analytics-overview
    * Headline KPIs plus change against the immediately preceding, equal-length window.
-   * Query params: foundationSlug (required), period, source_project_id, platform
+   * Query params: foundationSlug (required), period, sourceProjectId, platform
    */
   public async getAnalyticsOverview(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_analytics_overview';
@@ -246,7 +245,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/analytics-over-time
    * Mention volume bucketed by day (windows up to ~2 months) or month (anything longer).
-   * Query params: foundationSlug (required), period, source_project_id, platform
+   * Query params: foundationSlug (required), period, sourceProjectId, platform
    */
   public async getAnalyticsOverTime(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_analytics_over_time';
@@ -267,7 +266,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/analytics-platform-distribution
    * Mention share per platform within the current scope + window.
-   * Query params: foundationSlug (required), period, source_project_id, platform
+   * Query params: foundationSlug (required), period, sourceProjectId, platform
    */
   public async getAnalyticsPlatformDistribution(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_analytics_platform_distribution';
@@ -288,7 +287,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/analytics-sentiment-distribution
    * Mention share per sentiment bucket within the current scope + window.
-   * Query params: foundationSlug (required), period, source_project_id, platform
+   * Query params: foundationSlug (required), period, sourceProjectId, platform
    */
   public async getAnalyticsSentimentDistribution(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_analytics_sentiment_distribution';
@@ -309,7 +308,7 @@ export class SocialListeningController {
   /**
    * GET /api/social-listening/analytics-top-projects
    * Sub-projects ranked by mention volume.
-   * Query params: foundationSlug (required), period, source_project_id, platform, limit
+   * Query params: foundationSlug (required), period, sourceProjectId, platform, limit
    */
   public async getAnalyticsTopProjects(req: Request, res: Response, next: NextFunction): Promise<void> {
     const operation = 'get_social_listening_analytics_top_projects';

--- a/apps/lfx-one/src/server/helpers/snowflake-schema.helper.ts
+++ b/apps/lfx-one/src/server/helpers/snowflake-schema.helper.ts
@@ -42,3 +42,17 @@ export function resolveLfxOnePlatinumSchema(): string {
 export function committeeEngagementTable(): string {
   return `${resolveLfxOnePlatinumSchema()}.COMMITTEE_MEETING_ATTENDANCE`;
 }
+
+/**
+ * The Octolens-sourced mentions feed behind Social Listening (LFXV2-3002), materialized hourly by
+ * the `platinum_social_listening_feed` dbt model (`lf-dbt`). It lives in PCC's dbt schema —
+ * `ANALYTICS.PLATINUM` — not this repo's `PLATINUM_LFX_ONE` schema, so it gets its own fully
+ * qualified `database.schema.table` override (`LFX_ONE_SOCIAL_LISTENING_FEED_TABLE`) rather than
+ * reusing `resolveLfxOnePlatinumSchema()`. The override is guarded to exactly three `WORD` segments
+ * for the same reason as `snowflakeQualifier()`: anything else is rejected in favor of the default.
+ */
+export function socialListeningFeedTable(): string {
+  const override = process.env['LFX_ONE_SOCIAL_LISTENING_FEED_TABLE']?.trim();
+  const qualified = override && /^[A-Z0-9_]+\.[A-Z0-9_]+\.[A-Z0-9_]+$/i.test(override) ? override.toUpperCase() : null;
+  return qualified ?? 'ANALYTICS.PLATINUM.SOCIAL_LISTENING_FEED';
+}

--- a/apps/lfx-one/src/server/helpers/snowflake-schema.helper.ts
+++ b/apps/lfx-one/src/server/helpers/snowflake-schema.helper.ts
@@ -43,14 +43,7 @@ export function committeeEngagementTable(): string {
   return `${resolveLfxOnePlatinumSchema()}.COMMITTEE_MEETING_ATTENDANCE`;
 }
 
-/**
- * The Octolens-sourced mentions feed behind Social Listening (LFXV2-3002), materialized hourly by
- * the `platinum_social_listening_feed` dbt model (`lf-dbt`). It lives in PCC's dbt schema —
- * `ANALYTICS.PLATINUM` — not this repo's `PLATINUM_LFX_ONE` schema, so it gets its own fully
- * qualified `database.schema.table` override (`LFX_ONE_SOCIAL_LISTENING_FEED_TABLE`) rather than
- * reusing `resolveLfxOnePlatinumSchema()`. The override is guarded to exactly three `WORD` segments
- * for the same reason as `snowflakeQualifier()`: anything else is rejected in favor of the default.
- */
+/** The Social Listening feed lives in PCC's `ANALYTICS.PLATINUM` schema, not `PLATINUM_LFX_ONE`, so it gets its own guarded three-segment override (`LFX_ONE_SOCIAL_LISTENING_FEED_TABLE`). */
 export function socialListeningFeedTable(): string {
   const override = process.env['LFX_ONE_SOCIAL_LISTENING_FEED_TABLE']?.trim();
   const qualified = override && /^[A-Z0-9_]+\.[A-Z0-9_]+\.[A-Z0-9_]+$/i.test(override) ? override.toUpperCase() : null;

--- a/apps/lfx-one/src/server/helpers/social-listening-params.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/social-listening-params.helper.spec.ts
@@ -26,9 +26,9 @@ vi.mock('@lfx-one/shared/constants', () => ({
     { label: 'Yes', value: 'yes' },
     { label: 'No', value: 'no' },
   ],
-  SOCIAL_LISTENING_MAX_FILTER_VALUES: 200,
-  SOCIAL_LISTENING_MAX_MENTION_IDS: 500,
-  SOCIAL_LISTENING_SERVER_PAGE_SIZE: 100,
+  MENTION_FILTER_MAX_VALUES: 200,
+  MENTION_IDS_MAX_VALUES: 500,
+  MENTION_SERVER_WINDOW_SIZE: 100,
   MONTH_FORMAT_REGEX: /^\d{4}-(0[1-9]|1[0-2])$/,
   AKRITES_STEWARD_ROLE_OPTIONS: [],
   AKRITES_ESCALATION_PATHS: [],
@@ -116,7 +116,7 @@ describe('parseSocialListeningScope', () => {
   });
 
   it('carries the two scope selects through', () => {
-    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'ytd', source_project_id: 'proj-1', platform: 'Reddit' }), OPERATION);
+    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'ytd', sourceProjectId: 'proj-1', platform: 'Reddit' }), OPERATION);
 
     expect(scope.sourceProjectId).toBe('proj-1');
     // Case is preserved here; the service lowercases the platform when it binds it.
@@ -124,7 +124,7 @@ describe('parseSocialListeningScope', () => {
   });
 
   it.each(['all', '', '   '])('normalizes a "%s" scope select to no filter', (value) => {
-    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'ytd', source_project_id: value, platform: value }), OPERATION);
+    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'ytd', sourceProjectId: value, platform: value }), OPERATION);
 
     expect(scope.sourceProjectId).toBeUndefined();
     expect(scope.platform).toBeUndefined();
@@ -153,7 +153,7 @@ describe('parseSocialListeningFilters', () => {
   it.each([
     { field: 'sentiment', value: 'positive' },
     { field: 'relevance', value: 'high' },
-    { field: 'has_title', value: 'yes' },
+    { field: 'hasTitle', value: 'yes' },
   ])('accepts a whitelisted $field value', ({ field, value }) => {
     const filters = parseSocialListeningFilters(request({ [field]: value }), OPERATION) as Record<string, unknown>;
 
@@ -163,21 +163,27 @@ describe('parseSocialListeningFilters', () => {
   it.each([
     { field: 'sentiment', value: 'furious' },
     { field: 'relevance', value: 'medium' },
-    { field: 'has_title', value: 'maybe' },
+    { field: 'hasTitle', value: 'maybe' },
   ])('rejects an off-whitelist $field value', ({ field, value }) => {
     expect(() => parseSocialListeningFilters(request({ [field]: value }), OPERATION)).toThrow(new RegExp(field));
   });
 
-  it.each(['sentiment', 'relevance', 'has_title'])('treats %s=all as no predicate', (field) => {
+  it.each(['sentiment', 'relevance', 'hasTitle'])('treats %s=all as no predicate', (field) => {
     const filters = parseSocialListeningFilters(request({ [field]: 'all' }), OPERATION) as Record<string, unknown>;
 
     expect(Object.values(filters).every((value) => value === undefined)).toBe(true);
   });
 
-  it('reads repeated query keys as a list and trims each value', () => {
-    const filters = parseSocialListeningFilters(request({ tags: ['  release ', 'security', ' '] }), OPERATION);
+  it('reads a comma-joined value as a list and trims each entry', () => {
+    const filters = parseSocialListeningFilters(request({ tags: '  release ,security, ' }), OPERATION);
 
     expect(filters.tags).toEqual(['release', 'security']);
+  });
+
+  it('tolerates repeated keys by splitting each element too', () => {
+    const filters = parseSocialListeningFilters(request({ tags: ['release,security', 'cncf'] }), OPERATION);
+
+    expect(filters.tags).toEqual(['release', 'security', 'cncf']);
   });
 
   it('reads a single occurrence as a one-element list', () => {
@@ -185,23 +191,23 @@ describe('parseSocialListeningFilters', () => {
   });
 
   it('preserves a present-but-empty id list — the service reads it as "nothing selected"', () => {
-    expect(parseSocialListeningFilters(request({ mention_ids: [] }), OPERATION).mentionIds).toEqual([]);
+    expect(parseSocialListeningFilters(request({ mentionIds: '' }), OPERATION).mentionIds).toEqual([]);
   });
 
   it.each([
     { field: 'keywords', cap: 200 },
     { field: 'tags', cap: 200 },
     { field: 'authors', cap: 200 },
-    { field: 'mention_ids', cap: 500 },
+    { field: 'mentionIds', cap: 500 },
   ])('rejects rather than truncates an over-cap $field list', ({ field, cap }) => {
     const atCap = Array.from({ length: cap }, (_, index) => `v${index}`);
 
-    expect(() => parseSocialListeningFilters(request({ [field]: atCap }), OPERATION)).not.toThrow();
-    expect(() => parseSocialListeningFilters(request({ [field]: [...atCap, 'one-too-many'] }), OPERATION)).toThrow(new RegExp(field));
+    expect(() => parseSocialListeningFilters(request({ [field]: atCap.join(',') }), OPERATION)).not.toThrow();
+    expect(() => parseSocialListeningFilters(request({ [field]: [...atCap, 'one-too-many'].join(',') }), OPERATION)).toThrow(new RegExp(field));
   });
 
   it('rejects an over-long value inside a list', () => {
-    expect(() => parseSocialListeningFilters(request({ tags: ['ok', 't'.repeat(201)] }), OPERATION)).toThrow(/tags/);
+    expect(() => parseSocialListeningFilters(request({ tags: `ok,${'t'.repeat(201)}` }), OPERATION)).toThrow(/tags/);
   });
 
   it('gives the search term more room than a single-token filter', () => {
@@ -212,7 +218,7 @@ describe('parseSocialListeningFilters', () => {
 
 describe('parseSocialListeningAuthorFilters', () => {
   it('omits authors and mention ids by construction — a multiselect must not filter its own options', () => {
-    const filters = parseSocialListeningAuthorFilters(request({ authors: ['@lf'], mention_ids: ['a'], sentiment: 'negative' }), OPERATION);
+    const filters = parseSocialListeningAuthorFilters(request({ authors: '@lf', mentionIds: 'a', sentiment: 'negative' }), OPERATION);
 
     expect(filters).not.toHaveProperty('authors');
     expect(filters).not.toHaveProperty('mentionIds');

--- a/apps/lfx-one/src/server/helpers/social-listening-params.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/social-listening-params.helper.spec.ts
@@ -1,0 +1,263 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Request } from 'express';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mirrors org-lens-meetings.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this
+// app's vitest config, so every runtime (non-type-only) import needs a stub. Option lists and caps
+// mirror `social-listening.constants.ts`; the akrites entries are only here because
+// `validation.helper` — the real module, since `getValidatedPeriod` is part of the behavior under
+// test — derives them at module scope.
+vi.mock('@lfx-one/shared/constants', () => ({
+  MENTION_SENTIMENT_OPTIONS: [
+    { label: 'All', value: 'all' },
+    { label: 'Positive', value: 'positive' },
+    { label: 'Neutral', value: 'neutral' },
+    { label: 'Negative', value: 'negative' },
+  ],
+  MENTION_RELEVANCE_OPTIONS: [
+    { label: 'All', value: 'all' },
+    { label: 'High', value: 'high' },
+    { label: 'Low', value: 'low' },
+  ],
+  MENTION_HAS_TITLE_OPTIONS: [
+    { label: 'All', value: 'all' },
+    { label: 'Yes', value: 'yes' },
+    { label: 'No', value: 'no' },
+  ],
+  SOCIAL_LISTENING_MAX_FILTER_VALUES: 200,
+  SOCIAL_LISTENING_MAX_MENTION_IDS: 500,
+  SOCIAL_LISTENING_SERVER_PAGE_SIZE: 100,
+  MONTH_FORMAT_REGEX: /^\d{4}-(0[1-9]|1[0-2])$/,
+  AKRITES_STEWARD_ROLE_OPTIONS: [],
+  AKRITES_ESCALATION_PATHS: [],
+  AKRITES_INACTIVE_REASON_OPTIONS: [],
+}));
+
+// Period resolution is stubbed so the assertions don't move with the wall clock. `endDate` is
+// exclusive and both bounds are month-aligned, matching the real `resolvePeriodRange()`.
+const RANGES: Record<string, { type: string; startDate: string; endDate: string; label: string }> = {
+  ytd: { type: 'ytd', startDate: '2026-01-01', endDate: '2026-08-01', label: 'YTD' },
+  '2026-03': { type: 'month', startDate: '2026-03-01', endDate: '2026-04-01', label: 'Mar 2026' },
+  '2020-01': { type: 'month', startDate: '2020-01-01', endDate: '2020-02-01', label: 'Jan 2020' },
+  '2026-07': { type: 'month', startDate: '2026-07-01', endDate: '2026-08-01', label: 'Jul 2026' },
+};
+
+vi.mock('@lfx-one/shared/utils', () => ({
+  resolvePeriodRange: (period: string) => RANGES[period] ?? null,
+  /** The client's own default — the previous complete calendar month. */
+  getDefaultMarketingImpactPeriod: () => '2026-07',
+}));
+
+const { ServiceValidationError } = await import('../errors');
+const {
+  parseFoundationSlug,
+  parseSocialListeningAuthorFilters,
+  parseSocialListeningFilters,
+  parseSocialListeningLimit,
+  parseSocialListeningPagination,
+  parseSocialListeningScope,
+} = await import('./social-listening-params.helper');
+
+const OPERATION = 'get_social_listening_test';
+
+function request(query: Record<string, unknown>): Request {
+  return { query } as unknown as Request;
+}
+
+describe('parseFoundationSlug', () => {
+  it('returns a well-formed slug', () => {
+    expect(parseFoundationSlug(request({ foundationSlug: 'cncf-projects' }), OPERATION)).toBe('cncf-projects');
+  });
+
+  it.each([
+    { label: 'a missing slug', query: {} },
+    { label: 'an empty slug', query: { foundationSlug: '' } },
+    { label: 'a repeated slug param', query: { foundationSlug: ['cncf', 'lfai'] } },
+    { label: 'an uppercased slug', query: { foundationSlug: 'CNCF' } },
+    { label: 'a slug with a space', query: { foundationSlug: 'cn cf' } },
+    { label: 'a slug with a wildcard', query: { foundationSlug: 'cncf%' } },
+    { label: 'an over-long slug', query: { foundationSlug: 'c'.repeat(201) } },
+  ])('rejects $label', ({ query }) => {
+    expect(() => parseFoundationSlug(request(query), OPERATION)).toThrow(ServiceValidationError);
+    expect(() => parseFoundationSlug(request(query), OPERATION)).toThrow(/foundationSlug/);
+  });
+});
+
+describe('parseSocialListeningScope', () => {
+  it('resolves the requested period into a half-open window', () => {
+    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', period: '2026-03' }), OPERATION);
+
+    expect(scope).toEqual({
+      foundationSlug: 'cncf',
+      startDate: '2026-03-01',
+      endDate: '2026-04-01',
+      sourceProjectId: undefined,
+      platform: undefined,
+    });
+  });
+
+  it('falls back to the previous calendar month when the client omits the period', () => {
+    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf' }), OPERATION);
+
+    expect(scope.startDate).toBe('2026-07-01');
+    expect(scope.endDate).toBe('2026-08-01');
+  });
+
+  it('still honors the legacy `month` param', () => {
+    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', month: '2020-01' }), OPERATION);
+
+    expect(scope.startDate).toBe('2020-01-01');
+  });
+
+  it('rejects an unknown period token', () => {
+    expect(() => parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'last-99' }), OPERATION)).toThrow(/period/);
+  });
+
+  it('carries the two scope selects through', () => {
+    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'ytd', source_project_id: 'proj-1', platform: 'Reddit' }), OPERATION);
+
+    expect(scope.sourceProjectId).toBe('proj-1');
+    // Case is preserved here; the service lowercases the platform when it binds it.
+    expect(scope.platform).toBe('Reddit');
+  });
+
+  it.each(['all', '', '   '])('normalizes a "%s" scope select to no filter', (value) => {
+    const scope = parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'ytd', source_project_id: value, platform: value }), OPERATION);
+
+    expect(scope.sourceProjectId).toBeUndefined();
+    expect(scope.platform).toBeUndefined();
+  });
+
+  it('rejects an over-long scope select', () => {
+    expect(() => parseSocialListeningScope(request({ foundationSlug: 'cncf', period: 'ytd', platform: 'p'.repeat(201) }), OPERATION)).toThrow(/platform/);
+  });
+});
+
+describe('parseSocialListeningFilters', () => {
+  it('normalizes an unfiltered request to no predicates at all', () => {
+    expect(parseSocialListeningFilters(request({}), OPERATION)).toEqual({
+      sentiment: undefined,
+      relevance: undefined,
+      hasTitle: undefined,
+      language: undefined,
+      search: undefined,
+      keywords: undefined,
+      tags: undefined,
+      authors: undefined,
+      mentionIds: undefined,
+    });
+  });
+
+  it.each([
+    { field: 'sentiment', value: 'positive' },
+    { field: 'relevance', value: 'high' },
+    { field: 'has_title', value: 'yes' },
+  ])('accepts a whitelisted $field value', ({ field, value }) => {
+    const filters = parseSocialListeningFilters(request({ [field]: value }), OPERATION) as Record<string, unknown>;
+
+    expect(Object.values(filters)).toContain(value);
+  });
+
+  it.each([
+    { field: 'sentiment', value: 'furious' },
+    { field: 'relevance', value: 'medium' },
+    { field: 'has_title', value: 'maybe' },
+  ])('rejects an off-whitelist $field value', ({ field, value }) => {
+    expect(() => parseSocialListeningFilters(request({ [field]: value }), OPERATION)).toThrow(new RegExp(field));
+  });
+
+  it.each(['sentiment', 'relevance', 'has_title'])('treats %s=all as no predicate', (field) => {
+    const filters = parseSocialListeningFilters(request({ [field]: 'all' }), OPERATION) as Record<string, unknown>;
+
+    expect(Object.values(filters).every((value) => value === undefined)).toBe(true);
+  });
+
+  it('reads repeated query keys as a list and trims each value', () => {
+    const filters = parseSocialListeningFilters(request({ tags: ['  release ', 'security', ' '] }), OPERATION);
+
+    expect(filters.tags).toEqual(['release', 'security']);
+  });
+
+  it('reads a single occurrence as a one-element list', () => {
+    expect(parseSocialListeningFilters(request({ keywords: 'kubernetes' }), OPERATION).keywords).toEqual(['kubernetes']);
+  });
+
+  it('preserves a present-but-empty id list — the service reads it as "nothing selected"', () => {
+    expect(parseSocialListeningFilters(request({ mention_ids: [] }), OPERATION).mentionIds).toEqual([]);
+  });
+
+  it.each([
+    { field: 'keywords', cap: 200 },
+    { field: 'tags', cap: 200 },
+    { field: 'authors', cap: 200 },
+    { field: 'mention_ids', cap: 500 },
+  ])('rejects rather than truncates an over-cap $field list', ({ field, cap }) => {
+    const atCap = Array.from({ length: cap }, (_, index) => `v${index}`);
+
+    expect(() => parseSocialListeningFilters(request({ [field]: atCap }), OPERATION)).not.toThrow();
+    expect(() => parseSocialListeningFilters(request({ [field]: [...atCap, 'one-too-many'] }), OPERATION)).toThrow(new RegExp(field));
+  });
+
+  it('rejects an over-long value inside a list', () => {
+    expect(() => parseSocialListeningFilters(request({ tags: ['ok', 't'.repeat(201)] }), OPERATION)).toThrow(/tags/);
+  });
+
+  it('gives the search term more room than a single-token filter', () => {
+    expect(parseSocialListeningFilters(request({ search: 's'.repeat(500) }), OPERATION).search).toHaveLength(500);
+    expect(() => parseSocialListeningFilters(request({ search: 's'.repeat(501) }), OPERATION)).toThrow(/search/);
+  });
+});
+
+describe('parseSocialListeningAuthorFilters', () => {
+  it('omits authors and mention ids by construction — a multiselect must not filter its own options', () => {
+    const filters = parseSocialListeningAuthorFilters(request({ authors: ['@lf'], mention_ids: ['a'], sentiment: 'negative' }), OPERATION);
+
+    expect(filters).not.toHaveProperty('authors');
+    expect(filters).not.toHaveProperty('mentionIds');
+    expect(filters.sentiment).toBe('negative');
+  });
+});
+
+describe('parseSocialListeningPagination', () => {
+  it('defaults to the first full server window', () => {
+    expect(parseSocialListeningPagination(request({}), OPERATION)).toEqual({ limit: 100, offset: 0 });
+  });
+
+  it.each([
+    { label: 'a limit above the server window', query: { limit: '500' }, expected: { limit: 100, offset: 0 } },
+    { label: 'a zero limit', query: { limit: '0' }, expected: { limit: 1, offset: 0 } },
+    { label: 'a negative offset', query: { offset: '-20' }, expected: { limit: 100, offset: 0 } },
+    { label: 'an offset past the scan ceiling', query: { offset: '999999' }, expected: { limit: 100, offset: 100000 } },
+    { label: 'blank values', query: { limit: '', offset: '' }, expected: { limit: 100, offset: 0 } },
+  ])('clamps $label', ({ query, expected }) => {
+    expect(parseSocialListeningPagination(request(query), OPERATION)).toEqual(expected);
+  });
+
+  it('passes an in-range window through untouched', () => {
+    expect(parseSocialListeningPagination(request({ limit: '20', offset: '40' }), OPERATION)).toEqual({ limit: 20, offset: 40 });
+  });
+
+  it.each([{ limit: 'abc' }, { limit: '10.5' }, { offset: 'NaN' }])('rejects a non-integer window bound (%o)', (query) => {
+    expect(() => parseSocialListeningPagination(request(query), OPERATION)).toThrow(ServiceValidationError);
+  });
+});
+
+describe('parseSocialListeningLimit', () => {
+  it('returns undefined when the caller omits the limit, so the service applies its own default', () => {
+    expect(parseSocialListeningLimit(request({}), OPERATION)).toBeUndefined();
+  });
+
+  it.each([
+    { raw: '5', expected: 5 },
+    { raw: '999', expected: 100 },
+    { raw: '0', expected: 1 },
+  ])('clamps a requested limit of $raw to $expected', ({ raw, expected }) => {
+    expect(parseSocialListeningLimit(request({ limit: raw }), OPERATION)).toBe(expected);
+  });
+
+  it('rejects a non-integer limit', () => {
+    expect(() => parseSocialListeningLimit(request({ limit: '7.5' }), OPERATION)).toThrow(/limit/);
+  });
+});

--- a/apps/lfx-one/src/server/helpers/social-listening-params.helper.ts
+++ b/apps/lfx-one/src/server/helpers/social-listening-params.helper.ts
@@ -1,0 +1,225 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import {
+  MENTION_HAS_TITLE_OPTIONS,
+  MENTION_RELEVANCE_OPTIONS,
+  MENTION_SENTIMENT_OPTIONS,
+  SOCIAL_LISTENING_MAX_FILTER_VALUES,
+  SOCIAL_LISTENING_MAX_MENTION_IDS,
+  SOCIAL_LISTENING_SERVER_PAGE_SIZE,
+} from '@lfx-one/shared/constants';
+import { getDefaultMarketingImpactPeriod, resolvePeriodRange } from '@lfx-one/shared/utils';
+import { Request } from 'express';
+
+import { ServiceValidationError } from '../errors';
+import { getStringQueryParam, getValidatedPeriod } from './validation.helper';
+
+import type { ResolvedPeriodRange, SocialListeningFilterParams, SocialListeningScopeParams } from '@lfx-one/shared/interfaces';
+
+/**
+ * Query-parameter parsing for the Social Listening endpoints. Every value is validated, normalized,
+ * and bounded here so the service only ever binds values the HTTP layer has already vetted — the
+ * service's own caps are defense in depth, not the first line.
+ *
+ * These helpers do NOT log; the centralized `apiErrorHandler` logs every `ServiceValidationError`
+ * at WARN. The wire keys are the snake_case `MentionFilters` keys the client builds with
+ * `buildMentionFilters()`, not the camelCase router params the page uses in the browser URL.
+ */
+
+/** Foundation slugs are lowercase alphanumeric + hyphens, matching every other foundation-scoped endpoint. */
+const FOUNDATION_SLUG_PATTERN = /^[a-z0-9-]+$/;
+
+const FOUNDATION_SLUG_MAX_LENGTH = 200;
+
+/** Upper bound for a single filter value (a keyword, tag, author handle, language code, or id). */
+const FILTER_VALUE_MAX_LENGTH = 200;
+
+/** Search terms get more room than a single-token filter but still can't be unbounded. */
+const SEARCH_MAX_LENGTH = 500;
+
+/** A page can never exceed the server window the client is built around. */
+const MAX_FEED_LIMIT = SOCIAL_LISTENING_SERVER_PAGE_SIZE;
+
+/** ~1000 windows deep. Past this, a paginated request is a scan, not navigation. */
+const MAX_FEED_OFFSET = 100_000;
+
+/** Ceiling for the caller-supplied `limit` on the ranked analytics panels (top tags, top projects). */
+const MAX_ANALYTICS_LIMIT = 100;
+
+const VALID_SENTIMENTS = MENTION_SENTIMENT_OPTIONS.map((option) => option.value);
+const VALID_RELEVANCES = MENTION_RELEVANCE_OPTIONS.map((option) => option.value);
+const VALID_HAS_TITLE = MENTION_HAS_TITLE_OPTIONS.map((option) => option.value);
+
+/**
+ * Required, format-checked foundation slug.
+ *
+ * Note: slugs longer than 64 characters clear this check but fail `isFilterSafeIdentifier()` inside
+ * `buildSocialListeningCacheKey()`, which fails closed to an uncached direct fetch. Correct either way.
+ */
+export function parseFoundationSlug(req: Request, operation: string): string {
+  const foundationSlug = getStringQueryParam(req, 'foundationSlug');
+
+  if (!foundationSlug) {
+    throw ServiceValidationError.forField('foundationSlug', 'foundationSlug query parameter is required', { operation });
+  }
+
+  if (foundationSlug.length > FOUNDATION_SLUG_MAX_LENGTH || !FOUNDATION_SLUG_PATTERN.test(foundationSlug)) {
+    throw ServiceValidationError.forField('foundationSlug', 'Invalid foundationSlug format', { operation });
+  }
+
+  return foundationSlug;
+}
+
+/**
+ * Foundation + half-open `[startDate, endDate)` window + the two selects that scope the whole page.
+ * A missing `period` resolves to the same default the client starts on, so a bare request is valid.
+ */
+export function parseSocialListeningScope(req: Request, operation: string): SocialListeningScopeParams {
+  const period = getValidatedPeriod(req, operation) ?? defaultPeriodRange(operation);
+
+  return {
+    foundationSlug: parseFoundationSlug(req, operation),
+    startDate: period.startDate,
+    endDate: period.endDate,
+    sourceProjectId: parseTextParam(req, 'source_project_id', FILTER_VALUE_MAX_LENGTH, operation),
+    platform: parseTextParam(req, 'platform', FILTER_VALUE_MAX_LENGTH, operation),
+  };
+}
+
+/** Every feed filter. `all` and blank values normalize to `undefined` (no predicate). */
+export function parseSocialListeningFilters(req: Request, operation: string): SocialListeningFilterParams {
+  return {
+    ...parseSocialListeningAuthorFilters(req, operation),
+    authors: parseArrayParam(req, 'authors', SOCIAL_LISTENING_MAX_FILTER_VALUES, operation),
+    mentionIds: parseArrayParam(req, 'mention_ids', SOCIAL_LISTENING_MAX_MENTION_IDS, operation),
+  };
+}
+
+/**
+ * The filter subset the author-option query cascades off. Omits `authors` and `mentionIds` by
+ * construction — a multiselect must never filter its own option list.
+ */
+export function parseSocialListeningAuthorFilters(req: Request, operation: string): Omit<SocialListeningFilterParams, 'authors' | 'mentionIds'> {
+  return {
+    sentiment: parseEnumParam(req, 'sentiment', VALID_SENTIMENTS, operation),
+    relevance: parseEnumParam(req, 'relevance', VALID_RELEVANCES, operation),
+    hasTitle: parseEnumParam(req, 'has_title', VALID_HAS_TITLE, operation),
+    language: parseTextParam(req, 'language', FILTER_VALUE_MAX_LENGTH, operation),
+    search: parseTextParam(req, 'search', SEARCH_MAX_LENGTH, operation),
+    keywords: parseArrayParam(req, 'keywords', SOCIAL_LISTENING_MAX_FILTER_VALUES, operation),
+    tags: parseArrayParam(req, 'tags', SOCIAL_LISTENING_MAX_FILTER_VALUES, operation),
+  };
+}
+
+/** Feed window bounds. Both default to the first page and are clamped, never silently wrapped. */
+export function parseSocialListeningPagination(req: Request, operation: string): { limit: number; offset: number } {
+  return {
+    limit: parseIntegerParam(req, 'limit', operation, { fallback: MAX_FEED_LIMIT, min: 1, max: MAX_FEED_LIMIT }),
+    offset: parseIntegerParam(req, 'offset', operation, { fallback: 0, min: 0, max: MAX_FEED_OFFSET }),
+  };
+}
+
+/** Optional row cap for a ranked analytics panel; `undefined` lets the service apply its own default. */
+export function parseSocialListeningLimit(req: Request, operation: string): number | undefined {
+  if (getStringQueryParam(req, 'limit') === undefined) {
+    return undefined;
+  }
+
+  return parseIntegerParam(req, 'limit', operation, { fallback: MAX_ANALYTICS_LIMIT, min: 1, max: MAX_ANALYTICS_LIMIT });
+}
+
+/** The window the client lands on before it picks a period — the previous complete calendar month. */
+function defaultPeriodRange(operation: string): ResolvedPeriodRange {
+  const range = resolvePeriodRange(getDefaultMarketingImpactPeriod());
+
+  if (!range) {
+    throw ServiceValidationError.forField('period', 'period query parameter is required', { operation });
+  }
+
+  return range;
+}
+
+/** Whitelisted single-select value. `all` means "no predicate" and normalizes to `undefined`. */
+function parseEnumParam(req: Request, name: string, allowed: string[], operation: string): string | undefined {
+  const raw = getStringQueryParam(req, name);
+
+  if (!raw) {
+    return undefined;
+  }
+
+  if (!allowed.includes(raw)) {
+    throw ServiceValidationError.forField(name, `Invalid ${name} value. Allowed: ${allowed.join(', ')}`, { operation });
+  }
+
+  return raw === 'all' ? undefined : raw;
+}
+
+/**
+ * Length-bounded free-text value. Values that reach Snowflake as binds (a language code, a platform
+ * key, a sub-project id, a search term) can't be whitelisted, so they are bounded instead.
+ */
+function parseTextParam(req: Request, name: string, maxLength: number, operation: string): string | undefined {
+  const raw = getStringQueryParam(req, name);
+
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const value = raw.trim();
+
+  if (!value || value === 'all') {
+    return undefined;
+  }
+
+  if (value.length > maxLength) {
+    throw ServiceValidationError.forField(name, `${name} exceeds the ${maxLength}-character limit`, { operation });
+  }
+
+  return value;
+}
+
+/**
+ * Repeated query keys (`tags=a&tags=b`) as a bounded string array. An over-long list is rejected
+ * rather than truncated — silently dropping filter values would return results the caller didn't ask
+ * for. A present-but-empty list is preserved as `[]`, which `mention_ids` reads as "nothing selected".
+ */
+function parseArrayParam(req: Request, name: string, cap: number, operation: string): string[] | undefined {
+  const raw = req.query[name];
+
+  if (raw === undefined) {
+    return undefined;
+  }
+
+  const values = (Array.isArray(raw) ? raw : [raw])
+    .filter((value): value is string => typeof value === 'string')
+    .map((value) => value.trim())
+    .filter(Boolean);
+
+  if (values.length > cap) {
+    throw ServiceValidationError.forField(name, `Too many ${name} values. Maximum is ${cap}`, { operation });
+  }
+
+  if (values.some((value) => value.length > FILTER_VALUE_MAX_LENGTH)) {
+    throw ServiceValidationError.forField(name, `A ${name} value exceeds the ${FILTER_VALUE_MAX_LENGTH}-character limit`, { operation });
+  }
+
+  return values;
+}
+
+/** Bounded integer query param. Rejects non-integers outright and clamps in-range values. */
+function parseIntegerParam(req: Request, name: string, operation: string, bounds: { fallback: number; min: number; max: number }): number {
+  const raw = getStringQueryParam(req, name);
+
+  if (raw === undefined || raw === '') {
+    return bounds.fallback;
+  }
+
+  const parsed = Number(raw);
+
+  if (!Number.isInteger(parsed)) {
+    throw ServiceValidationError.forField(name, `${name} must be an integer`, { operation });
+  }
+
+  return Math.min(Math.max(parsed, bounds.min), bounds.max);
+}

--- a/apps/lfx-one/src/server/helpers/social-listening-params.helper.ts
+++ b/apps/lfx-one/src/server/helpers/social-listening-params.helper.ts
@@ -2,12 +2,12 @@
 // SPDX-License-Identifier: MIT
 
 import {
+  MENTION_FILTER_MAX_VALUES,
   MENTION_HAS_TITLE_OPTIONS,
+  MENTION_IDS_MAX_VALUES,
   MENTION_RELEVANCE_OPTIONS,
   MENTION_SENTIMENT_OPTIONS,
-  SOCIAL_LISTENING_MAX_FILTER_VALUES,
-  SOCIAL_LISTENING_MAX_MENTION_IDS,
-  SOCIAL_LISTENING_SERVER_PAGE_SIZE,
+  MENTION_SERVER_WINDOW_SIZE,
 } from '@lfx-one/shared/constants';
 import { getDefaultMarketingImpactPeriod, resolvePeriodRange } from '@lfx-one/shared/utils';
 import { Request } from 'express';
@@ -15,7 +15,7 @@ import { Request } from 'express';
 import { ServiceValidationError } from '../errors';
 import { getStringQueryParam, getValidatedPeriod } from './validation.helper';
 
-import type { ResolvedPeriodRange, SocialListeningFilterParams, SocialListeningScopeParams } from '@lfx-one/shared/interfaces';
+import type { ResolvedPeriodRange, SocialListeningFilterParams, SocialListeningScopedOptionsParams } from '@lfx-one/shared/interfaces';
 
 /**
  * Query-parameter parsing for the Social Listening endpoints. Every value is validated, normalized,
@@ -23,8 +23,9 @@ import type { ResolvedPeriodRange, SocialListeningFilterParams, SocialListeningS
  * service's own caps are defense in depth, not the first line.
  *
  * These helpers do NOT log; the centralized `apiErrorHandler` logs every `ServiceValidationError`
- * at WARN. The wire keys are the snake_case `MentionFilters` keys the client builds with
- * `buildMentionFilters()`, not the camelCase router params the page uses in the browser URL.
+ * at WARN. The wire keys are the camelCase `MentionFilters` field names the client builds with
+ * `buildMentionFilters()`, with array values comma-joined (the 3016 service codec's `join(',')`) —
+ * not the snake_case router params the page uses in the browser URL.
  */
 
 /** Foundation slugs are lowercase alphanumeric + hyphens, matching every other foundation-scoped endpoint. */
@@ -39,7 +40,7 @@ const FILTER_VALUE_MAX_LENGTH = 200;
 const SEARCH_MAX_LENGTH = 500;
 
 /** A page can never exceed the server window the client is built around. */
-const MAX_FEED_LIMIT = SOCIAL_LISTENING_SERVER_PAGE_SIZE;
+const MAX_FEED_LIMIT = MENTION_SERVER_WINDOW_SIZE;
 
 /** ~1000 windows deep. Past this, a paginated request is a scan, not navigation. */
 const MAX_FEED_OFFSET = 100_000;
@@ -75,14 +76,14 @@ export function parseFoundationSlug(req: Request, operation: string): string {
  * Foundation + half-open `[startDate, endDate)` window + the two selects that scope the whole page.
  * A missing `period` resolves to the same default the client starts on, so a bare request is valid.
  */
-export function parseSocialListeningScope(req: Request, operation: string): SocialListeningScopeParams {
+export function parseSocialListeningScope(req: Request, operation: string): SocialListeningScopedOptionsParams {
   const period = getValidatedPeriod(req, operation) ?? defaultPeriodRange(operation);
 
   return {
     foundationSlug: parseFoundationSlug(req, operation),
     startDate: period.startDate,
     endDate: period.endDate,
-    sourceProjectId: parseTextParam(req, 'source_project_id', FILTER_VALUE_MAX_LENGTH, operation),
+    sourceProjectId: parseTextParam(req, 'sourceProjectId', FILTER_VALUE_MAX_LENGTH, operation),
     platform: parseTextParam(req, 'platform', FILTER_VALUE_MAX_LENGTH, operation),
   };
 }
@@ -91,8 +92,8 @@ export function parseSocialListeningScope(req: Request, operation: string): Soci
 export function parseSocialListeningFilters(req: Request, operation: string): SocialListeningFilterParams {
   return {
     ...parseSocialListeningAuthorFilters(req, operation),
-    authors: parseArrayParam(req, 'authors', SOCIAL_LISTENING_MAX_FILTER_VALUES, operation),
-    mentionIds: parseArrayParam(req, 'mention_ids', SOCIAL_LISTENING_MAX_MENTION_IDS, operation),
+    authors: parseArrayParam(req, 'authors', MENTION_FILTER_MAX_VALUES, operation),
+    mentionIds: parseArrayParam(req, 'mentionIds', MENTION_IDS_MAX_VALUES, operation),
   };
 }
 
@@ -104,11 +105,11 @@ export function parseSocialListeningAuthorFilters(req: Request, operation: strin
   return {
     sentiment: parseEnumParam(req, 'sentiment', VALID_SENTIMENTS, operation),
     relevance: parseEnumParam(req, 'relevance', VALID_RELEVANCES, operation),
-    hasTitle: parseEnumParam(req, 'has_title', VALID_HAS_TITLE, operation),
+    hasTitle: parseEnumParam(req, 'hasTitle', VALID_HAS_TITLE, operation),
     language: parseTextParam(req, 'language', FILTER_VALUE_MAX_LENGTH, operation),
     search: parseTextParam(req, 'search', SEARCH_MAX_LENGTH, operation),
-    keywords: parseArrayParam(req, 'keywords', SOCIAL_LISTENING_MAX_FILTER_VALUES, operation),
-    tags: parseArrayParam(req, 'tags', SOCIAL_LISTENING_MAX_FILTER_VALUES, operation),
+    keywords: parseArrayParam(req, 'keywords', MENTION_FILTER_MAX_VALUES, operation),
+    tags: parseArrayParam(req, 'tags', MENTION_FILTER_MAX_VALUES, operation),
   };
 }
 
@@ -180,9 +181,10 @@ function parseTextParam(req: Request, name: string, maxLength: number, operation
 }
 
 /**
- * Repeated query keys (`tags=a&tags=b`) as a bounded string array. An over-long list is rejected
+ * Comma-joined array params (`tags=a,b,c` — the client codec's `join(',')`) as a bounded string
+ * array. Repeated keys are tolerated by splitting each element too. An over-long list is rejected
  * rather than truncated — silently dropping filter values would return results the caller didn't ask
- * for. A present-but-empty list is preserved as `[]`, which `mention_ids` reads as "nothing selected".
+ * for. A present-but-empty value is preserved as `[]`, which `mentionIds` reads as "nothing selected".
  */
 function parseArrayParam(req: Request, name: string, cap: number, operation: string): string[] | undefined {
   const raw = req.query[name];
@@ -193,6 +195,7 @@ function parseArrayParam(req: Request, name: string, cap: number, operation: str
 
   const values = (Array.isArray(raw) ? raw : [raw])
     .filter((value): value is string => typeof value === 'string')
+    .flatMap((value) => value.split(','))
     .map((value) => value.trim())
     .filter(Boolean);
 

--- a/apps/lfx-one/src/server/helpers/social-listening-params.helper.ts
+++ b/apps/lfx-one/src/server/helpers/social-listening-params.helper.ts
@@ -45,7 +45,7 @@ const MAX_FEED_LIMIT = MENTION_SERVER_WINDOW_SIZE;
 /** ~1000 windows deep. Past this, a paginated request is a scan, not navigation. */
 const MAX_FEED_OFFSET = 100_000;
 
-/** Ceiling for the caller-supplied `limit` on the ranked analytics panels (top tags, top projects). */
+/** Ceiling for the caller-supplied `limit` on the analytics top-projects panel. */
 const MAX_ANALYTICS_LIMIT = 100;
 
 const VALID_SENTIMENTS = MENTION_SENTIMENT_OPTIONS.map((option) => option.value);
@@ -121,7 +121,7 @@ export function parseSocialListeningPagination(req: Request, operation: string):
   };
 }
 
-/** Optional row cap for a ranked analytics panel; `undefined` lets the service apply its own default. */
+/** Optional row cap for the analytics top-projects panel; `undefined` lets the service apply its own default. */
 export function parseSocialListeningLimit(req: Request, operation: string): number | undefined {
   if (getStringQueryParam(req, 'limit') === undefined) {
     return undefined;

--- a/apps/lfx-one/src/server/routes/social-listening.route.ts
+++ b/apps/lfx-one/src/server/routes/social-listening.route.ts
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Router } from 'express';
+
+import { SocialListeningController } from '../controllers/social-listening.controller';
+import { requireExecutiveDirector } from '../middleware/require-executive-director.middleware';
+
+const router = Router();
+
+const socialListeningController = new SocialListeningController();
+
+/**
+ * Social Listening is an ED-only surface (LFXV2-3002). The gate is applied to the whole router so
+ * every current and future endpoint is covered — the client-side `executiveDirectorGuard` is a
+ * routing concern, not an authorization boundary. Rate limiting comes from the app-wide
+ * `apiRateLimiter` mounted on `/api/` in `server.ts`; these are read-only Snowflake queries behind a
+ * 30-minute cache, so they don't warrant a tighter bucket than the shared 500/minute.
+ */
+router.use(requireExecutiveDirector);
+
+// Mentions feed + total
+router.get('/mentions-feed', (req, res, next) => socialListeningController.getMentionsFeed(req, res, next));
+router.get('/mentions-count', (req, res, next) => socialListeningController.getMentionsCount(req, res, next));
+
+// Filter + scope options
+router.get('/mentions-projects', (req, res, next) => socialListeningController.getMentionsProjects(req, res, next));
+router.get('/mentions-platforms', (req, res, next) => socialListeningController.getMentionsPlatforms(req, res, next));
+router.get('/mentions-languages', (req, res, next) => socialListeningController.getMentionsLanguages(req, res, next));
+router.get('/mentions-keywords', (req, res, next) => socialListeningController.getMentionsKeywords(req, res, next));
+router.get('/mentions-tags', (req, res, next) => socialListeningController.getMentionsTags(req, res, next));
+router.get('/mentions-authors', (req, res, next) => socialListeningController.getMentionsAuthors(req, res, next));
+
+// Analytics tab (feed-derived — see social-listening.service.ts)
+router.get('/analytics-overview', (req, res, next) => socialListeningController.getAnalyticsOverview(req, res, next));
+router.get('/analytics-over-time', (req, res, next) => socialListeningController.getAnalyticsOverTime(req, res, next));
+router.get('/analytics-platform-distribution', (req, res, next) => socialListeningController.getAnalyticsPlatformDistribution(req, res, next));
+router.get('/analytics-sentiment-distribution', (req, res, next) => socialListeningController.getAnalyticsSentimentDistribution(req, res, next));
+router.get('/analytics-top-projects', (req, res, next) => socialListeningController.getAnalyticsTopProjects(req, res, next));
+
+export default router;

--- a/apps/lfx-one/src/server/server.ts
+++ b/apps/lfx-one/src/server/server.ts
@@ -52,6 +52,7 @@ import publicProjectsRouter from './routes/public-projects.route';
 import rewardsRouter from './routes/rewards.route';
 import searchRouter from './routes/search.route';
 import sitemapRouter from './routes/sitemap.route';
+import socialListeningRouter from './routes/social-listening.route';
 import surveysRouter from './routes/surveys.route';
 import trainingRouter from './routes/training.route';
 import enrollmentRouter from './routes/enrollment.route';
@@ -325,6 +326,8 @@ app.use('/api/past-meetings', pastMeetingsRouter);
 app.use('/api/profile', profileRouter);
 app.use('/api/search', searchRouter);
 app.use('/api/analytics', analyticsRouter);
+// ED-only Foundation Lens surface — the router applies requireExecutiveDirector to every endpoint.
+app.use('/api/social-listening', socialListeningRouter);
 app.use('/api/user', userRouter);
 app.use('/api/user', personaRouter);
 app.use('/api/nav', navigationRouter);

--- a/apps/lfx-one/src/server/services/social-listening.service.spec.ts
+++ b/apps/lfx-one/src/server/services/social-listening.service.spec.ts
@@ -1,0 +1,395 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Request } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors org-lens-meetings.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this
+// app's vitest config, so every runtime (non-type-only) import needs a stub. Values mirror
+// `social-listening.constants.ts` / `valkey-cache.constants.ts`.
+vi.mock('@lfx-one/shared/constants', () => ({
+  SOCIAL_LISTENING_MAX_FILTER_VALUES: 200,
+  SOCIAL_LISTENING_MAX_MENTION_IDS: 500,
+  SOCIAL_LISTENING_TOP_TAGS_LIMIT: 20,
+  VALKEY_CACHE: { SOCIAL_LISTENING_TTL_SECONDS: 1800 },
+  // Unrelated to Social Listening, but `validation.helper` — the real module, since
+  // `escapeSqlLikePattern` is under test through the service — derives these at module scope.
+  AKRITES_STEWARD_ROLE_OPTIONS: [],
+  AKRITES_ESCALATION_PATHS: [],
+  AKRITES_INACTIVE_REASON_OPTIONS: [],
+}));
+
+// Also imported by `validation.helper` at module scope; nothing on this path calls into it.
+vi.mock('@lfx-one/shared/utils', () => ({ resolvePeriodRange: vi.fn() }));
+
+const { execute, withSocialListeningCache } = vi.hoisted(() => ({
+  execute: vi.fn(),
+  withSocialListeningCache: vi.fn(),
+}));
+
+vi.mock('./logger.service', () => ({ logger: { debug: vi.fn(), warning: vi.fn(), error: vi.fn() } }));
+vi.mock('./snowflake.service', () => ({ SnowflakeService: { getInstance: () => ({ execute }) } }));
+vi.mock('./valkey.service', () => ({ withSocialListeningCache }));
+
+const { SocialListeningService } = await import('./social-listening.service');
+
+const req = {} as Request;
+
+/** A month-aligned, half-open window — `endDate` is exclusive, as `resolvePeriodRange()` returns it. */
+const SCOPE = { foundationSlug: 'cncf', startDate: '2026-03-01', endDate: '2026-04-01' };
+
+const FEED_PARAMS = { ...SCOPE, limit: 100, offset: 0 };
+
+/** The SQL + binds the service handed to Snowflake, which is the whole contract under test. */
+function lastQuery(): { sql: string; binds: (string | number)[] } {
+  const [sql, binds] = execute.mock.calls.at(-1) as [string, (string | number)[]];
+  return { sql, binds };
+}
+
+/** Only the filter fragment's own binds — the shared scope always contributes the first three. */
+function filterBinds(): (string | number)[] {
+  return lastQuery().binds.slice(3);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  execute.mockResolvedValue({ rows: [] });
+  // Run the read-through factory directly so the query under test is what actually executes.
+  withSocialListeningCache.mockImplementation(
+    async (_slug: string, _resource: string, _discriminator: unknown, _ttl: number, fetcher: () => Promise<unknown>) => fetcher()
+  );
+});
+
+describe('SocialListeningService — scope predicate', () => {
+  it('scopes on the foundation slug and a half-open MENTION_TS window', async () => {
+    await new SocialListeningService().getMentionsFeed(req, FEED_PARAMS);
+
+    const { sql, binds } = lastQuery();
+    expect(sql).toContain('PROJECT_SLUG = ?');
+    expect(sql).toContain('MENTION_TS >= TO_DATE(?)');
+    expect(sql).toContain('MENTION_TS < TO_DATE(?)');
+    expect(binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 100, 0]);
+  });
+
+  it('drops the BOOKMARKED column and every fixed-range flag from the feed projection', async () => {
+    await new SocialListeningService().getMentionsFeed(req, FEED_PARAMS);
+
+    const { sql } = lastQuery();
+    expect(sql).toContain('BOOKMARKED');
+    expect(sql).toMatch(/EXCLUDE \([^)]*BOOKMARKED[^)]*IS_YTD[^)]*\)/);
+    expect(sql).toContain('RENAME _KEY AS MENTION_ID');
+  });
+
+  it.each([
+    { label: 'a sub-project id', params: { sourceProjectId: 'proj-1' }, clause: 'SOURCE_PROJECT_ID = ?', bind: 'proj-1' },
+    { label: 'a platform, lowercased', params: { platform: 'Twitter' }, clause: 'LOWER(SOURCE_PLATFORM) = ?', bind: 'twitter' },
+  ])('adds a predicate for $label', async ({ params, clause, bind }) => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, ...params });
+
+    expect(lastQuery().sql).toContain(clause);
+    expect(filterBinds()).toEqual([bind, 100, 0]);
+  });
+
+  it.each(['all', ''])('treats a "%s" scope select as no predicate', async (value) => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, sourceProjectId: value, platform: value });
+
+    const { sql } = lastQuery();
+    expect(sql).not.toContain('SOURCE_PROJECT_ID = ?');
+    expect(sql).not.toContain('LOWER(SOURCE_PLATFORM) = ?');
+  });
+});
+
+describe('SocialListeningService — filter predicates', () => {
+  it.each([
+    { field: 'sentiment', value: 'Positive', clause: 'LOWER(SENTIMENT) = ?', bind: 'positive' },
+    { field: 'relevance', value: 'High', clause: 'LOWER(RELEVANCE_SCORE) = ?', bind: 'high' },
+    { field: 'language', value: 'EN', clause: 'LOWER(LANGUAGE) = ?', bind: 'en' },
+  ])('binds $field lowercased', async ({ field, value, clause, bind }) => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, [field]: value });
+
+    expect(lastQuery().sql).toContain(clause);
+    expect(filterBinds()).toEqual([bind, 100, 0]);
+  });
+
+  it.each([
+    { hasTitle: 'yes', clause: "TITLE IS NOT NULL AND TITLE != ''" },
+    { hasTitle: 'no', clause: "(TITLE IS NULL OR TITLE = '')" },
+  ])('renders has-title=$hasTitle as a literal predicate with no bind', async ({ hasTitle, clause }) => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, hasTitle });
+
+    expect(lastQuery().sql).toContain(clause);
+    expect(filterBinds()).toEqual([100, 0]);
+  });
+
+  it('binds keywords as a lowercased IN list', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, keywords: ['Kubernetes', 'Argo'] });
+
+    expect(lastQuery().sql).toContain('LOWER(KEYWORD) IN (?, ?)');
+    expect(filterBinds()).toEqual(['kubernetes', 'argo', 100, 0]);
+  });
+
+  it('ANDs one escaped substring match per selected tag', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, tags: ['Release', '100%_win'] });
+
+    const { sql } = lastQuery();
+    expect(sql.match(/LOWER\(TAGS\) LIKE \? ESCAPE '!'/g)).toHaveLength(2);
+    // The user's own `%` and `_` are escaped so they match literally rather than as wildcards.
+    expect(filterBinds()).toEqual(['%release%', '%100!%!_win%', 100, 0]);
+  });
+
+  it('binds authors verbatim — handles are case-sensitive upstream', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, authors: ['@LinuxFoundation'] });
+
+    expect(lastQuery().sql).toContain('AUTHOR IN (?)');
+    expect(filterBinds()).toEqual(['@LinuxFoundation', 100, 0]);
+  });
+
+  it('searches title and body with the same escaped pattern', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, search: '50%_off' });
+
+    expect(lastQuery().sql).toContain("(TITLE ILIKE ? ESCAPE '!' OR BODY ILIKE ? ESCAPE '!')");
+    expect(filterBinds()).toEqual(['%50!%!_off%', '%50!%!_off%', 100, 0]);
+  });
+
+  it('trims filter values and drops blanks', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, keywords: ['  argo  ', '', '   '] });
+
+    expect(lastQuery().sql).toContain('LOWER(KEYWORD) IN (?)');
+    expect(filterBinds()).toEqual(['argo', 100, 0]);
+  });
+
+  it('omits a filter entirely when its value list is empty', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, keywords: [], tags: [], authors: [] });
+
+    const { sql } = lastQuery();
+    expect(sql).not.toContain('LOWER(KEYWORD) IN');
+    expect(sql).not.toContain('LOWER(TAGS) LIKE');
+    expect(sql).not.toContain('AUTHOR IN');
+  });
+});
+
+describe('SocialListeningService — mention id selection', () => {
+  it('binds an explicit id selection', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, mentionIds: ['a', 'b'] });
+
+    expect(lastQuery().sql).toContain('_KEY IN (?, ?)');
+    expect(filterBinds()).toEqual(['a', 'b', 100, 0]);
+  });
+
+  it('matches nothing when the id list is present but empty — "nothing selected", not "no filter"', async () => {
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, mentionIds: [] });
+
+    const { sql } = lastQuery();
+    expect(sql).toContain('1 = 0');
+    expect(sql).not.toContain('_KEY IN');
+    expect(filterBinds()).toEqual([100, 0]);
+  });
+
+  it('applies no id predicate at all when the list is absent', async () => {
+    await new SocialListeningService().getMentionsFeed(req, FEED_PARAMS);
+
+    const { sql } = lastQuery();
+    expect(sql).not.toContain('1 = 0');
+    expect(sql).not.toContain('_KEY IN');
+  });
+});
+
+describe('SocialListeningService — filter caps', () => {
+  it.each([
+    { field: 'keywords', cap: 200, requested: 250, clause: 'LOWER(KEYWORD) IN' },
+    { field: 'authors', cap: 200, requested: 250, clause: 'AUTHOR IN' },
+    { field: 'mentionIds', cap: 500, requested: 600, clause: '_KEY IN' },
+  ])('caps $field at $cap values', async ({ field, cap, requested, clause }) => {
+    const values = Array.from({ length: requested }, (_, index) => `v${index}`);
+
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, [field]: values });
+
+    const { sql } = lastQuery();
+    expect(sql).toContain(clause);
+    expect(sql.match(/\?/g)?.length).toBeGreaterThanOrEqual(cap);
+    // Scope (3) + the capped list + limit/offset (2).
+    expect(lastQuery().binds).toHaveLength(3 + cap + 2);
+  });
+
+  it('caps tags at 200 individual LIKE predicates', async () => {
+    const tags = Array.from({ length: 250 }, (_, index) => `t${index}`);
+
+    await new SocialListeningService().getMentionsFeed(req, { ...FEED_PARAMS, tags });
+
+    expect(lastQuery().sql.match(/LOWER\(TAGS\) LIKE \? ESCAPE '!'/g)).toHaveLength(200);
+  });
+});
+
+describe('SocialListeningService — feed and count responses', () => {
+  it('surfaces the dbt rebuild timestamp from the first row', async () => {
+    execute.mockResolvedValue({ rows: [{ COMPUTED_AT: '2026-03-31T10:00:00Z' }, { COMPUTED_AT: '2026-03-31T10:00:00Z' }] });
+
+    const response = await new SocialListeningService().getMentionsFeed(req, FEED_PARAMS);
+
+    expect(response.mentions).toHaveLength(2);
+    expect(response.computedAt).toBe('2026-03-31T10:00:00Z');
+  });
+
+  it('returns a null timestamp and an empty page when the window holds no mentions', async () => {
+    execute.mockResolvedValue({ rows: undefined });
+
+    const response = await new SocialListeningService().getMentionsFeed(req, FEED_PARAMS);
+
+    expect(response).toEqual({ mentions: [], computedAt: null });
+  });
+
+  it.each([
+    { rows: [{ TOTAL: 42 }], expected: 42 },
+    // Snowflake can hand back a numeric as a string.
+    { rows: [{ TOTAL: '42' }], expected: 42 },
+    { rows: [], expected: 0 },
+  ])('coerces the count to $expected', async ({ rows, expected }) => {
+    execute.mockResolvedValue({ rows });
+
+    await expect(new SocialListeningService().getMentionsCount(req, SCOPE)).resolves.toBe(expected);
+  });
+
+  it('counts against the same scope and filters as the feed', async () => {
+    await new SocialListeningService().getMentionsCount(req, { ...SCOPE, sentiment: 'negative' });
+
+    const { sql, binds } = lastQuery();
+    expect(sql).toContain('SELECT COUNT(*) AS TOTAL');
+    expect(sql).toContain('LOWER(SENTIMENT) = ?');
+    expect(binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 'negative']);
+  });
+});
+
+describe('SocialListeningService — tag aggregation', () => {
+  it('qualifies the scope with the join alias and groups by the expression, not the alias', async () => {
+    await new SocialListeningService().getMentionsTags(req, SCOPE);
+
+    const { sql, binds } = lastQuery();
+    expect(sql).toContain('m.PROJECT_SLUG = ?');
+    expect(sql).toContain('m.MENTION_TS >= TO_DATE(?)');
+    expect(sql).toContain("LATERAL FLATTEN(input => SPLIT(m.TAGS, ','))");
+    // Grouping by the `TAG` alias would silently group by a real column of that name.
+    expect(sql).toContain('GROUP BY TRIM(f.VALUE::STRING)');
+    expect(binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 20]);
+  });
+
+  it('honors a caller-supplied row cap', async () => {
+    await new SocialListeningService().getMentionsTags(req, { ...SCOPE, limit: 5 });
+
+    expect(lastQuery().binds.at(-1)).toBe(5);
+  });
+});
+
+describe('SocialListeningService — author options', () => {
+  it('cascades off the active filters and caps the option list', async () => {
+    await new SocialListeningService().getMentionsAuthors(req, { ...SCOPE, sentiment: 'positive' });
+
+    const { sql, binds } = lastQuery();
+    expect(sql).toContain('WHERE PLATFORM_RANK = 1');
+    expect(sql).toContain('LOWER(SENTIMENT) = ?');
+    expect(binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 'positive', 200]);
+  });
+});
+
+describe('SocialListeningService — analytics windows', () => {
+  it.each([
+    // Month-aligned windows shift back by whole months so February compares against all of January.
+    { label: 'a single calendar month', startDate: '2026-03-01', endDate: '2026-04-01', prevStart: '2026-02-01' },
+    { label: 'a trailing 3-month window', startDate: '2026-01-01', endDate: '2026-04-01', prevStart: '2025-10-01' },
+    { label: 'a 7-month YTD window', startDate: '2026-01-01', endDate: '2026-08-01', prevStart: '2025-06-01' },
+    // A window that isn't month-aligned falls back to an equal-length day shift.
+    { label: 'a 10-day window', startDate: '2026-03-10', endDate: '2026-03-20', prevStart: '2026-02-28' },
+  ])('compares $label against the window immediately before it', async ({ startDate, endDate, prevStart }) => {
+    await new SocialListeningService().getAnalyticsOverview(req, { ...SCOPE, startDate, endDate });
+
+    const { binds } = lastQuery();
+    // The base CTE spans previous-start → current-end so both windows are read in one pass.
+    expect(binds.slice(0, 3)).toEqual(['cncf', prevStart, endDate]);
+    expect(binds.slice(-4)).toEqual([startDate, endDate, prevStart, startDate]);
+  });
+
+  it('serves a zeroed overview when the query returns no rows', async () => {
+    execute.mockResolvedValue({ rows: [] });
+
+    const overview = await new SocialListeningService().getAnalyticsOverview(req, SCOPE);
+
+    expect(overview).toEqual({
+      TOTAL_MENTIONS: 0,
+      TOTAL_MENTIONS_CHANGE_PCT: null,
+      CHILD_PROJECTS_COUNT: 0,
+      POSITIVE_SENTIMENT_PERCENT: 0,
+      NEGATIVE_SENTIMENT_PERCENT: 0,
+      POSITIVE_SENTIMENT_CHANGE_PP: null,
+      NEGATIVE_SENTIMENT_CHANGE_PP: null,
+    });
+  });
+
+  it.each([
+    { label: 'a single month', startDate: '2026-03-01', endDate: '2026-04-01', unit: 'DAY', labelFormat: 'MON DD' },
+    { label: 'exactly the 62-day threshold', startDate: '2026-01-01', endDate: '2026-03-04', unit: 'DAY', labelFormat: 'MON DD' },
+    { label: 'one day past the threshold', startDate: '2026-01-01', endDate: '2026-03-05', unit: 'MONTH', labelFormat: 'MON YYYY' },
+    { label: 'a YTD window', startDate: '2026-01-01', endDate: '2026-08-01', unit: 'MONTH', labelFormat: 'MON YYYY' },
+  ])('buckets $label by $unit', async ({ startDate, endDate, unit, labelFormat }) => {
+    await new SocialListeningService().getAnalyticsOverTime(req, { ...SCOPE, startDate, endDate });
+
+    const { sql } = lastQuery();
+    expect(sql).toContain(`DATE_TRUNC('${unit}', MENTION_TS)`);
+    expect(sql).toContain(`'${labelFormat}'`);
+    // Grouping by the expression, not the `PERIOD_START` alias.
+    expect(sql).toContain(`GROUP BY DATE_TRUNC('${unit}', MENTION_TS)`);
+  });
+
+  it('defaults the top-projects row cap and binds it last', async () => {
+    await new SocialListeningService().getAnalyticsTopProjects(req, SCOPE);
+
+    expect(lastQuery().binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 10]);
+  });
+});
+
+describe('SocialListeningService — caching', () => {
+  it.each([
+    { method: 'getMentionsProjects', resource: 'projects' },
+    { method: 'getMentionsPlatforms', resource: 'platforms' },
+    { method: 'getMentionsLanguages', resource: 'languages' },
+    { method: 'getMentionsKeywords', resource: 'keywords' },
+    { method: 'getMentionsTags', resource: 'tags' },
+    { method: 'getAnalyticsOverview', resource: 'analytics-overview' },
+    { method: 'getAnalyticsPlatformDistribution', resource: 'analytics-platform-distribution' },
+    { method: 'getAnalyticsSentimentDistribution', resource: 'analytics-sentiment-distribution' },
+    { method: 'getAnalyticsTopProjects', resource: 'analytics-top-projects' },
+  ])('reads $method through the "$resource" cache namespace', async ({ method, resource }) => {
+    const service = new SocialListeningService() as unknown as Record<string, (req: Request, params: unknown) => Promise<unknown>>;
+
+    await service[method](req, SCOPE);
+
+    expect(withSocialListeningCache).toHaveBeenCalledWith('cncf', resource, expect.any(Array), 1800, expect.any(Function));
+  });
+
+  it('discriminates the over-time entry by grain so a day and a month rollup cannot collide', async () => {
+    const service = new SocialListeningService();
+
+    await service.getAnalyticsOverTime(req, SCOPE);
+    await service.getAnalyticsOverTime(req, { ...SCOPE, startDate: '2026-01-01', endDate: '2026-08-01' });
+
+    expect(withSocialListeningCache.mock.calls.map((call) => call[1])).toEqual(['analytics-over-time-DAY', 'analytics-over-time-MONTH']);
+  });
+
+  it('discriminates cache entries by the query binds', async () => {
+    const service = new SocialListeningService();
+
+    await service.getMentionsLanguages(req, SCOPE);
+    await service.getMentionsLanguages(req, { ...SCOPE, platform: 'reddit' });
+
+    const [first, second] = withSocialListeningCache.mock.calls.map((call) => call[2]);
+    expect(first).not.toEqual(second);
+  });
+
+  it('never caches the feed or the count — their filter cardinality makes the hit rate near zero', async () => {
+    const service = new SocialListeningService();
+
+    await service.getMentionsFeed(req, FEED_PARAMS);
+    await service.getMentionsCount(req, SCOPE);
+    await service.getMentionsAuthors(req, SCOPE);
+
+    expect(withSocialListeningCache).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/server/services/social-listening.service.spec.ts
+++ b/apps/lfx-one/src/server/services/social-listening.service.spec.ts
@@ -8,9 +8,9 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // app's vitest config, so every runtime (non-type-only) import needs a stub. Values mirror
 // `social-listening.constants.ts` / `valkey-cache.constants.ts`.
 vi.mock('@lfx-one/shared/constants', () => ({
-  SOCIAL_LISTENING_MAX_FILTER_VALUES: 200,
-  SOCIAL_LISTENING_MAX_MENTION_IDS: 500,
-  SOCIAL_LISTENING_TOP_TAGS_LIMIT: 20,
+  MENTION_FILTER_MAX_VALUES: 200,
+  MENTION_IDS_MAX_VALUES: 500,
+  MENTION_TOP_TAGS_LIMIT: 20,
   VALKEY_CACHE: { SOCIAL_LISTENING_TTL_SECONDS: 1800 },
   // Unrelated to Social Listening, but `validation.helper` — the real module, since
   // `escapeSqlLikePattern` is under test through the service — derives these at module scope.
@@ -271,12 +271,6 @@ describe('SocialListeningService — tag aggregation', () => {
     expect(sql).toContain('GROUP BY TRIM(f.VALUE::STRING)');
     expect(binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 20]);
   });
-
-  it('honors a caller-supplied row cap', async () => {
-    await new SocialListeningService().getMentionsTags(req, { ...SCOPE, limit: 5 });
-
-    expect(lastQuery().binds.at(-1)).toBe(5);
-  });
 });
 
 describe('SocialListeningService — author options', () => {
@@ -318,8 +312,8 @@ describe('SocialListeningService — analytics windows', () => {
       CHILD_PROJECTS_COUNT: 0,
       POSITIVE_SENTIMENT_PERCENT: 0,
       NEGATIVE_SENTIMENT_PERCENT: 0,
-      POSITIVE_SENTIMENT_CHANGE_PP: null,
-      NEGATIVE_SENTIMENT_CHANGE_PP: null,
+      POSITIVE_SENTIMENT_CHANGE_PCT: null,
+      NEGATIVE_SENTIMENT_CHANGE_PCT: null,
     });
   });
 
@@ -341,7 +335,7 @@ describe('SocialListeningService — analytics windows', () => {
   it('defaults the top-projects row cap and binds it last', async () => {
     await new SocialListeningService().getAnalyticsTopProjects(req, SCOPE);
 
-    expect(lastQuery().binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 10]);
+    expect(lastQuery().binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 5]);
   });
 });
 

--- a/apps/lfx-one/src/server/services/social-listening.service.spec.ts
+++ b/apps/lfx-one/src/server/services/social-listening.service.spec.ts
@@ -10,7 +10,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 vi.mock('@lfx-one/shared/constants', () => ({
   MENTION_FILTER_MAX_VALUES: 200,
   MENTION_IDS_MAX_VALUES: 500,
-  MENTION_TOP_TAGS_LIMIT: 20,
+  MENTION_TOP_TAGS_LIMIT: 10,
   VALKEY_CACHE: { SOCIAL_LISTENING_TTL_SECONDS: 1800 },
   // Unrelated to Social Listening, but `validation.helper` — the real module, since
   // `escapeSqlLikePattern` is under test through the service — derives these at module scope.
@@ -269,7 +269,7 @@ describe('SocialListeningService — tag aggregation', () => {
     expect(sql).toContain("LATERAL FLATTEN(input => SPLIT(m.TAGS, ','))");
     // Grouping by the `TAG` alias would silently group by a real column of that name.
     expect(sql).toContain('GROUP BY TRIM(f.VALUE::STRING)');
-    expect(binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 20]);
+    expect(binds).toEqual(['cncf', '2026-03-01', '2026-04-01', 10]);
   });
 });
 

--- a/apps/lfx-one/src/server/services/social-listening.service.ts
+++ b/apps/lfx-one/src/server/services/social-listening.service.ts
@@ -1,0 +1,641 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { SOCIAL_LISTENING_MAX_FILTER_VALUES, SOCIAL_LISTENING_MAX_MENTION_IDS, SOCIAL_LISTENING_TOP_TAGS_LIMIT, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import {
+  SocialListeningAnalyticsOverTimePoint,
+  SocialListeningAnalyticsOverview,
+  SocialListeningAnalyticsParams,
+  SocialListeningAnalyticsPlatformDistribution,
+  SocialListeningAnalyticsSentimentDistribution,
+  SocialListeningAnalyticsTopProject,
+  SocialListeningAuthorsParams,
+  SocialListeningCountParams,
+  SocialListeningFeedParams,
+  SocialListeningFeedResponse,
+  SocialListeningFilterParams,
+  SocialListeningKeywordsParams,
+  SocialListeningLanguagesParams,
+  SocialListeningMention,
+  SocialListeningMentionAuthor,
+  SocialListeningOptionsParams,
+  SocialListeningPlatform,
+  SocialListeningScopeParams,
+  SocialListeningSubProject,
+  SocialListeningTag,
+  SocialListeningTagsParams,
+} from '@lfx-one/shared/interfaces';
+import { Request } from 'express';
+
+import { escapeSqlLikePattern } from '../helpers/validation.helper';
+import { logger } from './logger.service';
+import { SnowflakeService } from './snowflake.service';
+import { withSocialListeningCache } from './valkey.service';
+
+/**
+ * Octolens-sourced mentions, materialized hourly by the `platinum_social_listening_feed` dbt model
+ * (`lf-dbt`). Scoped on `PROJECT_SLUG` — the foundation slug this app already carries everywhere —
+ * rather than the model's `PROJECT_ID`, which is a Salesforce id the frontend never holds.
+ */
+const FEED_TABLE = 'ANALYTICS.PLATINUM.SOCIAL_LISTENING_FEED';
+
+/**
+ * Columns dropped from the feed projection: the upstream source id, the global `BOOKMARKED` flag
+ * (per-user bookmarks are deferred — see LFXV2-3002), and every pre-computed range flag. The flags
+ * only express fixed windows (`IS_30D`, `IS_YTD`, …) and this app filters on an arbitrary
+ * `[startDate, endDate)` resolved from the shared period selector, so they are dead weight on the wire.
+ */
+const FEED_EXCLUDED_COLUMNS = [
+  'SOURCE_ID',
+  'BOOKMARKED',
+  'IS_YTD',
+  'IS_7D',
+  'IS_30D',
+  'IS_QUARTER',
+  'IS_90D',
+  'IS_12M',
+  'IS_ALL_TIME',
+  'IS_LAST_COMPLETED_YEAR',
+  'IS_PREV_COMPLETED_YEAR',
+  'IS_3RD_LAST_COMPLETED_YEAR',
+  'IS_4TH_LAST_COMPLETED_YEAR',
+  'IS_PREV_YTD',
+  'IS_PREV_7D',
+  'IS_PREV_30D',
+  'IS_PREV_90D',
+  'IS_PREV_QUARTER',
+  'IS_PREV_12M',
+].join(', ');
+
+/** Author options are capped so a foundation with a long tail can't build an unbounded response. */
+const AUTHOR_OPTIONS_LIMIT = 200;
+
+/** Distinct sub-projects contributing to a mention volume are the analytics "top projects" table's row cap. */
+const TOP_PROJECTS_LIMIT = 10;
+
+/**
+ * Day-grain buckets stay readable up to roughly two months; anything longer rolls up to months.
+ * A single calendar month or a trailing-30d window therefore charts daily, YTD / last-6 charts monthly.
+ */
+const DAY_GRAIN_MAX_DAYS = 62;
+
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * `LIKE`/`ILIKE` escape character. Must stay in sync with `escapeSqlLikePattern()`, which escapes
+ * `%`, `_`, and `!` itself. `!` rather than `\` so the SQL literal needs no backslash doubling —
+ * Snowflake also processes backslash escapes inside string literals.
+ */
+const LIKE_ESCAPE_CHAR = '!';
+
+/** Only ever `string | number` — every user-supplied value reaches Snowflake as a bind, never as SQL text. */
+type QueryBind = string | number;
+
+interface SqlFragment {
+  clause: string;
+  binds: QueryBind[];
+}
+
+/** Whitelisted `DATE_TRUNC` grain + `TO_CHAR` label format. Never derived from user input. */
+interface TimeGrain {
+  unit: 'DAY' | 'MONTH';
+  labelFormat: string;
+}
+
+const TIME_GRAINS: Record<'day' | 'month', TimeGrain> = {
+  day: { unit: 'DAY', labelFormat: 'MON DD' },
+  month: { unit: 'MONTH', labelFormat: 'MON YYYY' },
+};
+
+/**
+ * Snowflake reads for the Social Listening page (LFXV2-3002). Ported from PCC's
+ * `social-listening-queries.service.ts` with two deliberate departures:
+ *
+ * - Scoping and date filtering are explicit (`PROJECT_SLUG` + a `MENTION_TS` half-open range)
+ *   instead of PCC's fixed `IS_*` boolean range flags, so the shared period selector's arbitrary
+ *   `YYYY-MM` months are expressible.
+ * - Analytics is computed from the feed table rather than the pre-aggregated
+ *   `SOCIAL_LISTENING_MENTIONS_*` views, which only expose the same fixed range suffixes. No dbt
+ *   change is required either way.
+ */
+export class SocialListeningService {
+  private readonly snowflakeService: SnowflakeService;
+
+  public constructor() {
+    this.snowflakeService = SnowflakeService.getInstance();
+  }
+
+  /**
+   * One page of mentions, newest first. `computedAt` is the dbt rebuild timestamp carried on every
+   * row and is surfaced in the UI as "Data as of"; it is null for an empty page.
+   */
+  public async getMentionsFeed(req: Request, params: SocialListeningFeedParams): Promise<SocialListeningFeedResponse> {
+    const scope = this.buildScope(params);
+    const filters = this.buildFilters(params);
+
+    const sql = `
+      SELECT * EXCLUDE (${FEED_EXCLUDED_COLUMNS}) RENAME _KEY AS MENTION_ID
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}${filters.clause}
+      ORDER BY MENTION_TS DESC
+      LIMIT ? OFFSET ?
+    `;
+
+    logger.debug(req, 'social_listening_mentions_feed', 'Querying mentions feed', {
+      foundation_slug: params.foundationSlug,
+      limit: params.limit,
+      offset: params.offset,
+    });
+
+    const result = await this.snowflakeService.execute<SocialListeningMention>(sql, [...scope.binds, ...filters.binds, params.limit, params.offset]);
+    const mentions = result.rows ?? [];
+
+    return { mentions, computedAt: mentions[0]?.COMPUTED_AT ?? null };
+  }
+
+  /** Total rows matching the same scope + filters as the feed, for the paginator. */
+  public async getMentionsCount(req: Request, params: SocialListeningCountParams): Promise<number> {
+    const scope = this.buildScope(params);
+    const filters = this.buildFilters(params);
+
+    const sql = `
+      SELECT COUNT(*) AS TOTAL
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}${filters.clause}
+    `;
+
+    logger.debug(req, 'social_listening_mentions_count', 'Counting mentions', { foundation_slug: params.foundationSlug });
+
+    const result = await this.snowflakeService.execute<{ TOTAL: number }>(sql, [...scope.binds, ...filters.binds]);
+
+    return Number(result.rows?.[0]?.TOTAL ?? 0);
+  }
+
+  /**
+   * Sub-project options. Deliberately unscoped by date: the sub-project select drives the date-scoped
+   * queries, so narrowing it by the current window would make options disappear as the user pages back.
+   */
+  public async getMentionsProjects(req: Request, params: SocialListeningOptionsParams): Promise<SocialListeningSubProject[]> {
+    const sql = `
+      SELECT DISTINCT SOURCE_PROJECT_ID, SOURCE_PROJECT_NAME
+      FROM ${FEED_TABLE}
+      WHERE PROJECT_SLUG = ?
+        AND SOURCE_PROJECT_ID IS NOT NULL
+        AND SOURCE_PROJECT_NAME IS NOT NULL
+      ORDER BY SOURCE_PROJECT_NAME
+    `;
+
+    return this.cached(req, params.foundationSlug, 'projects', [], async () => {
+      const result = await this.snowflakeService.execute<SocialListeningSubProject>(sql, [params.foundationSlug]);
+      return result.rows ?? [];
+    });
+  }
+
+  /** Platform options — also date-unscoped, for the same reason as sub-projects. */
+  public async getMentionsPlatforms(req: Request, params: SocialListeningOptionsParams): Promise<SocialListeningPlatform[]> {
+    const sql = `
+      SELECT DISTINCT SOURCE_PLATFORM, SOCIAL_NETWORK
+      FROM ${FEED_TABLE}
+      WHERE PROJECT_SLUG = ?
+        AND SOURCE_PLATFORM IS NOT NULL
+        AND SOURCE_PLATFORM != ''
+      ORDER BY SOCIAL_NETWORK
+    `;
+
+    return this.cached(req, params.foundationSlug, 'platforms', [], async () => {
+      const result = await this.snowflakeService.execute<SocialListeningPlatform>(sql, [params.foundationSlug]);
+      return result.rows ?? [];
+    });
+  }
+
+  public async getMentionsLanguages(req: Request, params: SocialListeningLanguagesParams): Promise<string[]> {
+    const scope = this.buildScope(params);
+
+    const sql = `
+      SELECT DISTINCT LOWER(LANGUAGE) AS LANGUAGE
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}
+        AND LANGUAGE IS NOT NULL
+        AND LANGUAGE != ''
+      ORDER BY LANGUAGE
+    `;
+
+    return this.cached(req, params.foundationSlug, 'languages', scope.binds, async () => {
+      const result = await this.snowflakeService.execute<{ LANGUAGE: string }>(sql, scope.binds);
+      return (result.rows ?? []).map((row) => row.LANGUAGE);
+    });
+  }
+
+  public async getMentionsKeywords(req: Request, params: SocialListeningKeywordsParams): Promise<string[]> {
+    const scope = this.buildScope(params);
+
+    const sql = `
+      SELECT DISTINCT LOWER(KEYWORD) AS KEYWORD
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}
+        AND KEYWORD IS NOT NULL
+        AND KEYWORD != ''
+      ORDER BY KEYWORD
+    `;
+
+    return this.cached(req, params.foundationSlug, 'keywords', scope.binds, async () => {
+      const result = await this.snowflakeService.execute<{ KEYWORD: string }>(sql, scope.binds);
+      return (result.rows ?? []).map((row) => row.KEYWORD);
+    });
+  }
+
+  /**
+   * Tags with their mention volume, highest first. `TAGS` is a comma-joined string upstream, so it is
+   * exploded with `LATERAL FLATTEN` before grouping. Serves both the tag filter and the analytics
+   * top-tags panel — the filter sorts alphabetically client-side.
+   */
+  public async getMentionsTags(req: Request, params: SocialListeningTagsParams): Promise<SocialListeningTag[]> {
+    const scope = this.buildScope(params, 'm');
+    const limit = params.limit ?? SOCIAL_LISTENING_TOP_TAGS_LIMIT;
+
+    const sql = `
+      SELECT TRIM(f.VALUE::STRING) AS TAG, COUNT(*) AS TOTAL_COUNT
+      FROM ${FEED_TABLE} AS m,
+        LATERAL FLATTEN(input => SPLIT(m.TAGS, ',')) AS f
+      WHERE ${scope.clause}
+        AND m.TAGS IS NOT NULL
+        AND m.TAGS != ''
+        AND TRIM(f.VALUE::STRING) != ''
+      GROUP BY TRIM(f.VALUE::STRING)
+      ORDER BY TOTAL_COUNT DESC, TAG
+      LIMIT ?
+    `;
+
+    const binds: QueryBind[] = [...scope.binds, limit];
+
+    return this.cached(req, params.foundationSlug, 'tags', binds, async () => {
+      const result = await this.snowflakeService.execute<SocialListeningTag>(sql, binds);
+      return result.rows ?? [];
+    });
+  }
+
+  /**
+   * Author options, cascading off every other active filter so the list narrows with the feed.
+   * One row per author — an author posting on several platforms is attributed to their busiest one
+   * (`PLATFORM_RANK = 1`) so the multiselect can show a single platform icon.
+   */
+  public async getMentionsAuthors(req: Request, params: SocialListeningAuthorsParams): Promise<SocialListeningMentionAuthor[]> {
+    const scope = this.buildScope(params);
+    // `authors` and `mentionIds` are absent from this param type by construction — a multiselect
+    // must never filter its own option list.
+    const filters = this.buildFilters(params);
+
+    const sql = `
+      SELECT AUTHOR, PLATFORM, MENTION_COUNT
+      FROM (
+        SELECT AUTHOR,
+               SOURCE_PLATFORM AS PLATFORM,
+               SUM(COUNT(*)) OVER (PARTITION BY AUTHOR) AS MENTION_COUNT,
+               ROW_NUMBER() OVER (PARTITION BY AUTHOR ORDER BY COUNT(*) DESC) AS PLATFORM_RANK
+        FROM ${FEED_TABLE}
+        WHERE ${scope.clause}
+          AND AUTHOR IS NOT NULL
+          AND AUTHOR != ''${filters.clause}
+        GROUP BY AUTHOR, SOURCE_PLATFORM
+      )
+      WHERE PLATFORM_RANK = 1
+      ORDER BY MENTION_COUNT DESC
+      LIMIT ?
+    `;
+
+    logger.debug(req, 'social_listening_mentions_authors', 'Querying author options', { foundation_slug: params.foundationSlug });
+
+    const result = await this.snowflakeService.execute<SocialListeningMentionAuthor>(sql, [...scope.binds, ...filters.binds, AUTHOR_OPTIONS_LIMIT]);
+
+    return result.rows ?? [];
+  }
+
+  /**
+   * Headline KPIs plus change against the immediately preceding, equal-length window.
+   *
+   * A change figure is suppressed (null) when the previous window holds less than 20% of the current
+   * window's volume — carried over from PCC, where it stops a partially-backfilled comparison window
+   * from rendering as a spectacular jump.
+   */
+  public async getAnalyticsOverview(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningAnalyticsOverview> {
+    const previous = this.previousWindow(params.startDate, params.endDate);
+    // The base CTE spans previous-start → current-end so both windows are read in a single pass.
+    const base = this.buildScope({ ...params, startDate: previous.startDate, endDate: params.endDate });
+
+    const sql = `
+      WITH base AS (
+        SELECT SENTIMENT, SOURCE_PROJECT_ID, MENTION_TS
+        FROM ${FEED_TABLE}
+        WHERE ${base.clause}
+      ),
+      current_window AS (
+        SELECT COUNT(*) AS TOTAL,
+               COUNT(DISTINCT SOURCE_PROJECT_ID) AS CHILD_PROJECTS,
+               COUNT_IF(LOWER(SENTIMENT) = 'positive') AS POSITIVE,
+               COUNT_IF(LOWER(SENTIMENT) = 'negative') AS NEGATIVE
+        FROM base
+        WHERE MENTION_TS >= TO_DATE(?) AND MENTION_TS < TO_DATE(?)
+      ),
+      previous_window AS (
+        SELECT COUNT(*) AS TOTAL,
+               COUNT_IF(LOWER(SENTIMENT) = 'positive') AS POSITIVE,
+               COUNT_IF(LOWER(SENTIMENT) = 'negative') AS NEGATIVE
+        FROM base
+        WHERE MENTION_TS >= TO_DATE(?) AND MENTION_TS < TO_DATE(?)
+      )
+      SELECT c.TOTAL AS TOTAL_MENTIONS,
+             c.CHILD_PROJECTS AS CHILD_PROJECTS_COUNT,
+             CASE WHEN c.TOTAL = 0 THEN 0 ELSE ROUND(c.POSITIVE / c.TOTAL::FLOAT * 100, 1) END AS POSITIVE_SENTIMENT_PERCENT,
+             CASE WHEN c.TOTAL = 0 THEN 0 ELSE ROUND(c.NEGATIVE / c.TOTAL::FLOAT * 100, 1) END AS NEGATIVE_SENTIMENT_PERCENT,
+             CASE WHEN p.TOTAL = 0 OR p.TOTAL < c.TOTAL * 0.2 THEN NULL
+                  ELSE ROUND((c.TOTAL - p.TOTAL) / p.TOTAL::FLOAT * 100, 1) END AS TOTAL_MENTIONS_CHANGE_PCT,
+             CASE WHEN c.TOTAL = 0 OR p.TOTAL = 0 OR p.TOTAL < c.TOTAL * 0.2 THEN NULL
+                  ELSE ROUND(c.POSITIVE / c.TOTAL::FLOAT * 100 - p.POSITIVE / p.TOTAL::FLOAT * 100, 1) END AS POSITIVE_SENTIMENT_CHANGE_PP,
+             CASE WHEN c.TOTAL = 0 OR p.TOTAL = 0 OR p.TOTAL < c.TOTAL * 0.2 THEN NULL
+                  ELSE ROUND(c.NEGATIVE / c.TOTAL::FLOAT * 100 - p.NEGATIVE / p.TOTAL::FLOAT * 100, 1) END AS NEGATIVE_SENTIMENT_CHANGE_PP
+      FROM current_window c
+      CROSS JOIN previous_window p
+    `;
+
+    const binds: QueryBind[] = [...base.binds, params.startDate, params.endDate, previous.startDate, previous.endDate];
+
+    return this.cached(req, params.foundationSlug, 'analytics-overview', binds, async () => {
+      const result = await this.snowflakeService.execute<SocialListeningAnalyticsOverview>(sql, binds);
+      const row = result.rows?.[0];
+
+      if (!row) {
+        logger.warning(req, 'social_listening_analytics_overview', 'Overview query returned no rows — serving zeroed overview', {
+          foundation_slug: params.foundationSlug,
+        });
+        return {
+          TOTAL_MENTIONS: 0,
+          TOTAL_MENTIONS_CHANGE_PCT: null,
+          CHILD_PROJECTS_COUNT: 0,
+          POSITIVE_SENTIMENT_PERCENT: 0,
+          NEGATIVE_SENTIMENT_PERCENT: 0,
+          POSITIVE_SENTIMENT_CHANGE_PP: null,
+          NEGATIVE_SENTIMENT_CHANGE_PP: null,
+        };
+      }
+
+      return row;
+    });
+  }
+
+  /** Mention volume bucketed by day (windows up to ~2 months) or month (anything longer). */
+  public async getAnalyticsOverTime(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningAnalyticsOverTimePoint[]> {
+    const scope = this.buildScope(params);
+    const grain = this.resolveGrain(params.startDate, params.endDate);
+
+    const sql = `
+      SELECT TO_CHAR(DATE_TRUNC('${grain.unit}', MENTION_TS), 'YYYY-MM-DD') AS PERIOD_START,
+             TO_CHAR(DATE_TRUNC('${grain.unit}', MENTION_TS), '${grain.labelFormat}') AS PERIOD_LABEL,
+             COUNT(*) AS TOTAL_MENTIONS
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}
+      GROUP BY DATE_TRUNC('${grain.unit}', MENTION_TS)
+      ORDER BY DATE_TRUNC('${grain.unit}', MENTION_TS)
+    `;
+
+    return this.cached(req, params.foundationSlug, `analytics-over-time-${grain.unit}`, scope.binds, async () => {
+      const result = await this.snowflakeService.execute<SocialListeningAnalyticsOverTimePoint>(sql, scope.binds);
+      return result.rows ?? [];
+    });
+  }
+
+  public async getAnalyticsPlatformDistribution(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningAnalyticsPlatformDistribution[]> {
+    const scope = this.buildScope(params);
+
+    const sql = `
+      SELECT SOURCE_PLATFORM,
+             MAX(SOCIAL_NETWORK) AS PLATFORM_DISPLAY_NAME,
+             COUNT(*) AS MENTIONS_COUNT,
+             ROUND(COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0)::FLOAT * 100, 1) AS PERCENT_OF_TOTAL
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}
+        AND SOURCE_PLATFORM IS NOT NULL
+        AND SOURCE_PLATFORM != ''
+      GROUP BY SOURCE_PLATFORM
+      ORDER BY MENTIONS_COUNT DESC
+    `;
+
+    return this.cached(req, params.foundationSlug, 'analytics-platform-distribution', scope.binds, async () => {
+      const result = await this.snowflakeService.execute<SocialListeningAnalyticsPlatformDistribution>(sql, scope.binds);
+      return result.rows ?? [];
+    });
+  }
+
+  /** A null or blank upstream sentiment is bucketed as neutral, matching how the feed renders it. */
+  public async getAnalyticsSentimentDistribution(
+    req: Request,
+    params: SocialListeningAnalyticsParams
+  ): Promise<SocialListeningAnalyticsSentimentDistribution[]> {
+    const scope = this.buildScope(params);
+
+    const sql = `
+      SELECT COALESCE(NULLIF(LOWER(SENTIMENT), ''), 'neutral') AS SENTIMENT,
+             COUNT(*) AS MENTION_COUNT,
+             ROUND(COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0)::FLOAT * 100, 1) AS PERCENT_OF_TOTAL
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}
+      GROUP BY COALESCE(NULLIF(LOWER(SENTIMENT), ''), 'neutral')
+      ORDER BY MENTION_COUNT DESC
+    `;
+
+    return this.cached(req, params.foundationSlug, 'analytics-sentiment-distribution', scope.binds, async () => {
+      const result = await this.snowflakeService.execute<SocialListeningAnalyticsSentimentDistribution>(sql, scope.binds);
+      return result.rows ?? [];
+    });
+  }
+
+  public async getAnalyticsTopProjects(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningAnalyticsTopProject[]> {
+    const scope = this.buildScope(params);
+    const limit = params.limit ?? TOP_PROJECTS_LIMIT;
+
+    const sql = `
+      SELECT SOURCE_PROJECT_NAME, COUNT(*) AS TOTAL_MENTIONS
+      FROM ${FEED_TABLE}
+      WHERE ${scope.clause}
+        AND SOURCE_PROJECT_NAME IS NOT NULL
+        AND SOURCE_PROJECT_NAME != ''
+      GROUP BY SOURCE_PROJECT_NAME
+      ORDER BY TOTAL_MENTIONS DESC
+      LIMIT ?
+    `;
+
+    const binds: QueryBind[] = [...scope.binds, limit];
+
+    return this.cached(req, params.foundationSlug, 'analytics-top-projects', binds, async () => {
+      const result = await this.snowflakeService.execute<SocialListeningAnalyticsTopProject>(sql, binds);
+      return result.rows ?? [];
+    });
+  }
+
+  /**
+   * Foundation + half-open date window, plus the two scope selects that every query shares.
+   * `endDate` is exclusive — `resolvePeriodRange()` returns the first of the following month.
+   *
+   * `alias` prefixes the column references for the one query that joins (`getMentionsTags`).
+   */
+  private buildScope(params: SocialListeningScopeParams & { sourceProjectId?: string; platform?: string }, alias?: string): SqlFragment {
+    const col = (name: string): string => (alias ? `${alias}.${name}` : name);
+    const clauses = [`${col('PROJECT_SLUG')} = ?`, `${col('MENTION_TS')} >= TO_DATE(?)`, `${col('MENTION_TS')} < TO_DATE(?)`];
+    const binds: QueryBind[] = [params.foundationSlug, params.startDate, params.endDate];
+
+    if (params.sourceProjectId && params.sourceProjectId !== 'all') {
+      clauses.push(`${col('SOURCE_PROJECT_ID')} = ?`);
+      binds.push(params.sourceProjectId);
+    }
+
+    if (params.platform && params.platform !== 'all') {
+      clauses.push(`LOWER(${col('SOURCE_PLATFORM')}) = ?`);
+      binds.push(params.platform.toLowerCase());
+    }
+
+    return { clause: clauses.join('\n        AND '), binds };
+  }
+
+  /**
+   * Feed filters, as a fragment appended to an existing `WHERE` (every clause starts with `AND`).
+   * Every user-supplied value is a bind — nothing is interpolated. Array filters are capped so a
+   * crafted query can't build an unbounded `IN` list, and `LIKE`/`ILIKE` patterns escape the user's
+   * own wildcards so a literal `%` matches a `%`.
+   *
+   * `sourceProjectId` and `platform` are intentionally absent: they belong to the shared scope
+   * (`buildScope`) and would otherwise be applied twice.
+   */
+  private buildFilters(filters: SocialListeningFilterParams): SqlFragment {
+    const clauses: string[] = [];
+    const binds: QueryBind[] = [];
+
+    if (filters.sentiment && filters.sentiment !== 'all') {
+      clauses.push('LOWER(SENTIMENT) = ?');
+      binds.push(filters.sentiment.toLowerCase());
+    }
+
+    if (filters.relevance && filters.relevance !== 'all') {
+      clauses.push('LOWER(RELEVANCE_SCORE) = ?');
+      binds.push(filters.relevance.toLowerCase());
+    }
+
+    if (filters.language && filters.language !== 'all') {
+      clauses.push('LOWER(LANGUAGE) = ?');
+      binds.push(filters.language.toLowerCase());
+    }
+
+    if (filters.hasTitle === 'yes') {
+      clauses.push("TITLE IS NOT NULL AND TITLE != ''");
+    } else if (filters.hasTitle === 'no') {
+      clauses.push("(TITLE IS NULL OR TITLE = '')");
+    }
+
+    const keywords = this.capValues(filters.keywords, SOCIAL_LISTENING_MAX_FILTER_VALUES);
+    if (keywords.length > 0) {
+      clauses.push(`LOWER(KEYWORD) IN (${this.placeholders(keywords.length)})`);
+      binds.push(...keywords.map((keyword) => keyword.toLowerCase()));
+    }
+
+    // TAGS is a comma-joined string upstream, so each selected tag is a substring match ANDed
+    // together — a mention must carry all of them.
+    const tags = this.capValues(filters.tags, SOCIAL_LISTENING_MAX_FILTER_VALUES);
+    for (const tag of tags) {
+      clauses.push(`LOWER(TAGS) LIKE ? ESCAPE '${LIKE_ESCAPE_CHAR}'`);
+      binds.push(`%${escapeSqlLikePattern(tag.toLowerCase())}%`);
+    }
+
+    const authors = this.capValues(filters.authors, SOCIAL_LISTENING_MAX_FILTER_VALUES);
+    if (authors.length > 0) {
+      clauses.push(`AUTHOR IN (${this.placeholders(authors.length)})`);
+      binds.push(...authors);
+    }
+
+    if (filters.search) {
+      clauses.push(`(TITLE ILIKE ? ESCAPE '${LIKE_ESCAPE_CHAR}' OR BODY ILIKE ? ESCAPE '${LIKE_ESCAPE_CHAR}')`);
+      const pattern = `%${escapeSqlLikePattern(filters.search)}%`;
+      binds.push(pattern, pattern);
+    }
+
+    if (filters.mentionIds) {
+      const mentionIds = this.capValues(filters.mentionIds, SOCIAL_LISTENING_MAX_MENTION_IDS);
+      if (mentionIds.length > 0) {
+        clauses.push(`_KEY IN (${this.placeholders(mentionIds.length)})`);
+        binds.push(...mentionIds);
+      } else {
+        // An explicitly empty id list means "nothing selected", not "no filter".
+        clauses.push('1 = 0');
+      }
+    }
+
+    return { clause: clauses.map((clause) => `\n        AND ${clause}`).join(''), binds };
+  }
+
+  /**
+   * The contiguous, equal-length window immediately before `[startDate, endDate)`.
+   *
+   * Month-aligned windows (every period the shared selector produces: a calendar month, YTD, or a
+   * trailing 3/6 months) shift back by whole months so a 28-day February compares against a 31-day
+   * January rather than an arbitrary 28-day slice of it. Anything else falls back to a day shift.
+   */
+  private previousWindow(startDate: string, endDate: string): { startDate: string; endDate: string } {
+    const start = new Date(`${startDate}T00:00:00Z`);
+    const end = new Date(`${endDate}T00:00:00Z`);
+    const isMonthAligned = start.getUTCDate() === 1 && end.getUTCDate() === 1;
+
+    if (isMonthAligned) {
+      const months = (end.getUTCFullYear() - start.getUTCFullYear()) * 12 + (end.getUTCMonth() - start.getUTCMonth());
+      return {
+        startDate: this.toIsoDate(new Date(Date.UTC(start.getUTCFullYear(), start.getUTCMonth() - months, 1))),
+        endDate: startDate,
+      };
+    }
+
+    const spanMs = end.getTime() - start.getTime();
+    return { startDate: this.toIsoDate(new Date(start.getTime() - spanMs)), endDate: startDate };
+  }
+
+  private resolveGrain(startDate: string, endDate: string): TimeGrain {
+    const spanDays = (new Date(`${endDate}T00:00:00Z`).getTime() - new Date(`${startDate}T00:00:00Z`).getTime()) / MS_PER_DAY;
+    return spanDays <= DAY_GRAIN_MAX_DAYS ? TIME_GRAINS.day : TIME_GRAINS.month;
+  }
+
+  private toIsoDate(date: Date): string {
+    return date.toISOString().slice(0, 10);
+  }
+
+  /**
+   * Read-through cache for the filter-option and analytics queries — shared across callers, since
+   * the data is foundation-scoped rather than per-user (the ED gate lives in the route middleware).
+   * The feed itself is never cached: its filter cardinality makes the hit rate near zero.
+   *
+   * The query's own binds discriminate the entry, so a different window or scope can't read another's
+   * value. The feed is rebuilt hourly by dbt, so a 30-minute TTL never serves data a full rebuild stale.
+   */
+  private cached<T>(req: Request, foundationSlug: string, resource: string, binds: QueryBind[], fetcher: () => Promise<T>): Promise<T> {
+    logger.debug(req, 'social_listening_cached_query', 'Resolving cached Social Listening query', {
+      foundation_slug: foundationSlug,
+      resource,
+    });
+
+    return withSocialListeningCache(foundationSlug, resource, binds, VALKEY_CACHE.SOCIAL_LISTENING_TTL_SECONDS, fetcher);
+  }
+
+  private capValues(values: string[] | undefined, cap: number): string[] {
+    if (!values) {
+      return [];
+    }
+
+    const normalized = values.map((value) => value.trim()).filter(Boolean);
+    if (normalized.length > cap) {
+      logger.warning(undefined, 'social_listening_filter_cap', 'Truncated over-long filter value list', {
+        received: normalized.length,
+        cap,
+      });
+    }
+
+    return normalized.slice(0, cap);
+  }
+
+  private placeholders(count: number): string {
+    return Array(count).fill('?').join(', ');
+  }
+}

--- a/apps/lfx-one/src/server/services/social-listening.service.ts
+++ b/apps/lfx-one/src/server/services/social-listening.service.ts
@@ -1,43 +1,34 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { SOCIAL_LISTENING_MAX_FILTER_VALUES, SOCIAL_LISTENING_MAX_MENTION_IDS, SOCIAL_LISTENING_TOP_TAGS_LIMIT, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import { MENTION_FILTER_MAX_VALUES, MENTION_IDS_MAX_VALUES, MENTION_TOP_TAGS_LIMIT, VALKEY_CACHE } from '@lfx-one/shared/constants';
 import {
-  SocialListeningAnalyticsOverTimePoint,
   SocialListeningAnalyticsOverview,
   SocialListeningAnalyticsParams,
-  SocialListeningAnalyticsPlatformDistribution,
-  SocialListeningAnalyticsSentimentDistribution,
-  SocialListeningAnalyticsTopProject,
   SocialListeningAuthorsParams,
   SocialListeningCountParams,
   SocialListeningFeedParams,
   SocialListeningFeedResponse,
   SocialListeningFilterParams,
-  SocialListeningKeywordsParams,
-  SocialListeningLanguagesParams,
   SocialListeningMention,
   SocialListeningMentionAuthor,
   SocialListeningOptionsParams,
+  SocialListeningOverTimePoint,
   SocialListeningPlatform,
-  SocialListeningScopeParams,
+  SocialListeningPlatformDistribution,
+  SocialListeningScopedOptionsParams,
+  SocialListeningSentimentDistribution,
   SocialListeningSubProject,
-  SocialListeningTag,
-  SocialListeningTagsParams,
+  SocialListeningTagCount,
+  SocialListeningTopProject,
 } from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
+import { socialListeningFeedTable } from '../helpers/snowflake-schema.helper';
 import { escapeSqlLikePattern } from '../helpers/validation.helper';
 import { logger } from './logger.service';
 import { SnowflakeService } from './snowflake.service';
 import { withSocialListeningCache } from './valkey.service';
-
-/**
- * Octolens-sourced mentions, materialized hourly by the `platinum_social_listening_feed` dbt model
- * (`lf-dbt`). Scoped on `PROJECT_SLUG` — the foundation slug this app already carries everywhere —
- * rather than the model's `PROJECT_ID`, which is a Salesforce id the frontend never holds.
- */
-const FEED_TABLE = 'ANALYTICS.PLATINUM.SOCIAL_LISTENING_FEED';
 
 /**
  * Columns dropped from the feed projection: the upstream source id, the global `BOOKMARKED` flag
@@ -67,11 +58,8 @@ const FEED_EXCLUDED_COLUMNS = [
   'IS_PREV_12M',
 ].join(', ');
 
-/** Author options are capped so a foundation with a long tail can't build an unbounded response. */
-const AUTHOR_OPTIONS_LIMIT = 200;
-
-/** Distinct sub-projects contributing to a mention volume are the analytics "top projects" table's row cap. */
-const TOP_PROJECTS_LIMIT = 10;
+/** Distinct sub-projects contributing to a mention volume are the analytics "top projects" panel's default row cap. */
+const TOP_PROJECTS_LIMIT = 5;
 
 /**
  * Day-grain buckets stay readable up to roughly two months; anything longer rolls up to months.
@@ -135,7 +123,7 @@ export class SocialListeningService {
 
     const sql = `
       SELECT * EXCLUDE (${FEED_EXCLUDED_COLUMNS}) RENAME _KEY AS MENTION_ID
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}${filters.clause}
       ORDER BY MENTION_TS DESC
       LIMIT ? OFFSET ?
@@ -160,7 +148,7 @@ export class SocialListeningService {
 
     const sql = `
       SELECT COUNT(*) AS TOTAL
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}${filters.clause}
     `;
 
@@ -178,7 +166,7 @@ export class SocialListeningService {
   public async getMentionsProjects(req: Request, params: SocialListeningOptionsParams): Promise<SocialListeningSubProject[]> {
     const sql = `
       SELECT DISTINCT SOURCE_PROJECT_ID, SOURCE_PROJECT_NAME
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE PROJECT_SLUG = ?
         AND SOURCE_PROJECT_ID IS NOT NULL
         AND SOURCE_PROJECT_NAME IS NOT NULL
@@ -195,7 +183,7 @@ export class SocialListeningService {
   public async getMentionsPlatforms(req: Request, params: SocialListeningOptionsParams): Promise<SocialListeningPlatform[]> {
     const sql = `
       SELECT DISTINCT SOURCE_PLATFORM, SOCIAL_NETWORK
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE PROJECT_SLUG = ?
         AND SOURCE_PLATFORM IS NOT NULL
         AND SOURCE_PLATFORM != ''
@@ -208,12 +196,12 @@ export class SocialListeningService {
     });
   }
 
-  public async getMentionsLanguages(req: Request, params: SocialListeningLanguagesParams): Promise<string[]> {
+  public async getMentionsLanguages(req: Request, params: SocialListeningScopedOptionsParams): Promise<string[]> {
     const scope = this.buildScope(params);
 
     const sql = `
       SELECT DISTINCT LOWER(LANGUAGE) AS LANGUAGE
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}
         AND LANGUAGE IS NOT NULL
         AND LANGUAGE != ''
@@ -226,12 +214,12 @@ export class SocialListeningService {
     });
   }
 
-  public async getMentionsKeywords(req: Request, params: SocialListeningKeywordsParams): Promise<string[]> {
+  public async getMentionsKeywords(req: Request, params: SocialListeningScopedOptionsParams): Promise<string[]> {
     const scope = this.buildScope(params);
 
     const sql = `
       SELECT DISTINCT LOWER(KEYWORD) AS KEYWORD
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}
         AND KEYWORD IS NOT NULL
         AND KEYWORD != ''
@@ -249,13 +237,12 @@ export class SocialListeningService {
    * exploded with `LATERAL FLATTEN` before grouping. Serves both the tag filter and the analytics
    * top-tags panel — the filter sorts alphabetically client-side.
    */
-  public async getMentionsTags(req: Request, params: SocialListeningTagsParams): Promise<SocialListeningTag[]> {
+  public async getMentionsTags(req: Request, params: SocialListeningScopedOptionsParams): Promise<SocialListeningTagCount[]> {
     const scope = this.buildScope(params, 'm');
-    const limit = params.limit ?? SOCIAL_LISTENING_TOP_TAGS_LIMIT;
 
     const sql = `
       SELECT TRIM(f.VALUE::STRING) AS TAG, COUNT(*) AS TOTAL_COUNT
-      FROM ${FEED_TABLE} AS m,
+      FROM ${socialListeningFeedTable()} AS m,
         LATERAL FLATTEN(input => SPLIT(m.TAGS, ',')) AS f
       WHERE ${scope.clause}
         AND m.TAGS IS NOT NULL
@@ -266,10 +253,10 @@ export class SocialListeningService {
       LIMIT ?
     `;
 
-    const binds: QueryBind[] = [...scope.binds, limit];
+    const binds: QueryBind[] = [...scope.binds, MENTION_TOP_TAGS_LIMIT];
 
     return this.cached(req, params.foundationSlug, 'tags', binds, async () => {
-      const result = await this.snowflakeService.execute<SocialListeningTag>(sql, binds);
+      const result = await this.snowflakeService.execute<SocialListeningTagCount>(sql, binds);
       return result.rows ?? [];
     });
   }
@@ -292,7 +279,7 @@ export class SocialListeningService {
                SOURCE_PLATFORM AS PLATFORM,
                SUM(COUNT(*)) OVER (PARTITION BY AUTHOR) AS MENTION_COUNT,
                ROW_NUMBER() OVER (PARTITION BY AUTHOR ORDER BY COUNT(*) DESC) AS PLATFORM_RANK
-        FROM ${FEED_TABLE}
+        FROM ${socialListeningFeedTable()}
         WHERE ${scope.clause}
           AND AUTHOR IS NOT NULL
           AND AUTHOR != ''${filters.clause}
@@ -305,7 +292,7 @@ export class SocialListeningService {
 
     logger.debug(req, 'social_listening_mentions_authors', 'Querying author options', { foundation_slug: params.foundationSlug });
 
-    const result = await this.snowflakeService.execute<SocialListeningMentionAuthor>(sql, [...scope.binds, ...filters.binds, AUTHOR_OPTIONS_LIMIT]);
+    const result = await this.snowflakeService.execute<SocialListeningMentionAuthor>(sql, [...scope.binds, ...filters.binds, MENTION_FILTER_MAX_VALUES]);
 
     return result.rows ?? [];
   }
@@ -325,7 +312,7 @@ export class SocialListeningService {
     const sql = `
       WITH base AS (
         SELECT SENTIMENT, SOURCE_PROJECT_ID, MENTION_TS
-        FROM ${FEED_TABLE}
+        FROM ${socialListeningFeedTable()}
         WHERE ${base.clause}
       ),
       current_window AS (
@@ -350,9 +337,9 @@ export class SocialListeningService {
              CASE WHEN p.TOTAL = 0 OR p.TOTAL < c.TOTAL * 0.2 THEN NULL
                   ELSE ROUND((c.TOTAL - p.TOTAL) / p.TOTAL::FLOAT * 100, 1) END AS TOTAL_MENTIONS_CHANGE_PCT,
              CASE WHEN c.TOTAL = 0 OR p.TOTAL = 0 OR p.TOTAL < c.TOTAL * 0.2 THEN NULL
-                  ELSE ROUND(c.POSITIVE / c.TOTAL::FLOAT * 100 - p.POSITIVE / p.TOTAL::FLOAT * 100, 1) END AS POSITIVE_SENTIMENT_CHANGE_PP,
+                  ELSE ROUND(c.POSITIVE / c.TOTAL::FLOAT * 100 - p.POSITIVE / p.TOTAL::FLOAT * 100, 1) END AS POSITIVE_SENTIMENT_CHANGE_PCT,
              CASE WHEN c.TOTAL = 0 OR p.TOTAL = 0 OR p.TOTAL < c.TOTAL * 0.2 THEN NULL
-                  ELSE ROUND(c.NEGATIVE / c.TOTAL::FLOAT * 100 - p.NEGATIVE / p.TOTAL::FLOAT * 100, 1) END AS NEGATIVE_SENTIMENT_CHANGE_PP
+                  ELSE ROUND(c.NEGATIVE / c.TOTAL::FLOAT * 100 - p.NEGATIVE / p.TOTAL::FLOAT * 100, 1) END AS NEGATIVE_SENTIMENT_CHANGE_PCT
       FROM current_window c
       CROSS JOIN previous_window p
     `;
@@ -373,8 +360,8 @@ export class SocialListeningService {
           CHILD_PROJECTS_COUNT: 0,
           POSITIVE_SENTIMENT_PERCENT: 0,
           NEGATIVE_SENTIMENT_PERCENT: 0,
-          POSITIVE_SENTIMENT_CHANGE_PP: null,
-          NEGATIVE_SENTIMENT_CHANGE_PP: null,
+          POSITIVE_SENTIMENT_CHANGE_PCT: null,
+          NEGATIVE_SENTIMENT_CHANGE_PCT: null,
         };
       }
 
@@ -382,36 +369,38 @@ export class SocialListeningService {
     });
   }
 
-  /** Mention volume bucketed by day (windows up to ~2 months) or month (anything longer). */
-  public async getAnalyticsOverTime(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningAnalyticsOverTimePoint[]> {
+  /** Mention volume bucketed by day (windows up to ~2 months) or month (anything longer), split per sub-project. */
+  public async getAnalyticsOverTime(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningOverTimePoint[]> {
     const scope = this.buildScope(params);
     const grain = this.resolveGrain(params.startDate, params.endDate);
 
     const sql = `
       SELECT TO_CHAR(DATE_TRUNC('${grain.unit}', MENTION_TS), 'YYYY-MM-DD') AS PERIOD_START,
              TO_CHAR(DATE_TRUNC('${grain.unit}', MENTION_TS), '${grain.labelFormat}') AS PERIOD_LABEL,
+             SOURCE_PROJECT_ID,
+             SOURCE_PROJECT_NAME,
              COUNT(*) AS TOTAL_MENTIONS
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}
-      GROUP BY DATE_TRUNC('${grain.unit}', MENTION_TS)
+      GROUP BY DATE_TRUNC('${grain.unit}', MENTION_TS), SOURCE_PROJECT_ID, SOURCE_PROJECT_NAME
       ORDER BY DATE_TRUNC('${grain.unit}', MENTION_TS)
     `;
 
     return this.cached(req, params.foundationSlug, `analytics-over-time-${grain.unit}`, scope.binds, async () => {
-      const result = await this.snowflakeService.execute<SocialListeningAnalyticsOverTimePoint>(sql, scope.binds);
+      const result = await this.snowflakeService.execute<SocialListeningOverTimePoint>(sql, scope.binds);
       return result.rows ?? [];
     });
   }
 
-  public async getAnalyticsPlatformDistribution(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningAnalyticsPlatformDistribution[]> {
+  public async getAnalyticsPlatformDistribution(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningPlatformDistribution[]> {
     const scope = this.buildScope(params);
 
     const sql = `
       SELECT SOURCE_PLATFORM,
-             MAX(SOCIAL_NETWORK) AS PLATFORM_DISPLAY_NAME,
+             MAX(SOCIAL_NETWORK) AS SOCIAL_NETWORK,
              COUNT(*) AS MENTIONS_COUNT,
              ROUND(COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0)::FLOAT * 100, 1) AS PERCENT_OF_TOTAL
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}
         AND SOURCE_PLATFORM IS NOT NULL
         AND SOURCE_PLATFORM != ''
@@ -420,41 +409,38 @@ export class SocialListeningService {
     `;
 
     return this.cached(req, params.foundationSlug, 'analytics-platform-distribution', scope.binds, async () => {
-      const result = await this.snowflakeService.execute<SocialListeningAnalyticsPlatformDistribution>(sql, scope.binds);
+      const result = await this.snowflakeService.execute<SocialListeningPlatformDistribution>(sql, scope.binds);
       return result.rows ?? [];
     });
   }
 
   /** A null or blank upstream sentiment is bucketed as neutral, matching how the feed renders it. */
-  public async getAnalyticsSentimentDistribution(
-    req: Request,
-    params: SocialListeningAnalyticsParams
-  ): Promise<SocialListeningAnalyticsSentimentDistribution[]> {
+  public async getAnalyticsSentimentDistribution(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningSentimentDistribution[]> {
     const scope = this.buildScope(params);
 
     const sql = `
       SELECT COALESCE(NULLIF(LOWER(SENTIMENT), ''), 'neutral') AS SENTIMENT,
              COUNT(*) AS MENTION_COUNT,
              ROUND(COUNT(*) / NULLIF(SUM(COUNT(*)) OVER (), 0)::FLOAT * 100, 1) AS PERCENT_OF_TOTAL
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}
       GROUP BY COALESCE(NULLIF(LOWER(SENTIMENT), ''), 'neutral')
       ORDER BY MENTION_COUNT DESC
     `;
 
     return this.cached(req, params.foundationSlug, 'analytics-sentiment-distribution', scope.binds, async () => {
-      const result = await this.snowflakeService.execute<SocialListeningAnalyticsSentimentDistribution>(sql, scope.binds);
+      const result = await this.snowflakeService.execute<SocialListeningSentimentDistribution>(sql, scope.binds);
       return result.rows ?? [];
     });
   }
 
-  public async getAnalyticsTopProjects(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningAnalyticsTopProject[]> {
+  public async getAnalyticsTopProjects(req: Request, params: SocialListeningAnalyticsParams): Promise<SocialListeningTopProject[]> {
     const scope = this.buildScope(params);
     const limit = params.limit ?? TOP_PROJECTS_LIMIT;
 
     const sql = `
       SELECT SOURCE_PROJECT_NAME, COUNT(*) AS TOTAL_MENTIONS
-      FROM ${FEED_TABLE}
+      FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}
         AND SOURCE_PROJECT_NAME IS NOT NULL
         AND SOURCE_PROJECT_NAME != ''
@@ -466,7 +452,7 @@ export class SocialListeningService {
     const binds: QueryBind[] = [...scope.binds, limit];
 
     return this.cached(req, params.foundationSlug, 'analytics-top-projects', binds, async () => {
-      const result = await this.snowflakeService.execute<SocialListeningAnalyticsTopProject>(sql, binds);
+      const result = await this.snowflakeService.execute<SocialListeningTopProject>(sql, binds);
       return result.rows ?? [];
     });
   }
@@ -477,7 +463,7 @@ export class SocialListeningService {
    *
    * `alias` prefixes the column references for the one query that joins (`getMentionsTags`).
    */
-  private buildScope(params: SocialListeningScopeParams & { sourceProjectId?: string; platform?: string }, alias?: string): SqlFragment {
+  private buildScope(params: SocialListeningScopedOptionsParams, alias?: string): SqlFragment {
     const col = (name: string): string => (alias ? `${alias}.${name}` : name);
     const clauses = [`${col('PROJECT_SLUG')} = ?`, `${col('MENTION_TS')} >= TO_DATE(?)`, `${col('MENTION_TS')} < TO_DATE(?)`];
     const binds: QueryBind[] = [params.foundationSlug, params.startDate, params.endDate];
@@ -529,7 +515,7 @@ export class SocialListeningService {
       clauses.push("(TITLE IS NULL OR TITLE = '')");
     }
 
-    const keywords = this.capValues(filters.keywords, SOCIAL_LISTENING_MAX_FILTER_VALUES);
+    const keywords = this.capValues(filters.keywords, MENTION_FILTER_MAX_VALUES);
     if (keywords.length > 0) {
       clauses.push(`LOWER(KEYWORD) IN (${this.placeholders(keywords.length)})`);
       binds.push(...keywords.map((keyword) => keyword.toLowerCase()));
@@ -537,13 +523,13 @@ export class SocialListeningService {
 
     // TAGS is a comma-joined string upstream, so each selected tag is a substring match ANDed
     // together — a mention must carry all of them.
-    const tags = this.capValues(filters.tags, SOCIAL_LISTENING_MAX_FILTER_VALUES);
+    const tags = this.capValues(filters.tags, MENTION_FILTER_MAX_VALUES);
     for (const tag of tags) {
       clauses.push(`LOWER(TAGS) LIKE ? ESCAPE '${LIKE_ESCAPE_CHAR}'`);
       binds.push(`%${escapeSqlLikePattern(tag.toLowerCase())}%`);
     }
 
-    const authors = this.capValues(filters.authors, SOCIAL_LISTENING_MAX_FILTER_VALUES);
+    const authors = this.capValues(filters.authors, MENTION_FILTER_MAX_VALUES);
     if (authors.length > 0) {
       clauses.push(`AUTHOR IN (${this.placeholders(authors.length)})`);
       binds.push(...authors);
@@ -556,7 +542,7 @@ export class SocialListeningService {
     }
 
     if (filters.mentionIds) {
-      const mentionIds = this.capValues(filters.mentionIds, SOCIAL_LISTENING_MAX_MENTION_IDS);
+      const mentionIds = this.capValues(filters.mentionIds, MENTION_IDS_MAX_VALUES);
       if (mentionIds.length > 0) {
         clauses.push(`_KEY IN (${this.placeholders(mentionIds.length)})`);
         binds.push(...mentionIds);

--- a/apps/lfx-one/src/server/services/social-listening.service.ts
+++ b/apps/lfx-one/src/server/services/social-listening.service.ts
@@ -382,6 +382,8 @@ export class SocialListeningService {
              COUNT(*) AS TOTAL_MENTIONS
       FROM ${socialListeningFeedTable()}
       WHERE ${scope.clause}
+        AND SOURCE_PROJECT_ID IS NOT NULL
+        AND SOURCE_PROJECT_NAME IS NOT NULL
       GROUP BY DATE_TRUNC('${grain.unit}', MENTION_TS), SOURCE_PROJECT_ID, SOURCE_PROJECT_NAME
       ORDER BY DATE_TRUNC('${grain.unit}', MENTION_TS)
     `;

--- a/apps/lfx-one/src/server/services/valkey.service.ts
+++ b/apps/lfx-one/src/server/services/valkey.service.ts
@@ -4,6 +4,7 @@
 import { VALKEY_CACHE } from '@lfx-one/shared/constants';
 import { CachePort } from '@lfx-one/shared/interfaces';
 import { isFilterSafeIdentifier, isFilterSafeUsername } from '@lfx-one/shared/utils';
+import { createHash } from 'crypto';
 import Redis from 'ioredis';
 
 import { addShutdownHook } from '../utils/shutdown';
@@ -317,6 +318,31 @@ export function buildUserCacheKey(namespace: string, username: string): string |
 export function buildMemberV1MappingCacheKey(memberUid: string): string | null {
   if (!isFilterSafeIdentifier(memberUid)) return null;
   return `${keyPrefix()}:${VALKEY_CACHE.MEMBER_V1_MAPPING_NAMESPACE}:${memberUid}`;
+}
+
+/**
+ * Per-foundation Social Listening cache key. `discriminator` values are the query's own bind
+ * parameters (date window, scope selects, limits) — hashed rather than concatenated so an arbitrary
+ * user-supplied filter value can neither corrupt the `:`-delimited key nor blow past Valkey's key
+ * length limit, while two different windows still resolve to different entries. Null (fail-closed →
+ * direct fetch) when the foundation slug isn't filter-safe.
+ */
+export function buildSocialListeningCacheKey(foundationSlug: string, resource: string, discriminator: readonly (string | number)[]): string | null {
+  if (!isFilterSafeIdentifier(foundationSlug)) return null;
+  const digest = createHash('sha256').update(JSON.stringify(discriminator)).digest('hex').slice(0, 16);
+  return `${keyPrefix()}:${VALKEY_CACHE.SOCIAL_LISTENING_NAMESPACE}:${foundationSlug}:${resource}:${digest}`;
+}
+
+/** Read-through helper for the per-foundation Social Listening namespace; a null key (unsafe slug) fetches directly. */
+export function withSocialListeningCache<T>(
+  foundationSlug: string,
+  resource: string,
+  discriminator: readonly (string | number)[],
+  ttlSeconds: number,
+  fetcher: () => Promise<T>,
+  accept?: (value: unknown) => boolean
+): Promise<T> {
+  return valkeyService.withCache(buildSocialListeningCacheKey(foundationSlug, resource, discriminator), ttlSeconds, fetcher, accept);
 }
 
 /** Read-through helper for the per-org Snowflake-backed namespace; a null key (unsafe account id) fetches directly. */

--- a/packages/shared/src/constants/index.ts
+++ b/packages/shared/src/constants/index.ts
@@ -93,3 +93,4 @@ export * from './writer-grants.constants';
 export * from './http-retry.constants';
 export * from './committee-engagement.constants';
 export * from './weekly-brief.constants';
+export * from './social-listening.constants';

--- a/packages/shared/src/constants/social-listening.constants.ts
+++ b/packages/shared/src/constants/social-listening.constants.ts
@@ -88,6 +88,9 @@ export const MENTION_FILTER_MAX_VALUES = 200;
 /** Reserved for the deferred bookmarked-mentions filter (follow-up ticket). */
 export const MENTION_IDS_MAX_VALUES = 500;
 
+/** Row cap for the `mentions-tags` endpoint — serves both the tag filter dropdown and the analytics top-tags panel. */
+export const MENTION_TOP_TAGS_LIMIT = 10;
+
 /** Interval for refreshing relative timestamps ("2h ago") on rendered mention cards. */
 export const MENTION_TIME_TICK_INTERVAL_MS = 60_000;
 

--- a/packages/shared/src/constants/valkey-cache.constants.ts
+++ b/packages/shared/src/constants/valkey-cache.constants.ts
@@ -43,6 +43,9 @@ export const VALKEY_CACHE = {
    */
   MEMBER_V1_MAPPING_NAMESPACE: 'member-v1-mapping:v1',
 
+  /** Domain + schema-version segment for the per-foundation Snowflake-backed Social Listening cache (filter options + analytics; shared across callers, since the data is foundation-scoped rather than per-user). */
+  SOCIAL_LISTENING_NAMESPACE: 'social-listening-sf:v1',
+
   /** Default freshness window for membership entries (carried over from the prior 30_000 ms memo). */
   ORG_MEMBERSHIP_TTL_SECONDS: 30,
 
@@ -66,6 +69,9 @@ export const VALKEY_CACHE = {
 
   /** Short negative-cache TTL (1 hour) for a member confirmed to have no v1 mapping — long enough that a large roster of genuinely-unmapped members doesn't hammer NATS on every request, short enough that a mapping added later (e.g. after a backfill) shows up within the hour. Only ever written for a *confirmed* "no mapping" NATS response, never for an indeterminate one (a timed-out or budget-cut-off lookup) — see `v1-mapping-batch.helper.ts`'s `confirmedUnresolved` distinction. TODO(LFXV2-2973): remove once the bridge is deleted. */
   MEMBER_V1_MAPPING_DEGRADE_TTL_SECONDS: 3600,
+
+  /** Freshness window for the Social Listening filter-option and analytics caches (30 minutes). The `platinum_social_listening_feed` dbt model rebuilds hourly, so a half-hour TTL can never serve a value that predates the last rebuild by more than one cycle. */
+  SOCIAL_LISTENING_TTL_SECONDS: 1800,
 
   /** Fallback session TTL when express-openid-connect doesn't supply a per-session expiry (matches its `session.absoluteDuration` default of 7 days). Normally the store derives the actual TTL from the session's own `cookie.maxAge` instead. */
   SESSION_FALLBACK_TTL_SECONDS: 7 * 24 * 60 * 60,

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -310,3 +310,6 @@ export * from './committee-engagement.internal.interface';
 
 // Weekly Brief interfaces
 export * from './weekly-brief.interface';
+
+// Social Listening interfaces (LFXV2-3002)
+export * from './social-listening.interface';

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -55,3 +55,5 @@ export * from './committee-engagement-classifier.utils';
 export * from './committee-engagement-display.utils';
 export * from './committee-engagement-freshness.utils';
 export * from './public-profile.utils';
+export * from './social-listening.utils';
+export * from './social-listening-filter.utils';


### PR DESCRIPTION
## Summary

Ports PCC's Social Listening query layer onto the Express BFF: 13 read-only `GET` endpoints under `/api/social-listening/*`, all Snowflake reads against `ANALYTICS.PLATINUM.SOCIAL_LISTENING_FEED`, scoped by `PROJECT_SLUG` plus an explicit half-open `MENTION_TS` date range resolved from the shared period selector. PCC's WebSocket gateway is deliberately replaced by REST, and its six pre-aggregated analytics views are dropped in favor of aggregating the feed table at query time — the only way to express the selector's arbitrary calendar months. This is slice 2 of the LFXV2-3002 stack; the Angular client (LFXV2-3016) and filters panel (LFXV2-3017) consume exactly these endpoints.

Deferred scope (stated per the stack plan): per-mention bookmarks, read/unread state, and saved views are **not** in this ticket — a follow-up covers durable per-user state. `mentionIds` is reserved in the filter contract for the bookmark filter.

Resolves LFXV2-3015

## Behavior changes

| Before | After |
|---|---|
| Social Listening data was only reachable through PCC (a WebSocket gateway on the NestJS BFF); this app had no way to serve mentions, filter options, or analytics | The app serves the full Social Listening surface over REST: a paginated mentions feed, a separate total count, filter/scope option lists (sub-projects, platforms, languages, keywords, tags, authors), and the four analytics panels (overview KPIs with period-over-period change, volume over time, platform and sentiment distribution, top projects) |
| Filter values and pagination were unbounded inputs to PCC's query builder | Every query parameter is validated and bounded at the HTTP boundary (whitelisted enums, length caps, comma-joined arrays capped at 200/500 values, clamped limit/offset); over-cap lists are rejected with a 400 rather than silently truncated |

## Technical changes

`apps/lfx-one/src/server/services/social-listening.service.ts` — Snowflake query layer
- 13 query methods ported from PCC's `social-listening-queries.service.ts`, with two deliberate departures: explicit `MENTION_TS >= TO_DATE(?) AND MENTION_TS < TO_DATE(?)` range filtering instead of PCC's fixed `IS_*` flags, and feed-derived analytics instead of the pre-aggregated views
- Every user value is a bind parameter; conditional `AND` fragments carry exactly-matching bind spreads; array filters capped (`MENTION_FILTER_MAX_VALUES` / `MENTION_IDS_MAX_VALUES`); `LIKE`/`ILIKE` patterns escaped with `ESCAPE '!'` via the shared `escapeSqlLikePattern`
- Feed keeps PCC's `SELECT * EXCLUDE (…) RENAME _KEY AS MENTION_ID` projection (drops `BOOKMARKED` + the dead range flags), orders `MENTION_TS DESC`, and returns `computedAt` (`MAX(COMPUTED_AT)` watermark) for the UI's "Data as of"
- Overview computes change % against the immediately preceding equal-length window (month-aligned windows shift whole months); change is null when the previous window held under 20% of current volume
- Over-time buckets by day (≤62-day windows) or month, grouped by `DATE_TRUNC` expression (never the alias) plus `SOURCE_PROJECT_ID`/`SOURCE_PROJECT_NAME`, with NULL sub-projects excluded to match the non-null contract
- Filter-option and analytics queries read through the Valkey cache (`withSocialListeningCache`, 30-min TTL, binds-discriminated keys); the feed, count, and author options are deliberately uncached (filter cardinality ⇒ near-zero hit rate)
- Error posture: option/analytics queries degrade to empty defaults with a warning; the feed and count hard-fail so an error never renders as "no mentions"

`apps/lfx-one/src/server/helpers/social-listening-params.helper.ts` — query-param parsing/validation
- `parseFoundationSlug` (format-checked), `parseSocialListeningScope` (period via `getValidatedPeriod`, fallback to the shared default period), filter/author-filter/pagination/limit parsers
- Wire keys are the camelCase `MentionFilters` field names; array params arrive comma-joined (the 3016 client codec's contract), split/trimmed, with over-cap lists rejected (400) rather than truncated
- Enum whitelists derive from the shared option lists (`MENTION_SENTIMENT_OPTIONS` etc.) so values can't desync

`apps/lfx-one/src/server/controllers/social-listening.controller.ts` — HTTP boundary
- One handler per endpoint; each validates through the params helper, logs via `startOperation`/`success`, and defers error handling to `apiErrorHandler` with a bare `next(error)`

`apps/lfx-one/src/server/routes/social-listening.route.ts`, `apps/lfx-one/src/server/server.ts` — routing
- 13 routes under `/api/social-listening` with router-level `requireExecutiveDirector`, so future endpoints are gated by default
- Note on audience: the sidebar link (3016) is shown to ED **and** LF Staff while the guard/middleware here are ED-only — same mismatch as Health Metrics; server-verified ED-only posture is kept intentionally
- No dedicated rate-limit bucket: the app-wide `apiRateLimiter` (500 req/min/IP) already covers `/api/*`; recorded in the route file's doc comment

`apps/lfx-one/src/server/services/valkey.service.ts`, `packages/shared/src/constants/valkey-cache.constants.ts` — cache plumbing
- `buildSocialListeningCacheKey` + `withSocialListeningCache` in the `social-listening-sf:v1` namespace (1800s TTL); bind discriminators are sha256-truncated so user filter values can't corrupt keys; unsafe slugs fail closed to a direct fetch

`apps/lfx-one/src/server/helpers/snowflake-schema.helper.ts` — schema resolution
- `socialListeningFeedTable()` — the feed lives in PCC's `ANALYTICS.PLATINUM` schema, not this repo's `PLATINUM_LFX_ONE`; env-overridable via `LFX_ONE_SOCIAL_LISTENING_FEED_TABLE` with a guarded `WORD.WORD.WORD` format, never hard-coded inline in SQL

`packages/shared/src/constants/social-listening.constants.ts` — shared constants
- Adds `MENTION_TOP_TAGS_LIMIT` (10) for the merged `mentions-tags` endpoint (PCC's separate `analytics-tags` endpoint is deliberately dropped — one endpoint serves the tag filter and the top-tags panel)

`apps/lfx-one/src/server/services/social-listening.service.spec.ts`, `apps/lfx-one/src/server/helpers/social-listening-params.helper.spec.ts` — tests
- 107 vitest cases: scope/filter predicate SQL with exact bind alignment, caps, `ESCAPE '!'` patterns, `mentionIds: []` → `WHERE 1 = 0`, previous-window month shifting, day/month grain selection, cache vs no-cache split, slug/period/whitelist validation, comma-joined array parsing, over-cap 400s, limit/offset clamping

`packages/shared/src/constants/index.ts`, `packages/shared/src/interfaces/index.ts`, `packages/shared/src/utils/index.ts` — barrels
- Export the 3002 social-listening contract (interfaces, constants, filter utils) consumed by this server slice

**Known follow-up (not this PR):** the 3002 contract's `SocialListeningTag` (`{ TAG: string | null }`) is now orphaned — nothing in any slice references it, and its shape contradicts the live `mentions-tags` payload (`SocialListeningTagCount`, non-null `TAG` + `TOTAL_COUNT`). It lives in slice 1's contract file, so removal is flagged for the LFXV2-3002 owner rather than changed here.
