### PR TITLE
fix(committees): move chat_webhook_url to committee settings contract

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.spec.ts
@@ -241,40 +241,6 @@ describe('CommitteeSettingsTabComponent — Slack webhook (LFXV2-3080)', () => {
     expect(component.form.controls.chat_webhook_url.disabled).toBe(true);
   });
 
-  it('surfaces the SLACK_WEBHOOK_NOT_PERSISTED 409 without resetting the dirty control, and still emits committeeUpdated', () => {
-    updateCommittee.mockReturnValueOnce(throwError(() => ({ status: 409, error: { code: 'SLACK_WEBHOOK_NOT_PERSISTED', error: 'Could not store webhook' } })));
-    component.form.controls.chat_webhook_url.setValue('https://hooks.slack.com/services/T1/B1/X');
-    component.form.controls.chat_webhook_url.markAsDirty();
-
-    const emitted: void[] = [];
-    component.committeeUpdated.subscribe(() => emitted.push(undefined));
-
-    component.saveSettings();
-
-    expect(component.form.controls.chat_webhook_url.dirty).toBe(true);
-    expect(component.form.controls.chat_webhook_url.value).toBe('https://hooks.slack.com/services/T1/B1/X');
-    expect(emitted).toHaveLength(1);
-    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Could not store webhook' }));
-  });
-
-  it('surfaces the SLACK_WEBHOOK_UNVERIFIED 409 without resetting the dirty control, and still emits committeeUpdated', () => {
-    updateCommittee.mockReturnValueOnce(
-      throwError(() => ({ status: 409, error: { code: 'SLACK_WEBHOOK_UNVERIFIED', error: 'Could not confirm webhook status' } }))
-    );
-    component.form.controls.chat_webhook_url.setValue('https://hooks.slack.com/services/T1/B1/X');
-    component.form.controls.chat_webhook_url.markAsDirty();
-
-    const emitted: void[] = [];
-    component.committeeUpdated.subscribe(() => emitted.push(undefined));
-
-    component.saveSettings();
-
-    expect(component.form.controls.chat_webhook_url.dirty).toBe(true);
-    expect(component.form.controls.chat_webhook_url.value).toBe('https://hooks.slack.com/services/T1/B1/X');
-    expect(emitted).toHaveLength(1);
-    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Could not confirm webhook status' }));
-  });
-
   it('surfaces IMPERSONATION_READ_ONLY (403) without emitting committeeUpdated', () => {
     updateCommittee.mockReturnValueOnce(throwError(() => ({ status: 403, error: { code: 'IMPERSONATION_READ_ONLY' } })));
     component.form.controls.chat_webhook_url.setValue('https://hooks.slack.com/services/T1/B1/X');

--- a/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
@@ -104,11 +104,12 @@ export class CommitteeSettingsTabComponent {
 
   // Dark-launch gate for the whole Slack webhook card — mirrors committee-overview.component.ts's
   // 'wg-weekly-brief' flag on the brief card itself, but as its own flag: the upstream
-  // committee-service has no chat_webhook_url field yet (see committee.service.ts's
-  // updateCommittee/getSlackWebhookUrlStrict comments), so every save deterministically fails
-  // with 409 SLACK_WEBHOOK_NOT_PERSISTED today. Rendering the card unconditionally would show
-  // every user a dead end; this keeps it hidden until the upstream schema change lands and the
-  // flag is flipped on.
+  // committee-service declares chat_webhook_url on the settings resource per PR #177
+  // (LFXV2-3094), but #177 is not yet merged/deployed as of this writing (see
+  // committee.service.ts's updateCommittee/getSlackWebhookUrlStrict comments), so every save
+  // still deterministically fails with 409 SLACK_WEBHOOK_NOT_PERSISTED today. Rendering the card
+  // unconditionally would show every user a dead end; this keeps it hidden until the upstream
+  // schema change is deployed and the flag is flipped on.
   public slackWebhookEnabled: Signal<boolean> = this.featureFlagService.getBooleanFlag(WG_WEEKLY_BRIEF_SLACK_FLAG, false);
 
   // Server-blocked (committee.service.ts's updateCommittee) as well — surfaced here too so the

--- a/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
@@ -103,11 +103,12 @@ export class CommitteeSettingsTabComponent {
   public mlLoading = computed(() => this.mlLoadingInternal() && !!this.committee()?.uid);
 
   // Dark-launch gate for the whole Slack webhook card — mirrors committee-overview.component.ts's
-  // 'wg-weekly-brief' flag on the brief card itself, but as its own flag: the server-side kill
-  // switch (ServerFeatureFlag.WeeklyBriefSlack, committee.service.ts's updateCommittee) is the
-  // real enforcement boundary, but that flag only gates the write — rendering the card
-  // unconditionally would still show every user a card that 409s on save until this UI-only flag
-  // is flipped on too.
+  // 'wg-weekly-brief' flag on the brief card itself, but as its own flag. Purely a UI-visibility
+  // gate: the real enforcement boundary is the server-side kill switch
+  // (ServerFeatureFlag.WeeklyBriefSlack, committee.service.ts's updateCommittee — env-var only,
+  // defaults off, this OpenFeature/GrowthBook flag can't reach it). Both must be on for a save to
+  // actually succeed; this flag alone controls whether the card renders at all, so it stays off
+  // until the feature is ready to roll out to users, independent of when the server flag flips.
   public slackWebhookEnabled: Signal<boolean> = this.featureFlagService.getBooleanFlag(WG_WEEKLY_BRIEF_SLACK_FLAG, false);
 
   // Server-blocked (committee.service.ts's updateCommittee) as well — surfaced here too so the

--- a/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-settings-tab/committee-settings-tab.component.ts
@@ -103,13 +103,11 @@ export class CommitteeSettingsTabComponent {
   public mlLoading = computed(() => this.mlLoadingInternal() && !!this.committee()?.uid);
 
   // Dark-launch gate for the whole Slack webhook card — mirrors committee-overview.component.ts's
-  // 'wg-weekly-brief' flag on the brief card itself, but as its own flag: the upstream
-  // committee-service declares chat_webhook_url on the settings resource per PR #177
-  // (LFXV2-3094), but #177 is not yet merged/deployed as of this writing (see
-  // committee.service.ts's updateCommittee/getSlackWebhookUrlStrict comments), so every save
-  // still deterministically fails with 409 SLACK_WEBHOOK_NOT_PERSISTED today. Rendering the card
-  // unconditionally would show every user a dead end; this keeps it hidden until the upstream
-  // schema change is deployed and the flag is flipped on.
+  // 'wg-weekly-brief' flag on the brief card itself, but as its own flag: the server-side kill
+  // switch (ServerFeatureFlag.WeeklyBriefSlack, committee.service.ts's updateCommittee) is the
+  // real enforcement boundary, but that flag only gates the write — rendering the card
+  // unconditionally would still show every user a card that 409s on save until this UI-only flag
+  // is flipped on too.
   public slackWebhookEnabled: Signal<boolean> = this.featureFlagService.getBooleanFlag(WG_WEEKLY_BRIEF_SLACK_FLAG, false);
 
   // Server-blocked (committee.service.ts's updateCommittee) as well — surfaced here too so the
@@ -140,9 +138,7 @@ export class CommitteeSettingsTabComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((c) => {
-        // A dirty chat_webhook_url means the user has an unsaved edit in progress (including
-        // "saved everything except the webhook" — see saveSettings' SLACK_WEBHOOK_NOT_PERSISTED
-        // branch, which emits committeeUpdated without resetting this control). Preserve it
+        // A dirty chat_webhook_url means the user has an unsaved edit in progress. Preserve it
         // across the resulting refresh instead of silently discarding what they typed; a
         // successful save already reset the control itself (see saveSettings' next handler), so
         // this only ever preserves a genuinely unsaved value.
@@ -344,26 +340,7 @@ export class CommitteeSettingsTabComponent {
           const code = err?.error?.code;
           const status = err?.status;
           let detail = 'Failed to save settings';
-          if (status === 409 && code === 'SLACK_WEBHOOK_NOT_PERSISTED') {
-            detail = err.error.error ?? 'Your other changes were saved, but the Slack webhook could not be stored.';
-            // Everything else the user set did persist (see committee.service.ts's
-            // updateCommittee — this check runs last, after the core PUT and settings update), so
-            // still emit to refresh the rest of the page (e.g. the committee header's public/
-            // voting-enabled indicators) from that saved state. chat_webhook_url is deliberately
-            // left dirty here (not reset) — the constructor's committee-refresh subscription
-            // preserves a dirty control's current value instead of nulling it, so the URL the
-            // user just typed survives this refresh instead of vanishing before they can read
-            // the error.
-            this.committeeUpdated.emit();
-          } else if (status === 409 && code === 'SLACK_WEBHOOK_UNVERIFIED') {
-            // Same rationale as SLACK_WEBHOOK_NOT_PERSISTED above: everything the user set did
-            // persist (this check only runs after the core PUT and settings update both already
-            // succeeded), the webhook's status just couldn't be confirmed — e.g. a transient
-            // upstream outage on the confirmation read, not a real rejection. Still emit + leave
-            // the control dirty for the same reasons as that branch.
-            detail = err.error.error ?? 'Your other changes were saved, but the Slack webhook status could not be confirmed.';
-            this.committeeUpdated.emit();
-          } else if (status === 403 && code === 'IMPERSONATION_READ_ONLY') {
+          if (status === 403 && code === 'IMPERSONATION_READ_ONLY') {
             // Backstop only — the control is already disabled during impersonation (see the
             // constructor's combineLatest subscription), so this path shouldn't normally be
             // reachable from this form. Kept for direct-API-caller parity with the server guard.

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -17,10 +17,9 @@ import { WeeklyBriefCardComponent } from './weekly-brief-card.component';
 
 /**
  * Covers performShareToSlack's error classifier (weekly-brief-card.component.ts's largest new
- * surface on LFXV2-3080, previously untested) — the branches make materially different safety
- * claims to the user (SLACK_SEND_FAILED: "nothing was posted, safe to retry" vs. the >=500/0/408
- * branch: "may not have completed, check the channel first"), so getting them swapped is a silent
- * correctness bug with no compiler signal. ConfirmationService is the real class, not a fake —
+ * surface on LFXV2-3080, previously untested) — getting a branch's message wrong (e.g. an
+ * ambiguous 5xx claiming "safe to retry") is a silent correctness bug with no compiler signal.
+ * ConfirmationService is the real class, not a fake —
  * PrimeNG's own <p-confirmDialog> in the template subscribes to its internal Subjects directly in
  * its constructor (see committee-settings-tab.component.spec.ts for the same finding) — but its
  * `confirm()` method is spied so the accept callback can be invoked directly without going through
@@ -62,7 +61,7 @@ describe('WeeklyBriefCardComponent — Share to Slack (LFXV2-3080)', () => {
   };
 
   beforeEach(async () => {
-    shareWeeklyBriefToSlack = vi.fn(() => of({ committee_name: COMMITTEE.name }));
+    shareWeeklyBriefToSlack = vi.fn(() => of({}));
     messageAdd = vi.fn();
     impersonating = signal(false);
 
@@ -146,26 +145,7 @@ describe('WeeklyBriefCardComponent — Share to Slack (LFXV2-3080)', () => {
     expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining('No Slack webhook') }));
   });
 
-  it('SLACK_SEND_FAILED (502) says the message was rejected and nothing was posted — distinct from the ambiguous 5xx branch below', () => {
-    shareWeeklyBriefToSlack.mockReturnValueOnce(throwError(() => ({ status: 502, error: { code: 'SLACK_SEND_FAILED' } })));
-
-    shareToSlack();
-
-    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining('rejected') }));
-  });
-
-  it("SLACK_SEND_FAILED uses the server's specific rejection reason (e.g. rate_limited) instead of always blaming the webhook URL — a rate-limited or policy-blocked send is not a bad URL", () => {
-    shareWeeklyBriefToSlack.mockReturnValueOnce(
-      throwError(() => ({ status: 502, error: { code: 'SLACK_SEND_FAILED', error: 'Slack rejected the message: rate_limited' } }))
-    );
-
-    shareToSlack();
-
-    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ detail: 'Slack rejected the message: rate_limited' }));
-    expect(messageAdd).not.toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining('webhook URL') }));
-  });
-
-  it('an unclassified 5xx says the send may not have completed — must not be confused with SLACK_SEND_FAILED\'s "safe to retry" claim', () => {
+  it('an unclassified 5xx says the send may not have completed', () => {
     shareWeeklyBriefToSlack.mockReturnValueOnce(throwError(() => ({ status: 503, error: {} })));
 
     shareToSlack();

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -97,9 +97,8 @@ export class WeeklyBriefCardComponent {
   public readonly impersonating = this.userService.impersonating;
 
   // Same dark-launch gate as committee-settings-tab.component.ts's Slack webhook card — without
-  // it, once wg-weekly-brief is on, every user would see a permanently-disabled Share to Slack
-  // button (has_slack_webhook can never become true; see the settings-tab flag's doc comment)
-  // with a hint pointing at settings UI that's itself still flag-hidden.
+  // it, once wg-weekly-brief is on, every user would see a Share to Slack button pointing at
+  // settings UI (the webhook card) that's itself still flag-hidden, with no way to configure it.
   public readonly slackShareEnabled: Signal<boolean> = this.featureFlagService.getBooleanFlag(WG_WEEKLY_BRIEF_SLACK_FLAG, false);
 
   // Template-bound constant — mirrors upstream's brief_text bound so the editor can't

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -818,22 +818,13 @@ export class WeeklyBriefCardComponent {
           } else if (status === 400) {
             const fieldErrors = (err?.error as { errors?: ValidationError[] } | undefined)?.errors;
             detail = fieldErrors?.[0]?.message ?? 'Failed to share brief. Please try again.';
-          } else if (status === 502 && code === 'SLACK_SEND_FAILED') {
-            // Slack answered synchronously with a rejection — invalid_payload, channel_not_found,
-            // rate_limited, action_prohibited, etc. (see SLACK_ERROR_TOKEN_PATTERN) — not only a
-            // bad webhook URL, so a single hardcoded "check the webhook URL" message would send a
-            // rate-limited or policy-blocked caller down the wrong troubleshooting path and invite
-            // an immediate retry that just gets rejected again. The server's own message already
-            // embeds the specific reason when it's recognizable (weekly-brief.service.ts's
-            // clientSafeReason); fall back to the generic wording only when it isn't. Either way
-            // the POST was never accepted, so nothing was posted — safe to retry once resolved.
-            detail = err.error?.error ?? 'Slack rejected the message. Check the webhook URL in Group Settings and try again.';
           } else if (status === 0 || status === 408 || status >= 500) {
-            // Ambiguous, same rationale as performShare's identical status-range branch: this
-            // covers SLACK_UNREACHABLE (a network error or AbortSignal.timeout talking to Slack)
-            // alongside a dropped connection or gateway timeout talking to our own BFF — in
-            // either case there's no confirmation Slack didn't already receive the POST before
-            // the failure, unlike the SLACK_SEND_FAILED branch above.
+            // committee-service now owns composing and sending the Slack message itself
+            // (LFXV2-3094 / lfx-v2-committee-service PR #178) — this BFF no longer talks to Slack
+            // directly, so there's no BFF-side SLACK_UNREACHABLE/SLACK_SEND_FAILED distinction to
+            // make any more. A 5xx (or a dropped/timed-out connection to our own BFF) here is
+            // ambiguous either way: there's no confirmation the message wasn't already sent before
+            // the failure, same rationale as performShare's identical status-range branch.
             detail = 'The send may not have completed — check the Slack channel before trying again.';
           } else {
             detail = 'Failed to share brief. Please try again.';

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -14,6 +14,7 @@ import {
   CommitteeJoinApplication,
   CommitteeMember,
   CommitteeOrganizationReference,
+  CommitteeSettingsData,
   CommitteeUpdateData,
   CommitteeUser,
   CreateCommitteeDocumentRequest,
@@ -125,7 +126,10 @@ export class CommitteeService {
     return this.http.post<Committee>('/api/committees', committee).pipe(take(1));
   }
 
-  public updateCommittee(id: string, committee: CommitteeUpdateData): Observable<Committee> {
+  // chat_webhook_url lives on CommitteeSettingsData, not CommitteeUpdateData (LFXV2-3094) — this
+  // one PUT still accepts it alongside base fields in a single merged payload; the BFF routes it
+  // to the settings sub-resource internally (committee.service.ts's updateCommittee).
+  public updateCommittee(id: string, committee: CommitteeUpdateData & Pick<CommitteeSettingsData, 'chat_webhook_url'>): Observable<Committee> {
     return this.http.put<Committee>(`/api/committees/${id}`, committee).pipe(take(1));
   }
 

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -409,8 +409,19 @@ describe('WeeklyBriefController', () => {
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
     });
 
+    it('rejects a non-integer or non-positive revision — same bound as validateRateBriefBody/validateClearRatingBody, since this now crosses the wire as the committee-service share-to-chat body (UInt64, Minimum(1))', async () => {
+      for (const badRevision of [0, -1, 1.5]) {
+        const next = vi.fn();
+
+        await controller.shareToSlack(buildReq({ revision: badRevision }), buildRes(), next);
+
+        expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+      }
+      expect(weeklyBriefSvc.shareToSlack).not.toHaveBeenCalled();
+    });
+
     it('accepts a valid body and forwards the revision to the service', async () => {
-      weeklyBriefSvc.shareToSlack.mockResolvedValue({ committee_name: 'Test Committee' });
+      weeklyBriefSvc.shareToSlack.mockResolvedValue({});
 
       await controller.shareToSlack(buildReq({ revision: 3 }), buildRes(), vi.fn());
 
@@ -420,7 +431,7 @@ describe('WeeklyBriefController', () => {
 
   describe('shareToSlack (LFXV2-3080) — read access gate', () => {
     it('checks committee read access before sharing — same gate shape as shareBrief: the service enforces the real project-writer boundary', async () => {
-      weeklyBriefSvc.shareToSlack.mockResolvedValue({ committee_name: 'Test Committee' });
+      weeklyBriefSvc.shareToSlack.mockResolvedValue({});
 
       await controller.shareToSlack(buildReq({ revision: 1 }), buildRes(), vi.fn());
 
@@ -465,7 +476,7 @@ describe('WeeklyBriefController', () => {
     });
 
     it('returns the service result as JSON', async () => {
-      const result = { committee_name: 'Test Committee' };
+      const result = {};
       weeklyBriefSvc.shareToSlack.mockResolvedValue(result);
       const res = buildRes();
 

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -409,8 +409,8 @@ describe('WeeklyBriefController', () => {
       expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
     });
 
-    it('rejects a non-integer or non-positive revision — same bound as validateRateBriefBody/validateClearRatingBody, since this now crosses the wire as the committee-service share-to-chat body (UInt64, Minimum(1))', async () => {
-      for (const badRevision of [0, -1, 1.5]) {
+    it('rejects a non-integer, non-positive, or unsafe-integer revision — same bound as validateRateBriefBody/validateClearRatingBody, since this now crosses the wire as the committee-service share-to-chat body (UInt64, Minimum(1))', async () => {
+      for (const badRevision of [0, -1, 1.5, 1e20]) {
         const next = vi.fn();
 
         await controller.shareToSlack(buildReq({ revision: badRevision }), buildRes(), next);

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -75,14 +75,21 @@ function validateGenerateBriefBody(body: unknown): { ok: true; value: GenerateWe
  * dialog shows a specific rendered revision — the caller must send it back so the
  * service can reject a stale approval (another writer saved an edit in between)
  * instead of silently sharing content the caller never actually reviewed.
+ *
+ * Same bound as `validateRateBriefBody`/`validateClearRatingBody` (integer, >= 1), not the
+ * looser finite-number check this used to have (LFXV2-3080): shareBrief's revision only ever
+ * fed a local equality comparison, but shareToSlack's now also crosses the wire as the
+ * committee-service share-to-chat request body, which declares it `UInt64, Minimum(1)` — a
+ * malformed value here should fail loudly at this boundary with a clear 400, not ride into an
+ * upstream Goa validation error.
  */
 function validateShareBriefBody(body: unknown): { ok: true; value: { revision: number } } | { ok: false; fieldErrors: Record<string, string> } {
   if (!body || typeof body !== 'object') {
     return { ok: false, fieldErrors: { body: 'Request body must be a JSON object' } };
   }
   const b = body as Record<string, unknown>;
-  if (typeof b['revision'] !== 'number' || !Number.isFinite(b['revision'] as number)) {
-    return { ok: false, fieldErrors: { revision: 'revision is required and must be a finite number' } };
+  if (typeof b['revision'] !== 'number' || !Number.isInteger(b['revision']) || b['revision'] < 1) {
+    return { ok: false, fieldErrors: { revision: 'revision is required and must be an integer of at least 1' } };
   }
   return { ok: true, value: { revision: b['revision'] as number } };
 }
@@ -114,9 +121,9 @@ function validateRateBriefBody(body: unknown): { ok: true; value: RateWeeklyBrie
  * Narrow `req.body` to `{ revision: number }` for the clear-rating (DELETE) endpoint. The caller
  * must send back the revision they actually saw so the service can reject a stale clear (PR #1361
  * review) instead of silently deleting whatever revision happens to be current. Same bound as
- * `validateRateBriefBody`'s revision check (integer, >= 1) rather than `validateShareBriefBody`'s
- * looser finite-number check — rate and clear are the same closed pair of endpoints and should
- * share one boundary contract (PR #1361 review, round 2).
+ * `validateRateBriefBody`'s (and now `validateShareBriefBody`'s) revision check (integer, >= 1) —
+ * rate and clear are the same closed pair of endpoints and should share one boundary contract
+ * (PR #1361 review, round 2).
  */
 function validateClearRatingBody(body: unknown): { ok: true; value: { revision: number } } | { ok: false; fieldErrors: Record<string, string> } {
   if (!body || typeof body !== 'object') {

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -81,14 +81,17 @@ function validateGenerateBriefBody(body: unknown): { ok: true; value: GenerateWe
  * fed a local equality comparison, but shareToSlack's now also crosses the wire as the
  * committee-service share-to-chat request body, which declares it `UInt64, Minimum(1)` — a
  * malformed value here should fail loudly at this boundary with a clear 400, not ride into an
- * upstream Goa validation error.
+ * upstream Goa validation error. `isSafeInteger`, not just `isInteger`: a value beyond
+ * `Number.MAX_SAFE_INTEGER` (e.g. `1e20`) still passes `isInteger` but can't faithfully
+ * represent a `UInt64` — same failure mode as an out-of-range value, just one `isInteger` alone
+ * wouldn't catch.
  */
 function validateShareBriefBody(body: unknown): { ok: true; value: { revision: number } } | { ok: false; fieldErrors: Record<string, string> } {
   if (!body || typeof body !== 'object') {
     return { ok: false, fieldErrors: { body: 'Request body must be a JSON object' } };
   }
   const b = body as Record<string, unknown>;
-  if (typeof b['revision'] !== 'number' || !Number.isInteger(b['revision']) || b['revision'] < 1) {
+  if (typeof b['revision'] !== 'number' || !Number.isSafeInteger(b['revision']) || b['revision'] < 1) {
     return { ok: false, fieldErrors: { revision: 'revision is required and must be an integer of at least 1' } };
   }
   return { ok: true, value: { revision: b['revision'] as number } };

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -137,6 +137,17 @@ export enum ServerFeatureFlag {
    * API caller with ordinary project-writer access could configure or use Slack sharing while the
    * UI still hides it. OFF by default, same as the UI flag, so both must be turned on for the
    * feature to actually be reachable.
+   *
+   * DO NOT ENABLE until lfx-v2-committee-service escapes Slack mrkdwn control characters
+   * (`&`, `<`, `>`) in `brief_text` before sending — as of this writing (LFXV2-3080's
+   * backend-send-ownership migration) it does not: `internal/infrastructure/slack/webhook_sender.go`
+   * posts `brief.BriefText` to Slack verbatim. This BFF used to escape it before every send
+   * (`escapeSlackMrkdwn`, removed when the send moved server-side) specifically because
+   * AI-generated brief text is sourced from meeting/document titles — content editable by a
+   * broader set of users than project writers — so an unescaped `<!channel>`/`<!here>` would page
+   * the entire channel, and `<https://evil.example|label>` would render as a deceptive hyperlink.
+   * That mitigation has no server-side equivalent today. File/track the upstream fix before
+   * flipping this on in any environment that isn't fully trusted content end-to-end.
    */
   WeeklyBriefSlack = 'LFX_WEEKLY_BRIEF_SLACK_ENABLED',
 }

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -349,13 +349,14 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
   });
 
   describe('getCommitteeById', () => {
-    it('computes has_slack_webhook from the settings-resource chat_webhook_url field and never returns the raw value', async () => {
-      // Seeded on the SETTINGS response (second proxyRequest call), not the base one — per
-      // LFXV2-3094 / lfx-v2-committee-service PR #177, chat_webhook_url lives on
-      // GET /committees/:id/settings, not the base committee resource.
+    it('computes has_slack_webhook from the settings-resource has_chat_webhook boolean and never returns the raw value', async () => {
+      // Seeded on the SETTINGS response (second proxyRequest call), not the base one, and via the
+      // upstream-computed has_chat_webhook boolean — per LFXV2-3094 / lfx-v2-committee-service
+      // PR #179, upstream never returns the raw chat_webhook_url on any read, so has_chat_webhook
+      // is the only real signal available.
       proxyRequest
         .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // GET /committees/:id
-        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL }); // GET /committees/:id/settings
+        .mockResolvedValueOnce({ has_chat_webhook: true }); // GET /committees/:id/settings
 
       const result = await service.getCommitteeById(req, COMMITTEE_UID);
 
@@ -364,34 +365,23 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
     });
 
     it('reports has_slack_webhook: false when no webhook is configured upstream', async () => {
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }).mockResolvedValueOnce({});
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }).mockResolvedValueOnce({ has_chat_webhook: false });
 
       const result = await service.getCommitteeById(req, COMMITTEE_UID);
 
       expect(result.has_slack_webhook).toBe(false);
-    });
-
-    it('reports has_slack_webhook: false for a settings-resource value that fails the Slack allowlist (e.g. written by a non-BFF caller)', async () => {
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
-        .mockResolvedValueOnce({ chat_webhook_url: 'https://evil.example.com/x' });
-
-      const result = await service.getCommitteeById(req, COMMITTEE_UID);
-
-      expect(result.has_slack_webhook).toBe(false);
-      expect('chat_webhook_url' in result).toBe(false);
     });
 
     it('strips a chat_webhook_url that unexpectedly shows up on the base committee resource too — defense-in-depth beyond the settings-resource source', async () => {
       proxyRequest
         .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL })
-        .mockResolvedValueOnce({});
+        .mockResolvedValueOnce({ has_chat_webhook: false });
 
       const result = await service.getCommitteeById(req, COMMITTEE_UID);
 
       expect('chat_webhook_url' in result).toBe(false);
-      // has_slack_webhook is sourced from settings only — a base-resource leak alone must not
-      // flip it true.
+      // has_slack_webhook is sourced from settings.has_chat_webhook only — a base-resource leak
+      // of the raw URL alone must not flip it true.
       expect(result.has_slack_webhook).toBe(false);
     });
 
@@ -625,54 +615,68 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect(updateWithETag).not.toHaveBeenCalled();
     });
 
-    it('accepts a well-formed hooks.slack.com URL', async () => {
-      // Webhook-only payload — no core field — so this goes through the settings-only branch:
-      // a plain GET for project_uid/response-shaping, then the settings fetchWithETag/updateWithETag
-      // pair, then the read-back confirmation GET.
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // webhook-only branch's committee GET
-        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL }); // getSlackWebhookUrlStrict's read-back settings GET
+    it('accepts a well-formed hooks.slack.com URL, PUTting it through the settings endpoint (not the base committee PUT)', async () => {
+      // Webhook-only payload — no core field — so this goes through the settings-only branch: a
+      // plain GET for project_uid/response-shaping, then the settings fetchWithETag/updateWithETag
+      // pair. No read-back confirmation GET — the upstream schema (LFXV2-3094/#177) is merged and
+      // deployed, so a normal updateWithETag failure already surfaces correctly on its own.
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }); // webhook-only branch's committee GET
       fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // updateCommitteeSettings' own fetch
       updateWithETag.mockResolvedValueOnce(undefined); // updateCommitteeSettings' own PUT
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).resolves.toMatchObject({ uid: COMMITTEE_UID });
+
+      // Pins the actual contract this PR is about: chat_webhook_url must land in the SETTINGS
+      // PUT body, not the base committee PUT — a regression that dropped it from the settings
+      // body or hit the wrong resource would otherwise still pass every other test here.
+      expect(updateWithETag).toHaveBeenCalledWith(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${COMMITTEE_UID}/settings`,
+        'settings-etag-1',
+        expect.objectContaining({ chat_webhook_url: VALID_WEBHOOK_URL }),
+        'update_committee_settings'
+      );
     });
 
-    it('throws SLACK_WEBHOOK_NOT_PERSISTED when upstream silently drops the field instead of reporting a false success (schema not deployed yet — LFXV2-3094/#177 unmerged)', async () => {
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // webhook-only branch's committee GET
-        // The read-back confirmation GET comes back without it — simulates today's real
-        // committee-service, which doesn't persist the field yet.
-        .mockResolvedValueOnce({});
-      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
-      updateWithETag.mockResolvedValueOnce(undefined);
+    it('accepts a combined core-field + webhook change, PUTting the core fields to the base resource and chat_webhook_url to settings', async () => {
+      // The production UI (committee-settings-tab.component.ts) always sends chat_channel/
+      // join_mode/website alongside chat_webhook_url in one save — this is the actual happy path
+      // that reaches upstream, not the webhook-only branch alone. Every other core+webhook test
+      // above only covers the authorization-failure side of this branch.
+      fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'core-etag-1' });
+      updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_channel: '#general' }); // core PUT
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // updateCommitteeSettings' own fetch
+      updateWithETag.mockResolvedValueOnce(undefined); // updateCommitteeSettings' own PUT
 
-      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).rejects.toMatchObject({
-        statusCode: 409,
-        code: 'SLACK_WEBHOOK_NOT_PERSISTED',
+      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_channel: '#general', chat_webhook_url: VALID_WEBHOOK_URL })).resolves.toMatchObject({
+        uid: COMMITTEE_UID,
+        chat_channel: '#general',
       });
-    });
 
-    it('throws SLACK_WEBHOOK_UNVERIFIED (distinct from SLACK_WEBHOOK_NOT_PERSISTED) when the confirmation read itself fails, after the settings update already succeeded', async () => {
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
-        // getSlackWebhookUrlStrict's read-back GET fails outright (e.g. a transient upstream
-        // outage) — must not be reported the same way as a confirmed mismatch, since everything
-        // requested up to this point already committed.
-        .mockRejectedValueOnce(new Error('upstream unavailable'));
-      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
-      updateWithETag.mockResolvedValueOnce(undefined);
-
-      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).rejects.toMatchObject({
-        statusCode: 409,
-        code: 'SLACK_WEBHOOK_UNVERIFIED',
-      });
+      expect(checkSingleAccessStrict).toHaveBeenCalledWith(req, { resource: 'project', id: 'project-1', access: 'writer' });
+      expect(updateWithETag).toHaveBeenNthCalledWith(
+        1,
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${COMMITTEE_UID}`,
+        'core-etag-1',
+        expect.objectContaining({ chat_channel: '#general' }),
+        'update_committee'
+      );
+      expect(updateWithETag).toHaveBeenNthCalledWith(
+        2,
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${COMMITTEE_UID}/settings`,
+        'settings-etag-1',
+        expect.objectContaining({ chat_webhook_url: VALID_WEBHOOK_URL }),
+        'update_committee_settings'
+      );
     });
 
     it('never returns chat_webhook_url on the response even if upstream happens to echo it back', async () => {
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL })
-        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL });
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL });
       fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
       updateWithETag.mockResolvedValueOnce(undefined);
 
@@ -681,47 +685,54 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect('chat_webhook_url' in result).toBe(false);
     });
 
-    it('does not perform the read-back confirmation GET, and does not run the webhook-only branch, when chat_webhook_url is not part of the update', async () => {
+    it('does not run the webhook-only branch when chat_webhook_url is not part of the update', async () => {
       fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' });
       updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Updated', project_uid: 'project-1' });
 
       await service.updateCommittee(req, COMMITTEE_UID, { name: 'Updated' });
 
-      // Neither the webhook-only branch's committee GET nor the read-back check
-      // (getSlackWebhookUrlStrict) issue a bare proxyRequest call in this flow — its absence
-      // proves both were skipped.
+      // The webhook-only branch's committee GET is the only bare proxyRequest call site in this
+      // flow — its absence proves the branch was skipped.
       expect(proxyRequest).not.toHaveBeenCalled();
     });
 
-    it('normalizes an empty-string chat_webhook_url to null instead of a spurious read-back mismatch', async () => {
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
-        // Read-back GET — nothing configured upstream, matching the normalized null.
-        .mockResolvedValueOnce({});
+    it('normalizes an empty-string chat_webhook_url to null in the settings PUT payload (clear, not a literal empty string)', async () => {
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
       fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
       updateWithETag.mockResolvedValueOnce(undefined);
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: '' })).resolves.toMatchObject({ uid: COMMITTEE_UID });
+
+      expect(updateWithETag).toHaveBeenCalledWith(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${COMMITTEE_UID}/settings`,
+        'settings-etag-1',
+        expect.objectContaining({ chat_webhook_url: null }),
+        'update_committee_settings'
+      );
     });
 
-    it('runs the read-back check after the settings update, so unrelated settings changes are not silently discarded when the webhook fails to persist', async () => {
-      // chat_webhook_url and is_audit_enabled are both settings-routed fields — no core field
-      // in this payload, so only ONE PUT happens (settings), not two.
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // webhook-only branch's committee GET
-        .mockResolvedValueOnce({}); // read-back GET, still no webhook
-      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // settings fetch
-      updateWithETag.mockResolvedValueOnce(undefined); // settings PUT — webhook silently dropped
+    it('sends chat_webhook_url alongside other settings fields in a single settings PUT when there is no core update', async () => {
+      // chat_webhook_url and is_audit_enabled are both settings-routed fields — no core field in
+      // this payload, so only ONE PUT happens (settings), not two.
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }); // webhook-only branch's committee GET
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
+      updateWithETag.mockResolvedValueOnce(undefined);
 
-      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL, is_audit_enabled: true })).rejects.toMatchObject({
-        statusCode: 409,
-        code: 'SLACK_WEBHOOK_NOT_PERSISTED',
+      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL, is_audit_enabled: true })).resolves.toMatchObject({
+        uid: COMMITTEE_UID,
       });
 
-      // The settings PUT (carrying both is_audit_enabled and chat_webhook_url) ran before the
-      // throw — is_audit_enabled was not silently dropped just because the webhook failed to
-      // persist.
       expect(updateWithETag).toHaveBeenCalledTimes(1);
+      expect(updateWithETag).toHaveBeenCalledWith(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${COMMITTEE_UID}/settings`,
+        'settings-etag-1',
+        expect.objectContaining({ chat_webhook_url: VALID_WEBHOOK_URL, is_audit_enabled: true }),
+        'update_committee_settings'
+      );
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -618,6 +618,23 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       );
     });
 
+    it('never echoes has_chat_webhook (upstream read-only computed field) back in the settings PUT body, even though it rides in via the current-settings fetch', async () => {
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
+      fetchWithETag.mockResolvedValueOnce({
+        data: { business_email_required: false, has_chat_webhook: true },
+        etag: 'settings-etag-1',
+      });
+      updateWithETag.mockResolvedValueOnce(undefined);
+
+      await service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL });
+
+      const settingsPutBody = updateWithETag.mock.calls[0][4];
+      expect('has_chat_webhook' in settingsPutBody).toBe(false);
+      // Confirms the strip targets only has_chat_webhook — a real current setting alongside it
+      // must still survive into the PUT body unchanged.
+      expect(settingsPutBody.business_email_required).toBe(false);
+    });
+
     it('accepts a combined core-field + webhook change, PUTting the core fields to the base resource and chat_webhook_url to settings', async () => {
       // The production UI (committee-settings-tab.component.ts) always sends chat_channel/
       // join_mode/website alongside chat_webhook_url in one save — this is the actual happy path

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -608,6 +608,26 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect(updateWithETag).not.toHaveBeenCalled();
     });
 
+    it('throws a typed 502 (not a misleading 403 NOT_PROJECT_WRITER) for a webhook-only change on a committee that no longer exists', async () => {
+      // The webhook-only branch's committee GET resolves null (deleted/nonexistent committee) —
+      // must skip the authorization check (there's no project to authorize against) and fall
+      // through to the generic empty-response guard, matching the final `else` branch's behavior
+      // for the same case, rather than surfacing NOT_PROJECT_WRITER for a committee that was
+      // never found. The settings write is still attempted first (same "settings write must not
+      // be blocked by the response-shaping guard" ordering as the no-core-update 502 test above).
+      proxyRequest.mockResolvedValueOnce(null); // webhook-only branch's committee GET
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // updateCommitteeSettings' own fetch
+      updateWithETag.mockResolvedValueOnce({}); // updateCommitteeSettings' own PUT
+
+      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).rejects.toMatchObject({
+        statusCode: 502,
+        code: 'UPSTREAM_INVALID_RESPONSE',
+      });
+
+      expect(checkSingleAccessStrict).not.toHaveBeenCalled();
+      expect(updateWithETag).toHaveBeenCalledOnce();
+    });
+
     it('accepts a well-formed hooks.slack.com URL', async () => {
       // Webhook-only payload — no core field — so this goes through the settings-only branch:
       // a plain GET for project_uid/response-shaping, then the settings fetchWithETag/updateWithETag

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -349,10 +349,13 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
   });
 
   describe('getCommitteeById', () => {
-    it('computes has_slack_webhook from the upstream chat_webhook_url field and never returns the raw value', async () => {
+    it('computes has_slack_webhook from the settings-resource chat_webhook_url field and never returns the raw value', async () => {
+      // Seeded on the SETTINGS response (second proxyRequest call), not the base one — per
+      // LFXV2-3094 / lfx-v2-committee-service PR #177, chat_webhook_url lives on
+      // GET /committees/:id/settings, not the base committee resource.
       proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL })
-        .mockResolvedValueOnce({}); // GET /committees/:id/settings
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // GET /committees/:id
+        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL }); // GET /committees/:id/settings
 
       const result = await service.getCommitteeById(req, COMMITTEE_UID);
 
@@ -368,10 +371,10 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect(result.has_slack_webhook).toBe(false);
     });
 
-    it('reports has_slack_webhook: false for a stored value that fails the Slack allowlist (e.g. written by a non-BFF caller)', async () => {
+    it('reports has_slack_webhook: false for a settings-resource value that fails the Slack allowlist (e.g. written by a non-BFF caller)', async () => {
       proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: 'https://evil.example.com/x' })
-        .mockResolvedValueOnce({});
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
+        .mockResolvedValueOnce({ chat_webhook_url: 'https://evil.example.com/x' });
 
       const result = await service.getCommitteeById(req, COMMITTEE_UID);
 
@@ -379,18 +382,17 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect('chat_webhook_url' in result).toBe(false);
     });
 
-    it('never returns chat_webhook_url even if a future upstream schema change lands it on the settings resource instead of the base one', async () => {
-      // Forward-looking: LFXV2-3094 hasn't landed the field on either resource yet, so today
-      // this scenario can't occur — but the settings response is spread into the merged result
-      // unstripped, so if it ever does land here instead of the base resource, only the final
-      // stripChatWebhookUrl call on the returned object closes the leak.
+    it('strips a chat_webhook_url that unexpectedly shows up on the base committee resource too — defense-in-depth beyond the settings-resource source', async () => {
       proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
-        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL });
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL })
+        .mockResolvedValueOnce({});
 
       const result = await service.getCommitteeById(req, COMMITTEE_UID);
 
       expect('chat_webhook_url' in result).toBe(false);
+      // has_slack_webhook is sourced from settings only — a base-resource leak alone must not
+      // flip it true.
+      expect(result.has_slack_webhook).toBe(false);
     });
 
     it('never returns chat_webhook_url on the includeProjectMetadata: true (enriched) path — the one actually used by GET /api/committees/:id', async () => {
@@ -420,25 +422,31 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
   // dedicated describe block calling it directly.
 
   describe('getCommitteeForSlackShare', () => {
-    it('returns name, project_uid, and the raw webhook URL from a single fetch', async () => {
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL });
+    it('returns name, project_uid (base resource), and the raw webhook URL (settings resource) from two parallel fetches', async () => {
+      // Array order in the Promise.all inside getCommitteeForSlackShare determines mock order:
+      // base committee first, settings second.
+      proxyRequest
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
+        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL });
 
       await expect(service.getCommitteeForSlackShare(req, COMMITTEE_UID)).resolves.toEqual({
         name: 'Test',
         project_uid: 'project-1',
         chat_webhook_url: VALID_WEBHOOK_URL,
       });
-      expect(proxyRequest).toHaveBeenCalledOnce();
+      // Two calls, not one — chat_webhook_url no longer lives on the same resource as
+      // name/project_uid (LFXV2-3094), so a single fetch can no longer cover all three.
+      expect(proxyRequest).toHaveBeenCalledTimes(2);
     });
 
     it('returns chat_webhook_url: null when not configured', async () => {
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }).mockResolvedValueOnce({});
 
       await expect(service.getCommitteeForSlackShare(req, COMMITTEE_UID)).resolves.toMatchObject({ chat_webhook_url: null });
     });
 
-    it('throws 404 when the committee does not exist', async () => {
-      proxyRequest.mockResolvedValueOnce(undefined);
+    it('throws 404 when the base committee does not exist, regardless of the settings fetch', async () => {
+      proxyRequest.mockResolvedValueOnce(undefined).mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL });
 
       await expect(service.getCommitteeForSlackShare(req, COMMITTEE_UID)).rejects.toMatchObject({ statusCode: 404 });
     });
@@ -583,22 +591,44 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect(proxyRequest).not.toHaveBeenCalled();
     });
 
+    it('rejects a webhook-only change (403 NOT_PROJECT_WRITER) with no other core or settings field, before any write — the project-writer check must not depend on another core field being present to trigger it', async () => {
+      // No core field in this payload, so the old (pre-LFXV2-3094) code path would have skipped
+      // the authorization check entirely by going straight to the no-core-update GET fallback.
+      // The webhook-only branch must fetch project_uid and run the same check regardless.
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }); // webhook-only branch's committee GET
+      checkSingleAccessStrict.mockResolvedValueOnce(false);
+
+      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).rejects.toMatchObject({
+        statusCode: 403,
+        code: 'NOT_PROJECT_WRITER',
+      });
+
+      expect(checkSingleAccessStrict).toHaveBeenCalledWith(req, { resource: 'project', id: 'project-1', access: 'writer' });
+      expect(fetchWithETag).not.toHaveBeenCalled();
+      expect(updateWithETag).not.toHaveBeenCalled();
+    });
+
     it('accepts a well-formed hooks.slack.com URL', async () => {
-      fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' });
-      updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL });
-      // getSlackWebhookUrlStrict's read-back confirmation GET.
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, chat_webhook_url: VALID_WEBHOOK_URL });
+      // Webhook-only payload — no core field — so this goes through the settings-only branch:
+      // a plain GET for project_uid/response-shaping, then the settings fetchWithETag/updateWithETag
+      // pair, then the read-back confirmation GET.
+      proxyRequest
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // webhook-only branch's committee GET
+        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL }); // getSlackWebhookUrlStrict's read-back settings GET
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // updateCommitteeSettings' own fetch
+      updateWithETag.mockResolvedValueOnce(undefined); // updateCommitteeSettings' own PUT
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).resolves.toMatchObject({ uid: COMMITTEE_UID });
     });
 
-    it('throws SLACK_WEBHOOK_NOT_PERSISTED when upstream silently drops the field instead of reporting a false success (no committee-service schema support yet)', async () => {
-      fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' });
-      // Upstream's PUT response doesn't echo chat_webhook_url back — simulates today's real
-      // committee-service, which has no field for it at all.
-      updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
-      // The read-back confirmation GET also comes back without it.
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID });
+    it('throws SLACK_WEBHOOK_NOT_PERSISTED when upstream silently drops the field instead of reporting a false success (schema not deployed yet — LFXV2-3094/#177 unmerged)', async () => {
+      proxyRequest
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // webhook-only branch's committee GET
+        // The read-back confirmation GET comes back without it — simulates today's real
+        // committee-service, which doesn't persist the field yet.
+        .mockResolvedValueOnce({});
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
+      updateWithETag.mockResolvedValueOnce(undefined);
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).rejects.toMatchObject({
         statusCode: 409,
@@ -606,13 +636,15 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       });
     });
 
-    it('throws SLACK_WEBHOOK_UNVERIFIED (distinct from SLACK_WEBHOOK_NOT_PERSISTED) when the confirmation read itself fails, after the core PUT and settings update already succeeded', async () => {
-      fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' });
-      updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
-      // getSlackWebhookUrlStrict's read-back GET fails outright (e.g. a transient upstream
-      // outage) — must not be reported the same way as a confirmed mismatch, since everything
-      // requested up to this point already committed.
-      proxyRequest.mockRejectedValueOnce(new Error('upstream unavailable'));
+    it('throws SLACK_WEBHOOK_UNVERIFIED (distinct from SLACK_WEBHOOK_NOT_PERSISTED) when the confirmation read itself fails, after the settings update already succeeded', async () => {
+      proxyRequest
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
+        // getSlackWebhookUrlStrict's read-back GET fails outright (e.g. a transient upstream
+        // outage) — must not be reported the same way as a confirmed mismatch, since everything
+        // requested up to this point already committed.
+        .mockRejectedValueOnce(new Error('upstream unavailable'));
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
+      updateWithETag.mockResolvedValueOnce(undefined);
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).rejects.toMatchObject({
         statusCode: 409,
@@ -621,52 +653,58 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
     });
 
     it('never returns chat_webhook_url on the response even if upstream happens to echo it back', async () => {
-      fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' });
-      updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL });
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, chat_webhook_url: VALID_WEBHOOK_URL });
+      proxyRequest
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', chat_webhook_url: VALID_WEBHOOK_URL })
+        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL });
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
+      updateWithETag.mockResolvedValueOnce(undefined);
 
       const result = await service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL });
 
       expect('chat_webhook_url' in result).toBe(false);
     });
 
-    it('does not perform the read-back confirmation GET when chat_webhook_url is not part of the update', async () => {
+    it('does not perform the read-back confirmation GET, and does not run the webhook-only branch, when chat_webhook_url is not part of the update', async () => {
       fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' });
       updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Updated', project_uid: 'project-1' });
 
       await service.updateCommittee(req, COMMITTEE_UID, { name: 'Updated' });
 
-      // The read-back check (getSlackWebhookUrlStrict) is the only caller of a bare GET
-      // /committees/:id via proxyRequest in this flow — its absence proves the check was skipped.
+      // Neither the webhook-only branch's committee GET nor the read-back check
+      // (getSlackWebhookUrlStrict) issue a bare proxyRequest call in this flow — its absence
+      // proves both were skipped.
       expect(proxyRequest).not.toHaveBeenCalled();
     });
 
     it('normalizes an empty-string chat_webhook_url to null instead of a spurious read-back mismatch', async () => {
-      fetchWithETag.mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' });
-      updateWithETag.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
-      // Read-back GET — nothing configured upstream, matching the normalized null.
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID });
+      proxyRequest
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
+        // Read-back GET — nothing configured upstream, matching the normalized null.
+        .mockResolvedValueOnce({});
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
+      updateWithETag.mockResolvedValueOnce(undefined);
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: '' })).resolves.toMatchObject({ uid: COMMITTEE_UID });
     });
 
     it('runs the read-back check after the settings update, so unrelated settings changes are not silently discarded when the webhook fails to persist', async () => {
-      fetchWithETag
-        .mockResolvedValueOnce({ data: { uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }, etag: 'etag-1' }) // core committee fetch
-        .mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // settings fetch
-      updateWithETag
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // core PUT — webhook silently dropped
-        .mockResolvedValueOnce(undefined); // settings PUT
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID }); // read-back GET, still no webhook
+      // chat_webhook_url and is_audit_enabled are both settings-routed fields — no core field
+      // in this payload, so only ONE PUT happens (settings), not two.
+      proxyRequest
+        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }) // webhook-only branch's committee GET
+        .mockResolvedValueOnce({}); // read-back GET, still no webhook
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // settings fetch
+      updateWithETag.mockResolvedValueOnce(undefined); // settings PUT — webhook silently dropped
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL, is_audit_enabled: true })).rejects.toMatchObject({
         statusCode: 409,
         code: 'SLACK_WEBHOOK_NOT_PERSISTED',
       });
 
-      // Both the core PUT and the settings PUT ran before the throw — is_audit_enabled was not
-      // silently dropped just because the webhook failed to persist.
-      expect(updateWithETag).toHaveBeenCalledTimes(2);
+      // The settings PUT (carrying both is_audit_enabled and chat_webhook_url) ran before the
+      // throw — is_audit_enabled was not silently dropped just because the webhook failed to
+      // persist.
+      expect(updateWithETag).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -42,6 +42,7 @@ vi.mock('@lfx-one/shared/enums', () => ({
 vi.mock('@lfx-one/shared/utils', () => ({ invitationRequiresOrganization: vi.fn() }));
 vi.mock('@lfx-one/shared/constants', () => ({
   SLACK_INCOMING_WEBHOOK_URL_PATTERN: /^https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9]+\/B[A-Za-z0-9]+\/[A-Za-z0-9]+$/,
+  CHAT_WEBHOOK_URL_MAX_LENGTH: 500,
 }));
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
@@ -536,13 +537,24 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect(proxyRequest).not.toHaveBeenCalled();
     });
 
-    it("rejects non-string chat_webhook_url JSON values (false, 0, objects) with a 400 before any write — the declared string|null type doesn't stop a raw req.body cast, and falsy non-strings would otherwise skip the pattern test and only fail post-write via the read-back mismatch", async () => {
+    it("rejects non-string chat_webhook_url JSON values (false, 0, objects) with a 400 before any write — the declared string|null type doesn't stop a raw req.body cast, and a truthiness-only check would otherwise let falsy non-strings skip the pattern test entirely", async () => {
       for (const badValue of [false, 0, { url: VALID_WEBHOOK_URL }]) {
         await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: badValue as unknown as string })).rejects.toMatchObject({
           statusCode: 400,
           code: 'VALIDATION_ERROR',
         });
       }
+
+      expect(fetchWithETag).not.toHaveBeenCalled();
+      expect(proxyRequest).not.toHaveBeenCalled();
+    });
+
+    it('rejects a chat_webhook_url longer than CHAT_WEBHOOK_URL_MAX_LENGTH, even if it otherwise matches the pattern, before touching upstream', async () => {
+      const overLongUrl = `https://hooks.slack.com/services/T000/B000/${'X'.repeat(500)}`;
+
+      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: overLongUrl })).rejects.toMatchObject({
+        statusCode: 400,
+      });
 
       expect(fetchWithETag).not.toHaveBeenCalled();
       expect(proxyRequest).not.toHaveBeenCalled();

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -608,24 +608,21 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect(updateWithETag).not.toHaveBeenCalled();
     });
 
-    it('throws a typed 502 (not a misleading 403 NOT_PROJECT_WRITER) for a webhook-only change on a committee that no longer exists', async () => {
-      // The webhook-only branch's committee GET resolves null (deleted/nonexistent committee) —
-      // must skip the authorization check (there's no project to authorize against) and fall
-      // through to the generic empty-response guard, matching the final `else` branch's behavior
-      // for the same case, rather than surfacing NOT_PROJECT_WRITER for a committee that was
-      // never found. The settings write is still attempted first (same "settings write must not
-      // be blocked by the response-shaping guard" ordering as the no-core-update 502 test above).
+    it('throws a typed 404 (not a misleading 403 NOT_PROJECT_WRITER, and before any write) for a webhook-only change on a committee that no longer exists', async () => {
+      // The webhook-only branch's committee GET resolves null (deleted/nonexistent committee).
+      // Thrown immediately, before the authorization check and before updateCommitteeSettings —
+      // deferring to the generic response-shaping guard further down would let the settings
+      // write (including the webhook itself) commit with no project-writer check at all, since
+      // assertWebhookChangeAuthorized never runs without a project_uid to check against.
       proxyRequest.mockResolvedValueOnce(null); // webhook-only branch's committee GET
-      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' }); // updateCommitteeSettings' own fetch
-      updateWithETag.mockResolvedValueOnce({}); // updateCommitteeSettings' own PUT
 
       await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: VALID_WEBHOOK_URL })).rejects.toMatchObject({
-        statusCode: 502,
-        code: 'UPSTREAM_INVALID_RESPONSE',
+        statusCode: 404,
       });
 
       expect(checkSingleAccessStrict).not.toHaveBeenCalled();
-      expect(updateWithETag).toHaveBeenCalledOnce();
+      expect(fetchWithETag).not.toHaveBeenCalled();
+      expect(updateWithETag).not.toHaveBeenCalled();
     });
 
     it('accepts a well-formed hooks.slack.com URL', async () => {

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -362,6 +362,10 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
 
       expect(result.has_slack_webhook).toBe(true);
       expect('chat_webhook_url' in result).toBe(false);
+      // has_chat_webhook itself is upstream's raw wire field, not part of the Committee contract
+      // (has_slack_webhook is) — it must not ride out on the response just because it's spread
+      // in from the settings fetch.
+      expect('has_chat_webhook' in result).toBe(false);
     });
 
     it('reports has_slack_webhook: false when no webhook is configured upstream', async () => {
@@ -402,43 +406,6 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
 
       expect('chat_webhook_url' in result).toBe(false);
       expect(result.project_slug).toBe('test-project');
-    });
-  });
-
-  // getSlackWebhookUrlStrict is private (its only caller is updateCommittee, in this same
-  // class) — its "returns the raw URL when configured" / "returns null when not configured"
-  // behavior is exercised indirectly by updateCommittee's read-back tests below (e.g. "accepts
-  // a well-formed hooks.slack.com URL" and "throws SLACK_WEBHOOK_NOT_PERSISTED..."), not by a
-  // dedicated describe block calling it directly.
-
-  describe('getCommitteeForSlackShare', () => {
-    it('returns name, project_uid (base resource), and the raw webhook URL (settings resource) from two parallel fetches', async () => {
-      // Array order in the Promise.all inside getCommitteeForSlackShare determines mock order:
-      // base committee first, settings second.
-      proxyRequest
-        .mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' })
-        .mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL });
-
-      await expect(service.getCommitteeForSlackShare(req, COMMITTEE_UID)).resolves.toEqual({
-        name: 'Test',
-        project_uid: 'project-1',
-        chat_webhook_url: VALID_WEBHOOK_URL,
-      });
-      // Two calls, not one — chat_webhook_url no longer lives on the same resource as
-      // name/project_uid (LFXV2-3094), so a single fetch can no longer cover all three.
-      expect(proxyRequest).toHaveBeenCalledTimes(2);
-    });
-
-    it('returns chat_webhook_url: null when not configured', async () => {
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' }).mockResolvedValueOnce({});
-
-      await expect(service.getCommitteeForSlackShare(req, COMMITTEE_UID)).resolves.toMatchObject({ chat_webhook_url: null });
-    });
-
-    it('throws 404 when the base committee does not exist, regardless of the settings fetch', async () => {
-      proxyRequest.mockResolvedValueOnce(undefined).mockResolvedValueOnce({ chat_webhook_url: VALID_WEBHOOK_URL });
-
-      await expect(service.getCommitteeForSlackShare(req, COMMITTEE_UID)).rejects.toMatchObject({ statusCode: 404 });
     });
   });
 
@@ -696,7 +663,7 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
       expect(proxyRequest).not.toHaveBeenCalled();
     });
 
-    it('normalizes an empty-string chat_webhook_url to null in the settings PUT payload (clear, not a literal empty string)', async () => {
+    it("sends an empty-string chat_webhook_url through to the settings PUT payload as-is — upstream treats null/omitted as preserve, only '' as clear", async () => {
       proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
       fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
       updateWithETag.mockResolvedValueOnce(undefined);
@@ -708,7 +675,24 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
         'LFX_V2_SERVICE',
         `/committees/${COMMITTEE_UID}/settings`,
         'settings-etag-1',
-        expect.objectContaining({ chat_webhook_url: null }),
+        expect.objectContaining({ chat_webhook_url: '' }),
+        'update_committee_settings'
+      );
+    });
+
+    it("normalizes an explicit null chat_webhook_url to '' in the settings PUT payload too — a caller sending null to THIS API means clear, same as '', even though upstream's own null means preserve", async () => {
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1' });
+      fetchWithETag.mockResolvedValueOnce({ data: {}, etag: 'settings-etag-1' });
+      updateWithETag.mockResolvedValueOnce(undefined);
+
+      await expect(service.updateCommittee(req, COMMITTEE_UID, { chat_webhook_url: null })).resolves.toMatchObject({ uid: COMMITTEE_UID });
+
+      expect(updateWithETag).toHaveBeenCalledWith(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${COMMITTEE_UID}/settings`,
+        'settings-etag-1',
+        expect.objectContaining({ chat_webhook_url: '' }),
         'update_committee_settings'
       );
     });

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -391,9 +391,15 @@ export class CommitteeService {
       options.includeMailingListStatus ? this.getMailingListCountByCommittee(req, committeeId) : Promise.resolve(null),
     ]);
 
+    // has_chat_webhook is upstream's raw wire field (settings.has_chat_webhook) — read into
+    // has_slack_webhook below, then excluded from the spread so it doesn't ride out on the
+    // response undeclared (Committee has no has_chat_webhook field of its own).
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional strip, not a read */
+    const { has_chat_webhook: _hasChatWebhook, ...settingsForResponse } = settings;
+
     const merged = {
       ...withAccess,
-      ...settings,
+      ...settingsForResponse,
       ...(membership && { my_role: membership.role, my_member_uid: membership.member_uid }),
       ...(inheritedPermissions && { inherited_writers: inheritedPermissions.writers, inherited_auditors: inheritedPermissions.auditors }),
       ...(mlCount !== null && { has_mailing_list: mlCount > 0 }),
@@ -550,9 +556,8 @@ export class CommitteeService {
     }
 
     // A truthiness-only check below would let falsy non-strings through: they'd skip the pattern
-    // test, ride the settings PUT, and only surface after the write via the read-back mismatch.
-    // The check below therefore rejects every value that isn't absent, null, or a string —
-    // before any write happens.
+    // test entirely and ride straight into the settings PUT payload. The check below therefore
+    // rejects every value that isn't absent, null, or a string — before any write happens.
     if (
       rawChatWebhookUrl !== undefined &&
       rawChatWebhookUrl !== null &&
@@ -565,11 +570,17 @@ export class CommitteeService {
       });
     }
 
-    // Normalized once, up front: an empty string must behave identically to omission/null
-    // everywhere below it's used (hasSettingsUpdate and the settings PUT payload) — a stored
-    // empty string isn't a meaningful "configured" state, and upstream's own clear semantics
-    // (LFXV2-3094) treat '' the same as sending null.
-    const chatWebhookUrlToSave: string | null | undefined = rawChatWebhookUrl === '' ? null : (rawChatWebhookUrl as string | null | undefined);
+    // Normalized to upstream's OWN clear signal, not this API's usual null-means-clear
+    // convention (see mailing_list/chat_channel elsewhere on this same type): upstream treats
+    // omitted/null as "preserve the existing value" and only an explicit '' as "clear" — see
+    // lfx-v2-committee-service's committee_writer.go UpdateSettings, which documents this
+    // specifically because chat_webhook_url is write-only, so a GET→PUT round-trip here always
+    // sends nil for it and must not be read as "wipe the credential". A caller sending either ''
+    // or null to THIS API means "clear" (both are an explicit action, unlike omission — see the
+    // impersonation guard above, which blocks both the same as setting a real URL); both are
+    // normalized to upstream's '' here so the settings PUT actually clears rather than silently
+    // preserving the old value.
+    const chatWebhookUrlToSave: string | undefined = rawChatWebhookUrl === '' || rawChatWebhookUrl === null ? '' : (rawChatWebhookUrl as string | undefined);
 
     const hasSettingsUpdate =
       business_email_required !== undefined ||
@@ -1747,38 +1758,6 @@ export class CommitteeService {
       tags: `committee_uid:${committeeId}`,
     });
     return count > 0;
-  }
-
-  /**
-   * Fetch variant for `shareToSlack`: `name`, `project_uid`, and the raw webhook URL — not
-   * {@link getCommitteeById}'s settings/membership/access-check enrichment, none of which
-   * `shareToSlack` reads. See {@link getSlackWebhookUrlStrict}'s doc comment for why this exists
-   * as its own method rather than composing the two.
-   *
-   * Two upstream calls, run in parallel via `Promise.all`, not one: per LFXV2-3094,
-   * `chat_webhook_url` lives on the settings sub-resource while `name`/`project_uid` live on the
-   * base one, so a single fetch can no longer cover all three (it could before the field moved).
-   * Running both concurrently keeps the TOCTOU window between "read the webhook" and "use it"
-   * as small as it can be given two separate reads — sequential fetches would only widen it.
-   *
-   * @internal Cannot be `private` like {@link getSlackWebhookUrlStrict} — `WeeklyBriefService`
-   * must call it — but that also means nothing mechanically stops a future caller from obtaining
-   * the raw credential through it. Only `WeeklyBriefService.shareToSlack` may call this today;
-   * treat any new call site as a review flag, not a routine addition.
-   */
-  public async getCommitteeForSlackShare(req: Request, committeeId: string): Promise<{ name: string; project_uid: string; chat_webhook_url: string | null }> {
-    const [committee, settings] = await Promise.all([
-      this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET'),
-      this.microserviceProxy.proxyRequest<CommitteeSettingsData>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/settings`, 'GET'),
-    ]);
-    if (!committee) {
-      throw new ResourceNotFoundError('Committee', committeeId, {
-        operation: 'get_committee_for_slack_share',
-        service: 'committee_service',
-        path: `/committees/${committeeId}`,
-      });
-    }
-    return { name: committee.name, project_uid: committee.project_uid, chat_webhook_url: settings?.chat_webhook_url ?? null };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -365,12 +365,7 @@ export class CommitteeService {
     // LFXV2-2914). Compute it the same way the query-service-backed list
     // endpoints (getCommittees/getMyCommittees) do: a direct count against
     // the mailing-list index.
-    const rawCommittee = await this.microserviceProxy.proxyRequest<Committee & { chat_webhook_url?: string | null }>(
-      req,
-      'LFX_V2_SERVICE',
-      `/committees/${committeeId}`,
-      'GET'
-    );
+    const rawCommittee = await this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
 
     if (!rawCommittee) {
       throw new ResourceNotFoundError('Committee', committeeId, {
@@ -380,11 +375,11 @@ export class CommitteeService {
       });
     }
 
-    // chat_webhook_url is a bearer credential — strip it immediately after the upstream fetch so
-    // it never flows into the access-check merge, project-metadata enrichment, or the HTTP
-    // response. has_slack_webhook is the only signal any read gets; see the doc comment on
-    // Committee.has_slack_webhook and CommitteeUpdateData.chat_webhook_url.
-    const { chat_webhook_url: chatWebhookUrl, ...committee } = rawCommittee;
+    // chat_webhook_url does not live on the base committee resource (see LFXV2-3094 below), but
+    // strip it defensively anyway before it can flow into the access-check merge, project-metadata
+    // enrichment, or the HTTP response — a no-op today, cheap insurance if that ever changes.
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional strip, not a read */
+    const { chat_webhook_url: _baseChatWebhookUrl, ...committee } = rawCommittee as Committee & { chat_webhook_url?: string | null };
 
     // Fetch settings, optional caller membership, access, optional inherited
     // (parent-project) permissions, and optional mailing-list status in parallel.
@@ -396,6 +391,13 @@ export class CommitteeService {
       options.includeMailingListStatus ? this.getMailingListCountByCommittee(req, committeeId) : Promise.resolve(null),
     ]);
 
+    // chat_webhook_url lives on the settings sub-resource (GET /committees/:id/settings), not the
+    // base committee object — confirmed against lfx-v2-committee-service PR #177 (LFXV2-3094):
+    // ChatWebhookURLAttribute() is added only to CommitteeSettingsAttributes(), deliberately kept
+    // off the base Committee type so the webhook isn't visible to every committee viewer. #177 is
+    // not yet merged/deployed as of this writing.
+    const settingsChatWebhookUrl = settings.chat_webhook_url;
+
     const merged = {
       ...withAccess,
       ...settings,
@@ -406,23 +408,12 @@ export class CommitteeService {
       // (e.g. stored by a non-BFF writer, since this repo isn't the only writer of the field)
       // must not show as "Configured" — shareToSlack re-validates the same pattern at send time,
       // and a Configured badge over a value that's guaranteed to 409 there is a dead end.
-      //
-      // Base-resource-only, like getSlackWebhookUrlStrict and getCommitteeForSlackShare below —
-      // none of the three read this from `settings`. If LFXV2-3094 lands the field on the
-      // settings resource instead of the base one, this trio silently under-reports rather than
-      // leaking: has_slack_webhook stays false for a genuinely configured committee (Share stays
-      // disabled, the settings card shows "Not configured"), with no error surfaced anywhere.
-      // Deliberately not guessing at a dual-source read for an undecided schema — whichever
-      // resource LFXV2-3094 actually lands on, update all three read sites together then.
-      has_slack_webhook: !!chatWebhookUrl && SLACK_INCOMING_WEBHOOK_URL_PATTERN.test(chatWebhookUrl),
+      has_slack_webhook: !!settingsChatWebhookUrl && SLACK_INCOMING_WEBHOOK_URL_PATTERN.test(settingsChatWebhookUrl),
     };
 
-    // Defense-in-depth beyond the base-resource strip above: `settings` is a raw, uncast
-    // GET /committees/:id/settings body spread into `merged` alongside `withAccess` above,
-    // un-stripped — if the upstream schema change (LFXV2-3094) lands chat_webhook_url on the
-    // settings resource rather than the base one (undecided as of this writing), this is what
-    // stops it from leaking here. A no-op today either way, since neither resource carries the
-    // field yet.
+    // `settings` above is a raw, uncast GET /committees/:id/settings body spread into `merged`
+    // alongside `withAccess`, un-stripped — this is what stops chat_webhook_url itself (not just
+    // the has_slack_webhook boolean derived from it) from leaking into the response.
     if (!options.includeProjectMetadata) {
       return this.stripChatWebhookUrl(merged);
     }
@@ -437,7 +428,7 @@ export class CommitteeService {
    */
   public async createCommittee(req: Request, data: CommitteeCreateData): Promise<Committee> {
     // chat_webhook_url is deliberately absent from CommitteeCreateData — it's update-only (see
-    // CommitteeUpdateData.chat_webhook_url), with its own SLACK_INCOMING_WEBHOOK_URL_PATTERN
+    // CommitteeSettingsData.chat_webhook_url), with its own SLACK_INCOMING_WEBHOOK_URL_PATTERN
     // check and impersonation guard in updateCommittee, neither of which this method runs. The
     // type omission alone doesn't stop a raw req.body cast (committee.controller.ts) from
     // carrying the key at runtime, so strip it explicitly rather than relying on the type system.
@@ -497,7 +488,38 @@ export class CommitteeService {
   /**
    * Updates an existing committee using ETag for concurrency control
    */
-  public async updateCommittee(req: Request, committeeId: string, data: CommitteeUpdateData): Promise<Committee> {
+  public async updateCommittee(
+    req: Request,
+    committeeId: string,
+    data: CommitteeUpdateData & Pick<CommitteeSettingsData, 'chat_webhook_url'>
+  ): Promise<Committee> {
+    // Extract settings fields — writers/auditors/chat_webhook_url all belong to
+    // UpdateCommitteeSettingsRequestBody, NOT UpdateCommitteeBaseRequestBody, so they must go
+    // through the settings endpoint (updateCommitteeSettings), never the core PUT below.
+    // chat_webhook_url comes from CommitteeSettingsData, not CommitteeUpdateData (see
+    // LFXV2-3094) — this method's parameter type is deliberately CommitteeUpdateData intersected
+    // with just that one settings field, since this single endpoint accepts one merged payload
+    // and internally routes pieces of it to two different upstream resources. Naming it
+    // explicitly here, rather than letting it fall into `...committeeData`, is what keeps it out
+    // of the core PUT body.
+    const {
+      business_email_required,
+      is_audit_enabled,
+      show_meeting_attendees,
+      member_visibility,
+      writers,
+      auditors,
+      chat_webhook_url: rawChatWebhookUrlTyped,
+      ...committeeData
+    } = data;
+
+    // Read as `unknown`, not trusting the declared `string | null | undefined` type: this body
+    // arrives as raw JSON (the controller casts req.body to this method's parameter type via a
+    // bare variable annotation, which performs no runtime validation — see
+    // committee.controller.ts), so a direct API caller can send any JSON value — false, 0, {},
+    // [].
+    const rawChatWebhookUrl: unknown = rawChatWebhookUrlTyped;
+
     // Server-side kill switch, independent of WG_WEEKLY_BRIEF_SLACK_FLAG (the Angular UI's
     // OpenFeature/GrowthBook flag) — that flag only gates rendering of the settings card, since
     // the OpenFeature Web SDK it's evaluated through never runs on this server. Without this, any
@@ -505,7 +527,7 @@ export class CommitteeService {
     // the API while the UI still hides the card. Checked first, before the impersonation guard
     // below, so a disabled environment reports the same "not available" outcome regardless of who's
     // asking.
-    if (data.chat_webhook_url !== undefined && !isServerFeatureEnabled(ServerFeatureFlag.WeeklyBriefSlack)) {
+    if (rawChatWebhookUrl !== undefined && !isServerFeatureEnabled(ServerFeatureFlag.WeeklyBriefSlack)) {
       throw new ConflictError('Slack webhook sharing is not enabled in this environment', 'FEATURE_DISABLED', {
         operation: 'update_committee',
         service: 'committee_service',
@@ -521,7 +543,7 @@ export class CommitteeService {
     // it is rejected whole, before any write (ETag fetch, core PUT, settings update), so name /
     // chat_channel / business_email_required / etc. sent *alongside* chat_webhook_url in the same
     // request are rejected too — resubmit them without the webhook field to save just those.
-    if (data.chat_webhook_url !== undefined && isImpersonating(req)) {
+    if (rawChatWebhookUrl !== undefined && isImpersonating(req)) {
       logger.warning(req, 'impersonation_readonly', 'Blocked chat_webhook_url write during impersonation', {
         committee_id: committeeId,
         impersonator_sub: req.appSession?.['impersonator']?.sub,
@@ -535,22 +557,10 @@ export class CommitteeService {
       });
     }
 
-    // Read as `unknown` first: the static type says `string | null | undefined`, but this body
-    // arrives as raw JSON (the controller casts req.body), so a direct API caller can send any
-    // JSON value — false, 0, {}, []. A truthiness-only check below would let falsy non-strings
-    // through: they'd skip the pattern test, ride the core PUT, and only surface after the write
-    // via the read-back mismatch (or via upstream unmarshalling once the LFXV2-3094 schema
-    // lands). The check below therefore rejects every value that isn't absent, null, or a
-    // string — before any write happens.
-    const rawChatWebhookUrl = (data as CommitteeUpdateData & { chat_webhook_url?: unknown }).chat_webhook_url;
-
-    // Normalized once, up front: an empty string must behave identically to omission/null
-    // everywhere below it's used (validation skip, the PUT payload, and the read-back
-    // comparison) — otherwise a direct API caller sending '' would skip validation (falsy,
-    // intentionally) but then fail the read-back check with a spurious mismatch against the
-    // `null` getSlackWebhookUrlStrict actually returns for "not configured".
-    const normalizedData: CommitteeUpdateData = { ...data, ...(rawChatWebhookUrl === '' && { chat_webhook_url: null }) };
-
+    // A truthiness-only check below would let falsy non-strings through: they'd skip the pattern
+    // test, ride the settings PUT, and only surface after the write via the read-back mismatch.
+    // The check below therefore rejects every value that isn't absent, null, or a string —
+    // before any write happens.
     if (
       rawChatWebhookUrl !== undefined &&
       rawChatWebhookUrl !== null &&
@@ -563,9 +573,12 @@ export class CommitteeService {
       });
     }
 
-    // Extract settings fields — writers/auditors belong to UpdateCommitteeSettingsRequestBody,
-    // NOT UpdateCommitteeBaseRequestBody, so they must go through the settings endpoint
-    const { business_email_required, is_audit_enabled, show_meeting_attendees, member_visibility, writers, auditors, ...committeeData } = normalizedData;
+    // Normalized once, up front: an empty string must behave identically to omission/null
+    // everywhere below it's used (hasSettingsUpdate, the settings PUT payload, and the read-back
+    // comparison) — otherwise a direct API caller sending '' would skip validation (falsy,
+    // intentionally) but then fail the read-back check with a spurious mismatch against the
+    // `null` getSlackWebhookUrlStrict actually returns for "not configured".
+    const chatWebhookUrlToSave: string | null | undefined = rawChatWebhookUrl === '' ? null : (rawChatWebhookUrl as string | null | undefined);
 
     const hasSettingsUpdate =
       business_email_required !== undefined ||
@@ -573,7 +586,8 @@ export class CommitteeService {
       show_meeting_attendees !== undefined ||
       member_visibility !== undefined ||
       writers !== undefined ||
-      auditors !== undefined;
+      auditors !== undefined ||
+      chatWebhookUrlToSave !== undefined;
     const hasCoreUpdate = Object.keys(committeeData).length > 0;
 
     let updatedCommittee: Committee | null;
@@ -594,26 +608,15 @@ export class CommitteeService {
       // without this, a committee writer who is not a project writer could point the webhook at a
       // Slack workspace they control, and a later legitimate project-writer send would deliver
       // brief content there. Checked here (post-fetch, since currentCommittee.project_uid is
-      // needed) rather than before, to avoid a second upstream round trip only for this field.
-      if (normalizedData.chat_webhook_url !== undefined) {
-        const isProjectWriter = await this.accessCheckService.checkSingleAccessStrict(req, {
-          resource: 'project',
-          // Authorize against the effective post-update project, not the committee's current
-          // one: if this same PUT also moves the committee (committeeData.project_uid lands in
-          // mergedData below), a writer of only the old project could otherwise pair the move
-          // with a webhook they control — and a later legitimate writer of the new project
-          // would send briefs there.
-          id: committeeData.project_uid ?? currentCommittee.project_uid,
-          access: 'writer',
-        });
-        if (!isProjectWriter) {
-          throw new AuthorizationError('Only project writers can configure the Slack webhook', {
-            operation: 'update_committee',
-            service: 'committee_service',
-            path: `/committees/${committeeId}`,
-            code: 'NOT_PROJECT_WRITER',
-          });
-        }
+      // needed) rather than before, to avoid a second upstream round trip only for this field —
+      // and, like the settings-only branch below, before any write.
+      if (chatWebhookUrlToSave !== undefined) {
+        // Authorize against the effective post-update project, not the committee's current one:
+        // if this same PUT also moves the committee (committeeData.project_uid lands in
+        // mergedData below), a writer of only the old project could otherwise pair the move with
+        // a webhook they control — and a later legitimate writer of the new project would send
+        // briefs there.
+        await this.assertWebhookChangeAuthorized(req, committeeId, committeeData.project_uid ?? currentCommittee.project_uid);
       }
 
       // Step 2: Strip read-only and computed fields, then merge with update data (PUT replaces the entire resource)
@@ -649,6 +652,15 @@ export class CommitteeService {
         mergedData,
         'update_committee'
       );
+    } else if (chatWebhookUrlToSave !== undefined) {
+      // No core fields to update, but the webhook itself is changing (the common case: saving
+      // just the Slack card). Still needs the committee's project_uid to run the same
+      // project-writer authorization as the core-update branch above — a plain (non-ETag) GET is
+      // enough since nothing here writes the base resource, and its result doubles as the
+      // response-shaping fetch the final `else` branch below would otherwise need.
+      const currentCommittee = await this.microserviceProxy.proxyRequest<Committee | null>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
+      await this.assertWebhookChangeAuthorized(req, committeeId, currentCommittee?.project_uid);
+      updatedCommittee = currentCommittee;
     } else {
       // No core fields to update — fetch current committee for the response
       updatedCommittee = await this.microserviceProxy.proxyRequest<Committee | null>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
@@ -665,6 +677,7 @@ export class CommitteeService {
         member_visibility,
         writers,
         auditors,
+        chat_webhook_url: chatWebhookUrlToSave,
       });
     }
 
@@ -689,29 +702,31 @@ export class CommitteeService {
       });
     }
 
-    // Defensive check, run LAST (after every other write above has already committed): unlike
-    // mailing_list/chat_channel, the upstream committee-service schema does not (yet) declare
-    // chat_webhook_url as of this writing — an unknown key in the core PUT body is silently
-    // dropped by Go's JSON unmarshaling rather than rejected. Confirm via a fresh read whether it
-    // actually persisted rather than trusting a false "saved" response. Deliberately checked
-    // after the core PUT and settings update, not before — this is the one field in the whole
-    // payload that can fail here, and every other field the caller submitted (name, chat_channel,
-    // website, business_email_required, etc.) must still be reported as saved rather than
-    // silently discarded because of it. Remove this check once the upstream schema change lands
-    // (LFXV2-3094).
+    // Defensive check, run LAST (after every other write above has already committed): the
+    // committee-service schema declares chat_webhook_url on the settings resource per
+    // lfx-v2-committee-service PR #177 (LFXV2-3094), but #177 is not yet merged/deployed as of
+    // this writing — until it is, an unknown key in the settings PUT body may still be silently
+    // dropped rather than rejected. Confirm via a fresh read whether it actually persisted rather
+    // than trusting a false "saved" response. Deliberately checked after the core PUT and
+    // settings update, not before — this is the one field in the whole payload that can fail
+    // here, and every other field the caller submitted (name, chat_channel, website,
+    // business_email_required, etc.) must still be reported as saved rather than silently
+    // discarded because of it. Safe to remove once #177 has been merged, deployed, and verified
+    // stable — read-back-verifying a field the upstream schema already declares is defense in
+    // depth at that point, not a required correctness guard.
     //
     // Asymmetric today for a clear (chat_webhook_url: null): persistedWebhookUrl reads back null
     // both when a real clear persisted and when upstream has no such field to persist to in the
-    // first place, so this can't distinguish them — a clear would false-report success on today's
-    // schema-less upstream the same way a set correctly fails loud. Low-impact in practice: the
-    // Remove button (clearing an already-*configured* webhook) can't be reached until
+    // first place, so this can't distinguish them — a clear would false-report success on
+    // today's pre-#177 upstream the same way a set correctly fails loud. Low-impact in practice:
+    // the Remove button (clearing an already-*configured* webhook) can't be reached until
     // has_slack_webhook is true, which requires a webhook to have actually persisted upstream
     // (via this check or any other writer) — so that path implies the schema already exists
     // upstream. The one reachable
     // case today is typing then deleting on a never-configured committee (the control goes dirty
     // with an empty value, so saveSettings sends chat_webhook_url: null with no prior set) —
     // harmless, since nothing was actually persisted before or after either way.
-    if (committeeData.chat_webhook_url !== undefined) {
+    if (chatWebhookUrlToSave !== undefined) {
       // getSlackWebhookUrlStrict fails closed by design (propagates upstream errors rather than
       // defaulting to null) — correct for its other caller (shareToSlack, where a transient
       // outage must not be misread as "no webhook configured"), but wrong here: by this point
@@ -738,7 +753,7 @@ export class CommitteeService {
           }
         );
       }
-      if (persistedWebhookUrl !== committeeData.chat_webhook_url) {
+      if (persistedWebhookUrl !== chatWebhookUrlToSave) {
         throw new ConflictError(
           'Your other changes were saved, but the Slack webhook could not be stored — this environment does not support it yet.',
           'SLACK_WEBHOOK_NOT_PERSISTED',
@@ -1792,10 +1807,16 @@ export class CommitteeService {
   }
 
   /**
-   * Lean single-fetch variant for `shareToSlack`: only `name`, `project_uid`, and the raw webhook
-   * URL — not {@link getCommitteeById}'s settings/membership/access-check enrichment, none of
-   * which `shareToSlack` reads. See {@link getSlackWebhookUrlStrict}'s doc comment for why this
-   * exists as its own method rather than composing the two.
+   * Fetch variant for `shareToSlack`: `name`, `project_uid`, and the raw webhook URL — not
+   * {@link getCommitteeById}'s settings/membership/access-check enrichment, none of which
+   * `shareToSlack` reads. See {@link getSlackWebhookUrlStrict}'s doc comment for why this exists
+   * as its own method rather than composing the two.
+   *
+   * Two upstream calls, run in parallel via `Promise.all`, not one: per LFXV2-3094,
+   * `chat_webhook_url` lives on the settings sub-resource while `name`/`project_uid` live on the
+   * base one, so a single fetch can no longer cover all three (it could before the field moved).
+   * Running both concurrently keeps the TOCTOU window between "read the webhook" and "use it"
+   * as small as it can be given two separate reads — sequential fetches would only widen it.
    *
    * @internal Cannot be `private` like {@link getSlackWebhookUrlStrict} — `WeeklyBriefService`
    * must call it — but that also means nothing mechanically stops a future caller from obtaining
@@ -1803,12 +1824,10 @@ export class CommitteeService {
    * treat any new call site as a review flag, not a routine addition.
    */
   public async getCommitteeForSlackShare(req: Request, committeeId: string): Promise<{ name: string; project_uid: string; chat_webhook_url: string | null }> {
-    const committee = await this.microserviceProxy.proxyRequest<Committee & { chat_webhook_url?: string | null }>(
-      req,
-      'LFX_V2_SERVICE',
-      `/committees/${committeeId}`,
-      'GET'
-    );
+    const [committee, settings] = await Promise.all([
+      this.microserviceProxy.proxyRequest<Committee>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET'),
+      this.microserviceProxy.proxyRequest<CommitteeSettingsData>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/settings`, 'GET'),
+    ]);
     if (!committee) {
       throw new ResourceNotFoundError('Committee', committeeId, {
         operation: 'get_committee_for_slack_share',
@@ -1816,7 +1835,7 @@ export class CommitteeService {
         path: `/committees/${committeeId}`,
       });
     }
-    return { name: committee.name, project_uid: committee.project_uid, chat_webhook_url: committee.chat_webhook_url ?? null };
+    return { name: committee.name, project_uid: committee.project_uid, chat_webhook_url: settings?.chat_webhook_url ?? null };
   }
 
   /**
@@ -1826,21 +1845,49 @@ export class CommitteeService {
    * `chat_webhook_url` from every response it returns. Used by `updateCommittee`'s read-back
    * check, where only the URL itself is needed. `shareToSlack` uses
    * {@link getCommitteeForSlackShare} instead — it needs `name`/`project_uid` too, and fetching
-   * those separately via `getCommitteeById` would mean two upstream round trips (and a TOCTOU
-   * window on the webhook value) for one send. Both are internal call sites allowed to see the
-   * raw credential, and only to act on it directly; never expose it via any controller/route.
+   * those separately via `getCommitteeById` would mean extra upstream round trips (and a wider
+   * TOCTOU window on the webhook value) for one send. Both are internal call sites allowed to see
+   * the raw credential, and only to act on it directly; never expose it via any controller/route.
    * `private` (unlike {@link getCommitteeForSlackShare}, which a different service must call)
    * enforces that last sentence mechanically rather than by comment alone — its only caller is
    * `updateCommittee`, in this same class.
+   *
+   * Reads the settings sub-resource, not the base committee — see LFXV2-3094.
    */
   private async getSlackWebhookUrlStrict(req: Request, committeeId: string): Promise<string | null> {
-    const committee = await this.microserviceProxy.proxyRequest<Committee & { chat_webhook_url?: string | null }>(
-      req,
-      'LFX_V2_SERVICE',
-      `/committees/${committeeId}`,
-      'GET'
-    );
-    return committee?.chat_webhook_url ?? null;
+    const settings = await this.microserviceProxy.proxyRequest<CommitteeSettingsData>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/settings`, 'GET');
+    return settings?.chat_webhook_url ?? null;
+  }
+
+  /**
+   * Enforces that only a project writer may configure the committee's Slack webhook — mirrors
+   * `shareToSlack`'s own strict project-writer gate (weekly-brief.service.ts), so choosing the
+   * Slack destination requires the same authorization as sending to it. Stricter than upstream's
+   * committee-writer check on the settings PUT: direct committee grants exist independently of
+   * project writer (see `getDirectGrantCommittees`), so without this a committee writer who is
+   * not a project writer could point the webhook at a Slack workspace they control.
+   *
+   * Shared by both `updateCommittee` branches that can change `chat_webhook_url` (the core-update
+   * branch, which already has `currentCommittee.project_uid` from its own ETag fetch, and the
+   * settings-only branch, which fetches it separately) — each calls this at the point where a
+   * `project_uid` is available but no write has happened yet, so a caller who fails this check
+   * is rejected before any write in either branch, not just the core-PUT one.
+   */
+  private async assertWebhookChangeAuthorized(req: Request, committeeId: string, projectUid: string | undefined): Promise<void> {
+    // Fail closed when there's no project to check against (e.g. the committee-only fetch that
+    // resolves projectUid came back empty) — same posture as every other branch here: absence of
+    // proof is not proof of authorization.
+    const isProjectWriter = projectUid
+      ? await this.accessCheckService.checkSingleAccessStrict(req, { resource: 'project', id: projectUid, access: 'writer' })
+      : false;
+    if (!isProjectWriter) {
+      throw new AuthorizationError('Only project writers can configure the Slack webhook', {
+        operation: 'update_committee',
+        service: 'committee_service',
+        path: `/committees/${committeeId}`,
+        code: 'NOT_PROJECT_WRITER',
+      });
+    }
   }
 
   /**
@@ -1853,10 +1900,10 @@ export class CommitteeService {
    * hand-audited call sites. {@link getCommitteeById} calls this too, on top of (not instead of)
    * its own inline destructure of the base resource — the inline strip keeps the credential out
    * of the access-check and project-metadata enrichment inputs, while this call is what
-   * guarantees the response itself is clean no matter which resource (base or settings) the field
-   * lands on. A no-op today
-   * (upstream doesn't store the field on either resource yet), but load-bearing the moment the
-   * schema change referenced in `updateCommittee` lands.
+   * guarantees the response itself is clean regardless of which resource (base or settings) the
+   * field is present on. The field now lives on the settings sub-resource per LFXV2-3094, but
+   * this strip is intentionally resource-agnostic — cheap insurance against it ever showing up on
+   * the base object too (e.g. a future upstream change, or a raw pass-through response).
    *
    * Deliberately not null-tolerant: `proxyRequest` can return `null` for an empty upstream body
    * (documented at committee-activity.service.ts's four guarded call sites), and both
@@ -2208,6 +2255,7 @@ export class CommitteeService {
       ...(settings.is_audit_enabled !== undefined && { is_audit_enabled: settings.is_audit_enabled }),
       ...(settings.show_meeting_attendees !== undefined && { show_meeting_attendees: settings.show_meeting_attendees }),
       ...(settings.member_visibility !== undefined && { member_visibility: settings.member_visibility }),
+      ...(settings.chat_webhook_url !== undefined && { chat_webhook_url: settings.chat_webhook_url }),
       ...(settings.writers !== undefined && { writers: settings.writers }),
       ...(settings.auditors !== undefined && { auditors: settings.auditors }),
     };

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -603,8 +603,9 @@ export class CommitteeService {
 
       // Choosing the Slack destination must require the same authorization as sending to it —
       // shareToSlack (weekly-brief.service.ts) gates the send on strict project-writer, not
-      // committee-writer. Upstream's own PUT /committees/:uid only enforces committee-writer
-      // (direct grants exist independently of project writer — see getDirectGrantCommittees), so
+      // committee-writer. Upstream's own PUT /committees/:uid/settings only enforces
+      // committee-writer (direct grants exist independently of project writer — see
+      // getDirectGrantCommittees), so
       // without this, a committee writer who is not a project writer could point the webhook at a
       // Slack workspace they control, and a later legitimate project-writer send would deliver
       // brief content there. Checked here (post-fetch, since currentCommittee.project_uid is
@@ -659,7 +660,14 @@ export class CommitteeService {
       // enough since nothing here writes the base resource, and its result doubles as the
       // response-shaping fetch the final `else` branch below would otherwise need.
       const currentCommittee = await this.microserviceProxy.proxyRequest<Committee | null>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
-      await this.assertWebhookChangeAuthorized(req, committeeId, currentCommittee?.project_uid);
+      // Only run the authorization check when there's a committee to authorize against — a null
+      // result (deleted/nonexistent committee) must fall through to the generic
+      // UPSTREAM_INVALID_RESPONSE guard below, matching the final `else` branch's behavior for
+      // the same case, rather than surfacing a misleading NOT_PROJECT_WRITER for a committee that
+      // was never found.
+      if (currentCommittee) {
+        await this.assertWebhookChangeAuthorized(req, committeeId, currentCommittee.project_uid);
+      }
       updatedCommittee = currentCommittee;
     } else {
       // No core fields to update — fetch current committee for the response

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -391,24 +391,16 @@ export class CommitteeService {
       options.includeMailingListStatus ? this.getMailingListCountByCommittee(req, committeeId) : Promise.resolve(null),
     ]);
 
-    // chat_webhook_url lives on the settings sub-resource (GET /committees/:id/settings), not the
-    // base committee object — confirmed against lfx-v2-committee-service PR #177 (LFXV2-3094):
-    // ChatWebhookURLAttribute() is added only to CommitteeSettingsAttributes(), deliberately kept
-    // off the base Committee type so the webhook isn't visible to every committee viewer. #177 is
-    // not yet merged/deployed as of this writing.
-    const settingsChatWebhookUrl = settings.chat_webhook_url;
-
     const merged = {
       ...withAccess,
       ...settings,
       ...(membership && { my_role: membership.role, my_member_uid: membership.member_uid }),
       ...(inheritedPermissions && { inherited_writers: inheritedPermissions.writers, inherited_auditors: inheritedPermissions.auditors }),
       ...(mlCount !== null && { has_mailing_list: mlCount > 0 }),
-      // Format-checked, not just presence: a value that fails SLACK_INCOMING_WEBHOOK_URL_PATTERN
-      // (e.g. stored by a non-BFF writer, since this repo isn't the only writer of the field)
-      // must not show as "Configured" — shareToSlack re-validates the same pattern at send time,
-      // and a Configured badge over a value that's guaranteed to 409 there is a dead end.
-      has_slack_webhook: !!settingsChatWebhookUrl && SLACK_INCOMING_WEBHOOK_URL_PATTERN.test(settingsChatWebhookUrl),
+      // Upstream (lfx-v2-committee-service PR #179 / LFXV2-3094) computes this server-side from
+      // chat_webhook_url and never returns the raw URL on any read — settings.chat_webhook_url is
+      // always undefined here, so has_chat_webhook is the only real signal a read ever gets.
+      has_slack_webhook: settings.has_chat_webhook === true,
     };
 
     // `settings` above is a raw, uncast GET /committees/:id/settings body spread into `merged`
@@ -574,10 +566,9 @@ export class CommitteeService {
     }
 
     // Normalized once, up front: an empty string must behave identically to omission/null
-    // everywhere below it's used (hasSettingsUpdate, the settings PUT payload, and the read-back
-    // comparison) — otherwise a direct API caller sending '' would skip validation (falsy,
-    // intentionally) but then fail the read-back check with a spurious mismatch against the
-    // `null` getSlackWebhookUrlStrict actually returns for "not configured".
+    // everywhere below it's used (hasSettingsUpdate and the settings PUT payload) — a stored
+    // empty string isn't a meaningful "configured" state, and upstream's own clear semantics
+    // (LFXV2-3094) treat '' the same as sending null.
     const chatWebhookUrlToSave: string | null | undefined = rawChatWebhookUrl === '' ? null : (rawChatWebhookUrl as string | null | undefined);
 
     const hasSettingsUpdate =
@@ -716,70 +707,6 @@ export class CommitteeService {
         service: 'committee_service',
         path: `/committees/${committeeId}`,
       });
-    }
-
-    // Defensive check, run LAST (after every other write above has already committed): the
-    // committee-service schema declares chat_webhook_url on the settings resource per
-    // lfx-v2-committee-service PR #177 (LFXV2-3094), but #177 is not yet merged/deployed as of
-    // this writing — until it is, an unknown key in the settings PUT body may still be silently
-    // dropped rather than rejected. Confirm via a fresh read whether it actually persisted rather
-    // than trusting a false "saved" response. Deliberately checked after the core PUT and
-    // settings update, not before — this is the one field in the whole payload that can fail
-    // here, and every other field the caller submitted (name, chat_channel, website,
-    // business_email_required, etc.) must still be reported as saved rather than silently
-    // discarded because of it. Safe to remove once #177 has been merged, deployed, and verified
-    // stable — read-back-verifying a field the upstream schema already declares is defense in
-    // depth at that point, not a required correctness guard.
-    //
-    // Asymmetric today for a clear (chat_webhook_url: null): persistedWebhookUrl reads back null
-    // both when a real clear persisted and when upstream has no such field to persist to in the
-    // first place, so this can't distinguish them — a clear would false-report success on
-    // today's pre-#177 upstream the same way a set correctly fails loud. Low-impact in practice:
-    // the Remove button (clearing an already-*configured* webhook) can't be reached until
-    // has_slack_webhook is true, which requires a webhook to have actually persisted upstream
-    // (via this check or any other writer) — so that path implies the schema already exists
-    // upstream. The one reachable
-    // case today is typing then deleting on a never-configured committee (the control goes dirty
-    // with an empty value, so saveSettings sends chat_webhook_url: null with no prior set) —
-    // harmless, since nothing was actually persisted before or after either way.
-    if (chatWebhookUrlToSave !== undefined) {
-      // getSlackWebhookUrlStrict fails closed by design (propagates upstream errors rather than
-      // defaulting to null) — correct for its other caller (shareToSlack, where a transient
-      // outage must not be misread as "no webhook configured"), but wrong here: by this point
-      // the core PUT and settings PUT have both already committed, so a transient failure on
-      // this confirmation-only read must not read to the caller as "the save failed" — everything
-      // requested actually did save, we just couldn't confirm the one field that might not have.
-      // Distinguished from the genuine SLACK_WEBHOOK_NOT_PERSISTED mismatch below with its own
-      // code so the client doesn't conflate "confirmed not persisted" with "couldn't check".
-      let persistedWebhookUrl: string | null;
-      try {
-        persistedWebhookUrl = await this.getSlackWebhookUrlStrict(req, committeeId);
-      } catch (err) {
-        logger.warning(req, 'update_committee', 'Could not confirm chat_webhook_url persistence after an otherwise-successful save', {
-          committee_id: committeeId,
-          err,
-        });
-        throw new ConflictError(
-          'Your other changes were saved, but the Slack webhook status could not be confirmed. Reload to check whether it was saved.',
-          'SLACK_WEBHOOK_UNVERIFIED',
-          {
-            operation: 'update_committee',
-            service: 'committee_service',
-            path: `/committees/${committeeId}`,
-          }
-        );
-      }
-      if (persistedWebhookUrl !== chatWebhookUrlToSave) {
-        throw new ConflictError(
-          'Your other changes were saved, but the Slack webhook could not be stored — this environment does not support it yet.',
-          'SLACK_WEBHOOK_NOT_PERSISTED',
-          {
-            operation: 'update_committee',
-            service: 'committee_service',
-            path: `/committees/${committeeId}`,
-          }
-        );
-      }
     }
 
     return {
@@ -1852,27 +1779,6 @@ export class CommitteeService {
       });
     }
     return { name: committee.name, project_uid: committee.project_uid, chat_webhook_url: settings?.chat_webhook_url ?? null };
-  }
-
-  /**
-   * Strict single-committee Slack-webhook fetch, mirroring {@link hasMailingListStrict}'s
-   * fail-closed contract — propagates an upstream failure instead of silently reporting "no
-   * webhook configured". Deliberately bypasses {@link getCommitteeById}, which strips
-   * `chat_webhook_url` from every response it returns. Used by `updateCommittee`'s read-back
-   * check, where only the URL itself is needed. `shareToSlack` uses
-   * {@link getCommitteeForSlackShare} instead — it needs `name`/`project_uid` too, and fetching
-   * those separately via `getCommitteeById` would mean extra upstream round trips (and a wider
-   * TOCTOU window on the webhook value) for one send. Both are internal call sites allowed to see
-   * the raw credential, and only to act on it directly; never expose it via any controller/route.
-   * `private` (unlike {@link getCommitteeForSlackShare}, which a different service must call)
-   * enforces that last sentence mechanically rather than by comment alone — its only caller is
-   * `updateCommittee`, in this same class.
-   *
-   * Reads the settings sub-resource, not the base committee — see LFXV2-3094.
-   */
-  private async getSlackWebhookUrlStrict(req: Request, committeeId: string): Promise<string | null> {
-    const settings = await this.microserviceProxy.proxyRequest<CommitteeSettingsData>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}/settings`, 'GET');
-    return settings?.chat_webhook_url ?? null;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -605,12 +605,12 @@ export class CommitteeService {
       // shareToSlack (weekly-brief.service.ts) gates the send on strict project-writer, not
       // committee-writer. Upstream's own PUT /committees/:uid/settings only enforces
       // committee-writer (direct grants exist independently of project writer — see
-      // getDirectGrantCommittees), so
-      // without this, a committee writer who is not a project writer could point the webhook at a
-      // Slack workspace they control, and a later legitimate project-writer send would deliver
-      // brief content there. Checked here (post-fetch, since currentCommittee.project_uid is
-      // needed) rather than before, to avoid a second upstream round trip only for this field —
-      // and, like the settings-only branch below, before any write.
+      // getDirectGrantCommittees), so without this, a committee writer who is not a project
+      // writer could point the webhook at a Slack workspace they control, and a later legitimate
+      // project-writer send would deliver brief content there. Checked here (post-fetch, since
+      // currentCommittee.project_uid is needed) rather than before, to avoid a second upstream
+      // round trip only for this field — and, like the settings-only branch below, before any
+      // write.
       if (chatWebhookUrlToSave !== undefined) {
         // Authorize against the effective post-update project, not the committee's current one:
         // if this same PUT also moves the committee (committeeData.project_uid lands in
@@ -660,14 +660,22 @@ export class CommitteeService {
       // enough since nothing here writes the base resource, and its result doubles as the
       // response-shaping fetch the final `else` branch below would otherwise need.
       const currentCommittee = await this.microserviceProxy.proxyRequest<Committee | null>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
-      // Only run the authorization check when there's a committee to authorize against — a null
-      // result (deleted/nonexistent committee) must fall through to the generic
-      // UPSTREAM_INVALID_RESPONSE guard below, matching the final `else` branch's behavior for
-      // the same case, rather than surfacing a misleading NOT_PROJECT_WRITER for a committee that
-      // was never found.
-      if (currentCommittee) {
-        await this.assertWebhookChangeAuthorized(req, committeeId, currentCommittee.project_uid);
+      // Thrown here, immediately, rather than deferred to the generic UPSTREAM_INVALID_RESPONSE
+      // guard further down: that guard runs AFTER the hasSettingsUpdate block below has already
+      // called updateCommitteeSettings — a real PUT /committees/:id/settings with its own
+      // fetchWithETag/updateWithETag round trip, unaffected by this GET coming back empty.
+      // Deferring the check here would let that settings write (including the webhook itself)
+      // commit with no project-writer authorization at all for a committee this GET couldn't
+      // find, since assertWebhookChangeAuthorized never even runs in that case. A 404 here is
+      // also the more honest response than a 502 for "the committee doesn't exist" anyway.
+      if (!currentCommittee) {
+        throw new ResourceNotFoundError('Committee', committeeId, {
+          operation: 'update_committee',
+          service: 'committee_service',
+          path: `/committees/${committeeId}`,
+        });
       }
+      await this.assertWebhookChangeAuthorized(req, committeeId, currentCommittee.project_uid);
       updatedCommittee = currentCommittee;
     } else {
       // No core fields to update — fetch current committee for the response

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { SLACK_INCOMING_WEBHOOK_URL_PATTERN } from '@lfx-one/shared/constants';
+import { CHAT_WEBHOOK_URL_MAX_LENGTH, SLACK_INCOMING_WEBHOOK_URL_PATTERN } from '@lfx-one/shared/constants';
 import { CommitteeMemberRole } from '@lfx-one/shared/enums';
 import {
   AcceptCommitteeInviteRequest,
@@ -409,9 +409,9 @@ export class CommitteeService {
       has_slack_webhook: settings.has_chat_webhook === true,
     };
 
-    // `settings` above is a raw, uncast GET /committees/:id/settings body spread into `merged`
-    // alongside `withAccess`, un-stripped — this is what stops chat_webhook_url itself (not just
-    // the has_slack_webhook boolean derived from it) from leaking into the response.
+    // `settingsForResponse` above is stripped only of `has_chat_webhook` (the raw upstream signal
+    // has_slack_webhook is derived from) — chat_webhook_url itself is stopped from leaking by
+    // stripChatWebhookUrl below, applied to the fully-merged response either way.
     if (!options.includeProjectMetadata) {
       return this.stripChatWebhookUrl(merged);
     }
@@ -557,11 +557,15 @@ export class CommitteeService {
 
     // A truthiness-only check below would let falsy non-strings through: they'd skip the pattern
     // test entirely and ride straight into the settings PUT payload. The check below therefore
-    // rejects every value that isn't absent, null, or a string — before any write happens.
+    // rejects every value that isn't absent, null, or a string — before any write happens. The
+    // length bound mirrors upstream's own MaxLength(500) — without it here, an over-length value
+    // that still happens to match the pattern would pass this check and fail upstream's instead,
+    // with a less actionable error.
     if (
       rawChatWebhookUrl !== undefined &&
       rawChatWebhookUrl !== null &&
-      (typeof rawChatWebhookUrl !== 'string' || (rawChatWebhookUrl !== '' && !SLACK_INCOMING_WEBHOOK_URL_PATTERN.test(rawChatWebhookUrl)))
+      (typeof rawChatWebhookUrl !== 'string' ||
+        (rawChatWebhookUrl !== '' && (rawChatWebhookUrl.length > CHAT_WEBHOOK_URL_MAX_LENGTH || !SLACK_INCOMING_WEBHOOK_URL_PATTERN.test(rawChatWebhookUrl))))
     ) {
       throw ServiceValidationError.forField('chat_webhook_url', 'Must be a valid Slack Incoming Webhook URL (https://hooks.slack.com/services/...)', {
         operation: 'update_committee',

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -2153,9 +2153,16 @@ export class CommitteeService {
       'update_committee_settings'
     );
 
+    // has_chat_webhook is upstream's read-only computed field (GET/PUT .../settings response
+    // only) — excluded here so it doesn't ride back out in the PUT body alongside the rest of
+    // the unchanged current settings, which is otherwise a field the write contract never
+    // declares.
+    /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- intentional strip, not a read */
+    const { has_chat_webhook: _hasChatWebhook, ...currentSettingsForWrite } = currentSettings;
+
     // Merge provided fields over current settings
     const settingsData = {
-      ...currentSettings,
+      ...currentSettingsForWrite,
       ...(settings.business_email_required !== undefined && { business_email_required: settings.business_email_required }),
       ...(settings.is_audit_enabled !== undefined && { is_audit_enabled: settings.is_audit_enabled }),
       ...(settings.show_meeting_attendees !== undefined && { show_meeting_attendees: settings.show_meeting_attendees }),

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -24,7 +24,6 @@ const {
   buildWeeklyBriefRatingCacheKeyMock,
   extractBriefActionItems,
   buildCacheKey,
-  getCommitteeForSlackShareMock,
   checkSingleAccessStrictMock,
   getCommitteeByIdMock,
   hasMailingListStrictMock,
@@ -72,11 +71,8 @@ const {
     buildCacheKey: vi.fn(
       (committeeId: string, briefUid: string, revision: number): string | null => `weekly-brief-action-items:${committeeId}:${briefUid}:${revision}`
     ),
-    // shareToSlack's (LFXV2-3080) collaborators — controlled per-test below via
-    // mockResolvedValue in the 'shareToSlack' describe block's own beforeEach; other describe
-    // blocks in this file never call them, since shareBrief/shareToSlack are the only methods
-    // that touch committeeService/accessCheckService.
-    getCommitteeForSlackShareMock: vi.fn(),
+    // shareBrief's / shareToSlack's shared access-check collaborator — controlled per-test in
+    // their respective describe blocks below.
     checkSingleAccessStrictMock: vi.fn(),
     // shareBrief's (LFXV2-2914 / LFXV2-3093) own committee + newsletter collaborators —
     // controlled per-test in the 'shareBrief' describe block below.
@@ -95,12 +91,6 @@ vi.mock('@lfx-one/shared/constants', () => ({
   WEEKLY_BRIEF_ACTION_ITEMS_MAX: 5,
   NEWSLETTER_SUBJECT_MAX_LENGTH: 200,
   NEWSLETTER_BODY_MAX_LENGTH: 100_000,
-  SLACK_WEBHOOK_POST_TIMEOUT_MS: 10_000,
-  SLACK_MESSAGE_TEXT_MAX_LENGTH: 40_000,
-  SLACK_ERROR_BODY_MAX_LENGTH: 500,
-  SLACK_ERROR_TOKEN_PATTERN: /^[a-z_]{1,64}$/,
-  SLACK_INCOMING_WEBHOOK_URL_PATTERN: /^https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9]+\/B[A-Za-z0-9]+\/[A-Za-z0-9]+$/,
-  SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN: /https:\/\/hooks\.slack\.com\/services\/\S*/g,
   AI_MODEL: 'mock-ai-model',
   VALKEY_CACHE: { WEEKLY_BRIEF_RATING_TTL_SECONDS: 7_776_000, WEEKLY_BRIEF_ACTION_ITEMS_TTL_SECONDS: 604800 },
 }));
@@ -122,14 +112,13 @@ vi.mock('./microservice-proxy.service', () => ({
 vi.mock('./logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
 }));
-// shareBrief's / shareToSlack's collaborators — getCommitteeForSlackShare / checkSingleAccessStrict
-// back shareToSlack's (LFXV2-3080) precondition chain (see the 'shareToSlack' describe block
-// below); getCommitteeById / hasMailingListStrict / createNewsletter / sendNewsletter /
-// deleteNewsletter back shareBrief's (LFXV2-2914 / LFXV2-3093) precondition + send chain (see the
-// 'shareBrief' describe block below).
+// shareBrief's own committee collaborator (shareToSlack no longer calls committeeService at
+// all — it needs only project_uid, fetched directly via a plain proxyRequest GET, same as any
+// other upstream call in this file). getCommitteeById / hasMailingListStrict / createNewsletter /
+// sendNewsletter / deleteNewsletter back shareBrief's (LFXV2-2914 / LFXV2-3093) precondition +
+// send chain (see the 'shareBrief' describe block below).
 vi.mock('./committee.service', () => ({
   CommitteeService: class {
-    public getCommitteeForSlackShare = getCommitteeForSlackShareMock;
     public getCommitteeById = getCommitteeByIdMock;
     public hasMailingListStrict = hasMailingListStrictMock;
   },
@@ -161,7 +150,6 @@ vi.mock('./valkey.service', () => ({
   valkeyService: valkeyServiceMock,
 }));
 
-import { SLACK_ERROR_BODY_MAX_LENGTH } from '@lfx-one/shared/constants';
 import type { Request } from 'express';
 
 import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID } from '../constants';
@@ -893,41 +881,12 @@ describe('WeeklyBriefService', () => {
   });
 
   describe('shareToSlack (LFXV2-3080)', () => {
-    /** Builds a minimal fetch Response stand-in with the given status and text body. */
-    function mockResponse(status: number, body: string): Response {
-      return {
-        ok: status >= 200 && status < 300,
-        status,
-        statusText: `status ${status}`,
-        text: async () => body,
-        body: new ReadableStream<Uint8Array>({
-          start(controller) {
-            controller.enqueue(new TextEncoder().encode(body));
-            controller.close();
-          },
-        }),
-      } as unknown as Response;
-    }
-
-    let fetchMock: ReturnType<typeof vi.fn>;
-
     beforeEach(() => {
       process.env['WEEKLY_BRIEF_BACKEND'] = 'live';
       // On by default here — the dedicated FEATURE_DISABLED test below covers it off; every other
       // test in this block exercises what happens once the kill switch is enabled.
       process.env[ServerFeatureFlag.WeeklyBriefSlack] = 'true';
-      getCommitteeForSlackShareMock.mockResolvedValue({
-        name: 'Test Committee',
-        project_uid: 'project-1',
-        chat_webhook_url: 'https://hooks.slack.com/services/T000/B000/XXXX',
-      });
       checkSingleAccessStrictMock.mockResolvedValue(true);
-      fetchMock = vi.fn();
-      vi.stubGlobal('fetch', fetchMock);
-    });
-
-    afterEach(() => {
-      vi.unstubAllGlobals();
     });
 
     /** A brief in a shareable state, queued up for the getCurrentBrief call shareToSlack makes internally. */
@@ -946,182 +905,86 @@ describe('WeeklyBriefService', () => {
       });
     }
 
+    /** The plain committee GET shareToSlack makes for project_uid — queued up right after mockShareableBrief. */
+    function mockCommittee(overrides: Record<string, unknown> = {}): void {
+      proxyRequest.mockResolvedValueOnce({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1', ...overrides });
+    }
+
     it('throws 409 FEATURE_DISABLED before any upstream call when the server-side kill switch is off, independent of WG_WEEKLY_BRIEF_SLACK_FLAG which never reaches this method', async () => {
       delete process.env[ServerFeatureFlag.WeeklyBriefSlack];
 
       await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 409, code: 'FEATURE_DISABLED' });
 
       expect(proxyRequest).not.toHaveBeenCalled();
-      expect(getCommitteeForSlackShareMock).not.toHaveBeenCalled();
-      expect(fetchMock).not.toHaveBeenCalled();
     });
 
     it('throws 404 when there is no brief to share', async () => {
       proxyRequest.mockResolvedValueOnce({ brief: null, throttle: null });
 
       await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 404 });
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(proxyRequest).toHaveBeenCalledOnce();
     });
 
     it('throws 404 when the brief is not in a shareable state', async () => {
       mockShareableBrief({ state: 'generating' });
 
       await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 404 });
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(proxyRequest).toHaveBeenCalledOnce();
     });
 
     it('throws 409 REVISION_MISMATCH when the caller-supplied revision is stale', async () => {
       mockShareableBrief({ revision: 2 });
 
       await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 409, code: 'REVISION_MISMATCH' });
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(proxyRequest).toHaveBeenCalledOnce();
     });
 
-    it('throws 403 NOT_PROJECT_WRITER when the caller is not a project writer', async () => {
+    it('throws 404 when the committee no longer exists, before running the project-writer check', async () => {
       mockShareableBrief();
+      proxyRequest.mockResolvedValueOnce(null);
+
+      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 404 });
+      expect(checkSingleAccessStrictMock).not.toHaveBeenCalled();
+    });
+
+    it("throws 403 NOT_PROJECT_WRITER when the caller is not a project writer — this repo's own boundary, stricter than Heimdall's committee-writer enforcement on the upstream endpoint itself", async () => {
+      mockShareableBrief();
+      mockCommittee();
       checkSingleAccessStrictMock.mockResolvedValue(false);
 
       await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 403, code: 'NOT_PROJECT_WRITER' });
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(proxyRequest).toHaveBeenCalledTimes(2);
     });
 
-    it('throws 409 NO_SLACK_WEBHOOK when the committee has no webhook configured', async () => {
-      mockShareableBrief();
-      getCommitteeForSlackShareMock.mockResolvedValue({ name: 'Test Committee', project_uid: 'project-1', chat_webhook_url: null });
-
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 409, code: 'NO_SLACK_WEBHOOK' });
-      expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    it('throws 409 NO_SLACK_WEBHOOK — not a raw POST — when the stored URL fails the allowlist, even though a value is configured (defense-in-depth: the BFF is not the only writer of chat_webhook_url upstream), and logs (not returns) the distinction for operators', async () => {
-      mockShareableBrief();
-      getCommitteeForSlackShareMock.mockResolvedValue({
-        name: 'Test Committee',
-        project_uid: 'project-1',
-        chat_webhook_url: 'https://evil.example.com/exfiltrate',
-      });
-
-      // The response body must stay byte-identical to the "genuinely unconfigured" case — no
-      // `metadata` (BaseApiError.toResponse() serializes `metadata` straight into the client
-      // response, which would leak "something is stored" vs. "nothing configured" per committee).
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
-        statusCode: 409,
-        code: 'NO_SLACK_WEBHOOK',
-        metadata: undefined,
-      });
-      expect(vi.mocked(logger.warning)).toHaveBeenCalledWith(
-        req,
-        'share_weekly_brief_slack',
-        expect.stringContaining('failed the Slack allowlist'),
-        expect.objectContaining({ committee_id: 'committee-1' })
-      );
-      expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    it('throws 409 BACKEND_NOT_LIVE when WEEKLY_BRIEF_BACKEND is not "live" — checked only after every other precondition passes', async () => {
+    it('throws 409 BACKEND_NOT_LIVE when WEEKLY_BRIEF_BACKEND is not "live" — checked only after every other local precondition passes, before the committee-service call', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      mockShareableBrief();
+      // getCurrentBrief is itself gated on isLive() and returns a canned mock brief (revision 1,
+      // 'generated') without calling proxyRequest when not live — so mockShareableBrief() isn't
+      // used here. The committee GET below is NOT gated on isLive() (it's a real precondition
+      // check, enforced "regardless of backend mode" per this method's own doc comment), so it's
+      // still the one and only real proxyRequest call in this scenario.
+      mockCommittee();
 
       await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 409, code: 'BACKEND_NOT_LIVE' });
-      expect(fetchMock).not.toHaveBeenCalled();
+      expect(proxyRequest).toHaveBeenCalledOnce();
     });
 
-    it("throws 400 when the composed message exceeds SLACK_MESSAGE_TEXT_MAX_LENGTH, before ever POSTing (mirrors shareBrief's NEWSLETTER_BODY_MAX_LENGTH guard)", async () => {
-      mockShareableBrief({ brief_text: 'x'.repeat(40_001) });
-
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 400 });
-      expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    it('rejects an astral-plane-heavy brief whose UTF-16 length exceeds the limit even though its code-point count does not — the guard counts UTF-16 units, not code points', async () => {
-      // Each 😀 is 1 code point but 2 UTF-16 units — 25,000 of them is 25,000 code points
-      // (under SLACK_MESSAGE_TEXT_MAX_LENGTH) but 50,000 UTF-16 units (over it). Since Slack's own
-      // "40,000 characters" limit doesn't specify an encoding, the guard deliberately uses
-      // text.length (UTF-16 units, always >= the code-point count) rather than the smaller
-      // code-point count — a pre-flight check should err toward rejecting too early, not toward
-      // letting something through that Slack itself then 502s on.
-      mockShareableBrief({ brief_text: '😀'.repeat(25_000) });
-
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 400 });
-      expect(fetchMock).not.toHaveBeenCalled();
-    });
-
-    it('does not reject a brief whose code-point count and UTF-16 length both sit under the limit', async () => {
-      mockShareableBrief({ brief_text: 'x'.repeat(1000) });
-      fetchMock.mockResolvedValueOnce(mockResponse(200, 'ok'));
-
-      await expect(service.shareToSlack(req, 'committee-1', 1)).resolves.toEqual({ committee_name: 'Test Committee' });
-      expect(fetchMock).toHaveBeenCalledOnce();
-    });
-
-    it('POSTs the brief text to the stored webhook URL and resolves on a 200 from Slack', async () => {
+    it('POSTs { revision } to the committee-service share-to-chat endpoint and resolves on a 204', async () => {
       mockShareableBrief();
-      fetchMock.mockResolvedValueOnce(mockResponse(200, 'ok'));
+      mockCommittee();
+      proxyRequest.mockResolvedValueOnce(undefined);
 
-      const result = await service.shareToSlack(req, 'committee-1', 1);
+      await expect(service.shareToSlack(req, 'committee-1', 1)).resolves.toEqual({});
 
-      expect(result).toEqual({ committee_name: 'Test Committee' });
-      expect(fetchMock).toHaveBeenCalledWith(
-        'https://hooks.slack.com/services/T000/B000/XXXX',
-        expect.objectContaining({
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          // A redirect could relocate the POST body off hooks.slack.com — must reject outright,
-          // not follow it.
-          redirect: 'error',
-        })
-      );
-      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-      expect(body.text).toContain('Hello committee');
-    });
-
-    it('drains (cancels) the success-response body instead of leaving it unconsumed', async () => {
-      mockShareableBrief();
-      let cancelled = false;
-      const stream = new ReadableStream<Uint8Array>({
-        // Enqueuing (not just closing) matters: per the Streams spec, cancel() on an
-        // already-"closed" stream short-circuits without invoking the underlying source's
-        // cancel algorithm. controller.close() with a pending enqueued chunk defers the
-        // closed transition, so the stream is still "readable" — and cancel() therefore
-        // still reaches this callback — at the moment the service calls it.
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('ok'));
-          controller.close();
-        },
-        cancel() {
-          cancelled = true;
-        },
+      expect(proxyRequest).toHaveBeenNthCalledWith(3, req, 'LFX_V2_SERVICE', '/committees/committee-1/weekly-briefs/share-to-chat', 'POST', undefined, {
+        revision: 1,
       });
-      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'status 200', body: stream } as unknown as Response);
-
-      await service.shareToSlack(req, 'committee-1', 1);
-
-      expect(cancelled).toBe(true);
     });
 
-    it('still resolves successfully (and still logs the send) even if draining the success-response body itself rejects', async () => {
+    it('logs the sending user (as their opaque sub, not the human-readable username) on a successful send — the committee-service call carries no caller identity of its own beyond the bearer token, so this is the only record of who shared it', async () => {
       mockShareableBrief();
-      const stream = new ReadableStream<Uint8Array>({
-        start(controller) {
-          controller.enqueue(new TextEncoder().encode('ok'));
-          controller.close();
-        },
-        // Rejects rather than throws synchronously — undici's real cancel() is async and rejects
-        // on failure, so this models the actual failure mode .catch() below guards against
-        // instead of depending on the Streams spec's sync-throw-to-rejection conversion.
-        cancel() {
-          return Promise.reject(new Error('cancel failed'));
-        },
-      });
-      fetchMock.mockResolvedValueOnce({ ok: true, status: 200, statusText: 'status 200', body: stream } as unknown as Response);
-
-      await expect(service.shareToSlack(req, 'committee-1', 1)).resolves.toEqual({ committee_name: 'Test Committee' });
-      expect(logger.info).toHaveBeenCalledWith(req, 'share_weekly_brief_slack_sent', expect.any(String), expect.any(Object));
-    });
-
-    it('logs the sending user (as their opaque sub, not the human-readable username) on a successful send — the webhook POST body itself carries no caller identity, so this is the only record of who shared it', async () => {
-      mockShareableBrief();
-      fetchMock.mockResolvedValueOnce(mockResponse(200, 'ok'));
+      mockCommittee();
+      proxyRequest.mockResolvedValueOnce(undefined);
 
       await service.shareToSlack(userReq, 'committee-1', 1);
 
@@ -1131,134 +994,63 @@ describe('WeeklyBriefService', () => {
       });
     });
 
-    it("escapes Slack mrkdwn control characters in brief_text and the committee name, so an AI-generated brief can't trigger @channel/@here or a deceptive link", async () => {
-      mockShareableBrief({ brief_text: 'Ping <!channel> and see <https://evil.example|this link>' });
-      getCommitteeForSlackShareMock.mockResolvedValue({
-        name: 'A & B Committee',
-        project_uid: 'project-1',
-        chat_webhook_url: 'https://hooks.slack.com/services/T000/B000/XXXX',
+    describe('committee-service response mapping', () => {
+      beforeEach(() => {
+        mockShareableBrief();
+        mockCommittee();
       });
-      fetchMock.mockResolvedValueOnce(mockResponse(200, 'ok'));
 
-      await service.shareToSlack(req, 'committee-1', 1);
+      it('maps a 400 (brief not shareable) to a 404 — a race between the local shareable-state check and this call landing, not the primary path', async () => {
+        proxyRequest.mockRejectedValueOnce(new MicroserviceError('Brief is not in a shareable state', 400, 'BAD_REQUEST'));
 
-      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-      expect(body.text).not.toContain('<!channel>');
-      expect(body.text).not.toContain('<https://evil.example|this link>');
-      expect(body.text).toContain('&lt;!channel&gt;');
-      expect(body.text).toContain('A &amp; B Committee');
-    });
-
-    it("throws 502 SLACK_SEND_FAILED with Slack's error text when Slack rejects the message", async () => {
-      mockShareableBrief();
-      fetchMock.mockResolvedValueOnce(mockResponse(400, 'invalid_payload'));
-
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
-        statusCode: 502,
-        code: 'SLACK_SEND_FAILED',
-        message: expect.stringContaining('invalid_payload'),
+        await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 404 });
       });
-    });
 
-    it('does not reflect a non-token-shaped Slack response body into the client-facing message, but still keeps the full text in errorBody.reason for operators', async () => {
-      mockShareableBrief();
-      const htmlBody = '<html><body>502 Bad Gateway</body></html>';
-      fetchMock.mockResolvedValueOnce(mockResponse(502, htmlBody));
+      it('maps a 403 to NOT_PROJECT_WRITER — defense-in-depth beyond the local strict check above', async () => {
+        proxyRequest.mockRejectedValueOnce(new MicroserviceError('Forbidden', 403, 'FORBIDDEN'));
 
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
-        statusCode: 502,
-        code: 'SLACK_SEND_FAILED',
-        message: 'Slack rejected the message',
-        errorBody: { status: 502, reason: htmlBody },
+        await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 403, code: 'NOT_PROJECT_WRITER' });
       });
-    });
 
-    it('still echoes a legitimate Slack token into the client message even with a trailing newline, while errorBody.reason keeps the untrimmed body', async () => {
-      mockShareableBrief();
-      fetchMock.mockResolvedValueOnce(mockResponse(400, 'invalid_payload\n'));
+      it('maps a 404 straight through to a 404', async () => {
+        proxyRequest.mockRejectedValueOnce(new MicroserviceError('Not found', 404, 'NOT_FOUND'));
 
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
-        statusCode: 502,
-        code: 'SLACK_SEND_FAILED',
-        message: 'Slack rejected the message: invalid_payload',
-        errorBody: { status: 400, reason: 'invalid_payload\n' },
+        await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 404 });
       });
-    });
 
-    it('truncates an oversized Slack error body to SLACK_ERROR_BODY_MAX_LENGTH', async () => {
-      mockShareableBrief();
-      fetchMock.mockResolvedValueOnce(mockResponse(400, 'x'.repeat(10_000)));
+      it('maps a 409 to REVISION_MISMATCH, with the same client-facing message the local revision check uses', async () => {
+        proxyRequest.mockRejectedValueOnce(new MicroserviceError('stale revision', 409, 'REVISION_CONFLICT'));
 
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
-        statusCode: 502,
-        code: 'SLACK_SEND_FAILED',
-        errorBody: { status: 400, reason: 'x'.repeat(SLACK_ERROR_BODY_MAX_LENGTH) },
+        await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
+          statusCode: 409,
+          code: 'REVISION_MISMATCH',
+          message: 'The brief has been updated since you last viewed it. Reload to review the latest version before sharing.',
+        });
       });
-    });
 
-    it('stops reading the stream once SLACK_ERROR_BODY_MAX_LENGTH is reached, instead of pulling every chunk of an oversized body', async () => {
-      mockShareableBrief();
-      // A single mockResponse() enqueue-then-close body would satisfy this same assertion under
-      // the OLD response.text() implementation too, since text() also buffers everything before
-      // slicing — that's the case this test is guarding against. A chunked, pull-driven stream is
-      // required to actually exercise (and prove) the early-cancel behavior: SLACK_ERROR_BODY_MAX_LENGTH
-      // is 500 and each chunk is 100 chars, so the default ReadableStream queuing strategy
-      // (highWaterMark: 1) should hit the bound and cancel after ~5 pulls, not all 1000.
-      let pullCount = 0;
-      let cancelled = false;
-      const chunk = 'x'.repeat(100);
-      const stream = new ReadableStream<Uint8Array>({
-        pull(controller) {
-          pullCount++;
-          if (pullCount > 1000) {
-            controller.close();
-            return;
-          }
-          controller.enqueue(new TextEncoder().encode(chunk));
-        },
-        cancel() {
-          cancelled = true;
-        },
+      it('maps a 422 to NO_SLACK_WEBHOOK — the Settings-tab "not configured" UX depends on this exact code', async () => {
+        proxyRequest.mockRejectedValueOnce(new MicroserviceError('no webhook', 422, 'UNPROCESSABLE_ENTITY'));
+
+        await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
+          statusCode: 409,
+          code: 'NO_SLACK_WEBHOOK',
+          message: 'Committee has no Slack webhook configured',
+        });
       });
-      fetchMock.mockResolvedValueOnce({
-        ok: false,
-        status: 400,
-        statusText: 'status 400',
-        body: stream,
-      } as unknown as Response);
 
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({
-        statusCode: 502,
-        code: 'SLACK_SEND_FAILED',
-        errorBody: { reason: 'x'.repeat(SLACK_ERROR_BODY_MAX_LENGTH) },
+      it('passes a 500/503 MicroserviceError through unchanged rather than reshaping it', async () => {
+        const upstreamError = new MicroserviceError('Internal server error', 500, 'INTERNAL_SERVER_ERROR');
+        proxyRequest.mockRejectedValueOnce(upstreamError);
+
+        await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toBe(upstreamError);
       });
-      // ~5 pulls expected (500 / 100); a small margin allows for queuing-strategy prefetch
-      // without loosening the bound so much a near-full-buffer regression could still pass.
-      expect(pullCount).toBeLessThanOrEqual(10);
-      expect(cancelled).toBe(true);
-    });
 
-    it('throws 502 SLACK_UNREACHABLE instead of letting a raw network error escape', async () => {
-      mockShareableBrief();
-      fetchMock.mockRejectedValueOnce(new TypeError('fetch failed'));
+      it('rethrows a non-MicroserviceError as-is instead of trying to map a status code off it', async () => {
+        const genericError = new Error('network blip');
+        proxyRequest.mockRejectedValueOnce(genericError);
 
-      await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 502, code: 'SLACK_UNREACHABLE' });
-    });
-
-    it('redacts an embedded webhook URL from the caught fetch error before it becomes originalError — getLogContext() logs original_error unsanitized (SENSITIVE_FIELDS does not cover it), so a future fetch/undici version that puts the request URL in its error message must not leak the credential', async () => {
-      mockShareableBrief();
-      fetchMock.mockRejectedValueOnce(new TypeError('fetch failed: https://hooks.slack.com/services/T000/B000/XXXX unreachable'));
-
-      let caught: MicroserviceError | undefined;
-      try {
-        await service.shareToSlack(req, 'committee-1', 1);
-      } catch (error) {
-        caught = error as MicroserviceError;
-      }
-
-      const originalError = caught?.getLogContext()['original_error'] as string | undefined;
-      expect(originalError).toContain('[redacted-url]');
-      expect(originalError).not.toContain('hooks.slack.com');
+        await expect(service.shareToSlack(req, 'committee-1', 1)).rejects.toBe(genericError);
+      });
     });
   });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -891,8 +891,9 @@ export class WeeklyBriefService {
 
     // Re-validated against SLACK_INCOMING_WEBHOOK_URL_PATTERN here, not just trusted from
     // upstream storage — the BFF's own updateCommittee is not the only possible writer of
-    // chat_webhook_url on the committee record (any client with a token can PUT /committees/:uid
-    // directly), so the stored value is untrusted input at the point of use. Without this, an
+    // chat_webhook_url on the committee settings resource (any client with a token can
+    // PUT /committees/:uid/settings directly), so the stored value is untrusted input at the
+    // point of use. Without this, an
     // arbitrary URL written some other way would turn this into a server-initiated POST of brief
     // content to an attacker-chosen destination — exactly what the allowlist exists to prevent.
     // A malformed value is treated the same as "not configured" — from the caller's perspective

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -4,12 +4,6 @@
 import {
   NEWSLETTER_BODY_MAX_LENGTH,
   NEWSLETTER_SUBJECT_MAX_LENGTH,
-  SLACK_ERROR_BODY_MAX_LENGTH,
-  SLACK_ERROR_TOKEN_PATTERN,
-  SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN,
-  SLACK_INCOMING_WEBHOOK_URL_PATTERN,
-  SLACK_MESSAGE_TEXT_MAX_LENGTH,
-  SLACK_WEBHOOK_POST_TIMEOUT_MS,
   VALKEY_CACHE,
   WEEKLY_BRIEF_ACTION_ITEMS_MAX,
   WEEKLY_BRIEF_DEFAULT_THROTTLE,
@@ -17,6 +11,7 @@ import {
   WEEKLY_BRIEF_SHAREABLE_STATES,
 } from '@lfx-one/shared/constants';
 import {
+  Committee,
   GenerateWeeklyBriefRequest,
   GenerateWeeklyBriefResponse,
   GetWeeklyBriefActionItemsResponse,
@@ -65,19 +60,6 @@ function briefTextToHtml(text: string): string {
     .split(/\n{2,}/)
     .map((paragraph) => `<p>${escape(paragraph).replace(/\n/g, '<br>')}</p>`)
     .join('');
-}
-
-/**
- * Escapes Slack mrkdwn control characters per Slack's own escaping rules
- * (https://api.slack.com/reference/surfaces/formatting#escaping) — `&`, `<`, `>` are the only
- * three that matter. Slack's incoming webhooks parse `text` as mrkdwn by default: an unescaped
- * `<!channel>`/`<!here>` anywhere in `brief_text` (AI-generated from meeting/document titles —
- * content a broader set of users than project writers can influence, then further editable by
- * writers) would page the entire channel, and `<https://evil.example|label>` would render as a
- * deceptive hyperlink.
- */
-function escapeSlackMrkdwn(text: string): string {
-  return text.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
 }
 
 /**
@@ -829,14 +811,14 @@ export class WeeklyBriefService {
   }
 
   /**
-   * Shares the current brief to the committee's configured Slack channel via an Incoming
-   * Webhook POST. Precondition chain mirrors {@link shareBrief} exactly (brief exists +
-   * shareable state, revision matches, caller is a project writer, `WEEKLY_BRIEF_BACKEND=live`)
-   * with one swap: "has a mailing list configured" becomes "has a Slack webhook configured".
-   *
-   * Unlike shareBrief's newsletter-service handoff (async accept-then-fan-out), a webhook POST
-   * is synchronous — Slack's own response is authoritative. A resolved promise means Slack
-   * accepted the message, not that it was merely queued.
+   * Shares the current brief to the committee's configured Slack channel. The committee-service
+   * itself owns composing and sending the message (lfx-v2-committee-service PR #178 /
+   * LFXV2-3094) — it reads the stored `chat_webhook_url` from its own storage and posts to
+   * Slack, so the raw credential never needs to reach this BFF. Precondition chain otherwise
+   * mirrors {@link shareBrief} (brief exists + shareable state, revision matches, caller is a
+   * project writer, `WEEKLY_BRIEF_BACKEND=live`) — those checks stay local so a disabled/mock
+   * environment and a stale revision fail the same way they always have, before any upstream
+   * call.
    */
   public async shareToSlack(req: Request, committeeId: string, expectedRevision: number): Promise<ShareWeeklyBriefToSlackResult> {
     // Same server-side kill switch as committee.service.ts's updateCommittee, and for the same
@@ -865,17 +847,24 @@ export class WeeklyBriefService {
       });
     }
 
-    // One fetch, not two: getCommitteeForSlackShare returns exactly what this method needs
-    // (name, project_uid, the raw webhook URL) from a single upstream call — going through
-    // getCommitteeById (settings/membership/access-check enrichment this method never reads)
-    // plus a second, separate getSlackWebhookUrlStrict call would cost an extra round trip and
-    // open a TOCTOU window on the webhook value between the two reads. See
-    // getSlackWebhookUrlStrict's doc comment for the full rationale.
-    const committee = await this.committeeService.getCommitteeForSlackShare(req, committeeId);
+    // Needs project_uid for the strict project-writer check below — a plain GET, not
+    // getCommitteeById, since this method reads nothing from its settings/membership/access-check
+    // enrichment.
+    const committee = await this.microserviceProxy.proxyRequest<Committee | null>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
+    if (!committee) {
+      throw new ResourceNotFoundError('Committee', committeeId, {
+        operation: 'share_weekly_brief_slack',
+        service: 'weekly_brief_service',
+      });
+    }
 
     // Same strict project-writer boundary as shareBrief, for the same reason: sharing is a
-    // deliberate, low-frequency action where misattributing a transient access-check outage as
-    // a permission denial is worse than the extra strict-variant call.
+    // deliberate, low-frequency action where misattributing a transient access-check outage as a
+    // permission denial is worse than the extra strict-variant call. Stricter than the upstream
+    // endpoint's own committee-writer enforcement (via Heimdall) — direct committee grants exist
+    // independently of project writer (see `getDirectGrantCommittees`), so without this a
+    // committee writer who is not a project writer could trigger a send to a webhook they don't
+    // control the destination of.
     const isProjectWriter = await this.accessCheckService.checkSingleAccessStrict(req, {
       resource: 'project',
       id: committee.project_uid,
@@ -889,37 +878,9 @@ export class WeeklyBriefService {
       });
     }
 
-    // Re-validated against SLACK_INCOMING_WEBHOOK_URL_PATTERN here, not just trusted from
-    // upstream storage — the BFF's own updateCommittee is not the only possible writer of
-    // chat_webhook_url on the committee settings resource (any client with a token can
-    // PUT /committees/:uid/settings directly), so the stored value is untrusted input at the
-    // point of use. Without this, an
-    // arbitrary URL written some other way would turn this into a server-initiated POST of brief
-    // content to an attacker-chosen destination — exactly what the allowlist exists to prevent.
-    // A malformed value is treated the same as "not configured" — from the caller's perspective
-    // both are equally unactionable.
-    const webhookUrl = committee.chat_webhook_url;
-    const isAllowedWebhook = !!webhookUrl && SLACK_INCOMING_WEBHOOK_URL_PATTERN.test(webhookUrl);
-    if (webhookUrl && !isAllowedWebhook) {
-      // Logged, not put in the thrown error's `metadata` — BaseApiError.toResponse() serializes
-      // `metadata` straight into the client-facing JSON body, which would let the response leak
-      // "something is stored" vs. "nothing is configured" per committee. The caller-facing
-      // message/code must stay byte-identical either way; this operator-only signal (never the
-      // URL itself) is the one place that distinction is allowed to exist.
-      logger.warning(req, 'share_weekly_brief_slack', 'Stored chat_webhook_url failed the Slack allowlist — treating as unconfigured', {
-        committee_id: committeeId,
-      });
-    }
-    if (!isAllowedWebhook) {
-      throw new ConflictError('Committee has no Slack webhook configured', 'NO_SLACK_WEBHOOK', {
-        operation: 'share_weekly_brief_slack',
-        service: 'weekly_brief_service',
-      });
-    }
-
     // Preconditions above are enforced regardless of backend mode; only the actual send is
     // gated on isLive() — same rationale as shareBrief: mock-mode content must never actually
-    // post to a real Slack channel.
+    // reach committee-service's real Slack-sending path.
     if (!this.isLive(req)) {
       throw new ConflictError('Sharing is not available in this environment (WEEKLY_BRIEF_BACKEND is not "live")', 'BACKEND_NOT_LIVE', {
         operation: 'share_weekly_brief_slack',
@@ -927,94 +888,73 @@ export class WeeklyBriefService {
       });
     }
 
-    const text = `*Weekly Brief — ${escapeSlackMrkdwn(committee.name)}* (${formatUtcDateRangeLabel(brief.window_start, brief.window_end)})\n\n${escapeSlackMrkdwn(brief.brief_text)}`;
-    // text.length (UTF-16 code units), deliberately not [...text].length (code points) — the
-    // latter is always <= the former for any string, so the two are never actually in tension;
-    // this is a one-sided choice, not a comparison. This guard's job is to pre-empt an opaque 502
-    // from Slack, and Slack's own "40,000 characters" doc doesn't specify an encoding, so the
-    // conservative (larger) count is used here — unlike the controller's brief_text *save*
-    // validation, which uses the code-point count for a different reason (matching upstream's own
-    // declared maxLength exactly, not being conservative). An emoji-heavy brief the editor accepts
-    // at the code-point-based save cap can therefore still be rejected by this UTF-16-based share
-    // guard — a real, if narrow, asymmetry between the two limits, not a bug in either.
-    if (text.length > SLACK_MESSAGE_TEXT_MAX_LENGTH) {
-      // Phrased in terms of shortening the brief, not the post-escaping/post-header character
-      // ceiling above — that number (40,000) would be confusing next to the brief editor's own
-      // much smaller cap (WEEKLY_BRIEF_TEXT_MAX_LENGTH, 20,000).
-      throw ServiceValidationError.forField('brief_text', 'Brief is too long to share to Slack. Shorten the brief text and try again.', {
-        operation: 'share_weekly_brief_slack',
-        service: 'weekly_brief_service',
-      });
+    // The committee-service composes the message, validates/re-reads the stored webhook, and
+    // posts to Slack itself — see this method's doc comment. Its response codes are mapped below
+    // onto the same client-facing messages/codes this method already used for the equivalent
+    // local checks, so the Angular error-handling contract doesn't change.
+    try {
+      await this.microserviceProxy.proxyRequest<void>(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${encodeURIComponent(committeeId)}/weekly-briefs/share-to-chat`,
+        'POST',
+        undefined,
+        { revision: expectedRevision }
+      );
+    } catch (error) {
+      if (!(error instanceof MicroserviceError)) {
+        throw error;
+      }
+      switch (error.statusCode) {
+        case 400:
+          // Race window between the local shareable-state check above and this call landing
+          // upstream — same shape as that local check's own 404, not a new error to the client.
+          throw new ResourceNotFoundError('Weekly brief', committeeId, {
+            operation: 'share_weekly_brief_slack',
+            service: 'weekly_brief_service',
+          });
+        case 403:
+          // Defense-in-depth — the strict project-writer check above normally rejects this
+          // first; this only fires if Heimdall's committee-writer boundary disagrees with it.
+          throw new AuthorizationError('Only project writers can share the weekly brief to Slack', {
+            operation: 'share_weekly_brief_slack',
+            service: 'weekly_brief_service',
+            code: 'NOT_PROJECT_WRITER',
+          });
+        case 404:
+          throw new ResourceNotFoundError('Weekly brief', committeeId, {
+            operation: 'share_weekly_brief_slack',
+            service: 'weekly_brief_service',
+          });
+        case 409:
+          throw new ConflictError(
+            'The brief has been updated since you last viewed it. Reload to review the latest version before sharing.',
+            'REVISION_MISMATCH',
+            { operation: 'share_weekly_brief_slack', service: 'weekly_brief_service' }
+          );
+        case 422:
+          throw new ConflictError('Committee has no Slack webhook configured', 'NO_SLACK_WEBHOOK', {
+            operation: 'share_weekly_brief_slack',
+            service: 'weekly_brief_service',
+          });
+        default:
+          throw error;
+      }
     }
 
-    const response = await fetch(webhookUrl, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ text }),
-      // A redirect response could relocate the POST body off hooks.slack.com entirely —
-      // 'error' rejects the fetch outright instead of silently following it.
-      redirect: 'error',
-      signal: AbortSignal.timeout(SLACK_WEBHOOK_POST_TIMEOUT_MS),
-    }).catch((error: unknown) => {
-      throw new MicroserviceError('Unable to reach Slack — the webhook request failed or timed out', 502, 'SLACK_UNREACHABLE', {
-        operation: 'share_weekly_brief_slack',
-        service: 'weekly_brief_service',
-        // Redacted, not passed through as-is: getLogContext() logs this message unsanitized
-        // (`sanitize()` only redacts top-level keys, and `original_error` isn't one of them).
-        // Today's undici fetch-failure/abort messages don't embed the request URL, so this is
-        // defense-in-depth against a future fetch/undici version that does.
-        originalError: error instanceof Error ? new Error(error.message.replace(SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN, '[redacted-url]')) : undefined,
-      });
-    });
-
-    if (!response.ok) {
-      // Slack's incoming-webhook error responses are a plain-text body (e.g. `invalid_payload`,
-      // `channel_not_found`, `action_prohibited`), not JSON. Read via a bounded stream reader
-      // rather than response.text() — text() buffers the entire body before any slicing can
-      // happen, so a single huge response (whether from a Slack bug or a misbehaving proxy)
-      // would still be fully materialized in memory even though only SLACK_ERROR_BODY_MAX_LENGTH
-      // characters of it are ever used.
-      const slackErrorText = await this.readBoundedText(response, SLACK_ERROR_BODY_MAX_LENGTH).catch(() => '');
-      // SLACK_ERROR_TOKEN_PATTERN gates what's safe to echo into the client-facing message —
-      // BaseApiError#toResponse puts `message` directly in the client response, and slackErrorText
-      // is otherwise arbitrary third-party content (a Slack-side HTML error page, an intermediary
-      // proxy's response). The untrimmed (but SLACK_ERROR_BODY_MAX_LENGTH-bounded) text still
-      // reaches operators either way, via errorBody.reason below (log-only, and only when the
-      // body was actually readable — see that line's own comment for the empty/unreadable case)
-      // — only this client-safety check trims, so a trailing newline Slack or a proxy might add
-      // doesn't disqualify an otherwise-legitimate token.
-      const trimmedErrorText = slackErrorText.trim();
-      const clientSafeReason = SLACK_ERROR_TOKEN_PATTERN.test(trimmedErrorText) ? trimmedErrorText : '';
-      throw new MicroserviceError(`Slack rejected the message${clientSafeReason ? `: ${clientSafeReason}` : ''}`, 502, 'SLACK_SEND_FAILED', {
-        operation: 'share_weekly_brief_slack',
-        service: 'weekly_brief_service',
-        // status/reason are log-only (MicroserviceError#toResponse never echoes errorBody to the
-        // client except via its details/errors sub-keys) — reason keeps the full truncated body
-        // for operators even when it didn't qualify for the client-facing message above, and
-        // status lets an operator tell a 429 rate-limit apart from a 403 revoked webhook even
-        // when the body itself is empty or unreadable.
-        errorBody: { status: response.status, reason: slackErrorText || 'unknown error' },
-      });
-    }
-
-    // Slack's success body is a tiny, unused 'ok' — drain it so undici releases the connection
-    // back to the pool immediately instead of holding it until the stream is GC'd. The !response.ok
-    // branch above already drains its body via readBoundedText; this is the fetch's only other exit.
-    await response.body?.cancel().catch(() => undefined);
-
-    // shared_by is the one place this action's actor is recorded at all: the webhook POST body
-    // itself carries no caller identity (it's why /share-slack blocks during impersonation in the
-    // first place — see impersonation-readonly.middleware.ts), and unlike shareBrief, a successful
-    // send leaves no other persisted record (e.g. a newsletter draft) an operator could trace back
-    // to a user later. Opaque OIDC sub, not the LFID username, same rationale as rating_recorded
-    // above: this log line is retained indefinitely, and a human-readable username is PII (PR #1361
-    // review — docs/reviews/knowledge-base/security.md's `security/pii-in-logs-and-identifiers`).
+    // shared_by is the one place this action's actor is recorded at all in this BFF — the
+    // committee-service call carries no caller identity beyond the bearer token itself (it's why
+    // /share-slack blocks during impersonation in the first place — see
+    // impersonation-readonly.middleware.ts). Opaque OIDC sub, not the LFID username, same
+    // rationale as rating_recorded above: this log line is retained indefinitely, and a
+    // human-readable username is PII (PR #1361 review —
+    // docs/reviews/knowledge-base/security.md's `security/pii-in-logs-and-identifiers`).
     logger.info(req, 'share_weekly_brief_slack_sent', 'Weekly brief sent to the committee Slack channel', {
       committee_id: committeeId,
       shared_by: getEffectiveSub(req),
     });
 
-    return { committee_name: committee.name };
+    return {};
   }
 
   /**
@@ -1045,34 +985,6 @@ export class WeeklyBriefService {
     }
     logger.warning(req, 'weekly_brief_mock_mode', 'Serving mock weekly-brief data — WEEKLY_BRIEF_BACKEND is not "live"', {});
     return false;
-  }
-
-  /**
-   * Reads `response`'s body in chunks and returns at most `maxChars` characters, cancelling the
-   * underlying stream once that many have been read instead of continuing to buffer — unlike
-   * `response.text()`, which always buffers the entire body first regardless of how much of it
-   * ends up used. The accumulator may briefly hold up to one extra transport chunk beyond
-   * `maxChars` between reads; only the final, returned string is guaranteed capped.
-   */
-  private async readBoundedText(response: Response, maxChars: number): Promise<string> {
-    const reader = response.body?.getReader();
-    if (!reader) {
-      return '';
-    }
-    const decoder = new TextDecoder();
-    let text = '';
-    try {
-      while (text.length < maxChars) {
-        const { done, value } = await reader.read();
-        if (done) {
-          break;
-        }
-        text += decoder.decode(value, { stream: true });
-      }
-    } finally {
-      await reader.cancel().catch(() => undefined);
-    }
-    return text.slice(0, maxChars);
   }
 
   /**

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -819,6 +819,13 @@ export class WeeklyBriefService {
    * project writer, `WEEKLY_BRIEF_BACKEND=live`) — those checks stay local so a disabled/mock
    * environment and a stale revision fail the same way they always have, before any upstream
    * call.
+   *
+   * Known behavior change from the pre-LFXV2-3080-migration send: the posted message is
+   * `brief_text` alone — as of this writing, committee-service's `WebhookSender` does not add
+   * back the `*Weekly Brief — {committee}* ({date range})` heading this BFF used to prepend
+   * before composing moved server-side. Flag to product/upstream if that context is missed in a
+   * channel receiving briefs from more than one committee; not addressed in this BFF, since it no
+   * longer composes the message at all.
    */
   public async shareToSlack(req: Request, committeeId: string, expectedRevision: number): Promise<ShareWeeklyBriefToSlackResult> {
     // Same server-side kill switch as committee.service.ts's updateCommittee, and for the same

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -850,7 +850,12 @@ export class WeeklyBriefService {
     // Needs project_uid for the strict project-writer check below — a plain GET, not
     // getCommitteeById, since this method reads nothing from its settings/membership/access-check
     // enrichment.
-    const committee = await this.microserviceProxy.proxyRequest<Committee | null>(req, 'LFX_V2_SERVICE', `/committees/${committeeId}`, 'GET');
+    const committee = await this.microserviceProxy.proxyRequest<Committee | null>(
+      req,
+      'LFX_V2_SERVICE',
+      `/committees/${encodeURIComponent(committeeId)}`,
+      'GET'
+    );
     if (!committee) {
       throw new ResourceNotFoundError('Committee', committeeId, {
         operation: 'share_weekly_brief_slack',
@@ -892,6 +897,7 @@ export class WeeklyBriefService {
     // posts to Slack itself — see this method's doc comment. Its response codes are mapped below
     // onto the same client-facing messages/codes this method already used for the equivalent
     // local checks, so the Angular error-handling contract doesn't change.
+    logger.debug(req, 'share_weekly_brief_slack', 'Proxying to committee-service', { committee_id: committeeId, revision: expectedRevision });
     try {
       await this.microserviceProxy.proxyRequest<void>(
         req,
@@ -905,6 +911,15 @@ export class WeeklyBriefService {
       if (!(error instanceof MicroserviceError)) {
         throw error;
       }
+      // Logged before remapping — the remapped client-facing error (esp. the 400 case below,
+      // which collapses both a stale local/upstream state race AND a genuine BFF↔upstream
+      // contract bug to the same "brief not found" 404) would otherwise leave no operator-visible
+      // trace of what upstream actually said.
+      logger.warning(req, 'share_weekly_brief_slack', 'committee-service rejected the share-to-chat request', {
+        committee_id: committeeId,
+        upstream_status: error.statusCode,
+        upstream_code: error.code,
+      });
       switch (error.statusCode) {
         case 400:
           // Race window between the local shareable-state check above and this call landing

--- a/packages/shared/src/constants/committees.constants.spec.ts
+++ b/packages/shared/src/constants/committees.constants.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN, SLACK_INCOMING_WEBHOOK_URL_PATTERN } from './committees.constants';
+import { SLACK_INCOMING_WEBHOOK_URL_PATTERN } from './committees.constants';
 
 /**
  * Tests the real, imported constant — not a hand-copied regex literal in a test's own mock, the
@@ -44,28 +44,5 @@ describe('SLACK_INCOMING_WEBHOOK_URL_PATTERN', () => {
     expect(SLACK_INCOMING_WEBHOOK_URL_PATTERN.test('https://hooks.slack.com/')).toBe(false);
     expect(SLACK_INCOMING_WEBHOOK_URL_PATTERN.test('https://hooks.slack.com/services/')).toBe(false);
     expect(SLACK_INCOMING_WEBHOOK_URL_PATTERN.test('https://hooks.slack.com/services/T1/B1/')).toBe(false);
-  });
-});
-
-describe('SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN', () => {
-  it('strips a webhook URL embedded in arbitrary surrounding text', () => {
-    const redacted = 'fetch failed: https://hooks.slack.com/services/T000/B000/XXXX unreachable'.replace(
-      SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN,
-      '[redacted-url]'
-    );
-    expect(redacted).toBe('fetch failed: [redacted-url] unreachable');
-  });
-
-  it('strips every occurrence when the URL appears more than once', () => {
-    const redacted = 'https://hooks.slack.com/services/T1/B1/X and again https://hooks.slack.com/services/T2/B2/Y'.replace(
-      SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN,
-      '[redacted-url]'
-    );
-    expect(redacted).not.toContain('hooks.slack.com');
-  });
-
-  it('leaves text with no embedded webhook URL unchanged', () => {
-    const text = 'fetch failed: connect ETIMEDOUT';
-    expect(text.replace(SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN, '[redacted-url]')).toBe(text);
   });
 });

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -25,30 +25,25 @@ export const COMMITTEE_VALID_TABS: CommitteeTab[] = ['overview', 'about', 'membe
 
 /**
  * Slack Incoming Webhook URLs always live under this stable, documented prefix. Enforced as a
- * hard allowlist (not just format hinting) because `chat_webhook_url` drives a server-initiated
- * outbound POST to a URL the committee writer fully controls — without a domain allowlist, an
- * arbitrary URL here would let the BFF be used as an SSRF vector.
+ * hard allowlist (not just format hinting) on write (`committee.service.ts`'s `updateCommittee`) —
+ * committee-service itself now owns the actual outbound POST to Slack (LFXV2-3094 /
+ * lfx-v2-committee-service PR #178), enforcing the same host allowlist independently at send
+ * time, but this BFF-side check still matters: it's what gives the caller an actionable 400 at
+ * save time instead of a webhook that silently 422s every future share attempt.
  *
  * The `hooks.slack.com` host is duplicated as a literal in `apps/lfx-one/otel.mjs`'s
- * `ignoreRequestHook` (LFXV2-3080) — that carve-out exists because this URL carries a bearer
- * credential in its path, which OTel's undici instrumentation would otherwise export unredacted
- * on every outbound share. It checks only the derived request URL's hostname — deliberately
- * broader than this path-anchored full-URL pattern, since suppressing every request to the host
- * is the safe direction for a redaction guard — and the OTel bootstrap deliberately imports no
- * app-side package so nothing app-side loads before instrumentations register. If this pattern's
- * host ever changes or a second host is added, `otel.mjs`'s carve-out must be updated to match,
- * or the credential leak reopens silently.
+ * `ignoreRequestHook`. That carve-out predates the send moving server-side (LFXV2-3080) — this
+ * BFF no longer makes any outbound request to hooks.slack.com itself, so it's dormant today, kept
+ * as defense-in-depth against a future direct-fetch path being reintroduced. It checks only the
+ * derived request URL's hostname — deliberately broader than this path-anchored full-URL pattern,
+ * since suppressing every request to the host is the safe direction for a redaction guard. If
+ * this pattern's host ever changes or a second host is added, update `otel.mjs`'s carve-out to
+ * match, in case that dormant path is ever reactivated.
  */
 export const SLACK_INCOMING_WEBHOOK_URL_PATTERN = /^https:\/\/hooks\.slack\.com\/services\/T[A-Za-z0-9]+\/B[A-Za-z0-9]+\/[A-Za-z0-9]+$/;
 
-/**
- * Non-anchored, `/g`-flagged sibling of {@link SLACK_INCOMING_WEBHOOK_URL_PATTERN} — for
- * scrubbing a webhook URL that might appear *embedded* in arbitrary third-party text (e.g. a
- * caught fetch error's message), not for validating a whole string. Deliberately looser than the
- * validation pattern (no path-segment shape requirement past `/services/`) since a defensive
- * redaction site should err toward over-matching, not under-matching, a potential credential.
- */
-export const SLACK_INCOMING_WEBHOOK_URL_IN_TEXT_PATTERN = /https:\/\/hooks\.slack\.com\/services\/\S*/g;
+/** Mirrors upstream's `chat_webhook_url` bound (lfx-v2-committee-service's `ChatWebhookURLAttribute`, `dsl.MaxLength(500)`) — checked alongside {@link SLACK_INCOMING_WEBHOOK_URL_PATTERN} so an over-length value fails loud with an actionable 400 at the BFF boundary instead of an opaque upstream rejection. */
+export const CHAT_WEBHOOK_URL_MAX_LENGTH = 500;
 
 /**
  * Configurable labels for committees displayed throughout the UI

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -15,8 +15,10 @@ export const ORG_LENS_ROI_ENABLED_FLAG = 'org-lens-roi-enabled';
  * parent flag (committee-overview.component.ts), but committee-settings-tab does not sit behind
  * it at all (rendered unconditionally from the Settings tab in committee-view.component.html) —
  * so flipping this flag alone is sufficient to expose the settings card. Default false: the
- * upstream committee-service has no chat_webhook_url field yet, so every save would 409 today —
- * see committee.service.ts's updateCommittee/getSlackWebhookUrlStrict comments.
+ * upstream committee-service declares chat_webhook_url on the settings resource per
+ * lfx-v2-committee-service PR #177 (LFXV2-3094), but #177 is not yet merged/deployed as of this
+ * writing, so every save would still 409 today — see committee.service.ts's
+ * updateCommittee/getSlackWebhookUrlStrict comments.
  *
  * **UI-only** — this is an OpenFeature/GrowthBook flag evaluated through the OpenFeature Web SDK,
  * which never runs server-side, so it cannot gate an Express handler. The actual write

--- a/packages/shared/src/constants/feature-flags.constants.ts
+++ b/packages/shared/src/constants/feature-flags.constants.ts
@@ -14,11 +14,8 @@ export const ORG_LENS_ROI_ENABLED_FLAG = 'org-lens-roi-enabled';
  * directly. Not a strict child of 'wg-weekly-brief': weekly-brief-card does render under that
  * parent flag (committee-overview.component.ts), but committee-settings-tab does not sit behind
  * it at all (rendered unconditionally from the Settings tab in committee-view.component.html) —
- * so flipping this flag alone is sufficient to expose the settings card. Default false: the
- * upstream committee-service declares chat_webhook_url on the settings resource per
- * lfx-v2-committee-service PR #177 (LFXV2-3094), but #177 is not yet merged/deployed as of this
- * writing, so every save would still 409 today — see committee.service.ts's
- * updateCommittee/getSlackWebhookUrlStrict comments.
+ * so flipping this flag alone is sufficient to expose the settings card. Default false: this is a
+ * dark launch, gating rollout independently of when the code itself ships.
  *
  * **UI-only** — this is an OpenFeature/GrowthBook flag evaluated through the OpenFeature Web SDK,
  * which never runs server-side, so it cannot gate an Express handler. The actual write

--- a/packages/shared/src/constants/weekly-brief.constants.spec.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.spec.ts
@@ -9,49 +9,11 @@
 
 import { describe, expect, it } from 'vitest';
 
-import {
-  SLACK_ERROR_BODY_MAX_LENGTH,
-  SLACK_ERROR_TOKEN_PATTERN,
-  SLACK_MESSAGE_TEXT_MAX_LENGTH,
-  WEEKLY_BRIEF_DEFAULT_THROTTLE,
-  WEEKLY_BRIEF_TEXT_MAX_LENGTH,
-} from './weekly-brief.constants';
+import { WEEKLY_BRIEF_DEFAULT_THROTTLE, WEEKLY_BRIEF_TEXT_MAX_LENGTH } from './weekly-brief.constants';
 
 describe('WEEKLY_BRIEF_TEXT_MAX_LENGTH', () => {
   it('matches upstream UpdateCurrentWeeklyBriefRequestBody.brief_text maxLength', () => {
     expect(WEEKLY_BRIEF_TEXT_MAX_LENGTH).toBe(20_000);
-  });
-});
-
-describe('SLACK_MESSAGE_TEXT_MAX_LENGTH', () => {
-  // Same rationale as WEEKLY_BRIEF_TEXT_MAX_LENGTH above: weekly-brief.service.spec.ts's
-  // wholesale `@lfx-one/shared/constants` mock hand-copies this value, so a real-value change
-  // here wouldn't be caught there — this is the one place it's checked against the real export.
-  it("matches Slack's documented incoming-webhook text field limit", () => {
-    expect(SLACK_MESSAGE_TEXT_MAX_LENGTH).toBe(40_000);
-  });
-});
-
-describe('SLACK_ERROR_BODY_MAX_LENGTH', () => {
-  // Same rationale as the two describes above: weekly-brief.service.spec.ts's wholesale
-  // `@lfx-one/shared/constants` mock hand-copies this value too.
-  it('is a small, deliberate bound', () => {
-    expect(SLACK_ERROR_BODY_MAX_LENGTH).toBe(500);
-  });
-});
-
-describe('SLACK_ERROR_TOKEN_PATTERN', () => {
-  it("matches Slack's documented short lowercase/underscore error tokens", () => {
-    expect(SLACK_ERROR_TOKEN_PATTERN.test('invalid_payload')).toBe(true);
-    expect(SLACK_ERROR_TOKEN_PATTERN.test('channel_not_found')).toBe(true);
-    expect(SLACK_ERROR_TOKEN_PATTERN.test('action_prohibited')).toBe(true);
-  });
-
-  it('rejects arbitrary third-party content that is not a Slack error token', () => {
-    expect(SLACK_ERROR_TOKEN_PATTERN.test('<html><body>502 Bad Gateway</body></html>')).toBe(false);
-    expect(SLACK_ERROR_TOKEN_PATTERN.test('invalid_payload\n')).toBe(false);
-    expect(SLACK_ERROR_TOKEN_PATTERN.test('x'.repeat(65))).toBe(false);
-    expect(SLACK_ERROR_TOKEN_PATTERN.test('')).toBe(false);
   });
 });
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -37,42 +37,6 @@ export const WEEKLY_BRIEF_DEFAULT_THROTTLE = {
 /** Mirrors upstream's `brief_text` bound (`UpdateCurrentWeeklyBriefRequestBody`: maxLength 20000, non-empty). */
 export const WEEKLY_BRIEF_TEXT_MAX_LENGTH = 20_000;
 
-/**
- * Timeout for the "Share to Slack" incoming-webhook POST. A plain webhook call should complete
- * in well under a second; this is generous headroom, not a tuned budget — deliberately far
- * short of `NEWSLETTER_SEND_TIMEOUT_MS` (120s), which accounts for an entirely different,
- * heavier upstream call.
- */
-export const SLACK_WEBHOOK_POST_TIMEOUT_MS = 10_000;
-
-/**
- * Slack's documented hard limit on an incoming-webhook message's `text` field. Checked
- * server-side before the POST (mirrors shareBrief's NEWSLETTER_BODY_MAX_LENGTH guard) so an
- * oversized brief surfaces as an actionable 400 instead of an opaque 502 from Slack. Escaping
- * (`&`→`&amp;`, `<`→`&lt;`, `>`→`&gt;`) can expand brief_text up to 5x, so this is checked
- * against the final composed text, not brief_text's own (smaller) WEEKLY_BRIEF_TEXT_MAX_LENGTH.
- */
-export const SLACK_MESSAGE_TEXT_MAX_LENGTH = 40_000;
-
-/**
- * Cap on how much of Slack's plain-text error response (invalid_payload, channel_not_found,
- * etc.) is read and surfaced when a webhook POST is rejected — bounds both the log line and the
- * client-facing error message against an unexpectedly large response body.
- */
-export const SLACK_ERROR_BODY_MAX_LENGTH = 500;
-
-/**
- * Matches Slack's own documented incoming-webhook error strings — short lowercase/underscore
- * tokens (`invalid_payload`, `channel_not_found`, `action_prohibited`, `rate_limited`, …). Used
- * to gate whether a rejected share's response body is safe to echo into the client-facing error
- * message: the actual body could be arbitrary third-party content (an HTML error page, an
- * intermediary proxy's response), and only a recognizable Slack token should ever reach a
- * browser toast. The untrimmed body — still bounded by SLACK_ERROR_BODY_MAX_LENGTH above, and
- * only when the body was actually readable — reaches operators via the log-only
- * `errorBody.reason` regardless of whether it matches this pattern.
- */
-export const SLACK_ERROR_TOKEN_PATTERN = /^[a-z_]{1,64}$/;
-
 /** Max AI-extracted action items surfaced per brief revision (LFXV2-3043) — guards against an overlong Pending Actions list and bounds AI spend per extraction. */
 export const WEEKLY_BRIEF_ACTION_ITEMS_MAX = 5;
 

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -428,12 +428,12 @@ export interface Committee {
    * value doesn't match `SLACK_INCOMING_WEBHOOK_URL_PATTERN`, not just presence, since this repo's
    * write path isn't the only possible writer of the field. The raw `chat_webhook_url` is a bearer
    * credential and is deliberately never returned by any read — see
-   * {@link CommitteeUpdateData.chat_webhook_url}. This boolean is the only signal reads get.
+   * {@link CommitteeSettingsData.chat_webhook_url}. This boolean is the only signal reads get.
    *
-   * Populated only by `GET /committees/:uid` (`getCommitteeById`), unlike `has_mailing_list`,
-   * which list endpoints enrich too. Absence on a list result (`getCommittees`,
-   * `getCommitteesByIds`, etc.) means "not looked up here", not "not configured" — check the
-   * single-committee endpoint before relying on it being `false`.
+   * Sourced from `GET /committees/:uid/settings` (fetched by `getCommitteeById` alongside the base
+   * committee resource), unlike `has_mailing_list`, which list endpoints enrich too. Absence on a
+   * list result (`getCommittees`, `getCommitteesByIds`, etc.) means "not looked up here", not "not
+   * configured" — check the single-committee endpoint before relying on it being `false`.
    */
   has_slack_webhook?: boolean;
 
@@ -583,11 +583,6 @@ export interface CommitteeUpdateData extends Partial<CommitteeCreateData> {
   mailing_list?: string | null;
   /** Update or clear chat channel */
   chat_channel?: string | null;
-  /**
-   * Update or clear the Slack incoming webhook URL (must match `hooks.slack.com/services/...`).
-   * Write-only — never echoed back on any read; see {@link Committee.has_slack_webhook}.
-   */
-  chat_webhook_url?: string | null;
   /** Update the list of users with manage (write) access */
   writers?: CommitteeUser[];
   /** Update the list of users with review (audit) access */
@@ -607,6 +602,13 @@ export interface CommitteeSettingsData {
   member_visibility?: CommitteeMemberVisibility;
   /** Update show meeting attendees setting */
   show_meeting_attendees?: boolean;
+  /**
+   * Update or clear the Slack incoming webhook URL (must match `hooks.slack.com/services/...`).
+   * Lives on the settings sub-resource, not the base committee object, per LFXV2-3094 — the
+   * webhook is deliberately kept off the base resource so it isn't visible to every committee
+   * viewer. Write-only — never echoed back on any read; see {@link Committee.has_slack_webhook}.
+   */
+  chat_webhook_url?: string | null;
   /** Update the list of users with manage (write) access */
   writers?: CommitteeUser[];
   /** Update the list of users with review (audit) access */

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -424,11 +424,11 @@ export interface Committee {
   /** Chat channel URL or identifier associated with the group (plain string from upstream). Set to null to clear. */
   chat_channel?: string | null;
   /**
-   * Whether the committee has a *valid* Slack incoming webhook configured — `false` if the stored
-   * value doesn't match `SLACK_INCOMING_WEBHOOK_URL_PATTERN`, not just presence, since this repo's
-   * write path isn't the only possible writer of the field. The raw `chat_webhook_url` is a bearer
-   * credential and is deliberately never returned by any read — see
-   * {@link CommitteeSettingsData.chat_webhook_url}. This boolean is the only signal reads get.
+   * Whether the committee has a Slack incoming webhook configured. The raw `chat_webhook_url` is
+   * a bearer credential and is deliberately never returned by any read — see
+   * {@link CommitteeSettingsData.chat_webhook_url}. This boolean is the only signal reads get,
+   * sourced directly from the upstream-computed {@link CommitteeSettingsData.has_chat_webhook}
+   * (LFXV2-3094 / lfx-v2-committee-service PR #179) — the URL itself is never inspected here.
    *
    * Sourced from `GET /committees/:uid/settings` (fetched by `getCommitteeById` alongside the base
    * committee resource), unlike `has_mailing_list`, which list endpoints enrich too. Absence on a
@@ -609,6 +609,13 @@ export interface CommitteeSettingsData {
    * viewer. Write-only — never echoed back on any read; see {@link Committee.has_slack_webhook}.
    */
   chat_webhook_url?: string | null;
+  /**
+   * Whether a Slack incoming webhook is configured — computed server-side by upstream
+   * (`chat_webhook_url` set to a non-empty value), never the raw URL itself. Read-only: only ever
+   * present on a `GET`/`PUT .../settings` response, never accepted on a write. See
+   * {@link Committee.has_slack_webhook}, which is sourced from this field.
+   */
+  has_chat_webhook?: boolean;
   /** Update the list of users with manage (write) access */
   writers?: CommitteeUser[];
   /** Update the list of users with review (audit) access */

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -180,13 +180,13 @@ export interface ShareWeeklyBriefResult {
 }
 
 /**
- * Unlike {@link ShareWeeklyBriefResult}, a Slack incoming webhook POST is synchronous — Slack
- * accepts or rejects the message in the same request, so there is no recipient-count/fan-out
- * concept to report here. A resolved promise means Slack accepted the message.
+ * The committee-service composes and sends the Slack message itself (lfx-v2-committee-service
+ * PR #178 / LFXV2-3094), responding `204 No Content` on success — there is nothing to report
+ * back beyond a resolved promise meaning Slack accepted the message. Empty on purpose, not a
+ * placeholder: the Angular success handler never read `committee_name` even when this interface
+ * carried it, and this BFF no longer fetches the committee for its own sake to populate it.
  */
-export interface ShareWeeklyBriefToSlackResult {
-  committee_name: string;
-}
+export type ShareWeeklyBriefToSlackResult = Record<string, never>;
 
 /**
  * An AI-extracted follow-up item from a brief's `brief_text` (LFXV2-3043). Extraction runs


### PR DESCRIPTION
## Summary

LFXV2-3080 (weekly brief → Slack share, originally merged as #1386, dark-launched behind `wg-weekly-brief-slack`, currently **off** for all users) originally bet on a design where the BFF read the committee's raw Slack webhook URL and posted to Slack directly. That design was overturned mid-flight: a bearer credential like a Slack webhook URL must never be handed back to a client, so the committee-service backend now owns both storage *and* sending. This PR now covers the full migration, in three commits:

1. **Settings-contract move** — `chat_webhook_url` lives on the committee **settings** sub-resource (`GET/PUT /committees/:id/settings`), not the base committee object ([lfx-v2-committee-service#177](https://github.com/linuxfoundation/lfx-v2-committee-service/pull/177), merged). Routes `updateCommittee`'s webhook writes through `updateCommitteeSettings`, decouples the project-writer authorization check from `hasCoreUpdate` so a webhook-only save is still authorized correctly before any write.
2. **`has_slack_webhook` sourcing fix** — now sourced from upstream's computed `has_chat_webhook` boolean ([lfx-v2-committee-service#179](https://github.com/linuxfoundation/lfx-v2-committee-service/pull/179), merged), not a pattern-test against a raw URL upstream never actually returns. Without this fix `has_slack_webhook` would have stayed permanently `false` for every committee.
3. **Backend send-ownership migration** — `shareToSlack` now delegates the actual Slack POST to `POST /committees/:uid/weekly-briefs/share-to-chat` ([lfx-v2-committee-service#178](https://github.com/linuxfoundation/lfx-v2-committee-service/pull/178), merged) instead of fetching the webhook URL and POSTing to Slack itself. The raw credential never reaches this BFF at all now. Deletes the now-dead direct-send machinery (`getCommitteeForSlackShare`, `getSlackWebhookUrlStrict`, message composition/escaping, the settings read-back verification workaround) and the constants exclusive to it.

The BFF never returns the raw webhook URL to any reader via any response — only `has_slack_webhook` is ever exposed — and that invariant is preserved throughout.

## ⚠️ Known gap — do not enable in production yet

**`ServerFeatureFlag.WeeklyBriefSlack` and `wg-weekly-brief-slack` both still default off, and should stay off until this is resolved.** This BFF used to escape Slack mrkdwn control characters (`&`, `<`, `>`) in `brief_text` before every send, specifically because AI-generated brief text is sourced from meeting/document titles — content editable by a broader set of users than project writers — so an unescaped `<!channel>`/`<!here>` would page the entire channel, and `<https://evil.example|label>` would render as a deceptive hyperlink. That escaping was removed as part of step 3 above (the BFF no longer composes the message at all), and **lfx-v2-committee-service does not re-implement it** — `internal/infrastructure/slack/webhook_sender.go` posts `brief.BriefText` verbatim. This needs an upstream fix before either flag is flipped on anywhere. Documented on `ServerFeatureFlag.WeeklyBriefSlack`'s doc comment; tracking ticket to follow.

**Separately (not a security issue, a product/UX change worth a conscious call):** the posted Slack message also loses the `*Weekly Brief — {committee}* ({date range})` heading this BFF used to prepend. Committee-service's `WebhookSender` posts `brief.BriefText` alone — it doesn't compose that context back in. A channel receiving briefs from more than one committee would see unlabeled text. Not blocking, since the flags are off either way, but flag to product/upstream before enabling.

## Related

- LFXV2-3080: https://linuxfoundation.atlassian.net/browse/LFXV2-3080
- LFXV2-3094: https://linuxfoundation.atlassian.net/browse/LFXV2-3094
- Upstream (all merged): linuxfoundation/lfx-v2-committee-service#177, #178, #179

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] `committee.service.spec.ts` — settings save includes `chat_webhook_url`; `''`/`null` both normalize to upstream's own clear signal (`''`, not `null` — upstream treats `null`/omitted as *preserve*); `has_slack_webhook` sourced from `settings.has_chat_webhook`; `has_chat_webhook` itself never leaks onto the response; webhook-only save enforces project-writer auth before any write, including on a nonexistent committee (404, not a misleading 403)
- [x] `weekly-brief.service.spec.ts` — `shareToSlack` mocks the `share-to-chat` proxy call and asserts every response-code mapping (204/400/403/404/409/422/500/503) against the same client-facing messages/codes the Angular UI already handles
- [x] `weekly-brief.controller.spec.ts`, `committee-settings-tab.component.spec.ts`, `weekly-brief-card.component.spec.ts` updated for the simplified response shape and the now-dead error branches removed
- [ ] Live verification against a deployed committee-service — flags stay off until the mrkdwn-escaping gap above is resolved

