### PR TITLE
feat(profile): unify avatar display across sidebar, header, and profile pages

### DIFF
--- a/apps/lfx-one/e2e/profile-avatar.spec.ts
+++ b/apps/lfx-one/e2e/profile-avatar.spec.ts
@@ -69,15 +69,24 @@ test.describe('Profile header avatar', () => {
     await expect(image).toHaveAttribute('src', PNG_DATA_URI);
   });
 
-  test('falls back to initials when no picture is set', async ({ page }) => {
+  test('falls back to the Auth0 OIDC picture claim (or initials) when no uploaded avatar is set', async ({ page }) => {
     await mockProfile(page, null);
     await page.goto('/profile/attributions', { waitUntil: 'domcontentloaded' });
     skipWhenAuthMissing(page);
 
     await expect(page.getByTestId('profile-display-name')).toContainText('Ada Lovelace', { timeout: 10000 });
 
-    await expect(page.getByTestId('profile-avatar-image')).not.toBeAttached();
-    await expect(page.getByTestId('profile-avatar')).toContainText('A');
+    // With no uploaded avatar, the effective source is the always-present Auth0 OIDC `picture` claim
+    // on the signed-in e2e test account (LFXV2-2628) — this mock only controls user_metadata.picture,
+    // not that claim, so whether it's actually populated depends on the test account's Auth0 profile.
+    // Branch on what's actually rendered instead of assuming either outcome.
+    const image = page.getByTestId('profile-avatar-image');
+    if (await image.isVisible().catch(() => false)) {
+      await expect(image).toHaveAttribute('src', /^https?:\/\//);
+    } else {
+      await expect(image).not.toBeAttached();
+      await expect(page.getByTestId('profile-avatar')).toContainText('A');
+    }
   });
 
   test('falls back to initials when the picture URL fails to load', async ({ page }) => {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -100,8 +100,10 @@ export class ProfileLayoutComponent {
   // Computed signals
   public readonly displayUsername = computed(() => stripAuthPrefixOrNull(this.profileData()?.username));
 
-  // Avatar image URL sourced from auth0 user_metadata.picture (empty when unset)
-  public readonly avatarUrl = computed(() => this.profileData()?.avatarUrl || '');
+  // Avatar image URL: prefer the uploaded avatar (auth0 user_metadata.picture) and fall back to
+  // the always-present Auth0 OIDC picture claim, so this rail never shows a placeholder for a user
+  // who simply hasn't uploaded a custom avatar (LFXV2-2628).
+  public readonly avatarUrl = computed(() => this.profileData()?.avatarUrl || this.userService.user()?.picture || '');
 
   public readonly displayName = computed(() => {
     const data = this.profileData();
@@ -194,6 +196,13 @@ export class ProfileLayoutComponent {
   /** Apply the optimistic update emitted by the edit drawer's `saved` output. */
   public onProfileSaved(metadata: Partial<UserMetadata>): void {
     this.applyOptimisticProfileUpdate(metadata);
+
+    // Sync a fresh avatar upload into the shared signal immediately, so the home sidebar/header
+    // (which read UserService.effectiveAvatarUrl, not this layout's own profileData) reflect it in
+    // the same session without waiting for the next full-page load's post-hydration fetch.
+    if (metadata.picture) {
+      this.userService.uploadedAvatarUrl.set(metadata.picture);
+    }
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -110,7 +110,10 @@ export class ProfileEditDrawerComponent {
   // The avatar URL that failed to load, if any — mirrors ProfilePanelComponent's fallback pattern
   // so a broken/expired picture URL falls back to initials instead of a broken image icon.
   private readonly avatarErrorUrl = signal<string | null>(null);
-  public readonly avatarUrl = computed(() => this.combinedProfile()?.profile?.picture || '');
+  // Uploaded avatar, falling back to the always-present Auth0 OIDC picture claim (same priority
+  // chain as ProfileLayoutComponent.avatarUrl) — otherwise the drawer preview shows initials for a
+  // user who simply hasn't uploaded a custom avatar (LFXV2-2628).
+  public readonly avatarUrl = computed(() => this.combinedProfile()?.profile?.picture || this.userService.user()?.picture || '');
   public readonly avatarInitials = computed(() => {
     const profile = this.combinedProfile();
     if (!profile) return 'U';

--- a/apps/lfx-one/src/app/modules/public-profile/components/public-profile-hero/public-profile-hero.component.html
+++ b/apps/lfx-one/src/app/modules/public-profile/components/public-profile-hero/public-profile-hero.component.html
@@ -14,7 +14,8 @@
         shape="circle"
         [style]="{ width: '148px', height: '148px', fontSize: '3rem' }"
         styleClass="bg-gray-100 text-gray-600"
-        data-testid="hero-avatar"></lfx-avatar>
+        data-testid="hero-avatar"
+        (onImageError)="handleAvatarError()"></lfx-avatar>
     </div>
 
     <!-- Name / affiliation, with social links + share on the same row -->

--- a/apps/lfx-one/src/app/modules/public-profile/components/public-profile-hero/public-profile-hero.component.ts
+++ b/apps/lfx-one/src/app/modules/public-profile/components/public-profile-hero/public-profile-hero.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, inject, input, PLATFORM_ID, Signal } from '@angular/core';
+import { Component, computed, inject, input, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { AvatarComponent } from '@components/avatar/avatar.component';
 import { MarkdownRendererComponent } from '@components/markdown-renderer/markdown-renderer.component';
 import { PublicProfileBasic, PublicProfileSocialLink } from '@lfx-one/shared/interfaces';
@@ -22,13 +22,34 @@ export class PublicProfileHeroComponent {
   protected readonly name = computed(() => this.basic()?.Name?.trim() || 'LFX Contributor');
   protected readonly title = computed(() => this.basic()?.Title?.trim() || '');
   protected readonly bio = computed(() => this.basic()?.Bio?.trim() || '');
-  protected readonly avatarImage = computed(() => this.basic()?.LogoURL || '');
+
+  // Prefers the uploaded avatar (guessed from username, existence unverified) over the SFDC-derived
+  // LogoURL artifact — falls back to LogoURL if the uploaded one 404s (e.g. no avatar ever
+  // uploaded), tracked by comparing against the exact URL that errored (LFXV2-2628).
+  private readonly erroredAvatarUrl = signal<string | null>(null);
+  protected readonly avatarImage = computed(() => {
+    const basic = this.basic();
+    const uploaded = basic?.avatarUrl?.trim();
+    if (uploaded && this.erroredAvatarUrl() !== uploaded) {
+      return uploaded;
+    }
+    return basic?.LogoURL?.trim() || '';
+  });
+
   protected readonly accountLogo = computed(() => this.basic()?.AccountLogoURL?.trim() || '');
 
   // "Individual" is an upstream placeholder for "no employer" — hide it (matches myprofile).
   protected readonly company = computed(() => resolveAffiliationCompany(this.basic()));
 
   protected readonly socials: Signal<PublicProfileSocialLink[]> = this.initSocials();
+
+  /** Record the uploaded-avatar URL as errored so `avatarImage` falls back to LogoURL. */
+  protected handleAvatarError(): void {
+    const uploaded = this.basic()?.avatarUrl?.trim();
+    if (uploaded) {
+      this.erroredAvatarUrl.set(uploaded);
+    }
+  }
 
   // Share the current profile URL — native share sheet when available, clipboard otherwise.
   // Guarded for SSR since it touches navigator/window (see .claude/rules/ssr-safety.md).

--- a/apps/lfx-one/src/app/modules/public-profile/components/public-profile-topbar/public-profile-topbar.component.html
+++ b/apps/lfx-one/src/app/modules/public-profile/components/public-profile-topbar/public-profile-topbar.component.html
@@ -44,7 +44,8 @@
         [label]="name()"
         shape="circle"
         [style]="{ width: '34px', height: '34px' }"
-        styleClass="bg-gray-100 text-gray-600"></lfx-avatar>
+        styleClass="bg-gray-100 text-gray-600"
+        (onImageError)="handleAvatarError()"></lfx-avatar>
       <div class="flex flex-col gap-0.5 leading-tight">
         <span class="whitespace-nowrap text-[17px] font-bold text-gray-900">{{ name() }}</span>
         @if (headline()) {

--- a/apps/lfx-one/src/app/modules/public-profile/components/public-profile-topbar/public-profile-topbar.component.ts
+++ b/apps/lfx-one/src/app/modules/public-profile/components/public-profile-topbar/public-profile-topbar.component.ts
@@ -25,7 +25,18 @@ export class PublicProfileTopbarComponent {
   protected readonly scrolled = signal(false);
 
   protected readonly name = computed(() => this.basic()?.Name?.trim() || 'LFX Contributor');
-  protected readonly avatarImage = computed(() => this.basic()?.LogoURL || '');
+
+  // Same two-tier fallback as the hero (LFXV2-2628): prefer the uploaded avatar, fall back to
+  // LogoURL if it 404s (tracked by comparing against the exact URL that errored).
+  private readonly erroredAvatarUrl = signal<string | null>(null);
+  protected readonly avatarImage = computed(() => {
+    const basic = this.basic();
+    const uploaded = basic?.avatarUrl?.trim();
+    if (uploaded && this.erroredAvatarUrl() !== uploaded) {
+      return uploaded;
+    }
+    return basic?.LogoURL?.trim() || '';
+  });
 
   // "{Title} at {Company}" — mirrors the hero, hiding the "Individual" no-employer placeholder.
   protected readonly headline = computed(() => formatAffiliation(this.basic()));
@@ -46,5 +57,13 @@ export class PublicProfileTopbarComponent {
       this.scrolled.set(window.scrollY > IDENTITY_REVEAL_OFFSET);
       this.scrollFramePending = false;
     });
+  }
+
+  /** Record the uploaded-avatar URL as errored so `avatarImage` falls back to LogoURL. */
+  protected handleAvatarError(): void {
+    const uploaded = this.basic()?.avatarUrl?.trim();
+    if (uploaded) {
+      this.erroredAvatarUrl.set(uploaded);
+    }
   }
 }

--- a/apps/lfx-one/src/app/shared/components/avatar/avatar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/avatar/avatar.component.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, input, output, signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { AvatarProps } from '@lfx-one/shared/interfaces';
 import { AvatarModule } from 'primeng/avatar';
 
@@ -52,6 +53,15 @@ export class AvatarComponent {
   // Output events
   public readonly onClick = output<Event>();
   public readonly onImageError = output<Event>();
+
+  public constructor() {
+    // Reset the error flag whenever a caller swaps to a different image URL (e.g. a multi-source
+    // fallback chain retrying with a new candidate) — otherwise a URL that later succeeds still
+    // renders blank because a previous, different URL failed earlier in this component's lifetime.
+    toObservable(this.image)
+      .pipe(takeUntilDestroyed())
+      .subscribe(() => this.imageErrorSignal.set(false));
+  }
 
   // Event handlers
   protected handleClick(event: Event): void {

--- a/apps/lfx-one/src/app/shared/components/header/header.component.html
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.html
@@ -56,7 +56,7 @@
                       </a>
                     }
                     <lfx-avatar
-                      [image]="userService.user()?.picture"
+                      [image]="userService.effectiveAvatarUrl()"
                       [icon]="'fa-light fa-user'"
                       [label]="userService.user()?.name"
                       size="normal"

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.html
@@ -59,7 +59,7 @@
             <!-- Avatar with persona badges anchored bottom-right -->
             <div class="relative shrink-0">
               <lfx-avatar
-                [image]="user()?.picture ?? ''"
+                [image]="avatarUrl()"
                 [label]="user()?.name ?? ''"
                 shape="square"
                 size="large"

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -102,6 +102,7 @@ export class SidebarComponent {
 
   protected readonly user = this.userService.user;
   protected readonly userInitials = this.userService.userInitials;
+  protected readonly avatarUrl = this.userService.effectiveAvatarUrl;
   protected readonly personaLabels: Signal<{ label: string; icon: string; names: string[]; ariaLabel: string }[]> = this.initPersonaLabels();
   // Hide the persona badge when the user is a root-writer — executive-director is spoofed, not naturally detected.
   protected readonly showPersonaBadge: Signal<boolean> = computed(() => !this.personaService.isRootWriter());

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpClient } from '@angular/common/http';
-import { computed, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
+import { afterNextRender, computed, inject, Injectable, Signal, signal, WritableSignal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { MessageService } from 'primeng/api';
 import {
@@ -49,6 +49,17 @@ export class UserService {
   public canImpersonate: WritableSignal<boolean> = signal<boolean>(false);
   public readonly userInitials: Signal<string> = this.initUserInitials();
   /**
+   * The current user's uploaded avatar (Auth0 user_metadata.picture), null until the one-time
+   * post-hydration profile fetch resolves — that field never reaches `user` (it's absent from the
+   * OIDC claims `user` is seeded from) or is set from the profile-edit upload flow (LFXV2-2628).
+   */
+  public readonly uploadedAvatarUrl: WritableSignal<string | null> = signal<string | null>(null);
+  /**
+   * Single source of truth for "which avatar to show" everywhere in the app for the logged-in
+   * user: the uploaded avatar when set, else the always-present Auth0 OIDC `picture` claim.
+   */
+  public readonly effectiveAvatarUrl: Signal<string> = computed(() => this.uploadedAvatarUrl() || this.user()?.picture || '');
+  /**
    * The viewer's LFID as it appears on meeting `created_by` / host records — null when unresolved.
    * Single source for viewer-identity comparisons (e.g. the "Organized by you" chip and the
    * "Organized by me" meetings filter), so those surfaces can never resolve identity differently.
@@ -87,6 +98,12 @@ export class UserService {
         takeUntilDestroyed()
       )
       .subscribe(() => {
+        // Drop the previous user's uploaded avatar — impersonation start/stop swaps `user` without
+        // a page reload, and without this reset the new user's sidebar/header would briefly (or
+        // permanently, if they never uploaded one themselves) show the previous user's avatar
+        // until/unless a fresh post-hydration fetch happens to overwrite it (LFXV2-2628).
+        this.uploadedAvatarUrl.set(null);
+
         // Tear down the old chains first — their shareReplay keeps the source alive under
         // refCount:false, so nulling the field alone would leave them subscribed to refresh$.
         this.userMeetingsDestroy$.next();
@@ -99,6 +116,31 @@ export class UserService {
         this.userPastMeetings$ = null;
         this.userLatestPastMeetings$ = null;
       });
+
+    // Client-only, one-time: user_metadata.picture isn't part of the OIDC claims transferred from
+    // SSR (see server.ts's AuthContext), so the only way to learn it is a follow-up fetch of the
+    // existing /api/profile endpoint. afterNextRender never runs during SSR, so this never adds
+    // latency to a server-rendered response — it fires once, after the first client render.
+    afterNextRender(() => {
+      if (!this.user()) {
+        return;
+      }
+      this.getCurrentUserProfile()
+        .pipe(take(1))
+        .subscribe({
+          next: (profile) => {
+            // Only seed from this fetch if nothing has set the signal since it was kicked off —
+            // an in-session upload (onProfileSaved) that completes first must win, not get
+            // clobbered by this slower, now-stale fetch resolving afterward.
+            if (profile.profile?.picture && this.uploadedAvatarUrl() === null) {
+              this.uploadedAvatarUrl.set(profile.profile.picture);
+            }
+          },
+          // Best-effort: leave uploadedAvatarUrl null so effectiveAvatarUrl falls back to the
+          // Auth0 picture claim, which is already showing.
+          error: () => {},
+        });
+    });
   }
 
   // Create a new user with permissions

--- a/apps/lfx-one/src/server/services/object-store.service.ts
+++ b/apps/lfx-one/src/server/services/object-store.service.ts
@@ -4,21 +4,8 @@
 import { BucketLocationConstraint, CreateBucketCommand, HeadBucketCommand, NotFound, PutObjectCommand, S3Client } from '@aws-sdk/client-s3';
 import { Request } from 'express';
 
+import { buildAvatarUrl, getAvatarCdnPrefix, toAvatarKeySegment } from '../utils/avatar-url.util';
 import { logger } from './logger.service';
-
-/**
- * Escapes the two characters that break the raw-key / percent-encoded-URL round trip: a literal
- * `/` would split the key into extra S3 path segments that don't survive as `%2F` (CDNs/S3
- * gateways decode an encoded slash inconsistently — some refuse it, some collapse it), and a
- * literal `%` would collide with our own escape sequence. Escaping `%` first means a username that
- * already contains a literal `%2F`-shaped substring can't be mistaken for an escaped `/`, keeping
- * the mapping collision-free. Every other character (letters, digits, `.`, `@`, `+`, unicode) is
- * left as-is, staying human-readable and matching packages/shared/src/utils/avatar.utils.ts's
- * buildMyprofileAvatarUrl convention of an unencoded key, encoded only at URL-construction time.
- */
-function toAvatarKeySegment(sanitizedUsername: string): string {
-  return sanitizedUsername.replace(/%/g, '%25').replace(/\//g, '%2F');
-}
 
 /**
  * Generic S3-compatible object-store service for managing bucket readiness and uploads.
@@ -97,12 +84,9 @@ export class ObjectStoreService {
         })
       );
 
-      // Percent-encode the same key segment used for storage — a single decode hop in transit
-      // reconstructs `keySegment` exactly (including any literal `%2F`/`%25` text from
-      // toAvatarKeySegment), so the URL always resolves back to the stored key.
-      const cdnPrefix = this.getCdnPrefix();
+      const cdnPrefix = getAvatarCdnPrefix();
       const versionHint = Math.floor(Date.now() / 1000);
-      const url = cdnPrefix ? `${cdnPrefix}/avatars/${encodeURIComponent(keySegment)}?v=${versionHint}` : null;
+      const url = cdnPrefix ? `${buildAvatarUrl(cdnPrefix, keySegment)}?v=${versionHint}` : null;
 
       logger.success(req, 'object_store_upload_profile_picture', startTime, { key, has_cdn_url: !!url });
 
@@ -142,25 +126,6 @@ export class ObjectStoreService {
       throw new Error('AWS_REGION environment variable is required');
     }
     return region;
-  }
-
-  /**
-   * Returns the normalized CDN prefix (trailing slashes stripped), or null when CDN_URL_PREFIX is
-   * unset — that's degraded mode (callers fall back to no public_url), not a fatal error. When
-   * set, it must be an absolute http(s) URL: infra sometimes hands back a bare hostname (e.g.
-   * `avatars-public.dev.downloads.lfx.community`), and interpolating that verbatim would silently
-   * produce a relative URL that then gets persisted (e.g. into Auth0 user_metadata) as if it were
-   * absolute.
-   */
-  private getCdnPrefix(): string | null {
-    const cdnPrefix = process.env['CDN_URL_PREFIX'];
-    if (!cdnPrefix) {
-      return null;
-    }
-    if (!/^https?:\/\//i.test(cdnPrefix)) {
-      throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
-    }
-    return cdnPrefix.replace(/\/+$/, '');
   }
 
   private async doEnsureBucket(): Promise<void> {

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -31,6 +31,7 @@ let fetchMock: ReturnType<typeof vi.fn>;
 beforeEach(() => {
   vi.clearAllMocks();
   delete process.env[BUCKET_ENV];
+  delete process.env['CDN_URL_PREFIX'];
   fetchMock = vi.fn();
   vi.stubGlobal('fetch', fetchMock);
 });
@@ -165,6 +166,23 @@ describe('projectPublicProfile', () => {
     expect(projected.isPublic).toBe(false);
     // Round-trip through JSON to drop undefined keys, mirroring the wire payload.
     expect(JSON.parse(JSON.stringify(projected))).toEqual({ isPublic: false, basic: { Name: 'Jane' } });
+  });
+
+  it('derives basic.avatarUrl from the requested username when CDN_URL_PREFIX is configured', () => {
+    process.env['CDN_URL_PREFIX'] = 'https://cdn.example.com/';
+    const projected = projectPublicProfile({ basic: { Name: 'Jane' } }, req, 'Jane.Doe');
+    expect(projected.basic?.avatarUrl).toBe('https://cdn.example.com/avatars/jane.doe');
+  });
+
+  it('omits basic.avatarUrl when no username is passed (e.g. unit-testing projection in isolation)', () => {
+    process.env['CDN_URL_PREFIX'] = 'https://cdn.example.com/';
+    const projected = projectPublicProfile({ basic: { Name: 'Jane' } });
+    expect(projected.basic?.avatarUrl).toBeUndefined();
+  });
+
+  it('omits basic.avatarUrl when CDN_URL_PREFIX is unset, even with a username', () => {
+    const projected = projectPublicProfile({ basic: { Name: 'Jane' } }, req, 'jane-doe');
+    expect(projected.basic?.avatarUrl).toBeUndefined();
   });
 });
 

--- a/apps/lfx-one/src/server/services/public-profile.service.spec.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.spec.ts
@@ -184,6 +184,13 @@ describe('projectPublicProfile', () => {
     const projected = projectPublicProfile({ basic: { Name: 'Jane' } }, req, 'jane-doe');
     expect(projected.basic?.avatarUrl).toBeUndefined();
   });
+
+  it('omits basic.avatarUrl instead of throwing when CDN_URL_PREFIX is a bare hostname (misconfigured)', () => {
+    process.env['CDN_URL_PREFIX'] = 'avatars-public.dev.downloads.lfx.community';
+    expect(() => projectPublicProfile({ basic: { Name: 'Jane' } }, req, 'jane-doe')).not.toThrow();
+    const projected = projectPublicProfile({ basic: { Name: 'Jane' } }, req, 'jane-doe');
+    expect(projected.basic?.avatarUrl).toBeUndefined();
+  });
 });
 
 describe('PublicProfileService.getPublicProfile', () => {

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -23,6 +23,7 @@ import {
   PUBLIC_PROFILES_BUCKET_URL_ENV,
 } from '../constants';
 import { MicroserviceError } from '../errors';
+import { deriveAvatarUrl } from '../utils/avatar-url.util';
 import { logger } from './logger.service';
 
 /**
@@ -67,7 +68,7 @@ function asRecordArray(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.map(asRecord).filter((entry): entry is Record<string, unknown> => entry !== undefined) : [];
 }
 
-function projectBasic(value: unknown): PublicProfileBasic | undefined {
+function projectBasic(value: unknown, username?: string): PublicProfileBasic | undefined {
   const basic = asRecord(value);
   if (!basic) {
     return undefined;
@@ -77,10 +78,11 @@ function projectBasic(value: unknown): PublicProfileBasic | undefined {
   // to keep this endpoint's render-only PII boundary intact.
   const firstUsername = asRecordArray(basic['Identities'])
     .map((identity) => pickString(identity['Username']))
-    .find((username) => !!username && !!username.trim());
+    .find((identityUsername) => !!identityUsername && !!identityUsername.trim());
   return {
     Name: pickString(basic['Name']),
     LogoURL: pickString(basic['LogoURL']),
+    avatarUrl: (username && deriveAvatarUrl(username)) || undefined,
     TwitterID: pickString(basic['TwitterID']),
     LinkedInID: pickString(basic['LinkedInID']),
     GithubID: pickString(basic['GithubID']),
@@ -196,10 +198,10 @@ function projectBadges(value: unknown): PublicProfileBadge[] | undefined {
  * Projects the raw S3 artifact down to the render-only allowlist — fail closed, so any field not
  * listed here never reaches the client. This is the sole PII boundary for the anonymous endpoint.
  */
-export function projectPublicProfile(record: Record<string, unknown>, req?: Request): PublicProfile {
+export function projectPublicProfile(record: Record<string, unknown>, req?: Request, username?: string): PublicProfile {
   return {
     isPublic: resolvePublicFlag(record),
-    basic: projectBasic(record['basic']),
+    basic: projectBasic(record['basic'], username),
     About: pickString(record['About']),
     technical_contribution: projectTechnicalContribution(record['technical_contribution']),
     certification_activities: projectCertificationActivities(record['certification_activities']),
@@ -351,6 +353,6 @@ export class PublicProfileService {
     }
 
     const record = parsed as Record<string, unknown>;
-    return projectPublicProfile(record, req);
+    return projectPublicProfile(record, req, username);
   }
 }

--- a/apps/lfx-one/src/server/services/public-profile.service.ts
+++ b/apps/lfx-one/src/server/services/public-profile.service.ts
@@ -68,6 +68,18 @@ function asRecordArray(value: unknown): Record<string, unknown>[] {
   return Array.isArray(value) ? value.map(asRecord).filter((entry): entry is Record<string, unknown> => entry !== undefined) : [];
 }
 
+// deriveAvatarUrl throws when CDN_URL_PREFIX is set but misconfigured (not an absolute http(s) URL) —
+// that's the right behavior for the upload path (a real config error worth failing loudly), but this
+// endpoint has no LogoURL-fallback signal for it, so a bad env var must degrade to "no avatarUrl"
+// rather than 500 the whole public-profile response.
+function safeDeriveAvatarUrl(username: string): string | undefined {
+  try {
+    return deriveAvatarUrl(username) || undefined;
+  } catch {
+    return undefined;
+  }
+}
+
 function projectBasic(value: unknown, username?: string): PublicProfileBasic | undefined {
   const basic = asRecord(value);
   if (!basic) {
@@ -82,7 +94,7 @@ function projectBasic(value: unknown, username?: string): PublicProfileBasic | u
   return {
     Name: pickString(basic['Name']),
     LogoURL: pickString(basic['LogoURL']),
-    avatarUrl: (username && deriveAvatarUrl(username)) || undefined,
+    avatarUrl: (username && safeDeriveAvatarUrl(username)) || undefined,
     TwitterID: pickString(basic['TwitterID']),
     LinkedInID: pickString(basic['LinkedInID']),
     GithubID: pickString(basic['GithubID']),

--- a/apps/lfx-one/src/server/utils/avatar-url.util.ts
+++ b/apps/lfx-one/src/server/utils/avatar-url.util.ts
@@ -1,0 +1,71 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Escapes the two characters that break the raw-key / percent-encoded-URL round trip: a literal
+ * `/` would split the key into extra S3 path segments that don't survive as `%2F` (CDNs/S3
+ * gateways decode an encoded slash inconsistently — some refuse it, some collapse it), and a
+ * literal `%` would collide with our own escape sequence. Escaping `%` first means a username that
+ * already contains a literal `%2F`-shaped substring can't be mistaken for an escaped `/`, keeping
+ * the mapping collision-free. Every other character (letters, digits, `.`, `@`, `+`, unicode) is
+ * left as-is, staying human-readable and matching packages/shared/src/utils/avatar.utils.ts's
+ * buildMyprofileAvatarUrl convention of an unencoded key, encoded only at URL-construction time.
+ */
+export function toAvatarKeySegment(sanitizedUsername: string): string {
+  return sanitizedUsername.replace(/%/g, '%25').replace(/\//g, '%2F');
+}
+
+/**
+ * Returns the raw (unencoded) S3 object key an upload for this username was/would be stored under.
+ * Stable per user — a re-upload overwrites the same object — so a lookup by username always lands
+ * on the object that user's upload would have written.
+ */
+export function toAvatarObjectKey(username: string): string {
+  return `avatars/${toAvatarKeySegment(username.trim().toLowerCase())}`;
+}
+
+/**
+ * Returns the normalized CDN prefix (trailing slashes stripped), or null when CDN_URL_PREFIX is
+ * unset — that's degraded mode (callers fall back to no public_url / to a lower-priority avatar
+ * source), not a fatal error. When set, it must be an absolute http(s) URL: infra sometimes hands
+ * back a bare hostname (e.g. `avatars-public.dev.downloads.lfx.community`), and interpolating that
+ * verbatim would silently produce a relative URL that then gets persisted (e.g. into Auth0
+ * user_metadata) as if it were absolute.
+ */
+export function getAvatarCdnPrefix(): string | null {
+  const cdnPrefix = process.env['CDN_URL_PREFIX'];
+  if (!cdnPrefix) {
+    return null;
+  }
+  if (!/^https?:\/\//i.test(cdnPrefix)) {
+    throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
+  }
+  return cdnPrefix.replace(/\/+$/, '');
+}
+
+/**
+ * Builds the CDN-fronted public URL for an avatar object key. `avatars/` is a literal path
+ * separator and stays unencoded; only the key segment after it is percent-encoded — a single
+ * decode hop in transit reconstructs the segment exactly (including any literal `%2F`/`%25` text
+ * from toAvatarKeySegment), so the URL always resolves back to the stored key.
+ */
+export function buildAvatarUrl(cdnPrefix: string, keySegment: string): string {
+  return `${cdnPrefix}/avatars/${encodeURIComponent(keySegment)}`;
+}
+
+/**
+ * Derives the public avatar URL for a username without confirming the object exists — this is a
+ * guess based on the upload key convention, not a fresh-upload confirmation, so it carries no
+ * cache-busting `?v=` hint. Callers must treat a 404 on this URL as "no avatar uploaded" and fall
+ * back to another source; that's an acceptable tradeoff only because the object's Cache-Control is
+ * short-lived (see object-store.service.ts), so a stale hit self-heals within a day. Returns null
+ * when CDN_URL_PREFIX is unset, mirroring uploadProfilePicture's degraded-mode contract.
+ */
+export function deriveAvatarUrl(username: string): string | null {
+  const cdnPrefix = getAvatarCdnPrefix();
+  if (!cdnPrefix) {
+    return null;
+  }
+  const sanitizedUsername = username.trim().toLowerCase();
+  return buildAvatarUrl(cdnPrefix, toAvatarKeySegment(sanitizedUsername));
+}

--- a/packages/shared/src/interfaces/public-profile.interface.ts
+++ b/packages/shared/src/interfaces/public-profile.interface.ts
@@ -41,6 +41,14 @@ export interface PublicProfileSocialLink {
 export interface PublicProfileBasic {
   Name?: string;
   LogoURL?: string;
+  /**
+   * Proxy-derived avatar URL (camelCase — unlike the PascalCase fields above, not sourced from the
+   * upstream artifact). Guessed from the profile's username using the same key convention as the
+   * avatar-upload service; existence is not verified server-side. The client should prefer this
+   * over LogoURL and fall back to LogoURL on load error, since it reflects any avatar the user has
+   * uploaded through this app, which LogoURL (a separate, batch-generated artifact) does not.
+   */
+  avatarUrl?: string;
   TwitterID?: string;
   LinkedInID?: string;
   GithubID?: string;


### PR DESCRIPTION
## Summary

- Unify the logged-in user's avatar across the home sidebar, header, edit drawer, and own profile page behind one priority order: uploaded S3/CDN avatar > Auth0 `user_metadata.picture` > Auth0 OIDC `picture` claim. A shared `UserService.effectiveAvatarUrl` signal is the single source of truth, seeded by a one-time post-hydration profile fetch and updated immediately on upload so it propagates without a reload.
- For other users' public profile pages, avoid any backend/Auth0 Management API lookup: derive a plausible avatar URL directly from username using the same S3 key convention the upload path uses, falling back to the existing SFDC `LogoURL` artifact on `<img>` load error. Existence is not verified server-side — deliberate, approved constraint.

## Test plan

- [x] `yarn lint` — 0 errors
- [x] `yarn build` — succeeds
- [x] License headers — pass
- [x] Reviewed against repo conventions, KB patterns, and general code review (no Critical findings; one pre-existing Important — hero/topbar avatar-fallback duplication — tracked as a follow-up, not blocking)
- [ ] Manual: upload an avatar in the edit drawer, confirm it appears immediately in sidebar/header without reload
- [ ] Manual: view another user's public profile with no uploaded avatar, confirm SFDC `LogoURL` fallback renders on image load error

LFXV2-2628