### PR TITLE
fix(meetings): show empty select groups state when none assigned

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
@@ -8,6 +8,7 @@ import { MultiSelectComponent } from '@components/multi-select/multi-select.comp
 import { Committee, CommitteeMember, MeetingCommittee } from '@lfx-one/shared';
 import { CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
 import { COMMITTEE_LABEL, MEETING_VOTING_STATUSES } from '@lfx-one/shared/constants';
+import { sanitizeMeetingCommittees, sanitizeMeetingCommitteeUids } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { TooltipModule } from 'primeng/tooltip';
@@ -72,20 +73,21 @@ export class MeetingCommitteeManagerComponent {
     this.committeeForm
       .get('committees')
       ?.valueChanges.pipe(takeUntilDestroyed())
-      .subscribe((committeeIds: string[]) => {
-        this.selectedCommitteeIds.set(committeeIds || []);
-        this.updateParentForm(committeeIds);
+      .subscribe((committeeIds: string[] | null) => {
+        const ids = this.normalizeCommitteeUids(committeeIds);
+        this.selectedCommitteeIds.set(ids);
+        this.updateParentForm(ids);
 
         // Clear voting statuses if no voting committees selected
         const committees = this.committeeOptions();
-        const hasVotingCommittees = committees.some((c) => (committeeIds || []).includes(c.uid) && c.enable_voting);
+        const hasVotingCommittees = committees.some((c) => ids.includes(c.uid) && c.enable_voting);
         if (!hasVotingCommittees) {
           this.committeeForm.patchValue({ votingStatuses: [] }, { emitEvent: false });
           this.selectedVotingStatuses.set([]);
         }
 
         // If any selected committee has show_meeting_attendees enabled, toggle it on for the meeting
-        const hasShowMeetingAttendees = committees.some((c) => (committeeIds || []).includes(c.uid) && c.show_meeting_attendees === true);
+        const hasShowMeetingAttendees = committees.some((c) => ids.includes(c.uid) && c.show_meeting_attendees === true);
         if (hasShowMeetingAttendees) {
           this.form().get('show_meeting_attendees')?.setValue(true);
         }
@@ -118,12 +120,13 @@ export class MeetingCommitteeManagerComponent {
    * Initialize the component state from the selected committees input
    */
   private initializeFromSelectedCommittees(committees: MeetingCommittee[]): void {
-    const committeeIds = committees.map((c) => c.uid);
+    const validCommittees = sanitizeMeetingCommittees(committees);
+    const committeeIds = validCommittees.map((c) => c.uid);
     this.selectedCommitteeIds.set(committeeIds);
 
     // Get voting statuses
     const existingVotingStatuses: string[] = [];
-    committees.forEach((committee) => {
+    validCommittees.forEach((committee) => {
       if (committee.allowed_voting_statuses) {
         existingVotingStatuses.push(...committee.allowed_voting_statuses);
       }
@@ -166,13 +169,26 @@ export class MeetingCommitteeManagerComponent {
     );
   }
 
+  /**
+   * Coerce a MultiSelect model to valid UIDs. Writes `[]` back when PrimeNG
+   * emits `null` / `[null]` so the trigger shows the placeholder, not "null".
+   */
+  private normalizeCommitteeUids(committeeIds: (string | null | undefined)[] | null | undefined): string[] {
+    const ids = sanitizeMeetingCommitteeUids(committeeIds);
+    if (!Array.isArray(committeeIds) || committeeIds.length !== ids.length) {
+      this.committeeForm.get('committees')?.setValue(ids, { emitEvent: false });
+    }
+    return ids;
+  }
+
   private updateParentForm(committeeIds: string[]): void {
     const selectedVotingStatuses = this.selectedVotingStatuses();
     const committees = this.committeeOptions();
-    const hasVotingCommittees = committees.some((c) => committeeIds.includes(c.uid) && c.enable_voting);
+    const ids = sanitizeMeetingCommitteeUids(committeeIds);
+    const hasVotingCommittees = committees.some((c) => ids.includes(c.uid) && c.enable_voting);
     const allowedVotingStatuses = hasVotingCommittees ? selectedVotingStatuses : [];
 
-    const committeeData: MeetingCommittee[] = committeeIds.map((uid) => ({
+    const committeeData: MeetingCommittee[] = ids.map((uid) => ({
       uid,
       allowed_voting_statuses: allowedVotingStatuses,
     }));

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-modal/meeting-committee-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-modal/meeting-committee-modal.component.ts
@@ -11,6 +11,7 @@ import { TableComponent } from '@components/table/table.component';
 import { COMMITTEE_LABEL, MEETING_VOTING_STATUSES } from '@lfx-one/shared';
 import { CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
 import { Committee, CommitteeMember, Meeting } from '@lfx-one/shared/interfaces';
+import { sanitizeMeetingCommittees, sanitizeMeetingCommitteeUids } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -108,13 +109,14 @@ export class MeetingCommitteeModalComponent {
     });
 
     // Set initial selected committees
-    if (this.meeting.committees && this.meeting.committees.length > 0) {
-      const committeeIds = this.meeting.committees.map((c) => c.uid);
+    const validCommittees = sanitizeMeetingCommittees(this.meeting.committees);
+    if (validCommittees.length > 0) {
+      const committeeIds = validCommittees.map((c) => c.uid);
       this.selectedCommitteeIds.set(committeeIds);
 
       // Get initial voting statuses from meeting committees
       const existingVotingStatuses: string[] = [];
-      this.meeting.committees.forEach((committee) => {
+      validCommittees.forEach((committee) => {
         if (committee.allowed_voting_statuses) {
           existingVotingStatuses.push(...committee.allowed_voting_statuses);
         }
@@ -137,13 +139,17 @@ export class MeetingCommitteeModalComponent {
     this.form
       .get('committees')
       ?.valueChanges.pipe(takeUntilDestroyed())
-      .subscribe((committeeIds: string[]) => {
-        this.selectedCommitteeIds.set(committeeIds || []);
-        this.loadCommitteeMembers(committeeIds || []);
+      .subscribe((committeeIds: string[] | null) => {
+        const ids = sanitizeMeetingCommitteeUids(committeeIds);
+        if (!Array.isArray(committeeIds) || committeeIds.length !== ids.length) {
+          this.form.get('committees')?.setValue(ids, { emitEvent: false });
+        }
+        this.selectedCommitteeIds.set(ids);
+        this.loadCommitteeMembers(ids);
 
         // Clear voting statuses if no committees with voting are selected
         const committees = this.committees();
-        const hasVotingCommittees = committees.some((c) => (committeeIds || []).includes(c.uid) && c.enable_voting);
+        const hasVotingCommittees = committees.some((c) => ids.includes(c.uid) && c.enable_voting);
         if (!hasVotingCommittees) {
           this.form.patchValue({ votingStatuses: [] }, { emitEvent: false });
           this.selectedVotingStatuses.set([]);
@@ -164,12 +170,13 @@ export class MeetingCommitteeModalComponent {
   }
 
   public onSave(): void {
-    const selectedIds = this.form.value.committees as string[];
+    const selectedIds = sanitizeMeetingCommitteeUids(this.form.value.committees);
     const selectedVotingStatuses = (this.form.value.votingStatuses as string[]) || [];
 
     // If no changes, just close
-    const currentIds = this.meeting.committees?.map((c) => c.uid) || [];
-    const currentVotingStatuses = this.meeting.committees?.flatMap((c) => c.allowed_voting_statuses || []) || [];
+    const currentCommittees = sanitizeMeetingCommittees(this.meeting.committees);
+    const currentIds = currentCommittees.map((c) => c.uid);
+    const currentVotingStatuses = currentCommittees.flatMap((c) => c.allowed_voting_statuses || []);
     if (
       JSON.stringify(selectedIds.sort()) === JSON.stringify(currentIds.sort()) &&
       JSON.stringify(selectedVotingStatuses.sort()) === JSON.stringify(currentVotingStatuses.sort())

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -48,6 +48,7 @@ import {
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
+  sanitizeMeetingCommittees,
 } from '@lfx-one/shared/utils';
 import { editModeDateTimeValidator, futureDateTimeValidator } from '@lfx-one/shared/validators';
 import { MeetingService } from '@services/meeting.service';
@@ -571,7 +572,7 @@ export class MeetingManageComponent {
         : undefined,
       recurrence: recurrenceObject,
       platform: formValue.platform || DEFAULT_MEETING_TOOL,
-      committees: formValue.committees || [],
+      committees: sanitizeMeetingCommittees(formValue.committees),
     };
   }
 
@@ -848,7 +849,7 @@ export class MeetingManageComponent {
       reminderHours: reminderHours,
       reminderMinutes: reminderTotalMinutes % 60,
       recurrenceType: finalRecurrenceValue,
-      committees: meeting.committees || [],
+      committees: sanitizeMeetingCommittees(meeting.committees),
     });
 
     // Populate the recurrence FormGroup if there's recurrence data

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -1109,7 +1109,7 @@ describe('sanitizeMeetingCommittees', () => {
 
   it('drops null entries, blank uids, and keeps valid committees', () => {
     const valid: MeetingCommittee = { uid: 'group-1', name: 'TSC' };
-    const result = sanitizeMeetingCommittees([null, { uid: null as unknown as string }, { uid: '' }, valid, undefined]);
+    const result = sanitizeMeetingCommittees([null, { uid: null as unknown as string }, { uid: '' }, { uid: '   ' }, valid, undefined]);
 
     expect(result).toEqual([valid]);
   });
@@ -1123,6 +1123,6 @@ describe('sanitizeMeetingCommitteeUids', () => {
   });
 
   it('drops null, undefined, and blank uids', () => {
-    expect(sanitizeMeetingCommitteeUids([null, undefined, '', 'group-1', 'group-2'])).toEqual(['group-1', 'group-2']);
+    expect(sanitizeMeetingCommitteeUids([null, undefined, '', '   ', 'group-1', 'group-2'])).toEqual(['group-1', 'group-2']);
   });
 });

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -22,6 +22,7 @@ import {
 import {
   CustomRecurrencePattern,
   Meeting,
+  MeetingCommittee,
   MeetingOccurrence,
   MeetingRecurrence,
   PastMeeting,
@@ -57,6 +58,8 @@ import {
   resolveRsvpOccurrenceId,
   resolveSurveyCalendarColors,
   resolveVoteCalendarColors,
+  sanitizeMeetingCommittees,
+  sanitizeMeetingCommitteeUids,
   selectCommitteeCadenceMeeting,
   selectPrimaryPastMeetingSummary,
   sortPastMeetingsDescending,
@@ -1094,5 +1097,32 @@ describe('buildOccurrenceNavTimeline', () => {
 
     expect(result[0].duration).toBe(30);
     expect(result[1].duration).toBe(45);
+  });
+});
+
+describe('sanitizeMeetingCommittees', () => {
+  it('returns [] for null, undefined, and empty input', () => {
+    expect(sanitizeMeetingCommittees(null)).toEqual([]);
+    expect(sanitizeMeetingCommittees(undefined)).toEqual([]);
+    expect(sanitizeMeetingCommittees([])).toEqual([]);
+  });
+
+  it('drops null entries, blank uids, and keeps valid committees', () => {
+    const valid: MeetingCommittee = { uid: 'group-1', name: 'TSC' };
+    const result = sanitizeMeetingCommittees([null, { uid: null as unknown as string }, { uid: '' }, valid, undefined]);
+
+    expect(result).toEqual([valid]);
+  });
+});
+
+describe('sanitizeMeetingCommitteeUids', () => {
+  it('returns [] for null, undefined, and empty input', () => {
+    expect(sanitizeMeetingCommitteeUids(null)).toEqual([]);
+    expect(sanitizeMeetingCommitteeUids(undefined)).toEqual([]);
+    expect(sanitizeMeetingCommitteeUids([])).toEqual([]);
+  });
+
+  it('drops null, undefined, and blank uids', () => {
+    expect(sanitizeMeetingCommitteeUids([null, undefined, '', 'group-1', 'group-2'])).toEqual(['group-1', 'group-2']);
   });
 });

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -1265,7 +1265,7 @@ export function sanitizeMeetingCommittees(committees: ReadonlyArray<MeetingCommi
     return [];
   }
 
-  return committees.filter((committee): committee is MeetingCommittee => Boolean(committee?.uid));
+  return committees.filter((committee): committee is MeetingCommittee => Boolean(committee?.uid?.trim()));
 }
 
 /**
@@ -1277,5 +1277,5 @@ export function sanitizeMeetingCommitteeUids(uids: ReadonlyArray<string | null |
     return [];
   }
 
-  return uids.filter((uid): uid is string => typeof uid === 'string' && uid.length > 0);
+  return uids.filter((uid): uid is string => typeof uid === 'string' && uid.trim().length > 0);
 }

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -23,6 +23,7 @@ import {
   CalendarColor,
   CustomRecurrencePattern,
   Meeting,
+  MeetingCommittee,
   MeetingHostCandidate,
   MeetingOccurrence,
   MeetingOccurrenceRoute,
@@ -1249,4 +1250,32 @@ export function compareMeetingPeopleByHostThenName<T extends { host?: boolean; f
     return rankDelta;
   }
   return a.first_name?.localeCompare(b.first_name ?? '') ?? 0;
+}
+
+/**
+ * Drops null/blank committee entries from a meeting payload.
+ *
+ * PrimeNG MultiSelect builds its trigger label with `label += getLabelByValue(...)`.
+ * Unmatched values return JS `null`, and `'' + null === 'null'`, so a committees
+ * array of `[null]` / `{ uid: null }` renders the literal label "null" instead of
+ * the empty placeholder (GH-1430).
+ */
+export function sanitizeMeetingCommittees(committees: ReadonlyArray<MeetingCommittee | null | undefined> | null | undefined): MeetingCommittee[] {
+  if (!Array.isArray(committees) || committees.length === 0) {
+    return [];
+  }
+
+  return committees.filter((committee): committee is MeetingCommittee => Boolean(committee?.uid));
+}
+
+/**
+ * Drops null/blank committee UIDs from a MultiSelect form value so the control
+ * stays `[]` rather than `[null]` / `[undefined]`.
+ */
+export function sanitizeMeetingCommitteeUids(uids: ReadonlyArray<string | null | undefined> | null | undefined): string[] {
+  if (!Array.isArray(uids) || uids.length === 0) {
+    return [];
+  }
+
+  return uids.filter((uid): uid is string => typeof uid === 'string' && uid.length > 0);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Sanitize null and blank meeting committee entries before they are bound to PrimeNG MultiSelect. An unmatched/`null` selected value is concatenated into the trigger label (`'' + null === 'null'`), so edit-meeting step 5 showed the literal text "null" instead of the empty placeholder.

## Changes
- Add `sanitizeMeetingCommittees` / `sanitizeMeetingCommitteeUids` in `@lfx-one/shared`
- Use them when populating and saving the meeting form, and in the Select Groups manager and committee modal
- Write `[]` back to the MultiSelect control when PrimeNG emits `null` / `[null]`

Closes #1430

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-3464dbba-239f-428d-9df3-09c58c8434f7?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3464dbba-239f-428d-9df3-09c58c8434f7&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved meeting committee selection handling by removing blank, invalid, or missing committee values.
  - Ensured committee data remains consistent when creating, editing, loading, and saving meetings.
  - Prevented invalid committee entries from affecting voting eligibility, member loading, or saved meeting updates.

- **Tests**
  - Added coverage for valid, empty, null, undefined, and malformed committee selections.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->