### PR TITLE
fix(org-lens): harden the all-time axis read path in the project detail BFF

### DIFF
--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -375,11 +375,14 @@ test.describe('Org Project Detail — all-time range', () => {
     expect(Array.isArray(influenceBody.periods)).toBe(true);
     expect(influenceBody.periods!.length).toBeGreaterThan(0);
     expect(influenceBody.periods!.length).toBeLessThanOrEqual(12);
-    // Every label must be one of the four documented bucket formats — `MMM YYYY`, `Q# YYYY`, `YYYY`,
-    // `YYYY–YYYY`. A length-only assertion passes on empty or malformed labels, which is exactly what
-    // an unparseable bucket start produces, so it would hide a regression in the label derivation.
+    // Every label must be one of the formats the server can emit — `MMM YYYY`, `Q# YYYY`, `YYYY`,
+    // `YYYY–YYYY`, plus `YYYY–?` for a multi-year bucket whose end date is missing. A length-only
+    // assertion passes on empty or malformed labels, which is exactly what an unparseable bucket start
+    // produces, so it would hide a regression in the label derivation. The unknown-end form is allowed
+    // rather than rejected: it is deliberate server output, so failing on it would turn this spec into
+    // a warehouse data-quality gate.
     for (const period of influenceBody.periods!) {
-      expect(period).toMatch(/^(?:[A-Z][a-z]{2} \d{4}|Q[1-4] \d{4}|\d{4}(?:\u2013\d{4})?)$/);
+      expect(period).toMatch(/^(?:[A-Z][a-z]{2} \d{4}|Q[1-4] \d{4}|\d{4}(?:\u2013(?:\d{4}|\?))?)$/);
     }
     const sparkline = influenceBody.technical?.[0]?.sparkline;
     expect(Array.isArray(sparkline)).toBe(true);

--- a/apps/lfx-one/e2e/org-project-detail.spec.ts
+++ b/apps/lfx-one/e2e/org-project-detail.spec.ts
@@ -375,6 +375,12 @@ test.describe('Org Project Detail — all-time range', () => {
     expect(Array.isArray(influenceBody.periods)).toBe(true);
     expect(influenceBody.periods!.length).toBeGreaterThan(0);
     expect(influenceBody.periods!.length).toBeLessThanOrEqual(12);
+    // Every label must be one of the four documented bucket formats — `MMM YYYY`, `Q# YYYY`, `YYYY`,
+    // `YYYY–YYYY`. A length-only assertion passes on empty or malformed labels, which is exactly what
+    // an unparseable bucket start produces, so it would hide a regression in the label derivation.
+    for (const period of influenceBody.periods!) {
+      expect(period).toMatch(/^(?:[A-Z][a-z]{2} \d{4}|Q[1-4] \d{4}|\d{4}(?:\u2013\d{4})?)$/);
+    }
     const sparkline = influenceBody.technical?.[0]?.sparkline;
     expect(Array.isArray(sparkline)).toBe(true);
     expect(sparkline!.length).toBe(influenceBody.periods!.length);

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -473,9 +473,10 @@ export class OrgLensProjectDetailService {
         ecosystem: isNonLf || !viewing ? null : (this.mapBand(viewing.LEVEL_ECOSYSTEM) ?? 'silent'),
       },
       // Only the all-time axis is variable/bucketed; 1y/2y stay client-derived (periods omitted).
-      // Tested against undefined rather than truthiness on purpose: an all-time project with an empty
-      // bucket spine yields `[]`, which must still be emitted, or the cache validator would reject the
-      // very block that was just written and re-query Snowflake on every request.
+      // The requirement this states: an all-time project with an empty bucket spine yields `[]`, and
+      // that MUST still be emitted, or `hasAdaptivePeriods` would reject the block just written. An
+      // empty array is truthy, so a truthiness test behaves identically here; the explicit undefined
+      // check just makes the intent legible without relying on the reader recalling that.
       ...(sparkData.periods === undefined ? {} : { periods: sparkData.periods }),
     };
     if (key !== null) {
@@ -921,7 +922,8 @@ export class OrgLensProjectDetailService {
 
   /**
    * Adaptive-bucket axis label for the wire `periods[]` (D9): monthly `MMM YYYY`, quarterly `Q# YYYY`,
-   * yearly `YYYY`, multi-year `YYYY–YYYY`. Derived from the bucket's start (and end for multi-year).
+   * yearly `YYYY`, multi-year `YYYY–YYYY`, and `YYYY–?` for a multi-year bucket whose end date is
+   * missing or unparseable. Derived from the bucket's start (and end for multi-year).
    */
   private bucketLabel(granularity: string | null, start: Date | string | null, end: Date | string | null): string {
     const startDate = this.parseUtcDate(start);

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -472,11 +472,8 @@ export class OrgLensProjectDetailService {
         technical: viewing ? (this.mapBand(viewing.LEVEL_TECHNICAL) ?? 'silent') : null,
         ecosystem: isNonLf || !viewing ? null : (this.mapBand(viewing.LEVEL_ECOSYSTEM) ?? 'silent'),
       },
-      // Only the all-time axis is variable/bucketed; 1y/2y stay client-derived (periods omitted).
-      // The requirement this states: an all-time project with an empty bucket spine yields `[]`, and
-      // that MUST still be emitted, or `hasAdaptivePeriods` would reject the block just written. An
-      // empty array is truthy, so a truthiness test behaves identically here; the explicit undefined
-      // check just makes the intent legible without relying on the reader recalling that.
+      // Only the all-time axis is variable/bucketed; 1y/2y omit `periods` and derive labels client-side.
+      // An empty axis must still be emitted as `[]`, or `hasAdaptivePeriods` rejects the block just written.
       ...(sparkData.periods === undefined ? {} : { periods: sparkData.periods }),
     };
     if (key !== null) {
@@ -1853,6 +1850,12 @@ export class OrgLensProjectDetailService {
    * An EMPTY array is accepted on purpose: a project with no rows in the bucket spine legitimately
    * caches `periods: []`, and requiring a non-empty axis would reject that entry on every read and
    * re-query Snowflake for the life of the TTL.
+   *
+   * Deliberately not gated any tighter. An entry written before the series builder placed values by
+   * bucket index still passes, so a misaligned series could be served until the 1h TTL rotates. A
+   * cache-key bump would close that window at deploy time, but it would force a cold read for every
+   * project, and the largest ones exceed the query timeout on a cold read (LFXV2-3231) — a certain
+   * outage traded against a misalignment that requires a sparse row set no project currently has.
    */
   private static hasAdaptivePeriods(value: unknown): boolean {
     const periods = (value as { periods?: unknown }).periods;

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -473,7 +473,10 @@ export class OrgLensProjectDetailService {
         ecosystem: isNonLf || !viewing ? null : (this.mapBand(viewing.LEVEL_ECOSYSTEM) ?? 'silent'),
       },
       // Only the all-time axis is variable/bucketed; 1y/2y stay client-derived (periods omitted).
-      ...(sparkData.periods ? { periods: sparkData.periods } : {}),
+      // Tested against undefined rather than truthiness on purpose: an all-time project with an empty
+      // bucket spine yields `[]`, which must still be emitted, or the cache validator would reject the
+      // very block that was just written and re-query Snowflake on every request.
+      ...(sparkData.periods === undefined ? {} : { periods: sparkData.periods }),
     };
     if (key !== null) {
       await valkeyService.setJson(key, block, VALKEY_CACHE.ORG_LENS_SNOWFLAKE_TTL_SECONDS);

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -502,7 +502,15 @@ export class OrgLensProjectDetailService {
     if (range === 'all') {
       const [heroRow, trendRows, axis] = await Promise.all([this.fetchHeroRow(orgUid, slug), this.fetchTrendLifetime(slug), this.fetchLifetimeAxis(slug)]);
       if (!heroRow) return null;
-      block = { trend: this.buildTrendSeries(this.buildTrendLifetimeByAccount(trendRows)), periods: axis.map((bucket) => bucket.label) };
+      block = {
+        trend: this.buildTrendSeries(
+          this.buildTrendLifetimeByAccount(
+            trendRows,
+            axis.map((bucket) => bucket.index)
+          )
+        ),
+        periods: axis.map((bucket) => bucket.label),
+      };
     } else {
       const [heroRow, trendRows] = await Promise.all([this.fetchHeroRow(orgUid, slug), this.fetchTrend(slug)]);
       if (!heroRow) return null;
@@ -925,7 +933,10 @@ export class OrgLensProjectDetailService {
         return `${year}`;
       case 'multi_year': {
         const endDate = this.parseUtcDate(end);
-        const endYear = endDate === null ? year : endDate.getUTCFullYear();
+        // A missing end date must not collapse to a bare `YYYY`: that is indistinguishable from a
+        // yearly bucket and understates the span. Mark the end as unknown so the gap is visible.
+        if (endDate === null) return `${year}\u2013?`;
+        const endYear = endDate.getUTCFullYear();
         return endYear > year ? `${year}\u2013${endYear}` : `${year}`;
       }
       default:
@@ -1320,21 +1331,34 @@ export class OrgLensProjectDetailService {
   }
 
   /**
-   * Group the lifetime-bucketed trend rows into per-org series (combined oldest → newest by bucket).
-   * The read model is dense per (account, bucket) over the project's shared axis and already ordered
-   * by bucket index, so each series lands aligned 1:1 with the emitted `periods[]`.
+   * Group the lifetime-bucketed trend rows into per-org series over the project's shared bucket axis.
+   * Values are placed BY bucket index and the axis is zero-filled, rather than pushed in row order,
+   * so every series is exactly `axis.length` long and stays positionally aligned with the emitted
+   * `periods[]` labels even if the read model ever returns a sparse row set (a backfill gap would
+   * otherwise shift a series against the axis and silently mislabel every one of its points). This
+   * mirrors how the card sparklines densify over their axis in `denseSeries`.
    */
-  private buildTrendLifetimeByAccount(rows: TrendLifetimeRow[]): Map<string, TrendSeries> {
-    const byAccount = new Map<string, TrendSeries>();
+  private buildTrendLifetimeByAccount(rows: TrendLifetimeRow[], axis: number[]): Map<string, TrendSeries> {
+    const scoresByAccount = new Map<string, { orgName: string; orgLogoUrl: string; byBucket: Map<number, number> }>();
     for (const row of rows) {
       const accountId = row.ACCOUNT_ID;
-      if (!accountId) continue;
-      let series = byAccount.get(accountId);
-      if (!series) {
-        series = { accountId, orgName: row.ORG_NAME ?? '', orgLogoUrl: row.ORG_LOGO_URL ?? '', combined: [] };
-        byAccount.set(accountId, series);
+      if (!accountId || row.BUCKET_INDEX === null || row.BUCKET_INDEX === undefined) continue;
+      let entry = scoresByAccount.get(accountId);
+      if (!entry) {
+        entry = { orgName: row.ORG_NAME ?? '', orgLogoUrl: row.ORG_LOGO_URL ?? '', byBucket: new Map() };
+        scoresByAccount.set(accountId, entry);
       }
-      series.combined.push(this.round1(this.num(row.COMBINED_INFLUENCE_SCORE)));
+      entry.byBucket.set(this.num(row.BUCKET_INDEX), this.round1(this.num(row.COMBINED_INFLUENCE_SCORE)));
+    }
+
+    const byAccount = new Map<string, TrendSeries>();
+    for (const [accountId, entry] of scoresByAccount) {
+      byAccount.set(accountId, {
+        accountId,
+        orgName: entry.orgName,
+        orgLogoUrl: entry.orgLogoUrl,
+        combined: axis.map((bucketIndex) => entry.byBucket.get(bucketIndex) ?? 0),
+      });
     }
     return byAccount;
   }
@@ -1818,9 +1842,16 @@ export class OrgLensProjectDetailService {
     return Array.isArray((value as OrgLensTrendBlock).trend);
   }
 
+  /**
+   * Whether a cached `all` block carries the adaptive-bucket axis, i.e. was written by this version.
+   * Pre-deploy entries have no `periods` at all, so the presence of the array is what rejects them.
+   * An EMPTY array is accepted on purpose: a project with no rows in the bucket spine legitimately
+   * caches `periods: []`, and requiring a non-empty axis would reject that entry on every read and
+   * re-query Snowflake for the life of the TTL.
+   */
   private static hasAdaptivePeriods(value: unknown): boolean {
     const periods = (value as { periods?: unknown }).periods;
-    return Array.isArray(periods) && periods.length > 0 && periods.every((label) => typeof label === 'string');
+    return Array.isArray(periods) && periods.every((label) => typeof label === 'string');
   }
 
   private static isLeaderboardPage(value: unknown): value is OrgLensLeaderboardPage {

--- a/packages/shared/src/constants/org-lens-project-detail.constants.ts
+++ b/packages/shared/src/constants/org-lens-project-detail.constants.ts
@@ -104,14 +104,20 @@ export const PD_TIME_RANGE_OPTIONS: { id: OrgLensLeaderboardTimeRange; label: st
 ];
 
 /**
+ * Stand-in "window length" for the all-time range: not a real month count, so never do arithmetic
+ * on it (`PD_ALL_TIME_WINDOW - 12` is meaningless). It exists only so a residual `slice(-months)`
+ * over an all-time series is a no-op and returns the payload whole.
+ */
+export const PD_ALL_TIME_WINDOW = Number.MAX_SAFE_INTEGER;
+
+/**
  * Trailing monthly window per range for the recent-monthly representation. `1y`/`2y` slice the
  * trailing 12 / 24 monthly points client-side. `all` is NO LONGER a fixed length (was 36): under
  * "All time" the payload carries a variable, adaptively-bucketed series (hard cap ≤ 12 points) with
  * its own `periods[]` axis labels (see `OrgLensTrendBlock.periods`), so the client renders the
- * payload as-is instead of slicing to a fixed count. The `all` entry is a defensive upper-bound
- * sentinel only — any residual `slice(-months)` on an already-≤12 all-time array is a no-op.
+ * payload as-is instead of slicing to a fixed count.
  */
-export const PD_TIME_RANGE_MONTHS: Record<OrgLensLeaderboardTimeRange, number> = { '1y': 12, '2y': 24, all: Number.MAX_SAFE_INTEGER };
+export const PD_TIME_RANGE_MONTHS: Record<OrgLensLeaderboardTimeRange, number> = { '1y': 12, '2y': 24, all: PD_ALL_TIME_WINDOW };
 
 /** 11-slot palette for the stacked trend chart — top-10 companies + "All others". */
 export const PD_STACKED_PALETTE: string[] = [

--- a/packages/shared/src/constants/org-lens-project-detail.constants.ts
+++ b/packages/shared/src/constants/org-lens-project-detail.constants.ts
@@ -108,7 +108,7 @@ export const PD_TIME_RANGE_OPTIONS: { id: OrgLensLeaderboardTimeRange; label: st
  * on it (`PD_ALL_TIME_WINDOW - 12` is meaningless). It exists only so a residual `slice(-months)`
  * over an all-time series is a no-op and returns the payload whole.
  */
-export const PD_ALL_TIME_WINDOW = Number.MAX_SAFE_INTEGER;
+const PD_ALL_TIME_WINDOW = Number.MAX_SAFE_INTEGER;
 
 /**
  * Trailing monthly window per range for the recent-monthly representation. `1y`/`2y` slice the


### PR DESCRIPTION
Follow-up to [#1305](https://github.com/linuxfoundation/lfx-self-serve/pull/1305), which merged before @audigregorie's review feedback was addressed. This lands the findings that have a real effect on the running system and leaves the rest as-is.

## What's here

**Lifetime trend series are now aligned to the bucket axis by index.** They were built by pushing scores in row order, which trusts the read model to be dense per (account, bucket), while the downstream `buildTrendSeries` never pads named orgs to the axis length. One missing row would have shifted a series against `periods[]` and silently mislabelled every point on it. Values are now placed **by bucket index** into a zero-filled array of the axis length — the same way card sparklines densify in `denseSeries` — so each series is `periods.length` long by construction rather than by convention.

**That also changes the top-10 ranking key, which is worth naming.** `buildTrendSeries` ranks orgs by the last element of `combined`, i.e. the most recent bucket. Under the old push-order build, an org with no row in the final bucket was ranked by its last *available* bucket — so orgs were being compared at different points in time. Zero-filling to the axis means such an org now ranks at `0`, which is what "current influence" should mean.

This is latent rather than active. All **3,555,035** (project, organization) series in `ORG_LENS_PROJECT_DETAIL_TREND_LIFETIME` are dense today — none is sparse, and none is missing its final bucket — so no chart's top-10 selection changes with this PR. The new key only takes effect in the sparse case this fix exists to survive, and there it is the coherent ordering. The 1y/2y path (`buildTrendByAccount`) is untouched and still builds in row order.

**The all-time cache validator no longer rejects its own entries.** `hasAdaptivePeriods` required a non-empty `periods` array. A project with no rows in the bucket spine legitimately caches `periods: []`, so the validator rejected that entry on every read and re-queried Snowflake for the life of the TTL. Presence of the array is what rejects stale pre-deploy entries, so dropping the emptiness check loses nothing.

**A `multi_year` bucket with a missing end date no longer renders as a bare `YYYY`**, which was indistinguishable from a yearly bucket and understated the span.

**Supporting changes:** the all-time window sentinel is named (`PD_ALL_TIME_WINDOW`) with a note that it is not a real month count and must not be used in arithmetic — kept module-local, since `PD_TIME_RANGE_MONTHS` in the same file is its only reader — and the E2E spec now asserts each bucket label matches one of the four documented formats rather than only checking array shape and length.

## What's deliberately not here

**The client-side leading-bucket trims from #1305 are kept.** The review flagged that the trend chart and the influence cards trim on different criteria, which is accurate — but the two render on different tabs, values are correct in both, and within each block labels and data are sliced by the same index, so nothing is mislabelled. The empty leading buckets those trims hide come from the unbounded bucket-spine anchor, which is tracked and documented in [LFXV2-3231](https://linuxfoundation.atlassian.net/browse/LFXV2-3231); reverting the trims to keep that symptom visible in the UI is not needed now that it's captured there.

**The cache key is not bumped.** A pre-deploy all-time entry with a non-empty axis still passes the validator, so a series written by the old row-order builder can be served until the 1h TTL rotates. Bumping the key would close that window at deploy time, but it would force a cold Snowflake read for every project — and the largest ones currently exceed the 15s query timeout on a cold read, a separate defect now documented on [LFXV2-3231](https://linuxfoundation.atlassian.net/browse/LFXV2-3231). That would trade a certain failure for a misalignment which, per the density measurement above, no project's row set can currently produce. The reasoning is recorded on the validator so the next reader does not have to re-derive it.

## Verification

`yarn format:check`, `yarn lint:check` (1 pre-existing warning, unrelated), `yarn check-types`, `yarn test` (796 + 1093 + 254 passing), `yarn build` — all green.

[LFXV2-3231]: https://linuxfoundation.atlassian.net/browse/LFXV2-3231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
