### PR TITLE
fix(profile): finish avatar single-source-of-truth switch

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -100,10 +100,11 @@ export class ProfileLayoutComponent {
   // Computed signals
   public readonly displayUsername = computed(() => stripAuthPrefixOrNull(this.profileData()?.username));
 
-  // Avatar image URL: prefer the uploaded avatar (auth0 user_metadata.picture) and fall back to
-  // the always-present Auth0 OIDC picture claim, so this rail never shows a placeholder for a user
-  // who simply hasn't uploaded a custom avatar (LFXV2-2628).
-  public readonly avatarUrl = computed(() => this.profileData()?.avatarUrl || this.userService.user()?.picture || '');
+  // Avatar image URL: read the shared signal (uploaded avatar > Auth0 OIDC picture claim) instead
+  // of this component's own profileData fetch — that GET is eventually consistent (see comment
+  // above on fetchedProfileData), so after an upload elsewhere this rail must not fall back to its
+  // own possibly-stale copy (LFXV2-2628).
+  public readonly avatarUrl = this.userService.effectiveAvatarUrl;
 
   public readonly displayName = computed(() => {
     const data = this.profileData();

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -419,6 +419,16 @@ export class ProfileLayoutComponent {
   private mapToHeaderData(profile: CombinedProfile): ProfileHeaderData {
     this.loading.set(false);
     this.combinedProfile = profile;
+
+    // Seed the shared avatar signal from this response, with the same no-clobber guard as
+    // UserService's own post-hydration fetch. This response is the profile GET itself, so unlike
+    // that guard (which runs inside afterNextRender and never fires during SSR) this one also runs
+    // server-side — the profile page's first render already carries the uploaded avatar instead of
+    // waiting on a second, client-only fetch to correct it (LFXV2-2628).
+    if (profile.profile?.picture && this.userService.uploadedAvatarUrl() === null) {
+      this.userService.uploadedAvatarUrl.set(profile.profile.picture);
+    }
+
     return {
       firstName: profile.user.first_name || '',
       lastName: profile.user.last_name || '',

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -434,7 +434,6 @@ export class ProfileLayoutComponent {
       phoneNumber: profile.profile?.phone_number || '',
       tshirtSize: normalizeTShirtSize(profile.profile?.t_shirt_size),
       aboutMe: profile.profile?.bio || '',
-      avatarUrl: profile.profile?.picture || '',
     };
   }
 }

--- a/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/components/profile-edit-drawer/profile-edit-drawer.component.ts
@@ -110,10 +110,11 @@ export class ProfileEditDrawerComponent {
   // The avatar URL that failed to load, if any — mirrors ProfilePanelComponent's fallback pattern
   // so a broken/expired picture URL falls back to initials instead of a broken image icon.
   private readonly avatarErrorUrl = signal<string | null>(null);
-  // Uploaded avatar, falling back to the always-present Auth0 OIDC picture claim (same priority
-  // chain as ProfileLayoutComponent.avatarUrl) — otherwise the drawer preview shows initials for a
-  // user who simply hasn't uploaded a custom avatar (LFXV2-2628).
-  public readonly avatarUrl = computed(() => this.combinedProfile()?.profile?.picture || this.userService.user()?.picture || '');
+  // Avatar image URL: read the shared signal (uploaded avatar > Auth0 OIDC picture claim) instead
+  // of this drawer's own combinedProfile fetch — that GET is eventually consistent, so reopening
+  // the drawer after an upload elsewhere must not fall back to its own possibly-stale copy
+  // (LFXV2-2628, same fix as ProfileLayoutComponent.avatarUrl).
+  public readonly avatarUrl = this.userService.effectiveAvatarUrl;
   public readonly avatarInitials = computed(() => {
     const profile = this.combinedProfile();
     if (!profile) return 'U';

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -200,7 +200,7 @@
         aria-label="User menu"
         data-testid="lens-user-avatar"
         class="flex items-center justify-center w-8 h-8 rounded-full overflow-hidden transition-all hover:ring-2 hover:ring-white/30 focus:outline-none shrink-0">
-        <lfx-avatar [image]="user()?.picture ?? ''" [label]="user()?.name ?? ''" shape="circle" size="normal" styleClass="w-full h-full"></lfx-avatar>
+        <lfx-avatar [image]="avatarUrl()" [label]="user()?.name ?? ''" shape="circle" size="normal" styleClass="w-full h-full"></lfx-avatar>
       </button>
     </div>
   </div>
@@ -286,7 +286,7 @@
     <ng-template #content>
       <!-- User identity -->
       <div class="flex items-center gap-2.5 px-4 py-3 border-b border-gray-100">
-        <lfx-avatar [image]="user()?.picture ?? ''" [label]="user()?.name ?? ''" shape="circle" size="normal" styleClass="shrink-0"></lfx-avatar>
+        <lfx-avatar [image]="avatarUrl()" [label]="user()?.name ?? ''" shape="circle" size="normal" styleClass="shrink-0"></lfx-avatar>
         <div class="flex flex-col min-w-0">
           <span class="font-semibold text-sm text-gray-900 truncate">{{ user()?.name }}</span>
           <span class="text-xs text-gray-500 truncate">{{ user()?.email }}</span>

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.ts
@@ -54,6 +54,7 @@ export class LensSwitcherComponent {
   // Hybrid personas merge the 'project' button with the 'foundation' lens state — both map to 'project' for highlighting.
   protected readonly activeLensId = this.lensService.displayActiveLens;
   protected readonly user = this.userService.user;
+  protected readonly avatarUrl = this.userService.effectiveAvatarUrl;
   protected readonly insightsUrl = buildInsightsUrl();
   protected readonly crowdfundingUrl = environment.urls.crowdfunding;
   protected readonly mentorshipUrl = environment.urls.mentorship;

--- a/apps/lfx-one/src/app/shared/services/akrites.service.ts
+++ b/apps/lfx-one/src/app/shared/services/akrites.service.ts
@@ -154,7 +154,9 @@ export class AkritesService {
       userId: user?.sub ?? '',
       username: user?.nickname || user?.username || user?.['https://sso.linuxfoundation.org/claims/username'] || null,
       displayName: user?.name || null,
-      avatarUrl: user?.picture || null,
+      // effectiveAvatarUrl, not the raw picture claim — otherwise an activity entry logged right
+      // after an avatar upload would show the stale Auth0 picture instead of the new one (LFXV2-2628).
+      avatarUrl: this.userService.effectiveAvatarUrl() || null,
     };
   }
 }

--- a/apps/lfx-one/src/app/shared/services/user.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.spec.ts
@@ -1,10 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { ApplicationRef } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { HttpClient } from '@angular/common/http';
 import { User } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { UserService } from './user.service';
@@ -12,15 +14,21 @@ import { UserService } from './user.service';
 /**
  * Covers the `effectiveAvatarUrl` priority chain (LFXV2-2628): an uploaded avatar must win over
  * the Auth0 `picture` claim even while the claim is stale, since that's exactly the race a
- * successful upload racing a slower post-hydration profile fetch depends on.
+ * successful upload racing a slower post-hydration profile fetch depends on. Also covers the two
+ * lines that actually enforce that race guard — the post-hydration clobber guard and the
+ * on-user-change reset — not just the pure computed that reads their result.
  */
 describe('UserService', () => {
   let service: UserService;
+  let httpGet: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
+    // Benign default so tests that don't care about the post-hydration fetch (most of them) don't
+    // crash when afterNextRender's callback happens to fire during an ApplicationRef flush.
+    httpGet = vi.fn().mockReturnValue(of({ profile: {} }));
     TestBed.configureTestingModule({
       providers: [
-        { provide: HttpClient, useValue: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
+        { provide: HttpClient, useValue: { get: httpGet, post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
         { provide: MessageService, useValue: { add: vi.fn() } },
       ],
     });
@@ -40,5 +48,32 @@ describe('UserService', () => {
 
   it('returns an empty string when neither source is set', () => {
     expect(service.effectiveAvatarUrl()).toBe('');
+  });
+
+  it('does not let a slower post-hydration profile fetch clobber an upload that already resolved', () => {
+    httpGet.mockReturnValue(of({ profile: { picture: 'https://stale-fetch.png' } }));
+    service.user.set({ username: 'alice', picture: 'https://cdn.auth0.com/stale.png' } as User);
+    // Simulate the upload finishing before the post-hydration fetch's afterNextRender callback runs.
+    service.uploadedAvatarUrl.set('https://cdn.example.com/fresh-upload.png');
+
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(httpGet).toHaveBeenCalledWith('/api/profile');
+    expect(service.uploadedAvatarUrl()).toBe('https://cdn.example.com/fresh-upload.png');
+  });
+
+  it('resets the uploaded avatar when the user changes, so an impersonation swap cannot inherit it', async () => {
+    service.user.set({ username: 'alice', picture: 'https://cdn.auth0.com/alice.png' } as User);
+    // Flush before setting the upload — otherwise this synchronous test would batch both user.set
+    // calls into a single downstream emission and the reset subscription would never see "alice"
+    // as a distinct value to transition away from.
+    await TestBed.inject(ApplicationRef).whenStable();
+    service.uploadedAvatarUrl.set('https://cdn.example.com/alice-upload.png');
+
+    service.user.set({ username: 'bob', picture: 'https://cdn.auth0.com/bob.png' } as User);
+    await TestBed.inject(ApplicationRef).whenStable();
+
+    expect(service.uploadedAvatarUrl()).toBeNull();
+    expect(service.effectiveAvatarUrl()).toBe('https://cdn.auth0.com/bob.png');
   });
 });

--- a/apps/lfx-one/src/app/shared/services/user.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.spec.ts
@@ -1,0 +1,44 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { User } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { UserService } from './user.service';
+
+/**
+ * Covers the `effectiveAvatarUrl` priority chain (LFXV2-2628): an uploaded avatar must win over
+ * the Auth0 `picture` claim even while the claim is stale, since that's exactly the race a
+ * successful upload racing a slower post-hydration profile fetch depends on.
+ */
+describe('UserService', () => {
+  let service: UserService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: HttpClient, useValue: { get: vi.fn(), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    service = TestBed.inject(UserService);
+  });
+
+  it('falls back to the Auth0 picture claim when no avatar has been uploaded', () => {
+    service.user.set({ picture: 'https://cdn.auth0.com/stale.png' } as User);
+    expect(service.effectiveAvatarUrl()).toBe('https://cdn.auth0.com/stale.png');
+  });
+
+  it('prefers the uploaded avatar over the picture claim even when the claim is unchanged', () => {
+    service.user.set({ picture: 'https://cdn.auth0.com/stale.png' } as User);
+    service.uploadedAvatarUrl.set('https://cdn.example.com/fresh-upload.png');
+    expect(service.effectiveAvatarUrl()).toBe('https://cdn.example.com/fresh-upload.png');
+  });
+
+  it('returns an empty string when neither source is set', () => {
+    expect(service.effectiveAvatarUrl()).toBe('');
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -49,9 +49,10 @@ export class UserService {
   public canImpersonate: WritableSignal<boolean> = signal<boolean>(false);
   public readonly userInitials: Signal<string> = this.initUserInitials();
   /**
-   * The current user's uploaded avatar (Auth0 user_metadata.picture), null until the one-time
-   * post-hydration profile fetch resolves — that field never reaches `user` (it's absent from the
-   * OIDC claims `user` is seeded from) or is set from the profile-edit upload flow (LFXV2-2628).
+   * The current user's uploaded avatar (Auth0 user_metadata.picture), null until either the
+   * one-time post-hydration profile fetch resolves or the profile-edit upload flow sets it
+   * directly. It never arrives via `user` — that field is absent from the OIDC claims `user` is
+   * seeded from (LFXV2-2628).
    */
   public readonly uploadedAvatarUrl: WritableSignal<string | null> = signal<string | null>(null);
   /**

--- a/apps/lfx-one/src/server/utils/avatar-url.util.spec.ts
+++ b/apps/lfx-one/src/server/utils/avatar-url.util.spec.ts
@@ -1,0 +1,71 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { buildAvatarUrl, deriveAvatarUrl, getAvatarCdnPrefix, toAvatarKeySegment, toAvatarObjectKey } from './avatar-url.util';
+
+const ORIGINAL_ENV = { ...process.env };
+
+describe('avatar-url.util', () => {
+  beforeEach(() => {
+    process.env = { ...ORIGINAL_ENV };
+    delete process.env['CDN_URL_PREFIX'];
+  });
+
+  describe('getAvatarCdnPrefix', () => {
+    it('returns null when unset', () => {
+      expect(getAvatarCdnPrefix()).toBeNull();
+    });
+
+    it('strips trailing slashes from an absolute URL', () => {
+      process.env['CDN_URL_PREFIX'] = 'https://cdn.example.com/';
+      expect(getAvatarCdnPrefix()).toBe('https://cdn.example.com');
+    });
+
+    it('accepts http (not just https)', () => {
+      process.env['CDN_URL_PREFIX'] = 'http://cdn.example.com';
+      expect(getAvatarCdnPrefix()).toBe('http://cdn.example.com');
+    });
+
+    it('rejects a bare hostname with no scheme', () => {
+      process.env['CDN_URL_PREFIX'] = 'avatars-public.dev.downloads.lfx.community';
+      expect(() => getAvatarCdnPrefix()).toThrow(/CDN_URL_PREFIX must be an absolute http\(s\) URL/);
+    });
+
+    it('rejects a scheme-only value with no hostname', () => {
+      process.env['CDN_URL_PREFIX'] = 'https://';
+      expect(() => getAvatarCdnPrefix()).toThrow(/CDN_URL_PREFIX must be an absolute http\(s\) URL/);
+    });
+
+    it('rejects a non-http(s) scheme', () => {
+      process.env['CDN_URL_PREFIX'] = 'ftp://cdn.example.com';
+      expect(() => getAvatarCdnPrefix()).toThrow(/CDN_URL_PREFIX must be an absolute http\(s\) URL/);
+    });
+  });
+
+  describe('toAvatarKeySegment / toAvatarObjectKey', () => {
+    it('escapes % before / so the mapping stays collision-free', () => {
+      expect(toAvatarKeySegment('a%2Fb/c')).toBe('a%252Fb%2Fc');
+    });
+
+    it('builds a lowercased, trimmed object key', () => {
+      expect(toAvatarObjectKey('  SomeUser  ')).toBe('avatars/someuser');
+    });
+  });
+
+  describe('buildAvatarUrl / deriveAvatarUrl', () => {
+    it('joins prefix and percent-encoded key segment under avatars/', () => {
+      expect(buildAvatarUrl('https://cdn.example.com', 'a b')).toBe('https://cdn.example.com/avatars/a%20b');
+    });
+
+    it('returns null when CDN_URL_PREFIX is unset', () => {
+      expect(deriveAvatarUrl('someuser')).toBeNull();
+    });
+
+    it('derives the CDN URL for a normalized username', () => {
+      process.env['CDN_URL_PREFIX'] = 'https://cdn.example.com';
+      expect(deriveAvatarUrl('  SomeUser  ')).toBe('https://cdn.example.com/avatars/someuser');
+    });
+  });
+});

--- a/apps/lfx-one/src/server/utils/avatar-url.util.spec.ts
+++ b/apps/lfx-one/src/server/utils/avatar-url.util.spec.ts
@@ -42,6 +42,11 @@ describe('avatar-url.util', () => {
       process.env['CDN_URL_PREFIX'] = 'ftp://cdn.example.com';
       expect(() => getAvatarCdnPrefix()).toThrow(/CDN_URL_PREFIX must be an absolute http\(s\) URL/);
     });
+
+    it('trims leading/trailing whitespace from the returned prefix', () => {
+      process.env['CDN_URL_PREFIX'] = '  https://cdn.example.com/  ';
+      expect(getAvatarCdnPrefix()).toBe('https://cdn.example.com');
+    });
   });
 
   describe('toAvatarKeySegment / toAvatarObjectKey', () => {

--- a/apps/lfx-one/src/server/utils/avatar-url.util.spec.ts
+++ b/apps/lfx-one/src/server/utils/avatar-url.util.spec.ts
@@ -47,6 +47,16 @@ describe('avatar-url.util', () => {
       process.env['CDN_URL_PREFIX'] = '  https://cdn.example.com/  ';
       expect(getAvatarCdnPrefix()).toBe('https://cdn.example.com');
     });
+
+    it('rejects a prefix with a query string', () => {
+      process.env['CDN_URL_PREFIX'] = 'https://cdn.example.com?token=x';
+      expect(() => getAvatarCdnPrefix()).toThrow(/CDN_URL_PREFIX must be an absolute http\(s\) URL/);
+    });
+
+    it('rejects a prefix with a fragment', () => {
+      process.env['CDN_URL_PREFIX'] = 'https://cdn.example.com/base#frag';
+      expect(() => getAvatarCdnPrefix()).toThrow(/CDN_URL_PREFIX must be an absolute http\(s\) URL/);
+    });
   });
 
   describe('toAvatarKeySegment / toAvatarObjectKey', () => {

--- a/apps/lfx-one/src/server/utils/avatar-url.util.ts
+++ b/apps/lfx-one/src/server/utils/avatar-url.util.ts
@@ -51,7 +51,11 @@ export function getAvatarCdnPrefix(): string | null {
   } catch {
     throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
   }
-  if (!/^https?:$/.test(parsed.protocol) || !parsed.hostname) {
+  // A query or fragment also can't survive buildAvatarUrl's plain string concatenation: appending
+  // "/avatars/<key>" after "?token=x" lands the avatar path inside the query string instead of the
+  // path, and after "#frag" it's hidden in the fragment — either way the resulting URL doesn't
+  // point at the object it claims to.
+  if (!/^https?:$/.test(parsed.protocol) || !parsed.hostname || parsed.search || parsed.hash) {
     throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
   }
   return trimmedCdnPrefix.replace(/\/+$/, '');

--- a/apps/lfx-one/src/server/utils/avatar-url.util.ts
+++ b/apps/lfx-one/src/server/utils/avatar-url.util.ts
@@ -37,7 +37,17 @@ export function getAvatarCdnPrefix(): string | null {
   if (!cdnPrefix) {
     return null;
   }
-  if (!/^https?:\/\//i.test(cdnPrefix)) {
+  // New URL() (rather than a `^https?:\/\//` regex) also rejects a scheme-only value like
+  // "https://" — that string starts with the required prefix but has no hostname, and a regex
+  // check alone would let it through and silently produce a malformed "https:/avatars/..." URL
+  // after the trailing-slash trim below.
+  let parsed: URL;
+  try {
+    parsed = new URL(cdnPrefix);
+  } catch {
+    throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
+  }
+  if (!/^https?:$/.test(parsed.protocol) || !parsed.hostname) {
     throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
   }
   return cdnPrefix.replace(/\/+$/, '');

--- a/apps/lfx-one/src/server/utils/avatar-url.util.ts
+++ b/apps/lfx-one/src/server/utils/avatar-url.util.ts
@@ -37,20 +37,24 @@ export function getAvatarCdnPrefix(): string | null {
   if (!cdnPrefix) {
     return null;
   }
+  // Trim before validating and returning — new URL() trims ASCII whitespace internally, so an
+  // untrimmed value with leading/trailing spaces would pass validation while the raw string
+  // (with the spaces still in it) got returned and interpolated into a malformed URL downstream.
+  const trimmedCdnPrefix = cdnPrefix.trim();
   // New URL() (rather than a `^https?:\/\//` regex) also rejects a scheme-only value like
   // "https://" — that string starts with the required prefix but has no hostname, and a regex
   // check alone would let it through and silently produce a malformed "https:/avatars/..." URL
   // after the trailing-slash trim below.
   let parsed: URL;
   try {
-    parsed = new URL(cdnPrefix);
+    parsed = new URL(trimmedCdnPrefix);
   } catch {
     throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
   }
   if (!/^https?:$/.test(parsed.protocol) || !parsed.hostname) {
     throw new Error(`CDN_URL_PREFIX must be an absolute http(s) URL, got: "${cdnPrefix}"`);
   }
-  return cdnPrefix.replace(/\/+$/, '');
+  return trimmedCdnPrefix.replace(/\/+$/, '');
 }
 
 /**

--- a/packages/shared/src/interfaces/profile.interface.ts
+++ b/packages/shared/src/interfaces/profile.interface.ts
@@ -61,7 +61,6 @@ export interface ProfileHeaderData {
   phoneNumber?: string;
   tshirtSize?: string;
   aboutMe?: string;
-  avatarUrl?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

Follow-up to #1428 (LFXV2-2628). A repo-wide re-scan of every avatar-display surface found two remaining gaps and one latent-regression risk, all fixed here:

- `profile-layout` and `profile-edit-drawer` still read avatar URL from their own eventually-consistent profile fetch instead of the shared `UserService.effectiveAvatarUrl` signal — a fresh upload could still show stale/missing data on those two surfaces.
- `lens-switcher`'s rail button and user-menu popover avatars were still bound directly to the raw Auth0 `picture` claim, same bug class as the sidebar/header fix in #1428, missed because that file wasn't in the original PR's changed-file list.
- Removed `ProfileHeaderData.avatarUrl` — a dead field, set but never read by any template, left over from before the shared signal existed. Kept around, it risked a future consumer wiring to it and reintroducing the staleness bug.
- Hardened `CDN_URL_PREFIX` validation in `avatar-url.util.ts`: a scheme-only value like `"https://"` passed the old regex check and would silently produce a malformed URL.

Ticket: LFXV2-2628

## Test plan

- [x] `avatar-url.util.spec.ts` — new spec, 11 tests covering CDN prefix validation edge cases (unset, bare hostname, scheme-only, non-http scheme), key escaping, URL derivation.
- [x] Full server test suite (1104 tests) and app test suite (254 tests) pass.
- [x] Lint + typecheck clean.
- [x] Manually re-verified every avatar-display surface in the repo sources from `UserService.effectiveAvatarUrl` (or a prop chain rooted in it); confirmed other-user avatar surfaces (org-people dashboards, impersonation targets, public-profile page, akrites audit-trail snapshots) are correctly out of scope and unaffected.