### PR TITLE
feat(social-listening): add mentions feed filters panel (LFXV2-3017)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
@@ -58,5 +58,22 @@
         styleClass="w-56"
         data-testid="feed-header-search" />
     }
+
+    <!-- Filters trigger (feed tab only) — hover/focus arms the page's lazy option fetches -->
+    @if (!isAnalyticsTab()) {
+      <lfx-button
+        icon="fa-light fa-sliders"
+        severity="secondary"
+        [outlined]="true"
+        size="small"
+        ariaLabel="Filters"
+        [ariaPressed]="filtersVisible()"
+        [badge]="activeFilterCount() > 0 ? activeFilterCount().toString() : undefined"
+        badgeSeverity="info"
+        (onClick)="toggleFilters()"
+        (onFocus)="filtersPrefetch.emit()"
+        (mouseenter)="filtersPrefetch.emit()"
+        data-testid="social-listening-filters-button" />
+    }
   </div>
 </lfx-card-tabs-bar>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
@@ -1,9 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, DestroyRef, effect, inject, model } from '@angular/core';
+import { Component, computed, DestroyRef, effect, inject, input, model, output } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { ButtonComponent } from '@components/button/button.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
@@ -20,7 +21,9 @@ const SOCIAL_LISTENING_TAB_OPTIONS: FilterPillOption[] = [
 /**
  * Social Listening feed header (LFXV2-3016): Feed/Analytics tabs on the left (via
  * `lfx-card-tabs-bar`), sub-project / platform / period selects and the search input on the
- * right. The Filters button + badge are intentionally absent — LFXV2-3017 adds them.
+ * right. LFXV2-3017 adds the Filters button: icon + active-filter count badge, toggles the
+ * filters panel via the `filtersVisible` model, and arms the page's lazy option fetches early
+ * (`filtersPrefetch` on hover/focus) so the round-trip hides behind the intent→click gap.
  *
  * State lives in the page container and round-trips through query params; this component only
  * two-way-binds it via `model()`. The `lfx-select` / `lfx-input-text` wrappers are form-bound,
@@ -29,7 +32,7 @@ const SOCIAL_LISTENING_TAB_OPTIONS: FilterPillOption[] = [
  */
 @Component({
   selector: 'lfx-feed-header',
-  imports: [ReactiveFormsModule, CardTabsBarComponent, SelectComponent, InputTextComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, CardTabsBarComponent, SelectComponent, InputTextComponent],
   templateUrl: './feed-header.component.html',
   styleUrl: './feed-header.component.scss',
 })
@@ -46,6 +49,11 @@ export class FeedHeaderComponent {
   public readonly projectOptions = model.required<SocialListeningOption[]>();
   public readonly platformOptions = model.required<SocialListeningOption[]>();
   public readonly optionsLoading = model<boolean>(false);
+
+  // === Filters panel trigger (LFXV2-3017) ===
+  public readonly filtersVisible = model(false);
+  public readonly activeFilterCount = input(0);
+  public readonly filtersPrefetch = output<void>();
 
   // Neutral defaults — the model→form effects below populate the real values at construction
   // (required models can't be read in field initializers).
@@ -91,5 +99,9 @@ export class FeedHeaderComponent {
     if (tabId === 'feed' || tabId === 'analytics') {
       this.activeTab.set(tabId);
     }
+  }
+
+  protected toggleFilters(): void {
+    this.filtersVisible.update((visible) => !visible);
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/filters-panel/filters-panel.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/filters-panel/filters-panel.component.html
@@ -1,0 +1,156 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- Click-outside backdrop (writes the visible model directly — the genuine two-way close path) -->
+<div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-filters-backdrop" (click)="visible.set(false)"></div>
+
+<div #panelContainer class="filters-panel" role="dialog" aria-label="Filters" tabindex="-1" data-testid="social-listening-filters-panel">
+  <div class="mb-5 flex items-center justify-between">
+    <h3 class="text-sm font-bold tracking-wide text-gray-800">FILTERS</h3>
+    @if (activeFilterCount() > 0) {
+      <button type="button" class="clear-btn" data-testid="social-listening-filters-clear-all" (click)="clearFilters()">Clear all</button>
+    }
+  </div>
+
+  <!-- Sentiment -->
+  <div class="filter-group">
+    <label class="filter-label" for="sl-filter-sentiment">Sentiment</label>
+    <lfx-select
+      [form]="filtersForm"
+      control="sentiment"
+      [options]="sentimentOptions"
+      optionLabel="label"
+      optionValue="value"
+      inputId="sl-filter-sentiment"
+      ariaLabel="Filter by sentiment"
+      styleClass="w-full"
+      data-testid="social-listening-filters-sentiment" />
+  </div>
+
+  <!-- Relevance -->
+  <div class="filter-group">
+    <label class="filter-label" for="sl-filter-relevance">Relevance</label>
+    <lfx-select
+      [form]="filtersForm"
+      control="relevance"
+      [options]="relevanceOptions"
+      optionLabel="label"
+      optionValue="value"
+      inputId="sl-filter-relevance"
+      ariaLabel="Filter by relevance"
+      styleClass="w-full"
+      data-testid="social-listening-filters-relevance" />
+  </div>
+
+  <!-- Language (options scoped by foundation + period) -->
+  <div class="filter-group">
+    <label class="filter-label" for="sl-filter-language">Language</label>
+    <lfx-select
+      [form]="filtersForm"
+      control="language"
+      [options]="languageOptions()"
+      optionLabel="label"
+      optionValue="value"
+      [loading]="languagesLoading()"
+      inputId="sl-filter-language"
+      ariaLabel="Filter by language"
+      styleClass="w-full"
+      data-testid="social-listening-filters-language" />
+  </div>
+
+  <!-- Has Title -->
+  <div class="filter-group">
+    <label class="filter-label" for="sl-filter-has-title">Has Title</label>
+    <lfx-select
+      [form]="filtersForm"
+      control="hasTitle"
+      [options]="hasTitleOptions"
+      optionLabel="label"
+      optionValue="value"
+      inputId="sl-filter-has-title"
+      ariaLabel="Filter by title presence"
+      styleClass="w-full"
+      data-testid="social-listening-filters-has-title" />
+  </div>
+
+  <!-- Authors (options cascade off every other filter) -->
+  <div class="filter-group">
+    <label class="filter-label" for="sl-filter-authors">Authors</label>
+    @if (authorsLoading()) {
+      <p-skeleton height="2.625rem" styleClass="w-full" data-testid="social-listening-filters-authors-loading" />
+    } @else {
+      <lfx-multi-select
+        [form]="filtersForm"
+        control="authors"
+        [options]="availableAuthors()"
+        optionLabel="AUTHOR"
+        optionValue="AUTHOR"
+        filterBy="AUTHOR"
+        [showToggleAll]="false"
+        placeholder="Select authors"
+        emptyMessage="No authors match the current filters"
+        emptyFilterMessage="No authors match the current filters"
+        panelStyleClass="sl-author-multiselect-panel"
+        inputId="sl-filter-authors"
+        ariaLabel="Filter by author"
+        styleClass="w-full"
+        data-testid="social-listening-filters-authors">
+        <ng-template let-option #item>
+          <div class="flex w-full items-center gap-2">
+            <i [class]="option.platformIcon + ' shrink-0 text-sm ' + option.platformIconClass" aria-hidden="true"></i>
+            <span class="min-w-0 flex-1 truncate text-sm">{{ option.AUTHOR }}</span>
+            <span class="shrink-0 text-xs text-gray-400">{{ option.MENTION_COUNT }} mentions</span>
+          </div>
+        </ng-template>
+      </lfx-multi-select>
+    }
+  </div>
+
+  <!-- Keywords -->
+  <div class="filter-group">
+    <label class="filter-label" for="sl-filter-keywords">Keywords</label>
+    @if (keywordsLoading()) {
+      <p-skeleton height="2.625rem" styleClass="w-full" data-testid="social-listening-filters-keywords-loading" />
+    } @else {
+      <lfx-multi-select
+        [form]="filtersForm"
+        control="keywords"
+        [options]="displayedKeywordOptions()"
+        optionLabel="label"
+        optionValue="value"
+        filterBy="label"
+        [showToggleAll]="false"
+        placeholder="Select keywords"
+        emptyMessage="No keywords match the current filters"
+        emptyFilterMessage="No keywords match the current filters"
+        inputId="sl-filter-keywords"
+        ariaLabel="Filter by keyword"
+        styleClass="w-full"
+        data-testid="social-listening-filters-keywords" />
+    }
+  </div>
+
+  <!-- Tags -->
+  <div class="filter-group">
+    <label class="filter-label" for="sl-filter-tags">Tags</label>
+    @if (tagsLoading()) {
+      <p-skeleton height="2.625rem" styleClass="w-full" data-testid="social-listening-filters-tags-loading" />
+    } @else {
+      <lfx-multi-select
+        [form]="filtersForm"
+        control="tags"
+        [options]="displayedTagOptions()"
+        optionLabel="label"
+        optionValue="value"
+        filterBy="label"
+        [showToggleAll]="false"
+        placeholder="Select tags"
+        emptyMessage="No tags match the current filters"
+        emptyFilterMessage="No tags match the current filters"
+        inputId="sl-filter-tags"
+        ariaLabel="Filter by tag"
+        styleClass="w-full"
+        data-testid="social-listening-filters-tags" />
+    }
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/filters-panel/filters-panel.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/filters-panel/filters-panel.component.scss
@@ -1,0 +1,41 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+:host {
+  @apply block;
+}
+
+// PrimeNG appends this overlay to <body> and left-aligns it under the ~15.5rem trigger
+// (panel w-72 minus p-5). Widen it for long author names, cap to the viewport, and shift
+// left by (trigger − effective width) so its right edge stays aligned with the trigger.
+// ::ng-deep is required because the overlay lives outside this component's view (ported
+// from PCC's author-multiselect-panel rules).
+::ng-deep .sl-author-multiselect-panel {
+  min-width: 32rem !important;
+  max-width: calc(100vw - 2rem);
+  transform: translateX(calc(15.5rem - min(32rem, 100vw - 2rem)));
+}
+
+.filters-panel {
+  @apply absolute right-0 top-full z-20 mt-1 max-h-[calc(100vh-8rem)] w-72 overflow-y-auto rounded-lg border border-gray-200 bg-white p-5 shadow-lg outline-none;
+}
+
+.clear-btn {
+  @apply cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-blue-600;
+
+  &:hover {
+    @apply text-blue-700 underline;
+  }
+}
+
+.filter-group {
+  @apply mb-4;
+
+  &:last-child {
+    @apply mb-0;
+  }
+}
+
+.filter-label {
+  @apply mb-1 block text-[0.813rem] font-medium text-gray-700;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/filters-panel/filters-panel.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/filters-panel/filters-panel.component.ts
@@ -1,0 +1,133 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { afterNextRender, Component, computed, DestroyRef, effect, ElementRef, inject, input, model, output, Signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormBuilder, ReactiveFormsModule } from '@angular/forms';
+import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
+import { SelectComponent } from '@components/select/select.component';
+import { MENTION_HAS_TITLE_OPTIONS, MENTION_RELEVANCE_OPTIONS, MENTION_SENTIMENT_OPTIONS } from '@lfx-one/shared/constants';
+import { capitalizeFirst, formatTag } from '@lfx-one/shared/utils';
+import { SkeletonModule } from 'primeng/skeleton';
+
+import type { AuthorOption, SocialListeningOption } from '@lfx-one/shared/interfaces';
+
+/**
+ * Social Listening filters panel (LFXV2-3017) — the dropdown that opens from the feed header's
+ * Filters button. Ports PCC's filters-panel: static sentiment / relevance / has-title selects, a
+ * scope-driven language select, and keywords / tags / authors multiselects with per-group loading
+ * skeletons. Author rows render the platform icon + mention count through the multiselect's
+ * `itemTemplate` hook. Save-as-View and the bookmark/read filters are deliberately absent
+ * (deferred scope — see lfxv2-3002-todo.md §6).
+ *
+ * State lives in the page container and round-trips through query params; this component only
+ * two-way-binds it via `model()`. The `lfx-select` / `lfx-multi-select` wrappers are form-bound,
+ * so an internal `filtersForm` bridges the two (form → model via `valueChanges`; model → form via
+ * `setValue(..., { emitEvent: false })`, which cannot loop) — the same pattern as the feed header.
+ *
+ * The panel owns its click-outside backdrop, which writes `visible` directly — that is what makes
+ * the open state genuinely two-way. "Clear all" only emits `filtersCleared`; the page performs the
+ * reset so the panel and the summary pills row share a single clear path.
+ */
+@Component({
+  selector: 'lfx-filters-panel',
+  imports: [ReactiveFormsModule, MultiSelectComponent, SelectComponent, SkeletonModule],
+  templateUrl: './filters-panel.component.html',
+  styleUrl: './filters-panel.component.scss',
+})
+export class FiltersPanelComponent {
+  private readonly fb = inject(FormBuilder);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // === Model signals (two-way bound by the page) ===
+  public readonly visible = model(false);
+  public readonly selectedSentiment = model.required<string>();
+  public readonly selectedRelevance = model.required<string>();
+  public readonly selectedLanguage = model.required<string>();
+  public readonly selectedHasTitle = model.required<string>();
+  public readonly selectedKeywords = model.required<string[]>();
+  public readonly selectedTags = model.required<string[]>();
+  public readonly selectedAuthors = model.required<string[]>();
+
+  // === Inputs (option lists + per-group loading, fetched lazily by the page) ===
+  public readonly languageOptions = input<SocialListeningOption[]>([]);
+  public readonly languagesLoading = input(false);
+  public readonly availableKeywords = input<string[]>([]);
+  public readonly keywordsLoading = input(false);
+  public readonly availableTags = input<string[]>([]);
+  public readonly tagsLoading = input(false);
+  public readonly availableAuthors = input<AuthorOption[]>([]);
+  public readonly authorsLoading = input(false);
+  public readonly activeFilterCount = input(0);
+
+  // === Outputs ===
+  public readonly filtersCleared = output<void>();
+
+  // Neutral defaults — the model→form effects below populate the real values at construction
+  // (required models can't be read in field initializers).
+  protected readonly filtersForm = this.fb.nonNullable.group({
+    sentiment: ['all'],
+    relevance: ['all'],
+    language: ['all'],
+    hasTitle: ['all'],
+    keywords: [[] as string[]],
+    tags: [[] as string[]],
+    authors: [[] as string[]],
+  });
+
+  protected readonly sentimentOptions = MENTION_SENTIMENT_OPTIONS;
+  protected readonly relevanceOptions = MENTION_RELEVANCE_OPTIONS;
+  protected readonly hasTitleOptions = MENTION_HAS_TITLE_OPTIONS;
+
+  // Selected values can fall out of the rescoped option lists (or arrive via URL before the
+  // options land) — kept as extra options so the multiselect chips still resolve a label (PCC port).
+  protected readonly displayedKeywordOptions: Signal<SocialListeningOption[]> = this.initDisplayedKeywordOptions();
+  protected readonly displayedTagOptions: Signal<SocialListeningOption[]> = this.initDisplayedTagOptions();
+
+  private readonly panelContainer = viewChild<ElementRef<HTMLElement>>('panelContainer');
+
+  public constructor() {
+    // External state (query-param decode, clear-all, pill removal) pushes into the form;
+    // emitEvent: false so the valueChanges bridges below don't echo it back and loop.
+    effect(() => this.filtersForm.controls.sentiment.setValue(this.selectedSentiment(), { emitEvent: false }));
+    effect(() => this.filtersForm.controls.relevance.setValue(this.selectedRelevance(), { emitEvent: false }));
+    effect(() => this.filtersForm.controls.language.setValue(this.selectedLanguage(), { emitEvent: false }));
+    effect(() => this.filtersForm.controls.hasTitle.setValue(this.selectedHasTitle(), { emitEvent: false }));
+    effect(() => this.filtersForm.controls.keywords.setValue(this.selectedKeywords(), { emitEvent: false }));
+    effect(() => this.filtersForm.controls.tags.setValue(this.selectedTags(), { emitEvent: false }));
+    effect(() => this.filtersForm.controls.authors.setValue(this.selectedAuthors(), { emitEvent: false }));
+
+    this.filtersForm.controls.sentiment.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.selectedSentiment.set(value));
+    this.filtersForm.controls.relevance.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.selectedRelevance.set(value));
+    this.filtersForm.controls.language.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.selectedLanguage.set(value));
+    this.filtersForm.controls.hasTitle.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.selectedHasTitle.set(value));
+    this.filtersForm.controls.keywords.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.selectedKeywords.set(value));
+    this.filtersForm.controls.tags.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.selectedTags.set(value));
+    this.filtersForm.controls.authors.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe((value) => this.selectedAuthors.set(value));
+
+    // Move focus into the dialog on open (the page only renders the panel while it is open, so
+    // mount === open). afterNextRender is browser-only by design — no SSR guard needed.
+    afterNextRender(() => this.panelContainer()?.nativeElement.focus());
+  }
+
+  /** Emits only — the page resets the predicate so the panel and the pills row share one clear path. */
+  protected clearFilters(): void {
+    this.filtersCleared.emit();
+  }
+
+  private initDisplayedKeywordOptions(): Signal<SocialListeningOption[]> {
+    return computed(() => {
+      const available = this.availableKeywords();
+      const extra = this.selectedKeywords().filter((keyword) => !available.includes(keyword));
+      return [...available, ...extra].map((keyword) => ({ label: capitalizeFirst(keyword), value: keyword }));
+    });
+  }
+
+  private initDisplayedTagOptions(): Signal<SocialListeningOption[]> {
+    return computed(() => {
+      const available = this.availableTags();
+      const extra = this.selectedTags().filter((tag) => !available.includes(tag));
+      return [...available, ...extra].map((tag) => ({ label: formatTag(tag), value: tag }));
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -15,18 +15,60 @@
       data-testid="social-listening-no-foundation" />
   } @else {
     <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="social-listening-card">
-      <lfx-feed-header
-        [(activeTab)]="activeTab"
-        [(selectedPeriod)]="selectedPeriod"
-        [(selectedProject)]="selectedProject"
-        [(selectedPlatform)]="selectedPlatform"
-        [(searchInput)]="searchInput"
-        [projectOptions]="subProjectOptions()"
-        [platformOptions]="platformOptions()"
-        [optionsLoading]="optionsLoading()" />
+      <!-- Positioning context for the filters panel dropdown (ports PCC's relative wrapper) -->
+      <div class="relative z-20">
+        <lfx-feed-header
+          [(activeTab)]="activeTab"
+          [(selectedPeriod)]="selectedPeriod"
+          [(selectedProject)]="selectedProject"
+          [(selectedPlatform)]="selectedPlatform"
+          [(searchInput)]="searchInput"
+          [(filtersVisible)]="filtersOpen"
+          [activeFilterCount]="activeFilterCount()"
+          [projectOptions]="subProjectOptions()"
+          [platformOptions]="platformOptions()"
+          [optionsLoading]="optionsLoading()"
+          (filtersPrefetch)="prefetchFilterOptions()" />
+
+        @if (filtersOpen() && activeTab() === 'feed') {
+          <lfx-filters-panel
+            [(visible)]="filtersOpen"
+            [(selectedSentiment)]="selectedSentiment"
+            [(selectedRelevance)]="selectedRelevance"
+            [(selectedLanguage)]="selectedLanguage"
+            [(selectedHasTitle)]="selectedHasTitle"
+            [(selectedKeywords)]="selectedKeywords"
+            [(selectedTags)]="selectedTags"
+            [(selectedAuthors)]="selectedAuthors"
+            [languageOptions]="languageOptions()"
+            [languagesLoading]="languagesLoading()"
+            [availableKeywords]="availableKeywords()"
+            [keywordsLoading]="keywordsLoading()"
+            [availableTags]="availableTags()"
+            [tagsLoading]="tagsLoading()"
+            [availableAuthors]="availableAuthors()"
+            [authorsLoading]="authorsLoading()"
+            [activeFilterCount]="activeFilterCount()"
+            (filtersCleared)="clearAllFilters()" />
+        }
+      </div>
 
       <div class="flex flex-col gap-4 px-5 py-5">
         @if (activeTab() === 'feed') {
+          <!-- Active-filter summary: one pill per active dimension — click a pill to remove that filter -->
+          @if (activeFilterPills().length > 0) {
+            <div class="flex flex-wrap items-center gap-2" aria-label="Active filters" data-testid="social-listening-filter-pills">
+              <lfx-filter-pills [options]="activeFilterPills()" selectedFilter="" (filterChange)="removeFilterPill($event)" />
+              <button
+                type="button"
+                class="cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+                data-testid="social-listening-filter-pills-clear-all"
+                (click)="clearAllFilters()">
+                Clear all
+              </button>
+            </div>
+          }
+
           @if (error(); as errorMessage) {
             <lfx-message severity="error" [text]="errorMessage" data-testid="social-listening-error" />
           }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -7,9 +7,11 @@ import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-i
 import { ActivatedRoute, Router } from '@angular/router';
 import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MessageComponent } from '@components/message/message.component';
 import {
   DEFAULT_MENTION_PAGE_SIZE,
+  DEFAULT_MENTION_PREDICATE,
   MENTION_MAX_CACHED_WINDOWS,
   MENTION_PAGE_SIZE_OPTIONS,
   MENTION_SEARCH_DEBOUNCE_MS,
@@ -19,13 +21,18 @@ import {
 } from '@lfx-one/shared/constants';
 import {
   applyPredicateToSignals,
+  buildActiveFilterPills,
   buildMentionFilters,
+  countActiveFilters,
   decodePredicateFromQueryParams,
   encodePredicateToQueryParams,
   getDefaultMarketingImpactPeriod,
+  mapAuthorsToOptions,
+  mapLanguagesToOptions,
   mapPlatformsToOptions,
   mapRawToMention,
   mapSubProjectsToOptions,
+  mergeSelectedAuthors,
   predicatesEqual,
   predicateFromSignals,
   queryParamsEqual,
@@ -47,10 +54,12 @@ import {
   of,
   startWith,
   switchMap,
+  take,
   tap,
 } from 'rxjs';
 
 import type {
+  AuthorOption,
   FilterPredicate,
   LoadableState,
   Mention,
@@ -60,12 +69,14 @@ import type {
   SocialListeningFeedRequest,
   SocialListeningFeedResponse,
   SocialListeningPlatform,
+  SocialListeningScopedOptionsRequest,
   SocialListeningSignals,
   SocialListeningSubProject,
   SocialListeningTab,
 } from '@lfx-one/shared/interfaces';
 
 import { FeedHeaderComponent } from './components/feed-header/feed-header.component';
+import { FiltersPanelComponent } from './components/filters-panel/filters-panel.component';
 import { MentionsListComponent } from './components/mentions-list/mentions-list.component';
 
 /** Shared immutable empty-feed value for initial/error/no-scope states. */
@@ -80,7 +91,7 @@ const EMPTY_FEED_RESPONSE: SocialListeningFeedResponse = { mentions: [], compute
  */
 @Component({
   selector: 'lfx-social-listening',
-  imports: [CardComponent, EmptyStateComponent, MessageComponent, FeedHeaderComponent, MentionsListComponent],
+  imports: [CardComponent, EmptyStateComponent, FilterPillsComponent, MessageComponent, FeedHeaderComponent, FiltersPanelComponent, MentionsListComponent],
   templateUrl: './social-listening.component.html',
   styleUrl: './social-listening.component.scss',
 })
@@ -118,6 +129,10 @@ export class SocialListeningComponent {
   private readonly windowCache = signal<Map<number, SocialListeningFeedResponse>>(new Map());
   private readonly backgroundLoading = signal(false);
 
+  // === Filters panel state (LFXV2-3017) ===
+  public readonly filtersOpen = signal(false);
+  private readonly filtersOpenedOnce = signal(false);
+
   /** Shared heartbeat that re-evaluates relative timestamps on rendered cards (one interval per page, not per card). */
   public readonly timeTick = signal(0);
 
@@ -145,6 +160,28 @@ export class SocialListeningComponent {
   public readonly subProjectOptions = computed(() => mapSubProjectsToOptions(this.subProjectsState().data));
   public readonly platformOptions = computed(() => mapPlatformsToOptions(this.platformsState().data));
   public readonly optionsLoading = computed(() => this.subProjectsState().loading || this.platformsState().loading);
+
+  // === Filter-option pipelines (3017): lazy — gated on filtersOpenedOnce, never fire on page load ===
+  private readonly languagesState: Signal<LoadableState<string[]>> = this.initLanguagesState();
+  private readonly keywordsState: Signal<LoadableState<string[]>> = this.initScopedOptionsState((req) => this.socialListeningService.getMentionsKeywords(req));
+  private readonly tagsState: Signal<LoadableState<string[]>> = this.initScopedOptionsState((req) =>
+    this.socialListeningService.getMentionsTags(req).pipe(map((tags) => tags.map((tag) => tag.TAG)))
+  );
+  private readonly authorsState: Signal<LoadableState<AuthorOption[]>> = this.initAuthorsState();
+
+  public readonly languageOptions = computed(() => mapLanguagesToOptions(this.languagesState().data));
+  public readonly languagesLoading = computed(() => this.languagesState().loading);
+  public readonly availableKeywords = computed(() => this.keywordsState().data);
+  public readonly keywordsLoading = computed(() => this.keywordsState().loading);
+  public readonly availableTags = computed(() => this.tagsState().data);
+  public readonly tagsLoading = computed(() => this.tagsState().loading);
+  // A kept author selection can drop out of the rescoped options — mergeSelectedAuthors re-adds
+  // it as a placeholder so the multiselect chip label still resolves.
+  public readonly availableAuthors = computed(() => mergeSelectedAuthors(this.authorsState().data, this.selectedAuthors()));
+  public readonly authorsLoading = computed(() => this.authorsState().loading);
+
+  public readonly activeFilterCount = computed(() => countActiveFilters(this.currentPredicate()));
+  public readonly activeFilterPills = computed(() => buildActiveFilterPills(this.currentPredicate()));
 
   private readonly currentWindowData = computed(() => this.windowCache().get(this.windowIndex()) ?? this.feedState().data);
 
@@ -255,11 +292,53 @@ export class SocialListeningComponent {
       }
       this.previousScopeKey = scopeKey;
     });
+
+    // One-way latch (3017) — defer filter-option requests until the panel is first opened. Covers
+    // keyboard/programmatic activation; pointer users typically arm it earlier via
+    // prefetchFilterOptions() on hover so the fetches are already in flight when the panel appears.
+    toObservable(this.filtersOpen)
+      .pipe(filter(Boolean), take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe(() => this.filtersOpenedOnce.set(true));
   }
 
   public onPageChange(event: { page: number; rows: number }): void {
     this.currentPage.set(event.page);
     this.pageSize.set(event.rows);
+  }
+
+  /**
+   * Arms the deferred filter-option fetches before the panel actually opens. Called on
+   * hover/focus of the Filters button so the network round-trip can happen during the
+   * ~150–500 ms between intent and click, hiding the skeletons (PCC port).
+   */
+  public prefetchFilterOptions(): void {
+    if (!this.filtersOpenedOnce()) {
+      this.filtersOpenedOnce.set(true);
+    }
+  }
+
+  /**
+   * Resets the predicate to DEFAULT_MENTION_PREDICATE (search included — the badge counts it).
+   * `applyPredicateToSignals` already clones the array fields, so every signal gets a fresh
+   * instance and the URL-write effect re-encodes to a clean query string.
+   */
+  public clearAllFilters(): void {
+    applyPredicateToSignals({ ...DEFAULT_MENTION_PREDICATE, keywords: [], tags: [], authors: [] }, this.signals);
+  }
+
+  /** Removes one active filter dimension from the summary pills row (id = FilterPredicate key). */
+  public removeFilterPill(id: string): void {
+    const resetters: Record<keyof FilterPredicate, () => void> = {
+      sentiment: () => this.selectedSentiment.set(DEFAULT_MENTION_PREDICATE.sentiment),
+      relevance: () => this.selectedRelevance.set(DEFAULT_MENTION_PREDICATE.relevance),
+      language: () => this.selectedLanguage.set(DEFAULT_MENTION_PREDICATE.language),
+      hasTitle: () => this.selectedHasTitle.set(DEFAULT_MENTION_PREDICATE.hasTitle),
+      keywords: () => this.selectedKeywords.set([]),
+      tags: () => this.selectedTags.set([]),
+      authors: () => this.selectedAuthors.set([]),
+      search: () => this.searchInput.set(''),
+    };
+    resetters[id as keyof FilterPredicate]?.();
   }
 
   private computeScopeKey(): string | null {
@@ -405,6 +484,119 @@ export class SocialListeningComponent {
 
   private initSubProjectsState(): Signal<LoadableState<SocialListeningSubProject[]>> {
     return this.initFoundationOptions((foundationSlug) => this.socialListeningService.getMentionsProjects({ foundationSlug }));
+  }
+
+  /**
+   * Languages option fetch (3017): scoped by foundation + period, deferred until the Filters
+   * button is first hovered/focused/opened (`filtersOpenedOnce`) so page load never fires it.
+   */
+  private initLanguagesState(): Signal<LoadableState<string[]>> {
+    return toSignal(
+      toObservable(computed(() => ({ foundationSlug: this.foundationSlug(), period: this.selectedPeriod(), opened: this.filtersOpenedOnce() }))).pipe(
+        debounceTime(0), // Coalesce synchronous signal changes (foundation switch + scope reset) into one fetch
+        filter((t) => !!t.foundationSlug && !!t.period && t.opened),
+        switchMap((t) =>
+          this.socialListeningService.getMentionsLanguages({ foundationSlug: t.foundationSlug, period: t.period }).pipe(
+            map((data): LoadableState<string[]> => ({ loading: false, error: null, data })),
+            catchError(() => of<LoadableState<string[]>>({ loading: false, error: 'Failed to load options', data: [] })),
+            startWith<LoadableState<string[]>>({ loading: true, error: null, data: [] })
+          )
+        )
+      ),
+      { initialValue: { loading: false, error: null, data: [] } }
+    );
+  }
+
+  /**
+   * Keywords/tags option fetches (3017): like languages but also refetch when the platform or
+   * sub-project scope changes (their option lists rescope — PCC's `initializeScopedFilterOptions`).
+   */
+  private initScopedOptionsState<T>(fetchFn: (req: SocialListeningScopedOptionsRequest) => Observable<T[]>): Signal<LoadableState<T[]>> {
+    return toSignal(
+      toObservable(
+        computed(() => ({
+          foundationSlug: this.foundationSlug(),
+          period: this.selectedPeriod(),
+          platform: this.selectedPlatform(),
+          sourceProjectId: this.selectedProject(),
+          opened: this.filtersOpenedOnce(),
+        }))
+      ).pipe(
+        debounceTime(0), // Coalesce synchronous signal changes (foundation switch + scope reset) into one fetch
+        filter((t) => !!t.foundationSlug && !!t.period && t.opened),
+        switchMap((t) =>
+          fetchFn({
+            foundationSlug: t.foundationSlug,
+            period: t.period,
+            platform: t.platform !== 'all' ? t.platform : undefined,
+            sourceProjectId: t.sourceProjectId !== 'all' ? t.sourceProjectId : undefined,
+          }).pipe(
+            map((data): LoadableState<T[]> => ({ loading: false, error: null, data })),
+            catchError(() => of<LoadableState<T[]>>({ loading: false, error: 'Failed to load options', data: [] })),
+            startWith<LoadableState<T[]>>({ loading: true, error: null, data: [] })
+          )
+        )
+      ),
+      { initialValue: { loading: false, error: null, data: [] } }
+    );
+  }
+
+  /**
+   * Author options (3017): cascade off every OTHER filter — the request deliberately never
+   * includes the current `authors` selection (`SocialListeningAuthorsRequest` omits it). The
+   * heavier aggregation waits for the feed load to finish plus a 300 ms debounce so it does not
+   * contend with feed/count for the server's Snowflake connection pool (PCC `initializeAuthors`).
+   */
+  private initAuthorsState(): Signal<LoadableState<AuthorOption[]>> {
+    return toSignal(
+      toObservable(
+        computed(() => {
+          const req = {
+            foundationSlug: this.foundationSlug(),
+            period: this.selectedPeriod(),
+            platform: this.selectedPlatform(),
+            sourceProjectId: this.selectedProject(),
+            sentiment: this.selectedSentiment(),
+            relevance: this.selectedRelevance(),
+            language: this.selectedLanguage(),
+            hasTitle: this.selectedHasTitle(),
+            keywords: this.selectedKeywords(),
+            tags: this.selectedTags(),
+            search: this.searchQuery(),
+          };
+          const ready = !!req.foundationSlug && !!req.period && this.filtersOpenedOnce() && !this.feedState().loading;
+          return { req, key: JSON.stringify(req), ready };
+        })
+      ).pipe(
+        filter((t) => t.ready),
+        debounceTime(300),
+        distinctUntilChanged((a, b) => a.key === b.key),
+        switchMap(({ req }) =>
+          this.socialListeningService
+            .getMentionsAuthors({
+              foundationSlug: req.foundationSlug,
+              period: req.period,
+              ...buildMentionFilters({
+                sentiment: req.sentiment,
+                relevance: req.relevance,
+                platform: req.platform,
+                keywords: req.keywords,
+                tags: req.tags,
+                sourceProjectId: req.sourceProjectId,
+                language: req.language,
+                hasTitle: req.hasTitle,
+                search: req.search,
+              }),
+            })
+            .pipe(
+              map((data): LoadableState<AuthorOption[]> => ({ loading: false, error: null, data: mapAuthorsToOptions(data) })),
+              catchError(() => of<LoadableState<AuthorOption[]>>({ loading: false, error: null, data: [] })),
+              startWith<LoadableState<AuthorOption[]>>({ loading: true, error: null, data: [] })
+            )
+        )
+      ),
+      { initialValue: { loading: false, error: null, data: [] } }
+    );
   }
 
   private initPlatformsState(): Signal<LoadableState<SocialListeningPlatform[]>> {

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.html
@@ -22,6 +22,8 @@
     [loading]="loading()"
     [emptyMessage]="emptyMessage()"
     [emptyFilterMessage]="emptyFilterMessage()"
+    [attr.aria-label]="ariaLabel()"
+    [inputId]="inputId()"
     (onFilter)="filterChange.emit($event.filter ?? '')"
     (onPanelShow)="onPanelShow()"
     class="w-full">
@@ -52,7 +54,11 @@
         }
       </ng-template>
     }
-    @if (optionSubLabel() || optionImage()) {
+    @if (itemTemplate()) {
+      <ng-template let-option #item>
+        <ng-container *ngTemplateOutlet="itemTemplate()!; context: { $implicit: option }"></ng-container>
+      </ng-template>
+    } @else if (optionSubLabel() || optionImage()) {
       <ng-template let-option pTemplate="item">
         <div class="flex items-center gap-2">
           @if (optionImage(); as imgKey) {

--- a/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
+++ b/apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts
@@ -1,14 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
-import { Component, ElementRef, inject, input, output, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser, NgTemplateOutlet } from '@angular/common';
+import { Component, contentChild, ElementRef, inject, input, output, PLATFORM_ID, TemplateRef } from '@angular/core';
 import { FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectModule } from 'primeng/multiselect';
 
 @Component({
   selector: 'lfx-multi-select',
-  imports: [MultiSelectModule, ReactiveFormsModule],
+  imports: [MultiSelectModule, ReactiveFormsModule, NgTemplateOutlet],
   templateUrl: './multi-select.component.html',
   styleUrl: './multi-select.component.scss',
 })
@@ -55,7 +55,18 @@ export class MultiSelectComponent {
    * overlay to its trigger (long labels/CSS floors mis-size it), so when true it's measured against the trigger and matched on each open.
    */
   public readonly matchTriggerWidth = input<boolean>(false);
+  /** Accessible label forwarded to the focusable input (PrimeNG `ariaLabel`). */
+  public readonly ariaLabel = input<string | undefined>(undefined);
+  /** Id applied to the focusable input — pair with an external `<label for>` (PrimeNG `inputId`). */
+  public readonly inputId = input<string | undefined>(undefined);
   public readonly filterChange = output<string>();
+
+  /**
+   * Optional custom option template (mirrors `lfx-select`'s `itemTemplate`) for rows richer than the
+   * built-in `optionSubLabel`/`optionImage` layout — e.g. a FontAwesome icon + label + meta count.
+   * Project as `<ng-template let-option #item>`. Takes precedence over the built-in layout.
+   */
+  public readonly itemTemplate = contentChild<TemplateRef<unknown>>('item');
 
   /** On panel open, match the body-appended overlay's width to the trigger (opt-in). Browser-only (touches document/rAF). */
   protected onPanelShow(): void {

--- a/apps/lfx-one/src/app/shared/pipes/format-tag.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/format-tag.pipe.ts
@@ -2,23 +2,18 @@
 // SPDX-License-Identifier: MIT
 
 import { Pipe, PipeTransform } from '@angular/core';
+import { formatTag } from '@lfx-one/shared/utils';
 
 /**
  * Formats a raw Social Listening tag for display: underscores become spaces, each word is
  * capitalized, and `ai` is special-cased to `AI` (e.g. `ai_agents` -> `AI Agents`).
+ * Thin wrapper over the standalone `formatTag` util so the transform is also usable programmatically.
  */
 @Pipe({
   name: 'formatTag',
 })
 export class FormatTagPipe implements PipeTransform {
   public transform(value: string): string {
-    if (!value) {
-      return '';
-    }
-
-    return value
-      .split('_')
-      .map((word) => (word === 'ai' ? 'AI' : word.charAt(0).toUpperCase() + word.slice(1)))
-      .join(' ');
+    return formatTag(value);
   }
 }

--- a/packages/shared/src/utils/social-listening.utils.ts
+++ b/packages/shared/src/utils/social-listening.utils.ts
@@ -6,9 +6,17 @@
  * Ported from PCC; the bookmark (`mentionIds`) client branch is deferred to a follow-up ticket.
  */
 
-import { MENTION_PLATFORM_CONFIG } from '../constants/social-listening.constants';
+import {
+  DEFAULT_MENTION_PREDICATE,
+  MENTION_HAS_TITLE_OPTIONS,
+  MENTION_PLATFORM_CONFIG,
+  MENTION_RELEVANCE_OPTIONS,
+  MENTION_SENTIMENT_OPTIONS,
+} from '../constants/social-listening.constants';
+import type { FilterPillOption } from '../interfaces/dashboard-metric.interface';
 import type {
   AuthorOption,
+  FilterPredicate,
   Mention,
   MentionFilters,
   MentionPlatform,
@@ -20,6 +28,7 @@ import type {
   SocialListeningPlatform,
   SocialListeningSubProject,
 } from '../interfaces/social-listening.interface';
+import { capitalizeFirst } from './string.utils';
 
 /** Lowercases + dedupes keywords so filter state and payloads stay canonical. */
 export const normalizeKeywords = (keywords: string[]): string[] => [...new Set(keywords.map((keyword) => keyword.toLowerCase()))];
@@ -118,6 +127,23 @@ export function mapAuthorsToOptions(authors: SocialListeningMentionAuthor[]): Au
 }
 
 /**
+ * Formats a raw Social Listening tag for display: underscores become spaces, each word is
+ * capitalized, and `ai` is special-cased to `AI` (e.g. `ai_agents` -> `AI Agents`).
+ * Standalone so non-template consumers (e.g. the filters panel's option mapping) share it
+ * with the `formatTag` pipe (rule: pipes needing programmatic access wrap a function).
+ */
+export function formatTag(value: string): string {
+  if (!value) {
+    return '';
+  }
+
+  return value
+    .split('_')
+    .map((word) => (word === 'ai' ? 'AI' : word.charAt(0).toUpperCase() + word.slice(1)))
+    .join(' ');
+}
+
+/**
  * The author list cascades off other filters, so a kept selection can drop out of
  * the rescoped options. Re-add those as placeholders so the multiselect chip label
  * still resolves.
@@ -155,4 +181,59 @@ function mapRelevance(score: string): MentionRelevance {
     return normalized;
   }
   return 'low';
+}
+
+/** First two values joined, then `+N more`; the full list rides along for the pill tooltip. */
+function summarizePillValues(values: string[]): { summary: string; full: string } {
+  const full = values.join(', ');
+  if (values.length <= 2) {
+    return { summary: full, full };
+  }
+  return { summary: `${values.slice(0, 2).join(', ')} +${values.length - 2} more`, full };
+}
+
+/**
+ * Builds the active-filter summary pills (LFXV2-3017): one `FilterPillOption` per non-default
+ * predicate dimension, in predicate field order, so the pills row always matches the Filters
+ * button badge (`countActiveFilters`). `id` is the `FilterPredicate` key — the page maps it back
+ * to the signal it resets when a pill is clicked. `fullLabel` carries the remove affordance plus
+ * the untruncated values (the pills component surfaces it as both tooltip and aria-label).
+ */
+export function buildActiveFilterPills(predicate: FilterPredicate): FilterPillOption[] {
+  const labelFor = (options: SocialListeningOption[], value: string): string => options.find((o) => o.value === value)?.label ?? value;
+  const pill = (id: string, dimension: string, summary: string, full?: string): FilterPillOption => ({
+    id,
+    label: `${dimension}: ${summary}`,
+    fullLabel: `Remove ${dimension}: ${full ?? summary}`,
+  });
+
+  const pills: FilterPillOption[] = [];
+  if (predicate.sentiment !== DEFAULT_MENTION_PREDICATE.sentiment) {
+    pills.push(pill('sentiment', 'Sentiment', labelFor(MENTION_SENTIMENT_OPTIONS, predicate.sentiment)));
+  }
+  if (predicate.relevance !== DEFAULT_MENTION_PREDICATE.relevance) {
+    pills.push(pill('relevance', 'Relevance', labelFor(MENTION_RELEVANCE_OPTIONS, predicate.relevance)));
+  }
+  if (predicate.language !== DEFAULT_MENTION_PREDICATE.language) {
+    pills.push(pill('language', 'Language', capitalizeFirst(predicate.language)));
+  }
+  if (predicate.hasTitle !== DEFAULT_MENTION_PREDICATE.hasTitle) {
+    pills.push(pill('hasTitle', 'Has Title', labelFor(MENTION_HAS_TITLE_OPTIONS, predicate.hasTitle)));
+  }
+  if (predicate.keywords.length > 0) {
+    const { summary, full } = summarizePillValues(predicate.keywords);
+    pills.push(pill('keywords', 'Keywords', summary, full));
+  }
+  if (predicate.tags.length > 0) {
+    const { summary, full } = summarizePillValues(predicate.tags.map(formatTag));
+    pills.push(pill('tags', 'Tags', summary, full));
+  }
+  if (predicate.authors.length > 0) {
+    const { summary, full } = summarizePillValues(predicate.authors);
+    pills.push(pill('authors', 'Authors', summary, full));
+  }
+  if (predicate.search !== DEFAULT_MENTION_PREDICATE.search) {
+    pills.push(pill('search', 'Search', predicate.search));
+  }
+  return pills;
 }


### PR DESCRIPTION
## Summary

Adds the filters panel to the Social Listening mentions feed: a Filters button in the feed header opens a dropdown with sentiment, relevance, has-title, language, keyword, tag, and author filters, and the active selection is summarized as removable pills above the feed. Filter state lives in the page container and round-trips through the URL query params; the option lists are fetched lazily, so nothing fires until the user shows intent to open the panel.

Resolves LFXV2-3017

## Behavior changes

| Before | After |
|---|---|
| The mentions feed could only be narrowed by the header's project, platform, period, and search controls — there was no Filters button. | A Filters button in the feed header opens a panel with sentiment, relevance, has-title, language, keyword, tag, and author filters, and shows a badge counting the active filters. Each active filter appears as a removable pill above the feed, next to a "Clear all" action, and the author list narrows to match the other active filters. Filter option lists load only on first hover/focus/open of the panel, so page load is unaffected; selections survive in the URL for sharing and refresh. |

## Technical changes

`apps/lfx-one/src/app/modules/dashboards/social-listening/components/filters-panel/` — Filters panel (new)
- New `FiltersPanelComponent`: static sentiment / relevance / has-title selects, a scope-driven language select, and keywords / tags / authors multiselects with per-group loading skeletons
- Two-way-binds all filter state via `model()`; an internal `filtersForm` bridges the form-bound `lfx-select` / `lfx-multi-select` wrappers (form → model via `valueChanges`, model → form via `setValue(..., { emitEvent: false })` so it cannot loop) — same pattern as the feed header
- Author rows render the platform icon + mention count through the multiselect's new `itemTemplate` hook
- Selected keywords/tags that fall out of a rescoped option list are kept as extra options so the multiselect chips still resolve a label
- Owns its click-outside backdrop (writes `visible` directly, making the open state genuinely two-way); "Clear all" only emits `filtersCleared` so the panel and the pills row share a single reset path; focus moves into the panel on open via `afterNextRender`

`apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts, social-listening.component.html` — Page container
- Adds `filtersOpen` / `filtersOpenedOnce` state; the four option pipelines (languages, keywords, tags, authors) are gated on first open so they never fire on page load
- `prefetchFilterOptions()` arms the lazy fetches on hover/focus of the Filters button so the network round-trip hides behind the intent→click gap
- Language options are scoped by foundation + period; keywords/tags additionally rescope on platform/sub-project changes; authors cascade off every other filter (the request deliberately omits the current author selection) and wait for the feed load to finish plus a 300 ms debounce to avoid contending for the server's Snowflake connection pool
- `activeFilterCount` / `activeFilterPills` computeds drive the header badge and the new summary pills row; `removeFilterPill` resets one predicate dimension, `clearAllFilters` resets the whole predicate to `DEFAULT_MENTION_PREDICATE` (search included — the badge counts it)
- Renders the panel inside a `relative z-20` positioning wrapper under the feed header, on the feed tab only

`apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts, feed-header.component.html` — Feed header
- Adds the Filters button (sliders icon, `aria-pressed` bound to panel visibility, active-count badge) that toggles the panel through a two-way `filtersVisible` model and emits `filtersPrefetch` on hover/focus

`apps/lfx-one/src/app/shared/components/multi-select/multi-select.component.ts, multi-select.component.html` — Shared multi-select
- Adds an `itemTemplate` content-child hook (mirrors `lfx-select`) for option rows richer than the built-in subLabel/image layout; takes precedence over the built-in layout
- Adds `ariaLabel` and `inputId` inputs forwarded to the PrimeNG focusable input

`packages/shared/src/utils/social-listening.utils.ts, apps/lfx-one/src/app/shared/pipes/format-tag.pipe.ts` — Shared utils
- Extracts `formatTag` into `@lfx-one/shared/utils` so the `formatTag` pipe becomes a thin wrapper and non-template consumers (the filters panel's option mapping) share the transform
- Adds `buildActiveFilterPills`: one pill per non-default predicate dimension, in field order, with first-two-values + "+N more" summaries and the full list carried for the tooltip/aria-label
