### PR TITLE
fix(weekly-brief): attribute mailing-list share to the real impersonator

### DIFF
--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -340,6 +340,56 @@ describe('WeeklyBriefController', () => {
     });
   });
 
+  describe('shareBrief (LFXV2-2914 / LFXV2-3093)', () => {
+    it('rejects a missing revision', async () => {
+      const next = vi.fn();
+
+      await controller.shareBrief(buildReq({}), buildRes(), next);
+
+      expect(weeklyBriefSvc.shareBrief).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.objectContaining({ statusCode: 400 }));
+    });
+
+    it('accepts a valid body and forwards the revision to the service', async () => {
+      weeklyBriefSvc.shareBrief.mockResolvedValue({ committee_name: 'Test Committee', total_recipients: 5 });
+
+      await controller.shareBrief(buildReq({ revision: 3 }), buildRes(), vi.fn());
+
+      expect(weeklyBriefSvc.shareBrief).toHaveBeenCalledWith(expect.anything(), COMMITTEE_ID, 3);
+    });
+
+    it('checks committee read access before sharing — the service enforces the real (LFXV2-3093: real-identity) project-writer boundary', async () => {
+      weeklyBriefSvc.shareBrief.mockResolvedValue({ committee_name: 'Test Committee', total_recipients: 5 });
+
+      await controller.shareBrief(buildReq({ revision: 1 }), buildRes(), vi.fn());
+
+      expect(assertCommitteeRead).toHaveBeenCalledWith(expect.anything(), COMMITTEE_ID, 'share_weekly_brief');
+      const accessOrder = assertCommitteeRead.mock.invocationCallOrder[0];
+      const shareOrder = weeklyBriefSvc.shareBrief.mock.invocationCallOrder[0];
+      expect(accessOrder).toBeLessThan(shareOrder);
+    });
+
+    it('propagates a service error via next instead of swallowing it (e.g. 403 NOT_PROJECT_WRITER)', async () => {
+      const upstreamError = Object.assign(new Error('not a writer'), { statusCode: 403, code: 'NOT_PROJECT_WRITER' });
+      weeklyBriefSvc.shareBrief.mockRejectedValue(upstreamError);
+      const next = vi.fn();
+
+      await controller.shareBrief(buildReq({ revision: 1 }), buildRes(), next);
+
+      expect(next).toHaveBeenCalledWith(upstreamError);
+    });
+
+    it('returns the service result as JSON', async () => {
+      const result = { committee_name: 'Test Committee', total_recipients: 5 };
+      weeklyBriefSvc.shareBrief.mockResolvedValue(result);
+      const res = buildRes();
+
+      await controller.shareBrief(buildReq({ revision: 1 }), res, vi.fn());
+
+      expect(res.json).toHaveBeenCalledWith(result);
+    });
+  });
+
   describe('shareToSlack (LFXV2-3080) — request body validation', () => {
     it('rejects a missing revision', async () => {
       const next = vi.fn();

--- a/apps/lfx-one/src/server/routes/weekly-brief.route.ts
+++ b/apps/lfx-one/src/server/routes/weekly-brief.route.ts
@@ -23,14 +23,13 @@ router.post('/:committeeId/weekly-briefs/generate', (req, res, next) => weeklyBr
 router.put('/:committeeId/weekly-briefs/current', (req, res, next) => weeklyBriefController.saveBrief(req, res, next));
 
 // POST /committees/:committeeId/weekly-briefs/share - share the current brief to the committee mailing list
-// NOT currently blocked during impersonation — this is a known, pre-existing gap (predates
-// LFXV2-3080), not a considered exception: shareBrief creates a persisted newsletter draft
-// (weekly-brief.service.ts's createNewsletter call) and sends it using the caller's own bearer
-// token, which auth.middleware.ts swaps to the impersonation target's token during
-// impersonation — so an impersonated send both persists an artifact and goes out attributed to
-// the target, the same "real, hard-to-retract, externally-visible action" criterion that gates
-// share-slack below. Left as-is here rather than silently expanding this ticket's scope to
-// change existing, already-shipped behavior — tracked as a follow-up in LFXV2-3093.
+// Deliberately NOT blocked during impersonation, unlike share-slack and rating below (LFXV2-3093):
+// staff still need to be able to trigger a mailing-list share while impersonating a chair for
+// support purposes. Instead, weekly-brief.service.ts's shareBrief resolves and authorizes the
+// write boundary (the project-writer check, and the newsletter create/send/cleanup) against the
+// REAL impersonating staff member's identity/token, not the impersonated target's — so the
+// outgoing email is never sent under, or misattributed to, a user who never took the action. See
+// shareBrief's own doc comment for the full rationale.
 router.post('/:committeeId/weekly-briefs/share', (req, res, next) => weeklyBriefController.shareBrief(req, res, next));
 
 // POST /committees/:committeeId/weekly-briefs/share-slack - share the current brief to the committee's Slack channel

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -26,6 +26,11 @@ const {
   buildCacheKey,
   getCommitteeForSlackShareMock,
   checkSingleAccessStrictMock,
+  getCommitteeByIdMock,
+  hasMailingListStrictMock,
+  createNewsletterMock,
+  sendNewsletterMock,
+  deleteNewsletterMock,
 } = vi.hoisted(() => {
   const valkeyStore = new Map<string, unknown>();
   const valkeyServiceMock = {
@@ -73,6 +78,13 @@ const {
     // that touch committeeService/accessCheckService.
     getCommitteeForSlackShareMock: vi.fn(),
     checkSingleAccessStrictMock: vi.fn(),
+    // shareBrief's (LFXV2-2914 / LFXV2-3093) own committee + newsletter collaborators —
+    // controlled per-test in the 'shareBrief' describe block below.
+    getCommitteeByIdMock: vi.fn(),
+    hasMailingListStrictMock: vi.fn(),
+    createNewsletterMock: vi.fn(),
+    sendNewsletterMock: vi.fn(),
+    deleteNewsletterMock: vi.fn(),
   };
 });
 
@@ -110,17 +122,25 @@ vi.mock('./microservice-proxy.service', () => ({
 vi.mock('./logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
 }));
-// shareBrief's collaborators — shareBrief itself isn't exercised by this spec, but
-// WeeklyBriefService's constructor instantiates all three, so they must at least be
-// constructible without pulling in their own real import chains. getCommitteeForSlackShare /
-// checkSingleAccessStrict back shareToSlack's (LFXV2-3080) precondition chain — see the
-// 'shareToSlack' describe block below.
+// shareBrief's / shareToSlack's collaborators — getCommitteeForSlackShare / checkSingleAccessStrict
+// back shareToSlack's (LFXV2-3080) precondition chain (see the 'shareToSlack' describe block
+// below); getCommitteeById / hasMailingListStrict / createNewsletter / sendNewsletter /
+// deleteNewsletter back shareBrief's (LFXV2-2914 / LFXV2-3093) precondition + send chain (see the
+// 'shareBrief' describe block below).
 vi.mock('./committee.service', () => ({
   CommitteeService: class {
     public getCommitteeForSlackShare = getCommitteeForSlackShareMock;
+    public getCommitteeById = getCommitteeByIdMock;
+    public hasMailingListStrict = hasMailingListStrictMock;
   },
 }));
-vi.mock('./newsletter.service', () => ({ NewsletterService: class {} }));
+vi.mock('./newsletter.service', () => ({
+  NewsletterService: class {
+    public createNewsletter = createNewsletterMock;
+    public sendNewsletter = sendNewsletterMock;
+    public deleteNewsletter = deleteNewsletterMock;
+  },
+}));
 vi.mock('./access-check.service', () => ({
   AccessCheckService: class {
     public checkSingleAccessStrict = checkSingleAccessStrictMock;
@@ -1239,6 +1259,199 @@ describe('WeeklyBriefService', () => {
       const originalError = caught?.getLogContext()['original_error'] as string | undefined;
       expect(originalError).toContain('[redacted-url]');
       expect(originalError).not.toContain('hooks.slack.com');
+    });
+  });
+
+  describe('shareBrief (LFXV2-2914 / LFXV2-3093)', () => {
+    beforeEach(() => {
+      process.env['WEEKLY_BRIEF_BACKEND'] = 'live';
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1' });
+      hasMailingListStrictMock.mockResolvedValue(true);
+      checkSingleAccessStrictMock.mockResolvedValue(true);
+      createNewsletterMock.mockResolvedValue({ id: 'newsletter-1', version: 1 });
+      sendNewsletterMock.mockResolvedValue({ total_recipients: 42 });
+    });
+
+    /** A brief in a shareable state, queued up for the getCurrentBrief call shareBrief makes internally. */
+    function mockShareableBrief(overrides: Record<string, unknown> = {}): void {
+      proxyRequest.mockResolvedValueOnce({
+        brief: {
+          uid: 'b1',
+          state: 'generated',
+          revision: 1,
+          brief_text: 'Hello committee',
+          window_start: '2026-01-01',
+          window_end: '2026-01-07',
+          ...overrides,
+        },
+        throttle: null,
+      });
+    }
+
+    const nonImpersonatingReq = { oidc: { user: { email: 'Writer@Example.com' } }, bearerToken: 'writer-token' } as unknown as Request;
+
+    /**
+     * Impersonation session: `bearerToken` starts as the impersonation token (what
+     * auth.middleware.ts would have set), `oidc.user.email` is the real staff member's own OIDC
+     * identity, and `oidc.accessToken` is the real staff member's own (never impersonation-swapped)
+     * session token — see resolveRealAccessToken's doc comment for why this is the source of the
+     * "real" identity during impersonation.
+     */
+    function buildImpersonatingReq(opts: { realTokenExpired?: boolean; refreshedToken?: string; refreshFails?: boolean } = {}): Request {
+      const refresh = opts.refreshFails
+        ? vi.fn(async () => {
+            throw new Error('refresh failed');
+          })
+        : vi.fn(async () => ({ access_token: opts.refreshedToken ?? 'refreshed-real-token' }));
+      return {
+        appSession: {
+          impersonationToken: 'imp-token',
+          impersonationExpiresAt: Date.now() + 60_000,
+          impersonationUser: { email: 'Target@Example.com', sub: 'auth0|target' },
+        },
+        oidc: {
+          user: { email: 'Staff@Example.com' },
+          accessToken: {
+            access_token: 'real-staff-token',
+            isExpired: () => !!opts.realTokenExpired,
+            refresh,
+          },
+        },
+        bearerToken: 'imp-token',
+      } as unknown as Request;
+    }
+
+    it("non-impersonating: authorizes and sends under the caller's own token/email, unaffected by the real-identity plumbing", async () => {
+      mockShareableBrief();
+
+      const result = await service.shareBrief(nonImpersonatingReq, 'committee-1', 1);
+
+      expect(result).toEqual({ committee_name: 'Test Committee', total_recipients: 42 });
+      expect(checkSingleAccessStrictMock).toHaveBeenCalledWith(nonImpersonatingReq, { resource: 'project', id: 'project-1', access: 'writer' });
+      expect(createNewsletterMock).toHaveBeenCalledWith(
+        nonImpersonatingReq,
+        'project-1',
+        expect.objectContaining({ ed_reply_email: 'writer@example.com', committee_uids: ['committee-1'] })
+      );
+      expect(nonImpersonatingReq.bearerToken).toBe('writer-token');
+    });
+
+    it("impersonating: authorizes and sends under the REAL staff member's token/email, not the impersonated target's, and restores the impersonation token afterward", async () => {
+      mockShareableBrief();
+      const req = buildImpersonatingReq();
+
+      let tokenDuringAuthCheck: string | undefined;
+      checkSingleAccessStrictMock.mockImplementationOnce(async (r: Request) => {
+        tokenDuringAuthCheck = r.bearerToken;
+        return true;
+      });
+      let tokenDuringMailingListCheck: string | undefined;
+      hasMailingListStrictMock.mockImplementationOnce(async (r: Request) => {
+        tokenDuringMailingListCheck = r.bearerToken;
+        return true;
+      });
+      let tokenDuringCreate: string | undefined;
+      createNewsletterMock.mockImplementationOnce(async (r: Request) => {
+        tokenDuringCreate = r.bearerToken;
+        return { id: 'newsletter-1', version: 1 };
+      });
+      let tokenDuringSend: string | undefined;
+      sendNewsletterMock.mockImplementationOnce(async (r: Request) => {
+        tokenDuringSend = r.bearerToken;
+        return { total_recipients: 7 };
+      });
+
+      const result = await service.shareBrief(req, 'committee-1', 1);
+
+      expect(result).toEqual({ committee_name: 'Test Committee', total_recipients: 7 });
+      expect(tokenDuringAuthCheck).toBe('real-staff-token');
+      expect(tokenDuringCreate).toBe('real-staff-token');
+      expect(tokenDuringSend).toBe('real-staff-token');
+      // hasMailingListStrict is a precondition READ — stays on the effective/target identity
+      // (the impersonation token), not the real one, same as every other read in this method.
+      expect(tokenDuringMailingListCheck).toBe('imp-token');
+      expect(createNewsletterMock).toHaveBeenCalledWith(req, 'project-1', expect.objectContaining({ ed_reply_email: 'staff@example.com' }));
+      // Restored to the impersonation token once the write finishes, regardless of outcome.
+      expect(req.bearerToken).toBe('imp-token');
+    });
+
+    it('impersonating: refreshes an expired real access token and sends under the refreshed token', async () => {
+      mockShareableBrief();
+      const req = buildImpersonatingReq({ realTokenExpired: true, refreshedToken: 'refreshed-token' });
+
+      let tokenDuringCreate: string | undefined;
+      createNewsletterMock.mockImplementationOnce(async (r: Request) => {
+        tokenDuringCreate = r.bearerToken;
+        return { id: 'newsletter-1', version: 1 };
+      });
+
+      await service.shareBrief(req, 'committee-1', 1);
+
+      expect(tokenDuringCreate).toBe('refreshed-token');
+      expect(req.bearerToken).toBe('imp-token');
+    });
+
+    it('impersonating: the REAL user being denied project-writer access is rejected even though the impersonated target might have it — proving authorization runs against the real identity', async () => {
+      mockShareableBrief();
+      const req = buildImpersonatingReq();
+      checkSingleAccessStrictMock.mockResolvedValueOnce(false);
+
+      await expect(service.shareBrief(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 403, code: 'NOT_PROJECT_WRITER' });
+      expect(createNewsletterMock).not.toHaveBeenCalled();
+      // Token restored even on the authorization-failure path.
+      expect(req.bearerToken).toBe('imp-token');
+    });
+
+    it('impersonating: fails closed with an AuthenticationError — never falls back to the impersonation token — when the real access token cannot be resolved', async () => {
+      mockShareableBrief();
+      const req = buildImpersonatingReq({ realTokenExpired: true, refreshFails: true });
+
+      await expect(service.shareBrief(req, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 401, code: 'AUTHENTICATION_REQUIRED' });
+      expect(checkSingleAccessStrictMock).not.toHaveBeenCalled();
+      expect(createNewsletterMock).not.toHaveBeenCalled();
+      expect(req.bearerToken).toBe('imp-token');
+    });
+
+    it('impersonating: cleans up the orphaned draft on a deterministic send rejection, still under the real token, and restores the impersonation token afterward', async () => {
+      mockShareableBrief();
+      const req = buildImpersonatingReq();
+      const rejection = new MicroserviceError('Bad request', 400, 'INVALID_REQUEST', {});
+      sendNewsletterMock.mockRejectedValueOnce(rejection);
+
+      await expect(service.shareBrief(req, 'committee-1', 1)).rejects.toBe(rejection);
+
+      expect(deleteNewsletterMock).toHaveBeenCalledWith(req, 'project-1', 'newsletter-1');
+      expect(req.bearerToken).toBe('imp-token');
+    });
+
+    it('throws 404 when there is no brief to share', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: null, throttle: null });
+
+      await expect(service.shareBrief(nonImpersonatingReq, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 404 });
+      expect(checkSingleAccessStrictMock).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 REVISION_MISMATCH when the caller-supplied revision is stale', async () => {
+      mockShareableBrief({ revision: 2 });
+
+      await expect(service.shareBrief(nonImpersonatingReq, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 409, code: 'REVISION_MISMATCH' });
+      expect(checkSingleAccessStrictMock).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 NO_MAILING_LIST when the committee has no mailing list configured', async () => {
+      mockShareableBrief();
+      hasMailingListStrictMock.mockResolvedValueOnce(false);
+
+      await expect(service.shareBrief(nonImpersonatingReq, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 409, code: 'NO_MAILING_LIST' });
+      expect(createNewsletterMock).not.toHaveBeenCalled();
+    });
+
+    it('throws 409 BACKEND_NOT_LIVE when WEEKLY_BRIEF_BACKEND is not "live" — checked only after every other precondition passes', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      mockShareableBrief();
+
+      await expect(service.shareBrief(nonImpersonatingReq, 'committee-1', 1)).rejects.toMatchObject({ statusCode: 409, code: 'BACKEND_NOT_LIVE' });
+      expect(createNewsletterMock).not.toHaveBeenCalled();
     });
   });
 });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -1402,6 +1402,31 @@ describe('WeeklyBriefService', () => {
       expect(req.bearerToken).toBe('imp-token');
     });
 
+    it('impersonating: restores the impersonation token even when checkSingleAccessStrict THROWS (not just returns false) — proving the finally, not just a linear post-call restore, is what closes this window', async () => {
+      mockShareableBrief();
+      const req = buildImpersonatingReq();
+      const outage = new MicroserviceError('Access-check service unavailable', 503, 'ACCESS_CHECK_UNAVAILABLE', {});
+      checkSingleAccessStrictMock.mockRejectedValueOnce(outage);
+
+      await expect(service.shareBrief(req, 'committee-1', 1)).rejects.toBe(outage);
+
+      expect(createNewsletterMock).not.toHaveBeenCalled();
+      expect(req.bearerToken).toBe('imp-token');
+    });
+
+    it('impersonating: restores the impersonation token even when createNewsletter itself THROWS, before any send is attempted', async () => {
+      mockShareableBrief();
+      const req = buildImpersonatingReq();
+      const createFailure = new MicroserviceError('Bad request', 400, 'INVALID_REQUEST', {});
+      createNewsletterMock.mockRejectedValueOnce(createFailure);
+
+      await expect(service.shareBrief(req, 'committee-1', 1)).rejects.toBe(createFailure);
+
+      expect(sendNewsletterMock).not.toHaveBeenCalled();
+      expect(deleteNewsletterMock).not.toHaveBeenCalled();
+      expect(req.bearerToken).toBe('imp-token');
+    });
+
     it('impersonating: fails closed with an AuthenticationError — never falls back to the impersonation token — when the real access token cannot be resolved', async () => {
       mockShareableBrief();
       const req = buildImpersonatingReq({ realTokenExpired: true, refreshFails: true });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -1340,6 +1340,11 @@ describe('WeeklyBriefService', () => {
       mockShareableBrief();
       const req = buildImpersonatingReq();
 
+      let tokenDuringCommitteeFetch: string | undefined;
+      getCommitteeByIdMock.mockImplementationOnce(async (r: Request) => {
+        tokenDuringCommitteeFetch = r.bearerToken;
+        return { uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1' };
+      });
       let tokenDuringAuthCheck: string | undefined;
       checkSingleAccessStrictMock.mockImplementationOnce(async (r: Request) => {
         tokenDuringAuthCheck = r.bearerToken;
@@ -1367,8 +1372,10 @@ describe('WeeklyBriefService', () => {
       expect(tokenDuringAuthCheck).toBe('real-staff-token');
       expect(tokenDuringCreate).toBe('real-staff-token');
       expect(tokenDuringSend).toBe('real-staff-token');
-      // hasMailingListStrict is a precondition READ — stays on the effective/target identity
-      // (the impersonation token), not the real one, same as every other read in this method.
+      // getCommitteeById and hasMailingListStrict are precondition READS — stay on the
+      // effective/target identity (the impersonation token), not the real one, same as every
+      // other read in this method (brief fetch included, via mockShareableBrief's proxyRequest).
+      expect(tokenDuringCommitteeFetch).toBe('imp-token');
       expect(tokenDuringMailingListCheck).toBe('imp-token');
       expect(createNewsletterMock).toHaveBeenCalledWith(req, 'project-1', expect.objectContaining({ ed_reply_email: 'staff@example.com' }));
       // Restored to the impersonation token once the write finishes, regardless of outcome.
@@ -1442,10 +1449,20 @@ describe('WeeklyBriefService', () => {
       const req = buildImpersonatingReq();
       const rejection = new MicroserviceError('Bad request', 400, 'INVALID_REQUEST', {});
       sendNewsletterMock.mockRejectedValueOnce(rejection);
+      // `req` is a mutable object the finally-restore mutates back to 'imp-token' before this
+      // test's own assertions run — a bare `toHaveBeenCalledWith(req, ...)` check would pass
+      // regardless of what token was live AT delete-call time, since it inspects the (by-then
+      // restored) object, not a snapshot. Capture the token synchronously inside the mock instead,
+      // the same way the auth-check/create/send captures above do.
+      let tokenDuringDelete: string | undefined;
+      deleteNewsletterMock.mockImplementationOnce(async (r: Request) => {
+        tokenDuringDelete = r.bearerToken;
+      });
 
       await expect(service.shareBrief(req, 'committee-1', 1)).rejects.toBe(rejection);
 
       expect(deleteNewsletterMock).toHaveBeenCalledWith(req, 'project-1', 'newsletter-1');
+      expect(tokenDuringDelete).toBe('real-staff-token');
       expect(req.bearerToken).toBe('imp-token');
     });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -37,7 +37,7 @@ import { Request } from 'express';
 import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID } from '../constants';
 import { AuthenticationError, AuthorizationError, ConflictError, MicroserviceError, ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { isServerFeatureEnabled, ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
-import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername } from '../utils/auth-helper';
+import { getEffectiveSub, getEffectiveUsername, getRealEmail, resolveRealAccessToken } from '../utils/auth-helper';
 
 import { AccessCheckService } from './access-check.service';
 import { AiService } from './ai.service';
@@ -605,6 +605,19 @@ export class WeeklyBriefService {
    * Requires `WEEKLY_BRIEF_BACKEND=live` — throws a 409 `BACKEND_NOT_LIVE`
    * otherwise, after still enforcing the brief/writer/mailing-list
    * preconditions below (so mock-mode testing exercises the same guards).
+   *
+   * Unlike `/share-slack` and `/rating`, this is NOT blocked during impersonation
+   * (LFXV2-3093) — it stays usable so LF staff can trigger a share while
+   * impersonating a chair for support purposes. Instead, the write boundary (from
+   * the project-writer check through the newsletter create/send/cleanup below)
+   * runs under the REAL impersonating staff member's identity/token, resolved via
+   * `resolveRealAccessToken`/`getRealEmail`, not the impersonated target's — so
+   * authorization and attribution stay consistent (whoever is authorized to send
+   * is also who the send is attributed to) and the outgoing email is never sent
+   * under, or misattributed to, a user who never took the action. Preconditions
+   * above this point (brief existence/state, committee lookup, mailing-list
+   * check) stay on the effective/target identity, same as every other read in
+   * this service — impersonation still shows staff what the target sees.
    */
   public async shareBrief(req: Request, committeeId: string, expectedRevision: number): Promise<ShareWeeklyBriefResult> {
     const { brief } = await this.getCurrentBrief(req, committeeId);
@@ -627,6 +640,22 @@ export class WeeklyBriefService {
     }
 
     const committee = await this.committeeService.getCommitteeById(req, committeeId);
+
+    // Everything from here through the newsletter create/send/cleanup below is the write
+    // boundary (LFXV2-3093) — resolved and authorized against the REAL impersonating staff
+    // member's identity, not the impersonated target's. Resolved once, up front: if the real
+    // token can't be resolved (no session token, or an expired one that fails to refresh),
+    // fail closed here rather than let the writer check pass against the target and only then
+    // fail deeper into the newsletter pipeline. A no-op when not impersonating (returns
+    // req.bearerToken as-is).
+    const realToken = await resolveRealAccessToken(req);
+    if (!realToken) {
+      throw new AuthenticationError('Unable to resolve your account for this action', {
+        operation: 'share_weekly_brief',
+        service: 'weekly_brief_service',
+      });
+    }
+
     // committee.writer is a superset of what we need here — per committee.interface.ts's
     // own doc comment, it's true for both a direct committee-level grant AND an inherited
     // project writer, but the newsletter service (which this repurposes for delivery)
@@ -635,7 +664,8 @@ export class WeeklyBriefService {
     // delegated/on-behalf-of token mechanism in this codebase to bridge that gap without
     // misattributing the send (the newsletter service resolves the sender's display name
     // from the signed JWT principal; an M2M token has none). Check the actual boundary
-    // directly instead, with the caller's own bearer token.
+    // directly instead, with the REAL caller's own bearer token (LFXV2-3093) — not the
+    // impersonated target's, so authorization and attribution stay consistent.
     //
     // checkSingleAccessStrict, not checkSingleAccess — the non-strict variant degrades a
     // transient access-check outage to "no access", which would surface here as a
@@ -644,11 +674,18 @@ export class WeeklyBriefService {
     // fail-closed-to-false is an acceptable trade-off), so misattributing an outage as a
     // permission denial is worse here — same rationale as committee-access.internal.helper.ts's
     // existing use of the strict variant.
-    const isProjectWriter = await this.accessCheckService.checkSingleAccessStrict(req, {
-      resource: 'project',
-      id: committee.project_uid,
-      access: 'writer',
-    });
+    const originalTokenForAuthCheck = req.bearerToken;
+    req.bearerToken = realToken;
+    let isProjectWriter: boolean;
+    try {
+      isProjectWriter = await this.accessCheckService.checkSingleAccessStrict(req, {
+        resource: 'project',
+        id: committee.project_uid,
+        access: 'writer',
+      });
+    } finally {
+      req.bearerToken = originalTokenForAuthCheck;
+    }
     if (!isProjectWriter) {
       throw new AuthorizationError('Only project writers can share the weekly brief by email', {
         operation: 'share_weekly_brief',
@@ -660,6 +697,8 @@ export class WeeklyBriefService {
     // getCommitteeById's includeMailingListStatus would otherwise compute — a transient
     // query-service failure here must not be misreported as "no mailing list configured"
     // (409 NO_MAILING_LIST is a real, actionable precondition failure; an outage isn't).
+    // Read on the effective/target identity (req.bearerToken was restored above) — only the
+    // write below runs under the real identity.
     const hasMailingList = await this.committeeService.hasMailingListStrict(req, committeeId);
     if (!hasMailingList) {
       throw new ConflictError('Committee has no mailing list configured', 'NO_MAILING_LIST', {
@@ -684,7 +723,10 @@ export class WeeklyBriefService {
 
     const subject = `[Weekly Brief] ${committee.name} — ${formatUtcDateRangeLabel(brief.window_start, brief.window_end)}`;
     const bodyHtml = briefTextToHtml(brief.brief_text);
-    const edReplyEmail = getEffectiveEmail(req);
+    // getRealEmail, not getEffectiveEmail (LFXV2-3093) — the reply-to must be the real
+    // sender's address, never the impersonated target's, matching the real identity the
+    // newsletter is created and sent under below.
+    const edReplyEmail = getRealEmail(req);
     if (!edReplyEmail) {
       throw ServiceValidationError.forField('ed_reply_email', 'Unable to resolve your account email for the reply-to address', {
         operation: 'share_weekly_brief',
@@ -708,72 +750,80 @@ export class WeeklyBriefService {
       );
     }
 
-    // isProjectWriter (checked above) is the newsletter service's actual authorization
-    // boundary, so the caller's own bearer token is used as-is here — no token swap at
-    // this layer (see NewsletterServiceClient#sendNewsletter's doc comment). The sender's
-    // display name resolves from that token's JWT principal — which, under impersonation,
-    // is the TARGET's principal, since auth.middleware.ts has already swapped
-    // req.bearerToken to the impersonation token by the time this method runs (known
-    // pre-existing gap, tracked in LFXV2-3093; see weekly-brief.route.ts's /share comment).
-    const newsletter: Newsletter = await this.newsletterService.createNewsletter(req, committee.project_uid, {
-      subject,
-      body_html: bodyHtml,
-      ed_reply_email: edReplyEmail,
-      committee_uids: [committeeId],
-    });
-
-    let sendResult: NewsletterSendResult;
+    // The newsletter draft is created and sent under the REAL caller's own bearer token
+    // (LFXV2-3093), restored to the impersonated/effective token in the finally below
+    // regardless of outcome — matching the save/mutate/restore convention this codebase
+    // already uses for M2M tokens (e.g. meeting.controller.ts's getMyMeetingRegistrants).
+    // isProjectWriter (checked above, also against the real identity) is the newsletter
+    // service's actual authorization boundary; the sender's display name resolves from
+    // this token's JWT principal too (see NewsletterServiceClient#sendNewsletter's doc
+    // comment), so both the authorization and the visible "from" identity are the real
+    // staff member's, not the impersonated target's.
+    const originalTokenForSend = req.bearerToken;
+    req.bearerToken = realToken;
     try {
-      sendResult = await this.newsletterService.sendNewsletter(req, committee.project_uid, newsletter.id, newsletter.version);
-    } catch (error) {
-      // Only clean up on a deterministic rejection (draft validation failed,
-      // not found, etc). The send is asynchronous — a timeout or 5xx *after*
-      // upstream accepted it is indistinguishable from a real rejection here,
-      // and deleting the draft in that case would desync us from a send that
-      // actually went out. Ambiguous failures are left in place and logged.
-      const isDeterministicRejection =
-        error instanceof MicroserviceError && error.statusCode >= 400 && error.statusCode < 500 && ![408, 409, 429].includes(error.statusCode);
-      if (isDeterministicRejection) {
-        try {
-          await this.newsletterService.deleteNewsletter(req, committee.project_uid, newsletter.id);
-        } catch (cleanupError) {
-          logger.warning(req, 'share_weekly_brief_cleanup_failed', 'Failed to delete orphaned draft newsletter after a failed send', {
-            committee_id: committeeId,
-            newsletter_id: newsletter.id,
-            error: cleanupError instanceof Error ? cleanupError.message : 'Unknown error',
-          });
-        }
-      } else {
-        // The original error is rethrown below and logged centrally by
-        // apiErrorHandler — no need to duplicate its message here, just the
-        // newsletter_id so an operator can find the orphaned draft.
-        logger.warning(
-          req,
-          'share_weekly_brief_ambiguous_send_failure',
-          'Send failed ambiguously (may have been accepted upstream) — leaving draft newsletter in place for manual review',
-          {
-            committee_id: committeeId,
-            newsletter_id: newsletter.id,
+      const newsletter: Newsletter = await this.newsletterService.createNewsletter(req, committee.project_uid, {
+        subject,
+        body_html: bodyHtml,
+        ed_reply_email: edReplyEmail,
+        committee_uids: [committeeId],
+      });
+
+      let sendResult: NewsletterSendResult;
+      try {
+        sendResult = await this.newsletterService.sendNewsletter(req, committee.project_uid, newsletter.id, newsletter.version);
+      } catch (error) {
+        // Only clean up on a deterministic rejection (draft validation failed,
+        // not found, etc). The send is asynchronous — a timeout or 5xx *after*
+        // upstream accepted it is indistinguishable from a real rejection here,
+        // and deleting the draft in that case would desync us from a send that
+        // actually went out. Ambiguous failures are left in place and logged.
+        const isDeterministicRejection =
+          error instanceof MicroserviceError && error.statusCode >= 400 && error.statusCode < 500 && ![408, 409, 429].includes(error.statusCode);
+        if (isDeterministicRejection) {
+          try {
+            await this.newsletterService.deleteNewsletter(req, committee.project_uid, newsletter.id);
+          } catch (cleanupError) {
+            logger.warning(req, 'share_weekly_brief_cleanup_failed', 'Failed to delete orphaned draft newsletter after a failed send', {
+              committee_id: committeeId,
+              newsletter_id: newsletter.id,
+              error: cleanupError instanceof Error ? cleanupError.message : 'Unknown error',
+            });
           }
-        );
+        } else {
+          // The original error is rethrown below and logged centrally by
+          // apiErrorHandler — no need to duplicate its message here, just the
+          // newsletter_id so an operator can find the orphaned draft.
+          logger.warning(
+            req,
+            'share_weekly_brief_ambiguous_send_failure',
+            'Send failed ambiguously (may have been accepted upstream) — leaving draft newsletter in place for manual review',
+            {
+              committee_id: committeeId,
+              newsletter_id: newsletter.id,
+            }
+          );
+        }
+        throw error;
       }
-      throw error;
+
+      // The newsletter API only accepts/queues the send here; upstream fan-out
+      // runs asynchronously in a detached job and can still fail completely
+      // afterward. Log as queued, not sent — an operator reading this event
+      // should not treat it as a delivery confirmation.
+      logger.info(req, 'share_weekly_brief_queued', 'Weekly brief queued for delivery via newsletter send pipeline', {
+        committee_id: committeeId,
+        newsletter_id: newsletter.id,
+        total_recipients: sendResult.total_recipients,
+      });
+
+      return {
+        committee_name: committee.name,
+        total_recipients: sendResult.total_recipients,
+      };
+    } finally {
+      req.bearerToken = originalTokenForSend;
     }
-
-    // The newsletter API only accepts/queues the send here; upstream fan-out
-    // runs asynchronously in a detached job and can still fail completely
-    // afterward. Log as queued, not sent — an operator reading this event
-    // should not treat it as a delivery confirmation.
-    logger.info(req, 'share_weekly_brief_queued', 'Weekly brief queued for delivery via newsletter send pipeline', {
-      committee_id: committeeId,
-      newsletter_id: newsletter.id,
-      total_recipients: sendResult.total_recipients,
-    });
-
-    return {
-      committee_name: committee.name,
-      total_recipients: sendResult.total_recipients,
-    };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -752,8 +752,10 @@ export class WeeklyBriefService {
 
     // The newsletter draft is created and sent under the REAL caller's own bearer token
     // (LFXV2-3093), restored to the impersonated/effective token in the finally below
-    // regardless of outcome — matching the save/mutate/restore convention this codebase
-    // already uses for M2M tokens (e.g. meeting.controller.ts's getMyMeetingRegistrants).
+    // regardless of outcome — the same save/mutate/restore shape this codebase already uses
+    // for M2M tokens (e.g. meeting.controller.ts's getMyMeetingRegistrants), but with
+    // try/finally rather than that precedent's linear post-call restore, so the token is
+    // restored even if one of the awaited calls below throws, not just on the happy path.
     // isProjectWriter (checked above, also against the real identity) is the newsletter
     // service's actual authorization boundary; the sender's display name resolves from
     // this token's JWT principal too (see NewsletterServiceClient#sendNewsletter's doc

--- a/apps/lfx-one/src/server/utils/auth-helper.spec.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.spec.ts
@@ -4,7 +4,7 @@
 import type { Request } from 'express';
 import { describe, expect, it } from 'vitest';
 
-import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername, resolveAuditUserDisplayName } from './auth-helper';
+import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername, getRealEmail, resolveAuditUserDisplayName, resolveRealAccessToken } from './auth-helper';
 
 interface TargetUser {
   email?: string;
@@ -73,6 +73,90 @@ describe('getEffectiveSub', () => {
   it('returns the OIDC sub when not impersonating', () => {
     const req = buildReq({ oidc: { sub: 'auth0|user' } });
     expect(getEffectiveSub(req)).toBe('auth0|user');
+  });
+});
+
+describe('getRealEmail', () => {
+  it('returns the OPERATOR OIDC email lowercased when impersonating — never the target', () => {
+    const req = buildReq({ impersonating: true, target: { email: 'target@example.com' }, oidc: OPERATOR_OIDC });
+    expect(getRealEmail(req)).toBe('operator@example.com');
+  });
+
+  it('returns the OIDC email lowercased when not impersonating', () => {
+    const req = buildReq({ oidc: { email: 'User@Example.com' } });
+    expect(getRealEmail(req)).toBe('user@example.com');
+  });
+
+  it('returns null when there is no OIDC email', () => {
+    const req = buildReq({});
+    expect(getRealEmail(req)).toBeNull();
+  });
+});
+
+describe('resolveRealAccessToken', () => {
+  interface FakeAccessToken {
+    access_token?: string;
+    isExpired: () => boolean;
+    refresh: () => Promise<{ access_token?: string } | undefined>;
+  }
+
+  // Separate fixture from buildReq: these tests need `bearerToken` and `oidc.accessToken`
+  // (isExpired/refresh), which the getEffective*/getRealEmail fixture above has no use for.
+  function buildTokenReq(opts: { impersonating?: boolean; bearerToken?: string; accessToken?: FakeAccessToken }): Request {
+    const appSession = opts.impersonating ? { impersonationToken: 'imp-token', impersonationExpiresAt: Date.now() + 60_000, impersonationUser: {} } : {};
+    return {
+      appSession,
+      bearerToken: opts.bearerToken,
+      oidc: { accessToken: opts.accessToken },
+    } as unknown as Request;
+  }
+
+  it('returns req.bearerToken as-is when not impersonating (no-op)', async () => {
+    const req = buildTokenReq({ bearerToken: 'user-token' });
+    await expect(resolveRealAccessToken(req)).resolves.toBe('user-token');
+  });
+
+  it('returns null when not impersonating and there is no bearer token', async () => {
+    const req = buildTokenReq({});
+    await expect(resolveRealAccessToken(req)).resolves.toBeNull();
+  });
+
+  it('returns the real (operator) access token when impersonating and it is not expired', async () => {
+    const req = buildTokenReq({
+      impersonating: true,
+      bearerToken: 'imp-token',
+      accessToken: { access_token: 'real-token', isExpired: () => false, refresh: async () => undefined },
+    });
+    await expect(resolveRealAccessToken(req)).resolves.toBe('real-token');
+  });
+
+  it('refreshes and returns the new token when impersonating and the real token is expired', async () => {
+    const req = buildTokenReq({
+      impersonating: true,
+      bearerToken: 'imp-token',
+      accessToken: { access_token: 'stale-token', isExpired: () => true, refresh: async () => ({ access_token: 'refreshed-token' }) },
+    });
+    await expect(resolveRealAccessToken(req)).resolves.toBe('refreshed-token');
+  });
+
+  it('returns null (fails closed) when impersonating and the refresh attempt throws', async () => {
+    const req = buildTokenReq({
+      impersonating: true,
+      bearerToken: 'imp-token',
+      accessToken: {
+        access_token: 'stale-token',
+        isExpired: () => true,
+        refresh: async () => {
+          throw new Error('refresh failed');
+        },
+      },
+    });
+    await expect(resolveRealAccessToken(req)).resolves.toBeNull();
+  });
+
+  it('returns null (fails closed) when impersonating and there is no real session access token at all', async () => {
+    const req = buildTokenReq({ impersonating: true, bearerToken: 'imp-token', accessToken: undefined });
+    await expect(resolveRealAccessToken(req)).resolves.toBeNull();
   });
 });
 

--- a/apps/lfx-one/src/server/utils/auth-helper.spec.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.spec.ts
@@ -102,8 +102,24 @@ describe('resolveRealAccessToken', () => {
 
   // Separate fixture from buildReq: these tests need `bearerToken` and `oidc.accessToken`
   // (isExpired/refresh), which the getEffective*/getRealEmail fixture above has no use for.
-  function buildTokenReq(opts: { impersonating?: boolean; bearerToken?: string; accessToken?: FakeAccessToken }): Request {
-    const appSession = opts.impersonating ? { impersonationToken: 'imp-token', impersonationExpiresAt: Date.now() + 60_000, impersonationUser: {} } : {};
+  // `impersonationSessionExpired` models the race window this function must not fail open on:
+  // an impersonation token still stored in the session (so req.bearerToken was set from it by
+  // auth.middleware.ts earlier in the request), but impersonationExpiresAt has since elapsed —
+  // i.e. isImpersonating(req) would now report false even though req.bearerToken is stale.
+  function buildTokenReq(opts: {
+    impersonating?: boolean;
+    impersonationSessionExpired?: boolean;
+    bearerToken?: string;
+    accessToken?: FakeAccessToken;
+  }): Request {
+    const appSession =
+      opts.impersonating || opts.impersonationSessionExpired
+        ? {
+            impersonationToken: 'imp-token',
+            impersonationExpiresAt: opts.impersonationSessionExpired ? Date.now() - 1000 : Date.now() + 60_000,
+            impersonationUser: {},
+          }
+        : {};
     return {
       appSession,
       bearerToken: opts.bearerToken,
@@ -157,6 +173,26 @@ describe('resolveRealAccessToken', () => {
   it('returns null (fails closed) when impersonating and there is no real session access token at all', async () => {
     const req = buildTokenReq({ impersonating: true, bearerToken: 'imp-token', accessToken: undefined });
     await expect(resolveRealAccessToken(req)).resolves.toBeNull();
+  });
+
+  it('does NOT fail open to the stale impersonation token when impersonationExpiresAt elapses mid-request (LFXV2-3093 race window) — resolves the real token instead', async () => {
+    // req.bearerToken is still the impersonation token here (set once by auth.middleware.ts
+    // earlier in the request) even though the session's impersonationExpiresAt has now passed —
+    // isImpersonating(req) would report false in this state, but the stored impersonationToken
+    // is still present, so this must NOT trust req.bearerToken as the real token.
+    const req = buildTokenReq({
+      impersonationSessionExpired: true,
+      bearerToken: 'imp-token',
+      accessToken: { access_token: 'real-token', isExpired: () => false, refresh: async () => undefined },
+    });
+    await expect(resolveRealAccessToken(req)).resolves.toBe('real-token');
+  });
+
+  it('fails closed (never the stale impersonation token) in the same expired-session race window when the real token cannot be resolved', async () => {
+    const req = buildTokenReq({ impersonationSessionExpired: true, bearerToken: 'imp-token', accessToken: undefined });
+    const result = await resolveRealAccessToken(req);
+    expect(result).not.toBe('imp-token');
+    expect(result).toBeNull();
   });
 });
 

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -83,6 +83,21 @@ export function getEffectiveEmail(req: Request): string | null {
 }
 
 /**
+ * Gets the REAL (impersonator's own) email, deliberately ignoring impersonation state — the one
+ * identity getter in this file that does NOT resolve to the impersonation target. `req.oidc.user`
+ * is always the actual authenticated user's OIDC session, impersonation or not (impersonation is
+ * layered on top via `req.appSession`, never by replacing `req.oidc.user`), so this is just
+ * `getEffectiveEmail`'s non-impersonating branch, unconditionally.
+ *
+ * Use this only where the real actor's identity — not the target's — must be attributed for a
+ * genuinely externally-visible, hard-to-retract action (e.g. weekly-brief mailing-list share,
+ * LFXV2-3093). Most callers want `getEffectiveEmail` instead.
+ */
+export function getRealEmail(req: Request): string | null {
+  return (req.oidc?.user?.['email'] as string)?.toLowerCase() || null;
+}
+
+/**
  * Gets the effective username for the current request context.
  * During impersonation, returns the target user's username from the impersonation session,
  * or null when the target has no stored username — it never falls back to the impersonator's
@@ -144,6 +159,42 @@ export function isImpersonating(req: Request): boolean {
   const token = req.appSession?.['impersonationToken'];
   const expiresAt = req.appSession?.['impersonationExpiresAt'];
   return typeof token === 'string' && !!token && typeof expiresAt === 'number' && Date.now() < expiresAt && !!req.appSession?.['impersonationUser'];
+}
+
+/**
+ * Resolves the REAL (impersonator's own) bearer token, even while impersonating — for the same
+ * narrow class of caller as `getRealEmail` (a write that must be authorized and attributed to the
+ * actual actor, not the impersonation target).
+ *
+ * `req.bearerToken` is swapped to the impersonation token by `auth.middleware.ts` during
+ * impersonation, but `req.oidc.accessToken` is never touched by that swap — it always reflects the
+ * real user's own OIDC session. The catch: `auth.middleware.ts`'s normal refresh-if-expired logic
+ * short-circuits before it runs whenever an impersonation token is active, so `req.oidc.accessToken`
+ * can legitimately be expired by the time this is called on a long-lived impersonation session
+ * (impersonation tokens can live up to ~24h; ordinary access tokens are typically shorter-lived).
+ * This refreshes it itself when needed, mirroring `extractBearerToken`'s own refresh step.
+ *
+ * Returns null when there is no real session token to resolve, or the refresh attempt fails —
+ * callers MUST treat null as "cannot safely attribute this action" and fail closed, never falling
+ * back to the impersonation token.
+ */
+export async function resolveRealAccessToken(req: Request): Promise<string | null> {
+  if (!isImpersonating(req)) {
+    return req.bearerToken ?? null;
+  }
+  const accessToken = req.oidc?.accessToken;
+  if (!accessToken) {
+    return null;
+  }
+  if (!accessToken.isExpired()) {
+    return accessToken.access_token ?? null;
+  }
+  try {
+    const refreshed = await accessToken.refresh();
+    return refreshed?.access_token ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**

--- a/apps/lfx-one/src/server/utils/auth-helper.ts
+++ b/apps/lfx-one/src/server/utils/auth-helper.ts
@@ -177,9 +177,21 @@ export function isImpersonating(req: Request): boolean {
  * Returns null when there is no real session token to resolve, or the refresh attempt fails —
  * callers MUST treat null as "cannot safely attribute this action" and fail closed, never falling
  * back to the impersonation token.
+ *
+ * Deliberately NOT gated on `isImpersonating(req)` — that's a live, time-gated check re-evaluated
+ * on every call, but `req.bearerToken` was set ONCE by `extractBearerToken` at the START of the
+ * request. If impersonation was active when the middleware ran (setting `req.bearerToken` to the
+ * impersonation token) but `impersonationExpiresAt` elapses before this runs later in the same
+ * request — plausible for a caller like `shareBrief`, which awaits several upstream calls first —
+ * `isImpersonating(req)` flips to false while `req.bearerToken` is still the STALE impersonation
+ * token. Gating on it here would return that impersonation token as if it were the real one,
+ * reintroducing the exact LFXV2-3093 misattribution in a narrow race window. Gated instead on the
+ * mere presence of a stored impersonation token — a time-independent signal that `req.bearerToken`
+ * might not be the real token, regardless of whether that token has since expired.
  */
 export async function resolveRealAccessToken(req: Request): Promise<string | null> {
-  if (!isImpersonating(req)) {
+  const hadImpersonationToken = typeof req.appSession?.['impersonationToken'] === 'string' && !!req.appSession['impersonationToken'];
+  if (!hadImpersonationToken) {
     return req.bearerToken ?? null;
   }
   const accessToken = req.oidc?.accessToken;

--- a/docs/architecture/backend/authentication.md
+++ b/docs/architecture/backend/authentication.md
@@ -141,6 +141,8 @@ Prefer the impersonation-aware helpers in `apps/lfx-one/src/server/utils/auth-he
 | `getEffectiveSub(req)`      | Impersonated sub or OIDC sub                                       | **`@deprecated`** for identity references generally — no upstream requires the prefixed `sub` — but still the right choice for indefinitely-retained server log metadata, where `username` would put readable PII in the log stream |
 | `getEffectiveEmail(req)`    | Impersonated email or OIDC email (lowercased)                      | For email-keyed lookups                                                                                                                                                                                                             |
 
+For the deliberate opposite case — resolving the REAL impersonator's identity/token for a write that must be attributed to the actual actor rather than the impersonation target — see [`getRealEmail`/`resolveRealAccessToken` in `impersonation.md`](./impersonation.md#5-identity-helpers) (LFXV2-3093).
+
 ### Migration: `sub` → `username`
 
 Backend identity references have migrated from the Auth0 `sub` to the LFID `username`. In this repo:

--- a/docs/architecture/backend/impersonation.md
+++ b/docs/architecture/backend/impersonation.md
@@ -171,6 +171,15 @@ For the full `username` vs `sub` distinction and the `sub` → `username` migrat
 
 These check `req.appSession['impersonationUser']` first, falling back to `req.oidc.user`. `isImpersonating(req)` (active-session predicate) rounds out the set. All controllers/services that filter by user identity use these helpers (meetings, events, committees, votes, surveys, mailing lists, documents, analytics, badges, persona detection).
 
+**Real (non-effective) identity — the deliberate exception (LFXV2-3093):** two helpers do the opposite of the `getEffective*` family — they resolve the real impersonator's own identity, ignoring impersonation state entirely:
+
+| Helper                        | Returns                                                                                | Notes                                                                                                                                                                                                                                                                                                                     |
+| ----------------------------- | -------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `getRealEmail(req)`           | The real user's OIDC email (lowercased), never the impersonation target's              | Use only where the actual actor — not the target — must be attributed for an externally-visible, hard-to-retract action                                                                                                                                                                                                   |
+| `resolveRealAccessToken(req)` | `Promise<string \| null>` — the real user's own bearer token, even while impersonating | Reads `req.oidc.accessToken` directly (never touched by the impersonation-token swap), refreshing it if expired since `extractBearerToken`'s own refresh step is skipped whenever impersonation is active; returns `null` (fail closed) if it can't be resolved — callers must never fall back to the impersonation token |
+
+The only current caller is `WeeklyBriefService.shareBrief()`'s mailing-list send — see Limitation 2 below.
+
 **Profile & account settings — read-only during impersonation (LFXV2-2572):** The profile controller's **read** endpoints resolve identity through the effective helpers, so Profile pages and Account Settings show the _target_ user's data:
 
 - `GET /api/profile`, `GET /api/profile/emails`, `GET /api/profile/linux-email` use `getEffectiveSub` / `getEffectiveEmail` / `getEffectiveUsername`.
@@ -275,7 +284,7 @@ impersonation_stopped: Impersonation session ended
 
 1. **Profile viewing is impersonated but read-only (LFXV2-2572)** — Profile pages and Account Settings show the _target_ user's data during impersonation (including CDP work history/identities and the target's individual-enrollment + Linux.com add-on status, fetched with the target's bearer token). All profile writes are blocked (`403 IMPERSONATION_READ_ONLY`), the developer API token is suppressed, and CDP writes (including the `getIdentities` reconciliation create) are suppressed. Edit affordances render visible-but-disabled; editing would act on the real user's account, so it is disabled rather than allowed. The Linux.com forward target is the one datum that can't be shown (needs the impersonator's Flow-C token).
 
-2. **Write operations use the target's identity** — creating meetings, committees, or votes while impersonating will attribute them to the target user (via the bearer token). The `created_by_name` field on committees is an exception (uses the real user's name).
+2. **Write operations use the target's identity** — creating meetings, committees, or votes while impersonating will attribute them to the target user (via the bearer token). The `created_by_name` field on committees is an exception (uses the real user's name), as is the weekly-brief mailing-list share (LFXV2-3093): `WeeklyBriefService.shareBrief()` authorizes and sends under the real impersonator's identity/token (`resolveRealAccessToken`/`getRealEmail`), not the target's, because it creates a real, persisted, hard-to-retract external send — see that method's doc comment for the full rationale.
 
 3. **Local dev (Authelia) not supported** — CTE is an Auth0-specific feature. Impersonation won't work with the Authelia dev auth provider.
 


### PR DESCRIPTION
## Summary

Fixes [LFXV2-3093](https://linuxfoundation.atlassian.net/browse/LFXV2-3093): during impersonation, `WeeklyBriefService.shareBrief()` (the "Share to Mailing List" action on the Weekly Brief card) authorized and sent under the **impersonated target's** identity/token, not the real impersonating LF staff member's — unlike `/share-slack` and `/rating`, which are already blocked outright during impersonation via `blockDuringImpersonation`.

`shareBrief` creates a persisted newsletter draft before sending, so this was a real, externally-visible, hard-to-retract action (an email to an entire committee mailing list) that could be triggered while impersonating and misattributed to the target with no trace back to the actual staff member.

## Decision (discussed in Plan Mode before implementation, not assumed)

The ticket asked for one of two explicit options to be chosen and documented:

1. **Block outright** during impersonation, matching `/share-slack`'s precedent — simplest, but would break the support workflow of sharing a brief while impersonating a chair.
2. **Allow, but attribute to the real impersonator** — keep the action usable during impersonation, but resolve authorization and the outgoing identity from the real staff member instead of the target.

**Option 2 was chosen**, plus a follow-on sub-decision: the project-writer *authorization* check was also moved to the real identity (not left on the target's), for full consistency between "who is authorized" and "who the send is attributed to" — rather than authorizing against one identity while sending as another.

### Implementation

- Two new helpers in `auth-helper.ts`: `getRealEmail(req)` (always the real OIDC email, never the impersonation target's) and `resolveRealAccessToken(req)` (the real user's own bearer token even while impersonating — reads `req.oidc.accessToken` directly, since it's never touched by the impersonation-token swap in `auth.middleware.ts`, refreshing it if expired since that middleware's own refresh path is skipped whenever impersonation is active).
- `shareBrief()`: from the project-writer check through the newsletter create/send/cleanup, `req.bearerToken` is temporarily swapped to the real token (save/mutate/restore via `try/finally`, restored on every exit path including thrown errors) and `getRealEmail` replaces `getEffectiveEmail` for the reply-to address. Precondition reads (brief fetch, committee fetch, mailing-list check) stay on the effective/target identity, unchanged — impersonation still shows staff what the target sees for reads.
- Fails closed (`AuthenticationError`, never falls back to the impersonation token) if the real token can't be resolved.
- Two architecture docs (`docs/architecture/backend/impersonation.md`, `authentication.md`) updated so the new real-identity exception is documented alongside the existing `getEffective*` family rather than going stale.

## Review

Reviewed with three independent passes (correctness/security, repo-convention audit, and a full cross-commit sweep) — no critical or important findings. Minor findings addressed in the second commit: a comment that overclaimed exact parity with an existing (less-safe) M2M token save/restore precedent elsewhere in the codebase, two added tests exercising the token-restore-on-thrown-error path directly, and the doc updates above.

## Test plan

- [x] `yarn lint && yarn format && yarn test && yarn build` all pass
- [x] New/updated unit tests cover: non-impersonating baseline, impersonating (real token used for auth+send, effective token used for reads, restored afterward), expired-real-token refresh, real user denied project-writer access even when the target would pass, fail-closed on unresolvable real token, cleanup-on-rejection still under the real token, and token restoration on thrown errors (not just returned-false/rejected-later)
- [ ] Manual verification not performed — this is a real, hard-to-retract mailing-list send, so it wasn't exercised live against prod data; relying on unit test coverage + review instead

[LFXV2-3093]: https://linuxfoundation.atlassian.net/browse/LFXV2-3093?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ