### PR TITLE
fix(ui): show create quick-link button on mobile

### DIFF
--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -278,7 +278,9 @@ test.describe('Create Quick-Link — search-fallback for an inherited-writer (LF
 // popover (data-testid="create-menu-mobile") — see LFXV2-3248. The regression this suite guards
 // (lens-switcher.component.scss's rail-anchoring CSS) is gated at the `lg` breakpoint (1024px,
 // matching tailwind.config.js), so the skip boundary matches that rather than `md` (768px) —
-// a viewport in [768, 1024) would still get the desktop-anchored popover CSS applied.
+// a viewport in [768, 1024) still renders the mobile drawer (the app's own responsive split is
+// keyed on `lg`, not `md`), so gating the skip at `md` would incorrectly treat that range as
+// desktop and skip M1 even though the regression this test guards still applies there.
 function skipOnDesktopViewport(page: Page): void {
   const viewport = page.viewportSize();
   if (viewport && viewport.width >= 1024) {
@@ -325,7 +327,15 @@ test.describe('Create Quick-Link — mobile trigger (LFXV2-3248)', () => {
     // button.component.ts does for `aria-pressed`), but adding that is a production-template
     // change out of scope for this test-only commit. The class this test already relies on to
     // scope the SCSS override is the stable hook available today.
-    const panel = page.locator('.p-popover.lfx-create-popover');
+    //
+    // `.filter({ visible: true })`: `lfx-lens-switcher` mounts twice at once (desktop rail +
+    // mobile drawer instances in main-layout.component.html), each with its own `.p-popover
+    // .lfx-create-popover` panel. This only resolves to one element today because PrimeNG lazily
+    // creates the panel DOM on first `show()`/`toggle()` — the never-toggled desktop instance's
+    // panel isn't in the DOM during this test. The visibility filter hardens that assumption so a
+    // future PrimeNG version with eager panel creation fails on the real regression instead of a
+    // Playwright strict-mode "resolved to 2 elements" error.
+    const panel = page.locator('.p-popover.lfx-create-popover').filter({ visible: true });
     const menuPosition = await panel.evaluate((el) => getComputedStyle(el).position);
     // PrimeNG's own anchor-relative default sets `position: absolute`; the regressed (rail-pinned)
     // state is `position: fixed`. Assert the specific expected value, not just an exclusion, so an

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -265,3 +265,46 @@ test.describe('Create Quick-Link — search-fallback for an inherited-writer (LF
     await expect(continueButton(page)).toBeEnabled();
   });
 });
+
+// The mobile drawer's own Create trigger is a separate element from the desktop rail button
+// (data-testid="create-rail-button-mobile"), opening a distinctly-testid'd copy of the same
+// popover (data-testid="create-menu-mobile") — see LFXV2-3248. Desktop projects (chromium,
+// firefox) never render the mobile drawer content behind a viewport this wide, so this suite
+// only runs on the narrow (mobile-chrome) project.
+function skipOnDesktopViewport(page: Page): void {
+  const viewport = page.viewportSize();
+  if (viewport && viewport.width >= 768) {
+    test.skip(true, 'Mobile-only trigger — desktop uses create-rail-button in the vertical rail');
+  }
+}
+
+test.describe('Create Quick-Link — mobile trigger (LFXV2-3248)', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto(APP_HOME, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    skipOnDesktopViewport(page);
+  });
+
+  // M1 — the mobile drawer's own Create button renders and opens its own popover instance
+  test('M1: the mobile "Create" button opens the artifact-type popover from the drawer', async ({ page }) => {
+    await page.getByTestId('mobile-menu-button').click();
+
+    const trigger = page.getByTestId('create-rail-button-mobile');
+    await expect(trigger).toBeVisible({ timeout: RAIL_TIMEOUT });
+    await trigger.click();
+
+    const menu = page.getByTestId('create-menu-mobile');
+    await expect(menu).toBeVisible({ timeout: 5_000 });
+    await expect(page.getByTestId('create-menu-mobile-option-meeting')).toBeVisible();
+
+    // Popover must actually open near the tapped button, not pinned at the desktop rail's fixed
+    // coordinates (left:56px/top:58px) — regression guard for the rail-anchoring CSS scoped to
+    // the `lg` breakpoint.
+    const [menuBox, triggerBox] = await Promise.all([menu.boundingBox(), trigger.boundingBox()]);
+    expect(menuBox).not.toBeNull();
+    expect(triggerBox).not.toBeNull();
+    if (menuBox && triggerBox) {
+      expect(Math.abs(menuBox.y - triggerBox.y)).toBeLessThan(150);
+    }
+  });
+});

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -319,6 +319,11 @@ test.describe('Create Quick-Link — mobile trigger (LFXV2-3248)', () => {
     // default `static` regardless of the outer panel's state, making the assertion a no-op. The
     // rail-anchoring rule (and PrimeNG's own base stylesheet) target the outer panel element,
     // identified here by its unique `lfx-create-popover` class.
+    //
+    // Deliberate exception to data-testid-first selection: PrimeNG's `p-popover` panel is
+    // CDK-portaled to `body` and exposes only `styleClass` as an extension point (no testid
+    // passthrough), so the class this test already relies on to scope the SCSS override is also
+    // the only stable hook available here.
     const panel = page.locator('.p-popover.lfx-create-popover');
     const menuPosition = await panel.evaluate((el) => getComputedStyle(el).position);
     // PrimeNG's own anchor-relative default sets `position: absolute`; the regressed (rail-pinned)

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -305,17 +305,17 @@ test.describe('Create Quick-Link — mobile trigger (LFXV2-3248)', () => {
     await expect(menu).toBeVisible({ timeout: 5_000 });
     await expect(page.getByTestId('create-menu-mobile-option-meeting')).toBeVisible();
 
-    // Popover must actually open near the tapped button, not pinned at the desktop rail's fixed
-    // coordinates (left:56px/top:58px) — regression guard for the rail-anchoring CSS scoped to
-    // the `lg` breakpoint. Check X, not Y: the mobile trigger sits in a right-aligned (`ml-auto`)
-    // icon group, far from the rail's x=56, while the rail's fixed top:58px happens to land close
-    // to the mobile trigger's real Y position too — so a Y-only check would likely still pass even
-    // if the `@media (min-width: 1024px)` scoping regressed. X actually distinguishes the two.
-    const [menuBox, triggerBox] = await Promise.all([menu.boundingBox(), trigger.boundingBox()]);
-    expect(menuBox).not.toBeNull();
-    expect(triggerBox).not.toBeNull();
-    if (menuBox && triggerBox) {
-      expect(Math.abs(menuBox.x - triggerBox.x)).toBeLessThan(150);
-    }
+    // Regression guard for the rail-anchoring CSS scoped to the `lg` breakpoint
+    // (lens-switcher.component.scss): assert the computed style directly rather than a pixel-
+    // distance heuristic. A bounding-box comparison against the trigger was tried first, but on
+    // the real Pixel 5 layout the mobile trigger's measured x (~115px, confirmed via a live
+    // authenticated session) sits close enough to the rail's fixed x=56 that any tolerance loose
+    // enough to avoid flaking on icon-group width (canImpersonate() adds/removes an icon,
+    // shifting the trailing `ml-auto` group) would also pass while the bug is present. Asserting
+    // `position` directly targets exactly what the `@media (min-width: 1024px)` scoping controls:
+    // PrimeNG's own anchor-relative default sets `position: absolute`; the regressed (rail-pinned)
+    // state is `position: fixed`.
+    const menuPosition = await menu.evaluate((el) => getComputedStyle(el).position);
+    expect(menuPosition).not.toBe('fixed');
   });
 });

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -320,10 +320,11 @@ test.describe('Create Quick-Link — mobile trigger (LFXV2-3248)', () => {
     // rail-anchoring rule (and PrimeNG's own base stylesheet) target the outer panel element,
     // identified here by its unique `lfx-create-popover` class.
     //
-    // Deliberate exception to data-testid-first selection: PrimeNG's `p-popover` panel is
-    // CDK-portaled to `body` and exposes only `styleClass` as an extension point (no testid
-    // passthrough), so the class this test already relies on to scope the SCSS override is also
-    // the only stable hook available here.
+    // Deliberate exception to data-testid-first selection: `<p-popover>` doesn't currently wire a
+    // data-testid onto its panel root — it could via PrimeNG's `pt.root` passthrough (as
+    // button.component.ts does for `aria-pressed`), but adding that is a production-template
+    // change out of scope for this test-only commit. The class this test already relies on to
+    // scope the SCSS override is the stable hook available today.
     const panel = page.locator('.p-popover.lfx-create-popover');
     const menuPosition = await panel.evaluate((el) => getComputedStyle(el).position);
     // PrimeNG's own anchor-relative default sets `position: absolute`; the regressed (rail-pinned)

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -38,6 +38,11 @@
  *       empty-tree/search-reachable bucket, since that shape isn't guaranteed by a single real
  *       account — but when it is, this exercises the path directly rather than only asserting
  *       picker shape.
+ * - M1: (separate describe block, `mobile-chrome` project only — see `skipOnDesktopViewport`)
+ *       LFXV2-3248: the mobile drawer's own Create trigger (`create-rail-button-mobile`) opens a
+ *       distinctly-testid'd popover (`create-menu-mobile`) anchored near the tapped button, not
+ *       pinned at the desktop rail's fixed coordinates — regression guard for the `lg`-scoped
+ *       rail-anchoring CSS in `lens-switcher.component.scss`.
  *
  * What this suite does NOT attempt: a deterministic "committee target selectable for meeting but
  * not newsletter" scenario. That requires a fixture user with a specific, known grant shape
@@ -53,6 +58,8 @@
  *   committee for S1-S8 to run past `beforeEach`; otherwise they skip (see
  *   `skipWhenNoCreatePermission`). S9 lives in its own describe block with a lighter beforeEach
  *   and self-skips independently — see its inline comment.
+ * - M1 only runs under the `mobile-chrome` Playwright project (viewport width < 1024px); it
+ *   self-skips on `chromium`/`firefox` via `skipOnDesktopViewport`.
  *
  * Note: this suite stops at the dialog boundary. It does not assert the post-Continue
  * create page — that path is enforced by each route's writerGuard.
@@ -268,12 +275,13 @@ test.describe('Create Quick-Link — search-fallback for an inherited-writer (LF
 
 // The mobile drawer's own Create trigger is a separate element from the desktop rail button
 // (data-testid="create-rail-button-mobile"), opening a distinctly-testid'd copy of the same
-// popover (data-testid="create-menu-mobile") — see LFXV2-3248. Desktop projects (chromium,
-// firefox) never render the mobile drawer content behind a viewport this wide, so this suite
-// only runs on the narrow (mobile-chrome) project.
+// popover (data-testid="create-menu-mobile") — see LFXV2-3248. The regression this suite guards
+// (lens-switcher.component.scss's rail-anchoring CSS) is gated at the `lg` breakpoint (1024px,
+// matching tailwind.config.js), so the skip boundary matches that rather than `md` (768px) —
+// a viewport in [768, 1024) would still get the desktop-anchored popover CSS applied.
 function skipOnDesktopViewport(page: Page): void {
   const viewport = page.viewportSize();
-  if (viewport && viewport.width >= 768) {
+  if (viewport && viewport.width >= 1024) {
     test.skip(true, 'Mobile-only trigger — desktop uses create-rail-button in the vertical rail');
   }
 }
@@ -299,12 +307,15 @@ test.describe('Create Quick-Link — mobile trigger (LFXV2-3248)', () => {
 
     // Popover must actually open near the tapped button, not pinned at the desktop rail's fixed
     // coordinates (left:56px/top:58px) — regression guard for the rail-anchoring CSS scoped to
-    // the `lg` breakpoint.
+    // the `lg` breakpoint. Check X, not Y: the mobile trigger sits in a right-aligned (`ml-auto`)
+    // icon group, far from the rail's x=56, while the rail's fixed top:58px happens to land close
+    // to the mobile trigger's real Y position too — so a Y-only check would likely still pass even
+    // if the `@media (min-width: 1024px)` scoping regressed. X actually distinguishes the two.
     const [menuBox, triggerBox] = await Promise.all([menu.boundingBox(), trigger.boundingBox()]);
     expect(menuBox).not.toBeNull();
     expect(triggerBox).not.toBeNull();
     if (menuBox && triggerBox) {
-      expect(Math.abs(menuBox.y - triggerBox.y)).toBeLessThan(150);
+      expect(Math.abs(menuBox.x - triggerBox.x)).toBeLessThan(150);
     }
   });
 });

--- a/apps/lfx-one/e2e/create-quick-link.spec.ts
+++ b/apps/lfx-one/e2e/create-quick-link.spec.ts
@@ -311,11 +311,19 @@ test.describe('Create Quick-Link — mobile trigger (LFXV2-3248)', () => {
     // the real Pixel 5 layout the mobile trigger's measured x (~115px, confirmed via a live
     // authenticated session) sits close enough to the rail's fixed x=56 that any tolerance loose
     // enough to avoid flaking on icon-group width (canImpersonate() adds/removes an icon,
-    // shifting the trailing `ml-auto` group) would also pass while the bug is present. Asserting
-    // `position` directly targets exactly what the `@media (min-width: 1024px)` scoping controls:
+    // shifting the trailing `ml-auto` group) would also pass while the bug is present.
+    //
+    // Read `position` off the actual `.p-popover` panel, not `menu` — `menu` (create-menu-mobile)
+    // is the projected content div PrimeNG renders *inside* the popover, and `position` isn't an
+    // inherited CSS property, so reading it off that inner div would always resolve to the UA
+    // default `static` regardless of the outer panel's state, making the assertion a no-op. The
+    // rail-anchoring rule (and PrimeNG's own base stylesheet) target the outer panel element,
+    // identified here by its unique `lfx-create-popover` class.
+    const panel = page.locator('.p-popover.lfx-create-popover');
+    const menuPosition = await panel.evaluate((el) => getComputedStyle(el).position);
     // PrimeNG's own anchor-relative default sets `position: absolute`; the regressed (rail-pinned)
-    // state is `position: fixed`.
-    const menuPosition = await menu.evaluate((el) => getComputedStyle(el).position);
-    expect(menuPosition).not.toBe('fixed');
+    // state is `position: fixed`. Assert the specific expected value, not just an exclusion, so an
+    // unrelated regression to some other value (e.g. `static`) doesn't slip through either.
+    expect(menuPosition).toBe('absolute');
   });
 });

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -20,6 +20,17 @@
 
     <!-- Mobile account actions -->
     <div class="ml-auto flex items-center gap-2">
+      <!-- Create quick-link — opens the same artifact-type popover as the desktop rail. -->
+      @if (createPermissionService.canShowCreateButton()) {
+        <button
+          type="button"
+          (click)="toggleCreateMenu($event)"
+          data-testid="create-rail-button-mobile"
+          aria-label="Create new artifact"
+          class="flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:bg-gray-100 transition-colors">
+          <i class="fa-light fa-plus text-sm"></i>
+        </button>
+      }
       <a
         routerLink="/docs"
         data-testid="lens-mobile-docs"
@@ -70,8 +81,8 @@
     </button>
 
     <!-- Create quick-link — opens a menu of creatable artifact types; only shown when the user can create at least one somewhere.
-         Desktop rail only by design (this @else branch): the popover is positioned against the vertical rail, so the mobile
-         horizontal strip has no equivalent yet. Mobile affordance is deferred to a follow-up (see PR description). -->
+         The mobile strip has its own trigger for the same #createMenu popover (hoisted below, outside this @else branch,
+         so it's reachable from both triggers). -->
     @if (createPermissionService.canShowCreateButton()) {
       <button
         type="button"
@@ -205,32 +216,6 @@
     </div>
   </div>
 
-  <!-- Create Popover — pick an artifact type, then a dialog resolves the project/foundation -->
-  <p-popover #createMenu appendTo="body" [styleClass]="bannerOffset() ? 'w-72 lfx-create-popover lfx-create-popover-banner-offset' : 'w-72 lfx-create-popover'">
-    <ng-template #content>
-      @let creatables = creatableArtifacts();
-      <div class="py-1" data-testid="create-menu">
-        @for (artifact of creatables; track artifact.type; let i = $index) {
-          <!-- Thin separator wherever the semantic group changes (Engage | Decide | Organize) -->
-          @if (i > 0 && artifact.group !== creatables[i - 1].group) {
-            <div role="separator" class="my-1 border-t border-gray-100"></div>
-          }
-          <button
-            type="button"
-            (click)="openCreateDialog(artifact)"
-            [attr.data-testid]="'create-menu-option-' + artifact.type"
-            class="group flex w-full items-start gap-3 px-4 py-2.5 text-left hover:bg-gray-50 transition-colors">
-            <i [class]="artifact.icon + ' fa-fw text-base text-gray-400 mt-0.5'"></i>
-            <span class="flex flex-col min-w-0">
-              <span class="text-sm font-medium text-gray-900">{{ artifact.label }}</span>
-              <span class="text-xs text-gray-500">{{ artifact.description }}</span>
-            </span>
-          </button>
-        }
-      </div>
-    </ng-template>
-  </p-popover>
-
   <!-- LFX Apps Popover -->
   <p-popover #appsMenu appendTo="body" styleClass="w-72 lfx-apps-popover">
     <ng-template #content>
@@ -335,3 +320,31 @@
   <!-- Changelog Drawer -->
   <lfx-changelog-drawer [(visible)]="changelogDrawerVisible" />
 }
+
+<!-- Create Popover — pick an artifact type, then a dialog resolves the project/foundation.
+     Hoisted outside the mobile/desktop @if/@else split: both the mobile strip's and the desktop
+     rail's Create buttons toggle this same #createMenu instance. -->
+<p-popover #createMenu appendTo="body" [styleClass]="bannerOffset() ? 'w-72 lfx-create-popover lfx-create-popover-banner-offset' : 'w-72 lfx-create-popover'">
+  <ng-template #content>
+    @let creatables = creatableArtifacts();
+    <div class="py-1" data-testid="create-menu">
+      @for (artifact of creatables; track artifact.type; let i = $index) {
+        <!-- Thin separator wherever the semantic group changes (Engage | Decide | Organize) -->
+        @if (i > 0 && artifact.group !== creatables[i - 1].group) {
+          <div role="separator" class="my-1 border-t border-gray-100"></div>
+        }
+        <button
+          type="button"
+          (click)="openCreateDialog(artifact)"
+          [attr.data-testid]="'create-menu-option-' + artifact.type"
+          class="group flex w-full items-start gap-3 px-4 py-2.5 text-left hover:bg-gray-50 transition-colors">
+          <i [class]="artifact.icon + ' fa-fw text-base text-gray-400 mt-0.5'"></i>
+          <span class="flex flex-col min-w-0">
+            <span class="text-sm font-medium text-gray-900">{{ artifact.label }}</span>
+            <span class="text-xs text-gray-500">{{ artifact.description }}</span>
+          </span>
+        </button>
+      }
+    </div>
+  </ng-template>
+</p-popover>

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -91,6 +91,8 @@
         (click)="toggleCreateMenu($event)"
         data-testid="create-rail-button"
         aria-label="Create new artifact"
+        aria-haspopup="menu"
+        [attr.aria-expanded]="createMenu.overlayVisible"
         pTooltip="New"
         tooltipPosition="right"
         class="group mb-3 flex flex-col items-center gap-1 w-full">

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -27,6 +27,8 @@
           (click)="toggleCreateMenu($event)"
           data-testid="create-rail-button-mobile"
           aria-label="Create new artifact"
+          aria-haspopup="menu"
+          [attr.aria-expanded]="createMenu.overlayVisible"
           class="flex items-center justify-center w-8 h-8 rounded-full text-gray-500 hover:bg-gray-100 transition-colors">
           <i class="fa-light fa-plus text-sm"></i>
         </button>

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.html
@@ -327,7 +327,11 @@
 <p-popover #createMenu appendTo="body" [styleClass]="bannerOffset() ? 'w-72 lfx-create-popover lfx-create-popover-banner-offset' : 'w-72 lfx-create-popover'">
   <ng-template #content>
     @let creatables = creatableArtifacts();
-    <div class="py-1" data-testid="create-menu">
+    <!-- `lfx-lens-switcher` is mounted twice at once (desktop rail + mobile drawer instances in
+         main-layout.component.html) — each renders its own copy of this popover, so the testid is
+         suffixed per-instance to keep it unique, mirroring the `-mobile` suffix already used on the
+         two trigger buttons. -->
+    <div class="py-1" [attr.data-testid]="mobile() ? 'create-menu-mobile' : 'create-menu'">
       @for (artifact of creatables; track artifact.type; let i = $index) {
         <!-- Thin separator wherever the semantic group changes (Engage | Decide | Organize) -->
         @if (i > 0 && artifact.group !== creatables[i - 1].group) {
@@ -336,7 +340,7 @@
         <button
           type="button"
           (click)="openCreateDialog(artifact)"
-          [attr.data-testid]="'create-menu-option-' + artifact.type"
+          [attr.data-testid]="(mobile() ? 'create-menu-mobile-option-' : 'create-menu-option-') + artifact.type"
           class="group flex w-full items-start gap-3 px-4 py-2.5 text-left hover:bg-gray-50 transition-colors">
           <i [class]="artifact.icon + ' fa-fw text-base text-gray-400 mt-0.5'"></i>
           <span class="flex flex-col min-w-0">

--- a/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.scss
+++ b/apps/lfx-one/src/app/shared/components/lens-switcher/lens-switcher.component.scss
@@ -74,10 +74,13 @@
 }
 
 // Create menu — same treatment as the LFX Apps menu (arrow hidden, no content
-// padding, pinned beside the rail). The Create button sits near the top of the
-// rail, so this panel is top-anchored and opens downward, mirroring how the
-// bottom-anchored apps menu opens upward from its button.
-// stylelint-disable-next-line selector-pseudo-element-no-unknown
+// padding). Reachable from two triggers: the desktop rail button and, since
+// LFXV2-3248, a mobile strip button. Only the desktop rail trigger needs a
+// fixed rail-anchored position (the button's position is otherwise constant);
+// the mobile trigger sits inline in a horizontal strip where PrimeNG's own
+// anchor-relative default positioning already places the panel correctly
+// under the tapped button, so the fixed overrides below are scoped to the
+// `lg` breakpoint (1024px, matching `tailwind.config.js`) — desktop rail only.
 ::ng-deep .lfx-create-popover.p-popover {
   // Hide arrow
   &::before,
@@ -90,27 +93,29 @@
     @apply p-0;
   }
 
-  // PrimeNG sets position/left/top inline via absolutePosition(); !important is
-  // required to override. Fixed keeps the menu put while the page scrolls.
-  // stylelint-disable-next-line declaration-no-important
-  position: fixed !important;
+  @media (min-width: 1024px) {
+    // PrimeNG sets position/left/top inline via absolutePosition(); !important is
+    // required to override. Fixed keeps the menu put while the page scrolls.
+    // stylelint-disable-next-line declaration-no-important
+    position: fixed !important;
 
-  // Just to the right of the rail: 56px = 48px rail + 8px gap.
-  // stylelint-disable-next-line declaration-no-important
-  left: 56px !important;
+    // Just to the right of the rail: 56px = 48px rail + 8px gap.
+    // stylelint-disable-next-line declaration-no-important
+    left: 56px !important;
 
-  // Align the menu's top edge with the Create button's top edge:
-  // rail padding (18) + LF logo (24) + gap (≈16) ≈ 58px from the viewport top.
-  // Unlike the bottom-anchored apps/user menus, a top-anchored panel is not immune to the
-  // impersonation banner, which shifts the rail down by `top-12` (48px) — see the variant below.
-  // stylelint-disable-next-line declaration-no-important
-  top: 58px !important;
+    // Align the menu's top edge with the Create button's top edge:
+    // rail padding (18) + LF logo (24) + gap (≈16) ≈ 58px from the viewport top.
+    // Unlike the bottom-anchored apps/user menus, a top-anchored panel is not immune to the
+    // impersonation banner, which shifts the rail down by `top-12` (48px) — see the variant below.
+    // stylelint-disable-next-line declaration-no-important
+    top: 58px !important;
 
-  // stylelint-disable-next-line declaration-no-important
-  bottom: auto !important;
+    // stylelint-disable-next-line declaration-no-important
+    bottom: auto !important;
 
-  // stylelint-disable-next-line declaration-no-important
-  margin-top: 0 !important;
+    // stylelint-disable-next-line declaration-no-important
+    margin-top: 0 !important;
+  }
 }
 
 // Applied when the host layout declares it shifts the rail down to clear a banner — `main-layout`
@@ -119,9 +124,11 @@
 // docs shell pins the rail at `top-0` and renders no banner even while impersonating. 58 + 48 = 106px.
 // Both classes are stacked deliberately: matching only `.lfx-create-popover-banner-offset` ties
 // the base rule on specificity, so this would win on source order alone and silently revert to
-// 58px if either block moved.
-// stylelint-disable-next-line selector-pseudo-element-no-unknown
+// 58px if either block moved. Desktop-only (see above) — the impersonation banner only shifts the
+// desktop rail; the mobile strip's own layout already accounts for it.
 ::ng-deep .lfx-create-popover.lfx-create-popover-banner-offset.p-popover {
-  // stylelint-disable-next-line declaration-no-important
-  top: 106px !important;
+  @media (min-width: 1024px) {
+    // stylelint-disable-next-line declaration-no-important
+    top: 106px !important;
+  }
 }


### PR DESCRIPTION
## Summary

- The rail "Create" quick-link button (opens a popover to create a meeting/newsletter/vote/survey/group/mailing-list) was scoped to the desktop-only branch of `lens-switcher.component.html`'s `@if (mobile()) {...} @else {...}` split, with an in-code comment explicitly deferring mobile support to a follow-up. It never appeared in the mobile drawer.
- Added the mobile trigger and hoisted the shared `<p-popover #createMenu>` outside the `@if/@else` split so both the desktop rail and mobile drawer instances of `lfx-lens-switcher` can open it.
- Review caught two real bugs in the first pass, both fixed:
  - The popover's SCSS was unconditionally pinned to the desktop rail's fixed coordinates (`position: fixed; left: 56px; top: 58px`) — opening it from the new mobile trigger would have rendered it in the wrong place. Scoped those rules to the `lg` breakpoint (1024px, matching `tailwind.config.js`), matching an existing pattern already used by `org-selector`/`project-selector` in this repo.
  - `lfx-lens-switcher` mounts twice simultaneously (desktop rail + mobile drawer instances in `main-layout.component.html`), so the hoisted popover was carrying a duplicate `data-testid` across both instances. Suffixed it `-mobile`, mirroring the existing convention on the two trigger buttons.
- Added mobile-viewport e2e coverage (`M1` in `create-quick-link.spec.ts`, gated to the `mobile-chrome` Playwright project). The regression-guard assertion itself went through a few rounds of tightening during review — an initial bounding-box heuristic turned out to be a weak/no-op guard; it now asserts the popover panel's computed `position` directly (`absolute` on mobile vs. the regressed `fixed`), verified live against both a real desktop-width session and a genuine narrow viewport.

## Test plan

- [x] `yarn format && yarn lint && yarn check-types && yarn build` all pass
- [x] `./check-headers.sh` passes
- [x] Manually verified in browser: mobile drawer shows the Create button, opens the artifact-type popover, correctly anchored (not pinned at desktop rail coordinates) on a genuine narrow viewport
- [x] `npx playwright test e2e/create-quick-link.spec.ts --project=mobile-chrome --list` confirms the new `M1` test registers correctly
- [ ] `M1` itself needs `TEST_USERNAME`/`TEST_PASSWORD` to execute (not available in this environment) — should run in CI

[LFXV2-3248](https://linuxfoundation.atlassian.net/browse/LFXV2-3248)

[LFXV2-3248]: https://linuxfoundation.atlassian.net/browse/LFXV2-3248?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ