### PR TITLE
feat(social-listening): add analytics tab with PNG export (LFXV2-3018)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
@@ -1,0 +1,180 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div #analyticsContent class="flex flex-col gap-4" data-testid="social-listening-analytics">
+  <!-- Row 1: KPI stat cards (error degrades the row to a message instead of zeroed cards) -->
+  @if (overviewError(); as overviewErrorMessage) {
+    <lfx-message severity="error" [text]="overviewErrorMessage" data-testid="social-listening-analytics-overview-error" />
+  } @else {
+    <lfx-stat-card-grid [cards]="statCards()" [loading]="overviewLoading()" [columns]="3" data-testid="social-listening-analytics-stats" />
+  }
+
+  <!-- Row 2: Mentions Over Time + Mentions by Platform -->
+  <div class="grid grid-cols-1 gap-4 lg:grid-cols-[13fr_7fr]">
+    <lfx-card>
+      <div class="analytics-panel" data-testid="social-listening-analytics-over-time">
+        <h3 class="panel-title">Mentions Over Time</h3>
+        @if (overTimeLoading()) {
+          <p-skeleton height="400px" />
+        } @else if (overTimeError(); as overTimeErrorMessage) {
+          <lfx-message severity="error" [text]="overTimeErrorMessage" data-testid="social-listening-analytics-over-time-error" />
+        } @else if (overTimeData(); as overTimeChartData) {
+          <div class="h-[400px] w-full">
+            <lfx-chart type="line" [data]="overTimeChartData" [options]="overTimeOptions" height="100%" />
+          </div>
+        } @else {
+          <lfx-empty-state
+            icon="fa-light fa-chart-line-up"
+            title="No mentions in this period"
+            subtitle="Try a different period or broaden the project or platform scope."
+            [withCard]="false"
+            data-testid="social-listening-analytics-over-time-empty" />
+        }
+      </div>
+    </lfx-card>
+
+    <lfx-card>
+      <div class="analytics-panel" data-testid="social-listening-analytics-platform">
+        <h3 class="panel-title">Mentions by Platform</h3>
+        @if (platformLoading()) {
+          <div class="flex flex-col gap-4">
+            @for (row of [1, 2, 3, 4, 5]; track row) {
+              <p-skeleton height="2.5rem" />
+            }
+          </div>
+        } @else if (platformError(); as platformErrorMessage) {
+          <lfx-message severity="error" [text]="platformErrorMessage" data-testid="social-listening-analytics-platform-error" />
+        } @else if (platformRows().length > 0) {
+          <div class="flex flex-col gap-4">
+            @for (row of platformRows(); track row.config.label) {
+              <div class="flex flex-col gap-2">
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-1.5">
+                    <i [class]="row.config.icon + ' ' + row.config.colorClass" aria-hidden="true"></i>
+                    <span class="text-sm font-medium text-gray-900">{{ row.config.label }}</span>
+                  </div>
+                  @if (showPlatformPercents()) {
+                    <span class="text-sm font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
+                  }
+                </div>
+                <div class="flex items-center gap-3">
+                  <div class="h-2.5 flex-1 overflow-hidden rounded-full bg-gray-200">
+                    <div class="h-full rounded-full" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal"></div>
+                  </div>
+                  <span class="min-w-12 flex-shrink-0 text-right text-sm font-medium text-gray-400">{{ row.mentionsCount | number }}</span>
+                </div>
+              </div>
+            }
+          </div>
+        } @else {
+          <lfx-empty-state
+            icon="fa-light fa-chart-pie"
+            title="No platform data"
+            subtitle="No mentions matched the current scope in this period."
+            [withCard]="false"
+            data-testid="social-listening-analytics-platform-empty" />
+        }
+      </div>
+    </lfx-card>
+  </div>
+
+  <!-- Row 3: Mentions by Tag + right column (Sentiment Distribution, Top Projects) -->
+  <div class="grid grid-cols-1 gap-4 lg:grid-cols-[13fr_7fr]">
+    <lfx-card>
+      <div class="analytics-panel" data-testid="social-listening-analytics-tags">
+        <h3 class="panel-title">Mentions by Tag</h3>
+        @if (tagsLoading()) {
+          <p-skeleton height="350px" />
+        } @else if (tagsError(); as tagsErrorMessage) {
+          <lfx-message severity="error" [text]="tagsErrorMessage" data-testid="social-listening-analytics-tags-error" />
+        } @else if (tagsData(); as tagsChartData) {
+          <div class="h-[350px] w-full">
+            <lfx-chart type="bar" [data]="tagsChartData" [options]="tagsChartOptions" height="100%" />
+          </div>
+        } @else {
+          <lfx-empty-state
+            icon="fa-light fa-tags"
+            title="No tags in this period"
+            subtitle="Tagged mentions appear here once they are ingested for the current scope."
+            [withCard]="false"
+            data-testid="social-listening-analytics-tags-empty" />
+        }
+      </div>
+    </lfx-card>
+
+    <div class="flex flex-col gap-4">
+      <lfx-card styleClass="h-full">
+        <div class="analytics-panel" data-testid="social-listening-analytics-sentiment">
+          <h3 class="panel-title">Sentiment Distribution</h3>
+          @if (sentimentLoading()) {
+            <div class="flex flex-col gap-3">
+              <p-skeleton height="0.75rem" />
+              <p-skeleton height="2rem" />
+              <p-skeleton height="2rem" />
+            </div>
+          } @else if (sentimentError(); as sentimentErrorMessage) {
+            <lfx-message severity="error" [text]="sentimentErrorMessage" data-testid="social-listening-analytics-sentiment-error" />
+          } @else if (sentimentRows().length > 0) {
+            <div class="flex h-3 w-full overflow-hidden rounded-full bg-gray-100" role="img" aria-label="Sentiment distribution bar">
+              @for (row of sentimentRows(); track row.sentiment) {
+                <div class="h-full" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal"></div>
+              }
+            </div>
+            <div class="flex flex-col gap-3">
+              @for (row of sentimentRows(); track row.sentiment) {
+                <div class="flex items-center justify-between">
+                  <div class="flex items-center gap-2.5">
+                    <span class="h-3 w-3 flex-shrink-0 rounded-full" [class]="row.config.barClass" aria-hidden="true"></span>
+                    <span class="text-sm font-medium text-gray-900">{{ row.config.label }}</span>
+                  </div>
+                  <span class="text-sm font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
+                </div>
+              }
+            </div>
+          } @else {
+            <lfx-empty-state
+              icon="fa-light fa-face-smile"
+              title="No sentiment data"
+              subtitle="Sentiment breakdown appears here when mentions exist for the current scope."
+              [withCard]="false"
+              data-testid="social-listening-analytics-sentiment-empty" />
+          }
+        </div>
+      </lfx-card>
+
+      <lfx-card styleClass="h-full">
+        <div class="analytics-panel" data-testid="social-listening-analytics-top-projects">
+          <h3 class="panel-title">Top Projects</h3>
+          @if (topProjectsLoading()) {
+            <div class="flex flex-col gap-3">
+              @for (row of [1, 2, 3, 4, 5]; track row) {
+                <p-skeleton height="3.5rem" />
+              }
+            </div>
+          } @else if (topProjectsError(); as topProjectsErrorMessage) {
+            <lfx-message severity="error" [text]="topProjectsErrorMessage" data-testid="social-listening-analytics-top-projects-error" />
+          } @else if (topProjects().length > 0) {
+            <div class="flex flex-col gap-3">
+              @for (project of topProjects(); track project.SOURCE_PROJECT_NAME; let idx = $index) {
+                <div class="top-project-row">
+                  <div class="project-rank">{{ idx + 1 }}</div>
+                  <div class="flex flex-1 flex-col">
+                    <div class="text-sm font-semibold text-gray-900">{{ project.SOURCE_PROJECT_NAME }}</div>
+                    <div class="text-xs text-gray-500">{{ project.TOTAL_MENTIONS | number }} mentions</div>
+                  </div>
+                </div>
+              }
+            </div>
+          } @else {
+            <lfx-empty-state
+              icon="fa-light fa-diagram-project"
+              title="No project data"
+              subtitle="Project mention rankings appear here when mentions exist for the current scope."
+              [withCard]="false"
+              data-testid="social-listening-analytics-top-projects-empty" />
+          }
+        </div>
+      </lfx-card>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
@@ -1,0 +1,20 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Panel chrome — every analytics panel is a card with a small-caps section title.
+.analytics-panel {
+  @apply flex flex-col gap-4;
+}
+
+.panel-title {
+  @apply m-0 text-xs font-bold tracking-wider text-gray-500 uppercase;
+}
+
+// Top Projects ranked rows.
+.top-project-row {
+  @apply flex items-center gap-4 rounded-lg bg-gray-50 p-3 transition-colors hover:bg-gray-100;
+}
+
+.project-rank {
+  @apply bg-blue-500 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold text-white;
+}

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
@@ -1,0 +1,259 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { DecimalPipe, isPlatformBrowser } from '@angular/common';
+import { Component, computed, effect, ElementRef, inject, input, model, PLATFORM_ID, Signal, untracked, viewChild } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { CardComponent } from '@components/card/card.component';
+import { ChartComponent } from '@components/chart/chart.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { MessageComponent } from '@components/message/message.component';
+import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
+import { ANALYTICS_TOP_PROJECTS_LIMIT, lfxColors } from '@lfx-one/shared/constants';
+import { buildAnalyticsDelta, buildOverTimeChartData, buildTagsChartData, mapPlatformDistributionRows, mapSentimentRows } from '@lfx-one/shared/utils';
+import { SocialListeningService } from '@services/social-listening.service';
+import { downloadCardAsImage } from '@shared/utils/download-card.util';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, debounceTime, map, Observable, of, startWith, switchMap } from 'rxjs';
+
+import type { ChartData, ChartOptions } from 'chart.js';
+
+import type {
+  LoadableState,
+  SocialListeningAnalyticsOverview,
+  SocialListeningAnalyticsRequest,
+  SocialListeningPlatformRow,
+  SocialListeningSentimentRow,
+  SocialListeningTopProject,
+  StatCardItem,
+} from '@lfx-one/shared/interfaces';
+
+/**
+ * Social Listening Analytics tab (LFXV2-3018), ported from PCC's
+ * `reports/social-listening/.../analytics` component. All six panels read the feed-derived
+ * 3015 endpoints (not PCC's pre-aggregated views — master §0) through declarative `toSignal`
+ * pipelines keyed off the page's scope signals, so period/platform/sub-project changes
+ * propagate automatically. A failed request degrades only its own panel.
+ *
+ * Bar visualizations (platform, sentiment) are CSS flex segments — export-safe and free of
+ * chart lifecycle concerns; only Mentions Over Time (line) and Mentions by Tag (bar) use
+ * `lfx-chart`, with options held as plain class properties (rule: `computed()` options churn
+ * the reference and force PrimeNG to destroy/rebuild the chart).
+ *
+ * Export: the page increments `exportNonce` (input-driven trigger, rule 12.7 — no viewChild
+ * calls); the component captures its own content grid via `downloadCardAsImage` and reports
+ * progress back through the `isExporting` model so the header button can spin.
+ */
+@Component({
+  selector: 'lfx-social-listening-analytics',
+  imports: [DecimalPipe, CardComponent, ChartComponent, EmptyStateComponent, MessageComponent, StatCardGridComponent, SkeletonModule],
+  templateUrl: './social-listening-analytics.component.html',
+  styleUrl: './social-listening-analytics.component.scss',
+})
+export class SocialListeningAnalyticsComponent {
+  private readonly platformId = inject(PLATFORM_ID);
+  private readonly socialListeningService = inject(SocialListeningService);
+
+  // === Scope inputs (page-owned signals, propagated down) ===
+  public readonly foundationSlug = input('');
+  public readonly period = input('');
+  public readonly platform = input('all');
+  public readonly sourceProjectId = input('all');
+
+  // === Export (page-triggered via nonce; progress reported back via model) ===
+  public readonly exportNonce = input(0);
+  public readonly isExporting = model(false);
+
+  private readonly analyticsContent = viewChild<ElementRef<HTMLElement>>('analyticsContent');
+
+  private readonly analyticsRequest: Signal<SocialListeningAnalyticsRequest | null> = this.initAnalyticsRequest();
+
+  // === Panel states (each pipeline degrades independently) ===
+  private readonly overviewState: Signal<LoadableState<SocialListeningAnalyticsOverview | null>> = this.initAnalyticsState(
+    (req) => this.socialListeningService.getAnalyticsOverview(req),
+    null
+  );
+  private readonly overTimeState: Signal<LoadableState<ChartData<'line'> | null>> = this.initAnalyticsState(
+    (req) => this.socialListeningService.getAnalyticsOverTime(req).pipe(map(buildOverTimeChartData)),
+    null
+  );
+  private readonly platformState: Signal<LoadableState<SocialListeningPlatformRow[]>> = this.initAnalyticsState(
+    (req) => this.socialListeningService.getAnalyticsPlatformDistribution(req).pipe(map((rows) => mapPlatformDistributionRows(rows))),
+    []
+  );
+  private readonly tagsState: Signal<LoadableState<ChartData<'bar'> | null>> = this.initAnalyticsState(
+    (req) => this.socialListeningService.getMentionsTags(req).pipe(map(buildTagsChartData)),
+    null
+  );
+  private readonly sentimentState: Signal<LoadableState<SocialListeningSentimentRow[]>> = this.initAnalyticsState(
+    (req) => this.socialListeningService.getAnalyticsSentimentDistribution(req).pipe(map(mapSentimentRows)),
+    []
+  );
+  private readonly topProjectsState: Signal<LoadableState<SocialListeningTopProject[]>> = this.initAnalyticsState(
+    (req) => this.socialListeningService.getAnalyticsTopProjects({ ...req, limit: ANALYTICS_TOP_PROJECTS_LIMIT }),
+    []
+  );
+
+  // === Template-facing derivations ===
+  public readonly statCards: Signal<StatCardItem[]> = this.initStatCards();
+  public readonly overviewLoading = computed(() => this.overviewState().loading);
+  public readonly overviewError = computed(() => this.overviewState().error);
+
+  public readonly overTimeData = computed(() => this.overTimeState().data);
+  public readonly overTimeLoading = computed(() => this.overTimeState().loading);
+  public readonly overTimeError = computed(() => this.overTimeState().error);
+
+  public readonly platformRows = computed(() => this.platformState().data);
+  public readonly platformLoading = computed(() => this.platformState().loading);
+  public readonly platformError = computed(() => this.platformState().error);
+  /** PCC behavior: the per-platform % label is only meaningful on the unfiltered (all-platforms) view. */
+  public readonly showPlatformPercents = computed(() => this.platform() === 'all');
+
+  public readonly tagsData = computed(() => this.tagsState().data);
+  public readonly tagsLoading = computed(() => this.tagsState().loading);
+  public readonly tagsError = computed(() => this.tagsState().error);
+
+  public readonly sentimentRows = computed(() => this.sentimentState().data);
+  public readonly sentimentLoading = computed(() => this.sentimentState().loading);
+  public readonly sentimentError = computed(() => this.sentimentState().error);
+
+  public readonly topProjects = computed(() => this.topProjectsState().data);
+  public readonly topProjectsLoading = computed(() => this.topProjectsState().loading);
+  public readonly topProjectsError = computed(() => this.topProjectsState().error);
+
+  // === Chart options — plain class properties, never computed() (rule 7.8) ===
+  protected readonly overTimeOptions: ChartOptions<'line'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: {
+        display: true,
+        position: 'bottom',
+        labels: { usePointStyle: true, pointStyle: 'line', padding: 15, color: lfxColors.gray[600] },
+      },
+      tooltip: { mode: 'index', intersect: false },
+    },
+    elements: {
+      line: { tension: 0.4, fill: false },
+      point: { radius: 3, hoverRadius: 5 },
+    },
+    scales: {
+      x: { display: true, grid: { display: false }, ticks: { color: lfxColors.gray[500] } },
+      y: { display: true, beginAtZero: true, grid: { color: lfxColors.gray[200] }, ticks: { color: lfxColors.gray[500] } },
+    },
+  };
+
+  protected readonly tagsChartOptions: ChartOptions<'bar'> = {
+    responsive: true,
+    maintainAspectRatio: false,
+    plugins: {
+      legend: { display: false },
+    },
+    scales: {
+      x: { grid: { display: false }, ticks: { color: lfxColors.gray[500], font: { size: 11 } } },
+      y: { display: true, beginAtZero: true, grid: { color: lfxColors.gray[200] }, ticks: { color: lfxColors.gray[500] } },
+    },
+  };
+
+  public constructor() {
+    // Export trigger: the page increments exportNonce; the component owns its content element
+    // and performs the capture itself. Effect = signal → imperative DOM sink (html-to-image),
+    // which is the sanctioned effect use; the initial run is a no-op via the nonce guard.
+    effect(() => {
+      if (this.exportNonce() === 0) return;
+      if (!isPlatformBrowser(this.platformId)) return;
+      untracked(() => void this.exportAnalytics());
+    });
+  }
+
+  private async exportAnalytics(): Promise<void> {
+    const element = this.analyticsContent()?.nativeElement;
+    if (!element || this.isExporting()) return;
+
+    this.isExporting.set(true);
+    // Yield a frame so Angular can paint the header spinner before html-to-image blocks the
+    // main thread with DOM traversal (PCC parity).
+    await new Promise((resolve) => requestAnimationFrame(resolve));
+    try {
+      await downloadCardAsImage(element, `social-listening-analytics-${this.period() || 'export'}`, { backgroundColor: lfxColors.white });
+    } finally {
+      this.isExporting.set(false);
+    }
+  }
+
+  /** Scope shared by all six analytics requests; null until the page has a foundation + period. */
+  private initAnalyticsRequest(): Signal<SocialListeningAnalyticsRequest | null> {
+    return computed(() => {
+      const foundationSlug = this.foundationSlug();
+      const period = this.period();
+      if (!foundationSlug || !period) return null;
+      return {
+        foundationSlug,
+        period,
+        platform: this.platform() !== 'all' ? this.platform() : undefined,
+        sourceProjectId: this.sourceProjectId() !== 'all' ? this.sourceProjectId() : undefined,
+      };
+    });
+  }
+
+  /**
+   * Shared declarative-state pipeline for the analytics panels: refetch on scope change
+   * (debounceTime(0) coalesces synchronous multi-signal changes into one round), loading via
+   * `startWith`, per-panel error via `catchError` (errors degrade one panel, not the tab).
+   */
+  private initAnalyticsState<T>(fetchFn: (req: SocialListeningAnalyticsRequest) => Observable<T>, empty: T): Signal<LoadableState<T>> {
+    return toSignal(
+      toObservable(this.analyticsRequest).pipe(
+        debounceTime(0),
+        switchMap((req) => {
+          if (req === null) {
+            return of<LoadableState<T>>({ loading: false, error: null, data: empty });
+          }
+          return fetchFn(req).pipe(
+            map((data): LoadableState<T> => ({ loading: false, error: null, data })),
+            catchError(() => of<LoadableState<T>>({ loading: false, error: 'Failed to load this panel', data: empty })),
+            startWith<LoadableState<T>>({ loading: true, error: null, data: empty })
+          );
+        })
+      ),
+      { initialValue: { loading: false, error: null, data: empty } }
+    );
+  }
+
+  /**
+   * KPI stat cards (Total Mentions / Negative / Positive Sentiment). Deltas come precomputed
+   * from the server; `buildAnalyticsDelta` hides them when the previous window was too thin
+   * (null) and flips colors on the negative card (an increase in negative sentiment is bad).
+   */
+  private initStatCards(): Signal<StatCardItem[]> {
+    return computed(() => {
+      const overview = this.overviewState().data;
+      return [
+        {
+          icon: 'fa-light fa-ear-listen',
+          iconContainerClass: 'bg-blue-100 text-blue-600',
+          label: 'Total Mentions',
+          value: overview ? overview.TOTAL_MENTIONS.toLocaleString() : '0',
+          subLine: overview ? `across ${overview.CHILD_PROJECTS_COUNT} projects` : undefined,
+          delta: buildAnalyticsDelta(overview?.TOTAL_MENTIONS_CHANGE_PCT ?? null),
+        },
+        {
+          icon: 'fa-light fa-face-frown',
+          iconContainerClass: 'bg-red-100 text-red-600',
+          label: 'Negative Sentiment',
+          value: overview ? `${overview.NEGATIVE_SENTIMENT_PERCENT}%` : '0%',
+          subLine: 'of all mentions',
+          delta: buildAnalyticsDelta(overview?.NEGATIVE_SENTIMENT_CHANGE_PCT ?? null, true),
+        },
+        {
+          icon: 'fa-light fa-face-smile',
+          iconContainerClass: 'bg-emerald-100 text-emerald-600',
+          label: 'Positive Sentiment',
+          value: overview ? `${overview.POSITIVE_SENTIMENT_PERCENT}%` : '0%',
+          subLine: 'of all mentions',
+          delta: buildAnalyticsDelta(overview?.POSITIVE_SENTIMENT_CHANGE_PCT ?? null),
+        },
+      ];
+    });
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
@@ -75,5 +75,19 @@
         (mouseenter)="filtersPrefetch.emit()"
         data-testid="social-listening-filters-button" />
     }
+
+    <!-- Export trigger (analytics tab only) — the page increments the analytics component's exportNonce -->
+    @if (isAnalyticsTab()) {
+      <lfx-button
+        icon="fa-light fa-arrow-down-to-bracket"
+        severity="secondary"
+        [outlined]="true"
+        size="small"
+        ariaLabel="Export analytics as PNG"
+        [loading]="exporting()"
+        [disabled]="exporting()"
+        (onClick)="exportAnalytics.emit()"
+        data-testid="social-listening-analytics-export" />
+    }
   </div>
 </lfx-card-tabs-bar>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
@@ -55,6 +55,10 @@ export class FeedHeaderComponent {
   public readonly activeFilterCount = input(0);
   public readonly filtersPrefetch = output<void>();
 
+  // === Analytics export (LFXV2-3018) — button renders on the Analytics tab only ===
+  public readonly exporting = input(false);
+  public readonly exportAnalytics = output<void>();
+
   // Neutral defaults — the model→form effects below populate the real values at construction
   // (required models can't be read in field initializers).
   protected readonly headerForm = this.fb.nonNullable.group({

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -28,7 +28,9 @@
           [projectOptions]="subProjectOptions()"
           [platformOptions]="platformOptions()"
           [optionsLoading]="optionsLoading()"
-          (filtersPrefetch)="prefetchFilterOptions()" />
+          [exporting]="exporting()"
+          (filtersPrefetch)="prefetchFilterOptions()"
+          (exportAnalytics)="onExportAnalytics()" />
 
         @if (filtersOpen() && activeTab() === 'feed') {
           <lfx-filters-panel
@@ -90,12 +92,13 @@
             platforms across the web. The Linux Foundation does not independently collect, enrich, or modify this data.
           </p>
         } @else {
-          <!-- Analytics tab content lands in LFXV2-3018 -->
-          <lfx-empty-state
-            icon="fa-light fa-chart-line-up"
-            title="Analytics are coming soon"
-            subtitle="Mention volumes, platform and sentiment breakdowns, and export are being migrated from PCC in an upcoming release."
-            data-testid="social-listening-analytics-placeholder" />
+          <lfx-social-listening-analytics
+            [foundationSlug]="foundationSlug()"
+            [period]="selectedPeriod()"
+            [platform]="selectedPlatform()"
+            [sourceProjectId]="selectedProject()"
+            [exportNonce]="exportNonce()"
+            [(isExporting)]="exporting" />
         }
       </div>
     </lfx-card>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -75,6 +75,7 @@ import type {
   SocialListeningTab,
 } from '@lfx-one/shared/interfaces';
 
+import { SocialListeningAnalyticsComponent } from './components/analytics/social-listening-analytics.component';
 import { FeedHeaderComponent } from './components/feed-header/feed-header.component';
 import { FiltersPanelComponent } from './components/filters-panel/filters-panel.component';
 import { MentionsListComponent } from './components/mentions-list/mentions-list.component';
@@ -91,7 +92,16 @@ const EMPTY_FEED_RESPONSE: SocialListeningFeedResponse = { mentions: [], compute
  */
 @Component({
   selector: 'lfx-social-listening',
-  imports: [CardComponent, EmptyStateComponent, FilterPillsComponent, MessageComponent, FeedHeaderComponent, FiltersPanelComponent, MentionsListComponent],
+  imports: [
+    CardComponent,
+    EmptyStateComponent,
+    FilterPillsComponent,
+    MessageComponent,
+    FeedHeaderComponent,
+    FiltersPanelComponent,
+    MentionsListComponent,
+    SocialListeningAnalyticsComponent,
+  ],
   templateUrl: './social-listening.component.html',
   styleUrl: './social-listening.component.scss',
 })
@@ -132,6 +142,10 @@ export class SocialListeningComponent {
   // === Filters panel state (LFXV2-3017) ===
   public readonly filtersOpen = signal(false);
   private readonly filtersOpenedOnce = signal(false);
+
+  // === Analytics export state (LFXV2-3018) — the header emits, the analytics component captures ===
+  public readonly exporting = signal(false);
+  public readonly exportNonce = signal(0);
 
   /** Shared heartbeat that re-evaluates relative timestamps on rendered cards (one interval per page, not per card). */
   public readonly timeTick = signal(0);
@@ -315,6 +329,14 @@ export class SocialListeningComponent {
     if (!this.filtersOpenedOnce()) {
       this.filtersOpenedOnce.set(true);
     }
+  }
+
+  /**
+   * Triggers a PNG export of the analytics dashboard (LFXV2-3018) by bumping the nonce the
+   * analytics component reacts to — input-driven child trigger, no viewChild method calls.
+   */
+  public onExportAnalytics(): void {
+    this.exportNonce.update((nonce) => nonce + 1);
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.html
@@ -19,7 +19,9 @@
             <p class="text-xs text-gray-400">{{ card.subLine }}</p>
           }
           @if (card.delta && !loading()) {
-            <p class="flex items-center gap-1 text-xs font-medium" [class]="deltaTextClass[card.delta.direction]">
+            <p
+              class="flex items-center gap-1 text-xs font-medium"
+              [class]="(card.delta.inverted ? invertedDeltaTextClass : deltaTextClass)[card.delta.direction]">
               <i [class]="deltaIcon[card.delta.direction]" aria-hidden="true"></i>
               {{ card.delta.label }}
             </p>

--- a/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
+++ b/apps/lfx-one/src/app/shared/components/stat-card-grid/stat-card-grid.component.ts
@@ -3,7 +3,13 @@
 
 import { Component, computed, input } from '@angular/core';
 import { CardComponent } from '@components/card/card.component';
-import { DELTA_DIRECTION_ICON, DELTA_DIRECTION_TEXT_CLASS, GRID_COLS_CLASS, GRID_DIVIDER_CLASS } from '@lfx-one/shared/constants';
+import {
+  DELTA_DIRECTION_ICON,
+  DELTA_DIRECTION_TEXT_CLASS,
+  GRID_COLS_CLASS,
+  GRID_DIVIDER_CLASS,
+  INVERTED_DELTA_DIRECTION_TEXT_CLASS,
+} from '@lfx-one/shared/constants';
 import { StatCardGridColumns, StatCardItem } from '@lfx-one/shared/interfaces';
 
 @Component({
@@ -21,4 +27,6 @@ export class StatCardGridComponent {
   protected readonly gridDividerClass = computed(() => GRID_DIVIDER_CLASS[this.columns()]);
   protected readonly deltaIcon = DELTA_DIRECTION_ICON;
   protected readonly deltaTextClass = DELTA_DIRECTION_TEXT_CLASS;
+  /** Flipped mapping for `StatCardDelta.inverted` deltas — an increase is bad (e.g. negative sentiment), so up renders red and down renders emerald. */
+  protected readonly invertedDeltaTextClass = INVERTED_DELTA_DIRECTION_TEXT_CLASS;
 }

--- a/apps/lfx-one/src/app/shared/utils/download-card.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/download-card.util.ts
@@ -5,10 +5,25 @@ import { toPng } from 'html-to-image';
 
 const IGNORE_CLASS = 'ignore-download';
 
-export async function downloadCardAsImage(element: HTMLElement, filename: string): Promise<void> {
+/** Optional capture tweaks for `downloadCardAsImage`. */
+export interface DownloadCardOptions {
+  /**
+   * Canvas background color (default: transparent, the historical behavior). Multi-panel
+   * dashboards want an explicit background — the captured container is transparent where the
+   * page background shows through (single cards are white themselves, so they don't need it).
+   */
+  backgroundColor?: string;
+}
+
+export async function downloadCardAsImage(element: HTMLElement, filename: string, options?: DownloadCardOptions): Promise<void> {
   try {
+    // Wait for webfonts so icon-font glyphs (Font Awesome) render in the capture — the browser
+    // may still be swapping them in when the export is triggered right after a tab switch.
+    await document.fonts.ready;
+
     const dataUrl = await toPng(element, {
       pixelRatio: 2,
+      backgroundColor: options?.backgroundColor,
       filter: (node: HTMLElement) => !node.classList?.contains(IGNORE_CLASS),
     });
 

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -14,6 +14,7 @@ import {
   lfxColors,
   lfxFontSizes,
   MENTION_PLATFORM_CONFIG,
+  MENTION_SENTIMENT_CONFIG,
   ORG_MEETINGS_KPI_ICON_CLASS,
 } from '@lfx-one/shared/constants';
 import PrimeUI from 'tailwindcss-primeui';
@@ -31,6 +32,9 @@ export default {
     ...AVATAR_COLORS,
     // Social Listening platform icon colors (MENTION_PLATFORM_CONFIG in @lfx-one/shared, not scanned here)
     ...Object.values(MENTION_PLATFORM_CONFIG).map((c) => c.colorClass),
+    // Social Listening analytics distribution bars (barClass on MENTION_PLATFORM_CONFIG / MENTION_SENTIMENT_CONFIG)
+    ...Object.values(MENTION_PLATFORM_CONFIG).map((c) => c.barClass),
+    ...Object.values(MENTION_SENTIMENT_CONFIG).map((c) => c.barClass),
     // Stat card grid columns/dividers: `GRID_COLS_CLASS`/`GRID_DIVIDER_CLASS` are defined in
     // @lfx-one/shared (outside `content`), and their responsive/arbitrary utilities need to be
     // scanned directly since they never appear as literal strings inside `content`.

--- a/packages/shared/src/constants/delta-direction.constants.ts
+++ b/packages/shared/src/constants/delta-direction.constants.ts
@@ -16,3 +16,10 @@ export const DELTA_DIRECTION_TEXT_CLASS: Record<StatCardDeltaDirection, string> 
   down: 'text-red-600',
   flat: 'text-gray-500',
 };
+
+/** Flipped color mapping for `StatCardDelta.inverted` deltas — an increase is bad (e.g. negative sentiment), so up renders red and down renders emerald. */
+export const INVERTED_DELTA_DIRECTION_TEXT_CLASS: Record<StatCardDeltaDirection, string> = {
+  up: DELTA_DIRECTION_TEXT_CLASS.down,
+  down: DELTA_DIRECTION_TEXT_CLASS.up,
+  flat: DELTA_DIRECTION_TEXT_CLASS.flat,
+};

--- a/packages/shared/src/constants/social-listening.constants.ts
+++ b/packages/shared/src/constants/social-listening.constants.ts
@@ -18,29 +18,30 @@ import type {
   ScopeState,
   SocialListeningOption,
 } from '../interfaces/social-listening.interface';
+import { lfxColors } from './colors.constants';
 
 // ---------------------------------------------------------------------------
 // Display config
 // ---------------------------------------------------------------------------
 
 export const MENTION_PLATFORM_CONFIG: Record<MentionPlatform, MentionPlatformConfigEntry> = {
-  twitter: { icon: 'fa-brands fa-x-twitter', label: 'Twitter / X', colorClass: 'text-gray-900' },
-  bluesky: { icon: 'fa-brands fa-bluesky', label: 'Bluesky', colorClass: 'text-sky-500' },
-  reddit: { icon: 'fa-brands fa-reddit', label: 'Reddit', colorClass: 'text-orange-600' },
-  youtube: { icon: 'fa-brands fa-youtube', label: 'YouTube', colorClass: 'text-red-600' },
-  facebook: { icon: 'fa-brands fa-facebook', label: 'Facebook', colorClass: 'text-blue-600' },
-  hackernews: { icon: 'fa-brands fa-hacker-news', label: 'Hacker News', colorClass: 'text-orange-500' },
-  dev: { icon: 'fa-brands fa-dev', label: 'DEV', colorClass: 'text-gray-900' },
-  podcasts: { icon: 'fa-light fa-podcast', label: 'Podcasts', colorClass: 'text-purple-600' },
-  github: { icon: 'fa-brands fa-github', label: 'GitHub', colorClass: 'text-gray-700' },
-  linkedin: { icon: 'fa-brands fa-linkedin', label: 'LinkedIn', colorClass: 'text-blue-700' },
-  other: { icon: 'fa-light fa-globe', label: 'Other', colorClass: 'text-gray-500' },
+  twitter: { icon: 'fa-brands fa-x-twitter', label: 'Twitter / X', colorClass: 'text-gray-900', barClass: 'bg-gray-900' },
+  bluesky: { icon: 'fa-brands fa-bluesky', label: 'Bluesky', colorClass: 'text-sky-500', barClass: 'bg-sky-500' },
+  reddit: { icon: 'fa-brands fa-reddit', label: 'Reddit', colorClass: 'text-orange-600', barClass: 'bg-orange-600' },
+  youtube: { icon: 'fa-brands fa-youtube', label: 'YouTube', colorClass: 'text-red-600', barClass: 'bg-red-600' },
+  facebook: { icon: 'fa-brands fa-facebook', label: 'Facebook', colorClass: 'text-blue-600', barClass: 'bg-blue-600' },
+  hackernews: { icon: 'fa-brands fa-hacker-news', label: 'Hacker News', colorClass: 'text-orange-500', barClass: 'bg-orange-500' },
+  dev: { icon: 'fa-brands fa-dev', label: 'DEV', colorClass: 'text-gray-900', barClass: 'bg-gray-900' },
+  podcasts: { icon: 'fa-light fa-podcast', label: 'Podcasts', colorClass: 'text-purple-600', barClass: 'bg-purple-600' },
+  github: { icon: 'fa-brands fa-github', label: 'GitHub', colorClass: 'text-gray-700', barClass: 'bg-gray-700' },
+  linkedin: { icon: 'fa-brands fa-linkedin', label: 'LinkedIn', colorClass: 'text-blue-700', barClass: 'bg-blue-700' },
+  other: { icon: 'fa-light fa-globe', label: 'Other', colorClass: 'text-gray-500', barClass: 'bg-gray-500' },
 };
 
 export const MENTION_SENTIMENT_CONFIG: Record<MentionSentiment, MentionSentimentConfigEntry> = {
-  positive: { icon: 'fa-light fa-face-smile', label: 'Positive', severity: 'success' },
-  neutral: { icon: 'fa-light fa-face-meh', label: 'Neutral', severity: 'secondary' },
-  negative: { icon: 'fa-light fa-thumbs-down', label: 'Negative', severity: 'danger' },
+  positive: { icon: 'fa-light fa-face-smile', label: 'Positive', severity: 'success', barClass: 'bg-emerald-500' },
+  neutral: { icon: 'fa-light fa-face-meh', label: 'Neutral', severity: 'secondary', barClass: 'bg-amber-400' },
+  negative: { icon: 'fa-light fa-thumbs-down', label: 'Negative', severity: 'danger', barClass: 'bg-red-500' },
 };
 
 export const MENTION_RELEVANCE_CONFIG: Record<MentionRelevance, MentionRelevanceConfigEntry> = {
@@ -90,6 +91,31 @@ export const MENTION_IDS_MAX_VALUES = 500;
 
 /** Row cap for the `mentions-tags` endpoint — serves both the tag filter dropdown and the analytics top-tags panel. */
 export const MENTION_TOP_TAGS_LIMIT = 10;
+
+/** Row cap for the analytics platform-distribution panel (client-side slice; the endpoint returns all platforms). */
+export const ANALYTICS_TOP_PLATFORMS_LIMIT = 5;
+
+/** Row cap requested for the analytics top-projects panel (mirrors the server's `TOP_PROJECTS_LIMIT` default). */
+export const ANALYTICS_TOP_PROJECTS_LIMIT = 5;
+
+/**
+ * Series colors for the analytics charts (LFXV2-3018) — `lfxColors` scales only (styling rule).
+ * Index 0 is reserved for the "Total" line on Mentions Over Time; per-project and per-tag
+ * series cycle from index 1. 500 shades first, then 300s so foundations with more than
+ * five child projects still get distinguishable lines.
+ */
+export const SOCIAL_LISTENING_CHART_PALETTE: string[] = [
+  lfxColors.gray[900],
+  lfxColors.blue[500],
+  lfxColors.emerald[500],
+  lfxColors.amber[500],
+  lfxColors.red[500],
+  lfxColors.violet[500],
+  lfxColors.blue[300],
+  lfxColors.emerald[300],
+  lfxColors.amber[300],
+  lfxColors.violet[300],
+];
 
 /** Interval for refreshing relative timestamps ("2h ago") on rendered mention cards. */
 export const MENTION_TIME_TICK_INTERVAL_MS = 60_000;

--- a/packages/shared/src/interfaces/social-listening.interface.ts
+++ b/packages/shared/src/interfaces/social-listening.interface.ts
@@ -302,6 +302,8 @@ export interface MentionPlatformConfigEntry {
   label: string;
   /** Tailwind text-color class (no hex — repo styling rule). */
   colorClass: string;
+  /** Tailwind bg-color class for the analytics platform-distribution bar (no hex — repo styling rule). */
+  barClass: string;
 }
 
 /** Display config for a sentiment value (see `MENTION_SENTIMENT_CONFIG`). */
@@ -309,6 +311,8 @@ export interface MentionSentimentConfigEntry {
   icon: string;
   label: string;
   severity: TagSeverity;
+  /** Tailwind bg-color class for the analytics sentiment-distribution bar segment (no hex — repo styling rule). */
+  barClass: string;
 }
 
 /** Display config for a relevance value (see `MENTION_RELEVANCE_CONFIG`). */
@@ -322,6 +326,23 @@ export interface AuthorOption extends SocialListeningMentionAuthor {
   platformIcon: string;
   /** Tailwind text-color class (no hex — repo styling rule). */
   platformIconClass: string;
+}
+
+/** Analytics platform-distribution row with display config pre-resolved (built by `mapPlatformDistributionRows`). */
+export interface SocialListeningPlatformRow {
+  config: MentionPlatformConfigEntry;
+  mentionsCount: number;
+  /** 0–100 share of in-scope mentions, one decimal (server-rounded). */
+  percentOfTotal: number;
+}
+
+/** Analytics sentiment-distribution row with display config pre-resolved (built by `mapSentimentRows`). */
+export interface SocialListeningSentimentRow {
+  sentiment: MentionSentiment;
+  config: MentionSentimentConfigEntry;
+  mentionCount: number;
+  /** 0–100 share of in-scope mentions, one decimal (server-rounded). */
+  percentOfTotal: number;
 }
 
 /** Declarative fetch state for the toSignal pipelines. */

--- a/packages/shared/src/interfaces/stat-card.interface.ts
+++ b/packages/shared/src/interfaces/stat-card.interface.ts
@@ -12,6 +12,12 @@ export interface StatCardDelta {
   /** Text rendered next to the delta arrow (e.g., "+8% vs. prior period"). */
   label: string;
   direction: StatCardDeltaDirection;
+  /**
+   * When true, the color mapping flips (up renders red, down renders emerald) while the
+   * arrow keeps the numeric direction — for metrics where an increase is bad
+   * (e.g. negative sentiment; PCC's `changeColorOpposite`).
+   */
+  inverted?: boolean;
 }
 
 /**

--- a/packages/shared/src/utils/social-listening.utils.ts
+++ b/packages/shared/src/utils/social-listening.utils.ts
@@ -6,12 +6,17 @@
  * Ported from PCC; the bookmark (`mentionIds`) client branch is deferred to a follow-up ticket.
  */
 
+import type { ChartData } from 'chart.js';
+
 import {
+  ANALYTICS_TOP_PLATFORMS_LIMIT,
   DEFAULT_MENTION_PREDICATE,
   MENTION_HAS_TITLE_OPTIONS,
   MENTION_PLATFORM_CONFIG,
   MENTION_RELEVANCE_OPTIONS,
+  MENTION_SENTIMENT_CONFIG,
   MENTION_SENTIMENT_OPTIONS,
+  SOCIAL_LISTENING_CHART_PALETTE,
 } from '../constants/social-listening.constants';
 import type { FilterPillOption } from '../interfaces/dashboard-metric.interface';
 import type {
@@ -25,9 +30,16 @@ import type {
   SocialListeningMention,
   SocialListeningMentionAuthor,
   SocialListeningOption,
+  SocialListeningOverTimePoint,
   SocialListeningPlatform,
+  SocialListeningPlatformDistribution,
+  SocialListeningPlatformRow,
+  SocialListeningSentimentDistribution,
+  SocialListeningSentimentRow,
   SocialListeningSubProject,
+  SocialListeningTagCount,
 } from '../interfaces/social-listening.interface';
+import type { StatCardDelta, StatCardDeltaDirection } from '../interfaces/stat-card.interface';
 import { capitalizeFirst } from './string.utils';
 
 /** Lowercases + dedupes keywords so filter state and payloads stay canonical. */
@@ -163,6 +175,148 @@ export function mergeSelectedAuthors(options: AuthorOption[], selected: string[]
     platformIconClass: config.colorClass,
   }));
   return [...options, ...placeholders];
+}
+
+// ---------------------------------------------------------------------------
+// Analytics tab builders (LFXV2-3018) — pure functions over the feed-derived endpoint rows
+// ---------------------------------------------------------------------------
+
+/** Palette index for the Nth series — index 0 is reserved for the "Total" line, so cycles run over the remaining slots and never collide with it. */
+function seriesColor(index: number): string {
+  return SOCIAL_LISTENING_CHART_PALETTE[1 + (index % (SOCIAL_LISTENING_CHART_PALETTE.length - 1))];
+}
+
+/** Snowflake's TO_CHAR month labels arrive uppercase (`MAR 2026`, `MAR 05`) — title-case the words for display. */
+function formatPeriodLabel(label: string): string {
+  return label.toLowerCase().replace(/\b[a-z]/g, (c) => c.toUpperCase());
+}
+
+/**
+ * Mentions Over Time line chart: one dataset per sub-project plus a leading "Total" line.
+ * Buckets order by `PERIOD_START` (the DATE_TRUNC ISO start), not `PERIOD_LABEL`, which is
+ * display-only and can't sort across grains. Projects group by NAME (PCC parity — children
+ * may share the parent's id in the feed) and duplicate (bucket, name) rows fold by summing,
+ * since the server groups by (bucket, id, name). Returns null when there's nothing to chart
+ * (drives the panel's empty state).
+ */
+export function buildOverTimeChartData(points: SocialListeningOverTimePoint[]): ChartData<'line'> | null {
+  if (points.length === 0) return null;
+
+  const bucketStarts = [...new Set(points.map((p) => p.PERIOD_START))].sort();
+  const labelByStart = new Map<string, string>();
+  for (const point of points) {
+    if (!labelByStart.has(point.PERIOD_START)) {
+      labelByStart.set(point.PERIOD_START, formatPeriodLabel(point.PERIOD_LABEL));
+    }
+  }
+  const labels = bucketStarts.map((start) => labelByStart.get(start) ?? start);
+
+  const projectMap = new Map<string, Map<string, number>>();
+  for (const point of points) {
+    let byPeriod = projectMap.get(point.SOURCE_PROJECT_NAME);
+    if (!byPeriod) {
+      byPeriod = new Map();
+      projectMap.set(point.SOURCE_PROJECT_NAME, byPeriod);
+    }
+    byPeriod.set(point.PERIOD_START, (byPeriod.get(point.PERIOD_START) ?? 0) + (point.TOTAL_MENTIONS || 0));
+  }
+
+  const totals = bucketStarts.map((start) => {
+    let sum = 0;
+    projectMap.forEach((byPeriod) => {
+      sum += byPeriod.get(start) ?? 0;
+    });
+    return sum;
+  });
+
+  const line = (label: string, data: number[], color: string) => ({
+    label,
+    data,
+    borderColor: color,
+    backgroundColor: color,
+    pointBackgroundColor: color,
+    borderWidth: 2,
+  });
+
+  const datasets = [line('Total', totals, SOCIAL_LISTENING_CHART_PALETTE[0])];
+  let index = 0;
+  projectMap.forEach((byPeriod, name) => {
+    datasets.push(
+      line(
+        name,
+        bucketStarts.map((start) => byPeriod.get(start) ?? 0),
+        seriesColor(index)
+      )
+    );
+    index++;
+  });
+
+  return { labels, datasets };
+}
+
+/**
+ * Mentions by Tag bar chart: server rows arrive pre-sorted and capped at `MENTION_TOP_TAGS_LIMIT`,
+ * labels are title-cased with underscores as spaces (`formatTag`). Returns null when empty.
+ */
+export function buildTagsChartData(tags: SocialListeningTagCount[]): ChartData<'bar'> | null {
+  const rows = tags.filter((tag) => !!tag.TAG);
+  if (rows.length === 0) return null;
+
+  return {
+    labels: rows.map((tag) => formatTag(tag.TAG)),
+    datasets: [
+      {
+        data: rows.map((tag) => tag.TOTAL_COUNT),
+        backgroundColor: rows.map((_, i) => seriesColor(i)),
+        borderRadius: 4,
+        borderSkipped: false,
+      },
+    ],
+  };
+}
+
+/** Top-N platform rows (default `ANALYTICS_TOP_PLATFORMS_LIMIT`) with display config pre-resolved. */
+export function mapPlatformDistributionRows(
+  rows: SocialListeningPlatformDistribution[],
+  limit: number = ANALYTICS_TOP_PLATFORMS_LIMIT
+): SocialListeningPlatformRow[] {
+  return rows.slice(0, limit).map((row) => ({
+    config: MENTION_PLATFORM_CONFIG[normalizePlatformKey(row.SOURCE_PLATFORM || row.SOCIAL_NETWORK)],
+    mentionsCount: row.MENTIONS_COUNT,
+    percentOfTotal: row.PERCENT_OF_TOTAL || 0,
+  }));
+}
+
+/** Sentiment share rows in fixed positive → neutral → negative display order; unknown upstream values are dropped. */
+export function mapSentimentRows(rows: SocialListeningSentimentDistribution[]): SocialListeningSentimentRow[] {
+  const order: MentionSentiment[] = ['positive', 'neutral', 'negative'];
+  return rows
+    .filter((row) => Object.hasOwn(MENTION_SENTIMENT_CONFIG, row.SENTIMENT))
+    .map((row) => {
+      const sentiment = row.SENTIMENT as MentionSentiment;
+      return {
+        sentiment,
+        config: MENTION_SENTIMENT_CONFIG[sentiment],
+        mentionCount: row.MENTION_COUNT,
+        percentOfTotal: row.PERCENT_OF_TOTAL || 0,
+      };
+    })
+    .sort((a, b) => order.indexOf(a.sentiment) - order.indexOf(b.sentiment));
+}
+
+/**
+ * Maps a server's signed change percentage to a stat-card delta: the arrow carries the numeric
+ * direction, the label shows the absolute value (PCC parity), and `inverted` flips the color
+ * mapping for metrics where an increase is bad (negative sentiment). Returns undefined when the
+ * server suppressed the comparison (null — previous window too thin), hiding the delta line.
+ */
+export function buildAnalyticsDelta(changePct: number | null, inverted = false): StatCardDelta | undefined {
+  if (changePct === null) return undefined;
+  let direction: StatCardDeltaDirection = 'flat';
+  if (changePct > 0) direction = 'up';
+  else if (changePct < 0) direction = 'down';
+  const sign = changePct > 0 ? '+' : '';
+  return { label: `${sign}${Math.abs(changePct).toFixed(1)}% vs last period`, direction, inverted };
 }
 
 function buildTags(tagsStr: string): string[] {


### PR DESCRIPTION
## Summary

Ports the Social Listening Analytics tab from PCC into LFX One. The tab now renders six panels — KPI stat cards (total mentions, negative/positive sentiment with period-over-period deltas), a mentions-over-time line chart, platform and sentiment distribution bars, a mentions-by-tag bar chart, and a top-projects panel — all fed by the feed-derived analytics endpoints and reacting to the page's period/platform/sub-project scope. An Export button in the header (Analytics tab only) downloads the whole dashboard as a PNG.

Resolves LFXV2-3018

## Behavior changes

### Analytics tab

| Before | After |
|---|---|
| The Analytics tab showed a "coming soon" placeholder while the feature was being migrated from PCC. | The Analytics tab shows a live dashboard: mention KPIs with trend arrows, a mentions-over-time chart broken out per project, platform and sentiment breakdowns, top tags, and top projects — all updating when the period, platform, or project filters change. |

### PNG export

| Before | After |
|---|---|
| There was no way to capture or share the analytics view. | An Export button appears in the header on the Analytics tab; clicking it downloads the entire dashboard as a PNG image (spinner shows while the capture runs). |

## Technical changes

`apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/` — Analytics tab component (new)

- Adds `SocialListeningAnalyticsComponent` with six panels, each on its own declarative `toSignal` pipeline (`debounceTime(0)` + `switchMap` + `startWith`/`catchError`) so a failed request degrades only its own panel
- Derives one shared `analyticsRequest` from the scope inputs (`foundationSlug`, `period`, `platform`, `sourceProjectId`); platform and sentiment bars are CSS flex segments, only the line/tag charts use `lfx-chart` with options as plain class properties (chart-options rule 7.8)
- Export flow: the page increments `exportNonce`; a browser-gated `effect` captures the component's own content grid via `downloadCardAsImage` and reports progress back through the `isExporting` model — no `viewChild` method calls (rule 12.7)

`apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts, .html` — Social Listening page

- Replaces the "coming soon" empty state with `lfx-social-listening-analytics`, passing the page's scope signals down and two-way binding `exporting`
- Adds `exportNonce`/`exporting` signals and `onExportAnalytics()`, which increments the nonce the analytics component reacts to

`apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts, .html` — Feed header

- Adds an Export button rendered on the Analytics tab only, with loading/disabled bound to the new `exporting` input and clicks surfaced via the `exportAnalytics` output

`apps/lfx-one/src/app/shared/components/stat-card-grid/` — Stat card grid

- Supports `StatCardDelta.inverted` through `INVERTED_DELTA_DIRECTION_TEXT_CLASS` — an increase in a bad metric (e.g. negative sentiment) renders red while the arrow keeps the numeric direction (PCC's `changeColorOpposite` parity)

`apps/lfx-one/src/app/shared/utils/download-card.util.ts` — PNG download helper

- Adds a `DownloadCardOptions` parameter with `backgroundColor` (transparent default preserved for existing single-card callers)
- Awaits `document.fonts.ready` before capture so icon-font glyphs render when the export fires right after a tab switch

`packages/shared/src/utils/social-listening.utils.ts` — Shared analytics builders

- Adds pure builders consumed by the analytics panels: `buildOverTimeChartData` (per-project line series plus a "Total" line, buckets ordered by `PERIOD_START`), `buildTagsChartData`, `mapPlatformDistributionRows`, `mapSentimentRows` (fixed positive → neutral → negative order), and `buildAnalyticsDelta` (hides the delta when the server suppresses a thin previous window; flips colors for inverted metrics)

`packages/shared/src/constants/, packages/shared/src/interfaces/` — Shared constants & types

- Adds `barClass` to `MENTION_PLATFORM_CONFIG` / `MENTION_SENTIMENT_CONFIG`, the `SOCIAL_LISTENING_CHART_PALETTE` (built from `lfxColors` scales only), and `ANALYTICS_TOP_PLATFORMS_LIMIT` / `ANALYTICS_TOP_PROJECTS_LIMIT` row caps
- Adds `INVERTED_DELTA_DIRECTION_TEXT_CLASS`, the optional `StatCardDelta.inverted` flag, and the `SocialListeningPlatformRow` / `SocialListeningSentimentRow` interfaces

`apps/lfx-one/tailwind.config.js` — Tailwind safelist

- Safelists the new `barClass` values from the platform/sentiment configs, which live in `@lfx-one/shared` outside Tailwind's content scanning
