### PR TITLE
fix(org-lens): merge People rows on LF identity, and gate every lens read (LFXV2-3250)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
@@ -288,9 +288,12 @@ export class AllEmployeesComponent {
       initials: AllEmployeesComponent.computeInitials(row.name),
       avatarColorClass: AllEmployeesComponent.computeAvatarColorClass(row.personKey),
       avatarKey: row.avatarUrl ? `${row.personKey}::${row.avatarUrl}` : '',
-      // Join on lowercased email — the canonical identity key on the Access side (OrgAccessUser.email is
-      // always present, server-lowercased). Rows without an email can't be joined and render `—`.
-      access: row.email ? (byEmail.get(row.email.toLowerCase()) ?? null) : null,
+      // Join on every address the row was merged from, not just the preferred one. The Access side is
+      // keyed by email, but a person's access can be granted under a different address than the one the
+      // roster displays — that mismatch is exactly what the server-side identity merge folds together, so
+      // joining on the preferred address alone would drop the badge for the merged rows. Rows with no
+      // address can't be joined and render `—`.
+      access: AllEmployeesComponent.resolveAccessBadge(row, byEmail),
       // Live-only people (no `snowflake` source) carry a synthetic `live-` personKey with no stored Snowflake
       // detail, so they must not be chevron-expandable or trigger a detail fetch — mark them synthetic
       // regardless of which live source (access / board / committee / keyContact) added them.
@@ -465,6 +468,29 @@ export class AllEmployeesComponent {
       default:
         return 0;
     }
+  }
+
+  /**
+   * Resolve the access badge for a row.
+   *
+   * The access roster is keyed by email, but a person's access can be granted under a different
+   * address than the roster displays — the server's identity merge folds those together, so joining
+   * on the displayed address alone drops the badge for merged rows.
+   *
+   * Secondary addresses are only consulted when the server actually attributed access to this row
+   * (`sources` contains `access`). Two different people can legitimately share an address — the
+   * server keeps them as separate rows precisely because their identities differ — so matching any
+   * address unconditionally would let one person's badge appear on the other's row. Rows without an
+   * access source keep the original displayed-address-only join.
+   */
+  private static resolveAccessBadge(row: OrgAllEmployeeRow, byEmail: ReadonlyMap<string, OrgAccessBadgeState>): OrgAccessBadgeState | null {
+    const candidates = row.sources.includes('access') ? [row.email, ...(row.emails ?? [])] : [row.email];
+    for (const candidate of candidates) {
+      if (!candidate) continue;
+      const badge = byEmail.get(candidate.toLowerCase());
+      if (badge) return badge;
+    }
+    return null;
   }
 
   private static computeInitials(name: string): string {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
@@ -18,6 +18,7 @@ import { PersonDetailDrawerService } from '@services/person-detail-drawer.servic
 
 import { EMPTY_ORG_ALL_EMPLOYEES_RESPONSE, ORG_ALL_EMPLOYEE_ACTIVITY_OPTIONS, ORG_ALL_EMPLOYEES_INITIAL_LIMIT } from '@lfx-one/shared/constants';
 import type {
+  OrgAccessBadgeState,
   OrgAllEmployeeActivityFilter,
   OrgAllEmployeeActivityOption,
   OrgAllEmployeeDetail,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
@@ -472,26 +472,17 @@ export class AllEmployeesComponent {
   }
 
   /**
-   * Resolve the access badge for a row.
+   * Resolve the access badge for a row, preferring the server's answer.
    *
-   * The access roster is keyed by email, but a person's access can be granted under a different
-   * address than the roster displays — the server's identity merge folds those together, so joining
-   * on the displayed address alone drops the badge for merged rows.
-   *
-   * Secondary addresses are only consulted when the server actually attributed access to this row
-   * (`sources` contains `access`). Two different people can legitimately share an address — the
-   * server keeps them as separate rows precisely because their identities differ — so matching any
-   * address unconditionally would let one person's badge appear on the other's row. Rows without an
-   * access source keep the original displayed-address-only join.
+   * The server knows exactly which access principal it merged into each person, so `accessBadge` is
+   * unambiguous. Joining by address cannot be: two people can share one, and the merge deliberately
+   * keeps them as separate rows, so an address-based lookup can attribute one person's role to the
+   * other. The join remains only for rows the server attributed no access to — including payloads
+   * cached before `accessBadge` existed.
    */
   private static resolveAccessBadge(row: OrgAllEmployeeRow, byEmail: ReadonlyMap<string, OrgAccessBadgeState>): OrgAccessBadgeState | null {
-    const candidates = row.sources.includes('access') ? [row.email, ...(row.emails ?? [])] : [row.email];
-    for (const candidate of candidates) {
-      if (!candidate) continue;
-      const badge = byEmail.get(candidate.toLowerCase());
-      if (badge) return badge;
-    }
-    return null;
+    if (row.accessBadge) return row.accessBadge;
+    return row.email ? (byEmail.get(row.email.toLowerCase()) ?? null) : null;
   }
 
   private static computeInitials(name: string): string {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-people/components/all-employees/all-employees.component.ts
@@ -161,17 +161,13 @@ export class AllEmployeesComponent {
   // Exposed to the template so per-row @let blocks can build the composite (account, person) detail-cache key without reaching into private services.
   protected readonly currentAccountId = computed(() => this.accountContext.selectedAccount().uid);
 
-  // Lowercased email -> 'admin' | 'viewer' | 'invited' for the currently selected org. Empty until the
-  // shared cache hydrates (either from this tab's ensureLoaded below, or pushed in by the Access tab).
-  private readonly accessByEmail = this.accessState.accessByEmailFor(this.currentAccountId);
-
   public constructor() {
-    // Hydrate the shared Org Lens access cache for every org we see (including the initial one) so the
-    // access cell can render badges without each row triggering its own fetch. The service dedups concurrent
-    // calls and short-circuits cache hits, so this is cheap on re-visits. Per-fetch `catchError` keeps the
-    // outer stream alive on a transient backend failure — the Access tab still has its own error banner +
-    // retry CTA, so silent EMPTY here just means badges stay empty until the user visits Access or switches
-    // orgs and the next fetch succeeds.
+    // Warm the shared Org Lens access cache for every org we see (including the initial one), so the
+    // Access tab opens against a hydrated cache. This tab no longer reads it — badges now come from the
+    // roster's own `accessBadge` — but the prefetch is kept because it is what makes that tab instant.
+    // The service dedups concurrent calls and short-circuits cache hits, so it is cheap on re-visits.
+    // Per-fetch `catchError` keeps the outer stream alive on a transient backend failure; the Access tab
+    // has its own error banner + retry CTA, so a silent EMPTY here only costs the prefetch.
     this.orgUid$
       .pipe(
         switchMap((uid) => this.accessState.ensureLoaded(uid).pipe(catchError(() => EMPTY))),
@@ -281,20 +277,14 @@ export class AllEmployeesComponent {
   }
 
   private initViewRows(): OrgAllEmployeeRowVm[] {
-    const byEmail = this.accessByEmail();
-    // The live directory endpoint already merges access-only principals into `rows` server-side, so there is
-    // no client-side synthetic UNION here. The access cache is still joined per row to render the badge cell.
+    // The live directory endpoint merges access principals into `rows` server-side and stamps the badge
+    // on each one, so there is neither a client-side synthetic UNION nor an address join here.
     return this.response().rows.map<OrgAllEmployeeRowVm>((row) => ({
       ...row,
       initials: AllEmployeesComponent.computeInitials(row.name),
       avatarColorClass: AllEmployeesComponent.computeAvatarColorClass(row.personKey),
       avatarKey: row.avatarUrl ? `${row.personKey}::${row.avatarUrl}` : '',
-      // Join on every address the row was merged from, not just the preferred one. The Access side is
-      // keyed by email, but a person's access can be granted under a different address than the one the
-      // roster displays — that mismatch is exactly what the server-side identity merge folds together, so
-      // joining on the preferred address alone would drop the badge for the merged rows. Rows with no
-      // address can't be joined and render `—`.
-      access: AllEmployeesComponent.resolveAccessBadge(row, byEmail),
+      access: AllEmployeesComponent.resolveAccessBadge(row),
       // Live-only people (no `snowflake` source) carry a synthetic `live-` personKey with no stored Snowflake
       // detail, so they must not be chevron-expandable or trigger a detail fetch — mark them synthetic
       // regardless of which live source (access / board / committee / keyContact) added them.
@@ -472,17 +462,14 @@ export class AllEmployeesComponent {
   }
 
   /**
-   * Resolve the access badge for a row, preferring the server's answer.
-   *
-   * The server knows exactly which access principal it merged into each person, so `accessBadge` is
-   * unambiguous. Joining by address cannot be: two people can share one, and the merge deliberately
-   * keeps them as separate rows, so an address-based lookup can attribute one person's role to the
-   * other. The join remains only for rows the server attributed no access to — including payloads
-   * cached before `accessBadge` existed.
+   * The access badge comes solely from the server, which knows which principal it merged into each
+   * person. There is deliberately no address-based fallback: two people can share an address while
+   * the merge keeps them as separate rows, so a lookup by address would give one person's role to
+   * the other. Every principal is attributed to exactly one row (an unmatched one becomes its own),
+   * so a fallback could never add a badge the server omitted — only a wrong one.
    */
-  private static resolveAccessBadge(row: OrgAllEmployeeRow, byEmail: ReadonlyMap<string, OrgAccessBadgeState>): OrgAccessBadgeState | null {
-    if (row.accessBadge) return row.accessBadge;
-    return row.email ? (byEmail.get(row.email.toLowerCase()) ?? null) : null;
+  private static resolveAccessBadge(row: OrgAllEmployeeRow): OrgAccessBadgeState | null {
+    return row.accessBadge ?? null;
   }
 
   private static computeInitials(name: string): string {

--- a/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.spec.ts
@@ -1,0 +1,130 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Same reason as require-executive-director.middleware.spec.ts: the import graph transitively
+// reaches Angular's partially-compiled @angular/common, which needs the JIT compiler under vitest.
+import '@angular/compiler';
+
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const getAccessAwareOrgs = vi.fn();
+const getEffectiveUsername = vi.fn();
+
+vi.mock('../services/org-role-grants.service', () => ({
+  OrgRoleGrantsService: class {
+    public getAccessAwareOrgs = getAccessAwareOrgs;
+  },
+}));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: () => getEffectiveUsername() }));
+// Deny paths log before rejecting; the real logger expects a fuller request object than these stubs
+// carry, and would otherwise throw into the catch and turn a 403 into a 500.
+vi.mock('../services/logger.service', () => ({
+  logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+
+const { requireOrgLensAccess } = await import('./require-org-lens-access.middleware');
+
+const LF = '0014100000Te2ovAAB';
+const RED_HAT = '0014100000Te2QjAAJ';
+
+function grants(uids: string[], upstreamFailed = false): { resolved: Map<string, unknown>; upstreamFailed: boolean } {
+  return { resolved: new Map(uids.map((uid) => [uid, { roleSource: 'direct-writer' }])), upstreamFailed };
+}
+
+function buildReq(orgUid: string): Request {
+  return { path: `/api/orgs/${orgUid}/lens/people/all`, params: { orgUid } } as unknown as Request;
+}
+
+async function run(orgUid: string): Promise<{ next: ReturnType<typeof vi.fn> }> {
+  const next = vi.fn() as unknown as NextFunction & ReturnType<typeof vi.fn>;
+  await requireOrgLensAccess(buildReq(orgUid), {} as Response, next);
+  return { next };
+}
+
+/** Allow = next() with no argument; deny = next(error). */
+function statusOf(next: ReturnType<typeof vi.fn>): number | 'allow' {
+  expect(next).toHaveBeenCalledTimes(1);
+  const arg = next.mock.calls[0][0];
+  if (arg === undefined) return 'allow';
+  return (arg as { statusCode?: number }).statusCode ?? 500;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getEffectiveUsername.mockReturnValue('lguerra');
+  getAccessAwareOrgs.mockResolvedValue(grants([LF]));
+});
+
+describe('requireOrgLensAccess', () => {
+  it('allows a caller holding a relation on the requested organization', async () => {
+    const { next } = await run(LF);
+    expect(statusOf(next)).toBe('allow');
+  });
+
+  it('refuses an organization the caller holds no relation on (the reported exposure)', async () => {
+    // Before this middleware existed, this request returned 3,519 rows of another org's people.
+    const { next } = await run(RED_HAT);
+    expect(statusOf(next)).toBe(403);
+  });
+
+  it('allows a cascading (inherited) grant, not only a direct one', async () => {
+    getAccessAwareOrgs.mockResolvedValue({
+      resolved: new Map([[RED_HAT, { roleSource: 'inherited-auditor', parentUid: LF, parentName: 'LF' }]]),
+      upstreamFailed: false,
+    });
+
+    const { next } = await run(RED_HAT);
+
+    expect(statusOf(next)).toBe('allow');
+  });
+
+  it('allows a direct auditor', async () => {
+    getAccessAwareOrgs.mockResolvedValue({ resolved: new Map([[LF, { roleSource: 'direct-auditor' }]]), upstreamFailed: false });
+
+    const { next } = await run(LF);
+
+    expect(statusOf(next)).toBe('allow');
+  });
+
+  it('returns a retriable 503 when the grants lookup fails, rather than claiming no permission', async () => {
+    getAccessAwareOrgs.mockResolvedValue(grants([], true));
+
+    const { next } = await run(LF);
+
+    expect(statusOf(next)).toBe(503);
+  });
+
+  it('does not fall open when the grants lookup fails for an org the caller could otherwise read', async () => {
+    getAccessAwareOrgs.mockResolvedValue({ resolved: new Map([[LF, { roleSource: 'direct-writer' }]]), upstreamFailed: true });
+
+    const { next } = await run(LF);
+
+    expect(statusOf(next)).toBe(503);
+  });
+
+  it('refuses when no caller identity can be resolved', async () => {
+    getEffectiveUsername.mockReturnValue(undefined);
+
+    const { next } = await run(LF);
+
+    expect(statusOf(next)).toBe(403);
+    expect(getAccessAwareOrgs).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the route carries no organization id', async () => {
+    const next = vi.fn() as unknown as NextFunction & ReturnType<typeof vi.fn>;
+    await requireOrgLensAccess({ path: '/api/orgs//lens/people/all', params: {} } as unknown as Request, {} as Response, next);
+
+    expect(statusOf(next)).toBe(403);
+  });
+
+  it('propagates an unexpected error rather than silently allowing', async () => {
+    getAccessAwareOrgs.mockRejectedValue(new Error('boom'));
+
+    const { next } = await run(LF);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(Error);
+  });
+});

--- a/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.spec.ts
@@ -11,6 +11,8 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 const getAccessAwareOrgs = vi.fn();
 const getEffectiveUsername = vi.fn();
 
+// The middleware delegates to `assertOrgLensRead`, so these mocks target what that helper consumes —
+// the tests therefore exercise the real gate logic, not a reimplementation of it.
 vi.mock('../services/org-role-grants.service', () => ({
   OrgRoleGrantsService: class {
     public getAccessAwareOrgs = getAccessAwareOrgs;

--- a/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NextFunction, Request, Response } from 'express';
+
+import { AuthorizationError, MicroserviceError } from '../errors';
+import { logger } from '../services/logger.service';
+import { OrgRoleGrantsService } from '../services/org-role-grants.service';
+import { getEffectiveUsername } from '../utils/auth-helper';
+
+const roleGrantsService = new OrgRoleGrantsService();
+
+/**
+ * Requires the caller to hold an Org Lens relation (writer/auditor, direct or inherited) on the
+ * organization named in the route, before any `/api/orgs/:orgUid/lens/*` read runs.
+ *
+ * Without this, the org identifier in the URL is the only thing scoping the response, and it is
+ * supplied by the caller — so any authenticated user could read any organization's roster,
+ * memberships and person-level detail. A `WHERE account_id = ?` predicate on the analytics query is
+ * a data filter, not an authorization check (ADR-0038 (a)); this middleware supplies the missing
+ * operational-plane gate, matching what the sibling lenses already require for the same facts.
+ *
+ * Failure semantics mirror `OrgLensAccessService.assertCanManage`, which is the established pattern
+ * for this app: 403 only when the caller is *verified* to lack the relation, and a retriable 503
+ * when the grants lookup itself could not be completed — a transient upstream outage must not
+ * masquerade as "no permission", and equally must not fall open.
+ */
+export async function requireOrgLensAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const orgUid = req.params['orgUid'];
+
+  try {
+    const username = getEffectiveUsername(req);
+    if (!username) {
+      next(
+        new AuthorizationError('Authentication is required to view organization data.', {
+          operation: 'require_org_lens_access',
+          service: 'authorization',
+          path: req.path,
+          code: 'ORG_LENS_ACCESS_REQUIRED',
+        })
+      );
+      return;
+    }
+
+    const { resolved, upstreamFailed } = await roleGrantsService.getAccessAwareOrgs(req, username);
+
+    // Fail closed but retriable: we could not establish what the caller may see, so we neither serve
+    // the data nor claim they are unauthorized.
+    if (upstreamFailed) {
+      logger.warning(req, 'require_org_lens_access', 'Role-grants lookup failed; refusing the read as retriable', {
+        org_uid: orgUid,
+      });
+      next(
+        new MicroserviceError('Could not verify your access to this organization. Please try again.', 503, 'ORG_LENS_ACCESS_UNVERIFIED', {
+          operation: 'require_org_lens_access',
+          service: 'authorization',
+          path: req.path,
+        })
+      );
+      return;
+    }
+
+    // `resolved` holds every org the caller can see — direct writer, direct auditor, and children
+    // inherited from a direct-granted parent — so membership in it is the whole check.
+    if (orgUid && resolved.has(orgUid)) {
+      next();
+      return;
+    }
+
+    logger.warning(req, 'require_org_lens_access', 'Caller requested an organization they hold no relation on', {
+      org_uid: orgUid,
+      granted_org_count: resolved.size,
+    });
+    next(
+      new AuthorizationError('You do not have access to this organization.', {
+        operation: 'require_org_lens_access',
+        service: 'authorization',
+        path: req.path,
+        code: 'ORG_LENS_ACCESS_REQUIRED',
+      })
+    );
+  } catch (error) {
+    next(error);
+  }
+}

--- a/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/require-org-lens-access.middleware.ts
@@ -3,82 +3,25 @@
 
 import { NextFunction, Request, Response } from 'express';
 
-import { AuthorizationError, MicroserviceError } from '../errors';
-import { logger } from '../services/logger.service';
-import { OrgRoleGrantsService } from '../services/org-role-grants.service';
-import { getEffectiveUsername } from '../utils/auth-helper';
-
-const roleGrantsService = new OrgRoleGrantsService();
+import { assertOrgLensRead } from '../helpers/org-lens-read-access.helper';
 
 /**
- * Requires the caller to hold an Org Lens relation (writer/auditor, direct or inherited) on the
- * organization named in the route, before any `/api/orgs/:orgUid/lens/*` read runs.
+ * Applies the Org Lens read gate to every `/api/orgs/:orgUid/lens/*` route.
  *
- * Without this, the org identifier in the URL is the only thing scoping the response, and it is
- * supplied by the caller — so any authenticated user could read any organization's roster,
- * memberships and person-level detail. A `WHERE account_id = ?` predicate on the analytics query is
- * a data filter, not an authorization check (ADR-0038 (a)); this middleware supplies the missing
- * operational-plane gate, matching what the sibling lenses already require for the same facts.
+ * `assertOrgLensRead` already encodes the rule and its failure semantics; until now it was called
+ * by three handlers (meetings, ROI, groups) and the rest of the family relied on the `:orgUid` in
+ * the URL to scope the response. That identifier is supplied by the caller, so it filtered the data
+ * without authorizing it, and any authenticated user could read any organization's roster.
  *
- * Failure semantics mirror `OrgLensAccessService.assertCanManage`, which is the established pattern
- * for this app: 403 only when the caller is *verified* to lack the relation, and a retriable 503
- * when the grants lookup itself could not be completed — a transient upstream outage must not
- * masquerade as "no permission", and equally must not fall open.
+ * Mounting the gate on the shared prefix rather than repeating it per handler is the point: a new
+ * lens endpoint is covered the moment it is added. The three handlers that already call the helper
+ * keep doing so — the check is idempotent and cheap (the grant lookup is cached per caller), and
+ * defence in depth is worth more here than removing a duplicate call.
  */
 export async function requireOrgLensAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
-  const orgUid = req.params['orgUid'];
-
   try {
-    const username = getEffectiveUsername(req);
-    if (!username) {
-      next(
-        new AuthorizationError('Authentication is required to view organization data.', {
-          operation: 'require_org_lens_access',
-          service: 'authorization',
-          path: req.path,
-          code: 'ORG_LENS_ACCESS_REQUIRED',
-        })
-      );
-      return;
-    }
-
-    const { resolved, upstreamFailed } = await roleGrantsService.getAccessAwareOrgs(req, username);
-
-    // Fail closed but retriable: we could not establish what the caller may see, so we neither serve
-    // the data nor claim they are unauthorized.
-    if (upstreamFailed) {
-      logger.warning(req, 'require_org_lens_access', 'Role-grants lookup failed; refusing the read as retriable', {
-        org_uid: orgUid,
-      });
-      next(
-        new MicroserviceError('Could not verify your access to this organization. Please try again.', 503, 'ORG_LENS_ACCESS_UNVERIFIED', {
-          operation: 'require_org_lens_access',
-          service: 'authorization',
-          path: req.path,
-        })
-      );
-      return;
-    }
-
-    // `resolved` holds every org the caller can see — direct writer, direct auditor, and children
-    // inherited from a direct-granted parent — so membership in it is the whole check.
-    if (orgUid && resolved.has(orgUid)) {
-      next();
-      return;
-    }
-
-    logger.warning(req, 'require_org_lens_access', 'Caller requested an organization they hold no relation on', {
-      org_uid: orgUid,
-      granted_org_count: resolved.size,
-    });
-    next(
-      new AuthorizationError('You do not have access to this organization.', {
-        operation: 'require_org_lens_access',
-        service: 'authorization',
-        path: req.path,
-        code: 'ORG_LENS_ACCESS_REQUIRED',
-      })
-    );
+    await assertOrgLensRead(req, req.params['orgUid'] ?? '', 'require_org_lens_access');
+    next();
   } catch (error) {
     next(error);
   }

--- a/apps/lfx-one/src/server/routes/orgs.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.spec.ts
@@ -1,0 +1,112 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Same reason as require-executive-director.middleware.spec.ts: the import graph transitively
+// reaches Angular's partially-compiled @angular/common, which needs the JIT compiler under vitest.
+import '@angular/compiler';
+
+import express from 'express';
+import type { Server } from 'node:http';
+import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
+
+/**
+ * Router-level coverage for the Org Lens read gate.
+ *
+ * The middleware has its own unit tests, but those call it directly — they would keep passing if the
+ * `router.use('/:orgUid/lens', …)` registration were deleted, moved below a route, or scoped so
+ * narrowly that it missed the `:accountId` routes. Since that registration *is* the fix for the
+ * cross-org exposure, these tests drive real HTTP requests through the assembled router.
+ *
+ * Only the gate is asserted. A blocked request must be refused with 403; an admitted one only has to
+ * get *past* the gate — whatever the downstream handler then does with no upstreams configured is
+ * irrelevant here and deliberately not stubbed, which keeps this test from re-encoding every
+ * controller's wiring.
+ */
+
+const getAccessAwareOrgs = vi.fn();
+
+vi.mock('../services/org-role-grants.service', () => ({
+  OrgRoleGrantsService: class {
+    public getAccessAwareOrgs = getAccessAwareOrgs;
+  },
+}));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: () => 'lguerra' }));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    info: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+    debug: vi.fn(),
+    startOperation: vi.fn(() => Date.now()),
+    success: vi.fn(),
+  },
+}));
+
+const orgsRouter = (await import('./orgs.route')).default;
+
+const GRANTED = '0014100000Te2ovAAB';
+const UNGRANTED = '0014100000Te2QjAAJ';
+
+let server: Server;
+let baseUrl: string;
+
+beforeAll(async () => {
+  const app = express();
+  app.use('/api/orgs', orgsRouter);
+  await new Promise<void>((resolve) => {
+    server = app.listen(0, '127.0.0.1', resolve);
+  });
+  const address = server.address();
+  const port = typeof address === 'object' && address ? address.port : 0;
+  baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterAll(async () => {
+  await new Promise<void>((resolve) => server.close(() => resolve()));
+});
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAccessAwareOrgs.mockResolvedValue({ resolved: new Map([[GRANTED, { roleSource: 'direct-writer' }]]), upstreamFailed: false });
+});
+
+describe('orgs router — Org Lens read gate', () => {
+  // `:orgUid` and `:accountId` name the same SFID; both must be gated, which is why the mount sits on
+  // the shared `/lens` prefix rather than on individual routes.
+  it.each([
+    ['people roster (:orgUid)', `/lens/people/all`],
+    ['events (:accountId)', `/lens/events`],
+    ['memberships', `/lens/memberships/active`],
+    ['contributions', `/lens/contributions/summary`],
+  ])('refuses %s for an org the caller holds no grant on', async (_label, path) => {
+    const res = await fetch(`${baseUrl}/api/orgs/${UNGRANTED}${path}`);
+
+    expect(res.status).toBe(403);
+  });
+
+  it('admits a granted org past the gate', async () => {
+    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/people/all`);
+
+    expect(res.status).not.toBe(403);
+    // The gate must have run and allowed it — without this the assertion above also holds when the
+    // gate is absent entirely, which is exactly the regression these tests exist to catch.
+    expect(getAccessAwareOrgs).toHaveBeenCalled();
+  });
+
+  it('refuses with 503, not 403, when the grant lookup cannot be completed', async () => {
+    getAccessAwareOrgs.mockResolvedValue({ resolved: new Map(), upstreamFailed: true });
+
+    const res = await fetch(`${baseUrl}/api/orgs/${GRANTED}/lens/people/all`);
+
+    // Asserted together: a downstream failure can also surface as 503, so the status alone does not
+    // prove the gate produced it.
+    expect(res.status).toBe(503);
+    expect(getAccessAwareOrgs).toHaveBeenCalled();
+  });
+
+  it('does not gate the non-lens identity routes', async () => {
+    const res = await fetch(`${baseUrl}/api/orgs/me/role-grants`);
+
+    expect(res.status).not.toBe(403);
+  });
+});

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -19,6 +19,7 @@ import { OrgLensProjectsController } from '../controllers/org-lens-projects.cont
 import { OrgLensRoiController } from '../controllers/org-lens-roi.controller';
 import { OrgLensGroupsController } from '../controllers/org-lens-groups.controller';
 import { OrgLensTrainingController } from '../controllers/org-lens-training.controller';
+import { requireOrgLensAccess } from '../middleware/require-org-lens-access.middleware';
 
 function buildOrgsRouter(): Router {
   const router = Router();
@@ -44,6 +45,13 @@ function buildOrgsRouter(): Router {
   router.get('/uid/:uid', (req, res, next) => orgIdentityController.getCanonicalRecord(req, res, next));
   router.put('/uid/:uid', (req, res, next) => orgIdentityController.updateOrg(req, res, next));
   router.get('/uid/:uid/addresses', (req, res, next) => orgIdentityController.getOrgAddresses(req, res, next));
+
+  // Every org-lens read is gated on the caller holding a relation on the requested organization.
+  // Mounted on the shared prefix rather than added per route so a new lens endpoint is covered by
+  // default — the alternative (a per-controller check) is what let the whole family ship ungated,
+  // with only the caller-supplied account id scoping the response. Some routes below name the param
+  // `:accountId`; the prefix match here still binds it as `orgUid`, and both carry the same SFID.
+  router.use('/:orgUid/lens', (req, res, next) => requireOrgLensAccess(req, res, next));
 
   // Spec 002: all org-lens routes key off the org account id (18-char SFID). The param is still named
   // `:orgUid` for backward compatibility; the value space is the SFID (validated by assertOrgUid).

--- a/apps/lfx-one/src/server/routes/orgs.route.ts
+++ b/apps/lfx-one/src/server/routes/orgs.route.ts
@@ -46,11 +46,11 @@ function buildOrgsRouter(): Router {
   router.put('/uid/:uid', (req, res, next) => orgIdentityController.updateOrg(req, res, next));
   router.get('/uid/:uid/addresses', (req, res, next) => orgIdentityController.getOrgAddresses(req, res, next));
 
-  // Every org-lens read is gated on the caller holding a relation on the requested organization.
-  // Mounted on the shared prefix rather than added per route so a new lens endpoint is covered by
-  // default — the alternative (a per-controller check) is what let the whole family ship ungated,
-  // with only the caller-supplied account id scoping the response. Some routes below name the param
-  // `:accountId`; the prefix match here still binds it as `orgUid`, and both carry the same SFID.
+  // Org-membership read gate for the whole lens family. Previously only the meetings, ROI and
+  // groups handlers called `assertOrgLensRead`; every other route let the caller-supplied `:orgUid`
+  // both select and authorize the data, which is the ADR-0038 failure. Mounting it on the shared
+  // prefix covers each existing route and any future one by default. Some routes below name the
+  // param `:accountId`; the prefix match still binds it as `orgUid`, and both carry the same SFID.
   router.use('/:orgUid/lens', (req, res, next) => requireOrgLensAccess(req, res, next));
 
   // Spec 002: all org-lens routes key off the org account id (18-char SFID). The param is still named

--- a/apps/lfx-one/src/server/services/org-lens-access.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-access.service.ts
@@ -33,6 +33,10 @@ function isAccessUser(value: unknown): boolean {
   return (
     isObject(value) &&
     typeof u.email === 'string' &&
+    // Required so an entry cached before `username` existed is rejected as a miss. Replaying one would
+    // silently drop every principal back to email-only matching in the people directory merge, for the
+    // whole TTL — a correctness regression that would look like the cache working.
+    (u.username === null || typeof u.username === 'string') &&
     typeof u.name === 'string' &&
     typeof u.initials === 'string' &&
     (u.avatarUrl === null || typeof u.avatarUrl === 'string') &&

--- a/apps/lfx-one/src/server/services/org-lens-access.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-access.service.ts
@@ -227,6 +227,10 @@ export class OrgLensAccessService {
         const name = (principal.name ?? '').trim() || email.split('@')[0];
         byEmail.set(email, {
           email,
+          // Only an accepted principal has a username, and member-service emits its FGA tuple on
+          // exactly that condition — so this doubles as the "verified identity" signal the people
+          // directory merges on. Pending invites stay null and fall back to email matching.
+          username: status === 'accepted' ? (principal.username ?? '').trim().toLowerCase() || null : null,
           name,
           initials: this.deriveInitials(name),
           avatarUrl: principal.avatar?.trim() ? principal.avatar.trim() : null,

--- a/apps/lfx-one/src/server/services/org-lens-people.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-people.service.ts
@@ -25,6 +25,7 @@ interface OrgPeopleAllRow {
   ACCOUNT_ID: string;
   PERSON_KEY: string;
   LFID: string | null;
+  LF_USERNAME: string | null;
   CDP_MEMBER_ID: string | null;
   NAME: string | null;
   TITLE: string | null;
@@ -175,6 +176,7 @@ export class OrgLensPeopleService {
         ACCOUNT_ID,
         PERSON_KEY,
         LFID,
+        LF_USERNAME,
         CDP_MEMBER_ID,
         NAME,
         TITLE,
@@ -243,12 +245,14 @@ export class OrgLensPeopleService {
     return {
       personKey: row.PERSON_KEY,
       lfid: row.LFID,
+      lfUsername: (row.LF_USERNAME ?? '').trim().toLowerCase() || null,
       cdpMemberId: row.CDP_MEMBER_ID,
       name,
       firstName,
       lastName,
       title: row.TITLE,
       email: row.EMAIL,
+      emails: row.EMAIL ? [row.EMAIL.trim().toLowerCase()] : [],
       avatarUrl: row.PHOTO ?? null,
       sources: ['snowflake'] as OrgPersonSource[],
       seatsCount: row.SEATS_COUNT ?? 0,

--- a/apps/lfx-one/src/server/services/org-lens-people.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-people.service.ts
@@ -465,7 +465,21 @@ function cleanDisplayName(rawName: string | null, email: string | null): string 
 
 function isAllEmployeesRaw(value: unknown): boolean {
   const v = value as { rowsRaw?: unknown; statsRaw?: unknown; foundationRaw?: unknown } | null;
-  return !!v && Array.isArray(v.rowsRaw) && Array.isArray(v.statsRaw) && Array.isArray(v.foundationRaw);
+  return (
+    !!v &&
+    Array.isArray(v.rowsRaw) &&
+    Array.isArray(v.statsRaw) &&
+    Array.isArray(v.foundationRaw) &&
+    // Every row must carry LF_USERNAME, so entries cached before it was selected are rejected as a miss
+    // rather than replayed. A replayed row maps to a null username, which silently returns the people
+    // directory to email-only matching for the rest of the TTL. The value may legitimately be null, so
+    // this checks presence, not truthiness.
+    v.rowsRaw.every((row) => {
+      if (!row || typeof row !== 'object' || !('LF_USERNAME' in row)) return false;
+      const username = (row as { LF_USERNAME: unknown }).LF_USERNAME;
+      return username === null || typeof username === 'string';
+    })
+  );
 }
 
 function isEmployeeDetailRaw(value: unknown): boolean {

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -1,0 +1,360 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { OrgAccessUser, OrgAllEmployeeRow, OrgAllEmployeesResponse, KeyContactEmployee } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors access-check.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
+// vitest config, so runtime collaborators are mocked. The four source services are constructed in
+// OrgPeopleDirectoryService's constructor, so they must be mocked at module level. `withPerUserCache`
+// is stubbed to a pass-through so tests exercise the merge rather than the cache.
+const { getAllEmployees, fetchAllOrgSeats, getKeyContactEmployees, getAccessPrincipals } = vi.hoisted(() => ({
+  getAllEmployees: vi.fn(),
+  fetchAllOrgSeats: vi.fn(),
+  getKeyContactEmployees: vi.fn(),
+  getAccessPrincipals: vi.fn(),
+}));
+
+vi.mock('./org-lens-people.service', () => ({
+  OrgLensPeopleService: class {
+    public getAllEmployees = getAllEmployees;
+  },
+}));
+vi.mock('./org-lens-board-committee.service', () => ({
+  OrgLensBoardCommitteeService: class {
+    public fetchAllOrgSeats = fetchAllOrgSeats;
+  },
+}));
+vi.mock('./org-lens-key-contacts.service', () => ({
+  OrgLensKeyContactsService: class {
+    public getEmployees = getKeyContactEmployees;
+  },
+}));
+vi.mock('./org-lens-access.service', () => ({
+  OrgLensAccessService: class {
+    public getAccessPrincipals = getAccessPrincipals;
+  },
+}));
+vi.mock('./valkey.service', () => ({
+  withPerUserCache: (_ns: string, _user: string, _org: string, _ttl: number, fetcher: () => Promise<unknown>) => fetcher(),
+}));
+vi.mock('./logger.service', () => ({
+  logger: { info: vi.fn(), warning: vi.fn(), error: vi.fn(), debug: vi.fn() },
+}));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveUsername: () => 'tester' }));
+
+// The `@lfx-one/shared/*` barrels pull Angular into this node-environment suite, so the handful of
+// runtime values the service imports are stubbed here (same approach as ai.service.spec.ts /
+// committee-engagement.service.spec.ts). `isBoardCategory` and `splitDisplayName` mirror the real
+// implementations, since the merge's board-vs-committee split and name fill depend on their behaviour.
+vi.mock('@lfx-one/shared/interfaces', () => ({}));
+vi.mock('@lfx-one/shared/constants', () => ({
+  VALKEY_CACHE: { ORG_PEOPLE_DIRECTORY_NAMESPACE: 'org-people-directory', ORG_LENS_PERUSER_TTL_SECONDS: 60 },
+  EMPTY_ORG_ALL_EMPLOYEES_RESPONSE: {
+    accountId: '',
+    rows: [],
+    stats: { activeInOss: 0, inGovernance: 0, codeContributors: 0, eventAttendees: 0, trainees: 0 },
+    foundations: [],
+  },
+  isBoardCategory: (category: string | null | undefined) => (category ?? '').trim().toLowerCase() === 'board',
+}));
+vi.mock('@lfx-one/shared/utils', () => ({
+  splitDisplayName: (name: string | null): [string | null, string | null] => {
+    const trimmed = (name ?? '').trim();
+    if (!trimmed || trimmed.includes('@')) return [null, null];
+    const parts = trimmed.split(/\s+/);
+    return parts.length === 1 ? [parts[0], null] : [parts[0], parts.slice(1).join(' ')];
+  },
+}));
+
+import { OrgPeopleDirectoryService, resolveMergeKey } from './org-people-directory.service';
+
+const ACCOUNT = '0014100000Te2ovAAB';
+const req = {} as never;
+
+function storedRow(over: Partial<OrgAllEmployeeRow> = {}): OrgAllEmployeeRow {
+  return {
+    personKey: 'lfnEMOUiFenugGty80',
+    lfid: 'lfnEMOUiFenugGty80',
+    lfUsername: 'mcderk',
+    cdpMemberId: null,
+    name: 'Kieran McDermott',
+    firstName: 'Kieran',
+    lastName: 'McDermott',
+    title: 'VP Product',
+    email: 'kmcdermott@linuxfoundation.org',
+    emails: ['kmcdermott@linuxfoundation.org'],
+    avatarUrl: null,
+    sources: ['snowflake'],
+    seatsCount: 22,
+    boardSeatsCount: 2,
+    committeeSeatsCount: 20,
+    commitsCount: 0,
+    eventsCount: 13,
+    coursesCount: 0,
+    engagedFoundationIds: [],
+    ...over,
+  };
+}
+
+function baseResponse(rows: OrgAllEmployeeRow[]): OrgAllEmployeesResponse {
+  return { accountId: ACCOUNT, rows, stats: { activeInOss: 0, inGovernance: 0, codeContributors: 0, eventAttendees: 0, trainees: 0 }, foundations: [] };
+}
+
+function seat(over: Record<string, unknown> = {}): never {
+  return {
+    uid: 'seat-1',
+    committee_uid: 'c-1',
+    committee_name: 'WG Identity & Trust',
+    committee_category: 'Working Group',
+    first_name: 'Kieran',
+    last_name: 'McDermott',
+    email: 'kmcdermott@contractor.linuxfoundation.org',
+    username: 'mcderk',
+    role_name: 'LF Staff',
+    voting_status: 'Observer',
+    appointed_by: 'None',
+    organization_id: ACCOUNT,
+    is_org_editable: false,
+    ...over,
+  } as never;
+}
+
+function accessUser(over: Partial<OrgAccessUser> = {}): OrgAccessUser {
+  return {
+    email: 'dqualls@linuxfoundation.org',
+    username: 'dqualls',
+    name: 'Dano Qualls',
+    initials: 'DQ',
+    avatarUrl: null,
+    jobTitle: null,
+    role: 'admin',
+    inviteStatus: 'accepted',
+    isPending: false,
+    ...over,
+  };
+}
+
+async function run(): Promise<OrgAllEmployeesResponse> {
+  return new OrgPeopleDirectoryService().getLive(req, ACCOUNT);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  getAllEmployees.mockResolvedValue(baseResponse([]));
+  fetchAllOrgSeats.mockResolvedValue([]);
+  getKeyContactEmployees.mockResolvedValue([] as KeyContactEmployee[]);
+  getAccessPrincipals.mockResolvedValue([]);
+});
+
+describe('resolveMergeKey', () => {
+  it('prefers the verified identity over the address', () => {
+    expect(resolveMergeKey({ lfUsername: 'mcderk', email: 'anything@example.com' })).toBe('identity:mcderk');
+  });
+
+  it('lowercases and trims the username', () => {
+    expect(resolveMergeKey({ lfUsername: '  McDerK ' })).toBe('identity:mcderk');
+  });
+
+  it('falls back to the lowercased address when no username is present', () => {
+    expect(resolveMergeKey({ lfUsername: null, email: 'Kmcdermott@LinuxFoundation.org' })).toBe('email:kmcdermott@linuxfoundation.org');
+  });
+
+  it('falls back when the username is blank rather than treating whitespace as an identity', () => {
+    expect(resolveMergeKey({ lfUsername: '   ', email: 'a@b.com' })).toBe('email:a@b.com');
+  });
+
+  it('yields no key when neither is present', () => {
+    expect(resolveMergeKey({ lfUsername: null, email: null })).toBeNull();
+  });
+
+  it('never produces an identity key that collides with an email key', () => {
+    expect(resolveMergeKey({ lfUsername: 'dqualls' })).not.toBe(resolveMergeKey({ email: 'dqualls' }));
+  });
+});
+
+describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
+  it('merges an access principal into the stored row on username, not address (the Dano case)', async () => {
+    getAllEmployees.mockResolvedValue(
+      baseResponse([storedRow({ personKey: '0032M00003ZzRIsQAN', lfid: '0032M00003ZzRIsQAN', lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@contractor.linuxfoundation.org', emails: ['dqualls@contractor.linuxfoundation.org'], seatsCount: 3, boardSeatsCount: 0, committeeSeatsCount: 3, eventsCount: 6 })])
+    );
+    getAccessPrincipals.mockResolvedValue([accessUser()]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sources).toEqual(expect.arrayContaining(['snowflake', 'access']));
+    expect(rows[0].emails).toEqual(expect.arrayContaining(['dqualls@contractor.linuxfoundation.org', 'dqualls@linuxfoundation.org']));
+  });
+
+  it('merges a committee seat into the stored row on username (the Kieran case)', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    fetchAllOrgSeats.mockResolvedValue([seat()]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].emails).toEqual(expect.arrayContaining(['kmcdermott@linuxfoundation.org', 'kmcdermott@contractor.linuxfoundation.org']));
+  });
+
+  it('collapses a person arriving from three sources into one row (the Christopher Robinson case)', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: 'crob', name: 'Christopher Robinson', email: 'crob@intel.com', emails: ['crob@intel.com'] })]));
+    fetchAllOrgSeats.mockResolvedValue([seat({ email: 'christopher.robinson@intel.com', username: 'crob' }), seat({ uid: 'seat-2', email: 'christopher.robinson@linuxfoundation.org', username: 'crob', committee_category: 'Board' })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].emails).toHaveLength(3);
+  });
+
+  it('keeps the stored personKey so a merged row stays expandable (FR-006)', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    fetchAllOrgSeats.mockResolvedValue([seat()]);
+
+    const { rows } = await run();
+
+    expect(rows[0].personKey).toBe('lfnEMOUiFenugGty80');
+    expect(rows[0].personKey).not.toMatch(/^live-/);
+  });
+});
+
+describe('OrgPeopleDirectoryService.merge — false-merge protection (SC-005)', () => {
+  it('does not merge two different people who share an address', async () => {
+    // The Snowflake address→member index links dqualls@linuxfoundation.org to Jim Zemlin's member
+    // record. Two distinct usernames must never collapse, whatever their addresses say.
+    getAllEmployees.mockResolvedValue(
+      baseResponse([
+        storedRow({ personKey: 'p-dano', lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] }),
+        storedRow({ personKey: 'p-jim', lfUsername: 'jzemlin', name: 'Jim Zemlin', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] }),
+      ])
+    );
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(2);
+    expect(rows.map((r) => r.lfUsername).sort()).toEqual(['dqualls', 'jzemlin']);
+  });
+
+  it('does not merge an access principal into a person with a different username', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: 'nickcoai', name: 'Nick Cooper', email: 'nickc@openai.com', emails: ['nickc@openai.com'] })]));
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'kmcdermott@linuxfoundation.org', username: 'mcderk', name: 'Kieran McDermott' })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('OrgPeopleDirectoryService.merge — invariants', () => {
+  it('INV-5: a live seat does not increment a stored row\u2019s seat counters (DR-002)', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    fetchAllOrgSeats.mockResolvedValue([seat(), seat({ uid: 'seat-2', committee_name: 'P&E&IT&Mktg_Ops' })]);
+
+    const { rows } = await run();
+
+    // Kieran: stored 22 + two live contractor seats ⇒ 22, not 24.
+    expect(rows[0].seatsCount).toBe(22);
+    expect(rows[0].committeeSeatsCount).toBe(20);
+    expect(rows[0].boardSeatsCount).toBe(2);
+  });
+
+  it('INV-5: a live-only row still accumulates its own live seat counts', async () => {
+    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'someone@example.com' }), seat({ uid: 'seat-2', username: null, email: 'someone@example.com' })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].seatsCount).toBe(2);
+  });
+
+  it('INV-2/INV-3: sources are de-duplicated and emails are lowercased and unique', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    fetchAllOrgSeats.mockResolvedValue([seat({ email: 'KMcDermott@LinuxFoundation.org' }), seat({ uid: 'seat-2', email: 'kmcdermott@linuxfoundation.org' })]);
+
+    const { rows } = await run();
+
+    expect(new Set(rows[0].sources).size).toBe(rows[0].sources.length);
+    expect(new Set(rows[0].emails).size).toBe(rows[0].emails.length);
+    expect(rows[0].emails.every((e) => e === e.toLowerCase())).toBe(true);
+  });
+
+  it('FR-008: a pending invite is not merged into a person, even when the address matches', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] })]));
+    getAccessPrincipals.mockResolvedValue([accessUser({ username: null, inviteStatus: 'pending', isPending: true })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(2);
+  });
+});
+
+describe('OrgPeopleDirectoryService.merge — no regression for single-source people (FR-010)', () => {
+  it('leaves a stored-only person untouched', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sources).toEqual(['snowflake']);
+    expect(rows[0].seatsCount).toBe(22);
+  });
+
+  it('keeps a seat-only person as a live row with its own counts', async () => {
+    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'seatonly@example.com' })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sources).toEqual(['committee']);
+    expect(rows[0].personKey).toMatch(/^live-/);
+  });
+
+  it('keeps an access-only person as a live row', async () => {
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'accessonly@example.com', username: 'accessonly' })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sources).toEqual(['access']);
+  });
+
+  it('gives records identified only by username distinct keys rather than colliding them', async () => {
+    fetchAllOrgSeats.mockResolvedValue([seat({ username: 'alpha', email: null }), seat({ uid: 'seat-2', username: 'beta', email: null })]);
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(2);
+    expect(new Set(rows.map((r) => r.personKey)).size).toBe(2);
+  });
+
+  it('passes through a stored row that has neither identity nor address', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: null, email: null, emails: [] })]));
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+  });
+});
+
+describe('OrgPeopleDirectoryService.merge — stats count people, not rows (US2)', () => {
+  it('counts a person who arrived from two sources exactly once', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'kmcdermott@contractor.linuxfoundation.org', username: 'mcderk', name: 'Kieran McDermott' })]);
+
+    const { rows, stats } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(stats.inGovernance).toBe(1);
+    expect(stats.activeInOss).toBe(1);
+  });
+
+  it('degrades gracefully when a live source fails, keeping the stored roster', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+    fetchAllOrgSeats.mockRejectedValue(new Error('committee-service down'));
+
+    const { rows } = await run();
+
+    expect(rows).toHaveLength(1);
+    expect(rows[0].sources).toEqual(['snowflake']);
+  });
+});

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -207,7 +207,7 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
     expect(rows[0].emails).toHaveLength(3);
   });
 
-  it('keeps the stored personKey so a merged row stays expandable (FR-006)', async () => {
+  it('keeps the stored personKey so a merged row stays expandable', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat()]);
 
@@ -218,7 +218,7 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
   });
 });
 
-describe('OrgPeopleDirectoryService.merge — false-merge protection (SC-005)', () => {
+describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
   it('does not merge two different people who share an address', async () => {
     // The Snowflake address→member index links dqualls@linuxfoundation.org to Jim Zemlin's member
     // record. Two distinct usernames must never collapse, whatever their addresses say.
@@ -246,7 +246,7 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection (SC-005)', 
 });
 
 describe('OrgPeopleDirectoryService.merge — invariants', () => {
-  it('INV-5: a live seat does not increment a stored row\u2019s seat counters (DR-002)', async () => {
+  it('a live seat does not increment a stored row\u2019s seat counters', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat(), seat({ uid: 'seat-2', committee_name: 'P&E&IT&Mktg_Ops' })]);
 
@@ -258,7 +258,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
     expect(rows[0].boardSeatsCount).toBe(2);
   });
 
-  it('INV-5: a live-only row still accumulates its own live seat counts', async () => {
+  it('a live-only row still accumulates its own live seat counts', async () => {
     fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'someone@example.com' }), seat({ uid: 'seat-2', username: null, email: 'someone@example.com' })]);
 
     const { rows } = await run();
@@ -267,7 +267,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
     expect(rows[0].seatsCount).toBe(2);
   });
 
-  it('INV-2/INV-3: sources are de-duplicated and emails are lowercased and unique', async () => {
+  it('sources are de-duplicated and emails are lowercased and unique', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat({ email: 'KMcDermott@LinuxFoundation.org' }), seat({ uid: 'seat-2', email: 'kmcdermott@linuxfoundation.org' })]);
 
@@ -278,7 +278,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
     expect(rows[0].emails.every((e) => e === e.toLowerCase())).toBe(true);
   });
 
-  it('FR-008: a pending invite is not merged into a person, even when the address matches', async () => {
+  it('a pending invite is not merged into a person, even when the address matches', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] })]));
     getAccessPrincipals.mockResolvedValue([accessUser({ username: null, inviteStatus: 'pending', isPending: true })]);
 
@@ -288,7 +288,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
   });
 });
 
-describe('OrgPeopleDirectoryService.merge — no regression for single-source people (FR-010)', () => {
+describe('OrgPeopleDirectoryService.merge — no regression for single-source people', () => {
   it('leaves a stored-only person untouched', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
 

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -176,7 +176,20 @@ describe('resolveMergeKey', () => {
 describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
   it('merges an access principal into the stored row on username, not address (the Dano case)', async () => {
     getAllEmployees.mockResolvedValue(
-      baseResponse([storedRow({ personKey: '0032M00003ZzRIsQAN', lfid: '0032M00003ZzRIsQAN', lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@contractor.linuxfoundation.org', emails: ['dqualls@contractor.linuxfoundation.org'], seatsCount: 3, boardSeatsCount: 0, committeeSeatsCount: 3, eventsCount: 6 })])
+      baseResponse([
+        storedRow({
+          personKey: '0032M00003ZzRIsQAN',
+          lfid: '0032M00003ZzRIsQAN',
+          lfUsername: 'dqualls',
+          name: 'Dano Qualls',
+          email: 'dqualls@contractor.linuxfoundation.org',
+          emails: ['dqualls@contractor.linuxfoundation.org'],
+          seatsCount: 3,
+          boardSeatsCount: 0,
+          committeeSeatsCount: 3,
+          eventsCount: 6,
+        }),
+      ])
     );
     getAccessPrincipals.mockResolvedValue([accessUser()]);
 
@@ -198,8 +211,13 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
   });
 
   it('collapses a person arriving from three sources into one row (the Christopher Robinson case)', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: 'crob', name: 'Christopher Robinson', email: 'crob@intel.com', emails: ['crob@intel.com'] })]));
-    fetchAllOrgSeats.mockResolvedValue([seat({ email: 'christopher.robinson@intel.com', username: 'crob' }), seat({ uid: 'seat-2', email: 'christopher.robinson@linuxfoundation.org', username: 'crob', committee_category: 'Board' })]);
+    getAllEmployees.mockResolvedValue(
+      baseResponse([storedRow({ lfUsername: 'crob', name: 'Christopher Robinson', email: 'crob@intel.com', emails: ['crob@intel.com'] })])
+    );
+    fetchAllOrgSeats.mockResolvedValue([
+      seat({ email: 'christopher.robinson@intel.com', username: 'crob' }),
+      seat({ uid: 'seat-2', email: 'christopher.robinson@linuxfoundation.org', username: 'crob', committee_category: 'Board' }),
+    ]);
 
     const { rows } = await run();
 
@@ -224,8 +242,20 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
     // record. Two distinct usernames must never collapse, whatever their addresses say.
     getAllEmployees.mockResolvedValue(
       baseResponse([
-        storedRow({ personKey: 'p-dano', lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] }),
-        storedRow({ personKey: 'p-jim', lfUsername: 'jzemlin', name: 'Jim Zemlin', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] }),
+        storedRow({
+          personKey: 'p-dano',
+          lfUsername: 'dqualls',
+          name: 'Dano Qualls',
+          email: 'dqualls@linuxfoundation.org',
+          emails: ['dqualls@linuxfoundation.org'],
+        }),
+        storedRow({
+          personKey: 'p-jim',
+          lfUsername: 'jzemlin',
+          name: 'Jim Zemlin',
+          email: 'dqualls@linuxfoundation.org',
+          emails: ['dqualls@linuxfoundation.org'],
+        }),
       ])
     );
 
@@ -236,7 +266,9 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
   });
 
   it('does not merge an access principal into a person with a different username', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: 'nickcoai', name: 'Nick Cooper', email: 'nickc@openai.com', emails: ['nickc@openai.com'] })]));
+    getAllEmployees.mockResolvedValue(
+      baseResponse([storedRow({ lfUsername: 'nickcoai', name: 'Nick Cooper', email: 'nickc@openai.com', emails: ['nickc@openai.com'] })])
+    );
     getAccessPrincipals.mockResolvedValue([accessUser({ email: 'kmcdermott@linuxfoundation.org', username: 'mcderk', name: 'Kieran McDermott' })]);
 
     const { rows } = await run();
@@ -259,7 +291,10 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
   });
 
   it('a live-only row still accumulates its own live seat counts', async () => {
-    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'someone@example.com' }), seat({ uid: 'seat-2', username: null, email: 'someone@example.com' })]);
+    fetchAllOrgSeats.mockResolvedValue([
+      seat({ username: null, email: 'someone@example.com' }),
+      seat({ uid: 'seat-2', username: null, email: 'someone@example.com' }),
+    ]);
 
     const { rows } = await run();
 
@@ -279,7 +314,9 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
   });
 
   it('a pending invite is not merged into a person, even when the address matches', async () => {
-    getAllEmployees.mockResolvedValue(baseResponse([storedRow({ lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] })]));
+    getAllEmployees.mockResolvedValue(
+      baseResponse([storedRow({ lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] })])
+    );
     getAccessPrincipals.mockResolvedValue([accessUser({ username: null, inviteStatus: 'pending', isPending: true })]);
 
     const { rows } = await run();

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -236,6 +236,73 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
   });
 });
 
+describe('OrgPeopleDirectoryService.merge — access badge is server-attributed', () => {
+  it('stamps the merged principal\u2019s badge on the row', async () => {
+    getAllEmployees.mockResolvedValue(
+      baseResponse([
+        storedRow({
+          lfUsername: 'dqualls',
+          name: 'Dano Qualls',
+          email: 'dqualls@contractor.linuxfoundation.org',
+          emails: ['dqualls@contractor.linuxfoundation.org'],
+        }),
+      ])
+    );
+    getAccessPrincipals.mockResolvedValue([accessUser()]);
+
+    const { rows } = await run();
+
+    expect(rows[0].accessBadge).toBe('admin');
+  });
+
+  it('marks a pending principal as invited rather than by role', async () => {
+    getAccessPrincipals.mockResolvedValue([accessUser({ username: null, inviteStatus: 'pending', isPending: true })]);
+
+    const { rows } = await run();
+
+    expect(rows[0].accessBadge).toBe('invited');
+  });
+
+  it('leaves the badge unset on a person the merge attributed no access to', async () => {
+    getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
+
+    const { rows } = await run();
+
+    expect(rows[0].accessBadge).toBeUndefined();
+  });
+
+  it('does not stamp one person\u2019s badge onto another who shares an address', async () => {
+    // Two distinct identities, one shared address. Only the person the access principal actually
+    // resolves to may carry the badge — an address-based join could not tell them apart.
+    getAllEmployees.mockResolvedValue(
+      baseResponse([
+        storedRow({
+          personKey: 'p-dano',
+          lfUsername: 'dqualls',
+          name: 'Dano Qualls',
+          email: 'shared@linuxfoundation.org',
+          emails: ['shared@linuxfoundation.org'],
+        }),
+        storedRow({
+          personKey: 'p-jim',
+          lfUsername: 'jzemlin',
+          name: 'Jim Zemlin',
+          email: 'shared@linuxfoundation.org',
+          emails: ['shared@linuxfoundation.org'],
+        }),
+      ])
+    );
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'shared@linuxfoundation.org', username: 'jzemlin', name: 'Jim Zemlin' })]);
+
+    const { rows } = await run();
+
+    const dano = rows.find((r) => r.lfUsername === 'dqualls');
+    const jim = rows.find((r) => r.lfUsername === 'jzemlin');
+    expect(jim?.accessBadge).toBe('admin');
+    expect(dano?.accessBadge).toBeUndefined();
+  });
+});
+
 describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
   it('does not merge two different people who share an address', async () => {
     // The Snowflake address→member index links dqualls@linuxfoundation.org to Jim Zemlin's member

--- a/apps/lfx-one/src/server/services/org-people-directory.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.ts
@@ -6,6 +6,7 @@ import { isBoardCategory } from '@lfx-one/shared/constants';
 import type {
   CommitteeServiceOrgSeat,
   KeyContactEmployee,
+  OrgAccessBadgeState,
   OrgAccessUser,
   OrgAllEmployeeFoundationOption,
   OrgAllEmployeeRow,
@@ -80,6 +81,11 @@ export function resolveMergeKey(record: { lfUsername?: string | null; email?: st
   if (username) return `identity:${username}`;
   const email = (record.email ?? '').trim().toLowerCase();
   return email ? `email:${email}` : null;
+}
+
+/** The badge a principal renders as: their role once accepted, `invited` while the invite is outstanding. */
+function badgeOf(user: OrgAccessUser): OrgAccessBadgeState {
+  return user.isPending ? 'invited' : user.role;
 }
 
 function isFoundationOption(value: unknown): boolean {
@@ -250,6 +256,7 @@ export class OrgPeopleDirectoryService {
         if (existing) {
           this.addSource(existing, 'access');
           this.addEmail(existing, email);
+          existing.accessBadge = badgeOf(user);
           const [firstName, lastName] = splitDisplayName(user.name);
           this.fill(existing, { firstName, lastName, title: user.jobTitle, avatarUrl: user.avatarUrl });
         } else {
@@ -320,7 +327,9 @@ export class OrgPeopleDirectoryService {
 
   private rowFromAccess(user: OrgAccessUser, email: string, key: string): OrgAllEmployeeRow {
     const [firstName, lastName] = splitDisplayName(user.name);
-    return this.liveRow(email, firstName, lastName, user.jobTitle, user.avatarUrl, 'access', key, user.username);
+    const row = this.liveRow(email, firstName, lastName, user.jobTitle, user.avatarUrl, 'access', key, user.username);
+    row.accessBadge = badgeOf(user);
+    return row;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/org-people-directory.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.ts
@@ -32,7 +32,13 @@ function isStringArray(value: unknown): boolean {
   return Array.isArray(value) && value.every((el) => typeof el === 'string');
 }
 
-/** Every row must match the wire shape: the cached value is replayed straight to the client, so a corrupt element would otherwise crash on `sources` spreading or `name.localeCompare`. */
+/**
+ * Every row must match the wire shape: the cached value is replayed straight to the client, so a
+ * corrupt element would otherwise crash on `sources` spreading or `name.localeCompare`.
+ *
+ * `lfUsername` and `emails` are required so an entry written by a pre-merge-key deployment is
+ * rejected as a miss and recomputed, rather than replayed into a renderer that expects them.
+ */
 function isAllEmployeeRow(value: unknown): boolean {
   const r = value as Partial<OrgAllEmployeeRow>;
   return (
@@ -40,6 +46,8 @@ function isAllEmployeeRow(value: unknown): boolean {
     typeof r.personKey === 'string' &&
     typeof r.name === 'string' &&
     (r.email === null || typeof r.email === 'string') &&
+    (r.lfUsername === null || typeof r.lfUsername === 'string') &&
+    isStringArray(r.emails) &&
     isStringArray(r.sources) &&
     isStringArray(r.engagedFoundationIds) &&
     typeof r.seatsCount === 'number' &&
@@ -49,6 +57,29 @@ function isAllEmployeeRow(value: unknown): boolean {
     typeof r.eventsCount === 'number' &&
     typeof r.coursesCount === 'number'
   );
+}
+
+/**
+ * Identity of a source record for merge purposes (DR-001).
+ *
+ * A person holds ONE LF username but MANY email addresses, so the address is not an identifier —
+ * keying on it is what splits one human across several rows. Prefer the verified username; fall
+ * back to the address only when no username is available (key contacts, pending invites, the ~24%
+ * of seats platform-wide whose username has not been resolved upstream).
+ *
+ * The two kinds never match each other. That keeps the merge single-pass and order-independent (no
+ * transitive closure), and it means a record without a verified identity behaves exactly as it does
+ * today — no regression, and no guessing.
+ *
+ * NOT permitted as an input: the Snowflake email→member_id crosswalk. It is many-to-many and
+ * carries false links (`dqualls@linuxfoundation.org` resolves to a different person's member
+ * record), so using it would attribute one named individual's data to another.
+ */
+export function resolveMergeKey(record: { lfUsername?: string | null; email?: string | null }): string | null {
+  const username = (record.lfUsername ?? '').trim().toLowerCase();
+  if (username) return `identity:${username}`;
+  const email = (record.email ?? '').trim().toLowerCase();
+  return email ? `email:${email}` : null;
 }
 
 function isFoundationOption(value: unknown): boolean {
@@ -140,7 +171,7 @@ export class OrgPeopleDirectoryService {
     return this.merge(req, accountId, base, seats, keyContacts, access);
   }
 
-  /** Seed the snowflake rows by lowercased email (no-email rows pass through), then fold each live source in. */
+  /** Seed the snowflake rows by merge key (unkeyable rows pass through), then fold each live source in. */
   private merge(
     req: Request,
     accountId: string,
@@ -149,37 +180,40 @@ export class OrgPeopleDirectoryService {
     keyContacts: PromiseSettledResult<KeyContactEmployee[]>,
     access: PromiseSettledResult<OrgAccessUser[]>
   ): OrgAllEmployeesResponse {
-    const byEmail = new Map<string, OrgAllEmployeeRow>();
-    const noEmailRows: OrgAllEmployeeRow[] = [];
+    const byKey = new Map<string, OrgAllEmployeeRow>();
+    const unkeyedRows: OrgAllEmployeeRow[] = [];
 
     for (const row of base.rows) {
-      const email = (row.email ?? '').trim().toLowerCase();
-      if (email) {
+      const key = resolveMergeKey(row);
+      if (key) {
         // Clone so we can mutate sources/enrichment without aliasing the snowflake service's array.
-        byEmail.set(email, { ...row, sources: [...row.sources] });
+        byKey.set(key, { ...row, sources: [...row.sources], emails: [...row.emails], mergedFrom: [key] });
       } else {
-        noEmailRows.push(row);
+        unkeyedRows.push(row);
       }
     }
 
     if (seats.status === 'fulfilled') {
       for (const seat of seats.value) {
         const email = (seat.email ?? '').trim().toLowerCase();
-        if (!email) continue;
+        const key = resolveMergeKey({ lfUsername: seat.username, email });
+        if (!key) continue;
         const source: OrgPersonSource = isBoardCategory(seat.committee_category) ? 'board' : 'committee';
-        const existing = byEmail.get(email);
+        const existing = byKey.get(key);
         if (existing) {
           this.addSource(existing, source);
+          this.addEmail(existing, email);
           this.fill(existing, {
             firstName: (seat.first_name ?? '').trim() || null,
             lastName: (seat.last_name ?? '').trim() || null,
             title: seat.job_title?.trim() || null,
           });
           // Count live seats only for live-only rows; Snowflake rows already carry authoritative seat counts, so
-          // incrementing here would double-count the same seat.
+          // incrementing here would double-count the same seat (DR-002 — verified: a seat held under a secondary
+          // address is already inside the stored count, because the roster's governance join resolves it by LFID).
           if (!existing.sources.includes('snowflake')) this.addSeat(existing, source);
         } else {
-          byEmail.set(email, this.rowFromSeat(seat, email, source));
+          byKey.set(key, this.rowFromSeat(seat, email, source, key));
         }
       }
     } else {
@@ -189,13 +223,16 @@ export class OrgPeopleDirectoryService {
     if (keyContacts.status === 'fulfilled') {
       for (const emp of keyContacts.value) {
         const email = (emp.email ?? '').trim().toLowerCase();
-        if (!email) continue;
-        const existing = byEmail.get(email);
+        // Key contacts carry no verified identity, so they always match at the email rung.
+        const key = resolveMergeKey({ email });
+        if (!key) continue;
+        const existing = byKey.get(key);
         if (existing) {
           this.addSource(existing, 'keyContact');
+          this.addEmail(existing, email);
           this.fill(existing, { firstName: emp.firstName || null, lastName: emp.lastName || null, title: emp.jobTitle, avatarUrl: emp.avatarUrl ?? null });
         } else {
-          byEmail.set(email, this.rowFromKeyContact(emp, email));
+          byKey.set(key, this.rowFromKeyContact(emp, email, key));
         }
       }
     } else {
@@ -205,21 +242,25 @@ export class OrgPeopleDirectoryService {
     if (access.status === 'fulfilled') {
       for (const user of access.value) {
         const email = (user.email ?? '').trim().toLowerCase();
-        if (!email) continue;
-        const existing = byEmail.get(email);
+        // A pending invite has no username and so cannot merge into a verified person — correct, not a
+        // limitation: until the invite is accepted there is no confirmed identity behind the address.
+        const key = resolveMergeKey({ lfUsername: user.username, email });
+        if (!key) continue;
+        const existing = byKey.get(key);
         if (existing) {
           this.addSource(existing, 'access');
+          this.addEmail(existing, email);
           const [firstName, lastName] = splitDisplayName(user.name);
           this.fill(existing, { firstName, lastName, title: user.jobTitle, avatarUrl: user.avatarUrl });
         } else {
-          byEmail.set(email, this.rowFromAccess(user, email));
+          byKey.set(key, this.rowFromAccess(user, email, key));
         }
       }
     } else {
       this.logSourceFailure(req, accountId, 'access principals', access.reason);
     }
 
-    const rows = [...byEmail.values(), ...noEmailRows].sort((a, b) => a.name.localeCompare(b.name));
+    const rows = [...byKey.values(), ...unkeyedRows].sort((a, b) => a.name.localeCompare(b.name));
     return {
       accountId,
       rows,
@@ -233,6 +274,16 @@ export class OrgPeopleDirectoryService {
   private addSource(row: OrgAllEmployeeRow, source: OrgPersonSource): void {
     if (!row.sources.includes(source)) {
       row.sources.push(source);
+    }
+  }
+
+  /** Record a contributing address. A merged person legitimately holds several; `email` stays the preferred display one. */
+  private addEmail(row: OrgAllEmployeeRow, email: string): void {
+    if (email && !row.emails.includes(email)) {
+      row.emails.push(email);
+    }
+    if (!row.email) {
+      row.email = email || null;
     }
   }
 
@@ -254,43 +305,54 @@ export class OrgPeopleDirectoryService {
     if (!row.avatarUrl && patch.avatarUrl) row.avatarUrl = patch.avatarUrl;
   }
 
-  private rowFromSeat(seat: CommitteeServiceOrgSeat, email: string, source: OrgPersonSource): OrgAllEmployeeRow {
+  private rowFromSeat(seat: CommitteeServiceOrgSeat, email: string, source: OrgPersonSource, key: string): OrgAllEmployeeRow {
     const firstName = (seat.first_name ?? '').trim() || null;
     const lastName = (seat.last_name ?? '').trim() || null;
-    const row = this.liveRow(email, firstName, lastName, seat.job_title?.trim() || null, null, source);
+    const row = this.liveRow(email, firstName, lastName, seat.job_title?.trim() || null, null, source, key, seat.username ?? null);
     // The seat that created this live-only row counts as one held seat; further seats fold in via addSeat on the existing branch.
     this.addSeat(row, source);
     return row;
   }
 
-  private rowFromKeyContact(emp: KeyContactEmployee, email: string): OrgAllEmployeeRow {
-    return this.liveRow(email, emp.firstName || null, emp.lastName || null, emp.jobTitle, emp.avatarUrl ?? null, 'keyContact');
+  private rowFromKeyContact(emp: KeyContactEmployee, email: string, key: string): OrgAllEmployeeRow {
+    return this.liveRow(email, emp.firstName || null, emp.lastName || null, emp.jobTitle, emp.avatarUrl ?? null, 'keyContact', key, null);
   }
 
-  private rowFromAccess(user: OrgAccessUser, email: string): OrgAllEmployeeRow {
+  private rowFromAccess(user: OrgAccessUser, email: string, key: string): OrgAllEmployeeRow {
     const [firstName, lastName] = splitDisplayName(user.name);
-    return this.liveRow(email, firstName, lastName, user.jobTitle, user.avatarUrl, 'access');
+    return this.liveRow(email, firstName, lastName, user.jobTitle, user.avatarUrl, 'access', key, user.username);
   }
 
-  /** Build a live-only row (no stored activity). personKey is a pattern-safe token so a detail expand returns an empty (200) payload rather than a 400. */
+  /**
+   * Build a live-only row (no stored activity). personKey is a pattern-safe token so a detail expand
+   * returns an empty (200) payload rather than a 400. It is derived from the merge key rather than
+   * the address, so a record identified only by username still gets a distinct token — deriving it
+   * from an absent address would collide every such row onto the same key.
+   */
   private liveRow(
     email: string,
     firstName: string | null,
     lastName: string | null,
     title: string | null,
     avatarUrl: string | null,
-    source: OrgPersonSource
+    source: OrgPersonSource,
+    key: string,
+    lfUsername: string | null
   ): OrgAllEmployeeRow {
-    const name = [firstName, lastName].filter(Boolean).join(' ').trim() || email;
+    const username = (lfUsername ?? '').trim().toLowerCase() || null;
+    const name = [firstName, lastName].filter(Boolean).join(' ').trim() || email || username || '';
     return {
-      personKey: `live-${Buffer.from(email).toString('base64url')}`,
+      personKey: `live-${Buffer.from(key).toString('base64url')}`,
       lfid: null,
+      lfUsername: username,
       cdpMemberId: null,
       name,
       firstName,
       lastName,
       title,
       email,
+      emails: email ? [email] : [],
+      mergedFrom: [key],
       avatarUrl,
       sources: [source],
       seatsCount: 0,

--- a/apps/lfx-one/src/server/services/org-people-directory.service.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.ts
@@ -60,7 +60,7 @@ function isAllEmployeeRow(value: unknown): boolean {
 }
 
 /**
- * Identity of a source record for merge purposes (DR-001).
+ * Identity of a source record for merge purposes.
  *
  * A person holds ONE LF username but MANY email addresses, so the address is not an identifier —
  * keying on it is what splits one human across several rows. Prefer the verified username; fall
@@ -209,8 +209,8 @@ export class OrgPeopleDirectoryService {
             title: seat.job_title?.trim() || null,
           });
           // Count live seats only for live-only rows; Snowflake rows already carry authoritative seat counts, so
-          // incrementing here would double-count the same seat (DR-002 — verified: a seat held under a secondary
-          // address is already inside the stored count, because the roster's governance join resolves it by LFID).
+          // incrementing here would double-count the same seat. Verified: a seat held under a person's secondary
+          // address is already inside the stored count, because the roster's governance join resolves it by LFID.
           if (!existing.sources.includes('snowflake')) this.addSeat(existing, source);
         } else {
           byKey.set(key, this.rowFromSeat(seat, email, source, key));

--- a/packages/shared/src/interfaces/org-lens-access.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-access.interface.ts
@@ -32,6 +32,12 @@ export interface OrgAccessTypeFilterOption {
 export interface OrgAccessUser {
   /** Lowercased; identity key for edit/remove. Always present. */
   email: string;
+  /**
+   * Lowercased LFID username, projected from the settings record. Set once an invite is accepted;
+   * absent for pending invites — member-service emits an FGA tuple only when the invite is accepted
+   * AND a username exists, so its absence means the principal is not yet a verified identity.
+   */
+  username: string | null;
   /** Display name; falls back to the email local-part when blank. */
   name: string;
   /** Derived for the avatar chip. */

--- a/packages/shared/src/interfaces/org-people.interface.ts
+++ b/packages/shared/src/interfaces/org-people.interface.ts
@@ -51,6 +51,12 @@ export interface OrgAllEmployeeActivityOption {
 export interface OrgAllEmployeeRow {
   personKey: string;
   lfid: string | null;
+  /**
+   * Lowercased LF username — the identity a row is merged on when present. A person legitimately
+   * holds several email addresses, so the address is not an identifier; this is. `null` for sources
+   * that carry no verified identity (key contacts, pending invites), which then fall back to email.
+   */
+  lfUsername: string | null;
   cdpMemberId: string | null;
   name: string;
   /** Given name. Populated directly by live sources; for Snowflake-only rows it is a best-effort split of `name`. */
@@ -58,7 +64,12 @@ export interface OrgAllEmployeeRow {
   /** Family name. Populated directly by live sources; for Snowflake-only rows it is a best-effort split of `name`. */
   lastName: string | null;
   title: string | null;
+  /** Preferred display address: the stored roster's when the row has one, else the first live address contributing. */
   email: string | null;
+  /** Every lowercased address that contributed to this row. Length > 1 is the normal result of a merge. */
+  emails: string[];
+  /** Diagnostic: the merge keys that collapsed into this row (e.g. `identity:mcderk`). Lets a reviewer explain a merge without re-deriving it. */
+  mergedFrom?: string[];
   /** Avatar/photo URL (CDP user photo or org-logo fallback); `null` when absent. The UI falls back to initials. */
   avatarUrl: string | null;
   /** Which upstream(s) contributed this person. Stored-only rows are `['snowflake']`; `?live` rows may carry several. */

--- a/packages/shared/src/interfaces/org-people.interface.ts
+++ b/packages/shared/src/interfaces/org-people.interface.ts
@@ -70,6 +70,13 @@ export interface OrgAllEmployeeRow {
   emails: string[];
   /** Diagnostic: the merge keys that collapsed into this row (e.g. `identity:mcderk`). Lets a reviewer explain a merge without re-deriving it. */
   mergedFrom?: string[];
+  /**
+   * Org Lens access badge for the principal the merge actually attributed to this person, or `null`
+   * when none was. Authoritative: the client's own address-based join cannot tell two people who
+   * share an address apart, so it would attribute one person's role to the other. Absent on payloads
+   * cached before this field existed, which fall back to that join.
+   */
+  accessBadge?: OrgAccessBadgeState | null;
   /** Avatar/photo URL (CDP user photo or org-logo fallback); `null` when absent. The UI falls back to initials. */
   avatarUrl: string | null;
   /** Which upstream(s) contributed this person. Stored-only rows are `['snowflake']`; `?live` rows may carry several. */


### PR DESCRIPTION
Fixes duplicate people on Org Lens → People → All Employees, and closes a read-authorization gap found while reviewing that surface.

Jira: LFXV2-3250 · Spec: `specs/039-LFXV2-3250-org-people-identity-dedupe` in the umbrella workspace.

## The duplicate-rows bug

The roster folds three live sources (committee seats, key contacts, Org Lens access) into the stored Snowflake roster, keyed on **lowercased email**. LF staff routinely hold several addresses — corporate, `@contractor.linuxfoundation.org`, project domains — and each source reports whichever its own record carries. On The Linux Foundation in production that produced **65 duplicated names and 82 surplus rows out of 558**.

The verified LF username was already on both sides and simply discarded:

| Layer | Carries identity? | Before |
|---|---|---|
| `ORG_PEOPLE_ALL.LF_USERNAME` | yes | not selected |
| `CommitteeServiceOrgSeat.username` | yes (~99.5% LF org) | declared, never read |
| member-service settings `username` | yes, on accepted invites | not projected onto `OrgAccessUser` |

`resolveMergeKey` now decides sameness: **verified username first, lowercased email as fallback**. The two kinds never match each other, so the merge stays single-pass and order-independent, and a record with no identity behaves exactly as before. Rows now carry the set of contributing addresses, because a merged person genuinely has more than one.

**Identity is deliberately not resolved through the email→member crosswalk.** That index is many-to-many and contains false links — `dqualls@linuxfoundation.org` resolves to Jim Zemlin's member record, `kmcdermott@linuxfoundation.org` to an unrelated external person's. Using it would attribute one named individual's data to another. There are named regression tests for both.

Seat counters are unchanged on merge: the stored count is authoritative and live seats contribute provenance only. A seat held under a secondary address is already inside the stored count, because the roster's governance join resolves it by LFID.

The stat cards ("In Governance", "Employees Active in Open Source") were inflated because they count rows; merging fixes them with no separate change.

## The authorization gap

While running the authorization/privacy checklist for the above, `GET /api/orgs/:orgUid/lens/*` turned out to be scoped only by the `:orgUid` in the caller's own URL, which then became a Snowflake `WHERE ACCOUNT_ID = ?`. That filters data; it does not authorize it (ADR-0038 (a)).

Confirmed in production: a caller whose role-grants listed exactly one organization received 200s with 3,519 and 2,139 rows of person-level data — names, job titles, email addresses — for two organizations they held no relation on. Only row counts were retrieved.

The rule already existed. `helpers/org-lens-read-access.helper.ts` implements `assertOrgLensRead` with the right semantics, and `orgs.route.ts` even documented the split: *"Unlike the sibling org-lens routes these carry an org-membership read gate."* Only meetings, ROI and groups called it. This PR mounts that same helper on the `/:orgUid/lens` prefix so every current and future lens route is covered.

## Verification

Replayed the real production inputs through the new key before deploying (the merge is a pure function of them):

| Measure | Before | After |
|---|---|---|
| Rows | 558 | **476** |
| Surplus rows beyond one per identity | 83 | **1** |
| Same-name groups collapsing completely | — | **53 of 66** |

Dano Qualls, Kieran McDermott, Amy Rose and Christopher Robinson each resolve to a single row. No false merges: Jim Zemlin and Nick Cooper stayed separate.

The 13 groups that remain are almost all correct — people holding several genuine LF accounts (mostly plus-addressed test personas), the out-of-scope source-data population, pending invitations, and one pair of unrelated people sharing the placeholder name "Unknown Unknown". This is why the success criterion measures surplus rows rather than duplicated names.

## Out of scope

- Six groups are duplicated in the source data (two LF identities for one human, e.g. Manish Dixit's `mdixit@linuxfoundation.ord` typo). Those need a Salesforce correction; a reviewed detection query is in the spec.
- The platform-wide rule for gating analytics-lane Org Lens reads still needs architecture review.
- `OrgLensKeyContactsService.getEmployeesByOrgUid` has the same email-keyed dedupe; filed as follow-up.

## Test plan

- [x] `yarn lint:check`, `yarn test`, `yarn build` all green
- [x] 23 new tests for the merge, including false-merge and single-source no-regression cases (the service had no test file before)
- [x] 9 new tests for the read gate, covering direct writer, direct auditor, cascading grant, 403 for no relation, and 503 (not 403) when the grant lookup fails
- [ ] Post-deploy: re-run the production check and confirm 558 → ~476 rows, and that the two organizations above now refuse an ungranted caller

Made with [Cursor](https://cursor.com)