### PR TITLE
fix(header): always navigate to me-lens from My Meetings button

### DIFF
--- a/apps/lfx-one/src/app/shared/components/header/header.component.html
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.html
@@ -46,14 +46,15 @@
                 @if (userService.authenticated()) {
                   <div class="flex items-center gap-4">
                     @if (showMyMeetings()) {
-                      <a
-                        routerLink="/meetings"
+                      <button
+                        type="button"
+                        (click)="navigateToMyMeetings()"
                         class="flex items-center gap-2 text-sm font-medium text-gray-600 border border-gray-200 hover:border-gray-300 hover:text-gray-800 hover:bg-gray-50 transition-colors px-3 py-1.5 rounded-md whitespace-nowrap"
                         data-testid="my-meetings-header-button">
                         <i class="fa-light fa-calendar text-xs"></i>
                         My Meetings
                         <i class="fa-light fa-arrow-up-right text-xs"></i>
-                      </a>
+                      </button>
                     }
                     <lfx-avatar
                       [image]="userService.effectiveAvatarUrl()"

--- a/apps/lfx-one/src/app/shared/components/header/header.component.ts
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.ts
@@ -146,7 +146,7 @@ export class HeaderComponent {
   }
 
   protected navigateToMyMeetings(): void {
-    this.lensService.switchLens('me');
+    this.lensService.setLens('me');
     void this.router.navigate(['/meetings']);
   }
 

--- a/apps/lfx-one/src/app/shared/components/header/header.component.ts
+++ b/apps/lfx-one/src/app/shared/components/header/header.component.ts
@@ -9,6 +9,7 @@ import { AvatarComponent } from '@components/avatar/avatar.component';
 import { MenubarComponent } from '@components/menubar/menubar.component';
 import { CombinedProfile, Project } from '@lfx-one/shared/interfaces';
 import { AppService } from '@services/app.service';
+import { LensService } from '@services/lens.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { MenuItem } from 'primeng/api';
@@ -26,6 +27,7 @@ import { MenuComponent } from '../menu/menu.component';
 })
 export class HeaderComponent {
   private readonly router = inject(Router);
+  private readonly lensService = inject(LensService);
   private readonly projectService = inject(ProjectService);
   private readonly appService = inject(AppService);
   public readonly userService = inject(UserService);
@@ -141,6 +143,11 @@ export class HeaderComponent {
 
   protected toggleMobileSidebar(): void {
     this.appService.toggleMobileSidebar();
+  }
+
+  protected navigateToMyMeetings(): void {
+    this.lensService.switchLens('me');
+    void this.router.navigate(['/meetings']);
   }
 
   private initializeUserProfile(): Signal<CombinedProfile | null> {


### PR DESCRIPTION
## Summary

- The **My Meetings** button in the header used `routerLink="/meetings"`. When the project or foundation lens was active, `lensRedirectGuard` redirected that flat route to `/project/meetings` or `/foundation/meetings` instead of the me-lens view.
- Replaced the `routerLink` with a click handler that calls `lensService.switchLens('me')` before navigating, so the guard always sees the me-lens and passes the request through unchanged.
- Changed the element from `<a>` to `<button type="button">` — semantically correct since this is now an action (lens switch + navigate) rather than a plain link.

## Ticket

Closes [#1429](https://github.com/linuxfoundation/lfx-self-serve/issues/1429)