### PR TITLE
fix(campaigns): derive the deliveryType error message from the constant

### DIFF
--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -163,10 +163,10 @@ export class CampaignController {
     // message, for a caller whose only mistake was a misspelling.
     //
     // Derived from the shared `CAMPAIGN_DELIVERY_TYPES`, and so is the MESSAGE below — the sibling
-    // `platform` check already interpolates its own Set for exactly this reason. The service now
-    // derives from the same constant too, so this is the single source of truth; a hardcoded tail
-    // in the error string would have been the last copy left to drift, and the one a reader trusts
-    // most because it is what the API actually says.
+    // `platform` check already interpolates its own Set for exactly this reason. An error string
+    // is the copy a reader trusts most, because it is what the API actually says, so a hardcoded
+    // tail there outlives every other duplicate. The two `Unsupported deliveryType` messages in
+    // `campaign-proxy.service.ts` are interpolated from the same constant for the same reason.
     const supportedDeliveryTypes = new Set<string>(CAMPAIGN_DELIVERY_TYPES.map((d) => d.id));
     if (body.deliveryType !== undefined && !supportedDeliveryTypes.has(body.deliveryType)) {
       _next(

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -162,12 +162,15 @@ export class CampaignController {
     // `'emial'` falls past it into those same paid-only checks and produces the same misleading
     // message, for a caller whose only mistake was a misspelling.
     //
-    // Derived from the shared `CAMPAIGN_DELIVERY_TYPES` rather than a fourth hardcoded list — the
-    // service already keeps its own copy, and a third one here would be the one that drifts.
+    // Derived from the shared `CAMPAIGN_DELIVERY_TYPES`, and so is the MESSAGE below — the sibling
+    // `platform` check already interpolates its own Set for exactly this reason. The service now
+    // derives from the same constant too, so this is the single source of truth; a hardcoded tail
+    // in the error string would have been the last copy left to drift, and the one a reader trusts
+    // most because it is what the API actually says.
     const supportedDeliveryTypes = new Set<string>(CAMPAIGN_DELIVERY_TYPES.map((d) => d.id));
     if (body.deliveryType !== undefined && !supportedDeliveryTypes.has(body.deliveryType)) {
       _next(
-        ServiceValidationError.forField('deliveryType', 'deliveryType must be one of: paid-marketing, email', {
+        ServiceValidationError.forField('deliveryType', `deliveryType must be one of: ${[...supportedDeliveryTypes].join(', ')}`, {
           operation: 'campaign_refine_brief',
           service: 'campaign_controller',
           path: req.path,

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -32,6 +32,9 @@ import { addShutdownHook, isShuttingDown } from '../utils/shutdown';
 /** Platforms that support the campaign status toggle endpoint. */
 const SUPPORTED_STATUS_PLATFORMS: ReadonlySet<CampaignPlatform> = new Set<CampaignPlatform>(['meta-ads', 'reddit-ads']);
 
+/** Derived from the shared constant so the validation and its error message cannot drift apart. */
+const SUPPORTED_DELIVERY_TYPES: ReadonlySet<string> = new Set(CAMPAIGN_DELIVERY_TYPES.map((d) => d.id));
+
 const NUMERIC_ID_RE = /^\d+$/;
 
 export class CampaignController {
@@ -167,10 +170,9 @@ export class CampaignController {
     // is the copy a reader trusts most, because it is what the API actually says, so a hardcoded
     // tail there outlives every other duplicate. The two `Unsupported deliveryType` messages in
     // `campaign-proxy.service.ts` are interpolated from the same constant for the same reason.
-    const supportedDeliveryTypes = new Set<string>(CAMPAIGN_DELIVERY_TYPES.map((d) => d.id));
-    if (body.deliveryType !== undefined && !supportedDeliveryTypes.has(body.deliveryType)) {
+    if (body.deliveryType !== undefined && !SUPPORTED_DELIVERY_TYPES.has(body.deliveryType)) {
       _next(
-        ServiceValidationError.forField('deliveryType', `deliveryType must be one of: ${[...supportedDeliveryTypes].join(', ')}`, {
+        ServiceValidationError.forField('deliveryType', `deliveryType must be one of: ${[...SUPPORTED_DELIVERY_TYPES].join(', ')}`, {
           operation: 'campaign_refine_brief',
           service: 'campaign_controller',
           path: req.path,

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
@@ -22,11 +22,23 @@ vi.mock('../helpers/url-validation', () => ({
   fetchSafeUrl: vi.fn(async () => ({ html: '<html><body></body></html>', ok: true, status: 200 })),
 }));
 
+import { CAMPAIGN_DELIVERY_TYPES } from '@lfx-one/shared/constants';
 import type { Request } from 'express';
 
 import { CampaignProxyService } from './campaign-proxy.service';
 
 const req = {} as unknown as Request;
+
+/**
+ * Derived from the same constant the service interpolates, so adding a delivery type updates this
+ * expectation with the code instead of failing on a hand-written list — a second literal here
+ * would be the drift this message was just changed to prevent.
+ *
+ * Asserted by EQUALITY rather than `.includes('deliveryType')`: the substring is satisfied by the
+ * word alone, so it passed whether the list rendered correctly, empty, or as `[object Object]` —
+ * it could not fail for the thing under test.
+ */
+const expectedUnsupportedMessage = `Unsupported deliveryType. Supported: ${CAMPAIGN_DELIVERY_TYPES.map((d) => d.id).join(', ')}.`;
 
 /**
  * The email brief must not generate ad copy — and `platforms` being absent CANNOT carry that,
@@ -199,7 +211,7 @@ describe('CampaignProxyService email delivery type', () => {
       }>
     );
 
-    expect(events.some((e) => e.type === 'error' && String(e.data).includes('deliveryType'))).toBe(true);
+    expect(events.some((e) => e.type === 'error' && String(e.data) === expectedUnsupportedMessage)).toBe(true);
     expect(generatedAdCopy()).toBe(false);
     expect(generatedKeywords()).toBe(false);
   });
@@ -213,7 +225,7 @@ describe('CampaignProxyService email delivery type', () => {
       ) as AsyncGenerator<{ type: string; data: unknown }>
     );
 
-    expect(events.some((e) => e.type === 'error' && String(e.data).includes('deliveryType'))).toBe(true);
+    expect(events.some((e) => e.type === 'error' && String(e.data) === expectedUnsupportedMessage)).toBe(true);
     expect(generatedAdCopy()).toBe(false);
   });
 

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.spec.ts
@@ -37,8 +37,13 @@ const req = {} as unknown as Request;
  * Asserted by EQUALITY rather than `.includes('deliveryType')`: the substring is satisfied by the
  * word alone, so it passed whether the list rendered correctly, empty, or as `[object Object]` —
  * it could not fail for the thing under test.
+ *
+ * Built through a `Set` to mirror production's exact transform, not just its output. The two are
+ * byte-identical while the ids are unique, so this is defensive: were the constant ever to gain a
+ * duplicate id, deriving from the raw array would let this test pass while production — which
+ * spreads a Set — rendered something different.
  */
-const expectedUnsupportedMessage = `Unsupported deliveryType. Supported: ${CAMPAIGN_DELIVERY_TYPES.map((d) => d.id).join(', ')}.`;
+const expectedUnsupportedMessage = `Unsupported deliveryType. Supported: ${[...new Set(CAMPAIGN_DELIVERY_TYPES.map((d) => d.id))].join(', ')}.`;
 
 /**
  * The email brief must not generate ad copy — and `platforms` being absent CANNOT carry that,

--- a/apps/lfx-one/src/server/services/campaign-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-proxy.service.ts
@@ -625,7 +625,7 @@ export class CampaignProxyService {
     // — a request that MEANT to suppress that spend causing it instead. Failing loudly is the
     // only reading that cannot cost money.
     if (body.deliveryType !== undefined && !SUPPORTED_DELIVERY_TYPES.has(body.deliveryType)) {
-      yield { type: 'error', data: `Unsupported deliveryType. Supported: paid-marketing, email.` };
+      yield { type: 'error', data: `Unsupported deliveryType. Supported: ${[...SUPPORTED_DELIVERY_TYPES].join(', ')}.` };
       return;
     }
 
@@ -878,7 +878,7 @@ export class CampaignProxyService {
     // paid branch and refines, which is what this endpoint did before the field existed — but a
     // caller who misspells the type should be told, not quietly given the other behaviour.
     if (body.deliveryType !== undefined && !SUPPORTED_DELIVERY_TYPES.has(body.deliveryType)) {
-      yield { type: 'error', data: `Unsupported deliveryType. Supported: paid-marketing, email.` };
+      yield { type: 'error', data: `Unsupported deliveryType. Supported: ${[...SUPPORTED_DELIVERY_TYPES].join(', ')}.` };
       return;
     }
 


### PR DESCRIPTION
Follow-up to David's nit on #1450, which merged before I pushed the fix.

## What

Three error messages hardcoded `paid-marketing, email` while the code right beside each one
already had the list **derived** from the shared `CAMPAIGN_DELIVERY_TYPES` constant:

| Site | Guard | Message before |
|---|---|---|
| `campaign.controller.ts:171` | `supportedDeliveryTypes` (derived) | hardcoded |
| `campaign-proxy.service.ts:628` | `SUPPORTED_DELIVERY_TYPES` (derived) | hardcoded |
| `campaign-proxy.service.ts:881` | `SUPPORTED_DELIVERY_TYPES` (derived) | hardcoded |

An error string is the copy a reader trusts most — it is what the API actually says — so a
hardcoded tail there outlives every other duplicate. The sibling `platform` check already
interpolates its own Set for exactly this reason.

All three now interpolate. **Rendered text is byte-identical at every site.**

> I initially opened this PR fixing only the controller and describing it as "the last hardcoded
> copy". That was wrong — the reviewer sim's *fixed-at-one-layer-only* check found the other two.
> David's nit was a class, not a line.

## Test quality

The two specs covering the proxy branches asserted only `.includes('deliveryType')` — a substring
the **word alone** satisfies. They passed whether the list rendered correctly, empty, or as
`[object Object]`, so they could not fail for the thing this PR changes.

Both now assert the complete message by equality, with the expectation derived from the same
constant so a new delivery type updates it with the code rather than failing on a hand-written
list.

**Mutation-verified:** replacing the interpolation with a stale hardcoded `paid-marketing.`
fails both specs; the previous `.includes` form passed that same mutation.

## Verification

- `npx tsc --noEmit` — 0 errors (`tsconfig.app.json` and `tsconfig.spec.json`)
- `yarn test` — 1291 server + 317 app passing
- `yarn lint` — 0 errors (1 pre-existing warning in `user.service.ts`)
- `./check-headers.sh` — passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFGQ59WQ2n8yLU4dGbMXnK