### PR TITLE
feat(campaigns): build the hubspot config so email can dispatch

### DIFF
--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -653,6 +653,88 @@ describe('CampaignController.createCampaign cutover', () => {
     expect(sent).not.toHaveProperty('budgetUsd');
     expect(sent['geoTargets']).toEqual(['US']);
   });
+
+  /**
+   * LFXV2-3256. The envelope key and field names are a CONTRACT with
+   * `internal/dispatch/hubspot.go:47-56` — the dispatcher reads `hubspotConfig.sourceEmailId`, and
+   * `unmarshalPlatformConfig` treats a missing key as a zero value rather than an error. A typo on
+   * either side therefore produces a silent zero-value dispatch, not a type error, which is why
+   * these assert the exact strings.
+   */
+  it('builds the hubspot envelope key the email dispatcher reads', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq({ platforms: ['hubspot'], hubspotConfig: { sourceEmailId: 'email-123' } }, { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    const sent = envelopeFor(createCampaigns)['hubspotConfig'] as Record<string, unknown>;
+    expect(sent).toEqual({ sourceEmailId: 'email-123' });
+  });
+
+  it('forwards utmCampaign only when it is set', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq({ platforms: ['hubspot'], hubspotConfig: { sourceEmailId: 'e-1', utmCampaign: 'kubecon-eu' } }, { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    expect(envelopeFor(createCampaigns)['hubspotConfig']).toEqual({ sourceEmailId: 'e-1', utmCampaign: 'kubecon-eu' });
+  });
+
+  /**
+   * Absence must stay absence. Upstream, an ABSENT `utmCampaign` means "derive one from the
+   * deterministic email name" — so forwarding `''` does not select that default, it hands the
+   * service an empty override. Asserting the key is missing, not that it is falsy.
+   */
+  it('omits a blank utmCampaign rather than sending an empty override', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq({ platforms: ['hubspot'], hubspotConfig: { sourceEmailId: 'e-1', utmCampaign: '   ' } }, { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    const sent = envelopeFor(createCampaigns)['hubspotConfig'] as Record<string, unknown>;
+    expect(sent).not.toHaveProperty('utmCampaign');
+    expect(sent['sourceEmailId']).toBe('e-1');
+  });
+
+  /**
+   * A blank id must read as UNCONFIGURED, so `hasPlatformConfig` refuses locally and names the
+   * problem. Upstream trims before its own emptiness check, so a whitespace-only id would pass a
+   * truthiness test here and be refused there — the split this guard exists to prevent.
+   *
+   * Asserts the key is ABSENT, not that it holds `''`: only absence reaches the refusal.
+   */
+  it.each([
+    ['whitespace only', '   '],
+    ['empty string', ''],
+  ])('treats a %s sourceEmailId as unconfigured rather than sending it', async (_label, sourceEmailId) => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(buildReq({ platforms: ['hubspot'], hubspotConfig: { sourceEmailId } }, { project: 'tlf', brief_id: 'b-1' }), res, next);
+
+    expect(envelopeFor(createCampaigns)).not.toHaveProperty('hubspotConfig');
+  });
+
+  it('omits hubspotConfig entirely when the request carries none', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(buildReq(googleBody({}), { project: 'tlf', brief_id: 'b-1' }), res, next);
+
+    expect(envelopeFor(createCampaigns)).not.toHaveProperty('hubspotConfig');
+  });
 });
 
 /**

--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -689,9 +689,13 @@ describe('CampaignController.createCampaign cutover', () => {
   });
 
   /**
-   * Absence must stay absence. Upstream, an ABSENT `utmCampaign` means "derive one from the
-   * deterministic email name" — so forwarding `''` does not select that default, it hands the
-   * service an empty override. Asserting the key is missing, not that it is falsy.
+   * Canonicalization, not a correctness guard: `utm.Resolve` trims and falls through to the
+   * name-derived slug on empty, so `''` and absent resolve the same upstream. Pinned anyway
+   * because the envelope should carry only fields that mean something — an empty string reads as
+   * a deliberate override to anyone inspecting the wire.
+   *
+   * Asserts the key is MISSING rather than falsy: `toBeFalsy()` would pass on `''`, which is the
+   * exact value this omits.
    */
   it('omits a blank utmCampaign rather than sending an empty override', async () => {
     createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
@@ -727,6 +731,49 @@ describe('CampaignController.createCampaign cutover', () => {
     expect(envelopeFor(createCampaigns)).not.toHaveProperty('hubspotConfig');
   });
 
+  /**
+   * `CampaignCreateRequest` is a compile-time assertion over `req.body`, and this route has no
+   * runtime validator — so a caller CAN send a number. Before the typeof checks, `.trim()` threw a
+   * TypeError and the request 500'd instead of taking the controlled refusal.
+   *
+   * `next` is asserted unused: an unhandled throw here surfaces through the catch as a 500, so a
+   * test that only checked the envelope would pass while the request errored.
+   */
+  it.each([
+    ['a numeric sourceEmailId', { sourceEmailId: 123 }],
+    ['a null sourceEmailId', { sourceEmailId: null }],
+    ['an object sourceEmailId', { sourceEmailId: {} }],
+  ])('refuses %s without throwing', async (_label, hubspotConfig) => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq({ platforms: ['hubspot'], hubspotConfig } as unknown as Record<string, unknown>, { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(envelopeFor(createCampaigns)).not.toHaveProperty('hubspotConfig');
+  });
+
+  it('drops a non-string utmCampaign rather than throwing on it', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq({ platforms: ['hubspot'], hubspotConfig: { sourceEmailId: 'e-1', utmCampaign: 42 } } as unknown as Record<string, unknown>, {
+        project: 'tlf',
+        brief_id: 'b-1',
+      }),
+      res,
+      next
+    );
+
+    expect(next).not.toHaveBeenCalled();
+    expect(envelopeFor(createCampaigns)['hubspotConfig']).toEqual({ sourceEmailId: 'e-1' });
+  });
+
   it('omits hubspotConfig entirely when the request carries none', async () => {
     createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
     legacyCreate.mockResolvedValue({ jobId: 'job_1' });
@@ -734,6 +781,63 @@ describe('CampaignController.createCampaign cutover', () => {
     await controller.createCampaign(buildReq(googleBody({}), { project: 'tlf', brief_id: 'b-1' }), res, next);
 
     expect(envelopeFor(createCampaigns)).not.toHaveProperty('hubspotConfig');
+  });
+
+  /**
+   * The path this ticket actually ships — the envelope tests above all run with the cutover DARK
+   * (they assert on the ARGUMENT handed to a mocked `createCampaigns` that reports `enabled:
+   * false`), so without this one nothing proves an email create succeeds when the cutover is on.
+   */
+  it('returns the campaign-service job id for an email create when the cutover is on', async () => {
+    createCampaigns.mockResolvedValue({ enabled: true, jobId: 'a3f1c2d4-0000-4000-8000-00000000000e', error: null });
+
+    await controller.createCampaign(
+      buildReq({ platforms: ['hubspot'], hubspotConfig: { sourceEmailId: 'email-123' } }, { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    expect(legacyCreate).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ jobId: 'a3f1c2d4-0000-4000-8000-00000000000e' });
+  });
+
+  /**
+   * The dark-cutover refusal, and the reason `hasPlatformConfig` cannot cover it: that guard lives
+   * inside `createCampaigns` and is gated by the same flags, so with the cutover off it never
+   * runs. Widening `platforms` to `CampaignAnyPlatform` is what made this reachable at all —
+   * `platforms: ['hubspot']` used to be a type error at every caller.
+   *
+   * The legacy path would NOT have failed loudly: it has no `includeHubspot` arm, so it records
+   * "Unsupported platform(s)" in an errors array and completes with an empty promise list — a job
+   * that finishes, after the inline 45s wait, having created nothing.
+   *
+   * Asserts `legacyCreate` was never called, not merely that an error came back: reaching that
+   * path at all is the defect.
+   */
+  it('refuses an email create instead of falling through to the legacy path', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq({ platforms: ['hubspot'], hubspotConfig: { sourceEmailId: 'email-123' } }, { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    expect(legacyCreate).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith({ jobId: '', error: expect.stringContaining('cutover') });
+  });
+
+  it('still runs the legacy path for a paid create when the cutover is dark', async () => {
+    // The contrast. Without it the refusal above would pass on a controller that refused every
+    // dark-cutover create, not just the email ones.
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_legacy_1' });
+
+    await controller.createCampaign(buildReq(googleBody({}), { project: 'tlf', brief_id: 'b-1' }), res, next);
+
+    expect(legacyCreate).toHaveBeenCalledTimes(1);
+    expect(res.json).toHaveBeenCalledWith({ jobId: 'job_legacy_1' });
   });
 });
 

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -359,6 +359,30 @@ export class CampaignController {
         return;
       }
 
+      // The email channel exists ONLY on the cutover path, so it must not fall through here.
+      //
+      // Widening `platforms` to `CampaignAnyPlatform` is what makes this reachable: before it,
+      // `platforms: ['hubspot']` was a type error at every caller. The legacy path has no HubSpot
+      // client and no `includeHubspot` arm — it pushes "Unsupported platform(s): hubspot" into its
+      // `errors` array and then completes with an EMPTY promise list. That is the shape this
+      // cutover exists to prevent: a job that finishes, after the inline 45s wait, having created
+      // nothing, reported through a partial-success envelope rather than as a refusal.
+      //
+      // `hasPlatformConfig` cannot catch it — that guard lives inside `createCampaigns`,
+      // deliberately gated by the flags, so with the cutover dark it never runs.
+      //
+      // Refused terminally rather than passed through, matching the `viaService.error` arm above:
+      // when we know the create cannot succeed, saying so beats a 45-second wait for a result that
+      // names zero campaigns.
+      if (platforms.includes('hubspot')) {
+        logger.warning(req, 'campaign_create', 'email campaign requested while the campaign-service cutover is dark', { briefId, projectSlug });
+        res.json({
+          jobId: '',
+          error: 'Email campaigns require the campaign-service cutover to be enabled. The legacy creation path cannot stage email.',
+        });
+        return;
+      }
+
       const result = await this.proxyService.createCampaign(req, req.body);
       logger.success(req, 'campaign_create', startTime, { jobId: result.jobId, via: 'legacy' });
       res.json(result);
@@ -1176,15 +1200,30 @@ export class CampaignController {
    * `strings.TrimSpace`s it before the check, so `' '` would pass a truthiness test here and be
    * refused there — the precise split this guard exists to avoid.
    *
-   * `utmCampaign` is only forwarded when non-blank. It is optional upstream, where ABSENT means
-   * "derive one from the email name" — so forwarding `''` would not select that default, it would
-   * hand the service an empty override. Absence has to stay absence.
+   * `utmCampaign` is only forwarded when non-blank — canonicalization, not a correctness guard.
+   * An earlier version of this comment claimed a blank one would suppress the upstream default;
+   * that was wrong. `utm.Resolve` (`internal/utm/resolve.go:47-60`) trims the value and falls
+   * through to the name-derived slug when the result is empty, so `''`, `'  '` and absent all
+   * resolve identically. Omitted anyway so the envelope carries only fields that mean something,
+   * and so a reader cannot mistake an empty string for a deliberate override.
+   *
+   * This envelope is read ONLY by the cutover path. With the flags dark, `createCampaign` refuses
+   * an email create outright rather than falling through — see the guard above the legacy call.
+   * The legacy path does NOT fail loudly on `hubspot`: it records "Unsupported platform(s)" in an
+   * errors array and then completes with nothing created, which is why the refusal is explicit.
    */
   private buildHubSpotConfig(body: CampaignCreateRequest): Record<string, unknown> | null {
-    const sourceEmailId = body?.hubspotConfig?.sourceEmailId?.trim();
+    // Type-checked at runtime, not just by the `CampaignCreateRequest` cast. This route has no
+    // body validator — `req.body` is asserted, not parsed — so a caller sending
+    // `sourceEmailId: 123` reaches here as a number and `.trim()` throws a TypeError, answering a
+    // malformed request with a 500 instead of the controlled "unconfigured" refusal. A wrong TYPE
+    // is the same non-answer as a blank one, and both should take the same exit.
+    const rawId = body?.hubspotConfig?.sourceEmailId;
+    const sourceEmailId = typeof rawId === 'string' ? rawId.trim() : '';
     if (!sourceEmailId) return null;
 
-    const utmCampaign = body.hubspotConfig?.utmCampaign?.trim();
+    const rawUtm = body.hubspotConfig?.utmCampaign;
+    const utmCampaign = typeof rawUtm === 'string' ? rawUtm.trim() : '';
     return utmCampaign ? { sourceEmailId, utmCampaign } : { sourceEmailId };
   }
 }

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -1036,6 +1036,9 @@ export class CampaignController {
     const metaConfig = this.buildMetaConfig(body);
     if (metaConfig) envelope['metaConfig'] = metaConfig;
 
+    const hubspotConfig = this.buildHubSpotConfig(body);
+    if (hubspotConfig) envelope['hubspotConfig'] = hubspotConfig;
+
     return envelope;
   }
 
@@ -1158,5 +1161,30 @@ export class CampaignController {
 
     const { budgetUsd, ...rest } = body.metaConfig;
     return { ...rest, budget: budgetUsd };
+  }
+
+  /**
+   * The email channel's config.
+   *
+   * A BLANK `sourceEmailId` returns null — i.e. UNCONFIGURED — rather than an object carrying an
+   * empty string. Upstream requires it (`hubspot.go:281-283` refuses a blank one), so both paths
+   * end in a refusal; the difference is where. Null makes `hasPlatformConfig` refuse locally with
+   * "No configuration was built for: hubspot", naming the actual problem. Sending `''` instead
+   * spends a round trip to learn the same thing, and the job is created before it fails.
+   *
+   * Trimmed because a whitespace-only id is the same non-answer as an absent one: upstream
+   * `strings.TrimSpace`s it before the check, so `' '` would pass a truthiness test here and be
+   * refused there — the precise split this guard exists to avoid.
+   *
+   * `utmCampaign` is only forwarded when non-blank. It is optional upstream, where ABSENT means
+   * "derive one from the email name" — so forwarding `''` would not select that default, it would
+   * hand the service an empty override. Absence has to stay absence.
+   */
+  private buildHubSpotConfig(body: CampaignCreateRequest): Record<string, unknown> | null {
+    const sourceEmailId = body?.hubspotConfig?.sourceEmailId?.trim();
+    if (!sourceEmailId) return null;
+
+    const utmCampaign = body.hubspotConfig?.utmCampaign?.trim();
+    return utmCampaign ? { sourceEmailId, utmCampaign } : { sourceEmailId };
   }
 }

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -1598,6 +1598,42 @@ describe('CampaignServiceClient.createCampaigns', () => {
   });
 
   /**
+   * LFXV2-3256 — the mapping that unblocks the email channel. Before it, `hubspot` fell to
+   * `requiredKey[platform] === undefined` and was refused here, so an email campaign could never
+   * reach the dispatcher no matter what the envelope carried.
+   *
+   * Both directions, because the guard's value is that it fails LOUDLY: mapping `hubspot` without
+   * a config builder would be the regression it exists to catch, and dropping the mapping would
+   * restore the block this ticket removed. One test alone cannot tell those apart.
+   */
+  it('dispatches an email campaign once hubspotConfig is present', async () => {
+    bothFlagsOn();
+    proxyRequestWithResponse.mockResolvedValueOnce({ data: { job_id: 'a3f1c2d4-0000-4000-8000-00000000000e' } });
+
+    const res = await new CampaignServiceClient().createCampaigns(req, 'b-1', 'tlf', ['hubspot'], {
+      hubspotConfig: { sourceEmailId: 'email-123' },
+    });
+
+    expect(proxyRequestWithResponse).toHaveBeenCalledTimes(1);
+    expect(res.jobId).toBe('a3f1c2d4-0000-4000-8000-00000000000e');
+    expect(res.error).toBeNull();
+  });
+
+  it('still refuses an email campaign whose hubspotConfig is missing', async () => {
+    // The envelope is non-empty but carries the WRONG key, which is the shape a half-built config
+    // builder produces. `unmarshalPlatformConfig` would read the absent `hubspotConfig` as a zero
+    // value and dispatch a clone of email id "" — so this must never reach the wire.
+    bothFlagsOn();
+
+    const res = await new CampaignServiceClient().createCampaigns(req, 'b-1', 'tlf', ['hubspot'], { hsToken: 'tok' });
+
+    expect(proxyRequestWithResponse).not.toHaveBeenCalled();
+    expect(res.enabled).toBe(true);
+    expect(res.jobId).toBeNull();
+    expect(res.error).toContain('hubspot');
+  });
+
+  /**
    * campaign-service has NO Demand Gen path — `internal/dispatch/googleads.go` creates a Search
    * campaign and nothing else. The legacy path does support it, so this is a capability the
    * cutover loses rather than one nobody has.

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -1388,10 +1388,14 @@ export function fromBriefResponse(found: CampaignServiceBrief): CampaignBriefOut
   // Narrowed to `CampaignPlatform`, NOT `CampaignAnyPlatform`, deliberately: this feeds the PAID
   // planner's channel selection, and `hubspot` is not one of its channels. That means a stored
   // email brief's `hubspot` is filtered out here and — because of the guard below — would read as
-  // UNREADABLE rather than as an email brief. Latent today, since email skips brief restore
-  // entirely (`planning-tab.component.ts:309`); it becomes reachable the moment email persistence
-  // lands, which is LFXV2-3224's problem to solve deliberately rather than this ticket's to
-  // paper over. Restoring an email brief needs a different shape, not a wider filter.
+  // UNREADABLE rather than as an email brief.
+  //
+  // No client sends such a brief TODAY (the email planner omits `platforms`), but that is a client
+  // guarantee and this is a server reading whatever campaign-service stored, so it does not bound
+  // what can arrive — the same reasoning `campaign-proxy.service.ts` applies to its own inputs.
+  // The case is deferred rather than dismissed: restoring an email brief needs a different shape,
+  // not a wider filter here, and widening this one would hand `hubspot` to a paid channel picker
+  // that has no such channel. That is LFXV2-3224's to solve deliberately.
   const selectedPlatforms = (found.platforms ?? []).filter((p): p is CampaignPlatform => CAMPAIGN_PLATFORMS.some((o) => o.id === p));
 
   // A stored brief that names platforms, none of which this build recognises, is UNREADABLE —

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -162,9 +162,15 @@ export function isCampaignServiceJobId(jobId: string): boolean {
  * platform list. That was wrong for the same reason the LinkedIn-strategy guard was: `twitter-ads`
  * and `microsoft-ads` are `disabled: true` in `CAMPAIGN_PLATFORMS`, but that is a CLIENT guarantee,
  * and the upstream `CampaignCreateInput` accepts all three of twitter/microsoft/hubspot. This
- * service builds no `twitterConfig`, `microsoftConfig` or `hubspotConfig` at all, so waving them
- * through queued a job whose dispatcher reads an absent key as a zero value — exactly the defect
- * the mapped four are protected from.
+ * service builds no `twitterConfig` or `microsoftConfig`, so waving those through queued a job
+ * whose dispatcher reads an absent key as a zero value — exactly the defect the mapped platforms
+ * are protected from.
+ *
+ * `hubspot` joined the map when `buildHubSpotConfig` landed (LFXV2-3256), which is the order this
+ * guard is designed to enforce: map a platform only once something builds its config. Note that a
+ * mapped `hubspot` is necessary but NOT sufficient to stage an email — the dispatcher also needs
+ * the brief's audience to be BUILT (`hubspot.go:432-456`), which it resolves by `brief.ID` rather
+ * than from this envelope, so that failure surfaces upstream and not here.
  *
  * The cost of refusing is a clear error when a platform is enabled before its config builder
  * exists, which is the failure you want. The cost of allowing was a dispatched, unusable job.
@@ -175,6 +181,7 @@ function hasPlatformConfig(platform: string, envelope: Record<string, unknown>):
     'linkedin-ads': 'linkedInConfig',
     'reddit-ads': 'redditConfig',
     'meta-ads': 'metaConfig',
+    hubspot: 'hubspotConfig',
   };
   const key = requiredKey[platform];
   if (key === undefined) return false;
@@ -1377,6 +1384,14 @@ export function fromBriefResponse(found: CampaignServiceBrief): CampaignBriefOut
 
   // Narrowed against the union rather than passed through: an unknown platform id reaches a
   // template that indexes icon and label maps by it, and renders blank rather than erroring.
+  //
+  // Narrowed to `CampaignPlatform`, NOT `CampaignAnyPlatform`, deliberately: this feeds the PAID
+  // planner's channel selection, and `hubspot` is not one of its channels. That means a stored
+  // email brief's `hubspot` is filtered out here and — because of the guard below — would read as
+  // UNREADABLE rather than as an email brief. Latent today, since email skips brief restore
+  // entirely (`planning-tab.component.ts:309`); it becomes reachable the moment email persistence
+  // lands, which is LFXV2-3224's problem to solve deliberately rather than this ticket's to
+  // paper over. Restoring an email brief needs a different shape, not a wider filter.
   const selectedPlatforms = (found.platforms ?? []).filter((p): p is CampaignPlatform => CAMPAIGN_PLATFORMS.some((o) => o.id === p));
 
   // A stored brief that names platforms, none of which this build recognises, is UNREADABLE —

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -8,22 +8,17 @@
 export type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' | 'meta-ads' | 'reddit-ads' | 'twitter-ads';
 
 /**
- * The email channel's platform id, kept OUT of `CampaignPlatform` on purpose.
+ * Any platform a campaign can dispatch to — the paid ad channels plus the email channel.
  *
- * Upstream this is just another `platform` value (`docs/api-catalog.md` records the enum as
- * `"hubspot"`, and `campaigns` is unique on `(brief_id, platform)`), so the two look
- * interchangeable from the wire. They are not interchangeable HERE, because `CampaignPlatform` is
- * not only a type — its members are enumerated by `CAMPAIGN_PLATFORMS`, which renders the paid Ad
- * Channels picker (`planning-tab.component.ts:96`). Widening the union invites `hubspot` into that
- * list, where a paid brief could select it.
- *
- * Separate types keep the distinction the delivery-type work established: email is not an ad
- * channel, it is a different delivery type that happens to dispatch through one.
+ * `'hubspot'` is spelled out here rather than added to `CampaignPlatform`. Upstream the two are
+ * interchangeable (`docs/api-catalog.md` records the platform enum as `"hubspot"`, and `campaigns`
+ * is unique on `(brief_id, platform)`), but here they are not: `CampaignPlatform`'s members are
+ * enumerated by `CAMPAIGN_PLATFORMS`, which renders the paid Ad Channels picker
+ * (`planning-tab.component.ts:96`). Widening that union would offer HubSpot as an ad channel a
+ * paid brief could select — email is not an ad channel, it is a different delivery type that
+ * happens to dispatch through one.
  */
-export type CampaignEmailPlatform = 'hubspot';
-
-/** Any platform a campaign can dispatch to — paid ad channels plus the email channel. */
-export type CampaignAnyPlatform = CampaignPlatform | CampaignEmailPlatform;
+export type CampaignAnyPlatform = CampaignPlatform | 'hubspot';
 
 export type CampaignPhase = 'planning' | 'implementation' | 'insights' | 'optimization';
 

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -7,6 +7,24 @@
 
 export type CampaignPlatform = 'google-ads' | 'microsoft-ads' | 'linkedin-ads' | 'meta-ads' | 'reddit-ads' | 'twitter-ads';
 
+/**
+ * The email channel's platform id, kept OUT of `CampaignPlatform` on purpose.
+ *
+ * Upstream this is just another `platform` value (`docs/api-catalog.md` records the enum as
+ * `"hubspot"`, and `campaigns` is unique on `(brief_id, platform)`), so the two look
+ * interchangeable from the wire. They are not interchangeable HERE, because `CampaignPlatform` is
+ * not only a type — its members are enumerated by `CAMPAIGN_PLATFORMS`, which renders the paid Ad
+ * Channels picker (`planning-tab.component.ts:96`). Widening the union invites `hubspot` into that
+ * list, where a paid brief could select it.
+ *
+ * Separate types keep the distinction the delivery-type work established: email is not an ad
+ * channel, it is a different delivery type that happens to dispatch through one.
+ */
+export type CampaignEmailPlatform = 'hubspot';
+
+/** Any platform a campaign can dispatch to — paid ad channels plus the email channel. */
+export type CampaignAnyPlatform = CampaignPlatform | CampaignEmailPlatform;
+
 export type CampaignPhase = 'planning' | 'implementation' | 'insights' | 'optimization';
 
 export type LinkedInTargetingProfile = 'cloud-native' | 'mcp' | 'custom';
@@ -665,6 +683,31 @@ export interface CampaignBriefRefineRequest {
 // Campaign Creation (Implementation Phase)
 // ---------------------------------------------------------------------------
 
+/**
+ * The email channel's per-platform config, typed to what campaign-service's `hubspotConfig`
+ * actually reads (`internal/dispatch/hubspot.go:47-56`) rather than to the legacy request shape
+ * the ad platforms carry.
+ *
+ * Deliberately just these two fields. The rest of what the HubSpot dispatcher needs — the send
+ * list, its suppressions — is NOT config: it resolves the brief's BUILT audience by `brief.ID`
+ * (`hubspot.go:293`), so passing an audience here would be a second, divergent source of truth
+ * for something the service already owns.
+ */
+export interface HubSpotCampaignCreateRequest {
+  /**
+   * The HubSpot marketing-email id to clone. REQUIRED upstream — there is no default template,
+   * and `hubspot.go:281-283` refuses the dispatch when it is blank. Sourced from the template
+   * picker that `searchHubSpotEmails` feeds.
+   */
+  sourceEmailId: string;
+  /**
+   * Optional override for the `utm_campaign` applied to the email's links. When unset the service
+   * derives one from the deterministic email name, so links stay attributable either way — set it
+   * only to roll several briefs' emails up to one campaign in reporting.
+   */
+  utmCampaign?: string;
+}
+
 export interface CampaignCreateRequest {
   eventName: string;
   eventSlug: string;
@@ -686,10 +729,17 @@ export interface CampaignCreateRequest {
   geoTargets: string[];
   project?: string;
   driveFolderUrl?: string;
-  platforms?: CampaignPlatform[];
+  /**
+   * Widened to `CampaignAnyPlatform` — this is the ONE request where the email channel is a legal
+   * platform, because it is the only one that dispatches. The planning/refine requests keep the
+   * narrow `CampaignPlatform[]`: those drive ad-copy and keyword generation, which email does not
+   * use, so accepting `hubspot` there would type-check a request the generators cannot serve.
+   */
+  platforms?: CampaignAnyPlatform[];
   linkedInConfig?: LinkedInCampaignCreateRequest;
   redditConfig?: RedditCampaignCreateRequest;
   metaConfig?: MetaCampaignCreateRequest;
+  hubspotConfig?: HubSpotCampaignCreateRequest;
 }
 
 /**


### PR DESCRIPTION
Closes **LFXV2-3256**. Found auditing the LFXV2-2770 email epic: this is the *first* hard failure
on the email path, upstream of the audience work.

## The problem

`hasPlatformConfig` mapped four ad platforms and returned `false` for anything unmapped, so
`hubspot` was refused **client-side, before the request ever reached the Go dispatcher**.

That guard is correct and stays. `unmarshalPlatformConfig` treats an absent key as a **zero
value** rather than an error, so waving `hubspot` through would have dispatched a clone of email
id `""`. It was waiting on a config builder. This adds the builder, **then** maps it.

## What's here

**`buildHubSpotConfig`**, typed to what the dispatcher reads (`internal/dispatch/hubspot.go:47-56`):
`sourceEmailId` (required) and `utmCampaign` (optional). A blank, whitespace-only, or
**non-string** value reads as UNCONFIGURED so the existing guard refuses locally and names the
problem, rather than spending a round trip to learn the same thing after the job exists.

**A terminal refusal when the cutover is dark.** This is the part reviewers should look at
hardest, because it was missed in the first push:

Widening `platforms` to `CampaignAnyPlatform` is what made `['hubspot']` reachable — it used to be
a type error at every caller. With the flags off, `createCampaigns` returns `enabled: false` and
the controller falls through to the legacy path, which `hasPlatformConfig` **cannot see** (that
guard lives inside `createCampaigns`, gated by the same flags). The legacy path has no HubSpot
client and no `includeHubspot` arm: it records `"Unsupported platform(s)"` in an errors array and
then completes with an **empty promise list** — a job that finishes, after the inline 45s wait,
having created nothing. Now refused terminally in the controller, matching the existing
`viaService.error` arm.

## `hubspot` is deliberately NOT in `CampaignPlatform`

That union is enumerated by `CAMPAIGN_PLATFORMS`, which renders the paid **Ad Channels picker**
(`planning-tab.component.ts:96`) — widening it would offer HubSpot as an ad channel a paid brief
could select. Only `CampaignCreateRequest.platforms` widens; the planning/refine requests keep the
narrow type, since they drive ad-copy generation email does not use.

⚠️ One consequence is documented rather than fixed: the restored-brief filter
(`campaign-service.service.ts:1387`) narrows to `CampaignPlatform`, so a stored email brief's
`hubspot` would read as *unreadable*. No client sends one today, but that is a client guarantee
and this is a server — deferred to **LFXV2-3224**, which should solve it deliberately rather than
have this PR widen a paid-path filter.

## Review fixes (all verified against the Go source before acting)

| Finding | Outcome |
|---|---|
| Dark cutover reaches the legacy path | **Fixed** — terminal refusal + tests |
| Non-string `sourceEmailId` → `TypeError` → 500 | **Fixed** — `typeof` checks; this route has no body validator |
| My claim that `''` suppresses the upstream `utmCampaign` default | **I was wrong.** `utm.Resolve` (`resolve.go:47-60`) trims and falls through, so `''` and absent resolve identically. Behaviour kept as canonicalization; the false rationale removed |
| `CampaignEmailPlatform` — exported one-member alias, no importer | **Dropped**, inlined into `CampaignAnyPlatform` |

## Tests

14 new, each **mutation-verified** — reverting a fix fails exactly the test written for it:

| Mutation | Test that fails |
|---|---|
| drop the `hubspot` guard mapping | `dispatches an email campaign once hubspotConfig is present` |
| drop the dark-cutover refusal | `refuses an email create instead of falling through to the legacy path` |
| `(rawId as string)?.trim()` | `refuses a numeric/object sourceEmailId without throwing` |
| drop the `.trim()` | `treats a whitespace only sourceEmailId as unconfigured…` |
| forward a blank `utmCampaign` | `omits a blank utmCampaign rather than sending an empty override` |

The first round's controller tests all ran with the cutover **dark** and asserted only on the
argument handed to a mocked `createCampaigns` — so none exercised the path this ticket ships.
Added both directions, plus a paid contrast so the refusal cannot pass by refusing everything.

## Verification

- `npx tsc --noEmit` — 0 errors (`tsconfig.app.json` + `tsconfig.spec.json`)
- `yarn test` — **1316** server + **320** app passing
- `yarn lint` — 0 errors (1 pre-existing warning in `user.service.ts`)
- `./check-headers.sh` — passed

## Scope

Necessary but **not sufficient** to stage an email. The dispatcher also requires the brief's
audience to be **BUILT** (`hubspot.go:432-456`), resolved by `brief.ID` rather than from this
envelope — **LFXV2-3224**. The `sourceEmailId` comes from the template picker in **LFXV2-3198**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFGQ59WQ2n8yLU4dGbMXnK