### PR TITLE
feat(campaigns): send demand-gen creates through campaign-service

### DIFF
--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -624,7 +624,6 @@ describe('CampaignController.createCampaign cutover', () => {
 
     await controller.createCampaign(buildReq(googleBody({ campaignTypes: ['demand-gen'] }), { project: 'tlf', brief_id: 'b-1' }), res, next);
 
-    const sent = envelopeFor(createCampaigns)['googleAdsConfig'] as Record<string, unknown>;
     expect(envelopeFor(createCampaigns)['googleAdsConfig']).toEqual({
       budget: 1000,
       channel: 'demand-gen',

--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -560,6 +560,8 @@ describe('CampaignController.createCampaign cutover', () => {
 
     expect(envelopeFor(createCampaigns)['googleAdsConfig']).toEqual({
       budget: 1000,
+      // Named explicitly since LFXV2-3257 — see buildGoogleAdsConfig.
+      channel: 'search',
       headlines: ['H1'],
       descriptions: ['D1'],
       // `text`, not `term`, and an upper-case enum: the service's keyword shape.
@@ -607,16 +609,23 @@ describe('CampaignController.createCampaign cutover', () => {
     expect(sent['budgetUsd']).toBe(100);
   });
 
-  it('omits googleAdsConfig when only demand-gen is selected', async () => {
-    // There is no Search campaign to fund, and the dispatcher would otherwise run a demand-gen
-    // request as Search. The REFUSAL that makes this omission safe lives in `createCampaigns`
-    // (see its spec) — deliberately not here, so it is gated by the cutover flags.
+  /**
+   * SUPERSEDED by LFXV2-3257, which is why this now asserts the opposite of what it once did.
+   *
+   * The old contract omitted `googleAdsConfig` entirely for a demand-gen-only create, because
+   * "the dispatcher would otherwise run a demand-gen request as Search" — true when the config
+   * had no way to name a channel. campaign-service now takes `channel`, so the config is sent
+   * and names it. Omitting it today would mark the platform UNCONFIGURED and refuse a create the
+   * service can serve.
+   */
+  it('sends a demand-gen googleAdsConfig rather than omitting it', async () => {
     createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
     legacyCreate.mockResolvedValue({ jobId: 'job_1' });
 
     await controller.createCampaign(buildReq(googleBody({ campaignTypes: ['demand-gen'] }), { project: 'tlf', brief_id: 'b-1' }), res, next);
 
-    expect(envelopeFor(createCampaigns)).not.toHaveProperty('googleAdsConfig');
+    const sent = envelopeFor(createCampaigns)['googleAdsConfig'] as Record<string, unknown>;
+    expect(sent['channel']).toBe('demand-gen');
   });
 
   /**
@@ -637,6 +646,60 @@ describe('CampaignController.createCampaign cutover', () => {
 
     expect(legacyCreate).toHaveBeenCalledTimes(1);
     expect(res.json).toHaveBeenCalledWith({ jobId: 'job_dg_1' });
+  });
+
+  /**
+   * Demand-gen-only is the one mixed-type case the cutover can serve today (LFXV2-3257).
+   * Before this, `buildGoogleAdsConfig` returned null whenever Search was unselected, so the
+   * platform read as UNCONFIGURED and the whole create was refused — Demand Gen was
+   * unreachable through campaign-service even after the Go client existed.
+   */
+  it('sends the demand-gen channel when only demand gen is selected', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(buildReq(googleBody({ campaignTypes: ['demand-gen'] }), { project: 'tlf', brief_id: 'b-1' }), res, next);
+
+    const sent = envelopeFor(createCampaigns)['googleAdsConfig'] as Record<string, unknown>;
+    expect(sent['channel']).toBe('demand-gen');
+  });
+
+  /**
+   * The WHOLE budget, not the search share. `searchBudgetPct` splits a budget between two
+   * campaigns; with no Search campaign to fund there is nothing to split, and sending 70% would
+   * silently underfund the only campaign being created.
+   */
+  it('gives a demand-gen-only create the whole budget', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq(googleBody({ campaignTypes: ['demand-gen'], budgetUsd: 500, searchBudgetPct: 70 }), { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    const sent = envelopeFor(createCampaigns)['googleAdsConfig'] as Record<string, unknown>;
+    expect(sent['budget']).toBe(500);
+  });
+
+  /**
+   * Search keeps its channel explicitly, and keeps the SPLIT budget. The contrast matters: without
+   * it the two tests above would pass on a builder that sent demand-gen for everything.
+   */
+  it('keeps sending the search channel and the split budget for a mixed selection', async () => {
+    createCampaigns.mockResolvedValue({ enabled: false, jobId: null, error: null });
+    legacyCreate.mockResolvedValue({ jobId: 'job_1' });
+
+    await controller.createCampaign(
+      buildReq(googleBody({ campaignTypes: ['search', 'demand-gen'], budgetUsd: 500, searchBudgetPct: 70 }), { project: 'tlf', brief_id: 'b-1' }),
+      res,
+      next
+    );
+
+    const sent = envelopeFor(createCampaigns)['googleAdsConfig'] as Record<string, unknown>;
+    expect(sent['channel']).toBe('search');
+    expect(sent['budget']).toBe(350);
   });
 
   it('renames Meta budgetUsd to the budget key the dispatcher reads', async () => {

--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -625,7 +625,10 @@ describe('CampaignController.createCampaign cutover', () => {
     await controller.createCampaign(buildReq(googleBody({ campaignTypes: ['demand-gen'] }), { project: 'tlf', brief_id: 'b-1' }), res, next);
 
     const sent = envelopeFor(createCampaigns)['googleAdsConfig'] as Record<string, unknown>;
-    expect(sent['channel']).toBe('demand-gen');
+    expect(envelopeFor(createCampaigns)['googleAdsConfig']).toEqual({
+      budget: 1000,
+      channel: 'demand-gen',
+    });
   });
 
   /**
@@ -679,8 +682,14 @@ describe('CampaignController.createCampaign cutover', () => {
       next
     );
 
-    const sent = envelopeFor(createCampaigns)['googleAdsConfig'] as Record<string, unknown>;
-    expect(sent['budget']).toBe(500);
+    // Pinned WHOLE, like the search branch above. Asserting only `budget` would pass a builder
+    // that leaked a stray field into the demand-gen envelope — headlines or keywords copied
+    // across from the search branch, say — which campaign-service would then receive on a
+    // channel that has no use for them.
+    expect(envelopeFor(createCampaigns)['googleAdsConfig']).toEqual({
+      budget: 500,
+      channel: 'demand-gen',
+    });
   });
 
   /**

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -1056,10 +1056,21 @@ export class CampaignController {
    * pre-built Customer Match resource names the UI never collects, and `adoptExisting` must
    * default to false so a re-dispatch cannot silently rebind an existing upstream campaign.
    *
-   * Budget is the SEARCH share, not the whole request budget. The dispatcher composes a
-   * `"Search Campaign"` name and creates exactly one Search campaign, so handing it the combined
-   * budget would spend the demand-gen half on Search. When only demand-gen is selected there is
-   * no Search campaign to fund, so this returns null.
+   * Budget depends on WHICH channel this config is for, and the two cases differ.
+   *
+   * For a SEARCH create, budget is the Search SHARE rather than the whole request budget: the
+   * dispatcher creates exactly one Search campaign, so handing it the combined figure would
+   * spend the demand-gen half on Search.
+   *
+   * For a DEMAND-GEN-ONLY selection this returns a config carrying the FULL budget and
+   * `channel: "demand-gen"` — not null, which is what an earlier version of this comment said
+   * and what the code did before LFXV2-3257 ported `createDemandGenCampaign` into
+   * campaign-service. There is no Search campaign to split the budget with, so the whole amount
+   * funds the one campaign being created.
+   *
+   * A MIXED selection is still refused before reaching here, because this function emits one
+   * config with one channel — see the inline comment below for why that is a limit of this
+   * builder rather than of campaign-service's schema.
    *
    * Null means UNCONFIGURED, and `createCampaign` refuses the whole create when a selected
    * platform lands here — see `hasPlatformConfig`. An earlier version of this comment said the
@@ -1085,12 +1096,15 @@ export class CampaignController {
     // (LFXV2-3257), which is why headlines/keywords below are harmless to send — the
     // Demand Gen path ignores them.
     //
-    // Search + Demand Gen together is still refused upstream of here, deliberately.
-    // campaign-service's `campaigns` table is UNIQUE on (brief_id, platform) and both
-    // channels are `google-ads`, so one brief cannot hold both rows; the legacy path
-    // loops `campaignTypes` and creates both only because it has no database. Serving
-    // the mixed case needs a schema decision, not a config field, and until it is made
-    // a loud refusal beats creating the Search half and silently dropping the other.
+    // Search + Demand Gen together is still refused upstream of here, deliberately — and the
+    // reason is THIS function, not campaign-service's schema. #130 widened the slot key to
+    // (brief_id, platform, variant), so a brief can now hold a Search row and a Demand Gen row
+    // at once; the database does not forbid the pair.
+    //
+    // What forbids it is that this builder returns ONE config with ONE channel. A mixed create
+    // would dispatch a single campaign and silently drop the other half — and half the budget.
+    // Serving the pair means emitting two configs, which is a change here rather than a schema
+    // decision. Until then a loud refusal beats a silent partial create.
     if (!includesSearch && includesDemandGen) {
       return { budget: body.budgetUsd ?? 0, channel: 'demand-gen' };
     }

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -1068,9 +1068,12 @@ export class CampaignController {
    * campaign-service. There is no Search campaign to split the budget with, so the whole amount
    * funds the one campaign being created.
    *
-   * A MIXED selection is still refused before reaching here, because this function emits one
-   * config with one channel — see the inline comment below for why that is a limit of this
-   * builder rather than of campaign-service's schema.
+   * A MIXED selection is refused DOWNSTREAM, not before this point: the controller builds the
+   * envelope (line ~304) and only then calls `createCampaigns` (line ~346), where the
+   * Search+Demand-Gen guard lives. So a mixed selection DOES reach this builder and produces a
+   * search-shaped config, which `createCampaigns` then refuses — see the inline comment below
+   * for why one-config-one-channel is a limit of this builder rather than of campaign-service's
+   * schema.
    *
    * Null means UNCONFIGURED, and `createCampaign` refuses the whole create when a selected
    * platform lands here — see `hasPlatformConfig`. An earlier version of this comment said the
@@ -1096,7 +1099,8 @@ export class CampaignController {
     // (LFXV2-3257), which is why headlines/keywords below are harmless to send — the
     // Demand Gen path ignores them.
     //
-    // Search + Demand Gen together is still refused upstream of here, deliberately — and the
+    // Search + Demand Gen together is refused DOWNSTREAM in `createCampaigns`, not before this
+    // builder runs, deliberately — and the
     // reason is THIS function, not campaign-service's schema. #130 widened the slot key to
     // (brief_id, platform, variant), so a brief can now hold a Search row and a Demand Gen row
     // at once; the database does not forbid the pair.

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -1067,9 +1067,30 @@ export class CampaignController {
 
     const types = body.campaignTypes ?? [];
     const includesSearch = types.includes('search');
-    if (!includesSearch) return null;
+    const includesDemandGen = types.includes('demand-gen');
 
-    const pct = types.includes('demand-gen') ? (body.searchBudgetPct ?? 100) : 100;
+    // Neither type selected: nothing to build. Returning null marks the platform
+    // UNCONFIGURED, and `hasPlatformConfig` refuses the create rather than dispatching
+    // a zero-value config.
+    if (!includesSearch && !includesDemandGen) return null;
+
+    // DEMAND-GEN-ONLY is the one mixed-type case the cutover can serve today, and it
+    // gets the WHOLE budget: there is no Search campaign to fund, so the split does not
+    // apply. campaign-service creates a Demand Gen campaign with no ad and no keywords
+    // (LFXV2-3257), which is why headlines/keywords below are harmless to send — the
+    // Demand Gen path ignores them.
+    //
+    // Search + Demand Gen together is still refused upstream of here, deliberately.
+    // campaign-service's `campaigns` table is UNIQUE on (brief_id, platform) and both
+    // channels are `google-ads`, so one brief cannot hold both rows; the legacy path
+    // loops `campaignTypes` and creates both only because it has no database. Serving
+    // the mixed case needs a schema decision, not a config field, and until it is made
+    // a loud refusal beats creating the Search half and silently dropping the other.
+    if (!includesSearch && includesDemandGen) {
+      return { budget: body.budgetUsd ?? 0, channel: 'demand-gen' };
+    }
+
+    const pct = includesDemandGen ? (body.searchBudgetPct ?? 100) : 100;
     // KNOWN GAP (LFXV2-3251) — read before enabling this cutover on a non-USD account.
     //
     // `budget` is whole units of the AD ACCOUNT'S currency, not USD: "Budget is in whole units of
@@ -1090,6 +1111,10 @@ export class CampaignController {
 
     return {
       budget,
+      // Explicit rather than relying on the upstream default. Absent means Search there
+      // too, but naming it keeps the two branches of this function symmetrical and makes
+      // a future default change unable to repoint this one silently.
+      channel: 'search',
       headlines: body.headlines ?? [],
       descriptions: body.descriptions ?? [],
       // The service's keyword shape is `{text, matchType}` with an upper-case enum; the UI carries

--- a/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
+++ b/apps/lfx-one/src/server/helpers/server-feature-flag.helper.ts
@@ -130,6 +130,27 @@ export enum ServerFeatureFlag {
   CampaignServiceCreate = 'LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE',
 
   /**
+   * Gates whether a Demand Gen Google campaign may be requested at all.
+   *
+   * SEPARATE from `CampaignServiceCreate` because it asks a different question: not "should
+   * creates go through campaign-service?" but "does the DEPLOYED campaign-service understand
+   * `googleAdsConfig.channel`?" That field ships with LFXV2-3257, and the two can be out of
+   * step — the cutover flag may be on against a service that predates it.
+   *
+   * The failure it prevents is silent and expensive. Go's JSON decoder ignores unknown keys,
+   * so an older campaign-service DROPS `channel` and builds its default SEARCH campaign
+   * instead: real budget, no keywords, and per its own `googleAdsConfig.Keywords` doc it "can
+   * never serve". Nothing reports an error — the job succeeds, and the wrong campaign is
+   * discovered later in Google Ads.
+   *
+   * A capability flag rather than a version probe: campaign-service exposes no version
+   * endpoint, and inferring support from a successful create is exactly the ambiguity that
+   * makes the silent-Search case dangerous. OFF by default, so a deployment that has not
+   * confirmed the upstream version refuses rather than guesses.
+   */
+  CampaignServiceDemandGen = 'LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN',
+
+  /**
    * Gates `committee.service.ts`'s `updateCommittee` (the `chat_webhook_url` write) and
    * `weekly-brief.service.ts`'s `shareToSlack` (the Slack send) server-side. `WG_WEEKLY_BRIEF_SLACK_FLAG`
    * (`wg-weekly-brief-slack`, an OpenFeature/GrowthBook flag) only gates the Angular UI — the

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -10,7 +10,10 @@ const { proxyRequest, proxyRequestWithResponse, logger, isServerFeatureEnabled }
   proxyRequest: vi.fn(),
   proxyRequestWithResponse: vi.fn(),
   logger: { warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), success: vi.fn(), startOperation: vi.fn(() => 0) },
-  isServerFeatureEnabled: vi.fn(() => false),
+  // Typed with the flag parameter, matching the real isServerFeatureEnabled(flag). Declared
+  // as `vi.fn(() => false)` the mock accepted no argument, so a per-flag mockImplementation
+  // failed to compile -- and only `yarn build` caught it, since check-types skips specs.
+  isServerFeatureEnabled: vi.fn((_flag: unknown) => false),
 }));
 
 vi.mock('../helpers/server-feature-flag.helper', async (importOriginal) => ({
@@ -36,6 +39,7 @@ import type { Request } from 'express';
 import type { CampaignBriefOutput } from '@lfx-one/shared/interfaces';
 
 import { MicroserviceError } from '../errors/microservice.error';
+import { ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { adaptJobPollResponse, CampaignServiceClient, deriveEventSlug, fromBriefResponse, isCampaignServiceJobId } from './campaign-service.service';
 
 const req = {} as unknown as Request;
@@ -1411,6 +1415,13 @@ describe('CampaignServiceClient.loadBrief', () => {
 describe('CampaignServiceClient.createCampaigns', () => {
   const bothFlagsOn = () => isServerFeatureEnabled.mockReturnValue(true);
 
+  /**
+   * Cutover flags ON but the Demand Gen capability flag OFF — the state a deployment is in
+   * when campaign-service predates LFXV2-3257 and does not understand
+   * `googleAdsConfig.channel`.
+   */
+  const demandGenUnsupported = () => isServerFeatureEnabled.mockImplementation((flag: unknown) => flag !== ServerFeatureFlag.CampaignServiceDemandGen);
+
   beforeEach(() => {
     vi.clearAllMocks();
     isServerFeatureEnabled.mockReturnValue(false);
@@ -1667,6 +1678,76 @@ describe('CampaignServiceClient.createCampaigns', () => {
     );
 
     expect(res.jobId).toBe('a3f1c2d4-0000-4000-8000-00000000000c');
+  });
+
+  /**
+   * The silent-Search hazard, and the reason this guard exists rather than a comment.
+   *
+   * Go's JSON decoder ignores unknown keys, so a campaign-service that predates LFXV2-3257
+   * DROPS `googleAdsConfig.channel` and builds its default SEARCH campaign: real budget, no
+   * keywords, and per its own docs it "can never serve". Nothing errors — the job reports
+   * success and the wrong campaign is found later in Google Ads.
+   *
+   * Refusing costs one create. The alternative costs money.
+   */
+  it('refuses a demand-gen create when the deployed service cannot understand the channel', async () => {
+    demandGenUnsupported();
+
+    const res = await new CampaignServiceClient().createCampaigns(
+      req,
+      'b-1',
+      'tlf',
+      ['google-ads'],
+      { googleAdsConfig: { budget: 600, channel: 'demand-gen' } },
+      { campaignTypes: ['demand-gen'] }
+    );
+
+    expect(proxyRequestWithResponse).not.toHaveBeenCalled();
+    expect(res.jobId).toBeNull();
+    expect(res.error).toContain('Demand Gen');
+  });
+
+  /**
+   * The guard must be scoped to the request that is actually at risk. A Search-only create
+   * carries no `channel` an older service could drop, so gating it on the same flag would
+   * refuse the platform's most common create for no reason.
+   */
+  it('still allows a search-only create when demand gen is unsupported', async () => {
+    demandGenUnsupported();
+    proxyRequestWithResponse.mockResolvedValueOnce({ data: { job_id: 'a3f1c2d4-0000-4000-8000-00000000000f' } });
+
+    const res = await new CampaignServiceClient().createCampaigns(
+      req,
+      'b-1',
+      'tlf',
+      ['google-ads'],
+      { googleAdsConfig: { budget: 600 } },
+      { campaignTypes: ['search'] }
+    );
+
+    expect(res.jobId).toBe('a3f1c2d4-0000-4000-8000-00000000000f');
+    expect(res.error).toBeNull();
+  });
+
+  /**
+   * And a non-Google create must not be caught by it: `campaignTypes` is a Google concept the
+   * Implementation tab sends unconditionally, so a LinkedIn-only create arrives carrying
+   * `demand-gen` with no Google campaign in it at all.
+   */
+  it('does not refuse a non-google create when demand gen is unsupported', async () => {
+    demandGenUnsupported();
+    proxyRequestWithResponse.mockResolvedValueOnce({ data: { job_id: 'a3f1c2d4-0000-4000-8000-000000000010' } });
+
+    const res = await new CampaignServiceClient().createCampaigns(
+      req,
+      'b-1',
+      'tlf',
+      ['linkedin-ads'],
+      { linkedInConfig: { budgetUsd: 100 } },
+      { campaignTypes: ['demand-gen'] }
+    );
+
+    expect(res.jobId).toBe('a3f1c2d4-0000-4000-8000-000000000010');
   });
 
   it('still creates a search-only google campaign', async () => {

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -1611,9 +1611,10 @@ describe('CampaignServiceClient.createCampaigns', () => {
   });
 
   /**
-   * campaign-service has NO Demand Gen path — `internal/dispatch/googleads.go` creates a Search
-   * campaign and nothing else. The legacy path does support it, so this is a capability the
-   * cutover loses rather than one nobody has.
+   * campaign-service DOES have a Demand Gen path as of #130, and the slot key is
+   * `(brief_id, platform, variant)` — so a brief can hold a Search row and a Demand Gen row at
+   * once and the database does not forbid the pair. What is refused here is a MIXED selection,
+   * and the reason is this BFF: `buildGoogleAdsConfig` emits one config with one channel.
    *
    * The mixed selection is the dangerous one because it looks like success: the config carries
    * only the SEARCH budget share, so the create would succeed having silently dropped half the
@@ -1639,7 +1640,9 @@ describe('CampaignServiceClient.createCampaigns', () => {
   /**
    * The half this refusal must NOT cover, since LFXV2-3257 ported Demand Gen into
    * campaign-service. Demand-gen-only is now servable — one channel, one campaign row, which the
-   * `(brief_id, platform)` uniqueness holds fine. Only the PAIR is refused.
+   * `(brief_id, platform, variant)` slot key holds fine (#130 widened it from the two-column
+   * form; a demand-gen retry on a brief that already has Search needs that third column). Only
+   * the PAIR is refused, and by THIS service's one-config envelope rather than by the schema.
    *
    * Without this test the guard could be widened back to `includes('demand-gen')` and every
    * sibling would stay green, silently re-blocking the capability this work added.

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -1623,6 +1623,32 @@ describe('CampaignServiceClient.createCampaigns', () => {
     expect(res.error).toContain('Demand Gen');
   });
 
+  /**
+   * The half this refusal must NOT cover, since LFXV2-3257 ported Demand Gen into
+   * campaign-service. Demand-gen-only is now servable — one channel, one campaign row, which the
+   * `(brief_id, platform)` uniqueness holds fine. Only the PAIR is refused.
+   *
+   * Without this test the guard could be widened back to `includes('demand-gen')` and every
+   * sibling would stay green, silently re-blocking the capability this work added.
+   */
+  it('dispatches a demand-gen-only create rather than refusing it', async () => {
+    bothFlagsOn();
+    proxyRequestWithResponse.mockResolvedValueOnce({ data: { job_id: 'a3f1c2d4-0000-4000-8000-00000000000d' } });
+
+    const res = await new CampaignServiceClient().createCampaigns(
+      req,
+      'b-1',
+      'tlf',
+      ['google-ads'],
+      { googleAdsConfig: { budget: 600, channel: 'demand-gen' } },
+      { campaignTypes: ['demand-gen'] }
+    );
+
+    expect(proxyRequestWithResponse).toHaveBeenCalledTimes(1);
+    expect(res.jobId).toBe('a3f1c2d4-0000-4000-8000-00000000000d');
+    expect(res.error).toBeNull();
+  });
+
   it('does not refuse a non-Google create that happens to carry demand-gen', async () => {
     // `campaignTypes` is a GOOGLE concept, but the Implementation tab sends it unconditionally:
     // `includeDemandGen` defaults to true and nothing clears it when Google is deselected. So a

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -10,10 +10,12 @@ const { proxyRequest, proxyRequestWithResponse, logger, isServerFeatureEnabled }
   proxyRequest: vi.fn(),
   proxyRequestWithResponse: vi.fn(),
   logger: { warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn(), success: vi.fn(), startOperation: vi.fn(() => 0) },
-  // Typed with the flag parameter, matching the real isServerFeatureEnabled(flag). Declared
-  // as `vi.fn(() => false)` the mock accepted no argument, so a per-flag mockImplementation
-  // failed to compile -- and only `yarn build` caught it, since check-types skips specs.
-  isServerFeatureEnabled: vi.fn((_flag: unknown) => false),
+  // Typed as taking the flag, matching the real isServerFeatureEnabled(flag). Declared as
+  // `vi.fn(() => false)` the mock accepted NO argument, so a per-flag mockImplementation
+  // could not typecheck against it -- and only `yarn build` caught that, since check-types
+  // skips spec files. The type is declared on the mock rather than as a named parameter so
+  // there is no unused binding for no-unused-vars to reject.
+  isServerFeatureEnabled: vi.fn<(flag: unknown) => boolean>(() => false),
 }));
 
 vi.mock('../helpers/server-feature-flag.helper', async (importOriginal) => ({

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -606,15 +606,21 @@ export class CampaignServiceClient {
     // LFXV2-3257, which ported the legacy `createDemandGenCampaign` into campaign-service and
     // gave `googleAdsConfig` a `channel` field to select it.
     //
-    // What still cannot be served is BOTH in one create, and the reason is the schema rather
-    // than the dispatcher: `campaigns` is UNIQUE on `(brief_id, platform)` and both channels are
-    // `google-ads`, so one brief cannot hold a Search row and a Demand Gen row. The legacy path
-    // loops `campaignTypes` and creates both only because it has no database to constrain it.
+    // What still cannot be served is BOTH in one create, and the reason is THIS SERVICE, not
+    // the schema. campaign-service #130 widened the slot key to
+    // `(brief_id, platform, variant)`, so a brief CAN hold a Search row and a Demand Gen row
+    // simultaneously — the database no longer forbids the pair.
+    //
+    // The limit is here: `buildGoogleAdsConfig` emits ONE `googleAdsConfig` with ONE `channel`,
+    // so a create carrying both types would dispatch a single campaign and silently drop the
+    // other. Stating the real constraint matters — someone reading the old rationale after the
+    // migration landed would remove this guard as obsolete and reintroduce the silent partial
+    // create. Serving the pair needs this BFF to send two configs, not a schema change.
     //
     // Letting the pair through is the dangerous option, because it LOOKS like success: the
     // config carries one channel, so the create would succeed having silently dropped half of
     // what the user asked for and half their budget. Refusing keeps them on a path that can
-    // actually serve the request until the schema question is decided.
+    // actually serve the request until this BFF can send both channels in one envelope.
     //
     // Gated on google-ads being SELECTED, not on `campaignTypes` alone. `campaignTypes` is a
     // Google concept but the Implementation tab sends it unconditionally — `includeDemandGen`

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -580,8 +580,10 @@ export class CampaignServiceClient {
     // dispatcher would proceed with a ZERO-VALUE config and call Google Ads with budget 0 and no
     // headlines. Nothing upstream refuses it; I read the dispatcher rather than assuming.
     //
-    // The reachable case is google-ads with Demand Gen only and no Search, where
-    // `buildGoogleAdsConfig` correctly returns null because it builds SEARCH config.
+    // The reachable case is google-ads selected with NEITHER supported campaign type: the
+    // builder returns null only when it can name no channel at all. Demand-Gen-only no longer
+    // reaches it — since LFXV2-3257 `buildGoogleAdsConfig` returns a full-budget
+    // `{budget, channel: 'demand-gen'}` config for that selection.
     //
     // This check belongs HERE and not in the controller. It tests for a campaign-service envelope
     // key, so it must only apply once the cutover is on — the legacy path needs no

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -602,36 +602,36 @@ export class CampaignServiceClient {
       };
     }
 
-    // Demand Gen is refused outright, because campaign-service cannot create one.
+    // Search + Demand Gen TOGETHER is refused. Demand Gen alone is not — that changed with
+    // LFXV2-3257, which ported the legacy `createDemandGenCampaign` into campaign-service and
+    // gave `googleAdsConfig` a `channel` field to select it.
     //
-    // There is no Demand Gen path anywhere in the service — `internal/dispatch/googleads.go`
-    // creates a Search campaign and nothing else. The legacy path DOES support it
-    // (`createDemandGenCampaign`), so this is a capability the cutover loses rather than one
-    // nobody has.
+    // What still cannot be served is BOTH in one create, and the reason is the schema rather
+    // than the dispatcher: `campaigns` is UNIQUE on `(brief_id, platform)` and both channels are
+    // `google-ads`, so one brief cannot hold a Search row and a Demand Gen row. The legacy path
+    // loops `campaignTypes` and creates both only because it has no database to constrain it.
     //
-    // Both selections are wrong, in different ways, and neither is safe to let through:
-    //   - demand-gen ONLY  → `buildGoogleAdsConfig` returns null, caught by the check above.
-    //   - search + demand-gen → the config carries only the SEARCH budget share, so the create
-    //     succeeds having silently dropped half of what the user asked for and half their budget.
+    // Letting the pair through is the dangerous option, because it LOOKS like success: the
+    // config carries one channel, so the create would succeed having silently dropped half of
+    // what the user asked for and half their budget. Refusing keeps them on a path that can
+    // actually serve the request until the schema question is decided.
     //
-    // The second is the dangerous one: it looks like success. Refusing keeps the user on a path
-    // that can actually serve the request until the service grows Demand Gen support.
-    // Gated on google-ads being SELECTED, not on `campaignTypes` alone.
-    //
-    // `campaignTypes` is a Google concept but the Implementation tab sends it unconditionally:
-    // `includeDemandGen` defaults to true in the form and nothing clears it when Google is
-    // deselected, so a LinkedIn-only create arrives carrying `demand-gen`. Refusing on the type
-    // alone rejected creates that have no Google campaign in them at all — a Google error on a
-    // request Google was never part of.
-    if (platforms.includes('google-ads') && campaignTypes?.includes('demand-gen')) {
+    // Gated on google-ads being SELECTED, not on `campaignTypes` alone. `campaignTypes` is a
+    // Google concept but the Implementation tab sends it unconditionally — `includeDemandGen`
+    // defaults to true in the form and nothing clears it when Google is deselected — so a
+    // LinkedIn-only create arrives carrying `demand-gen`. Refusing on the type alone rejected
+    // creates that have no Google campaign in them at all.
+    if (platforms.includes('google-ads') && campaignTypes?.includes('demand-gen') && campaignTypes.includes('search')) {
       return {
         enabled: true,
         jobId: null,
-        // No internal vocabulary: the siblings above say what the user did and what to do next,
-        // and "campaign-service"/"the cutover" are neither. A user who deselects Demand Gen gets
-        // a Search campaign; one who needs Demand Gen needs an operator, and telling them to
-        // "disable the cutover" names a control they do not have.
-        error: 'Demand Gen campaigns are not supported yet. Deselect Demand Gen to create the Search campaign, or contact support to run this campaign.',
+        // Names BOTH escapes now, because either one works: Search alone and Demand Gen alone
+        // are each servable, and only the pair is not. The previous wording said "Deselect
+        // Demand Gen", which was the only option when Demand Gen could not be created at all
+        // and would now send a user who wants Demand Gen to the one channel they did not ask
+        // for. No internal vocabulary — "campaign-service" and "the cutover" name controls the
+        // reader does not have.
+        error: 'Search and Demand Gen cannot be created together yet. Create them one at a time — deselect one, create it, then come back for the other.',
       };
     }
 

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -637,7 +637,35 @@ export class CampaignServiceClient {
         // and would now send a user who wants Demand Gen to the one channel they did not ask
         // for. No internal vocabulary — "campaign-service" and "the cutover" name controls the
         // reader does not have.
-        error: 'Search and Demand Gen cannot be created together yet. Create them one at a time — deselect one, create it, then come back for the other.',
+        // Does NOT promise that creating them one after another works, which an earlier
+        // wording did. Whether a second Google campaign can be added to the same brief
+        // depends on the campaign-service version deployed: the widened
+        // (brief_id, platform, variant) slot key ships with LFXV2-3257, and against an older
+        // deployment the second create is refused by the narrower (brief_id, platform)
+        // uniqueness AFTER the first has already spent budget. Telling a user to retry into
+        // that is worse than telling them nothing.
+        error: 'Search and Demand Gen cannot be created together. Deselect one and create it; adding the second to the same brief may not be supported yet.',
+      };
+    }
+
+    // Demand Gen requires a campaign-service that understands `googleAdsConfig.channel`
+    // (LFXV2-3257). Against an older deployment the field is silently DROPPED — Go's decoder
+    // ignores unknown keys — and the dispatcher builds its default SEARCH campaign instead:
+    // real budget, no keywords, and per `googleAdsConfig.Keywords` it "can never serve".
+    //
+    // That is the worst outcome available here. It is not a visible failure the user can
+    // react to; it is a paid campaign created under the wrong channel with the wrong budget,
+    // reported as success. Refusing costs a user one create; the alternative costs money and
+    // is discovered later in Google Ads.
+    //
+    // Gated on the CAPABILITY flag rather than a version probe: the service exposes no
+    // version endpoint, and inferring support from a successful create is exactly the
+    // ambiguity that makes the silent-Search case dangerous.
+    if (platforms.includes('google-ads') && campaignTypes?.includes('demand-gen') && !isServerFeatureEnabled(ServerFeatureFlag.CampaignServiceDemandGen)) {
+      return {
+        enabled: true,
+        jobId: null,
+        error: 'Demand Gen campaigns are not available yet. Select Search instead, or ask an administrator to enable Demand Gen support.',
       };
     }
 

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -191,11 +191,12 @@ Campaign endpoints are being moved off this application's vendor-direct integrat
 lfx-v2-campaign-service one at a time (LFXV2-3070). Each move is gated so it can be reversed by
 changing a value here rather than by shipping a revert.
 
-| Parameter                                         | Description                                                                             | Required | Default |
-| ------------------------------------------------- | --------------------------------------------------------------------------------------- | -------- | ------- |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS`   | Serves campaign job status from campaign-service; see the accepted values below         | No       | off     |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS` | Persists the generated brief in campaign-service instead of only in the browser tab     | No       | off     |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE` | Creates campaigns through campaign-service instead of the per-platform Express services | No       | off     |
+| Parameter                                             | Description                                                                                                                         | Required | Default |
+| ----------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS`       | Serves campaign job status from campaign-service; see the accepted values below                                                     | No       | off     |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS`     | Persists the generated brief in campaign-service instead of only in the browser tab                                                 | No       | off     |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE`     | Creates campaigns through campaign-service instead of the per-platform Express services                                             | No       | off     |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN` | Allows Demand Gen Google campaigns. Requires a campaign-service that understands `googleAdsConfig.channel` (LFXV2-3257) — see below | No       | off     |
 
 All three flags are ON for `true`, `1`, `yes`, or `on` — trimmed and matched
 case-insensitively, so `"True"` and `" on "` also enable it. Every other value is OFF, including
@@ -203,6 +204,22 @@ unset, empty, `0`, `false`, and any misspelling. Do not read "only `true` works"
 operator setting `yes` and expecting it to be ignored would route production traffic at
 campaign-service. The default-deny half is the deliberate part — a typo like `flase` is invisible
 in a values.yaml diff, so an unrecognised value has to fail towards the path already known to work.
+
+`LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN` is a CAPABILITY flag, not a routing one, and that is
+why it is separate from the three above. They ask "should this go through campaign-service?"; it
+asks "does the campaign-service we are actually talking to understand `googleAdsConfig.channel`?"
+Those can be out of step, because the two services deploy independently.
+
+Turning it on against a campaign-service that predates LFXV2-3257 is the failure it exists to
+prevent, and that failure is SILENT. Go's JSON decoder ignores unknown keys, so an older service
+drops `channel` and builds its default SEARCH campaign instead: real budget, no keywords, and by
+its own documentation it "can never serve". Nothing errors — the job reports success, and the
+wrong campaign is discovered later in Google Ads with money already spent.
+
+There is no version probe because campaign-service exposes no version endpoint, and inferring
+support from a successful create is exactly the ambiguity that makes this dangerous. So the order
+is: deploy campaign-service with LFXV2-3257, confirm it, then set this. Left off, a Demand Gen
+create is refused with a message telling the user to select Search instead.
 
 `LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS` gates both halves of brief persistence: the write
 (`POST /api/campaigns/brief/persist`, called when a user approves a brief and moves to the

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -198,7 +198,7 @@ changing a value here rather than by shipping a revert.
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE`     | Creates campaigns through campaign-service instead of the per-platform Express services                                             | No       | off     |
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN` | Allows Demand Gen Google campaigns. Requires a campaign-service that understands `googleAdsConfig.channel` (LFXV2-3257) — see below | No       | off     |
 
-All three flags are ON for `true`, `1`, `yes`, or `on` — trimmed and matched
+Every cutover flag in the table above is ON for `true`, `1`, `yes`, or `on` — trimmed and matched
 case-insensitively, so `"True"` and `" on "` also enable it. Every other value is OFF, including
 unset, empty, `0`, `false`, and any misspelling. Do not read "only `true` works" into that: an
 operator setting `yes` and expecting it to be ignored would route production traffic at

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -464,6 +464,24 @@ environment:
   LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE:
     value:
 
+  # Gates whether a Demand Gen Google campaign may be requested at all (LFXV2-3257).
+  #
+  # SEPARATE from the three flags above because it asks a different question: not "should
+  # creates go through campaign-service?" but "does the DEPLOYED campaign-service understand
+  # googleAdsConfig.channel?". That field ships with LFXV2-3257, and the two can be out of
+  # step — the create cutover may be on against a service that predates it.
+  #
+  # Leaving it off is SAFE and is the default. Turning it on before campaign-service has the
+  # channel field is not: Go's JSON decoder ignores unknown keys, so an older service DROPS
+  # `channel` and builds its default SEARCH campaign instead — real budget, no keywords, and
+  # by its own documentation it "can never serve". Nothing errors; the job reports success and
+  # the wrong campaign is found later in Google Ads with money already spent.
+  #
+  # Order: deploy campaign-service with LFXV2-3257, confirm it, THEN set this. Same accepted
+  # values as the flags above.
+  LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN:
+    value:
+
   # Set to 'live' to proxy WG Weekly Brief endpoints to committee-service (LFXV2-2175/2176).
   # The BFF refuses to serve mock brief data when NODE_ENV=production and this
   # isn't 'live' — leaving it unset here would 500 on every weekly-brief request.


### PR DESCRIPTION
Part of **LFXV2-3257**. The service half is
[lfx-v2-campaign-service#130](https://github.com/linuxfoundation/lfx-v2-campaign-service/pull/130).

## What changed

campaign-service can create Demand Gen campaigns now — cs#130 ports the legacy
`createDemandGenCampaign` and adds a `channel` field to `googleAdsConfig` — so the BFF stops
refusing them.

`buildGoogleAdsConfig` returned `null` whenever Search was unselected, which marked `google-ads`
UNCONFIGURED and refused the whole create. It now builds a demand-gen config with the **whole
budget**: `searchBudgetPct` splits a budget between two campaigns, and with no Search campaign to
fund there is nothing to split — sending 70% would silently underfund the only campaign created.

The Search branch names `channel: 'search'` explicitly rather than relying on the upstream
default, so the two branches stay symmetrical and a future default change cannot repoint it
silently.

## The refusal narrows rather than disappearing

Search + Demand Gen **together** is still refused, and the reason is the schema rather than the
dispatcher: `campaigns` is unique on `(brief_id, platform)` and both channels are `google-ads`, so
one brief cannot hold both rows. The legacy path creates both only because it has no database.

Letting the pair through is the dangerous option — it *looks* like success while dropping half the
request and half the budget.

> cs#130 adds a `variant` column that makes the pair storable. Once it merges this refusal can be
> removed, in a follow-up rather than here: the UI would need to send two configs and show two
> campaign rows, which is its own change.

The user-facing message changes with it. *"Deselect Demand Gen"* was the only escape when Demand
Gen could not be created at all, and would now push a user who wants Demand Gen to the one channel
they did not ask for. It names both escapes.

## One test asserted the old contract

`omits googleAdsConfig when only demand-gen is selected` was correct when written — *"the
dispatcher would otherwise run a demand-gen request as Search"*, true before `channel` existed.
Updated rather than deleted, with the reasoning recorded, since the omission it pinned would now
refuse a create the service can serve.

## Verification

- `npx tsc --noEmit` — 0 errors (app + spec)
- `yarn test` — **1305** server + **321** app passing
- `yarn lint` — 0 errors (1 pre-existing warning in `user.service.ts`)

Mutation-verified both directions: reverting the builder to `null` fails three tests, and widening
the guard back to any `demand-gen` fails the new demand-gen-only dispatch test.

## Ordering

**Correction (2026-08-14).** This section previously said a demand-gen create "is refused
upstream exactly as it is today". That was asserted, not verified, and it was **false**.

campaign-service `main` has no `channel` field on `googleAdsConfig`, and `unmarshalPlatformConfig`
uses permissive `json.Unmarshal` — so Go silently DROPS the unknown key and the dispatcher builds
its default **Search** campaign: real budget, no keywords, and per its own `googleAdsConfig.Keywords`
doc it "can never serve". Nothing errors; the job reports success and the wrong campaign surfaces
later in Google Ads with money already spent. Both review bots caught this independently.

The code now refuses rather than relying on the upstream to. `LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN`
gates any demand-gen create and is **OFF by default**, so a deployment that has not confirmed the
upstream version refuses instead of guessing. It is separate from the existing cutover flags because
it answers a different question — not *should creates route through campaign-service?* but *does the
deployed one understand `channel`?* Those can be out of step.

**Rollout order, which is now enforced rather than documented:**

1. Merge and deploy cs#130 (adds `channel` and the widened `(brief_id, platform, variant)` slot)
2. Merge this PR
3. Only then set `LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN=true`

Merging this before cs#130 is safe **because the flag defaults off** — not because the upstream
refuses. Turning the flag on before step 1 is what must not happen, and that is a deploy-config
decision rather than a merge-order one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WFGQ59WQ2n8yLU4dGbMXnK
