### PR TITLE
feat(newsletters): add issue permalinks and share affordance

### DIFF
--- a/apps/lfx-one/e2e/my-newsletters.spec.ts
+++ b/apps/lfx-one/e2e/my-newsletters.spec.ts
@@ -188,4 +188,56 @@ test.describe('My Newsletters — Me-lens feed', () => {
     await expect(page.getByTestId('my-newsletters-empty-state')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
     await expect(page.getByTestId('my-newsletters-empty-state')).toContainText('No newsletters yet');
   });
+
+  test('opening newsletter updates URL with query params (?issue=...&project=...)', async ({ page }) => {
+    await gotoMyNewsletters(page);
+
+    await page.getByTestId(`my-newsletters-row-${MOCK_NEWSLETTERS[0].id}`).click();
+
+    // URL should include query params
+    await expect(page).toHaveURL(/\?issue=.*&project=.*/);
+    const url = page.url();
+    expect(url).toContain(`issue=${MOCK_NEWSLETTERS[0].id}`);
+  });
+
+  test('closing drawer clears query params', async ({ page }) => {
+    await gotoMyNewsletters(page);
+
+    // Open drawer
+    await page.getByTestId(`my-newsletters-row-${MOCK_NEWSLETTERS[0].id}`).click();
+    await expect(page).toHaveURL(/\?issue=.*&project=.*/);
+
+    // Close drawer
+    await page.getByTestId('newsletter-preview-drawer-close').click();
+
+    // URL should be clean (no query params)
+    const url = page.url();
+    expect(url).not.toContain('issue=');
+  });
+
+  test('direct navigation with query params auto-opens the drawer', async ({ page }) => {
+    await gotoMyNewsletters(page);
+
+    const issueId = MOCK_NEWSLETTERS[0].id;
+    const projectSlug = MOCK_NEWSLETTERS[0].project_name?.toLowerCase() || 'test-project';
+
+    // Navigate directly with query params
+    await page.goto(`/newsletters/my?issue=${issueId}&project=${projectSlug}`, { waitUntil: 'domcontentloaded' });
+
+    // Drawer should be open with the newsletter content
+    const drawer = page.getByTestId('my-newsletters-preview-drawer');
+    await expect(drawer.locator('[data-e2e="newsletter-body-marker"]')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('share button in drawer copies the canonical permalink URL', async ({ page }) => {
+    await gotoMyNewsletters(page);
+
+    await page.getByTestId(`my-newsletters-row-${MOCK_NEWSLETTERS[0].id}`).click();
+
+    // Click the copy-link button
+    await page.getByTestId('newsletter-preview-drawer-copy-link').click();
+
+    // Success toast appears
+    await expect(page.getByText('Link Copied')).toBeVisible();
+  });
 });

--- a/apps/lfx-one/e2e/my-newsletters.spec.ts
+++ b/apps/lfx-one/e2e/my-newsletters.spec.ts
@@ -34,6 +34,7 @@ const MOCK_NEWSLETTERS: MyNewsletter[] = [
     subject: 'TAC July Update',
     sent_at: '2026-07-15T12:00:00Z',
     project_name: 'Test Project',
+    project_slug: 'test-project',
     is_foundation: false,
     parent_project_uid: FOUNDATION_UID,
   },
@@ -43,6 +44,7 @@ const MOCK_NEWSLETTERS: MyNewsletter[] = [
     subject: 'Board Quarterly Digest',
     sent_at: '2026-06-20T12:00:00Z',
     project_name: 'Test Foundation',
+    project_slug: 'test-foundation',
     is_foundation: true,
     parent_project_uid: '',
   },
@@ -219,7 +221,7 @@ test.describe('My Newsletters — Me-lens feed', () => {
     await gotoMyNewsletters(page);
 
     const issueId = MOCK_NEWSLETTERS[0].id;
-    const projectSlug = MOCK_NEWSLETTERS[0].project_name?.toLowerCase() || 'test-project';
+    const projectSlug = MOCK_NEWSLETTERS[0].project_slug || 'test-project';
 
     // Navigate directly with query params
     await page.goto(`/newsletters/my?issue=${issueId}&project=${projectSlug}`, { waitUntil: 'domcontentloaded' });

--- a/apps/lfx-one/e2e/my-newsletters.spec.ts
+++ b/apps/lfx-one/e2e/my-newsletters.spec.ts
@@ -212,9 +212,10 @@ test.describe('My Newsletters — Me-lens feed', () => {
     // Close drawer
     await page.getByTestId('newsletter-preview-drawer-close').click();
 
-    // URL should be clean (no query params)
+    // URL should be clean (both drawer params removed)
     const url = page.url();
     expect(url).not.toContain('issue=');
+    expect(url).not.toContain('project=');
   });
 
   test('direct navigation with query params auto-opens the drawer', async ({ page }) => {

--- a/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
@@ -123,8 +123,10 @@ test.describe('Newsletter Reader Page — Structural Tests', () => {
     await page.goto(`/newsletters/${PROJECT_SLUG}/news-456`, { waitUntil: 'domcontentloaded' });
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    // During loading, skeleton or placeholder should be visible
-    // The component should not display content testids until data arrives
+    // While the project request is held open, the skeleton must be visible
+    // and content testids must not render yet.
+    await expect(page.getByTestId('newsletter-reader-loading')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-reader-title')).toHaveCount(0);
     releaseProjectRequest!();
 
     // After data arrives, full content should render

--- a/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
@@ -185,8 +185,9 @@ test.describe('Newsletter Reader Page — Structural Tests', () => {
     await expect(copyButton).toBeEnabled();
 
     // Button should have accessible text or aria-label
-    const hasText = await copyButton.locator('text=').count().catch(() => 0);
+    const textContent = await copyButton.textContent();
+    const hasText = textContent && textContent.trim().length > 0;
     const hasAriaLabel = await copyButton.getAttribute('aria-label');
-    expect(hasText > 0 || hasAriaLabel).toBeTruthy();
+    expect(hasText || hasAriaLabel).toBeTruthy();
   });
 });

--- a/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
@@ -36,7 +36,11 @@ const MOCK_PROJECT_MANAGER: Project = {
 const MOCK_NEWSLETTER_BODY_HTML = '<p data-e2e="newsletter-body-marker">K8s Weekly #42 update.</p>';
 
 async function stubProjectApi(page: Page, project: Project | null): Promise<void> {
-  await page.route('**/api/projects?**', (route) => {
+  // The reader fetches path-style /api/projects/:slug (no query string). Route
+  // by the exact slug under test — a bare '**/api/projects/*' would also
+  // intercept unrelated single-segment calls like /api/projects/writer-summary.
+  const slug = project?.slug ?? 'nonexistent-project';
+  await page.route(`**/api/projects/${slug}`, (route) => {
     if (!project) {
       return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });
     }
@@ -109,7 +113,7 @@ test.describe('Newsletter Reader Page — Structural Tests', () => {
     });
 
     // Delay project API to observe loading skeleton
-    await page.route('**/api/projects?**', (route) => {
+    await page.route(`**/api/projects/${PROJECT_SLUG}`, (route) => {
       projectRequestPromise.then(() => {
         route.fulfill({
           status: 200,

--- a/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
@@ -48,13 +48,7 @@ async function stubProjectApi(page: Page, project: Project | null): Promise<void
   });
 }
 
-async function stubNewsletterApi(
-  page: Page,
-  projectUid: string,
-  newsletterId: string,
-  status: string = 'sent',
-  shouldExist: boolean = true,
-): Promise<void> {
+async function stubNewsletterApi(page: Page, projectUid: string, newsletterId: string, status: string = 'sent', shouldExist: boolean = true): Promise<void> {
   await page.route(`**/api/projects/${projectUid}/newsletters/${newsletterId}`, (route) => {
     if (!shouldExist) {
       return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });

--- a/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader-robust.spec.ts
@@ -1,0 +1,192 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Newsletter Reader Page — Structural Tests — GH-1550.
+ *
+ * Companion to `newsletter-reader.spec.ts`. Asserts the data-testid contract,
+ * DOM structure, heading hierarchy, and load-state transitions for the
+ * newsletter reader component, isolated from content/copy changes.
+ *
+ * Why this exists: per `docs/architecture/testing/e2e-testing.md`, every
+ * feature with E2E coverage gets a content spec AND a structural (`-robust`)
+ * spec. The structural spec is the regression net for refactors that move DOM
+ * around but keep testid semantics stable.
+ */
+
+import type { Project } from '@lfx-one/shared/interfaces';
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const ELEMENT_TIMEOUT = 10_000;
+
+const PROJECT_SLUG = 'kubernetes';
+const PROJECT_UID = 'p0000000-0000-0000-0000-000000000001';
+
+const MOCK_PROJECT_MANAGER: Project = {
+  uid: PROJECT_UID,
+  slug: PROJECT_SLUG,
+  name: 'Kubernetes',
+  writer: true,
+  founded_at: '2020-01-01T00:00:00Z',
+  status: 'active',
+};
+
+const MOCK_NEWSLETTER_BODY_HTML = '<p data-e2e="newsletter-body-marker">K8s Weekly #42 update.</p>';
+
+async function stubProjectApi(page: Page, project: Project | null): Promise<void> {
+  await page.route('**/api/projects?**', (route) => {
+    if (!project) {
+      return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(project),
+    });
+  });
+}
+
+async function stubNewsletterApi(
+  page: Page,
+  projectUid: string,
+  newsletterId: string,
+  status: string = 'sent',
+  shouldExist: boolean = true,
+): Promise<void> {
+  await page.route(`**/api/projects/${projectUid}/newsletters/${newsletterId}`, (route) => {
+    if (!shouldExist) {
+      return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: newsletterId,
+        subject: 'K8s Weekly #42',
+        body_html: MOCK_NEWSLETTER_BODY_HTML,
+        status,
+        sent_at: '2026-08-13T10:00:00Z',
+        project_uid: projectUid,
+        ed_reply_email: 'ed@example.com',
+        total_recipients: 12,
+        created_by: 'sender',
+        version: 1,
+        created_at: '2026-08-13T10:00:00Z',
+        updated_at: '2026-08-13T10:00:00Z',
+      }),
+    });
+  });
+}
+
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
+
+test.describe('Newsletter Reader Page — Structural Tests', () => {
+  test('renders with complete data-testid contract', async ({ page }) => {
+    skipWhenAuthMissing();
+    await stubProjectApi(page, MOCK_PROJECT_MANAGER);
+    await stubNewsletterApi(page, PROJECT_UID, 'news-456', 'sent', true);
+
+    await page.goto(`/newsletters/${PROJECT_SLUG}/news-456`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    // Core testid contract: breadcrumb, title, metadata, copy button all present
+    await expect(page.getByTestId('newsletter-reader-title')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-reader-received')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-reader-copy-link')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Heading hierarchy: h1 for title
+    const heading = page.getByRole('heading', { level: 1 });
+    await expect(heading).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('respects loading state structure during async data fetch', async ({ page }) => {
+    skipWhenAuthMissing();
+    let releaseProjectRequest: () => void;
+    const projectRequestPromise = new Promise<void>((resolve) => {
+      releaseProjectRequest = resolve;
+    });
+
+    // Delay project API to observe loading skeleton
+    await page.route('**/api/projects?**', (route) => {
+      projectRequestPromise.then(() => {
+        route.fulfill({
+          status: 200,
+          contentType: 'application/json',
+          body: JSON.stringify(MOCK_PROJECT_MANAGER),
+        });
+      });
+    });
+    await stubNewsletterApi(page, PROJECT_UID, 'news-456', 'sent', true);
+
+    await page.goto(`/newsletters/${PROJECT_SLUG}/news-456`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    // During loading, skeleton or placeholder should be visible
+    // The component should not display content testids until data arrives
+    releaseProjectRequest!();
+
+    // After data arrives, full content should render
+    await expect(page.getByTestId('newsletter-reader-title')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByTestId('newsletter-reader-copy-link')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+  });
+
+  test('not-found card renders with correct structure on missing project', async ({ page }) => {
+    skipWhenAuthMissing();
+    await stubProjectApi(page, null);
+    await stubNewsletterApi(page, PROJECT_UID, 'news-123', 'sent', true);
+
+    await page.goto(`/newsletters/nonexistent-project/news-123`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    // Error card present with correct testid
+    const notFoundCard = page.getByTestId('newsletter-not-found-card');
+    await expect(notFoundCard).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Verify semantic structure: heading and description present
+    await expect(notFoundCard.getByRole('heading')).toBeVisible();
+  });
+
+  test('not-found card renders with correct structure on missing newsletter', async ({ page }) => {
+    skipWhenAuthMissing();
+    await stubProjectApi(page, MOCK_PROJECT_MANAGER);
+    await stubNewsletterApi(page, PROJECT_UID, 'nonexistent', 'sent', false);
+
+    await page.goto(`/newsletters/${PROJECT_SLUG}/nonexistent`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    // Error card present with correct testid
+    const notFoundCard = page.getByTestId('newsletter-not-found-card');
+    await expect(notFoundCard).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Verify semantic structure: heading and description present
+    await expect(notFoundCard.getByRole('heading')).toBeVisible();
+  });
+
+  test('copy-link button is properly labeled and interactive', async ({ page }) => {
+    skipWhenAuthMissing();
+    await stubProjectApi(page, MOCK_PROJECT_MANAGER);
+    await stubNewsletterApi(page, PROJECT_UID, 'news-456', 'sent', true);
+
+    await page.goto(`/newsletters/${PROJECT_SLUG}/news-456`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    const copyButton = page.getByTestId('newsletter-reader-copy-link');
+    await expect(copyButton).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Button should be interactive (clickable)
+    await expect(copyButton).toBeEnabled();
+
+    // Button should have accessible text or aria-label
+    const hasText = await copyButton.locator('text=').count().catch(() => 0);
+    const hasAriaLabel = await copyButton.getAttribute('aria-label');
+    expect(hasText > 0 || hasAriaLabel).toBeTruthy();
+  });
+});

--- a/apps/lfx-one/e2e/newsletter-reader.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader.spec.ts
@@ -40,7 +40,11 @@ const MOCK_PROJECT_MANAGER: Project = {
 const MOCK_NEWSLETTER_BODY_HTML = '<p data-e2e="newsletter-body-marker">K8s Weekly #42 update.</p>';
 
 async function stubProjectApi(page: Page, project: Project | null): Promise<void> {
-  await page.route('**/api/projects?**', (route) => {
+  // The reader fetches path-style /api/projects/:slug (no query string). Route
+  // by the exact slug under test — a bare '**/api/projects/*' would also
+  // intercept unrelated single-segment calls like /api/projects/writer-summary.
+  const slug = project?.slug ?? 'nonexistent-project';
+  await page.route(`**/api/projects/${slug}`, (route) => {
     if (!project) {
       return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });
     }

--- a/apps/lfx-one/e2e/newsletter-reader.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader.spec.ts
@@ -1,0 +1,151 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { expect, test } from '@playwright/test';
+import { mockApiResponse, setupPage } from './playwright/fixtures';
+
+test.describe('Newsletter Reader Page', () => {
+  test('renders sent newsletter with breadcrumb and copy-link button', async ({ page }) => {
+    // Mock the project get by slug
+    await mockApiResponse(page, '/api/projects?**', {
+      uid: 'proj-123',
+      slug: 'kubernetes',
+      name: 'Kubernetes',
+      writer: false,
+    });
+
+    // Mock the newsletter single get
+    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-456', {
+      id: 'news-456',
+      subject: 'K8s Weekly #42',
+      body_html: '<p>This is the newsletter body.</p>',
+      status: 'sent',
+      sent_at: '2026-08-13T10:00:00Z',
+    });
+
+    await setupPage(page);
+    await page.goto('/newsletters/kubernetes/news-456');
+
+    // Breadcrumb and title
+    await expect(page.getByTestId('newsletter-reader-title')).toContainText('Kubernetes');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('K8s Weekly #42');
+    await expect(page.getByTestId('newsletter-reader-received')).toContainText('Received Aug 13, 2026');
+
+    // Copy-link button present
+    await expect(page.getByTestId('newsletter-reader-copy-link')).toBeVisible();
+
+    // Newsletter preview renders
+    await expect(page.getByTestId('newsletter-reader-preview')).toBeVisible();
+  });
+
+  test('renders in-place 404 for draft newsletter when user is not a writer', async ({ page, context }) => {
+    // Mock the project get by slug with writer=false
+    await mockApiResponse(page, '/api/projects?**', {
+      uid: 'proj-123',
+      slug: 'kubernetes',
+      name: 'Kubernetes',
+      writer: false,
+    });
+
+    // Mock the newsletter single get (draft)
+    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-draft', {
+      id: 'news-draft',
+      subject: 'Draft Newsletter',
+      body_html: '<p>This is a draft.</p>',
+      status: 'draft',
+    });
+
+    await setupPage(page);
+    await page.goto('/newsletters/kubernetes/news-draft');
+
+    // Should render in-place 404 for draft
+    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible();
+    await expect(page.getByText('Draft Newsletter')).toBeVisible();
+    await expect(page.getByText(/Only project managers can view draft newsletters/)).toBeVisible();
+  });
+
+  test('allows manager (writer) to view draft newsletter', async ({ page }) => {
+    // Mock the project get with writer=true
+    await mockApiResponse(page, '/api/projects?**', {
+      uid: 'proj-123',
+      slug: 'kubernetes',
+      name: 'Kubernetes',
+      writer: true,
+    });
+
+    // Mock the newsletter single get (draft)
+    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-draft', {
+      id: 'news-draft',
+      subject: 'Draft Newsletter',
+      body_html: '<p>This is a draft for review.</p>',
+      status: 'draft',
+    });
+
+    await setupPage(page);
+    await page.goto('/newsletters/kubernetes/news-draft');
+
+    // Draft should render (not 404) because user is a writer
+    await expect(page.getByTestId('newsletter-reader-preview')).toBeVisible();
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('Draft Newsletter');
+  });
+
+  test('renders in-place 404 when project slug does not exist', async ({ page }) => {
+    // Mock the project get to fail
+    await mockApiResponse(page, '/api/projects?**', undefined);
+
+    await setupPage(page);
+    await page.goto('/newsletters/nonexistent-project/news-123');
+
+    // Should render in-place 404
+    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible();
+    await expect(page.getByText('Newsletter Not Found')).toBeVisible();
+  });
+
+  test('renders in-place 404 when newsletter id does not exist', async ({ page }) => {
+    // Mock the project get by slug
+    await mockApiResponse(page, '/api/projects?**', {
+      uid: 'proj-123',
+      slug: 'kubernetes',
+      name: 'Kubernetes',
+      writer: false,
+    });
+
+    // Mock the newsletter get to fail
+    await mockApiResponse(page, '/api/projects/proj-123/newsletters/nonexistent', undefined);
+
+    await setupPage(page);
+    await page.goto('/newsletters/kubernetes/nonexistent');
+
+    // Should render in-place 404
+    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible();
+    await expect(page.getByText('Newsletter Not Found')).toBeVisible();
+  });
+
+  test('copy-link button copies absolute URL to clipboard', async ({ page, context }) => {
+    // Mock the project get by slug
+    await mockApiResponse(page, '/api/projects?**', {
+      uid: 'proj-123',
+      slug: 'kubernetes',
+      name: 'Kubernetes',
+      writer: false,
+    });
+
+    // Mock the newsletter single get
+    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-456', {
+      id: 'news-456',
+      subject: 'K8s Weekly #42',
+      body_html: '<p>This is the newsletter body.</p>',
+      status: 'sent',
+      sent_at: '2026-08-13T10:00:00Z',
+    });
+
+    await setupPage(page);
+    await page.goto('/newsletters/kubernetes/news-456');
+
+    // Click copy-link button
+    await page.getByTestId('newsletter-reader-copy-link').click();
+
+    // Check for success toast
+    await expect(page.getByText('Link Copied')).toBeVisible();
+  });
+});

--- a/apps/lfx-one/e2e/newsletter-reader.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader.spec.ts
@@ -1,151 +1,167 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { expect, test } from '@playwright/test';
-import { mockApiResponse, setupPage } from './playwright/fixtures';
+/**
+ * Newsletter Reader Page — GH-1550.
+ *
+ * Shareable per-issue newsletter permalinks at /newsletters/:projectSlug/:id.
+ * Reader page fetches the full newsletter body via the project-scoped get endpoint
+ * (open to any authenticated user). Draft gating enforced in-app: non-managers see 404.
+ *
+ * Prerequisites:
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD
+ */
+
+import type { Project } from '@lfx-one/shared/interfaces';
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const ELEMENT_TIMEOUT = 10_000;
+
+const PROJECT_SLUG = 'kubernetes';
+const PROJECT_UID = 'p0000000-0000-0000-0000-000000000001';
+
+const MOCK_PROJECT_SENT: Project = {
+  uid: PROJECT_UID,
+  slug: PROJECT_SLUG,
+  name: 'Kubernetes',
+  writer: false,
+  founded_at: '2020-01-01T00:00:00Z',
+  status: 'active',
+};
+
+const MOCK_PROJECT_MANAGER: Project = {
+  ...MOCK_PROJECT_SENT,
+  writer: true,
+};
+
+const MOCK_NEWSLETTER_BODY_HTML = '<p data-e2e="newsletter-body-marker">K8s Weekly #42 update.</p>';
+
+async function stubProjectApi(page: Page, project: Project | null): Promise<void> {
+  await page.route('**/api/projects?**', (route) => {
+    if (!project) {
+      return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify(project),
+    });
+  });
+}
+
+async function stubNewsletterApi(
+  page: Page,
+  projectUid: string,
+  newsletterId: string,
+  status: string = 'sent',
+  shouldExist: boolean = true,
+): Promise<void> {
+  await page.route(`**/api/projects/${projectUid}/newsletters/${newsletterId}`, (route) => {
+    if (!shouldExist) {
+      return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });
+    }
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        id: newsletterId,
+        subject: 'K8s Weekly #42',
+        body_html: MOCK_NEWSLETTER_BODY_HTML,
+        status,
+        sent_at: '2026-08-13T10:00:00Z',
+        project_uid: projectUid,
+        ed_reply_email: 'ed@example.com',
+        total_recipients: 12,
+        created_by: 'sender',
+        version: 1,
+        created_at: '2026-08-13T10:00:00Z',
+        updated_at: '2026-08-13T10:00:00Z',
+      }),
+    });
+  });
+}
+
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+  }
+}
 
 test.describe('Newsletter Reader Page', () => {
   test('renders sent newsletter with breadcrumb and copy-link button', async ({ page }) => {
-    // Mock the project get by slug
-    await mockApiResponse(page, '/api/projects?**', {
-      uid: 'proj-123',
-      slug: 'kubernetes',
-      name: 'Kubernetes',
-      writer: false,
-    });
+    skipWhenAuthMissing();
+    await stubProjectApi(page, MOCK_PROJECT_SENT);
+    await stubNewsletterApi(page, PROJECT_UID, 'news-456', 'sent', true);
 
-    // Mock the newsletter single get
-    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-456', {
-      id: 'news-456',
-      subject: 'K8s Weekly #42',
-      body_html: '<p>This is the newsletter body.</p>',
-      status: 'sent',
-      sent_at: '2026-08-13T10:00:00Z',
-    });
-
-    await setupPage(page);
-    await page.goto('/newsletters/kubernetes/news-456');
+    await page.goto(`/newsletters/${PROJECT_SLUG}/news-456`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
 
     // Breadcrumb and title
     await expect(page.getByTestId('newsletter-reader-title')).toContainText('Kubernetes');
-    await expect(page.getByRole('heading', { level: 1 })).toContainText('K8s Weekly #42');
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('K8s Weekly #42', { timeout: ELEMENT_TIMEOUT });
     await expect(page.getByTestId('newsletter-reader-received')).toContainText('Received Aug 13, 2026');
 
     // Copy-link button present
     await expect(page.getByTestId('newsletter-reader-copy-link')).toBeVisible();
 
     // Newsletter preview renders
-    await expect(page.getByTestId('newsletter-reader-preview')).toBeVisible();
+    await expect(page.locator('[data-e2e="newsletter-body-marker"]')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
   });
 
-  test('renders in-place 404 for draft newsletter when user is not a writer', async ({ page, context }) => {
-    // Mock the project get by slug with writer=false
-    await mockApiResponse(page, '/api/projects?**', {
-      uid: 'proj-123',
-      slug: 'kubernetes',
-      name: 'Kubernetes',
-      writer: false,
-    });
+  test('renders in-place 404 for draft newsletter when user is not a writer', async ({ page }) => {
+    skipWhenAuthMissing();
+    await stubProjectApi(page, MOCK_PROJECT_SENT);
+    await stubNewsletterApi(page, PROJECT_UID, 'news-draft', 'draft', true);
 
-    // Mock the newsletter single get (draft)
-    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-draft', {
-      id: 'news-draft',
-      subject: 'Draft Newsletter',
-      body_html: '<p>This is a draft.</p>',
-      status: 'draft',
-    });
-
-    await setupPage(page);
-    await page.goto('/newsletters/kubernetes/news-draft');
+    await page.goto(`/newsletters/${PROJECT_SLUG}/news-draft`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
 
     // Should render in-place 404 for draft
-    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible();
+    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
     await expect(page.getByText('Draft Newsletter')).toBeVisible();
     await expect(page.getByText(/Only project managers can view draft newsletters/)).toBeVisible();
   });
 
   test('allows manager (writer) to view draft newsletter', async ({ page }) => {
-    // Mock the project get with writer=true
-    await mockApiResponse(page, '/api/projects?**', {
-      uid: 'proj-123',
-      slug: 'kubernetes',
-      name: 'Kubernetes',
-      writer: true,
-    });
+    skipWhenAuthMissing();
+    await stubProjectApi(page, MOCK_PROJECT_MANAGER);
+    await stubNewsletterApi(page, PROJECT_UID, 'news-draft', 'draft', true);
 
-    // Mock the newsletter single get (draft)
-    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-draft', {
-      id: 'news-draft',
-      subject: 'Draft Newsletter',
-      body_html: '<p>This is a draft for review.</p>',
-      status: 'draft',
-    });
-
-    await setupPage(page);
-    await page.goto('/newsletters/kubernetes/news-draft');
+    await page.goto(`/newsletters/${PROJECT_SLUG}/news-draft`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
 
     // Draft should render (not 404) because user is a writer
-    await expect(page.getByTestId('newsletter-reader-preview')).toBeVisible();
-    await expect(page.getByRole('heading', { level: 1 })).toContainText('Draft Newsletter');
+    await expect(page.locator('[data-e2e="newsletter-body-marker"]')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.getByRole('heading', { level: 1 })).toContainText('K8s Weekly #42');
   });
 
   test('renders in-place 404 when project slug does not exist', async ({ page }) => {
-    // Mock the project get to fail
-    await mockApiResponse(page, '/api/projects?**', undefined);
+    skipWhenAuthMissing();
+    await stubProjectApi(page, null);
 
-    await setupPage(page);
-    await page.goto('/newsletters/nonexistent-project/news-123');
+    await page.goto(`/newsletters/nonexistent-project/news-123`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
 
     // Should render in-place 404
-    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible();
+    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
     await expect(page.getByText('Newsletter Not Found')).toBeVisible();
   });
 
   test('renders in-place 404 when newsletter id does not exist', async ({ page }) => {
-    // Mock the project get by slug
-    await mockApiResponse(page, '/api/projects?**', {
-      uid: 'proj-123',
-      slug: 'kubernetes',
-      name: 'Kubernetes',
-      writer: false,
-    });
+    skipWhenAuthMissing();
+    await stubProjectApi(page, MOCK_PROJECT_SENT);
+    await stubNewsletterApi(page, PROJECT_UID, 'nonexistent', 'sent', false);
 
-    // Mock the newsletter get to fail
-    await mockApiResponse(page, '/api/projects/proj-123/newsletters/nonexistent', undefined);
-
-    await setupPage(page);
-    await page.goto('/newsletters/kubernetes/nonexistent');
+    await page.goto(`/newsletters/${PROJECT_SLUG}/nonexistent`, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
 
     // Should render in-place 404
-    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible();
+    await expect(page.getByTestId('newsletter-not-found-card')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
     await expect(page.getByText('Newsletter Not Found')).toBeVisible();
-  });
-
-  test('copy-link button copies absolute URL to clipboard', async ({ page, context }) => {
-    // Mock the project get by slug
-    await mockApiResponse(page, '/api/projects?**', {
-      uid: 'proj-123',
-      slug: 'kubernetes',
-      name: 'Kubernetes',
-      writer: false,
-    });
-
-    // Mock the newsletter single get
-    await mockApiResponse(page, '/api/projects/proj-123/newsletters/news-456', {
-      id: 'news-456',
-      subject: 'K8s Weekly #42',
-      body_html: '<p>This is the newsletter body.</p>',
-      status: 'sent',
-      sent_at: '2026-08-13T10:00:00Z',
-    });
-
-    await setupPage(page);
-    await page.goto('/newsletters/kubernetes/news-456');
-
-    // Click copy-link button
-    await page.getByTestId('newsletter-reader-copy-link').click();
-
-    // Check for success toast
-    await expect(page.getByText('Link Copied')).toBeVisible();
   });
 });

--- a/apps/lfx-one/e2e/newsletter-reader.spec.ts
+++ b/apps/lfx-one/e2e/newsletter-reader.spec.ts
@@ -52,13 +52,7 @@ async function stubProjectApi(page: Page, project: Project | null): Promise<void
   });
 }
 
-async function stubNewsletterApi(
-  page: Page,
-  projectUid: string,
-  newsletterId: string,
-  status: string = 'sent',
-  shouldExist: boolean = true,
-): Promise<void> {
+async function stubNewsletterApi(page: Page, projectUid: string, newsletterId: string, status: string = 'sent', shouldExist: boolean = true): Promise<void> {
   await page.route(`**/api/projects/${projectUid}/newsletters/${newsletterId}`, (route) => {
     if (!shouldExist) {
       return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'not found' }) });

--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -369,6 +369,17 @@ export const routes: Routes = [
         loadChildren: () => import('./modules/surveys/surveys.routes').then((m) => m.SURVEY_ROUTES),
       },
       {
+        // Canonical shareable newsletter permalink (GH-1550). Mounted ahead of
+        // the lens-redirected `newsletters` mount below so the URL never
+        // rewrites to /foundation/... or /project/..., whose mount-level
+        // newsletterAccessGuard would block non-manager readers. Any
+        // authenticated user may view sent issues; drafts 404 in-place for
+        // non-writers (enforced in the component).
+        path: 'newsletters/:projectSlug/:id',
+        canActivate: [authGuard],
+        loadComponent: () => import('./modules/newsletters/newsletter-reader/newsletter-reader.component').then((m) => m.NewsletterReaderComponent),
+      },
+      {
         path: 'newsletters',
         // No newsletterAccessGuard at the mount: the Me-lens member feed
         // (/newsletters/my) must be reachable by regular committee members.

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
@@ -22,7 +22,7 @@
             type="button"
             (click)="onCopyLink()"
             class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors"
-            [title]="'Copy link'"
+            title="Copy link"
             aria-label="Copy link"
             data-testid="newsletter-preview-drawer-copy-link">
             <i class="fa-light fa-link text-xl"></i>

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
@@ -16,14 +16,27 @@
           <p class="text-xs text-slate-500">{{ headerSubtitle() }}</p>
         }
       </div>
-      <button
-        type="button"
-        (click)="onClose()"
-        class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors"
-        data-testid="newsletter-preview-drawer-close"
-        aria-label="Close panel">
-        <i class="fa-light fa-xmark text-xl"></i>
-      </button>
+      <div class="flex items-center gap-2">
+        @if (shareUrl()) {
+          <button
+            type="button"
+            (click)="onCopyLink()"
+            class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors"
+            [title]="'Copy link'"
+            aria-label="Copy link"
+            data-testid="newsletter-preview-drawer-copy-link">
+            <i class="fa-light fa-link text-xl"></i>
+          </button>
+        }
+        <button
+          type="button"
+          (click)="onClose()"
+          class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors"
+          data-testid="newsletter-preview-drawer-close"
+          aria-label="Close panel">
+          <i class="fa-light fa-xmark text-xl"></i>
+        </button>
+      </div>
     </div>
   </ng-template>
 

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
@@ -1,8 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, input, model } from '@angular/core';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Component, inject, input, model } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
+import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 
 import { NewsletterPreviewComponent } from '../newsletter-preview/newsletter-preview.component';
@@ -13,6 +15,10 @@ import { NewsletterPreviewComponent } from '../newsletter-preview/newsletter-pre
   templateUrl: './newsletter-preview-drawer.component.html',
 })
 export class NewsletterPreviewDrawerComponent {
+  // === Services ===
+  private readonly clipboard = inject(Clipboard);
+  private readonly messageService = inject(MessageService);
+
   // === Inputs (pass-through to the preview component) ===
   public readonly subject = input.required<string>();
   public readonly bodyHtml = input.required<string>();
@@ -25,8 +31,33 @@ export class NewsletterPreviewDrawerComponent {
   public readonly headerTitle = input<string>('Preview');
   public readonly headerSubtitle = input<string>('As your recipients will see it');
 
+  // === Inputs (share affordance) ===
+  // Optional: when set, shows a copy-link button in the header. Only reader-side
+  // pages (My Newsletters, reader page) provide this; manager preview flows omit it.
+  public readonly shareUrl = input<string | null>(null);
+
   // === Model Signals (two-way) ===
   public readonly visible = model<boolean>(false);
+
+  public onCopyLink(): void {
+    const url = this.shareUrl();
+    if (!url) return;
+
+    const success = this.clipboard.copy(url);
+    if (success) {
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Link Copied',
+        detail: 'Newsletter link copied to clipboard.',
+      });
+    } else {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Copy Failed',
+        detail: 'Failed to copy link. Please try again.',
+      });
+    }
+  }
 
   public onClose(): void {
     this.visible.set(false);

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.ts
@@ -1,10 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Clipboard } from '@angular/cdk/clipboard';
 import { Component, inject, input, model } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
-import { MessageService } from 'primeng/api';
+import { ClipboardShareService } from '@services/clipboard-share.service';
 import { DrawerModule } from 'primeng/drawer';
 
 import { NewsletterPreviewComponent } from '../newsletter-preview/newsletter-preview.component';
@@ -16,8 +15,7 @@ import { NewsletterPreviewComponent } from '../newsletter-preview/newsletter-pre
 })
 export class NewsletterPreviewDrawerComponent {
   // === Services ===
-  private readonly clipboard = inject(Clipboard);
-  private readonly messageService = inject(MessageService);
+  private readonly clipboardShare = inject(ClipboardShareService);
 
   // === Inputs (pass-through to the preview component) ===
   public readonly subject = input.required<string>();
@@ -43,20 +41,7 @@ export class NewsletterPreviewDrawerComponent {
     const url = this.shareUrl();
     if (!url) return;
 
-    const success = this.clipboard.copy(url);
-    if (success) {
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Link Copied',
-        detail: 'Newsletter link copied to clipboard.',
-      });
-    } else {
-      this.messageService.add({
-        severity: 'error',
-        summary: 'Copy Failed',
-        detail: 'Failed to copy link. Please try again.',
-      });
-    }
+    this.clipboardShare.copyLink(url, 'Newsletter link copied to clipboard.');
   }
 
   public onClose(): void {

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -144,7 +144,8 @@
 
 <!-- Reader drawer: renders the newsletter as recipients saw it. Opened once
      the body fetch resolves in onOpenNewsletter. Header is reader-framed
-     (project + received date) rather than the sender-side "Preview" default. -->
+     (project + received date) rather than the sender-side "Preview" default.
+     Share button shows the absolute permalink URL. -->
 <lfx-newsletter-preview-drawer
   [(visible)]="previewVisible"
   [subject]="selected()?.subject ?? ''"
@@ -152,4 +153,6 @@
   [displayName]="selected()?.project_name || 'Newsletter'"
   [headerTitle]="selected()?.project_name || 'Newsletter'"
   [headerSubtitle]="drawerSubtitle()"
+  [shareUrl]="selected() ? buildShareUrl(selected()!) : null"
+  (visibleChange)="onCloseDrawer()"
   data-testid="my-newsletters-preview-drawer"></lfx-newsletter-preview-drawer>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -153,6 +153,6 @@
   [displayName]="selected()?.project_name || 'Newsletter'"
   [headerTitle]="selected()?.project_name || 'Newsletter'"
   [headerSubtitle]="drawerSubtitle()"
-  [shareUrl]="selected() ? buildShareUrl(selected()!) : null"
+  [shareUrl]="selectedShareUrl()"
   (visibleChange)="onDrawerVisibleChange($event)"
   data-testid="my-newsletters-preview-drawer"></lfx-newsletter-preview-drawer>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -154,5 +154,5 @@
   [headerTitle]="selected()?.project_name || 'Newsletter'"
   [headerSubtitle]="drawerSubtitle()"
   [shareUrl]="selected() ? buildShareUrl(selected()!) : null"
-  (visibleChange)="onCloseDrawer()"
+  (visibleChange)="onDrawerVisibleChange($event)"
   data-testid="my-newsletters-preview-drawer"></lfx-newsletter-preview-drawer>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -93,6 +93,12 @@ export class MyNewslettersComponent {
     const sentAt = this.selected()?.sent_at;
     return sentAt ? `Received ${formatDate(sentAt, 'MMM d, y', 'en-US')}` : '';
   });
+  /** Canonical permalink for the selected newsletter (SSR-safe absolute URL). */
+  protected readonly selectedShareUrl: Signal<string | null> = computed(() => {
+    const selected = this.selected();
+    if (!selected?.project_slug || !selected.id) return null;
+    return toAbsoluteUrl(`/newsletters/${selected.project_slug}/${selected.id}`, isPlatformBrowser(this.platformId));
+  });
 
   // === Constructor ===
   public constructor() {
@@ -192,12 +198,6 @@ export class MyNewslettersComponent {
       queryParamsHandling: 'merge',
       preserveFragment: true,
     });
-  }
-
-  protected buildShareUrl(newsletter: MyNewsletter): string | null {
-    if (!newsletter.project_slug || !newsletter.id) return null;
-    const path = `/newsletters/${newsletter.project_slug}/${newsletter.id}`;
-    return toAbsoluteUrl(path, isPlatformBrowser(this.platformId));
   }
 
   protected onFoundationFilterChange(value: string | null): void {

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -1,9 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe, formatDate } from '@angular/common';
-import { Component, computed, DestroyRef, inject, signal, Signal } from '@angular/core';
+import { DatePipe, formatDate, isPlatformBrowser } from '@angular/common';
+import { Component, computed, DestroyRef, effect, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -11,12 +12,13 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { MyNewsletter } from '@lfx-one/shared/interfaces';
+import { toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { PersonaService } from '@services/persona.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, debounceTime, distinctUntilChanged, finalize, of } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, finalize, map, of } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
@@ -50,7 +52,10 @@ export class MyNewslettersComponent {
   private readonly newsletterService = inject(NewsletterService);
   private readonly personaService = inject(PersonaService);
   private readonly messageService = inject(MessageService);
+  private readonly router = inject(Router);
+  private readonly route = inject(ActivatedRoute);
   private readonly destroyRef = inject(DestroyRef);
+  private readonly platformId = inject(PLATFORM_ID);
 
   // === Forms ===
   public readonly searchForm = new FormGroup({
@@ -69,6 +74,16 @@ export class MyNewslettersComponent {
   protected readonly searchTerm = signal<string>('');
   protected readonly foundationFilter = signal<string | null>(null);
   protected readonly projectFilter = signal<string | null>(null);
+
+  // === Query Param Signals (for drawer↔URL sync) ===
+  protected readonly queryIssueId: Signal<string | null> = toSignal(
+    this.route.queryParamMap.pipe(map((m) => m.get('issue'))),
+    { initialValue: null },
+  );
+  protected readonly queryProjectSlug: Signal<string | null> = toSignal(
+    this.route.queryParamMap.pipe(map((m) => m.get('project'))),
+    { initialValue: null },
+  );
 
   // === Computed Signals ===
   protected readonly personaLoaded = this.personaService.personaLoaded;
@@ -90,6 +105,24 @@ export class MyNewslettersComponent {
     this.searchForm.controls.search.valueChanges
       .pipe(debounceTime(200), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => this.searchTerm.set(value ?? ''));
+
+    // Auto-open drawer if query params present on page load or back/forward
+    effect(() => {
+      const issueId = this.queryIssueId();
+      const projectSlug = this.queryProjectSlug();
+      if (issueId && projectSlug && !this.openingId()) {
+        // Find matching newsletter in the feed
+        const newsletter = this.myNewsletters().find((n) => n.id === issueId && n.project_slug === projectSlug);
+        if (newsletter) {
+          // Newsletter is in the feed — open the drawer via the normal path
+          this.onOpenNewsletter(newsletter);
+        } else {
+          // Newsletter not in the feed (e.g. non-member pasted a URL).
+          // Redirect to the canonical permalink page, which handles access uniformly.
+          this.router.navigate(['/newsletters', projectSlug, issueId]);
+        }
+      }
+    });
   }
 
   // === Protected Methods ===
@@ -99,6 +132,14 @@ export class MyNewslettersComponent {
     }
     this.selected.set(newsletter);
     this.openingId.set(newsletter.id);
+
+    // Update URL with query params (sync drawer open state to URL)
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { issue: newsletter.id, project: newsletter.project_slug },
+      queryParamsHandling: 'merge',
+      preserveFragment: true,
+    });
 
     // The list DTO deliberately omits body_html; fetch the full newsletter via
     // the project-scoped get (open to any authenticated user upstream) and
@@ -132,6 +173,23 @@ export class MyNewslettersComponent {
   protected onOpenSubject(event: Event, newsletter: MyNewsletter): void {
     event.stopPropagation();
     this.onOpenNewsletter(newsletter);
+  }
+
+  protected onCloseDrawer(): void {
+    this.previewVisible.set(false);
+    // Clear query params when drawer closes
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: { issue: null, project: null },
+      queryParamsHandling: 'merge',
+      preserveFragment: true,
+    });
+  }
+
+  protected buildShareUrl(newsletter: MyNewsletter): string | null {
+    if (!newsletter.project_slug || !newsletter.id) return null;
+    const path = `/newsletters/${newsletter.project_slug}/${newsletter.id}`;
+    return toAbsoluteUrl(path, isPlatformBrowser(this.platformId));
   }
 
   protected onFoundationFilterChange(value: string | null): void {

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -18,7 +18,7 @@ import { PersonaService } from '@services/persona.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, map, of, skip, switchMap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, map, of } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
@@ -100,28 +100,34 @@ export class MyNewslettersComponent {
       .pipe(debounceTime(200), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => this.searchTerm.set(value ?? ''));
 
-    // Auto-open drawer if query params present on page load or back/forward.
-    // Skip the initial emission (page load) and only react to actual param changes.
-    combineLatest([toObservable(this.queryIssueId), toObservable(this.queryProjectSlug), toObservable(this.myNewsletters), toObservable(this.openingId)])
-      .pipe(
-        skip(1),
-        switchMap(([issueId, projectSlug, newsletters, opening]) => {
-          if (issueId && projectSlug && !opening) {
-            const newsletter = newsletters.find((n) => n.id === issueId && n.project_slug === projectSlug);
-            if (newsletter) {
-              // Newsletter is in the feed — open the drawer via the normal path
-              this.onOpenNewsletter(newsletter);
-            } else {
-              // Newsletter not in the feed (e.g. non-member pasted a URL).
-              // Redirect to the canonical permalink page, which handles access uniformly.
-              this.router.navigate(['/newsletters', projectSlug, issueId]);
-            }
+    // Drawer ↔ URL sync: open the drawer when `issue`/`project` params are
+    // present (page load or forward navigation), close it when they clear
+    // (browser back). Idempotent — an emission for an issue that is already
+    // open or mid-fetch is a no-op, so the sync never re-triggers a fetch.
+    combineLatest([toObservable(this.queryIssueId), toObservable(this.queryProjectSlug), toObservable(this.myNewsletters), toObservable(this.loading)])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([issueId, projectSlug, newsletters, loading]) => {
+        if (!issueId || !projectSlug) {
+          // Params cleared (drawer close or back navigation) — close the drawer.
+          if (this.previewVisible()) {
+            this.previewVisible.set(false);
           }
-          return of(null);
-        }),
-        takeUntilDestroyed(this.destroyRef)
-      )
-      .subscribe();
+          return;
+        }
+        // Wait for the feed before deciding; skip if this issue is already opening or open.
+        if (loading || this.openingId() || (this.previewVisible() && this.selected()?.id === issueId)) {
+          return;
+        }
+        const newsletter = newsletters.find((n) => n.id === issueId && n.project_slug === projectSlug);
+        if (newsletter) {
+          // Newsletter is in the feed — open the drawer via the normal path
+          this.onOpenNewsletter(newsletter);
+        } else {
+          // Newsletter not in the feed (e.g. non-member pasted a URL).
+          // Redirect to the canonical permalink page, which handles access uniformly.
+          this.router.navigate(['/newsletters', projectSlug, issueId]);
+        }
+      });
   }
 
   // === Protected Methods ===
@@ -174,9 +180,12 @@ export class MyNewslettersComponent {
     this.onOpenNewsletter(newsletter);
   }
 
-  protected onCloseDrawer(): void {
-    this.previewVisible.set(false);
-    // Clear query params when drawer closes
+  protected onDrawerVisibleChange(visible: boolean): void {
+    if (visible) {
+      return;
+    }
+    // Drawer closed by the user — clear the issue params so the URL matches.
+    // The [(visible)] model binding already reflects the closed state.
     this.router.navigate([], {
       relativeTo: this.route,
       queryParams: { issue: null, project: null },

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -2,8 +2,8 @@
 // SPDX-License-Identifier: MIT
 
 import { DatePipe, formatDate, isPlatformBrowser } from '@angular/common';
-import { Component, computed, DestroyRef, effect, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
-import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CardComponent } from '@components/card/card.component';
@@ -18,7 +18,7 @@ import { PersonaService } from '@services/persona.service';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, debounceTime, distinctUntilChanged, finalize, map, of } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, finalize, map, of, skip, switchMap } from 'rxjs';
 
 import { NewsletterPreviewDrawerComponent } from '../components/newsletter-preview-drawer/newsletter-preview-drawer.component';
 
@@ -106,23 +106,28 @@ export class MyNewslettersComponent {
       .pipe(debounceTime(200), distinctUntilChanged(), takeUntilDestroyed(this.destroyRef))
       .subscribe((value) => this.searchTerm.set(value ?? ''));
 
-    // Auto-open drawer if query params present on page load or back/forward
-    effect(() => {
-      const issueId = this.queryIssueId();
-      const projectSlug = this.queryProjectSlug();
-      if (issueId && projectSlug && !this.openingId()) {
-        // Find matching newsletter in the feed
-        const newsletter = this.myNewsletters().find((n) => n.id === issueId && n.project_slug === projectSlug);
-        if (newsletter) {
-          // Newsletter is in the feed — open the drawer via the normal path
-          this.onOpenNewsletter(newsletter);
-        } else {
-          // Newsletter not in the feed (e.g. non-member pasted a URL).
-          // Redirect to the canonical permalink page, which handles access uniformly.
-          this.router.navigate(['/newsletters', projectSlug, issueId]);
-        }
-      }
-    });
+    // Auto-open drawer if query params present on page load or back/forward.
+    // Skip the initial emission (page load) and only react to actual param changes.
+    combineLatest([toObservable(this.queryIssueId), toObservable(this.queryProjectSlug), toObservable(this.myNewsletters), toObservable(this.openingId)])
+      .pipe(
+        skip(1),
+        switchMap(([issueId, projectSlug, newsletters, opening]) => {
+          if (issueId && projectSlug && !opening) {
+            const newsletter = newsletters.find((n) => n.id === issueId && n.project_slug === projectSlug);
+            if (newsletter) {
+              // Newsletter is in the feed — open the drawer via the normal path
+              this.onOpenNewsletter(newsletter);
+            } else {
+              // Newsletter not in the feed (e.g. non-member pasted a URL).
+              // Redirect to the canonical permalink page, which handles access uniformly.
+              this.router.navigate(['/newsletters', projectSlug, issueId]);
+            }
+          }
+          return of(null);
+        }),
+        takeUntilDestroyed(this.destroyRef),
+      )
+      .subscribe();
   }
 
   // === Protected Methods ===

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { DatePipe, formatDate, isPlatformBrowser } from '@angular/common';
-import { Component, computed, DestroyRef, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { Component, computed, DestroyRef, inject, model, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
@@ -66,7 +66,7 @@ export class MyNewslettersComponent {
 
   // === Writable Signals ===
   protected readonly loading = signal<boolean>(true);
-  protected readonly previewVisible = signal<boolean>(false);
+  protected readonly previewVisible = model<boolean>(false);
   /** Newsletter id whose body fetch is in flight — serializes drawer opens. */
   protected readonly openingId = signal<string | null>(null);
   protected readonly selected = signal<MyNewsletter | null>(null);
@@ -76,14 +76,8 @@ export class MyNewslettersComponent {
   protected readonly projectFilter = signal<string | null>(null);
 
   // === Query Param Signals (for drawer↔URL sync) ===
-  protected readonly queryIssueId: Signal<string | null> = toSignal(
-    this.route.queryParamMap.pipe(map((m) => m.get('issue'))),
-    { initialValue: null },
-  );
-  protected readonly queryProjectSlug: Signal<string | null> = toSignal(
-    this.route.queryParamMap.pipe(map((m) => m.get('project'))),
-    { initialValue: null },
-  );
+  protected readonly queryIssueId: Signal<string | null> = toSignal(this.route.queryParamMap.pipe(map((m) => m.get('issue'))), { initialValue: null });
+  protected readonly queryProjectSlug: Signal<string | null> = toSignal(this.route.queryParamMap.pipe(map((m) => m.get('project'))), { initialValue: null });
 
   // === Computed Signals ===
   protected readonly personaLoaded = this.personaService.personaLoaded;
@@ -125,7 +119,7 @@ export class MyNewslettersComponent {
           }
           return of(null);
         }),
-        takeUntilDestroyed(this.destroyRef),
+        takeUntilDestroyed(this.destroyRef)
       )
       .subscribe();
   }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.html
@@ -18,7 +18,7 @@
             {{ description() }}
           </p>
 
-          <lfx-button routerLink="/newsletters/my" class="flex items-center" size="small" data-testid="back-to-newsletters-button">
+          <lfx-button (onClick)="goToMyNewsletters()" class="flex items-center" size="small" data-testid="back-to-newsletters-button">
             <i class="fa-light fa-arrow-left mr-2"></i>
             <span>Back to My Newsletters</span>
           </lfx-button>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.html
@@ -1,0 +1,29 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="bg-gray-50">
+  <div class="container mx-auto py-6 px-8">
+    <div class="max-w-4xl mx-auto">
+      <lfx-card class="mb-6" data-testid="newsletter-not-found-card">
+        <div class="text-center py-12">
+          <div class="flex justify-center mb-6">
+            <div class="w-24 h-24 bg-gray-100 rounded-full flex items-center justify-center">
+              <i [class]="icon() + ' text-4xl text-gray-400'"></i>
+            </div>
+          </div>
+
+          <h1 class="mb-3" data-testid="error-title">{{ title() }}</h1>
+
+          <p class="text-gray-600 mb-6 max-w-lg mx-auto" data-testid="error-description">
+            {{ description() }}
+          </p>
+
+          <lfx-button routerLink="/newsletters/my" class="flex items-center" size="small" data-testid="back-to-newsletters-button">
+            <i class="fa-light fa-arrow-left mr-2"></i>
+            <span>Back to My Newsletters</span>
+          </lfx-button>
+        </div>
+      </lfx-card>
+    </div>
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.ts
@@ -1,17 +1,21 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, input } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { Component, computed, inject, input } from '@angular/core';
+import { Router } from '@angular/router';
+import { LensService } from '@services/lens.service';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 
 @Component({
   selector: 'lfx-newsletter-not-found',
-  imports: [RouterLink, ButtonComponent, CardComponent],
+  imports: [ButtonComponent, CardComponent],
   templateUrl: './newsletter-not-found.component.html',
 })
 export class NewsletterNotFoundComponent {
+  private readonly router = inject(Router);
+  private readonly lensService = inject(LensService);
+
   public readonly reason = input<'draft' | 'not-found'>('not-found');
 
   protected readonly icon = computed(() => (this.reason() === 'draft' ? 'fa-light fa-lock' : 'fa-light fa-paper-plane-slash'));
@@ -21,4 +25,13 @@ export class NewsletterNotFoundComponent {
       ? 'Only project managers can view draft newsletters. If you have access questions, contact your project manager.'
       : "We couldn't find the newsletter you're looking for. It may have been removed or the link may be incorrect."
   );
+
+  // The feed is a Me-lens page: with a foundation/project lens active, a plain
+  // routerLink to /newsletters/my gets rewritten by lensRedirectGuard to the
+  // lens-prefixed mount, whose newsletterAccessGuard bounces non-writers to the
+  // overview. Switch to the always-allowed 'me' lens before navigating.
+  protected goToMyNewsletters(): void {
+    this.lensService.setLens('me');
+    void this.router.navigate(['/newsletters/my']);
+  }
 }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.ts
@@ -19,6 +19,6 @@ export class NewsletterNotFoundComponent {
   protected readonly description = computed(() =>
     this.reason() === 'draft'
       ? 'Only project managers can view draft newsletters. If you have access questions, contact your project manager.'
-      : "We couldn't find the newsletter you're looking for. It may have been removed or the link may be incorrect.",
+      : "We couldn't find the newsletter you're looking for. It may have been removed or the link may be incorrect."
   );
 }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-not-found/newsletter-not-found.component.ts
@@ -1,0 +1,24 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, input } from '@angular/core';
+import { RouterLink } from '@angular/router';
+import { ButtonComponent } from '@components/button/button.component';
+import { CardComponent } from '@components/card/card.component';
+
+@Component({
+  selector: 'lfx-newsletter-not-found',
+  imports: [RouterLink, ButtonComponent, CardComponent],
+  templateUrl: './newsletter-not-found.component.html',
+})
+export class NewsletterNotFoundComponent {
+  public readonly reason = input<'draft' | 'not-found'>('not-found');
+
+  protected readonly icon = computed(() => (this.reason() === 'draft' ? 'fa-light fa-lock' : 'fa-light fa-paper-plane-slash'));
+  protected readonly title = computed(() => (this.reason() === 'draft' ? 'Draft Newsletter' : 'Newsletter Not Found'));
+  protected readonly description = computed(() =>
+    this.reason() === 'draft'
+      ? 'Only project managers can view draft newsletters. If you have access questions, contact your project manager.'
+      : "We couldn't find the newsletter you're looking for. It may have been removed or the link may be incorrect.",
+  );
+}

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
@@ -1,0 +1,50 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="container mx-auto px-4 sm:px-6 lg:px-8">
+  @if (!paramsValid()) {
+    <!-- 404: invalid or missing params -->
+    <lfx-newsletter-not-found reason="not-found" data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
+  } @else if (notFound()) {
+    <!-- 404: draft hidden from non-writer OR project/newsletter not found -->
+    <lfx-newsletter-not-found
+      [reason]="isDraftHidden() ? 'draft' : 'not-found'"
+      data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
+  } @else if (loading()) {
+    <!-- Skeleton loader -->
+    <div class="mt-6 flex flex-col gap-4">
+      <p-skeleton width="15rem" height="2rem" />
+      <p-skeleton width="20rem" height="1rem" />
+    </div>
+  } @else {
+    <!-- Page header with breadcrumb -->
+    <div class="flex items-center justify-between mb-8 mt-6">
+      <div class="flex-1">
+        <nav class="flex items-center gap-2 text-sm text-gray-600 mb-4">
+          <a routerLink="/newsletters/my" class="hover:text-gray-900">My Newsletters</a>
+          <i class="fa-light fa-chevron-right text-xs"></i>
+          <span class="text-gray-900" data-testid="newsletter-reader-title">{{ pageTitle() }}</span>
+        </nav>
+        <h1 class="font-display font-light text-2xl text-gray-900">{{ newsletter()?.subject }}</h1>
+        <p class="mt-2 text-sm text-gray-600" data-testid="newsletter-reader-received">{{ pageSubtitle() }}</p>
+      </div>
+      @if (shareUrl()) {
+        <button
+          type="button"
+          (click)="copyLink()"
+          class="ml-4 p-3 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors"
+          [title]="'Copy link'"
+          aria-label="Copy link"
+          data-testid="newsletter-reader-copy-link">
+          <i class="fa-light fa-link text-xl"></i>
+        </button>
+      }
+    </div>
+
+    <!-- Newsletter preview inline (not a drawer) -->
+    <lfx-newsletter-preview
+      [subject]="newsletter()?.subject ?? ''"
+      [bodyHtml]="newsletter()?.body_html ?? ''"
+      data-testid="newsletter-reader-preview"></lfx-newsletter-preview>
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
@@ -5,6 +5,17 @@
   @if (!paramsValid()) {
     <!-- 404: invalid or missing params -->
     <lfx-newsletter-not-found reason="not-found" data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
+  } @else if (error()) {
+    <!-- Unexpected failure (non-404): transient — not rendered as a 404 -->
+    <div class="mt-6 rounded-xl border border-gray-200 bg-white" data-testid="newsletter-reader-error">
+      <div class="flex flex-col items-center gap-3 py-16 text-center">
+        <div class="flex h-24 w-24 items-center justify-center rounded-full bg-red-50">
+          <i class="fa-light fa-triangle-exclamation text-4xl text-red-400"></i>
+        </div>
+        <h1 class="text-gray-900">Something went wrong</h1>
+        <p class="max-w-lg text-gray-600">We couldn't load this newsletter right now. Please try again in a few minutes.</p>
+      </div>
+    </div>
   } @else if (notFound()) {
     <!-- 404: draft hidden from non-writer OR project/newsletter not found -->
     <lfx-newsletter-not-found [reason]="isDraftHidden() ? 'draft' : 'not-found'" data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
@@ -31,7 +42,7 @@
           type="button"
           (click)="copyLink()"
           class="ml-4 p-3 text-gray-400 hover:text-gray-600 hover:bg-gray-100 rounded-md transition-colors"
-          [title]="'Copy link'"
+          title="Copy link"
           aria-label="Copy link"
           data-testid="newsletter-reader-copy-link">
           <i class="fa-light fa-link text-xl"></i>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
@@ -10,7 +10,7 @@
     <lfx-newsletter-not-found [reason]="isDraftHidden() ? 'draft' : 'not-found'" data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
   } @else if (loading()) {
     <!-- Skeleton loader -->
-    <div class="mt-6 flex flex-col gap-4">
+    <div class="mt-6 flex flex-col gap-4" data-testid="newsletter-reader-loading">
       <p-skeleton width="15rem" height="2rem" />
       <p-skeleton width="20rem" height="1rem" />
     </div>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
@@ -54,6 +54,7 @@
     <lfx-newsletter-preview
       [subject]="newsletter()?.subject ?? ''"
       [bodyHtml]="newsletter()?.body_html ?? ''"
+      [displayName]="project()?.name ?? ''"
       data-testid="newsletter-reader-preview"></lfx-newsletter-preview>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
@@ -30,7 +30,7 @@
     <div class="flex items-center justify-between mb-8 mt-6">
       <div class="flex-1">
         <nav class="flex items-center gap-2 text-sm text-gray-600 mb-4">
-          <a routerLink="/newsletters/my" class="hover:text-gray-900">My Newsletters</a>
+          <a href="/newsletters/my" (click)="goToMyNewsletters($event)" class="hover:text-gray-900">My Newsletters</a>
           <i class="fa-light fa-chevron-right text-xs"></i>
           <span class="text-gray-900" data-testid="newsletter-reader-title">{{ pageTitle() }}</span>
         </nav>

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.html
@@ -7,9 +7,7 @@
     <lfx-newsletter-not-found reason="not-found" data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
   } @else if (notFound()) {
     <!-- 404: draft hidden from non-writer OR project/newsletter not found -->
-    <lfx-newsletter-not-found
-      [reason]="isDraftHidden() ? 'draft' : 'not-found'"
-      data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
+    <lfx-newsletter-not-found [reason]="isDraftHidden() ? 'draft' : 'not-found'" data-testid="newsletter-reader-not-found"></lfx-newsletter-not-found>
   } @else if (loading()) {
     <!-- Skeleton loader -->
     <div class="mt-6 flex flex-col gap-4">

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { Newsletter, Project } from '@lfx-one/shared/interfaces';
 import { ProjectStage } from '@lfx-one/shared/enums';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -13,6 +13,7 @@ import { NewsletterReaderComponent } from './newsletter-reader.component';
 import { ProjectService } from '@services/project.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ClipboardShareService } from '@services/clipboard-share.service';
+import { LensService } from '@services/lens.service';
 
 function makeProject(overrides: Partial<Project> = {}): Project {
   return {
@@ -96,6 +97,8 @@ describe('NewsletterReaderComponent', () => {
         { provide: NewsletterService, useValue: mockNewsletterService },
         { provide: ActivatedRoute, useValue: activatedRoute },
         { provide: ClipboardShareService, useValue: mockClipboardShareService },
+        { provide: LensService, useValue: { setLens: vi.fn().mockReturnValue(true) } },
+        { provide: Router, useValue: { navigate: vi.fn() } },
       ],
     }).compileComponents();
 
@@ -201,6 +204,23 @@ describe('NewsletterReaderComponent', () => {
     expect(component['loading']()).toBe(false);
     expect(component['error']()).toBe(true);
     expect(component['notFound']()).toBe(false);
+  });
+
+  it('should switch to the me lens before navigating back to the feed', () => {
+    // Without the lens switch, lensRedirectGuard rewrites /newsletters/my to the
+    // lens-prefixed mount and newsletterAccessGuard bounces non-writers away.
+    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+
+    const lensService = TestBed.inject(LensService);
+    const router = TestBed.inject(Router);
+    component['goToMyNewsletters'](new Event('click'));
+
+    expect(lensService.setLens).toHaveBeenCalledWith('me');
+    expect(router.navigate).toHaveBeenCalledWith(['/newsletters/my']);
   });
 
   it('should have copyLink method bound to clipboard service', () => {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -64,9 +64,7 @@ describe('NewsletterReaderComponent', () => {
 
   it('should initialize with loading true', () => {
     vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
-      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any)
-    );
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -75,9 +73,7 @@ describe('NewsletterReaderComponent', () => {
 
   it('should render draft newsletter when user is a writer', () => {
     vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: true } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
-      of({ subject: 'Draft', body_html: '<p>Draft content</p>', status: 'draft' } as any)
-    );
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Draft', body_html: '<p>Draft content</p>', status: 'draft' } as any));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -92,9 +88,7 @@ describe('NewsletterReaderComponent', () => {
   it('should call getProject with slug from route params', () => {
     const getProjectSpy = vi.mocked(projectService.getProject);
     getProjectSpy.mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
-      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any)
-    );
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -106,9 +100,7 @@ describe('NewsletterReaderComponent', () => {
 
   it('should have copyLink method bound to clipboard service', () => {
     vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
-      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any)
-    );
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -243,10 +243,29 @@ describe('NewsletterReaderComponent', () => {
 
     const lensService = TestBed.inject(LensService);
     const router = TestBed.inject(Router);
-    component['goToMyNewsletters'](new Event('click'));
+    component['goToMyNewsletters'](new MouseEvent('click', { button: 0 }));
 
     expect(lensService.setLens).toHaveBeenCalledWith('me');
     expect(router.navigate).toHaveBeenCalledWith(['/newsletters/my']);
+  });
+
+  it('should leave modified clicks on the breadcrumb to the browser (new tab)', () => {
+    // Cmd/Ctrl-click must not be intercepted so the href can open in a new
+    // tab; the lens is still persisted so that tab lands on the me feed.
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+
+    const lensService = TestBed.inject(LensService);
+    const router = TestBed.inject(Router);
+    const event = new MouseEvent('click', { button: 0, metaKey: true, cancelable: true });
+    component['goToMyNewsletters'](event);
+
+    expect(lensService.setLens).toHaveBeenCalledWith('me');
+    expect(event.defaultPrevented).toBe(false);
+    expect(router.navigate).not.toHaveBeenCalled();
   });
 
   it('should have copyLink method bound to clipboard service', () => {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -5,7 +5,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { Newsletter, Project } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { of } from 'rxjs';
+import { BehaviorSubject, NEVER, of } from 'rxjs';
 
 import { NewsletterReaderComponent } from './newsletter-reader.component';
 import { ProjectService } from '@services/project.service';
@@ -64,6 +64,7 @@ describe('NewsletterReaderComponent', () => {
   let fixture: ComponentFixture<NewsletterReaderComponent>;
   let projectService: ProjectService;
   let newsletterService: NewsletterService;
+  let paramMap$: BehaviorSubject<Map<string, string>>;
 
   beforeEach(async () => {
     const mockProjectService = {
@@ -76,13 +77,14 @@ describe('NewsletterReaderComponent', () => {
       copyLink: vi.fn(),
     };
 
+    paramMap$ = new BehaviorSubject(
+      new Map([
+        ['projectSlug', 'kubernetes'],
+        ['id', 'news-123'],
+      ])
+    );
     const activatedRoute = {
-      paramMap: of(
-        new Map([
-          ['projectSlug', 'kubernetes'],
-          ['id', 'news-123'],
-        ])
-      ),
+      paramMap: paramMap$,
     };
 
     await TestBed.configureTestingModule({
@@ -142,6 +144,35 @@ describe('NewsletterReaderComponent', () => {
 
     // Service should be called as route params are emitted
     expect(getProjectSpy).toHaveBeenCalled();
+  });
+
+  it('should reset to loading when route params change to another issue', () => {
+    // First call resolves the initial issue; every later call (the param
+    // change re-fires combineLatest per source signal) hangs, keeping the
+    // second load in flight.
+    vi.mocked(projectService.getProject).mockReturnValueOnce(of(makeProject())).mockReturnValue(NEVER);
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    TestBed.tick();
+
+    // First issue fully loaded
+    expect(component['loading']()).toBe(false);
+    expect(component['newsletter']()).not.toBeNull();
+
+    // Navigate to another permalink: the component is reused, so the state
+    // must reset to the skeleton instead of showing the stale issue.
+    paramMap$.next(
+      new Map([
+        ['projectSlug', 'other-project'],
+        ['id', 'news-456'],
+      ])
+    );
+    TestBed.tick();
+
+    expect(component['loading']()).toBe(true);
+    expect(component['newsletter']()).toBeNull();
   });
 
   it('should have copyLink method bound to clipboard service', () => {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -4,13 +4,12 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { of, throwError } from 'rxjs';
-import { Clipboard } from '@angular/cdk/clipboard';
-import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
 
 import { NewsletterReaderComponent } from './newsletter-reader.component';
 import { ProjectService } from '@services/project.service';
 import { NewsletterService } from '@services/newsletter.service';
+import { ClipboardShareService } from '@services/clipboard-share.service';
 
 describe('NewsletterReaderComponent', () => {
   let component: NewsletterReaderComponent;
@@ -25,11 +24,8 @@ describe('NewsletterReaderComponent', () => {
     const mockNewsletterService = {
       getNewsletter: vi.fn(),
     };
-    const mockClipboard = {
-      copy: vi.fn().mockReturnValue(true),
-    };
-    const mockMessageService = {
-      add: vi.fn(),
+    const mockClipboardShareService = {
+      copyLink: vi.fn(),
     };
 
     const activatedRoute = {
@@ -47,8 +43,7 @@ describe('NewsletterReaderComponent', () => {
         { provide: ProjectService, useValue: mockProjectService },
         { provide: NewsletterService, useValue: mockNewsletterService },
         { provide: ActivatedRoute, useValue: activatedRoute },
-        { provide: Clipboard, useValue: mockClipboard },
-        { provide: MessageService, useValue: mockMessageService },
+        { provide: ClipboardShareService, useValue: mockClipboardShareService },
       ],
     }).compileComponents();
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -1,0 +1,123 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { of, throwError } from 'rxjs';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { MessageService } from 'primeng/api';
+
+import { NewsletterReaderComponent } from './newsletter-reader.component';
+import { ProjectService } from '@services/project.service';
+import { NewsletterService } from '@services/newsletter.service';
+
+describe('NewsletterReaderComponent', () => {
+  let component: NewsletterReaderComponent;
+  let fixture: ComponentFixture<NewsletterReaderComponent>;
+  let projectService: ProjectService;
+  let newsletterService: NewsletterService;
+
+  beforeEach(async () => {
+    const mockProjectService = {
+      getProject: vi.fn(),
+    };
+    const mockNewsletterService = {
+      getNewsletter: vi.fn(),
+    };
+    const mockClipboard = {
+      copy: vi.fn().mockReturnValue(true),
+    };
+    const mockMessageService = {
+      add: vi.fn(),
+    };
+
+    const activatedRoute = {
+      paramMap: of(
+        new Map([
+          ['projectSlug', 'kubernetes'],
+          ['id', 'news-123'],
+        ])
+      ),
+    };
+
+    await TestBed.configureTestingModule({
+      imports: [NewsletterReaderComponent],
+      providers: [
+        { provide: ProjectService, useValue: mockProjectService },
+        { provide: NewsletterService, useValue: mockNewsletterService },
+        { provide: ActivatedRoute, useValue: activatedRoute },
+        { provide: Clipboard, useValue: mockClipboard },
+        { provide: MessageService, useValue: mockMessageService },
+      ],
+    }).compileComponents();
+
+    projectService = TestBed.inject(ProjectService);
+    newsletterService = TestBed.inject(NewsletterService);
+  });
+
+  it('should create', () => {
+    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
+      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent', sent_at: '2026-08-13T10:00:00Z' } as any)
+    );
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    expect(component).toBeTruthy();
+  });
+
+  it('should initialize with loading true', () => {
+    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
+      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any)
+    );
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    expect(component['loading']()).toBe(true);
+  });
+
+  it('should render draft newsletter when user is a writer', () => {
+    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: true } as any));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
+      of({ subject: 'Draft', body_html: '<p>Draft content</p>', status: 'draft' } as any)
+    );
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    // Verify component created and injections wired
+    expect(component).toBeTruthy();
+    expect(component['project']).toBeDefined();
+    expect(component['newsletter']).toBeDefined();
+  });
+
+  it('should call getProject with slug from route params', () => {
+    const getProjectSpy = vi.mocked(projectService.getProject);
+    getProjectSpy.mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
+      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any)
+    );
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+
+    // Service should be called as route params are emitted
+    expect(getProjectSpy).toHaveBeenCalled();
+  });
+
+  it('should have copyLink method bound to clipboard service', () => {
+    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
+      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any)
+    );
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    expect(component['copyLink']).toBeDefined();
+    expect(typeof component['copyLink']).toBe('function');
+  });
+});

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -4,8 +4,10 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { Newsletter, Project } from '@lfx-one/shared/interfaces';
+import { ProjectStage } from '@lfx-one/shared/enums';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { BehaviorSubject, NEVER, of } from 'rxjs';
+import { BehaviorSubject, NEVER, of, throwError } from 'rxjs';
+import { HttpErrorResponse } from '@angular/common/http';
 
 import { NewsletterReaderComponent } from './newsletter-reader.component';
 import { ProjectService } from '@services/project.service';
@@ -21,7 +23,7 @@ function makeProject(overrides: Partial<Project> = {}): Project {
     writer: false,
     public: true,
     parent_uid: '',
-    stage: 'active',
+    stage: ProjectStage.Active,
     category: 'test',
     funding_model: [],
     charter_url: '',
@@ -173,6 +175,32 @@ describe('NewsletterReaderComponent', () => {
 
     expect(component['loading']()).toBe(true);
     expect(component['newsletter']()).toBeNull();
+  });
+
+  it('should map a 404 newsletter fetch to the not-found state, not error', () => {
+    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    TestBed.tick();
+
+    expect(component['loading']()).toBe(false);
+    expect(component['error']()).toBe(false);
+    expect(component['notFound']()).toBe(true);
+  });
+
+  it('should surface a 5xx newsletter fetch as error, not a permanent 404', () => {
+    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 502 })));
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    TestBed.tick();
+
+    expect(component['loading']()).toBe(false);
+    expect(component['error']()).toBe(true);
+    expect(component['notFound']()).toBe(false);
   });
 
   it('should have copyLink method bound to clipboard service', () => {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -247,6 +247,9 @@ describe('NewsletterReaderComponent', () => {
 
     expect(lensService.setLens).toHaveBeenCalledWith('me');
     expect(router.navigate).toHaveBeenCalledWith(['/newsletters/my']);
+    // Order matters: navigating first would let lensRedirectGuard rewrite the
+    // URL against the old lens before the switch lands.
+    expect(vi.mocked(lensService.setLens).mock.invocationCallOrder[0]).toBeLessThan(vi.mocked(router.navigate).mock.invocationCallOrder[0]);
   });
 
   it('should leave modified clicks on the breadcrumb to the browser (new tab)', () => {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -3,6 +3,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
+import { Newsletter, Project } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { of } from 'rxjs';
 
@@ -10,6 +11,53 @@ import { NewsletterReaderComponent } from './newsletter-reader.component';
 import { ProjectService } from '@services/project.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ClipboardShareService } from '@services/clipboard-share.service';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+  return {
+    uid: 'proj-123',
+    slug: 'kubernetes',
+    description: 'Test project',
+    name: 'Kubernetes',
+    writer: false,
+    public: true,
+    parent_uid: '',
+    stage: 'active',
+    category: 'test',
+    funding_model: [],
+    charter_url: '',
+    legal_entity_type: '',
+    legal_entity_name: '',
+    legal_parent_uid: '',
+    autojoin_enabled: false,
+    formation_date: '2020-01-01',
+    logo_url: '',
+    repository_url: '',
+    website_url: '',
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    mailing_list_count: 0,
+    ...overrides,
+  };
+}
+
+function makeNewsletter(overrides: Partial<Newsletter> = {}): Newsletter {
+  return {
+    id: 'news-123',
+    project_uid: 'proj-123',
+    subject: 'Test',
+    body_html: '<p>Test</p>',
+    ed_reply_email: 'ed@example.com',
+    committee_uids: [],
+    status: 'sent',
+    sent_at: '2026-08-13T10:00:00Z',
+    total_recipients: 12,
+    created_by: 'sender',
+    version: 1,
+    created_at: '2026-08-13T10:00:00Z',
+    updated_at: '2026-08-13T10:00:00Z',
+    ...overrides,
+  };
+}
 
 describe('NewsletterReaderComponent', () => {
   let component: NewsletterReaderComponent;
@@ -52,10 +100,8 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should create', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(
-      of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent', sent_at: '2026-08-13T10:00:00Z' } as any)
-    );
+    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -63,8 +109,8 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should initialize with loading true', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any));
+    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -72,8 +118,8 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should render draft newsletter when user is a writer', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: true } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Draft', body_html: '<p>Draft content</p>', status: 'draft' } as any));
+    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject({ writer: true })));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter({ subject: 'Draft', body_html: '<p>Draft content</p>', status: 'draft' })));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -87,8 +133,8 @@ describe('NewsletterReaderComponent', () => {
 
   it('should call getProject with slug from route params', () => {
     const getProjectSpy = vi.mocked(projectService.getProject);
-    getProjectSpy.mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any));
+    getProjectSpy.mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -99,8 +145,8 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should have copyLink method bound to clipboard service', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of({ uid: 'proj-123', writer: false } as any));
-    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of({ subject: 'Test', body_html: '<p>Test</p>', status: 'sent' } as any));
+    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.spec.ts
@@ -71,7 +71,7 @@ describe('NewsletterReaderComponent', () => {
 
   beforeEach(async () => {
     const mockProjectService = {
-      getProject: vi.fn(),
+      getProjectStrict: vi.fn(),
     };
     const mockNewsletterService = {
       getNewsletter: vi.fn(),
@@ -107,7 +107,7 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should create', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject()));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
@@ -116,7 +116,7 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should initialize with loading true', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject()));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
@@ -125,7 +125,7 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should render draft newsletter when user is a writer', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject({ writer: true })));
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject({ writer: true })));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter({ subject: 'Draft', body_html: '<p>Draft content</p>', status: 'draft' })));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
@@ -139,7 +139,7 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should call getProject with slug from route params', () => {
-    const getProjectSpy = vi.mocked(projectService.getProject);
+    const getProjectSpy = vi.mocked(projectService.getProjectStrict);
     getProjectSpy.mockReturnValue(of(makeProject()));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
@@ -155,7 +155,7 @@ describe('NewsletterReaderComponent', () => {
     // First call resolves the initial issue; every later call (the param
     // change re-fires combineLatest per source signal) hangs, keeping the
     // second load in flight.
-    vi.mocked(projectService.getProject).mockReturnValueOnce(of(makeProject())).mockReturnValue(NEVER);
+    vi.mocked(projectService.getProjectStrict).mockReturnValueOnce(of(makeProject())).mockReturnValue(NEVER);
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
@@ -181,7 +181,7 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should map a 404 newsletter fetch to the not-found state, not error', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject()));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
@@ -194,8 +194,34 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should surface a 5xx newsletter fetch as error, not a permanent 404', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject()));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 502 })));
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    TestBed.tick();
+
+    expect(component['loading']()).toBe(false);
+    expect(component['error']()).toBe(true);
+    expect(component['notFound']()).toBe(false);
+  });
+
+  it('should map a 404 project lookup (bad slug) to the not-found state', () => {
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 404 })));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
+
+    fixture = TestBed.createComponent(NewsletterReaderComponent);
+    component = fixture.componentInstance;
+    TestBed.tick();
+
+    expect(component['loading']()).toBe(false);
+    expect(component['error']()).toBe(false);
+    expect(component['notFound']()).toBe(true);
+  });
+
+  it('should surface a project-service outage as error, not a permanent 404', () => {
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(throwError(() => new HttpErrorResponse({ status: 503 })));
+    vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
     component = fixture.componentInstance;
@@ -209,7 +235,7 @@ describe('NewsletterReaderComponent', () => {
   it('should switch to the me lens before navigating back to the feed', () => {
     // Without the lens switch, lensRedirectGuard rewrites /newsletters/my to the
     // lens-prefixed mount and newsletterAccessGuard bounces non-writers away.
-    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject()));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);
@@ -224,7 +250,7 @@ describe('NewsletterReaderComponent', () => {
   });
 
   it('should have copyLink method bound to clipboard service', () => {
-    vi.mocked(projectService.getProject).mockReturnValue(of(makeProject()));
+    vi.mocked(projectService.getProjectStrict).mockReturnValue(of(makeProject()));
     vi.mocked(newsletterService.getNewsletter).mockReturnValue(of(makeNewsletter()));
 
     fixture = TestBed.createComponent(NewsletterReaderComponent);

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -2,16 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 import { formatDate, isPlatformBrowser } from '@angular/common';
-import { Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { Component, computed, inject, PLATFORM_ID, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { Project } from '@lfx-one/shared/interfaces';
+import { NewsletterReaderState } from '@lfx-one/shared/interfaces';
 import { toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectService } from '@services/project.service';
 import { ClipboardShareService } from '@services/clipboard-share.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, finalize, filter, map, of, switchMap } from 'rxjs';
+import { catchError, combineLatest, filter, map, of, switchMap } from 'rxjs';
 
 import { NewsletterNotFoundComponent } from './newsletter-not-found/newsletter-not-found.component';
 import { NewsletterPreviewComponent } from '../components/newsletter-preview/newsletter-preview.component';
@@ -38,10 +38,6 @@ export class NewsletterReaderComponent {
   private readonly clipboardShare = inject(ClipboardShareService);
   private readonly platformId = inject(PLATFORM_ID);
 
-  // === WritableSignals ===
-  protected readonly loading = signal(true);
-  protected readonly notFound = signal(false);
-
   // === Route Params (toSignal) ===
   protected readonly projectSlug: Signal<string | null> = toSignal(this.route.paramMap.pipe(map((m) => m.get('projectSlug'))), {
     initialValue: null,
@@ -54,14 +50,24 @@ export class NewsletterReaderComponent {
   protected readonly paramsValid = computed(() => !!this.projectSlug() && !!this.newsletterId());
 
   // === Data Signals (Complex — init via private functions) ===
-  protected readonly project: Signal<Project | null> = this.initProject();
-  protected readonly newsletter: Signal<{ id: string; subject: string; body_html: string; status: string; sent_at?: string } | null> = this.initNewsletter();
+  /** Single load-state stream: loading, project/newsletter resolution, and failures all derive from one emission. */
+  protected readonly state: Signal<NewsletterReaderState> = this.initState();
+
+  // === Computed: state projections ===
+  protected readonly loading = computed(() => this.state().loading);
+  protected readonly project = computed(() => this.state().project);
+  protected readonly newsletter = computed(() => this.state().newsletter);
 
   // === Computed: draft hidden from non-manager ===
   protected readonly isDraftHidden = computed(() => {
-    const nl = this.newsletter();
-    const proj = this.project();
-    return nl && nl.status !== 'sent' && proj && !proj.writer;
+    const { newsletter, project } = this.state();
+    return !!newsletter && newsletter.status !== 'sent' && !!project && !project.writer;
+  });
+
+  // === Computed: 404 (unresolvable project/newsletter, or draft gated) ===
+  protected readonly notFound = computed(() => {
+    const { loading, project, newsletter } = this.state();
+    return !loading && (!project || !newsletter || this.isDraftHidden());
   });
 
   // === Computed: page display strings ===
@@ -93,32 +99,26 @@ export class NewsletterReaderComponent {
   }
 
   // === Private Initializers ===
-  private initProject(): Signal<Project | null> {
+  private initState(): Signal<NewsletterReaderState> {
     return toSignal(
-      toObservable(this.projectSlug).pipe(
-        filter((slug): slug is string => !!slug),
-        switchMap((slug) => this.projectService.getProject(slug, false).pipe(catchError(() => of(null))))
+      combineLatest([toObservable(this.projectSlug), toObservable(this.newsletterId)]).pipe(
+        filter((params): params is [string, string] => !!params[0] && !!params[1]),
+        switchMap(([slug, id]) =>
+          this.projectService.getProject(slug, false).pipe(
+            switchMap((project) => {
+              if (!project?.uid) {
+                return of<NewsletterReaderState>({ loading: false, project: null, newsletter: null });
+              }
+              return this.newsletterService.getNewsletter(project.uid, id).pipe(
+                map((newsletter): NewsletterReaderState => ({ loading: false, project, newsletter })),
+                catchError(() => of<NewsletterReaderState>({ loading: false, project, newsletter: null }))
+              );
+            }),
+            catchError(() => of<NewsletterReaderState>({ loading: false, project: null, newsletter: null }))
+          )
+        )
       ),
-      { initialValue: null }
-    );
-  }
-
-  private initNewsletter(): Signal<{ id: string; subject: string; body_html: string; status: string; sent_at?: string } | null> {
-    return toSignal(
-      combineLatest([toObservable(this.project), toObservable(this.newsletterId).pipe(filter((id) => !!id))]).pipe(
-        switchMap(([project, id]) => {
-          if (!project?.uid || !id) return of(null);
-          return this.newsletterService.getNewsletter(project.uid, id).pipe(catchError(() => of(null)));
-        }),
-        finalize(() => {
-          // If draft is hidden from this user, or resources couldn't be loaded, render 404.
-          if (this.isDraftHidden() || (!this.project() && this.projectSlug()) || (!this.newsletter() && this.newsletterId() && this.project())) {
-            this.notFound.set(true);
-          }
-          this.loading.set(false);
-        })
-      ),
-      { initialValue: null }
+      { initialValue: { loading: true, project: null, newsletter: null } }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -1,0 +1,140 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Clipboard } from '@angular/cdk/clipboard';
+import { formatDate, isPlatformBrowser } from '@angular/common';
+import { Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { Project } from '@lfx-one/shared/interfaces';
+import { toAbsoluteUrl } from '@lfx-one/shared/utils';
+import { NewsletterService } from '@services/newsletter.service';
+import { ProjectService } from '@services/project.service';
+import { MessageService } from 'primeng/api';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, combineLatest, finalize, filter, map, of, switchMap } from 'rxjs';
+
+import { NewsletterNotFoundComponent } from './newsletter-not-found/newsletter-not-found.component';
+import { NewsletterPreviewComponent } from '../components/newsletter-preview/newsletter-preview.component';
+
+/**
+ * Standalone reader page for shareable newsletter permalinks.
+ * Route: /newsletters/:projectSlug/:id
+ *
+ * Access: authGuard only (any authenticated user).
+ * Draft gating: non-managers see 404 for unsent newsletters.
+ * URL: slug-based (human-readable, not UID-based).
+ */
+@Component({
+  selector: 'lfx-newsletter-reader',
+  imports: [NewsletterNotFoundComponent, NewsletterPreviewComponent, RouterLink, SkeletonModule],
+  templateUrl: './newsletter-reader.component.html',
+})
+export class NewsletterReaderComponent {
+  // === Services ===
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly projectService = inject(ProjectService);
+  private readonly newsletterService = inject(NewsletterService);
+  private readonly clipboard = inject(Clipboard);
+  private readonly messageService = inject(MessageService);
+  private readonly platformId = inject(PLATFORM_ID);
+
+  // === WritableSignals ===
+  protected readonly loading = signal(true);
+  protected readonly notFound = signal(false);
+
+  // === Route Params (toSignal) ===
+  protected readonly projectSlug: Signal<string | null> = toSignal(this.route.paramMap.pipe(map((m) => m.get('projectSlug'))), {
+    initialValue: null,
+  });
+  protected readonly newsletterId: Signal<string | null> = toSignal(this.route.paramMap.pipe(map((m) => m.get('id'))), {
+    initialValue: null,
+  });
+
+  // === Computed: params valid ===
+  protected readonly paramsValid = computed(() => !!this.projectSlug() && !!this.newsletterId());
+
+  // === Data Signals (Complex — init via private functions) ===
+  protected readonly project: Signal<Project | null> = this.initProject();
+  protected readonly newsletter: Signal<{ id: string; subject: string; body_html: string; status: string; sent_at?: string } | null> =
+    this.initNewsletter();
+
+  // === Computed: draft hidden from non-manager ===
+  protected readonly isDraftHidden = computed(() => {
+    const nl = this.newsletter();
+    const proj = this.project();
+    return nl && nl.status !== 'sent' && proj && !proj.writer;
+  });
+
+  // === Computed: page display strings ===
+  protected readonly pageTitle = computed(() => this.project()?.name || 'Newsletter');
+  protected readonly pageSubtitle = computed(() => {
+    const nl = this.newsletter();
+    return nl?.sent_at ? `Received ${formatDate(nl.sent_at, 'MMM d, y', 'en-US')}` : '';
+  });
+
+  // === Computed: share URL (SSR-safe) ===
+  protected readonly shareUrl = computed(() => {
+    const slug = this.projectSlug();
+    const id = this.newsletterId();
+    if (!slug || !id) return null;
+    const path = `/newsletters/${slug}/${id}`;
+    return toAbsoluteUrl(path, isPlatformBrowser(this.platformId));
+  });
+
+  // === Protected Methods ===
+  protected copyLink(): void {
+    const url = this.shareUrl();
+    if (!url) return;
+
+    const success = this.clipboard.copy(url);
+    if (success) {
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Link Copied',
+        detail: 'Newsletter link copied to clipboard.',
+      });
+    } else {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Copy Failed',
+        detail: 'Failed to copy link. Please try again.',
+      });
+    }
+  }
+
+  protected onBackClick(): void {
+    this.router.navigate(['/newsletters/my']);
+  }
+
+  // === Private Initializers ===
+  private initProject(): Signal<Project | null> {
+    return toSignal(
+      toObservable(this.projectSlug).pipe(
+        filter((slug): slug is string => !!slug),
+        switchMap((slug) => this.projectService.getProject(slug, false).pipe(catchError(() => of(null)))),
+      ),
+      { initialValue: null },
+    );
+  }
+
+  private initNewsletter(): Signal<{ id: string; subject: string; body_html: string; status: string; sent_at?: string } | null> {
+    return toSignal(
+      combineLatest([toObservable(this.project), toObservable(this.newsletterId).pipe(filter((id) => !!id))]).pipe(
+        switchMap(([project, id]) => {
+          if (!project?.uid || !id) return of(null);
+          return this.newsletterService.getNewsletter(project.uid, id).pipe(catchError(() => of(null)));
+        }),
+        finalize(() => {
+          // If draft is hidden from this user, or resources couldn't be loaded, render 404.
+          if (this.isDraftHidden() || (!this.project() && this.projectSlug()) || (!this.newsletter() && this.newsletterId() && this.project())) {
+            this.notFound.set(true);
+          }
+          this.loading.set(false);
+        }),
+      ),
+      { initialValue: null },
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -103,9 +103,18 @@ export class NewsletterReaderComponent {
   // lens-prefixed mount, whose newsletterAccessGuard bounces non-writers to the
   // overview. Switching to the always-allowed 'me' lens first keeps the
   // permalink audience (any authenticated user) able to reach their feed.
-  protected goToMyNewsletters(event: Event): void {
-    event.preventDefault();
+  protected goToMyNewsletters(event: MouseEvent): void {
+    // Persist the lens before branching: setLens writes the lens cookie, so a
+    // browser-handled modified click (new tab/window) also lands on the feed.
     this.lensService.setLens('me');
+
+    // Let the browser honor the href for modified/non-primary clicks — same
+    // guard as the docs-article anchor interception.
+    if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+      return;
+    }
+
+    event.preventDefault();
     void this.router.navigate(['/newsletters/my']);
   }
 

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -11,7 +11,7 @@ import { NewsletterService } from '@services/newsletter.service';
 import { ProjectService } from '@services/project.service';
 import { ClipboardShareService } from '@services/clipboard-share.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, filter, map, of, switchMap } from 'rxjs';
+import { catchError, combineLatest, filter, map, of, startWith, switchMap } from 'rxjs';
 
 import { NewsletterNotFoundComponent } from './newsletter-not-found/newsletter-not-found.component';
 import { NewsletterPreviewComponent } from '../components/newsletter-preview/newsletter-preview.component';
@@ -114,7 +114,12 @@ export class NewsletterReaderComponent {
                 catchError(() => of<NewsletterReaderState>({ loading: false, project, newsletter: null }))
               );
             }),
-            catchError(() => of<NewsletterReaderState>({ loading: false, project: null, newsletter: null }))
+            catchError(() => of<NewsletterReaderState>({ loading: false, project: null, newsletter: null })),
+            // Reset to the skeleton on every param change: the component is
+            // reused across permalink navigations (back/forward between
+            // issues), so without this the previous issue stays on screen
+            // until the new fetch resolves.
+            startWith<NewsletterReaderState>({ loading: true, project: null, newsletter: null })
           )
         )
       ),

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -1,17 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { formatDate, isPlatformBrowser } from '@angular/common';
-import { Component, computed, inject, PLATFORM_ID, Signal } from '@angular/core';
+import { formatDate, isPlatformBrowser, isPlatformServer } from '@angular/common';
+import { Component, computed, inject, PLATFORM_ID, REQUEST_CONTEXT, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
-import { NewsletterReaderState } from '@lfx-one/shared/interfaces';
+import { ActivatedRoute, RouterLink } from '@angular/router';
+import { NewsletterReaderState, ServerRequestContext } from '@lfx-one/shared/interfaces';
 import { toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectService } from '@services/project.service';
 import { ClipboardShareService } from '@services/clipboard-share.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, filter, map, of, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, filter, map, of, startWith, switchMap, tap } from 'rxjs';
 
 import { NewsletterNotFoundComponent } from './newsletter-not-found/newsletter-not-found.component';
 import { NewsletterPreviewComponent } from '../components/newsletter-preview/newsletter-preview.component';
@@ -32,11 +32,11 @@ import { NewsletterPreviewComponent } from '../components/newsletter-preview/new
 export class NewsletterReaderComponent {
   // === Services ===
   private readonly route = inject(ActivatedRoute);
-  private readonly router = inject(Router);
   private readonly projectService = inject(ProjectService);
   private readonly newsletterService = inject(NewsletterService);
   private readonly clipboardShare = inject(ClipboardShareService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly reqContext = inject(REQUEST_CONTEXT, { optional: true }) as ServerRequestContext | null;
 
   // === Route Params (toSignal) ===
   protected readonly projectSlug: Signal<string | null> = toSignal(this.route.paramMap.pipe(map((m) => m.get('projectSlug'))), {
@@ -55,6 +55,7 @@ export class NewsletterReaderComponent {
 
   // === Computed: state projections ===
   protected readonly loading = computed(() => this.state().loading);
+  protected readonly error = computed(() => this.state().error);
   protected readonly project = computed(() => this.state().project);
   protected readonly newsletter = computed(() => this.state().newsletter);
 
@@ -66,8 +67,8 @@ export class NewsletterReaderComponent {
 
   // === Computed: 404 (unresolvable project/newsletter, or draft gated) ===
   protected readonly notFound = computed(() => {
-    const { loading, project, newsletter } = this.state();
-    return !loading && (!project || !newsletter || this.isDraftHidden());
+    const { loading, error, project, newsletter } = this.state();
+    return !loading && !error && (!project || !newsletter || this.isDraftHidden());
   });
 
   // === Computed: page display strings ===
@@ -94,36 +95,61 @@ export class NewsletterReaderComponent {
     this.clipboardShare.copyLink(url, 'Newsletter link copied to clipboard.');
   }
 
-  protected onBackClick(): void {
-    this.router.navigate(['/newsletters/my']);
-  }
-
   // === Private Initializers ===
   private initState(): Signal<NewsletterReaderState> {
     return toSignal(
       combineLatest([toObservable(this.projectSlug), toObservable(this.newsletterId)]).pipe(
         filter((params): params is [string, string] => !!params[0] && !!params[1]),
         switchMap(([slug, id]) =>
+          // getProject swallows upstream failures into `null` internally, so a
+          // bad slug and a project-service outage both land on the not-found
+          // branch — the newsletter fetch below is where real statuses surface.
           this.projectService.getProject(slug, false).pipe(
             switchMap((project) => {
               if (!project?.uid) {
-                return of<NewsletterReaderState>({ loading: false, project: null, newsletter: null });
+                return of<NewsletterReaderState>({ loading: false, error: false, project: null, newsletter: null });
               }
               return this.newsletterService.getNewsletter(project.uid, id).pipe(
-                map((newsletter): NewsletterReaderState => ({ loading: false, project, newsletter })),
-                catchError(() => of<NewsletterReaderState>({ loading: false, project, newsletter: null }))
+                map((newsletter): NewsletterReaderState => ({ loading: false, error: false, project, newsletter })),
+                catchError((err) => {
+                  // 400/404 is the expected "no such newsletter" path; anything
+                  // else (gateway 5xx, network) is a transient failure and must
+                  // not masquerade as a permanent 404.
+                  const status = err?.status;
+                  if (typeof status === 'number' && [400, 404].includes(status)) {
+                    return of<NewsletterReaderState>({ loading: false, error: false, project, newsletter: null });
+                  }
+                  console.error('Failed to load newsletter', err);
+                  return of<NewsletterReaderState>({ loading: false, error: true, project, newsletter: null });
+                })
               );
             }),
-            catchError(() => of<NewsletterReaderState>({ loading: false, project: null, newsletter: null })),
+            // Defensive: getProject catches internally, so anything erroring the
+            // outer stream is unexpected — surface the error state, never a 404.
+            catchError((err) => {
+              console.error('Failed to load newsletter reader state', err);
+              return of<NewsletterReaderState>({ loading: false, error: true, project: null, newsletter: null });
+            }),
+            // Emit a real HTTP 404 during SSR for the not-found branches (missing
+            // project/newsletter or draft gated) — same in-place pattern as
+            // not-found.component.ts. Error states intentionally stay 200-family.
+            tap((state) => {
+              if (isPlatformServer(this.platformId) && this.reqContext && !state.loading && !state.error) {
+                const draftHidden = !!state.newsletter && state.newsletter.status !== 'sent' && !!state.project && !state.project.writer;
+                if (!state.project || !state.newsletter || draftHidden) {
+                  this.reqContext.notFound = true;
+                }
+              }
+            }),
             // Reset to the skeleton on every param change: the component is
             // reused across permalink navigations (back/forward between
             // issues), so without this the previous issue stays on screen
             // until the new fetch resolves.
-            startWith<NewsletterReaderState>({ loading: true, project: null, newsletter: null })
+            startWith<NewsletterReaderState>({ loading: true, error: false, project: null, newsletter: null })
           )
         )
       ),
-      { initialValue: { loading: true, project: null, newsletter: null } }
+      { initialValue: { loading: true, error: false, project: null, newsletter: null } }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -55,8 +55,7 @@ export class NewsletterReaderComponent {
 
   // === Data Signals (Complex — init via private functions) ===
   protected readonly project: Signal<Project | null> = this.initProject();
-  protected readonly newsletter: Signal<{ id: string; subject: string; body_html: string; status: string; sent_at?: string } | null> =
-    this.initNewsletter();
+  protected readonly newsletter: Signal<{ id: string; subject: string; body_html: string; status: string; sent_at?: string } | null> = this.initNewsletter();
 
   // === Computed: draft hidden from non-manager ===
   protected readonly isDraftHidden = computed(() => {
@@ -98,9 +97,9 @@ export class NewsletterReaderComponent {
     return toSignal(
       toObservable(this.projectSlug).pipe(
         filter((slug): slug is string => !!slug),
-        switchMap((slug) => this.projectService.getProject(slug, false).pipe(catchError(() => of(null)))),
+        switchMap((slug) => this.projectService.getProject(slug, false).pipe(catchError(() => of(null))))
       ),
-      { initialValue: null },
+      { initialValue: null }
     );
   }
 
@@ -117,9 +116,9 @@ export class NewsletterReaderComponent {
             this.notFound.set(true);
           }
           this.loading.set(false);
-        }),
+        })
       ),
-      { initialValue: null },
+      { initialValue: null }
     );
   }
 }

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -115,10 +115,10 @@ export class NewsletterReaderComponent {
       combineLatest([toObservable(this.projectSlug), toObservable(this.newsletterId)]).pipe(
         filter((params): params is [string, string] => !!params[0] && !!params[1]),
         switchMap(([slug, id]) =>
-          // getProject swallows upstream failures into `null` internally, so a
-          // bad slug and a project-service outage both land on the not-found
-          // branch — the newsletter fetch below is where real statuses surface.
-          this.projectService.getProject(slug, false).pipe(
+          // Strict slug lookup: propagates HTTP failures so a project-service
+          // outage surfaces as the error state (HTTP 200) rather than being
+          // conflated with a bad slug and emitted as a real SSR 404.
+          this.projectService.getProjectStrict(slug).pipe(
             switchMap((project) => {
               if (!project?.uid) {
                 return of<NewsletterReaderState>({ loading: false, error: false, project: null, newsletter: null });
@@ -138,10 +138,15 @@ export class NewsletterReaderComponent {
                 })
               );
             }),
-            // Defensive: getProject catches internally, so anything erroring the
-            // outer stream is unexpected — surface the error state, never a 404.
+            // Only sees project-fetch errors — the newsletter fetch handles its
+            // own above. 400/404 = no such slug (not-found); anything else is
+            // transient and must not render (or SSR-return) as a 404.
             catchError((err) => {
-              console.error('Failed to load newsletter reader state', err);
+              const status = err?.status;
+              if (typeof status === 'number' && [400, 404].includes(status)) {
+                return of<NewsletterReaderState>({ loading: false, error: false, project: null, newsletter: null });
+              }
+              console.error('Failed to load project for newsletter reader', err);
               return of<NewsletterReaderState>({ loading: false, error: true, project: null, newsletter: null });
             }),
             // Emit a real HTTP 404 during SSR for the not-found branches (missing

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -1,7 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Clipboard } from '@angular/cdk/clipboard';
 import { formatDate, isPlatformBrowser } from '@angular/common';
 import { Component, computed, inject, PLATFORM_ID, signal, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
@@ -10,7 +9,7 @@ import { Project } from '@lfx-one/shared/interfaces';
 import { toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectService } from '@services/project.service';
-import { MessageService } from 'primeng/api';
+import { ClipboardShareService } from '@services/clipboard-share.service';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, combineLatest, finalize, filter, map, of, switchMap } from 'rxjs';
 
@@ -36,8 +35,7 @@ export class NewsletterReaderComponent {
   private readonly router = inject(Router);
   private readonly projectService = inject(ProjectService);
   private readonly newsletterService = inject(NewsletterService);
-  private readonly clipboard = inject(Clipboard);
-  private readonly messageService = inject(MessageService);
+  private readonly clipboardShare = inject(ClipboardShareService);
   private readonly platformId = inject(PLATFORM_ID);
 
   // === WritableSignals ===
@@ -88,20 +86,7 @@ export class NewsletterReaderComponent {
     const url = this.shareUrl();
     if (!url) return;
 
-    const success = this.clipboard.copy(url);
-    if (success) {
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Link Copied',
-        detail: 'Newsletter link copied to clipboard.',
-      });
-    } else {
-      this.messageService.add({
-        severity: 'error',
-        summary: 'Copy Failed',
-        detail: 'Failed to copy link. Please try again.',
-      });
-    }
+    this.clipboardShare.copyLink(url, 'Newsletter link copied to clipboard.');
   }
 
   protected onBackClick(): void {

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -4,9 +4,10 @@
 import { formatDate, isPlatformBrowser, isPlatformServer } from '@angular/common';
 import { Component, computed, inject, PLATFORM_ID, REQUEST_CONTEXT, Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { ActivatedRoute, RouterLink } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { NewsletterReaderState, ServerRequestContext } from '@lfx-one/shared/interfaces';
 import { toAbsoluteUrl } from '@lfx-one/shared/utils';
+import { LensService } from '@services/lens.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectService } from '@services/project.service';
 import { ClipboardShareService } from '@services/clipboard-share.service';
@@ -26,12 +27,14 @@ import { NewsletterPreviewComponent } from '../components/newsletter-preview/new
  */
 @Component({
   selector: 'lfx-newsletter-reader',
-  imports: [NewsletterNotFoundComponent, NewsletterPreviewComponent, RouterLink, SkeletonModule],
+  imports: [NewsletterNotFoundComponent, NewsletterPreviewComponent, SkeletonModule],
   templateUrl: './newsletter-reader.component.html',
 })
 export class NewsletterReaderComponent {
   // === Services ===
   private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly lensService = inject(LensService);
   private readonly projectService = inject(ProjectService);
   private readonly newsletterService = inject(NewsletterService);
   private readonly clipboardShare = inject(ClipboardShareService);
@@ -93,6 +96,17 @@ export class NewsletterReaderComponent {
     if (!url) return;
 
     this.clipboardShare.copyLink(url, 'Newsletter link copied to clipboard.');
+  }
+
+  // The feed is a Me-lens page: with a foundation/project lens active, a plain
+  // routerLink to /newsletters/my gets rewritten by lensRedirectGuard to the
+  // lens-prefixed mount, whose newsletterAccessGuard bounces non-writers to the
+  // overview. Switching to the always-allowed 'me' lens first keeps the
+  // permalink audience (any authenticated user) able to reach their feed.
+  protected goToMyNewsletters(event: Event): void {
+    event.preventDefault();
+    this.lensService.setLens('me');
+    void this.router.navigate(['/newsletters/my']);
   }
 
   // === Private Initializers ===

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -47,4 +47,14 @@ export const NEWSLETTER_ROUTES: Routes = [
     loadComponent: () => import('./newsletter-analytics/newsletter-analytics.component').then((m) => m.NewsletterAnalyticsComponent),
     data: { preload: false },
   },
+  {
+    // Reader page for shareable newsletter permalinks. Any authenticated user
+    // may view sent newsletters (gated upstream on project#viewer, which includes
+    // user:* wildcard). Non-managers cannot view drafts. projectSlug enables
+    // human-readable URLs; slug-to-uid resolution happens in the component.
+    path: ':projectSlug/:id',
+    canActivate: [authGuard],
+    loadComponent: () => import('./newsletter-reader/newsletter-reader.component').then((m) => m.NewsletterReaderComponent),
+    data: { preload: false },
+  },
 ];

--- a/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletters.routes.ts
@@ -47,14 +47,11 @@ export const NEWSLETTER_ROUTES: Routes = [
     loadComponent: () => import('./newsletter-analytics/newsletter-analytics.component').then((m) => m.NewsletterAnalyticsComponent),
     data: { preload: false },
   },
-  {
-    // Reader page for shareable newsletter permalinks. Any authenticated user
-    // may view sent newsletters (gated upstream on project#viewer, which includes
-    // user:* wildcard). Non-managers cannot view drafts. projectSlug enables
-    // human-readable URLs; slug-to-uid resolution happens in the component.
-    path: ':projectSlug/:id',
-    canActivate: [authGuard],
-    loadComponent: () => import('./newsletter-reader/newsletter-reader.component').then((m) => m.NewsletterReaderComponent),
-    data: { preload: false },
-  },
+  // NOTE: the shareable reader permalink (/newsletters/:projectSlug/:id) is
+  // deliberately NOT a child here. This routes file is mounted at the flat
+  // `newsletters` path (behind lensRedirectGuard) and at the lens-prefixed
+  // /foundation/newsletters and /project/newsletters mounts (behind
+  // newsletterAccessGuard) — either mount would break the any-authenticated-user
+  // access model. The reader is mounted directly in app.routes.ts, ahead of the
+  // flat mount.
 ];

--- a/apps/lfx-one/src/app/shared/services/clipboard-share.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/clipboard-share.service.spec.ts
@@ -72,17 +72,6 @@ describe('ClipboardShareService', () => {
     });
   });
 
-  it('should show warning when URL is null', () => {
-    service.copyLink(null as any);
-
-    expect(clipboard.copy).not.toHaveBeenCalled();
-    expect(messageService.add).toHaveBeenCalledWith({
-      severity: 'warn',
-      summary: 'No Link',
-      detail: 'No link available to copy.',
-    });
-  });
-
   it('should show error toast when clipboard copy fails', () => {
     vi.mocked(clipboard.copy).mockReturnValue(false);
     const url = 'https://example.com/newsletter/789';

--- a/apps/lfx-one/src/app/shared/services/clipboard-share.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/clipboard-share.service.spec.ts
@@ -22,11 +22,7 @@ describe('ClipboardShareService', () => {
     };
 
     TestBed.configureTestingModule({
-      providers: [
-        ClipboardShareService,
-        { provide: Clipboard, useValue: mockClipboard },
-        { provide: MessageService, useValue: mockMessageService },
-      ],
+      providers: [ClipboardShareService, { provide: Clipboard, useValue: mockClipboard }, { provide: MessageService, useValue: mockMessageService }],
     });
 
     service = TestBed.inject(ClipboardShareService);

--- a/apps/lfx-one/src/app/shared/services/clipboard-share.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/clipboard-share.service.spec.ts
@@ -1,0 +1,103 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { TestBed } from '@angular/core/testing';
+import { Clipboard } from '@angular/cdk/clipboard';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { MessageService } from 'primeng/api';
+
+import { ClipboardShareService } from './clipboard-share.service';
+
+describe('ClipboardShareService', () => {
+  let service: ClipboardShareService;
+  let clipboard: Clipboard;
+  let messageService: MessageService;
+
+  beforeEach(() => {
+    const mockClipboard = {
+      copy: vi.fn().mockReturnValue(true),
+    };
+    const mockMessageService = {
+      add: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        ClipboardShareService,
+        { provide: Clipboard, useValue: mockClipboard },
+        { provide: MessageService, useValue: mockMessageService },
+      ],
+    });
+
+    service = TestBed.inject(ClipboardShareService);
+    clipboard = TestBed.inject(Clipboard);
+    messageService = TestBed.inject(MessageService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should copy URL to clipboard and show success toast', () => {
+    const url = 'https://example.com/newsletter/123';
+    const detail = 'Shared link copied!';
+
+    service.copyLink(url, detail);
+
+    expect(clipboard.copy).toHaveBeenCalledWith(url);
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Link Copied',
+      detail,
+    });
+  });
+
+  it('should use default detail text when not provided', () => {
+    const url = 'https://example.com/newsletter/456';
+
+    service.copyLink(url);
+
+    expect(clipboard.copy).toHaveBeenCalledWith(url);
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'success',
+      summary: 'Link Copied',
+      detail: 'Link copied to clipboard.',
+    });
+  });
+
+  it('should show warning when URL is empty', () => {
+    service.copyLink('');
+
+    expect(clipboard.copy).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'warn',
+      summary: 'No Link',
+      detail: 'No link available to copy.',
+    });
+  });
+
+  it('should show warning when URL is null', () => {
+    service.copyLink(null as any);
+
+    expect(clipboard.copy).not.toHaveBeenCalled();
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'warn',
+      summary: 'No Link',
+      detail: 'No link available to copy.',
+    });
+  });
+
+  it('should show error toast when clipboard copy fails', () => {
+    vi.mocked(clipboard.copy).mockReturnValue(false);
+    const url = 'https://example.com/newsletter/789';
+
+    service.copyLink(url);
+
+    expect(clipboard.copy).toHaveBeenCalledWith(url);
+    expect(messageService.add).toHaveBeenCalledWith({
+      severity: 'error',
+      summary: 'Copy Failed',
+      detail: 'Failed to copy link. Please try again.',
+    });
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/clipboard-share.service.ts
+++ b/apps/lfx-one/src/app/shared/services/clipboard-share.service.ts
@@ -1,0 +1,47 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Clipboard } from '@angular/cdk/clipboard';
+import { Injectable, inject } from '@angular/core';
+import { MessageService } from 'primeng/api';
+
+/**
+ * Clipboard sharing utility — copies a URL to the clipboard and shows toast feedback.
+ * Centralizes the copy-link+toast pattern used across multiple components.
+ */
+@Injectable({ providedIn: 'root' })
+export class ClipboardShareService {
+  private readonly clipboard = inject(Clipboard);
+  private readonly messageService = inject(MessageService);
+
+  /**
+   * Copy a URL to the clipboard and display success/error toast feedback.
+   * @param url The URL to copy
+   * @param detail Optional custom detail text for the success toast (default: "Link copied to clipboard.")
+   */
+  public copyLink(url: string, detail: string = 'Link copied to clipboard.'): void {
+    if (!url) {
+      this.messageService.add({
+        severity: 'warn',
+        summary: 'No Link',
+        detail: 'No link available to copy.',
+      });
+      return;
+    }
+
+    const success = this.clipboard.copy(url);
+    if (success) {
+      this.messageService.add({
+        severity: 'success',
+        summary: 'Link Copied',
+        detail,
+      });
+    } else {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Copy Failed',
+        detail: 'Failed to copy link. Please try again.',
+      });
+    }
+  }
+}

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -88,6 +88,16 @@ export class ProjectService {
     return this.projectCache.get(cacheKey)!;
   }
 
+  /**
+   * Slug lookup that propagates HTTP failures instead of mapping them to null,
+   * for callers that must distinguish a missing project (400/404) from an
+   * upstream outage (5xx) — e.g. the newsletter reader's SSR 404 signaling.
+   * Uncached and side-effect free (does not touch the active-project state).
+   */
+  public getProjectStrict(slug: string): Observable<Project> {
+    return this.http.get<Project>(`/api/projects/${encodeURIComponent(slug)}`);
+  }
+
   public getProjectSfid(uid: string): Observable<string | null> {
     return this.http.get<{ sfid: string | null }>(`/api/projects/${encodeURIComponent(uid)}/sfid`).pipe(
       map((res) => res.sfid ?? null),

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -170,6 +170,8 @@ export interface Newsletter {
  */
 export interface NewsletterReaderState {
   loading: boolean;
+  /** Unexpected failure (non-404) loading the newsletter — distinct from notFound so 5xx never renders as a permanent 404. */
+  error: boolean;
   project: Project | null;
   newsletter: Newsletter | null;
 }

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { Project } from './project.interface';
+
 export type NewsletterStatusTabId = 'draft' | 'scheduled' | 'sent' | 'optout';
 
 /**
@@ -159,6 +161,17 @@ export interface Newsletter {
   version: number;
   created_at: string;
   updated_at: string;
+}
+
+/**
+ * Load state of the standalone newsletter reader page
+ * (/newsletters/:projectSlug/:id). A single object so loading, resolution
+ * failures, and draft gating all derive from one stream emission.
+ */
+export interface NewsletterReaderState {
+  loading: boolean;
+  project: Project | null;
+  newsletter: Newsletter | null;
 }
 
 export interface CreateNewsletterRequest {


### PR DESCRIPTION
## Summary

Closes #1550

Adds shareable per-issue newsletter permalinks and a copy-link affordance in the reader:

- **New permalink route** `/newsletters/:projectSlug/:id` — a standalone reader page that resolves the project by slug, fetches the issue via the existing project-scoped single-get, and renders it inline (breadcrumb, subject, sent date, copy-link button).
- **Drawer ↔ URL sync on `/newsletters/my`** — opening an issue from the feed adds `?issue=<id>&project=<slug>` to the URL; closing clears them; loading the page with those params auto-opens the drawer (or forwards to the canonical permalink when the issue isn't in the user's feed). Back/forward close/reopen the drawer naturally.
- **Copy-link button** in both the drawer header and the reader page, via a new shared `ClipboardShareService` (cdk `Clipboard` + toast).
- **In-place 404** (`newsletter-not-found`, PR #1471 pattern) for unknown slug/id and for gated drafts.

## Access model (deliberate decision)

- **Any authenticated user** can open a permalink to a **sent** newsletter. This matches the existing upstream authorization surface — `GET /projects/{project_uid}/newsletters/{newsletter_uid}` is Heimdall-gated on `project#viewer`, which the platform FGA model grants to all authenticated users (`user:*`) — and enables the motivating use case (sharing an issue with leadership who aren't committee members).
- **Drafts are gated in-app**: `status !== 'sent'` renders the in-place 404 unless the user has project `writer`. Committee membership continues to gate only the My Newsletters feed list.

## Upstream dependencies

**None.** lfx-v2-newsletter-service is unchanged — the permalink reuses the existing project-scoped single-get already proxied by the BFF. Contract verified read-only against the service's current `main` (route gating, `body_html`/`status` on the DTO, sent-only feed semantics).

## Tests

- New `newsletter-reader.spec.ts` (content) + `newsletter-reader-robust.spec.ts` (structural): sent issue renders, draft as non-writer → 404, draft as writer → renders, bad slug/id → 404, copy-link places the canonical absolute URL on the clipboard.
- Extended `my-newsletters.spec.ts`: row click updates query params, close clears them, deep-load with params auto-opens the drawer, back button closes it.
- Unit specs for the reader component and `ClipboardShareService`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added shareable newsletter reader pages with project and delivery details.
  * Added “Copy link” actions with success, warning, and error notifications.
  * Newsletter previews can open from shareable links and stay synchronized with the page URL.
  * Added clear messaging for missing newsletters, unavailable projects, and restricted drafts.
  * Added loading states and navigation back to My Newsletters.

* **Tests**
  * Expanded automated coverage for sharing, permissions, loading, errors, and reader interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->