### PR TITLE
fix(public-profile): left-align "Powered by" pill on 404 view

### DIFF
--- a/apps/lfx-one/src/app/modules/public-profile/public-profile-page/public-profile-page.component.html
+++ b/apps/lfx-one/src/app/modules/public-profile/public-profile-page/public-profile-page.component.html
@@ -4,7 +4,9 @@
 @if (notFound()) {
   <!-- Keep the "Powered by LFX" branding header on the not-found/private view, matching the loaded profile chrome. -->
   <div class="flex min-h-screen flex-col bg-white text-gray-900">
-    <div class="mx-auto max-w-[1240px] px-4 sm:px-10">
+    <!-- w-full is required here: the wrapper is `flex flex-col`, so without it this `mx-auto` child becomes a
+         shrink-to-content flex item and the "Powered by" pill centers instead of sitting left like the loaded view. -->
+    <div class="mx-auto w-full max-w-[1240px] px-4 sm:px-10">
       <lfx-public-profile-topbar></lfx-public-profile-topbar>
     </div>
     <lfx-public-profile-not-found [isPrivate]="isPrivate()" data-testid="public-profile-not-found"></lfx-public-profile-not-found>


### PR DESCRIPTION
## Summary

- Fix the public-profile **not-found (404)** view centering the "Powered by <LFX>" branding pill instead of left-aligning it like the loaded profile view.
- Root cause: the not-found branch wraps the topbar in a `flex flex-col` parent, which turned the `mx-auto max-w-[1240px]` topbar container into a shrink-to-content flex item — `align-items: stretch` is cancelled by the auto horizontal margins, so the container collapsed to the pill's width and `mx-auto` then centered it.
- Add `w-full` to that container so it fills the row (still capped at `max-w-[1240px]` and centered by `mx-auto`), matching the loaded view.
- Pre-existing bug on `main` (independent of the in-place 404 work in #1471); scoped to a single class change plus an explanatory comment.

Refs LFXV2-3095