### PR TITLE
feat(meetings): canonicalize meeting edit URLs by project tier (GH-1431)

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -65,7 +65,7 @@
             severity="secondary"
             data-testid="edit-meeting-button"
             tooltip="Edit Meeting"
-            [routerLink]="['/meetings', meeting().id, 'edit']"
+            [routerLink]="editCommands()"
             [queryParams]="editQueryParams()"></lfx-button>
         }
         @if (meeting().organizer) {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -44,6 +44,7 @@ import {
   DEFAULT_MEETING_TYPE_CONFIG,
   getCurrentOrNextOccurrence,
   getLargestSessionShareUrl,
+  getMeetingEditCommands,
   getPastMeetingResourceId,
   getPastMeetingTranscriptUrl,
   getUpcomingMeetingStartTime,
@@ -206,6 +207,9 @@ export class MeetingCardComponent implements OnInit {
     if (committeeUid) params['committee_uid'] = committeeUid;
     return params;
   });
+  // Canonical edit URL derives from the MEETING's project tier (is_foundation), not the viewer's
+  // active lens; falls back to the flat path (lensRedirectGuard) when the tier is unenriched.
+  public readonly editCommands: Signal<string[]> = computed(() => getMeetingEditCommands(this.meeting()) ?? ['/meetings', this.meeting().id, 'edit']);
 
   public readonly meetingDeleted = output<void>();
   public readonly project = this.projectService.project;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -45,6 +45,7 @@ import {
   formatTo12HourInTimezone,
   generateRecurrenceObject,
   getDefaultStartDateTime,
+  getMeetingEditCommands,
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
@@ -639,7 +640,13 @@ export class MeetingManageComponent {
         if (ctx) {
           editQueryParams['committee_uid'] = ctx.uid;
         }
-        this.router.navigate(['/meetings', meetingId, 'edit'], { queryParams: editQueryParams });
+        // Canonicalize on the created meeting's project tier — the create flow already resolved it
+        // (projectQueryParamGuard effectiveKind → isFoundationContext), so no extra fetch is needed.
+        const editCommands = getMeetingEditCommands({
+          id: meetingId,
+          is_foundation: this.projectContextService.isFoundationContext(),
+        });
+        this.router.navigate(editCommands ?? ['/meetings', meetingId, 'edit'], { queryParams: editQueryParams });
       } else {
         // Fallback to meetings list if no meeting ID
         this.navigateBack();

--- a/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
@@ -11,6 +11,9 @@ import { LensService } from '../services/lens.service';
  * the user to the lens-prefixed equivalent (`/foundation/...` or `/project/...`)
  * when foundation or project lens is active. Lets the request through unchanged
  * for `me` and `org` lenses, where the flat routes are the canonical destination.
+ * Carve-out: meeting EDIT links bypass this guard entirely — they canonicalize on the
+ * meeting's own project tier (`is_foundation`) via `getMeetingEditCommands`, so me/org-lens
+ * users land on the tier-prefixed `/foundation|project/meetings/{id}/edit` URL.
  *
  * Reads `state.url` so query params and trailing path segments (e.g.
  * `/groups/abc?tab=meetings`) are preserved verbatim across the redirect.

--- a/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
@@ -11,9 +11,11 @@ import { LensService } from '../services/lens.service';
  * the user to the lens-prefixed equivalent (`/foundation/...` or `/project/...`)
  * when foundation or project lens is active. Lets the request through unchanged
  * for `me` and `org` lenses, where the flat routes are the canonical destination.
- * Carve-out: meeting EDIT links bypass this guard entirely — they canonicalize on the
+ * Carve-out: ENRICHED meeting EDIT links bypass this guard entirely — they canonicalize on the
  * meeting's own project tier (`is_foundation`) via `getMeetingEditCommands`, so me/org-lens
- * users land on the tier-prefixed `/foundation|project/meetings/{id}/edit` URL.
+ * users land on the tier-prefixed `/foundation|project/meetings/{id}/edit` URL. When
+ * `is_foundation` is absent (unenriched payload), callers fall back to the flat
+ * `/meetings/{id}/edit` path, which still runs this guard and redirects by active lens.
  *
  * Reads `state.url` so query params and trailing path segments (e.g.
  * `/groups/abc?tab=meetings`) are preserved verbatim across the redirect.

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -19,7 +19,7 @@ import {
   SURVEY_COLOR,
   VOTE_COLOR,
 } from '../constants';
-import {
+import type {
   CustomRecurrencePattern,
   Meeting,
   MeetingOccurrence,
@@ -42,6 +42,7 @@ import {
   collectMeetingOrganizers,
   compareMeetingPeopleByHostThenName,
   convertRecurrenceToPattern,
+  getMeetingEditCommands,
   getMeetingOrganizerDisplayName,
   isCalendarDeadlinePast,
   isMeetingOccurrenceCancelled,
@@ -987,6 +988,20 @@ describe('buildMeetingOccurrenceRoute', () => {
       path: ['/meetings', '99152950841-1630560600000'],
       queryParams: undefined,
     });
+  });
+});
+
+describe('getMeetingEditCommands', () => {
+  it('prefixes foundation-owned meetings with /foundation', () => {
+    expect(getMeetingEditCommands({ id: 'abc-123', is_foundation: true })).toEqual(['/', 'foundation', 'meetings', 'abc-123', 'edit']);
+  });
+
+  it('prefixes regular-project meetings with /project', () => {
+    expect(getMeetingEditCommands({ id: 'abc-123', is_foundation: false })).toEqual(['/', 'project', 'meetings', 'abc-123', 'edit']);
+  });
+
+  it('returns null when is_foundation is absent so callers fall back to the flat path', () => {
+    expect(getMeetingEditCommands({ id: 'abc-123' })).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -18,7 +18,7 @@ import {
 import { lfxColors } from '../constants/colors.constants';
 import { RecurrenceType } from '../enums';
 import { PollStatus } from '../enums/poll.enum';
-import {
+import type {
   BuildMeetingOccurrenceRouteOptions,
   CalendarColor,
   CustomRecurrencePattern,
@@ -656,6 +656,21 @@ export function buildMeetingOccurrenceRoute(
     path: ['/meetings', meetingId],
     queryParams,
   };
+}
+
+/**
+ * Builds the canonical Angular router commands for a meeting's edit page, prefixing the path with
+ * the MEETING's own project tier (`is_foundation`) rather than the viewer's transient active lens:
+ * foundation-owned meetings edit under `/foundation/meetings/{id}/edit`, all other projects under
+ * `/project/meetings/{id}/edit`. Returns null when `is_foundation` is absent (unenriched payload)
+ * so callers can fall back to the flat `/meetings/{id}/edit` path handled by `lensRedirectGuard`.
+ */
+export function getMeetingEditCommands(meeting: Pick<Meeting, 'id' | 'is_foundation'>): string[] | null {
+  if (meeting.is_foundation === undefined) {
+    return null;
+  }
+
+  return ['/', meeting.is_foundation ? 'foundation' : 'project', 'meetings', meeting.id, 'edit'];
 }
 
 /**


### PR DESCRIPTION
## Summary

Meeting edit URLs now canonicalize on the meeting's own project tier instead of the viewer's active lens. Edit links from meeting cards and the post-create redirect resolve to `/foundation/meetings/{id}/edit` or `/project/meetings/{id}/edit` based on the meeting's `is_foundation` flag, falling back to the flat `/meetings/{id}/edit` path (handled by `lensRedirectGuard`) when the payload isn't tier-enriched.

Resolves #1431

## Behavior changes

| Before | After |
|---|---|
| Edit Meeting buttons and the redirect after creating a meeting always pointed at the unprefixed `/meetings/{id}/edit` URL, so where you landed depended on which lens (me, org, foundation, project) you happened to be viewing from. | Edit links go straight to the URL matching the meeting's own project — foundation-owned meetings edit under `/foundation/meetings/{id}/edit`, all other projects under `/project/meetings/{id}/edit` — regardless of the lens you're in. When the project tier isn't known, the old flat URL is used and the existing redirect guard takes over. |

## Technical changes

`packages/shared/src/utils/meeting.utils.ts` — Shared meeting utils
- adds `getMeetingEditCommands(meeting)`, returning tier-prefixed Angular router commands (`['/', 'foundation' | 'project', 'meetings', id, 'edit']`) keyed off the meeting's `is_foundation` flag
- returns `null` when `is_foundation` is absent (unenriched payload) so callers fall back to the flat `/meetings/{id}/edit` path handled by `lensRedirectGuard`

`packages/shared/src/utils/meeting.utils.spec.ts` — Tests
- covers foundation-owned meetings (`/foundation` prefix), regular-project meetings (`/project` prefix), and the unenriched case (`is_foundation` undefined → `null` fallback)

`apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts, meeting-card.component.html` — Meeting card
- replaces the hard-coded `['/meetings', meeting().id, 'edit']` routerLink with an `editCommands` computed that derives the canonical tier-prefixed URL from the meeting, with flat-path fallback; existing `editQueryParams` (committee context) unchanged

`apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts` — Post-create navigation
- post-create redirect now routes to the tier-prefixed edit URL, reusing the create flow's already-resolved `isFoundationContext()` (via `projectQueryParamGuard` effectiveKind) — no extra fetch needed

`apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts` — Guard docs
- documents the me/org-lens carve-out: meeting edit links bypass this guard by canonicalizing on the meeting's own project tier rather than the viewer's transient lens