### PR TITLE
fix(profile): overlay just-saved metadata on Flow C cold return

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -1,0 +1,86 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { computed, PLATFORM_ID, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, Router } from '@angular/router';
+import { PENDING_PROFILE_SAVE_KEY } from '@lfx-one/shared/constants';
+import { CombinedProfile, User } from '@lfx-one/shared/interfaces';
+import { FeatureFlagService } from '@services/feature-flag.service';
+import { UserService } from '@services/user.service';
+import { MessageService } from 'primeng/api';
+import { EMPTY, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProfileLayoutComponent } from './profile-layout.component';
+
+/**
+ * Guards the Flow C (management-token re-auth) cold-return read-your-writes fix (LFXV2-2933):
+ * on a full-page return the replayed save can resolve before the initial profile GET populates
+ * combinedProfile, so the save is stashed and re-applied once a GET lands — an eventually-consistent
+ * (pre-save) GET body must never mask the write. Template is overridden empty so the class logic runs
+ * without instantiating the edit/visibility/panel children and their service graph.
+ */
+describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-2933)', () => {
+  const STALE_PROFILE = {
+    user: { first_name: 'Ada', last_name: 'Lovelace', username: 'ada', email: 'ada@x.io' },
+    profile: { bio: 'OLD BIO', job_title: 'Engineer' },
+  } as unknown as CombinedProfile;
+
+  async function setup(queryParams: Record<string, string>, pendingSave?: unknown): Promise<ComponentFixture<ProfileLayoutComponent>> {
+    if (pendingSave !== undefined) {
+      sessionStorage.setItem(PENDING_PROFILE_SAVE_KEY, JSON.stringify(pendingSave));
+    }
+
+    const getCurrentUserProfile = vi.fn(() => of(STALE_PROFILE));
+    const userServiceMock = {
+      user: signal({ user_id: 'u1' } as unknown as User),
+      impersonating: signal(false),
+      uploadedAvatarUrl: signal<string | null>(null),
+      effectiveAvatarUrl: computed(() => ''),
+      identitiesRefresh$: EMPTY,
+      getCurrentUserProfile,
+      updateUserProfile: vi.fn(() => of({})),
+      getIdentities: vi.fn(() => of([])),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ProfileLayoutComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: ActivatedRoute, useValue: { queryParams: of(queryParams) } },
+        { provide: Router, useValue: { url: '/profile', navigateByUrl: vi.fn() } },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+    // Empty template: exercise the class without rendering the drawer/panel children.
+    TestBed.overrideComponent(ProfileLayoutComponent, { set: { template: '', imports: [] } });
+
+    const fixture = TestBed.createComponent(ProfileLayoutComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return fixture;
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  it('re-applies a stashed save after the initial GET lands, so the pre-save body cannot win', async () => {
+    const fixture = await setup({ success: 'profile_token_obtained' }, { savedAt: Date.now(), userMetadata: { bio: 'NEW BIO' } });
+
+    // The replayed save (bio: NEW BIO) resolved before the eventually-consistent GET (bio: OLD BIO);
+    // the optimistic override must reflect the write, not the stale refetch.
+    expect(fixture.componentInstance.aboutMe()).toBe('NEW BIO');
+  });
+
+  it('does not fabricate an override on a normal cold load with no pending save', async () => {
+    const fixture = await setup({});
+
+    // No stash → reapply is a no-op and the fetched GET body drives the view.
+    expect(fixture.componentInstance.aboutMe()).toBe('OLD BIO');
+  });
+});

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -15,13 +15,13 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ProfileLayoutComponent } from './profile-layout.component';
 
 /**
- * Guards the Flow C (management-token re-auth) cold-return read-your-writes fix (LFXV2-2933):
+ * Guards the Flow C (management-token re-auth) cold-return read-your-writes fix (LFXV2-3267):
  * on a full-page return the replayed save can resolve before the initial profile GET populates
  * combinedProfile, so the save is stashed and re-applied once a GET lands — an eventually-consistent
  * (pre-save) GET body must never mask the write. Template is overridden empty so the class logic runs
  * without instantiating the edit/visibility/panel children and their service graph.
  */
-describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-2933)', () => {
+describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-3267)', () => {
   const STALE_PROFILE = {
     user: { first_name: 'Ada', last_name: 'Lovelace', username: 'ada', email: 'ada@x.io' },
     profile: { bio: 'OLD BIO', job_title: 'Engineer' },

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -9,7 +9,7 @@ import { CombinedProfile, User } from '@lfx-one/shared/interfaces';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
-import { EMPTY, of } from 'rxjs';
+import { EMPTY, Observable, of, Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProfileLayoutComponent } from './profile-layout.component';
@@ -27,12 +27,28 @@ describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-
     profile: { bio: 'OLD BIO', job_title: 'Engineer' },
   } as unknown as CombinedProfile;
 
-  async function setup(queryParams: Record<string, string>, pendingSave?: unknown): Promise<ComponentFixture<ProfileLayoutComponent>> {
+  // A user-only GET body (no profile record) — merging into it would fabricate a profile.
+  const USER_ONLY_PROFILE = {
+    user: { first_name: 'Ada', last_name: 'Lovelace', username: 'ada', email: 'ada@x.io' },
+    profile: null,
+  } as unknown as CombinedProfile;
+
+  // A later, consistent GET carrying a server-side change the stash never touched.
+  const NEWER_PROFILE = {
+    user: { first_name: 'Ada', last_name: 'Lovelace', username: 'ada', email: 'ada@x.io' },
+    profile: { bio: 'SERVER BIO', job_title: 'Manager' },
+  } as unknown as CombinedProfile;
+
+  async function setup(
+    queryParams: Record<string, string>,
+    pendingSave?: unknown,
+    getProfile?: () => Observable<CombinedProfile>
+  ): Promise<ComponentFixture<ProfileLayoutComponent>> {
     if (pendingSave !== undefined) {
       sessionStorage.setItem(PENDING_PROFILE_SAVE_KEY, JSON.stringify(pendingSave));
     }
 
-    const getCurrentUserProfile = vi.fn(() => of(STALE_PROFILE));
+    const getCurrentUserProfile = vi.fn(getProfile ?? (() => of(STALE_PROFILE)));
     const userServiceMock = {
       user: signal({ user_id: 'u1' } as unknown as User),
       impersonating: signal(false),
@@ -70,10 +86,42 @@ describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-
   });
 
   it('re-applies a stashed save after the initial GET lands, so the pre-save body cannot win', async () => {
-    const fixture = await setup({ success: 'profile_token_obtained' }, { savedAt: Date.now(), userMetadata: { bio: 'NEW BIO' } });
+    // Deferred GET: the save is stashed during construction and cannot merge until we emit here, so
+    // the stash branch is provably the path under test — not a warm merge that happened to race first.
+    const profile$ = new Subject<CombinedProfile>();
+    const fixture = await setup({ success: 'profile_token_obtained' }, { savedAt: Date.now(), userMetadata: { bio: 'NEW BIO' } }, () =>
+      profile$.asObservable()
+    );
 
-    // The replayed save (bio: NEW BIO) resolved before the eventually-consistent GET (bio: OLD BIO);
-    // the optimistic override must reflect the write, not the stale refetch.
+    // GET has not resolved: the save was stashed (not applied), so nothing shows yet.
+    expect(fixture.componentInstance.aboutMe()).toBe('');
+
+    // Stale (pre-save) body lands; reapply must win over it.
+    profile$.next(STALE_PROFILE);
+    expect(fixture.componentInstance.aboutMe()).toBe('NEW BIO');
+    // A field the save didn't touch survives the merge.
+    expect(fixture.componentInstance.jobTitle()).toBe('Engineer');
+  });
+
+  it('retains the stash across a null-profile GET, applies once, then clears it', async () => {
+    const profile$ = new Subject<CombinedProfile>();
+    const fixture = await setup({ success: 'profile_token_obtained' }, { savedAt: Date.now(), userMetadata: { bio: 'NEW BIO' } }, () =>
+      profile$.asObservable()
+    );
+
+    // Null-profile GET: reapply is a no-op (merging would fabricate a profile), stash is retained.
+    profile$.next(USER_ONLY_PROFILE);
+    expect(fixture.componentInstance.aboutMe()).toBe('');
+
+    // Real profile lands: the retained stash applies and is cleared.
+    profile$.next(STALE_PROFILE);
+    expect(fixture.componentInstance.aboutMe()).toBe('NEW BIO');
+    expect(fixture.componentInstance.jobTitle()).toBe('Engineer');
+
+    // A later GET must not re-apply the cleared stash: the optimistic override persists (Engineer),
+    // it does not merge onto the newer body (which would surface Manager).
+    profile$.next(NEWER_PROFILE);
+    expect(fixture.componentInstance.jobTitle()).toBe('Engineer');
     expect(fixture.componentInstance.aboutMe()).toBe('NEW BIO');
   });
 

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -77,6 +77,10 @@ export class ProfileLayoutComponent {
   // Store raw CombinedProfile for passing to dialog
   private combinedProfile: CombinedProfile | null = null;
 
+  // A just-saved overlay awaiting a base profile: on the Flow C cold return the save can resolve before
+  // the initial GET, so we stash it and re-apply once a GET lands (see reapplyPendingOptimisticUpdate).
+  private pendingOptimisticMetadata: Partial<UserMetadata> | null = null;
+
   // Tab configuration. The read-only "My CLAs" tab is appended (before Transactions/Settings)
   // only when the `my-clas-enabled` flag is on — matching the route's CanMatch guard.
   private readonly myClasEnabled = this.featureFlagService.getBooleanFlag(MY_CLAS_ENABLED_FLAG, false);
@@ -212,17 +216,12 @@ export class ProfileLayoutComponent {
    * drawer is correct too) and sets it as the optimistic header override.
    */
   private applyOptimisticProfileUpdate(metadata: Partial<UserMetadata>): void {
-    if (!this.combinedProfile) {
-      // No base profile to merge into yet (e.g. Flow C cold load, where the save resolves before
-      // the initial profile GET populates combinedProfile). Fall back to a refetch so the UI still
-      // reflects the change — there's nothing cached to clobber in this case.
-      this.refreshProfile$.next();
-      return;
-    }
-
-    // A null profile means the GET never loaded; merging would fabricate a non-null profile and flip
-    // the drawer's metadataLoaded true, letting a later save wipe unloaded fields. Refetch instead.
-    if (this.combinedProfile.profile == null) {
+    // No base profile to merge into yet (Flow C cold load, or a user-only GET with no profile record
+    // where merging would fabricate one and flip the drawer's metadataLoaded true). Stash the save +
+    // refetch; reapplyPendingOptimisticUpdate merges it once a base profile lands, so an eventually-
+    // consistent (pre-save) body can't mask the write.
+    if (!this.combinedProfile || this.combinedProfile.profile == null) {
+      this.pendingOptimisticMetadata = { ...(this.pendingOptimisticMetadata ?? {}), ...metadata };
       this.refreshProfile$.next();
       return;
     }
@@ -247,6 +246,20 @@ export class ProfileLayoutComponent {
 
     this.combinedProfile = mergedProfile;
     this.optimisticProfileData.set(this.mapToHeaderData(mergedProfile));
+    // The merge supersedes any stash; clear it so a later GET doesn't re-apply a now-stale overlay.
+    this.pendingOptimisticMetadata = null;
+  }
+
+  // After a GET populates combinedProfile, re-apply a save that was stashed because no base profile
+  // existed when it resolved (Flow C cold return), so an eventually-consistent (pre-save) body can't
+  // mask the write. No-op until a real profile record lands (merging a null profile would fabricate one).
+  private reapplyPendingOptimisticUpdate(): void {
+    const pending = this.pendingOptimisticMetadata;
+    if (!pending || this.combinedProfile?.profile == null) {
+      return;
+    }
+    this.pendingOptimisticMetadata = null;
+    this.applyOptimisticProfileUpdate(pending);
   }
 
   /**
@@ -371,7 +384,13 @@ export class ProfileLayoutComponent {
             filter((user) => user !== null),
             switchMap(() =>
               this.userService.getCurrentUserProfile().pipe(
-                map((profile: CombinedProfile) => this.mapToHeaderData(profile)),
+                map((profile: CombinedProfile) => {
+                  const headerData = this.mapToHeaderData(profile);
+                  // Read-your-writes: if a save landed before this GET (Flow C cold return), re-apply it
+                  // now that combinedProfile is populated so a stale (pre-save) body can't win.
+                  this.reapplyPendingOptimisticUpdate();
+                  return headerData;
+                }),
                 catchError(() => of(null))
               )
             )

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -11,7 +11,7 @@ import { buildProfileTabs } from '@lfx-one/shared/utils';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
-import { BehaviorSubject, catchError, EMPTY, filter, map, of, startWith, switchMap } from 'rxjs';
+import { BehaviorSubject, catchError, EMPTY, filter, map, of, startWith, switchMap, tap } from 'rxjs';
 
 import { stripAuthPrefixOrNull } from '@app/shared/utils/strip-auth-prefix.util';
 import { ProfileEditDrawerComponent } from '../../modules/profile/components/profile-edit-drawer/profile-edit-drawer.component';
@@ -384,13 +384,10 @@ export class ProfileLayoutComponent {
             filter((user) => user !== null),
             switchMap(() =>
               this.userService.getCurrentUserProfile().pipe(
-                map((profile: CombinedProfile) => {
-                  const headerData = this.mapToHeaderData(profile);
-                  // Read-your-writes: if a save landed before this GET (Flow C cold return), re-apply it
-                  // now that combinedProfile is populated so a stale (pre-save) body can't win.
-                  this.reapplyPendingOptimisticUpdate();
-                  return headerData;
-                }),
+                map((profile: CombinedProfile) => this.mapToHeaderData(profile)),
+                // Read-your-writes: if a save landed before this GET (Flow C cold return), re-apply it
+                // now that combinedProfile is populated so a stale (pre-save) body can't win.
+                tap(() => this.reapplyPendingOptimisticUpdate()),
                 catchError(() => of(null))
               )
             )


### PR DESCRIPTION
## Summary

- On the Flow C (management-token re-auth) **cold return**, the replayed profile
  save can resolve before the initial profile GET populates `combinedProfile`.
  The old "no base profile yet" branch did a bare refetch, so an
  eventually-consistent (pre-save) GET body displayed with nothing to override
  it — briefly re-seeding the panel and a reopened edit drawer with the old
  value (worse for cleared free-text fields, which now send `''`).
- Stash the just-saved metadata in `pendingOptimisticMetadata` and re-apply it
  via `reapplyPendingOptimisticUpdate()` once a GET lands a base profile, giving
  cold return the same read-your-writes guarantee the warm path already has.
- The re-apply is a no-op until a real profile record lands (merging a null
  profile would fabricate one and wrongly flip the drawer's `metadataLoaded`),
  and the stash is cleared after a merge so a later GET can't re-apply a stale
  overlay.
- Add component unit tests: the cold-return re-apply (stashed save wins over the
  stale GET body) and the no-stash no-op path.

Fixes LFXV2-3267