### PR TITLE
feat(newsletters): open permalink in a new tab

### DIFF
--- a/apps/lfx-one/e2e/my-newsletters.spec.ts
+++ b/apps/lfx-one/e2e/my-newsletters.spec.ts
@@ -243,4 +243,30 @@ test.describe('My Newsletters — Me-lens feed', () => {
     // Success toast appears
     await expect(page.getByText('Link Copied')).toBeVisible();
   });
+
+  test('subject renders as a real link to the canonical permalink', async ({ page }) => {
+    await gotoMyNewsletters(page);
+
+    const subjectLink = page.getByTestId(`my-newsletters-open-${MOCK_NEWSLETTERS[0].id}`);
+    await expect(subjectLink).toHaveAttribute('href', `/newsletters/${MOCK_NEWSLETTERS[0].project_slug}/${MOCK_NEWSLETTERS[0].id}`);
+  });
+
+  test('new-tab button in drawer header opens the permalink in a new tab', async ({ page, context }) => {
+    await gotoMyNewsletters(page);
+
+    await page.getByTestId(`my-newsletters-row-${MOCK_NEWSLETTERS[0].id}`).click();
+    const drawer = page.getByTestId('my-newsletters-preview-drawer');
+    await expect(drawer.locator('[data-e2e="newsletter-body-marker"]')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    const newTabButton = page.getByTestId('newsletter-preview-drawer-open-new-tab');
+    await expect(newTabButton).toHaveAttribute('target', '_blank');
+    await expect(newTabButton).toHaveAttribute('rel', /noopener/);
+    await expect(newTabButton).toHaveAttribute('href', `/newsletters/${MOCK_NEWSLETTERS[0].project_slug}/${MOCK_NEWSLETTERS[0].id}`);
+
+    const [newPage] = await Promise.all([context.waitForEvent('page'), newTabButton.click()]);
+    await expect(newPage).toHaveURL(new RegExp(`/newsletters/${MOCK_NEWSLETTERS[0].project_slug}/${MOCK_NEWSLETTERS[0].id}`));
+
+    // Original tab's drawer stays open — the new tab is a separate context.
+    await expect(drawer).toBeVisible();
+  });
 });

--- a/apps/lfx-one/e2e/my-newsletters.spec.ts
+++ b/apps/lfx-one/e2e/my-newsletters.spec.ts
@@ -86,14 +86,14 @@ async function stubMyNewslettersApi(page: Page, newsletters: MyNewsletter[]): Pr
 
 // The preview drawer fetches the full newsletter (incl. body_html) via the
 // project-scoped get when a row is clicked.
-async function stubNewsletterDetailApi(page: Page): Promise<void> {
+async function stubNewsletterDetailApi(page: Page, newsletters: MyNewsletter[] = MOCK_NEWSLETTERS): Promise<void> {
   await page.route('**/api/projects/*/newsletters/*', (route) => {
     if (route.request().method() !== 'GET') {
       return route.fallback();
     }
     const pathname = new URL(route.request().url()).pathname;
     const newsletterUid = pathname.split('/').pop() ?? '';
-    const match = MOCK_NEWSLETTERS.find((n) => n.id === newsletterUid);
+    const match = newsletters.find((n) => n.id === newsletterUid);
     if (!match) {
       return route.fulfill({ status: 404, contentType: 'application/json', body: JSON.stringify({ message: 'newsletter not found' }) });
     }
@@ -268,5 +268,31 @@ test.describe('My Newsletters — Me-lens feed', () => {
 
     // Original tab's drawer stays open — the new tab is a separate context.
     await expect(drawer).toBeVisible();
+  });
+
+  test('subject without a resolved project_slug degrades to a plain drawer opener', async ({ page }) => {
+    // project_slug is an enrichment field that can fail to resolve upstream —
+    // the subject anchor should omit its href (no dead/misleading permalink)
+    // while the click-to-open-drawer behavior keeps working.
+    const newsletterWithoutSlug: MyNewsletter = {
+      id: 'c0000000-0000-0000-0000-000000000003',
+      project_uid: PROJECT_UID,
+      subject: 'Untitled Project Update',
+      sent_at: '2026-05-01T12:00:00Z',
+      project_name: 'Test Project',
+      is_foundation: false,
+      parent_project_uid: FOUNDATION_UID,
+    };
+    await stubMyNewslettersApi(page, [newsletterWithoutSlug]);
+    await stubNewsletterDetailApi(page, [newsletterWithoutSlug]);
+    await gotoMyNewsletters(page);
+
+    const subjectLink = page.getByTestId(`my-newsletters-open-${newsletterWithoutSlug.id}`);
+    await expect(subjectLink).not.toHaveAttribute('href');
+
+    // Clicking still opens the drawer via the fetch-then-open path.
+    await subjectLink.click();
+    const drawer = page.getByTestId('my-newsletters-preview-drawer');
+    await expect(drawer.locator('[data-e2e="newsletter-body-marker"]')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
   });
 });

--- a/apps/lfx-one/e2e/my-newsletters.spec.ts
+++ b/apps/lfx-one/e2e/my-newsletters.spec.ts
@@ -261,7 +261,10 @@ test.describe('My Newsletters — Me-lens feed', () => {
     const newTabButton = page.getByTestId('newsletter-preview-drawer-open-new-tab');
     await expect(newTabButton).toHaveAttribute('target', '_blank');
     await expect(newTabButton).toHaveAttribute('rel', /noopener/);
-    await expect(newTabButton).toHaveAttribute('href', `/newsletters/${MOCK_NEWSLETTERS[0].project_slug}/${MOCK_NEWSLETTERS[0].id}`);
+    // The drawer's shareUrl is the absolute permalink (toAbsoluteUrl against the current origin),
+    // unlike the list's row anchor, which is relative.
+    const expectedUrl = new URL(`/newsletters/${MOCK_NEWSLETTERS[0].project_slug}/${MOCK_NEWSLETTERS[0].id}`, page.url()).toString();
+    await expect(newTabButton).toHaveAttribute('href', expectedUrl);
 
     const [newPage] = await Promise.all([context.waitForEvent('page'), newTabButton.click()]);
     await expect(newPage).toHaveURL(new RegExp(`/newsletters/${MOCK_NEWSLETTERS[0].project_slug}/${MOCK_NEWSLETTERS[0].id}`));

--- a/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/components/newsletter-preview-drawer/newsletter-preview-drawer.component.html
@@ -18,6 +18,16 @@
       </div>
       <div class="flex items-center gap-2">
         @if (shareUrl()) {
+          <a
+            [href]="shareUrl()"
+            target="_blank"
+            rel="noopener noreferrer"
+            class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors no-underline"
+            title="Open in new tab"
+            aria-label="Open newsletter in a new tab"
+            data-testid="newsletter-preview-drawer-open-new-tab">
+            <i class="fa-light fa-arrow-up-right-from-square text-xl"></i>
+          </a>
           <button
             type="button"
             (click)="onCopyLink()"

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -88,7 +88,7 @@
             </lfx-empty-state>
           } @else {
             <lfx-table
-              [value]="filteredNewsletters()"
+              [value]="filteredNewsletterRows()"
               [loading]="loading()"
               [paginator]="filteredNewsletters().length > 10"
               [rows]="10"
@@ -112,20 +112,37 @@
                 <tr class="group cursor-pointer" (click)="onRowClick($event, newsletter)" [attr.data-testid]="'my-newsletters-row-' + newsletter.id">
                   <td>
                     <div class="flex items-center gap-2 min-w-0">
-                      <a
-                        [attr.href]="issuePath(newsletter)"
-                        class="lfx-table-name-link text-sm text-gray-900 font-medium truncate min-w-0"
-                        [attr.aria-label]="'Open newsletter ' + newsletter.subject"
-                        [pTooltip]="newsletter.subject"
-                        tooltipEvent="both"
-                        tooltipPosition="top"
-                        (click)="onOpenSubject($event, newsletter)"
-                        [attr.data-testid]="'my-newsletters-open-' + newsletter.id">
-                        {{ newsletter.subject }}
-                      </a>
+                      <!-- Real anchor when a permalink resolves (native new-tab/right-click);
+                           otherwise a button, so the href-less case stays keyboard-focusable
+                           and Enter/Space-activatable instead of a non-interactive <a>. -->
+                      @if (newsletter.issuePath) {
+                        <a
+                          [attr.href]="newsletter.issuePath"
+                          class="lfx-table-name-link text-sm text-gray-900 font-medium truncate min-w-0"
+                          [attr.aria-label]="'Open newsletter ' + newsletter.subject"
+                          [pTooltip]="newsletter.subject"
+                          tooltipEvent="both"
+                          tooltipPosition="top"
+                          (click)="onOpenSubject($event, newsletter)"
+                          [attr.data-testid]="'my-newsletters-open-' + newsletter.id">
+                          {{ newsletter.subject }}
+                        </a>
+                      } @else {
+                        <button
+                          type="button"
+                          class="lfx-table-name-link text-sm text-gray-900 font-medium truncate min-w-0 text-left"
+                          [attr.aria-label]="'Open newsletter ' + newsletter.subject"
+                          [pTooltip]="newsletter.subject"
+                          tooltipEvent="both"
+                          tooltipPosition="top"
+                          (click)="onOpenSubject($event, newsletter)"
+                          [attr.data-testid]="'my-newsletters-open-' + newsletter.id">
+                          {{ newsletter.subject }}
+                        </button>
+                      }
                       @if (openingId() === newsletter.id) {
                         <i class="fa-light fa-spinner-third fa-spin text-sm text-gray-400 flex-none" aria-hidden="true"></i>
-                      } @else if (issuePath(newsletter)) {
+                      } @else if (newsletter.issuePath) {
                         <i
                           class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 flex-none opacity-0 group-hover:opacity-100 transition-opacity"
                           aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -105,14 +105,16 @@
               </ng-template>
 
               <ng-template #body let-newsletter>
-                <!-- The subject button is the accessible control (real button role, native
-                     Enter/Space); the row click is a supplementary pointer convenience. -->
-                <tr class="cursor-pointer" (click)="onOpenNewsletter(newsletter)" [attr.data-testid]="'my-newsletters-row-' + newsletter.id">
+                <!-- The subject anchor is the accessible control (real link role, native
+                     Enter/Space, right-click "Open in new tab"); the row click is a
+                     supplementary pointer convenience. `group` scopes the hover-revealed
+                     new-tab icon to this row. -->
+                <tr class="group cursor-pointer" (click)="onRowClick($event, newsletter)" [attr.data-testid]="'my-newsletters-row-' + newsletter.id">
                   <td>
                     <div class="flex items-center gap-2 min-w-0">
-                      <button
-                        type="button"
-                        class="lfx-table-name-link text-sm text-gray-900 font-medium text-left truncate min-w-0"
+                      <a
+                        [attr.href]="issuePath(newsletter)"
+                        class="lfx-table-name-link text-sm text-gray-900 font-medium truncate min-w-0"
                         [attr.aria-label]="'Open newsletter ' + newsletter.subject"
                         [pTooltip]="newsletter.subject"
                         tooltipEvent="both"
@@ -120,9 +122,13 @@
                         (click)="onOpenSubject($event, newsletter)"
                         [attr.data-testid]="'my-newsletters-open-' + newsletter.id">
                         {{ newsletter.subject }}
-                      </button>
+                      </a>
                       @if (openingId() === newsletter.id) {
                         <i class="fa-light fa-spinner-third fa-spin text-sm text-gray-400 flex-none" aria-hidden="true"></i>
+                      } @else if (issuePath(newsletter)) {
+                        <i
+                          class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 flex-none opacity-0 group-hover:opacity-100 transition-opacity"
+                          aria-hidden="true"></i>
                       }
                     </div>
                   </td>

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -12,7 +12,7 @@ import { InputTextComponent } from '@components/input-text/input-text.component'
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
 import { MyNewsletter } from '@lfx-one/shared/interfaces';
-import { toAbsoluteUrl } from '@lfx-one/shared/utils';
+import { newsletterIssuePath, toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { PersonaService } from '@services/persona.service';
 import { MessageService } from 'primeng/api';
@@ -97,7 +97,7 @@ export class MyNewslettersComponent {
   protected readonly selectedShareUrl: Signal<string | null> = computed(() => {
     const selected = this.selected();
     if (!selected?.project_slug || !selected.id) return null;
-    return toAbsoluteUrl(`/newsletters/${selected.project_slug}/${selected.id}`, isPlatformBrowser(this.platformId));
+    return toAbsoluteUrl(newsletterIssuePath(selected.project_slug, selected.id), isPlatformBrowser(this.platformId));
   });
 
   // === Constructor ===
@@ -137,6 +137,21 @@ export class MyNewslettersComponent {
   }
 
   // === Protected Methods ===
+  /**
+   * Relative permalink href for a row's subject anchor — lets modified clicks,
+   * middle-click, and right-click ("Open in new tab") reach the reader page
+   * natively. `project_slug` is an enrichment field that can fail to resolve
+   * upstream; the anchor omits its `href` in that case (see `onOpenSubject`).
+   */
+  protected issuePath(newsletter: MyNewsletter): string | null {
+    return newsletter.project_slug ? newsletterIssuePath(newsletter.project_slug, newsletter.id) : null;
+  }
+
+  /** True for a modified click (new-tab intent) that the browser, not this component, should handle. */
+  protected isModifiedClick(event: MouseEvent): boolean {
+    return event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey;
+  }
+
   protected onOpenNewsletter(newsletter: MyNewsletter): void {
     if (this.openingId()) {
       return;
@@ -177,12 +192,26 @@ export class MyNewslettersComponent {
   }
 
   /**
-   * Subject-button click handler: the button is the accessible control (real
-   * role, native Enter/Space); stopPropagation keeps the supplementary row
-   * click from firing a second open.
+   * Subject-anchor click handler: the anchor is the accessible control (real
+   * link role, native Enter/Space, right-click "Open in new tab"/"Copy link
+   * address"); stopPropagation keeps the supplementary row click from firing
+   * a second open. A modified click (Cmd/Ctrl/Shift/Alt/middle-click) is left
+   * to the browser so it opens the permalink in a new tab instead of the drawer.
    */
-  protected onOpenSubject(event: Event, newsletter: MyNewsletter): void {
+  protected onOpenSubject(event: MouseEvent, newsletter: MyNewsletter): void {
     event.stopPropagation();
+    if (this.isModifiedClick(event)) {
+      return;
+    }
+    event.preventDefault();
+    this.onOpenNewsletter(newsletter);
+  }
+
+  /** Row click handler: same modified-click guard as the subject anchor, so a Cmd-click anywhere in the row is a no-op rather than opening the drawer with no new tab. */
+  protected onRowClick(event: MouseEvent, newsletter: MyNewsletter): void {
+    if (this.isModifiedClick(event)) {
+      return;
+    }
     this.onOpenNewsletter(newsletter);
   }
 

--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.ts
@@ -11,7 +11,7 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
-import { MyNewsletter } from '@lfx-one/shared/interfaces';
+import { MyNewsletter, MyNewsletterRow } from '@lfx-one/shared/interfaces';
 import { newsletterIssuePath, toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { NewsletterService } from '@services/newsletter.service';
 import { PersonaService } from '@services/persona.service';
@@ -85,6 +85,14 @@ export class MyNewslettersComponent {
   protected readonly foundationOptions: Signal<{ label: string; value: string | null }[]> = this.initFoundationOptions();
   protected readonly projectOptions: Signal<{ label: string; value: string | null }[]> = this.initProjectOptions();
   protected readonly filteredNewsletters: Signal<MyNewsletter[]> = this.initFilteredNewsletters();
+  /**
+   * `filteredNewsletters()` with each row's permalink path precomputed —
+   * the table template reads `row.issuePath` rather than calling a
+   * template function per row (frontend-checklist.md § 4).
+   */
+  protected readonly filteredNewsletterRows: Signal<MyNewsletterRow[]> = computed(() =>
+    this.filteredNewsletters().map((newsletter) => ({ ...newsletter, issuePath: this.issuePath(newsletter) }))
+  );
   protected readonly showFoundationFilter: Signal<boolean> = computed(() => this.foundationOptions().length > 1);
   protected readonly showProjectFilter: Signal<boolean> = computed(() => this.projectOptions().length > 1);
   protected readonly hasActiveFilters: Signal<boolean> = computed(() => !!(this.searchTerm().trim() || this.foundationFilter() || this.projectFilter()));

--- a/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
+++ b/apps/lfx-one/src/app/modules/newsletters/newsletter-reader/newsletter-reader.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, inject, PLATFORM_ID, REQUEST_CONTEXT, Signal } fro
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
 import { NewsletterReaderState, ServerRequestContext } from '@lfx-one/shared/interfaces';
-import { toAbsoluteUrl } from '@lfx-one/shared/utils';
+import { newsletterIssuePath, toAbsoluteUrl } from '@lfx-one/shared/utils';
 import { LensService } from '@services/lens.service';
 import { NewsletterService } from '@services/newsletter.service';
 import { ProjectService } from '@services/project.service';
@@ -86,8 +86,7 @@ export class NewsletterReaderComponent {
     const slug = this.projectSlug();
     const id = this.newsletterId();
     if (!slug || !id) return null;
-    const path = `/newsletters/${slug}/${id}`;
-    return toAbsoluteUrl(path, isPlatformBrowser(this.platformId));
+    return toAbsoluteUrl(newsletterIssuePath(slug, id), isPlatformBrowser(this.platformId));
   });
 
   // === Protected Methods ===

--- a/packages/shared/src/interfaces/newsletter.interface.ts
+++ b/packages/shared/src/interfaces/newsletter.interface.ts
@@ -249,6 +249,15 @@ export interface MyNewsletter extends CommitteeNewsletter {
   parent_project_uid?: string;
 }
 
+/**
+ * `MyNewsletter` row precomputed with its permalink path, so the My
+ * Newsletters list template reads `row.issuePath` instead of calling a
+ * template function per row (`null` when `project_slug` failed to resolve).
+ */
+export interface MyNewsletterRow extends MyNewsletter {
+  issuePath: string | null;
+}
+
 export interface NewsletterListParams {
   status?: NewsletterStatus;
   page_token?: string;

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -56,3 +56,4 @@ export * from './committee-engagement-display.utils';
 export * from './committee-engagement-freshness.utils';
 export * from './public-profile.utils';
 export * from './brand-kit.utils';
+export * from './newsletter.utils';

--- a/packages/shared/src/utils/newsletter.utils.spec.ts
+++ b/packages/shared/src/utils/newsletter.utils.spec.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { newsletterIssuePath } from './newsletter.utils';
+
+describe('newsletterIssuePath', () => {
+  it('builds the relative permalink path from a project slug and newsletter id', () => {
+    expect(newsletterIssuePath('cncf', 'abc123')).toBe('/newsletters/cncf/abc123');
+  });
+
+  it('does not encode or otherwise transform its inputs', () => {
+    expect(newsletterIssuePath('kubernetes', 'issue-42')).toBe('/newsletters/kubernetes/issue-42');
+  });
+});

--- a/packages/shared/src/utils/newsletter.utils.ts
+++ b/packages/shared/src/utils/newsletter.utils.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Builds the relative path to a newsletter issue's canonical permalink page
+ * (`NewsletterReaderComponent`, mounted at `/newsletters/:projectSlug/:id`).
+ * Combine with `toAbsoluteUrl` for a shareable/copyable absolute URL.
+ * @param projectSlug - The newsletter's project slug
+ * @param newsletterId - The newsletter issue id
+ * @returns The relative permalink path, e.g. `/newsletters/cncf/abc123`
+ */
+export function newsletterIssuePath(projectSlug: string, newsletterId: string): string {
+  return `/newsletters/${projectSlug}/${newsletterId}`;
+}


### PR DESCRIPTION
## Summary

Adds an "open in new tab" affordance for the newsletter issue permalink shipped in #1550:

- **Preview drawer header**: a new-tab icon (↗) placed before the existing copy-link icon, reusing the same `shareUrl`. Clicking opens the permalink in a new tab via a native `<a target="_blank" rel="noopener noreferrer">`; the drawer stays open in the original tab.
- **My Newsletters list**: the subject cell is now a real `<a>` pointing at the relative permalink (previously a `<button>` with no `href`), so Cmd/Ctrl-click, middle-click, and right-click → "Open in new tab" / "Copy link address" all work natively. A plain click still opens the drawer (via `preventDefault` + the existing fetch-then-open flow). A hover-revealed external-link icon signals the affordance without adding a table column.
- Row clicks and the subject anchor share a modified-click guard, so a Cmd-click anywhere in the row is a no-op rather than opening the drawer with no new tab.
- Extracted `newsletterIssuePath()` into `@lfx-one/shared/utils` so the permalink route shape (`/newsletters/:projectSlug/:id`) isn't duplicated across the drawer, list, and reader page.

Closes linuxfoundation/lfx-self-serve#1571
Follow-on to linuxfoundation/lfx-self-serve#1550

## Accepted trade-off

`project_slug` is an upstream enrichment field that can fail to resolve. When it's missing, the subject anchor intentionally has no `href` (rather than falling back to a misleading link, e.g. the newsletter listing page) — click-to-open-drawer still works. Covered by a dedicated e2e test (`subject without a resolved project_slug degrades to a plain drawer opener`).

## Testing

- `yarn build` — SSR bundle builds clean
- `yarn lint` — clean (1 pre-existing unrelated warning)
- `./check-headers.sh` — clean
- `packages/shared` vitest suite — 796/796 passing (incl. new `newsletter.utils.spec.ts`)
- New/updated Playwright coverage in `apps/lfx-one/e2e/my-newsletters.spec.ts`:
  - subject renders as a real link to the canonical permalink
  - new-tab button in drawer header opens the permalink in a new tab
  - subject without a resolved `project_slug` degrades to a plain drawer opener
  - Verified via CI — local Playwright runs in this environment hit a live Auth0 consent-page redirect that blocks all tests in this spec file (pre-existing tests fail identically), unrelated to this change.

## Reviews run pre-PR

- Post-commit trio (both commits) + full-branch sweep — `lfx-general-code-reviewer`, `lfx-self-serve-code-reviewer`, `lfx-self-serve-learnings-reviewer` — all clean, no findings.
- `/lfx-self-serve-pr-readiness` — READY.
- `/preflight` — all checks pass.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added canonical permalink links for newsletter subjects.
  - Added an option to open newsletter previews in a new browser tab.
  - Added hover and keyboard-accessible controls for newsletter links.
  - Preserved drawer navigation for standard clicks while supporting modified-click permalink behavior.

- **Bug Fixes**
  - Added fallback handling when a project slug is unavailable.
  - Standardized newsletter sharing and permalink URL generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->