### PR TITLE
fix(newsletters): drop hover new-tab icon from list rows

### DIFF
--- a/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
+++ b/apps/lfx-one/src/app/modules/newsletters/my-newsletters/my-newsletters.component.html
@@ -107,9 +107,8 @@
               <ng-template #body let-newsletter>
                 <!-- The subject anchor is the accessible control (real link role, native
                      Enter/Space, right-click "Open in new tab"); the row click is a
-                     supplementary pointer convenience. `group` scopes the hover-revealed
-                     new-tab icon to this row. -->
-                <tr class="group cursor-pointer" (click)="onRowClick($event, newsletter)" [attr.data-testid]="'my-newsletters-row-' + newsletter.id">
+                     supplementary pointer convenience. -->
+                <tr class="cursor-pointer" (click)="onRowClick($event, newsletter)" [attr.data-testid]="'my-newsletters-row-' + newsletter.id">
                   <td>
                     <div class="flex items-center gap-2 min-w-0">
                       <!-- Real anchor when a permalink resolves (native new-tab/right-click);
@@ -142,10 +141,6 @@
                       }
                       @if (openingId() === newsletter.id) {
                         <i class="fa-light fa-spinner-third fa-spin text-sm text-gray-400 flex-none" aria-hidden="true"></i>
-                      } @else if (newsletter.issuePath) {
-                        <i
-                          class="fa-light fa-arrow-up-right-from-square text-[11px] text-gray-400 flex-none opacity-0 group-hover:opacity-100 transition-opacity"
-                          aria-hidden="true"></i>
                       }
                     </div>
                   </td>


### PR DESCRIPTION
## Summary

Follow-up refinement to #1550 / #1571's new-tab affordances: removes the hover-revealed
external-link icon from the My Newsletters list rows.

The permalink is still reachable via the drawer's new-tab button (added in the earlier
PR). The list-row icon added visual noise on hover without a clear win now that the
subject cell itself already behaves like a real link (native new-tab/right-click via
its `href`) — the icon was redundant signaling.

## Changes

- `my-newsletters.component.html`: drop the hover-revealed `fa-arrow-up-right-from-square`
  icon and the now-unused `group` class/comment on the row `<tr>`. The subject anchor's
  href-driven new-tab/right-click behavior is unaffected.

## Testing

- `./check-headers.sh`, `yarn format:check`, `yarn lint:check`, `yarn build` — all clean
- Manual visual check: hovering a row subject no longer shows the icon; plain click still
  opens the drawer; Cmd/Ctrl-click / middle-click / right-click on the subject still work
  natively (unchanged, since the anchor's `href` is untouched)

## Reviews run pre-PR

- `/lfx-self-serve-pr-readiness` — READY (branch renamed to `feat/GH-1571` per convention)
- `/preflight` — all mechanical checks clean
