### PR TITLE
fix(committees): default send notification email to unchecked

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/add-member-dialog/add-member-dialog.component.ts
@@ -131,7 +131,7 @@ export class AddMemberDialogComponent {
     organization: new FormControl(''),
     organization_url: new FormControl(''),
     organization_id: new FormControl<string | null>(null),
-    send_notification: new FormControl<boolean>(true, { nonNullable: true }),
+    send_notification: new FormControl<boolean>(false, { nonNullable: true }),
   });
   public readonly searchForm = new FormGroup({ query: new FormControl('') });
 

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
@@ -316,7 +316,7 @@ export class MemberFormComponent {
         voting_status_start: new FormControl(null),
         voting_status_end: new FormControl(null),
         permission: new FormControl<CommitteePermissionLevel>('member'),
-        send_notification: new FormControl<boolean>(true, { nonNullable: true }),
+        send_notification: new FormControl<boolean>(false, { nonNullable: true }),
       },
       {
         validators: this.committee?.enable_voting


### PR DESCRIPTION
## Summary

- Default the **Send notification email** toggle to unchecked in both the Add Member dialog and the member form component.
- Operators can still opt in per-addition when a notification is actually desired.

## Changes

| File | Change |
|---|---|
| `add-member-dialog.component.ts` | `send_notification` FormControl initial value `true` → `false` |
| `member-form.component.ts` | `send_notification` FormControl initial value `true` → `false` |

## Motivation

Bulk additions and support-ticket-driven additions do not want notification emails sent. Defaulting to unchecked saves operators time and eliminates accidental emails.

Closes #1433

Made with [Cursor](https://cursor.com)