### PR TITLE
fix: enforceed auth on campaigns and marketing analytics routes

### DIFF
--- a/apps/lfx-one/src/server/middleware/require-executive-director.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/require-executive-director.middleware.spec.ts
@@ -134,4 +134,33 @@ describe('requireExecutiveDirector', () => {
 
     expect(verdict(next)).toBe('deny');
   });
+
+  // campaigns.route.ts scopes by `project` rather than `foundationSlug` — the middleware must
+  // honor that convention too, not just analytics.route.ts's.
+  it('allows an ED using the project parameter as scope', async () => {
+    getPersonas.mockResolvedValue(edFor(['tlf', 'cncf']));
+    const next = vi.fn();
+
+    await requireExecutiveDirector(buildReq({ project: 'cncf' }), {} as Response, next as unknown as NextFunction);
+
+    expect(verdict(next)).toBe('allow');
+  });
+
+  it('denies an ED requesting a project they do not hold the persona for', async () => {
+    getPersonas.mockResolvedValue(edFor(['tlf']));
+    const next = vi.fn();
+
+    await requireExecutiveDirector(buildReq({ project: 'cncf' }), {} as Response, next as unknown as NextFunction);
+
+    expect(verdict(next)).toBe('deny');
+  });
+
+  it('prefers foundationSlug over project when both are present', async () => {
+    getPersonas.mockResolvedValue(edFor(['tlf']));
+    const next = vi.fn();
+
+    await requireExecutiveDirector(buildReq({ foundationSlug: 'tlf', project: 'cncf' }), {} as Response, next as unknown as NextFunction);
+
+    expect(verdict(next)).toBe('allow');
+  });
 });

--- a/apps/lfx-one/src/server/middleware/require-executive-director.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/require-executive-director.middleware.ts
@@ -42,7 +42,11 @@ export async function requireExecutiveDirector(req: Request, res: Response, next
       return;
     }
 
-    const requestedSlug = typeof req.query['foundationSlug'] === 'string' ? req.query['foundationSlug'] : '';
+    // Analytics routes scope by `foundationSlug`; campaigns routes scope by `project` — same
+    // concept, two names carried over from each route file's own convention.
+    const requestedSlug =
+      (typeof req.query['foundationSlug'] === 'string' ? req.query['foundationSlug'] : '') ||
+      (typeof req.query['project'] === 'string' ? req.query['project'] : '');
 
     // No slug on the request means there is nothing to scope against — the handler is responsible
     // for rejecting a missing required parameter, and unscoped ED endpoints stay allowed.

--- a/apps/lfx-one/src/server/routes/analytics.route.ts
+++ b/apps/lfx-one/src/server/routes/analytics.route.ts
@@ -143,21 +143,22 @@ router.get('/org-involvement-event-attendance-monthly', (req, res, next) => anal
 router.get('/org-involvement-certified-employees-monthly', (req, res, next) => analyticsController.orgCertifiedEmployeesMonthly(req, res, next));
 router.get('/org-involvement-training-enrollments', (req, res, next) => analyticsController.orgTrainingEnrollments(req, res, next));
 
-// Web activities summary endpoint (marketing dashboard)
-router.get('/web-activities-summary', (req, res, next) => analyticsController.getWebActivitiesSummary(req, res, next));
+// Web activities summary endpoint (marketing dashboard) — ED-only surface, same as the
+// events-overview-summary/event-roster/event-detail endpoints below.
+router.get('/web-activities-summary', requireExecutiveDirector, (req, res, next) => analyticsController.getWebActivitiesSummary(req, res, next));
 
 // Email CTR endpoint (marketing dashboard)
-router.get('/email-ctr', (req, res, next) => analyticsController.getEmailCtr(req, res, next));
+router.get('/email-ctr', requireExecutiveDirector, (req, res, next) => analyticsController.getEmailCtr(req, res, next));
 
 // Social reach endpoint (marketing dashboard)
-router.get('/social-reach', (req, res, next) => analyticsController.getSocialReach(req, res, next));
+router.get('/social-reach', requireExecutiveDirector, (req, res, next) => analyticsController.getSocialReach(req, res, next));
 
 // Keyword performance endpoint (marketing dashboard)
-router.get('/keyword-performance', (req, res, next) => analyticsController.getKeywordPerformance(req, res, next));
+router.get('/keyword-performance', requireExecutiveDirector, (req, res, next) => analyticsController.getKeywordPerformance(req, res, next));
 
 // Social media endpoints (marketing dashboard)
-router.get('/social-media', (req, res, next) => analyticsController.getSocialMedia(req, res, next));
-router.get('/social-media/monthly', (req, res, next) => analyticsController.getSocialMediaMonthly(req, res, next));
+router.get('/social-media', requireExecutiveDirector, (req, res, next) => analyticsController.getSocialMedia(req, res, next));
+router.get('/social-media/monthly', requireExecutiveDirector, (req, res, next) => analyticsController.getSocialMediaMonthly(req, res, next));
 
 // North Star metrics endpoints (executive director dashboard)
 router.get('/member-retention', (req, res, next) => analyticsController.getMemberRetention(req, res, next));
@@ -203,13 +204,15 @@ router.get('/event-roster', requireExecutiveDirector, (req, res, next) => analyt
 // per-tier sponsorship breakdown and CFP status. The drawer that opens it is ED-only
 // client-side, so authorization is enforced here with server-verified persona detection.
 router.get('/event-detail', requireExecutiveDirector, (req, res, next) => analyticsController.getEventDetail(req, res, next));
-router.get('/brand-reach', (req, res, next) => analyticsController.getBrandReach(req, res, next));
-router.get('/brand-health', (req, res, next) => analyticsController.getBrandHealth(req, res, next));
-router.get('/revenue-impact', (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
-router.get('/marketing-attribution', (req, res, next) => analyticsController.getMarketingAttribution(req, res, next));
+router.get('/brand-reach', requireExecutiveDirector, (req, res, next) => analyticsController.getBrandReach(req, res, next));
+router.get('/brand-health', requireExecutiveDirector, (req, res, next) => analyticsController.getBrandHealth(req, res, next));
+router.get('/revenue-impact', requireExecutiveDirector, (req, res, next) => analyticsController.getRevenueImpact(req, res, next));
+router.get('/marketing-attribution', requireExecutiveDirector, (req, res, next) => analyticsController.getMarketingAttribution(req, res, next));
 
-// Multi-foundation summary endpoint (multi-foundation dashboard)
-router.get('/multi-foundation-summary', (req, res, next) => analyticsController.getMultiFoundationSummary(req, res, next));
+// Multi-foundation summary endpoint (multi-foundation dashboard). Scoped by a `slugs` list rather
+// than a single foundationSlug/project, so requireExecutiveDirector only enforces the ED gate here,
+// not per-slug scoping — same as any other unscoped ED endpoint.
+router.get('/multi-foundation-summary', requireExecutiveDirector, (req, res, next) => analyticsController.getMultiFoundationSummary(req, res, next));
 
 // Org Lens — bootstrap account context (display attrs + cdev mapping + tier)
 router.get('/org-lens-account-context', (req, res, next) => analyticsController.getOrgLensAccountContext(req, res, next));

--- a/apps/lfx-one/src/server/routes/campaigns.route.ts
+++ b/apps/lfx-one/src/server/routes/campaigns.route.ts
@@ -4,31 +4,35 @@
 import { Router } from 'express';
 
 import { CampaignController } from '../controllers/campaign.controller';
+import { requireExecutiveDirector } from '../middleware/require-executive-director.middleware';
 
 const router = Router();
 const campaignController = new CampaignController();
 
-router.post('/brief/generate', (req, res, next) => campaignController.generateBrief(req, res, next));
-router.post('/brief/refine', (req, res, next) => campaignController.refineBrief(req, res, next));
-router.post('/brief/persist', (req, res, next) => campaignController.persistBrief(req, res, next));
-router.get('/brief', (req, res, next) => campaignController.loadBrief(req, res, next));
-router.post('/create', (req, res, next) => campaignController.createCampaign(req, res, next));
-router.get('/jobs/:jobId', (req, res, next) => campaignController.getJobStatus(req, res, next));
+// Campaigns are an ED-only surface client-side (`executiveDirectorGuard` on /foundation/campaigns).
+// Every endpoint here is gated the same way server-side — none of this data or these actions
+// should be reachable by an authenticated non-ED caller.
+router.post('/brief/generate', requireExecutiveDirector, (req, res, next) => campaignController.generateBrief(req, res, next));
+router.post('/brief/refine', requireExecutiveDirector, (req, res, next) => campaignController.refineBrief(req, res, next));
+router.post('/brief/persist', requireExecutiveDirector, (req, res, next) => campaignController.persistBrief(req, res, next));
+router.get('/brief', requireExecutiveDirector, (req, res, next) => campaignController.loadBrief(req, res, next));
+router.post('/create', requireExecutiveDirector, (req, res, next) => campaignController.createCampaign(req, res, next));
+router.get('/jobs/:jobId', requireExecutiveDirector, (req, res, next) => campaignController.getJobStatus(req, res, next));
 // The email channel's template picker. Registered before `/hubspot/utm` only for reading order —
 // the paths do not overlap.
-router.get('/hubspot/emails', (req, res, next) => campaignController.searchHubSpotEmails(req, res, next));
-router.get('/hubspot/utm', (req, res, next) => campaignController.lookupHubSpotUtm(req, res, next));
-router.post('/hubspot/utm/create', (req, res, next) => campaignController.createHubSpotUtm(req, res, next));
-router.get('/monitor', (req, res, next) => campaignController.getMonitorData(req, res, next));
-router.get('/linkedin/accounts', (req, res) => campaignController.getLinkedInAccounts(req, res));
-router.get('/linkedin/monitor', (req, res, next) => campaignController.getLinkedInMonitor(req, res, next));
-router.get('/reddit/accounts', (req, res) => campaignController.getRedditAccounts(req, res));
-router.get('/reddit/monitor', (req, res, next) => campaignController.getRedditMonitor(req, res, next));
-router.get('/meta/accounts', (req, res) => campaignController.getMetaAccounts(req, res));
-router.get('/meta/monitor', (req, res, next) => campaignController.getMetaMonitor(req, res, next));
-router.get('/keywords', (req, res, next) => campaignController.getKeywords(req, res, next));
-router.get('/audience', (req, res, next) => campaignController.getAudience(req, res, next));
-router.post('/keywords/actions', (req, res, next) => campaignController.executeKeywordActions(req, res, next));
-router.patch('/:campaignId/status', (req, res, next) => campaignController.updateCampaignStatus(req, res, next));
+router.get('/hubspot/emails', requireExecutiveDirector, (req, res, next) => campaignController.searchHubSpotEmails(req, res, next));
+router.get('/hubspot/utm', requireExecutiveDirector, (req, res, next) => campaignController.lookupHubSpotUtm(req, res, next));
+router.post('/hubspot/utm/create', requireExecutiveDirector, (req, res, next) => campaignController.createHubSpotUtm(req, res, next));
+router.get('/monitor', requireExecutiveDirector, (req, res, next) => campaignController.getMonitorData(req, res, next));
+router.get('/linkedin/accounts', requireExecutiveDirector, (req, res) => campaignController.getLinkedInAccounts(req, res));
+router.get('/linkedin/monitor', requireExecutiveDirector, (req, res, next) => campaignController.getLinkedInMonitor(req, res, next));
+router.get('/reddit/accounts', requireExecutiveDirector, (req, res) => campaignController.getRedditAccounts(req, res));
+router.get('/reddit/monitor', requireExecutiveDirector, (req, res, next) => campaignController.getRedditMonitor(req, res, next));
+router.get('/meta/accounts', requireExecutiveDirector, (req, res) => campaignController.getMetaAccounts(req, res));
+router.get('/meta/monitor', requireExecutiveDirector, (req, res, next) => campaignController.getMetaMonitor(req, res, next));
+router.get('/keywords', requireExecutiveDirector, (req, res, next) => campaignController.getKeywords(req, res, next));
+router.get('/audience', requireExecutiveDirector, (req, res, next) => campaignController.getAudience(req, res, next));
+router.post('/keywords/actions', requireExecutiveDirector, (req, res, next) => campaignController.executeKeywordActions(req, res, next));
+router.patch('/:campaignId/status', requireExecutiveDirector, (req, res, next) => campaignController.updateCampaignStatus(req, res, next));
 
 export default router;


### PR DESCRIPTION
## Summary
- `campaigns.route.ts` applied no authorization middleware to any of its 17 endpoints, including writes (`POST /create`, `PATCH /:campaignId/status`) — gating was client-side only via the `executiveDirectorGuard` route guard.
- Several ED-only marketing analytics endpoints in `analytics.route.ts` had the same gap.
- Wires `requireExecutiveDirector` onto all of these, reusing the same server-verified persona check already applied to the three event-analytics endpoints.
- Generalizes `require-executive-director.middleware.ts`'s scope check to read either `foundationSlug` (analytics.route.ts's convention) or `project` (campaigns.route.ts's convention) — the two route families name the same scoping concept differently, so the middleware previously only ever scope-checked the analytics side even where applied.
- `multi-foundation-summary` and `PATCH /:campaignId/status` have no single-slug param to scope against (a `slugs` list and no param, respectively), so only the base ED-persona gate applies there, consistent with existing unscoped-endpoint behavior.

This closes a live server-side authorization hole (LFXV2-2231 epic gap-analysis, item G3) independent of the epic's FGA-based re-implementation — it reuses the existing ED-persona server check rather than attempting the epic's `campaign_manager`/`marketing_auditor` relation work.

JIRA: LFXV2-3290

## Test plan
- [x] `yarn format` / `yarn lint` / `yarn build` all pass
- [x] Added unit tests for the middleware's `project`/`foundationSlug` scope fallback and precedence (`require-executive-director.middleware.spec.ts`)
- [x] Reviewer trio (general, self-serve conventions, learnings) run clean on both commits and on the full-branch diff
- [ ] Manual verification in a deployed env: confirm a non-ED authenticated user gets 403 on `POST /api/campaigns/create` and `GET /api/analytics/brand-health`