### PR TITLE
fix(profile): make profile hub rail responsive on mobile

### DIFF
--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -98,9 +98,13 @@ const VIEWPORTS = [
   { name: 'desktop-narrow', width: 1439, height: 900 },
 ] as const;
 
-// The panel's own max-w-md cap (below sm only) — sm:max-w-none removes it from sm up.
+// The panel's own max-w-md cap (below sm only) — sm:max-w-none removes it from sm up. The cap's
+// pixel value is read off the element's computed style at assertion time (see below) rather than
+// hard-coded here: apps/lfx-one/src/styles.scss sets `html { font-size: 14px }`, so max-w-md
+// (28rem) actually renders at 392px in this app, not the browser-default-root 448px a naive
+// rem-to-px conversion would suggest — a hard-coded constant would silently drift from the real
+// cap on any root-font-size or Tailwind maxWidth change.
 const SM_BREAKPOINT = 640;
-const MAX_MD_WIDTH = 448;
 
 // Desktop control: at and above 2xl, the rail must be the fixed overlay again — the regression
 // guard for the rail disappearing entirely rather than just moving breakpoints. Requested a margin
@@ -205,15 +209,20 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
         const wrapperPosition = await panelRail.evaluate((el) => getComputedStyle(el).position);
         expect(wrapperPosition, `profile panel rail position at ${vp.width}px should not be fixed`).not.toBe('fixed');
 
-        // Below sm, the rail wrapper is capped at max-w-md (448px) so it stays a proportioned stacked
-        // card instead of stretching wide while its internals are still fully stacked (a content
-        // column can exceed 448px below the 640px sm breakpoint once page padding is this small, e.g.
-        // ~510px at a 550px viewport). This regression was introduced and reverted twice on this
-        // branch before this assertion existed.
-        if (vp.width < SM_BREAKPOINT) {
+        // Below sm, the rail wrapper is capped at max-w-md so it stays a proportioned stacked card
+        // instead of stretching wide while its internals are still fully stacked (the content column
+        // can exceed the cap below the 640px sm breakpoint once page padding is this small — this app
+        // renders max-w-md at 392px, not the naive 448px, because of the 14px root font-size noted
+        // above). This regression was introduced and reverted twice on this branch before this
+        // assertion existed. Gated on clientWidth, not vp.width, for the same scrollbar reason as the
+        // md/lg checks above — a classic desktop scrollbar can put clientWidth on the other side of
+        // SM_BREAKPOINT from vp.width.
+        if (overflow.clientWidth < SM_BREAKPOINT) {
           const railBox = await panelRail.boundingBox();
           expect(railBox, 'profile panel rail should have a bounding box').not.toBeNull();
-          expect(railBox!.width, `profile panel rail width at ${vp.width}px should be capped at max-w-md`).toBeLessThanOrEqual(MAX_MD_WIDTH + 1);
+          const capPx = await panelRail.evaluate((el) => parseFloat(getComputedStyle(el).maxWidth));
+          expect(capPx, `profile panel rail max-width at ${vp.width}px should be a real px cap, not "none"`).toBeGreaterThan(0);
+          expect(railBox!.width, `profile panel rail width at ${vp.width}px should be capped at max-w-md (${capPx}px)`).toBeLessThanOrEqual(capPx + 1);
         }
 
         // Inline placement: the panel should be left-aligned with the content column (both children of

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -27,8 +27,9 @@
  * Drives an explicit viewport matrix (mirrors e2e/docs/responsive.spec.ts) covering mobile and
  * tablet widths up to just under the `lg` breakpoint, rather than relying on whichever project
  * happens to run it — so the tablet band (768-1023px) is exercised too, not just mobile-chrome's
- * fixed 393px. Because that matrix forces its own viewport per test, it also runs under the
- * chromium/firefox desktop projects now (not just mobile-chrome) — so width comparisons read
+ * fixed 393px. This spec runs under all three playwright.config.ts projects (chromium, firefox,
+ * mobile-chrome — none scope out e2e/**); because the matrix forces its own viewport per test, the
+ * desktop projects exercise the sub-lg bands too, so width comparisons read
  * document.documentElement.clientWidth rather than the device viewport width, since desktop
  * projects render a classic scrollbar that mobile-emulated overlay scrollbars don't.
  *

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -82,8 +82,8 @@ const TWO_XL_BREAKPOINT = 1440;
 const CONTENT_MAX = 1024;
 
 // Sub-2xl matrix: narrow phone, the mobile-chrome project's own size (Pixel 5), a landscape-phone
-// band between 393 and the sm breakpoint (see MAX_MD_WIDTH below — this is the one viewport where
-// the panel's own max-w-md cap is load-bearing; regressed and reinstated twice on this branch
+// band between 393 and the sm breakpoint (see the max-w-md cap assertion below — this is the one
+// viewport where the panel's own cap is load-bearing; regressed and reinstated twice on this branch
 // without a dedicated assertion before this entry was added), the tablet band, iPad landscape, a
 // split-screen laptop window, and just under the 2xl breakpoint itself — every band the inline-card
 // layout now needs to hold up across.
@@ -98,13 +98,16 @@ const VIEWPORTS = [
   { name: 'desktop-narrow', width: 1439, height: 900 },
 ] as const;
 
-// The panel's own max-w-md cap (below sm only) — sm:max-w-none removes it from sm up. The cap's
-// pixel value is read off the element's computed style at assertion time (see below) rather than
-// hard-coded here: apps/lfx-one/src/styles.scss sets `html { font-size: 14px }`, so max-w-md
-// (28rem) actually renders at 392px in this app, not the browser-default-root 448px a naive
-// rem-to-px conversion would suggest — a hard-coded constant would silently drift from the real
-// cap on any root-font-size or Tailwind maxWidth change.
 const SM_BREAKPOINT = 640;
+
+// max-w-md is 28rem. apps/lfx-one/src/styles.scss sets `html { font-size: 14px }`, so it renders at
+// 392px in this app, not the browser-default-root 448px a naive rem-to-px conversion would suggest.
+// The expected cap below is computed from this rem value times the *actual* root font-size read at
+// assertion time (immune to a root-font-size change), not read off the tested element's own computed
+// max-width — reading the "expected" value off the same element being asserted on would make the
+// check tautological (box-sizing: border-box guarantees a rendered width can never exceed its own
+// max-width, so that assertion could never fail regardless of which class were actually applied).
+const MAX_MD_REM = 28;
 
 // Desktop control: at and above 2xl, the rail must be the fixed overlay again — the regression
 // guard for the rail disappearing entirely rather than just moving breakpoints. Requested a margin
@@ -211,18 +214,25 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
 
         // Below sm, the rail wrapper is capped at max-w-md so it stays a proportioned stacked card
         // instead of stretching wide while its internals are still fully stacked (the content column
-        // can exceed the cap below the 640px sm breakpoint once page padding is this small — this app
-        // renders max-w-md at 392px, not the naive 448px, because of the 14px root font-size noted
-        // above). This regression was introduced and reverted twice on this branch before this
-        // assertion existed. Gated on clientWidth, not vp.width, for the same scrollbar reason as the
-        // md/lg checks above — a classic desktop scrollbar can put clientWidth on the other side of
-        // SM_BREAKPOINT from vp.width.
+        // can exceed the cap below the 640px sm breakpoint once page padding is this small). This
+        // regression was introduced and reverted twice on this branch before this assertion existed.
+        // Gated on clientWidth, not vp.width, for the same scrollbar reason as the md/lg checks above
+        // — a classic desktop scrollbar can put clientWidth on the other side of SM_BREAKPOINT from
+        // vp.width.
         if (overflow.clientWidth < SM_BREAKPOINT) {
           const railBox = await panelRail.boundingBox();
           expect(railBox, 'profile panel rail should have a bounding box').not.toBeNull();
-          const capPx = await panelRail.evaluate((el) => parseFloat(getComputedStyle(el).maxWidth));
-          expect(capPx, `profile panel rail max-width at ${vp.width}px should be a real px cap, not "none"`).toBeGreaterThan(0);
-          expect(railBox!.width, `profile panel rail width at ${vp.width}px should be capped at max-w-md (${capPx}px)`).toBeLessThanOrEqual(capPx + 1);
+
+          // Expected cap is derived independently of the tested element (MAX_MD_REM x the actual root
+          // font-size), not read off panelRail's own computed max-width — reading the expectation off
+          // the same element being measured would make the assertion tautological (box-sizing: border-
+          // box guarantees a rendered width can never exceed its own max-width, so that comparison
+          // could never fail regardless of which class were actually applied).
+          const rootFontSize = await page.evaluate(() => parseFloat(getComputedStyle(document.documentElement).fontSize));
+          const expectedCapPx = MAX_MD_REM * rootFontSize;
+          expect(railBox!.width, `profile panel rail width at ${vp.width}px should be capped at max-w-md (${expectedCapPx}px)`).toBeLessThanOrEqual(
+            expectedCapPx + 1
+          );
         }
 
         // Inline placement: the panel should be left-aligned with the content column (both children of

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -12,9 +12,10 @@
  * (390 - 300px gutter - 40px page padding).
  *
  * The breakpoint moved from `lg` (1024px) to `2xl` (1440px) in a LFXV2-3285 follow-up: the hub
- * spends 712px on fixed chrome before any content — 348px left sidebar (lg:ml-[348px] on <main>,
- * unrelated and unchanged by this follow-up) + 300px rail + 64px page padding (md:px-8). At `lg`
- * that left a 312px content column, narrower than the rail beside it; at `2xl` it leaves 728px.
+ * spends 704px on fixed chrome before any content — 348px left sidebar (lg:ml-[348px] on <main>,
+ * unrelated and unchanged by this follow-up) + 300px rail + 56px page padding (md:px-8, which is
+ * 2rem per side at this app's 14px root — not the 64px a 16px-root assumption would give). At `lg`
+ * that left a 320px content column, narrower than the rail beside it; at `2xl` it leaves 736px.
  * Keeping the inline card until `2xl` also covers iPad landscape and split-screen laptop windows.
  *
  * The existing profile specs (profile-edit-drawer.spec.ts, profile-visibility-drawer.spec.ts) pass
@@ -203,11 +204,25 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
         // the real root font-size, not the 40px/64px a 16px-root assumption would give (35px/56px
         // here). Once the viewport crosses lg (the sidebar's own, unrelated breakpoint), the 348px
         // sidebar also reserves space, and the content column stops growing past max-w-[1024px]
-        // regardless. Both breakpoint checks key off clientWidth, not vp.width — the media queries the
-        // app actually evaluates run against the layout viewport, which a classic desktop scrollbar
-        // shrinks below the requested device width (same reasoning as the scrollWidth check above).
-        const pagePadding = (overflow.clientWidth >= MD_BREAKPOINT ? PAGE_PADDING_REM_AT_MD : PAGE_PADDING_REM_BELOW_MD) * rootFontSize;
-        const sidebar = overflow.clientWidth >= LG_BREAKPOINT ? SIDEBAR_WIDTH : 0;
+        // regardless.
+        //
+        // Whether md:/lg: are actually active is read via matchMedia rather than compared against
+        // clientWidth or vp.width: the matrix's own tablet viewport (768px) sits exactly on
+        // MD_BREAKPOINT, and browser engines don't agree on which viewport metric a min-width query
+        // resolves against when a classic scrollbar is present — Chromium tracks clientWidth (scrollbar
+        // excluded, same reasoning as the scrollWidth check above), but Firefox tracks the
+        // scrollbar-inclusive viewport, so a clientWidth-threshold comparison can read "below md" at
+        // exactly 768px in Firefox while the browser's own CSS has already applied md:px-8. Asking the
+        // engine directly sidesteps the disagreement entirely.
+        const { isMdActive, isLgActive } = await page.evaluate(
+          ([md, lg]) => ({
+            isMdActive: window.matchMedia(`(min-width: ${md}px)`).matches,
+            isLgActive: window.matchMedia(`(min-width: ${lg}px)`).matches,
+          }),
+          [MD_BREAKPOINT, LG_BREAKPOINT]
+        );
+        const pagePadding = (isMdActive ? PAGE_PADDING_REM_AT_MD : PAGE_PADDING_REM_BELOW_MD) * rootFontSize;
+        const sidebar = isLgActive ? SIDEBAR_WIDTH : 0;
         const expectedContentWidth = Math.min(CONTENT_MAX, overflow.clientWidth - sidebar - pagePadding);
         const contentBox = await content.boundingBox();
         expect(contentBox, 'content column should have a bounding box').not.toBeNull();

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -64,9 +64,14 @@ test.setTimeout(60_000);
 
 const LOAD_TIMEOUT = 20_000;
 
-// The breakpoint at which the page container's own horizontal padding steps up
-// (px-5 -> md:px-8, see main-layout.component.html), used to derive the width-slack tolerance.
+// The breakpoint at which the page container's own horizontal padding steps up (px-5 -> md:px-8,
+// see main-layout.component.html), used to derive the width-slack tolerance. In rem, not px — like
+// MAX_MD_REM below, this app's html { font-size: 14px } (styles.scss) means a naive 16px-root
+// rem-to-px conversion (px-5 -> 40px, md:px-8 -> 64px) would be wrong; the actual px value is
+// derived from the root font-size read at assertion time.
 const MD_BREAKPOINT = 768;
+const PAGE_PADDING_REM_BELOW_MD = 2.5; // px-5 = 1.25rem per side x 2
+const PAGE_PADDING_REM_AT_MD = 4; // md:px-8 = 2rem per side x 2
 
 // The sidebar's own breakpoint (unrelated to the profile-rail breakpoint this follow-up moves) —
 // <main> picks up lg:ml-[348px] here, which the content-width expectation below must account for.
@@ -101,12 +106,8 @@ const VIEWPORTS = [
 const SM_BREAKPOINT = 640;
 
 // max-w-md is 28rem. apps/lfx-one/src/styles.scss sets `html { font-size: 14px }`, so it renders at
-// 392px in this app, not the browser-default-root 448px a naive rem-to-px conversion would suggest.
-// The expected cap below is computed from this rem value times the *actual* root font-size read at
-// assertion time (immune to a root-font-size change), not read off the tested element's own computed
-// max-width — reading the "expected" value off the same element being asserted on would make the
-// check tautological (box-sizing: border-box guarantees a rendered width can never exceed its own
-// max-width, so that assertion could never fail regardless of which class were actually applied).
+// 392px in this app, not the browser-default-root 448px a naive rem-to-px conversion would suggest
+// (see the cap assertion below for how — and why — this is derived at assertion time).
 const MAX_MD_REM = 28;
 
 // Desktop control: at and above 2xl, the rail must be the fixed overlay again — the regression
@@ -186,15 +187,21 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
         }));
         expect(overflow.scrollWidth, `document scrollWidth at ${vp.width}px`).toBeLessThanOrEqual(overflow.clientWidth + 1);
 
+        // The root font-size this app actually renders at (styles.scss sets html { font-size: 14px })
+        // — shared by the page-padding and max-w-md cap derivations below so neither has to hard-code
+        // a px value that would silently drift from the real one on a root-font-size change.
+        const rootFontSize = await page.evaluate(() => parseFloat(getComputedStyle(document.documentElement).fontSize));
+
         // The content column must reclaim (close to) the available layout width — not be squeezed by
         // an unconditional right gutter reserved for a rail that, below 2xl, no longer renders as a
-        // fixed overlay. Page padding is px-5 (40px total) below md, md:px-8 (64px total) at md and up.
-        // Once the viewport crosses lg (the sidebar's own, unrelated breakpoint), the 348px sidebar
-        // also reserves space, and the content column stops growing past max-w-[1024px] regardless.
-        // Both breakpoint checks key off clientWidth, not vp.width — the media queries the app
-        // actually evaluates run against the layout viewport, which a classic desktop scrollbar
+        // fixed overlay. Page padding is px-5 below md, md:px-8 at md and up — derived from rem times
+        // the real root font-size, not the 40px/64px a 16px-root assumption would give (35px/56px
+        // here). Once the viewport crosses lg (the sidebar's own, unrelated breakpoint), the 348px
+        // sidebar also reserves space, and the content column stops growing past max-w-[1024px]
+        // regardless. Both breakpoint checks key off clientWidth, not vp.width — the media queries the
+        // app actually evaluates run against the layout viewport, which a classic desktop scrollbar
         // shrinks below the requested device width (same reasoning as the scrollWidth check above).
-        const pagePadding = overflow.clientWidth >= MD_BREAKPOINT ? 64 : 40;
+        const pagePadding = (overflow.clientWidth >= MD_BREAKPOINT ? PAGE_PADDING_REM_AT_MD : PAGE_PADDING_REM_BELOW_MD) * rootFontSize;
         const sidebar = overflow.clientWidth >= LG_BREAKPOINT ? SIDEBAR_WIDTH : 0;
         const expectedContentWidth = Math.min(CONTENT_MAX, overflow.clientWidth - sidebar - pagePadding);
         const contentBox = await content.boundingBox();
@@ -225,11 +232,21 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
 
           // Expected cap is derived independently of the tested element (MAX_MD_REM x the actual root
           // font-size), not read off panelRail's own computed max-width — reading the expectation off
-          // the same element being measured would make the assertion tautological (box-sizing: border-
-          // box guarantees a rendered width can never exceed its own max-width, so that comparison
-          // could never fail regardless of which class were actually applied).
-          const rootFontSize = await page.evaluate(() => parseFloat(getComputedStyle(document.documentElement).fontSize));
+          // the same element being measured would make the width assertion below tautological
+          // (box-sizing: border-box guarantees a rendered width can never exceed its own max-width, so
+          // that comparison could never fail regardless of which class were actually applied).
           const expectedCapPx = MAX_MD_REM * rootFontSize;
+
+          // Cap-existence check: at the two narrowest viewports (360/393) the uncapped rail would
+          // already render under 392px on its own (the content column itself is that narrow), so the
+          // width assertion below can't tell "correctly capped" from "cap silently removed" there —
+          // this compares the CSS property directly instead, at every sub-sm viewport including those.
+          const capPx = await panelRail.evaluate((el) => parseFloat(getComputedStyle(el).maxWidth));
+          expect(capPx, `profile panel rail max-width at ${vp.width}px should be the max-w-md cap (${expectedCapPx}px), not absent`).toBeCloseTo(
+            expectedCapPx,
+            0
+          );
+
           expect(railBox!.width, `profile panel rail width at ${vp.width}px should be capped at max-w-md (${expectedCapPx}px)`).toBeLessThanOrEqual(
             expectedCapPx + 1
           );

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -2,14 +2,20 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Profile & Account hub — mobile layout E2E — LFXV2-3285.
+ * Profile & Account hub — mobile/tablet/laptop layout E2E — LFXV2-3285.
  *
- * Regression coverage for the mobile-viewport layout fix: below the `lg` breakpoint the profile
- * rail's wrapper must resolve to a non-`fixed` CSS position (in normal document flow, left-aligned
- * with the content column) instead of a `position: fixed` 300px overlay, and the content column
- * must reclaim the full available width instead of reserving a gutter for a rail that no longer
- * floats there. The pre-fix bug left a 390px viewport with ~50px of usable content width
+ * Regression coverage for the profile-hub layout fix: below the `2xl` breakpoint (1440px) the
+ * profile rail's wrapper must resolve to a non-`fixed` CSS position (in normal document flow,
+ * left-aligned with the content column) instead of a `position: fixed` 300px overlay, and the
+ * content column must reclaim the available width instead of reserving a gutter for a rail that no
+ * longer floats there. The pre-fix bug left a 390px viewport with ~50px of usable content width
  * (390 - 300px gutter - 40px page padding).
+ *
+ * The breakpoint moved from `lg` (1024px) to `2xl` (1440px) in a LFXV2-3285 follow-up: the hub
+ * spends 712px on fixed chrome before any content — 348px left sidebar (lg:ml-[348px] on <main>,
+ * unrelated and unchanged by this follow-up) + 300px rail + 64px page padding (md:px-8). At `lg`
+ * that left a 312px content column, narrower than the rail beside it; at `2xl` it leaves 728px.
+ * Keeping the inline card until `2xl` also covers iPad landscape and split-screen laptop windows.
  *
  * The existing profile specs (profile-edit-drawer.spec.ts, profile-visibility-drawer.spec.ts) pass
  * under the mobile-chrome project today purely because they assert `toBeVisible()` on the panel —
@@ -24,16 +30,25 @@
  * The content-width assertion and the direct `position !== 'fixed'` / left-alignment checks below
  * are the ones that actually fail against the pre-fix template.
  *
- * Drives an explicit viewport matrix (mirrors e2e/docs/responsive.spec.ts) covering mobile and
- * tablet widths up to just under the `lg` breakpoint, rather than relying on whichever project
- * happens to run it — so the tablet band (768-1023px) is exercised too, not just mobile-chrome's
- * fixed 393px. This spec runs under all three playwright.config.ts projects (chromium, firefox,
- * mobile-chrome — none scope out e2e/**); because the matrix forces its own viewport per test, the
- * desktop projects exercise the sub-lg bands too, so width comparisons read
+ * Drives an explicit viewport matrix (mirrors e2e/docs/responsive.spec.ts) covering mobile, tablet,
+ * and laptop widths up to just under the `2xl` breakpoint, rather than relying on whichever project
+ * happens to run it — so the tablet-landscape/laptop-split/desktop-narrow bands are exercised too,
+ * not just mobile-chrome's fixed 393px. This spec runs under all three playwright.config.ts projects
+ * (chromium, firefox, mobile-chrome — none scope out e2e/**); because the matrix forces its own
+ * viewport per test, the desktop projects exercise the sub-2xl bands too, so width comparisons read
  * document.documentElement.clientWidth rather than the device viewport width, since desktop
  * projects render a classic scrollbar that mobile-emulated overlay scrollbars don't.
  *
- * The rail wrapper carries its own `profile-panel-rail` testid (added alongside this spec)
+ * The content-width expectation has to account for two more things once the viewport crosses `lg`
+ * (1024px, the *sidebar's own*, unrelated breakpoint): the 348px left sidebar starts reserving space
+ * via <main>'s lg:ml-[348px], and the content column itself is capped at max-w-[1024px] on the inner
+ * wrapper in profile-layout.component.html, so it stops growing well before `2xl`.
+ *
+ * A separate desktop-control test at 1440px asserts the OPPOSITE of the main matrix — the rail
+ * wrapper IS `position: fixed` and IS 300px wide — as a regression guard for the rail disappearing
+ * entirely if the breakpoint or its classes ever get dropped instead of moved.
+ *
+ * The rail wrapper carries its own `profile-panel-rail` testid (added alongside the original spec)
  * specifically so the CSS-position mechanism check below doesn't rely on a DOM-position hop off
  * `profile-panel` that would silently break if a wrapper element is ever inserted between them.
  *
@@ -52,14 +67,35 @@ const LOAD_TIMEOUT = 20_000;
 // (px-5 -> md:px-8, see main-layout.component.html), used to derive the width-slack tolerance.
 const MD_BREAKPOINT = 768;
 
-// Sub-lg matrix: narrow phone, the mobile-chrome project's own size (Pixel 5), and both ends of
-// the tablet band up to just under the lg breakpoint (1024px) the layout fix keys off.
+// The sidebar's own breakpoint (unrelated to the profile-rail breakpoint this follow-up moves) —
+// <main> picks up lg:ml-[348px] here, which the content-width expectation below must account for.
+const LG_BREAKPOINT = 1024;
+const SIDEBAR_WIDTH = 348;
+
+// The profile-panel-rail breakpoint this follow-up moves from lg (1024px) to 2xl (1440px, per
+// apps/lfx-one/tailwind.config.js). Below this, the rail renders inline; at and above it, fixed.
+const TWO_XL_BREAKPOINT = 1440;
+
+// max-w-[1024px] on the inner content wrapper in profile-layout.component.html — the content
+// column stops growing here even once the sidebar's 348px and the page padding are accounted for.
+const CONTENT_MAX = 1024;
+
+// Sub-2xl matrix: narrow phone, the mobile-chrome project's own size (Pixel 5), the tablet band,
+// iPad landscape, a split-screen laptop window, and just under the 2xl breakpoint itself — every
+// band the inline-card layout now needs to hold up across.
 const VIEWPORTS = [
   { name: 'mobile-narrow', width: 360, height: 640 },
   { name: 'mobile', width: 393, height: 727 },
   { name: 'tablet', width: 768, height: 1024 },
   { name: 'tablet-lg', width: 1023, height: 768 },
+  { name: 'tablet-landscape', width: 1194, height: 834 },
+  { name: 'laptop-split', width: 1280, height: 800 },
+  { name: 'desktop-narrow', width: 1439, height: 900 },
 ] as const;
+
+// Desktop control: at and above 2xl, the rail must be the fixed overlay again — the regression
+// guard for the rail disappearing entirely rather than just moving breakpoints.
+const DESKTOP_VIEWPORT = { name: 'desktop-2xl', width: 1440, height: 900 } as const;
 
 const ROUTES = ['/profile', '/profile/settings'] as const;
 
@@ -98,14 +134,14 @@ async function suppressCookieBanner(page: Page): Promise<void> {
   });
 }
 
-test.describe('Profile & Account hub — mobile layout (LFXV2-3285)', () => {
+test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285)', () => {
   test.beforeEach(async ({ page }) => {
     await suppressCookieBanner(page);
   });
 
   for (const vp of VIEWPORTS) {
     for (const route of ROUTES) {
-      test(`content column reclaims full width and the panel renders inline @ ${vp.name} (${vp.width}px) ${route}`, async ({ page }) => {
+      test(`content column reclaims available width and the panel renders inline @ ${vp.name} (${vp.width}px) ${route}`, async ({ page }) => {
         await page.setViewportSize({ width: vp.width, height: vp.height });
         await page.goto(route, { waitUntil: 'domcontentloaded' });
         skipWhenAuthMissing(page);
@@ -129,17 +165,21 @@ test.describe('Profile & Account hub — mobile layout (LFXV2-3285)', () => {
         }));
         expect(overflow.scrollWidth, `document scrollWidth at ${vp.width}px`).toBeLessThanOrEqual(overflow.clientWidth + 1);
 
-        // The content column must reclaim (close to) the full layout width — not be squeezed by an
-        // unconditional right gutter reserved for a rail that, below lg, no longer renders as a fixed
-        // overlay. Page padding is px-5 (40px total) below md, md:px-8 (64px total) at md and up.
+        // The content column must reclaim (close to) the available layout width — not be squeezed by
+        // an unconditional right gutter reserved for a rail that, below 2xl, no longer renders as a
+        // fixed overlay. Page padding is px-5 (40px total) below md, md:px-8 (64px total) at md and up.
+        // Once the viewport crosses lg (the sidebar's own, unrelated breakpoint), the 348px sidebar
+        // also reserves space, and the content column stops growing past max-w-[1024px] regardless.
         const pagePadding = vp.width >= MD_BREAKPOINT ? 64 : 40;
+        const sidebar = vp.width >= LG_BREAKPOINT ? SIDEBAR_WIDTH : 0;
+        const expectedContentWidth = Math.min(CONTENT_MAX, overflow.clientWidth - sidebar - pagePadding);
         const contentBox = await content.boundingBox();
         expect(contentBox, 'content column should have a bounding box').not.toBeNull();
-        expect(contentBox!.width, `content column width at ${vp.width}px viewport`).toBeGreaterThanOrEqual(overflow.clientWidth - pagePadding - 8);
+        expect(contentBox!.width, `content column width at ${vp.width}px viewport`).toBeGreaterThanOrEqual(expectedContentWidth - 8);
 
         // Direct mechanism check on the dedicated profile-panel-rail testid (not a DOM-position hop
         // off profile-panel, which would silently start reading the wrong ancestor and pass vacuously
-        // if a wrapper element is ever inserted between them): below lg it must NOT resolve to
+        // if a wrapper element is ever inserted between them): below 2xl it must NOT resolve to
         // position: fixed — this is what actually distinguishes "inline in normal flow" from "fixed
         // overlay pinned to the viewport"; bounding-box comparisons alone don't, since a fixed rail
         // still sits above the nav and (once the content column is squeezed thin enough) may not
@@ -171,5 +211,27 @@ test.describe('Profile & Account hub — mobile layout (LFXV2-3285)', () => {
         ).toBe(false);
       });
     }
+  }
+
+  for (const route of ROUTES) {
+    test(`desktop control: rail is a fixed 300px overlay at 2xl and up @ ${DESKTOP_VIEWPORT.name} (${DESKTOP_VIEWPORT.width}px) ${route}`, async ({
+      page,
+    }) => {
+      await page.setViewportSize({ width: DESKTOP_VIEWPORT.width, height: DESKTOP_VIEWPORT.height });
+      await page.goto(route, { waitUntil: 'domcontentloaded' });
+      skipWhenAuthMissing(page);
+
+      const panelRail = page.getByTestId('profile-panel-rail');
+      await expect(panelRail, 'profile panel rail wrapper should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+
+      // Regression guard for the rail disappearing entirely (as opposed to the breakpoint just
+      // moving) — the opposite assertion from the main matrix above.
+      const wrapperPosition = await panelRail.evaluate((el) => getComputedStyle(el).position);
+      expect(wrapperPosition, `profile panel rail position at ${DESKTOP_VIEWPORT.width}px should be fixed`).toBe('fixed');
+
+      const railBox = await panelRail.boundingBox();
+      expect(railBox, 'profile panel rail should have a bounding box').not.toBeNull();
+      expect(Math.abs(railBox!.width - 300), `profile panel rail width at ${DESKTOP_VIEWPORT.width}px should be 300px`).toBeLessThanOrEqual(1);
+    });
   }
 });

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -5,20 +5,29 @@
  * Profile & Account hub — mobile layout E2E — LFXV2-3285.
  *
  * Regression coverage for the mobile-viewport layout fix: below the `lg` breakpoint the profile
- * rail must render inline in the content column (not as a `position: fixed` 300px overlay), and
- * the content column must reclaim the full available width instead of reserving a gutter for a
- * rail that no longer floats there. The pre-fix bug left a 390px viewport with ~50px of usable
- * content width (390 - 300px gutter - 40px page padding).
+ * rail's wrapper must resolve to a non-`fixed` CSS position (in normal document flow, left-aligned
+ * with the content column) instead of a `position: fixed` 300px overlay, and the content column
+ * must reclaim the full available width instead of reserving a gutter for a rail that no longer
+ * floats there. The pre-fix bug left a 390px viewport with ~50px of usable content width
+ * (390 - 300px gutter - 40px page padding).
  *
  * The existing profile specs (profile-edit-drawer.spec.ts, profile-visibility-drawer.spec.ts) pass
  * under the mobile-chrome project today purely because they assert `toBeVisible()` on the panel —
  * the fixed-width rail was technically "visible" even when it starved the content column, and
  * because the content was compressed rather than overflowing, no overflow-based check caught it
- * either. This spec asserts the actual geometry instead.
+ * either. This spec asserts the actual geometry and the underlying CSS mechanism instead.
  *
- * Runs meaningfully only under the mobile-chrome project (393x727, per playwright.config.ts) — the
- * whole file skips itself at the `lg` breakpoint (1024px) and up, since the layout it covers is
- * identical to the (already-covered) desktop fixed-rail behavior there.
+ * Verified this spec actually discriminates the bug: bounding-box "renders above the subtab nav" /
+ * "does not overlap the content column" checks alone do NOT catch the pre-fix layout at a narrow
+ * viewport — a fixed rail pinned to the right edge still sits above the nav and, once the content
+ * column is squeezed thin enough, its box no longer geometrically overlaps the rail's box either.
+ * The content-width assertion and the direct `position !== 'fixed'` / left-alignment checks below
+ * are the ones that actually fail against the pre-fix template.
+ *
+ * Drives an explicit viewport matrix (mirrors e2e/docs/responsive.spec.ts) covering mobile and
+ * tablet widths up to just under the `lg` breakpoint, rather than relying on whichever project
+ * happens to run it — so the tablet band (768-1023px) is exercised too, not just mobile-chrome's
+ * fixed 393px.
  *
  * Prerequisites (mirrors profile-edit-drawer.spec.ts):
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -31,10 +40,18 @@ test.setTimeout(60_000);
 
 const LOAD_TIMEOUT = 20_000;
 
-const LG_BREAKPOINT = 1024;
-// px-5 page padding (40px total) plus slack for mobile chrome — matches the tolerance implied by
-// the original bug report (390px viewport - 300px gutter - 40px padding = ~50px of content).
-const WIDTH_SLACK = 80;
+// The breakpoint at which the page container's own horizontal padding steps up
+// (px-5 -> md:px-8, see main-layout.component.html), used to derive the width-slack tolerance.
+const MD_BREAKPOINT = 768;
+
+// Sub-lg matrix: narrow phone, the mobile-chrome project's own size (Pixel 5), and both ends of
+// the tablet band up to just under the lg breakpoint (1024px) the layout fix keys off.
+const VIEWPORTS = [
+  { name: 'mobile-narrow', width: 360, height: 640 },
+  { name: 'mobile', width: 393, height: 727 },
+  { name: 'tablet', width: 768, height: 1024 },
+  { name: 'tablet-lg', width: 1023, height: 768 },
+] as const;
 
 const ROUTES = ['/profile', '/profile/settings'] as const;
 
@@ -48,16 +65,6 @@ function skipWhenAuthMissing(page: Page): void {
     }
   } catch {
     // Malformed URL — keep running; a failure here is useful signal, not noise.
-  }
-}
-
-// This spec only covers the below-lg layout LFXV2-3285 fixed; skip entirely at lg and up rather
-// than hard-coding a project name, so it stays correct if the project list changes (mirrors
-// skipOnMobileViewport in me-profile-nav.spec.ts, inverted).
-function skipAtOrAboveLgViewport(page: Page): void {
-  const viewport = page.viewportSize();
-  if (!viewport || viewport.width >= LG_BREAKPOINT) {
-    test.skip(true, 'Mobile/tablet-only layout regression coverage — see playwright.config.ts mobile-chrome project');
   }
 }
 
@@ -85,56 +92,71 @@ async function suppressCookieBanner(page: Page): Promise<void> {
 
 test.describe('Profile & Account hub — mobile layout (LFXV2-3285)', () => {
   test.beforeEach(async ({ page }) => {
-    skipAtOrAboveLgViewport(page);
     await suppressCookieBanner(page);
   });
 
-  for (const route of ROUTES) {
-    test(`content column reclaims full width and the panel renders inline @ ${route}`, async ({ page }) => {
-      await page.goto(route, { waitUntil: 'domcontentloaded' });
-      skipWhenAuthMissing(page);
+  for (const vp of VIEWPORTS) {
+    for (const route of ROUTES) {
+      test(`content column reclaims full width and the panel renders inline @ ${vp.name} (${vp.width}px) ${route}`, async ({ page }) => {
+        await page.setViewportSize({ width: vp.width, height: vp.height });
+        await page.goto(route, { waitUntil: 'domcontentloaded' });
+        skipWhenAuthMissing(page);
 
-      const panel = page.getByTestId('profile-panel');
-      const content = page.getByTestId('profile-content');
-      const tabs = page.getByTestId('profile-tabs-desktop');
+        const panel = page.getByTestId('profile-panel');
+        const content = page.getByTestId('profile-content');
+        const tabs = page.getByTestId('profile-tabs-desktop');
 
-      await expect(panel, 'profile panel should render').toBeVisible({ timeout: LOAD_TIMEOUT });
-      await expect(content, 'profile content column should render').toBeVisible({ timeout: LOAD_TIMEOUT });
-      await expect(tabs, 'subtab nav should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+        await expect(panel, 'profile panel should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+        await expect(content, 'profile content column should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+        await expect(tabs, 'subtab nav should render').toBeVisible({ timeout: LOAD_TIMEOUT });
 
-      const viewport = page.viewportSize();
-      if (!viewport) {
-        throw new Error('viewport size unavailable');
-      }
+        // The content column must reclaim (close to) the full viewport width — not be squeezed by an
+        // unconditional right gutter reserved for a rail that, below lg, no longer renders as a fixed
+        // overlay. Page padding is px-5 (40px total) below md, md:px-8 (64px total) at md and up.
+        const pagePadding = vp.width >= MD_BREAKPOINT ? 64 : 40;
+        const contentBox = await content.boundingBox();
+        expect(contentBox, 'content column should have a bounding box').not.toBeNull();
+        expect(contentBox!.width, `content column width at ${vp.width}px viewport`).toBeGreaterThanOrEqual(vp.width - pagePadding - 8);
 
-      // The content column must reclaim (close to) the full viewport width — not be squeezed by an
-      // unconditional right gutter reserved for a rail that, below lg, no longer renders as a fixed
-      // overlay.
-      const contentBox = await content.boundingBox();
-      expect(contentBox, 'content column should have a bounding box').not.toBeNull();
-      expect(contentBox!.width, `content column width at ${viewport.width}px viewport`).toBeGreaterThanOrEqual(viewport.width - WIDTH_SLACK);
+        // No horizontal page scroll — the classic symptom of a fixed-width element bleeding past the
+        // viewport (1px fudge factor mirrors docs/responsive.spec.ts).
+        const overflow = await page.evaluate(() => ({
+          scrollWidth: document.documentElement.scrollWidth,
+          clientWidth: document.documentElement.clientWidth,
+        }));
+        expect(overflow.scrollWidth, `document scrollWidth at ${vp.width}px`).toBeLessThanOrEqual(overflow.clientWidth + 1);
 
-      // No horizontal page scroll — the classic symptom of a fixed-width element bleeding past the
-      // viewport (1px fudge factor mirrors docs/responsive.spec.ts).
-      const overflow = await page.evaluate(() => ({
-        scrollWidth: document.documentElement.scrollWidth,
-        clientWidth: document.documentElement.clientWidth,
-      }));
-      expect(overflow.scrollWidth, `document scrollWidth at ${viewport.width}px`).toBeLessThanOrEqual(overflow.clientWidth + 1);
+        // Direct mechanism check: the element two levels up from the `profile-panel` testid (the
+        // <aside>) is the wrapper <div> carrying `lg:fixed` in profile-layout.component.html. Below lg
+        // it must NOT resolve to position: fixed — this is what actually distinguishes "inline in
+        // normal flow" from "fixed overlay pinned to the viewport"; bounding-box comparisons alone
+        // don't, since a fixed rail still sits above the nav and (once the content column is squeezed
+        // thin enough) may not geometrically overlap it either.
+        const wrapperPosition = await panel.evaluate((el) => getComputedStyle(el.parentElement!.parentElement!).position);
+        expect(wrapperPosition, `profile panel wrapper position at ${vp.width}px should not be fixed`).not.toBe('fixed');
 
-      // The panel must render above the subtab nav, proving it's inline in normal flow rather than
-      // a `position: fixed` overlay pinned to the right edge (the pre-fix behavior at every width).
-      const panelBox = await panel.boundingBox();
-      const tabsBox = await tabs.boundingBox();
-      expect(panelBox, 'profile panel should have a bounding box').not.toBeNull();
-      expect(tabsBox, 'subtab nav should have a bounding box').not.toBeNull();
-      expect(panelBox!.y, 'profile panel should render above the subtab nav').toBeLessThan(tabsBox!.y);
+        // Inline placement: the panel should be left-aligned with the content column (both children of
+        // the same padded container) rather than offset toward the right edge like a fixed rail would be.
+        const panelBox = await panel.boundingBox();
+        expect(panelBox, 'profile panel should have a bounding box').not.toBeNull();
+        expect(Math.abs(panelBox!.x - contentBox!.x), `panel should be left-aligned with the content column at ${vp.width}px`).toBeLessThanOrEqual(1);
 
-      // The panel must not overlap the content column — if it did, it would still be acting as a
-      // fixed overlay laid on top of the page rather than a participant in normal flow.
-      const overlapsHorizontally = panelBox!.x < contentBox!.x + contentBox!.width && panelBox!.x + panelBox!.width > contentBox!.x;
-      const overlapsVertically = panelBox!.y < contentBox!.y + contentBox!.height && panelBox!.y + panelBox!.height > contentBox!.y;
-      expect(overlapsHorizontally && overlapsVertically, 'profile panel should not overlap the content column').toBe(false);
-    });
+        // The panel should still render above the subtab nav in the content flow.
+        const tabsBox = await tabs.boundingBox();
+        expect(tabsBox, 'subtab nav should have a bounding box').not.toBeNull();
+        expect(panelBox!.y, 'profile panel should render above the subtab nav').toBeLessThan(tabsBox!.y);
+
+        // The panel should not overlap the content column — a true 2D bounding-box intersection
+        // requires overlap on BOTH axes; checking each axis independently would misfire on any two
+        // elements that merely share a vertical range while sitting side by side.
+        const overlapsHorizontally = panelBox!.x < contentBox!.x + contentBox!.width && panelBox!.x + panelBox!.width > contentBox!.x;
+        const overlapsVertically = panelBox!.y < contentBox!.y + contentBox!.height && panelBox!.y + panelBox!.height > contentBox!.y;
+        expect(
+          overlapsHorizontally && overlapsVertically,
+          `profile panel (x:${panelBox!.x},y:${panelBox!.y},w:${panelBox!.width},h:${panelBox!.height}) should not overlap the content column ` +
+            `(x:${contentBox!.x},y:${contentBox!.y},w:${contentBox!.width},h:${contentBox!.height}) at ${vp.width}px`
+        ).toBe(false);
+      });
+    }
   }
 });

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -1,0 +1,140 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Profile & Account hub — mobile layout E2E — LFXV2-3285.
+ *
+ * Regression coverage for the mobile-viewport layout fix: below the `lg` breakpoint the profile
+ * rail must render inline in the content column (not as a `position: fixed` 300px overlay), and
+ * the content column must reclaim the full available width instead of reserving a gutter for a
+ * rail that no longer floats there. The pre-fix bug left a 390px viewport with ~50px of usable
+ * content width (390 - 300px gutter - 40px page padding).
+ *
+ * The existing profile specs (profile-edit-drawer.spec.ts, profile-visibility-drawer.spec.ts) pass
+ * under the mobile-chrome project today purely because they assert `toBeVisible()` on the panel —
+ * the fixed-width rail was technically "visible" even when it starved the content column, and
+ * because the content was compressed rather than overflowing, no overflow-based check caught it
+ * either. This spec asserts the actual geometry instead.
+ *
+ * Runs meaningfully only under the mobile-chrome project (393x727, per playwright.config.ts) — the
+ * whole file skips itself at the `lg` breakpoint (1024px) and up, since the layout it covers is
+ * identical to the (already-covered) desktop fixed-rail behavior there.
+ *
+ * Prerequisites (mirrors profile-edit-drawer.spec.ts):
+ *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ *   - apps/lfx-one/.env populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+test.setTimeout(60_000);
+
+const LOAD_TIMEOUT = 20_000;
+
+const LG_BREAKPOINT = 1024;
+// px-5 page padding (40px total) plus slack for mobile chrome — matches the tolerance implied by
+// the original bug report (390px viewport - 300px gutter - 40px padding = ~50px of content).
+const WIDTH_SLACK = 80;
+
+const ROUTES = ['/profile', '/profile/settings'] as const;
+
+// Hard skip when the auth-bootstrap failed — hostname-exact match so a crafted URL like
+// `https://auth0.com.evil.com/` can't fool the gate (mirrors profile-edit-drawer.spec.ts).
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — keep running; a failure here is useful signal, not noise.
+  }
+}
+
+// This spec only covers the below-lg layout LFXV2-3285 fixed; skip entirely at lg and up rather
+// than hard-coding a project name, so it stays correct if the project list changes (mirrors
+// skipOnMobileViewport in me-profile-nav.spec.ts, inverted).
+function skipAtOrAboveLgViewport(page: Page): void {
+  const viewport = page.viewportSize();
+  if (!viewport || viewport.width >= LG_BREAKPOINT) {
+    test.skip(true, 'Mobile/tablet-only layout regression coverage — see playwright.config.ts mobile-chrome project');
+  }
+}
+
+// Neutralize the Osano consent overlay, which otherwise intercepts pointer events and can affect
+// layout measurements. Registered via addInitScript so it applies before page scripts run (mirrors
+// profile-edit-drawer.spec.ts / me-profile-nav.spec.ts).
+async function suppressCookieBanner(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    const hide = (): void => {
+      if (document.getElementById('e2e-hide-osano')) {
+        return;
+      }
+      const style = document.createElement('style');
+      style.id = 'e2e-hide-osano';
+      style.textContent = '.osano-cm-window { display: none !important; pointer-events: none !important; }';
+      (document.head ?? document.documentElement).appendChild(style);
+    };
+    if (document.readyState === 'loading') {
+      document.addEventListener('DOMContentLoaded', hide);
+    } else {
+      hide();
+    }
+  });
+}
+
+test.describe('Profile & Account hub — mobile layout (LFXV2-3285)', () => {
+  test.beforeEach(async ({ page }) => {
+    skipAtOrAboveLgViewport(page);
+    await suppressCookieBanner(page);
+  });
+
+  for (const route of ROUTES) {
+    test(`content column reclaims full width and the panel renders inline @ ${route}`, async ({ page }) => {
+      await page.goto(route, { waitUntil: 'domcontentloaded' });
+      skipWhenAuthMissing(page);
+
+      const panel = page.getByTestId('profile-panel');
+      const content = page.getByTestId('profile-content');
+      const tabs = page.getByTestId('profile-tabs-desktop');
+
+      await expect(panel, 'profile panel should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+      await expect(content, 'profile content column should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+      await expect(tabs, 'subtab nav should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+
+      const viewport = page.viewportSize();
+      if (!viewport) {
+        throw new Error('viewport size unavailable');
+      }
+
+      // The content column must reclaim (close to) the full viewport width — not be squeezed by an
+      // unconditional right gutter reserved for a rail that, below lg, no longer renders as a fixed
+      // overlay.
+      const contentBox = await content.boundingBox();
+      expect(contentBox, 'content column should have a bounding box').not.toBeNull();
+      expect(contentBox!.width, `content column width at ${viewport.width}px viewport`).toBeGreaterThanOrEqual(viewport.width - WIDTH_SLACK);
+
+      // No horizontal page scroll — the classic symptom of a fixed-width element bleeding past the
+      // viewport (1px fudge factor mirrors docs/responsive.spec.ts).
+      const overflow = await page.evaluate(() => ({
+        scrollWidth: document.documentElement.scrollWidth,
+        clientWidth: document.documentElement.clientWidth,
+      }));
+      expect(overflow.scrollWidth, `document scrollWidth at ${viewport.width}px`).toBeLessThanOrEqual(overflow.clientWidth + 1);
+
+      // The panel must render above the subtab nav, proving it's inline in normal flow rather than
+      // a `position: fixed` overlay pinned to the right edge (the pre-fix behavior at every width).
+      const panelBox = await panel.boundingBox();
+      const tabsBox = await tabs.boundingBox();
+      expect(panelBox, 'profile panel should have a bounding box').not.toBeNull();
+      expect(tabsBox, 'subtab nav should have a bounding box').not.toBeNull();
+      expect(panelBox!.y, 'profile panel should render above the subtab nav').toBeLessThan(tabsBox!.y);
+
+      // The panel must not overlap the content column — if it did, it would still be acting as a
+      // fixed overlay laid on top of the page rather than a participant in normal flow.
+      const overlapsHorizontally = panelBox!.x < contentBox!.x + contentBox!.width && panelBox!.x + panelBox!.width > contentBox!.x;
+      const overlapsVertically = panelBox!.y < contentBox!.y + contentBox!.height && panelBox!.y + panelBox!.height > contentBox!.y;
+      expect(overlapsHorizontally && overlapsVertically, 'profile panel should not overlap the content column').toBe(false);
+    });
+  }
+});

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -223,9 +223,7 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
   }
 
   for (const route of ROUTES) {
-    test(`desktop control: rail is a fixed 300px overlay at 2xl and up @ ${DESKTOP_VIEWPORT.name} (${DESKTOP_VIEWPORT.width}px) ${route}`, async ({
-      page,
-    }) => {
+    test(`desktop control: rail is a fixed 300px overlay at 2xl and up @ ${DESKTOP_VIEWPORT.name} (${DESKTOP_VIEWPORT.width}px) ${route}`, async ({ page }) => {
       await page.setViewportSize({ width: DESKTOP_VIEWPORT.width, height: DESKTOP_VIEWPORT.height });
       await page.goto(route, { waitUntil: 'domcontentloaded' });
       skipWhenAuthMissing(page);

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -94,8 +94,13 @@ const VIEWPORTS = [
 ] as const;
 
 // Desktop control: at and above 2xl, the rail must be the fixed overlay again — the regression
-// guard for the rail disappearing entirely rather than just moving breakpoints.
-const DESKTOP_VIEWPORT = { name: 'desktop-2xl', width: 1440, height: 900 } as const;
+// guard for the rail disappearing entirely rather than just moving breakpoints. Requested a margin
+// above TWO_XL_BREAKPOINT (not exactly 1440) — desktop projects (chromium/firefox) render a classic
+// scrollbar, and CSS min-width media queries evaluate against the layout viewport (clientWidth),
+// which that scrollbar shrinks below the requested device width. Right at 1440 that can drop below
+// the breakpoint and make the 2xl: styles never apply. The test also asserts this precondition
+// explicitly below rather than assuming the margin is always enough.
+const DESKTOP_VIEWPORT = { name: 'desktop-2xl', width: TWO_XL_BREAKPOINT + 40, height: 900 } as const;
 
 const ROUTES = ['/profile', '/profile/settings'] as const;
 
@@ -170,8 +175,11 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
         // fixed overlay. Page padding is px-5 (40px total) below md, md:px-8 (64px total) at md and up.
         // Once the viewport crosses lg (the sidebar's own, unrelated breakpoint), the 348px sidebar
         // also reserves space, and the content column stops growing past max-w-[1024px] regardless.
-        const pagePadding = vp.width >= MD_BREAKPOINT ? 64 : 40;
-        const sidebar = vp.width >= LG_BREAKPOINT ? SIDEBAR_WIDTH : 0;
+        // Both breakpoint checks key off clientWidth, not vp.width — the media queries the app
+        // actually evaluates run against the layout viewport, which a classic desktop scrollbar
+        // shrinks below the requested device width (same reasoning as the scrollWidth check above).
+        const pagePadding = overflow.clientWidth >= MD_BREAKPOINT ? 64 : 40;
+        const sidebar = overflow.clientWidth >= LG_BREAKPOINT ? SIDEBAR_WIDTH : 0;
         const expectedContentWidth = Math.min(CONTENT_MAX, overflow.clientWidth - sidebar - pagePadding);
         const contentBox = await content.boundingBox();
         expect(contentBox, 'content column should have a bounding box').not.toBeNull();
@@ -223,6 +231,14 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
 
       const panelRail = page.getByTestId('profile-panel-rail');
       await expect(panelRail, 'profile panel rail wrapper should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+
+      // Precondition: confirm the layout viewport actually cleared the 2xl breakpoint before
+      // asserting on it — a classic desktop scrollbar can shrink clientWidth below the requested
+      // device width, and DESKTOP_VIEWPORT's margin over TWO_XL_BREAKPOINT is only a heuristic.
+      // Failing loudly here beats a confusing "position should be fixed but got static" failure
+      // that actually means the viewport never cleared the breakpoint at all.
+      const layoutWidth = await page.evaluate(() => document.documentElement.clientWidth);
+      expect(layoutWidth, 'layout viewport must clear the 2xl breakpoint for this control to be meaningful').toBeGreaterThanOrEqual(TWO_XL_BREAKPOINT);
 
       // Regression guard for the rail disappearing entirely (as opposed to the breakpoint just
       // moving) — the opposite assertion from the main matrix above.

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -65,11 +65,16 @@ test.setTimeout(60_000);
 const LOAD_TIMEOUT = 20_000;
 
 // The breakpoint at which the page container's own horizontal padding steps up (px-5 -> md:px-8,
-// see main-layout.component.html), used to derive the width-slack tolerance. In rem, not px — like
-// MAX_MD_REM below, this app's html { font-size: 14px } (styles.scss) means a naive 16px-root
-// rem-to-px conversion (px-5 -> 40px, md:px-8 -> 64px) would be wrong; the actual px value is
-// derived from the root font-size read at assertion time.
+// see main-layout.component.html). This is px, not rem — apps/lfx-one/tailwind.config.js defines
+// theme.screens as px literals, and even where a breakpoint were expressed in rem, a media query's
+// rem always resolves against the browser's initial 16px root, never this app's 14px html font-size.
 const MD_BREAKPOINT = 768;
+
+// The page padding itself, unlike the breakpoint above, IS rem-denominated (px-5 / md:px-8 are
+// Tailwind spacing utilities, which do resolve against the in-page root font-size) — like MAX_MD_REM
+// below, this app's html { font-size: 14px } (styles.scss) means a naive 16px-root rem-to-px
+// conversion (px-5 -> 40px, md:px-8 -> 64px) would be wrong; the actual px value is derived from the
+// root font-size read at assertion time.
 const PAGE_PADDING_REM_BELOW_MD = 2.5; // px-5 = 1.25rem per side x 2
 const PAGE_PADDING_REM_AT_MD = 4; // md:px-8 = 2rem per side x 2
 
@@ -250,6 +255,13 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
           expect(railBox!.width, `profile panel rail width at ${vp.width}px should be capped at max-w-md (${expectedCapPx}px)`).toBeLessThanOrEqual(
             expectedCapPx + 1
           );
+        } else {
+          // Mirror of the cap-existence check above: sm:max-w-none must actually lift the cap at and
+          // above sm, or the rail would stay pinned at ~392px all the way to 2xl with nothing else in
+          // this matrix catching it — the width-only assertion above only runs below sm, and left-
+          // alignment/no-overlap still pass for a narrow-but-left-aligned panel.
+          const capPx = await panelRail.evaluate((el) => getComputedStyle(el).maxWidth);
+          expect(capPx, `profile panel rail max-width at ${vp.width}px should be lifted by sm:max-w-none`).toBe('none');
         }
 
         // Inline placement: the panel should be left-aligned with the content column (both children of

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -27,7 +27,14 @@
  * Drives an explicit viewport matrix (mirrors e2e/docs/responsive.spec.ts) covering mobile and
  * tablet widths up to just under the `lg` breakpoint, rather than relying on whichever project
  * happens to run it — so the tablet band (768-1023px) is exercised too, not just mobile-chrome's
- * fixed 393px.
+ * fixed 393px. Because that matrix forces its own viewport per test, it also runs under the
+ * chromium/firefox desktop projects now (not just mobile-chrome) — so width comparisons read
+ * document.documentElement.clientWidth rather than the device viewport width, since desktop
+ * projects render a classic scrollbar that mobile-emulated overlay scrollbars don't.
+ *
+ * The rail wrapper carries its own `profile-panel-rail` testid (added alongside this spec)
+ * specifically so the CSS-position mechanism check below doesn't rely on a DOM-position hop off
+ * `profile-panel` that would silently break if a wrapper element is ever inserted between them.
  *
  * Prerequisites (mirrors profile-edit-drawer.spec.ts):
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -103,6 +110,7 @@ test.describe('Profile & Account hub — mobile layout (LFXV2-3285)', () => {
         skipWhenAuthMissing(page);
 
         const panel = page.getByTestId('profile-panel');
+        const panelRail = page.getByTestId('profile-panel-rail');
         const content = page.getByTestId('profile-content');
         const tabs = page.getByTestId('profile-tabs-desktop');
 
@@ -110,30 +118,34 @@ test.describe('Profile & Account hub — mobile layout (LFXV2-3285)', () => {
         await expect(content, 'profile content column should render').toBeVisible({ timeout: LOAD_TIMEOUT });
         await expect(tabs, 'subtab nav should render').toBeVisible({ timeout: LOAD_TIMEOUT });
 
-        // The content column must reclaim (close to) the full viewport width — not be squeezed by an
-        // unconditional right gutter reserved for a rail that, below lg, no longer renders as a fixed
-        // overlay. Page padding is px-5 (40px total) below md, md:px-8 (64px total) at md and up.
-        const pagePadding = vp.width >= MD_BREAKPOINT ? 64 : 40;
-        const contentBox = await content.boundingBox();
-        expect(contentBox, 'content column should have a bounding box').not.toBeNull();
-        expect(contentBox!.width, `content column width at ${vp.width}px viewport`).toBeGreaterThanOrEqual(vp.width - pagePadding - 8);
-
-        // No horizontal page scroll — the classic symptom of a fixed-width element bleeding past the
-        // viewport (1px fudge factor mirrors docs/responsive.spec.ts).
+        // Read the layout viewport (clientWidth), not the device viewport (vp.width) — desktop
+        // projects (chromium/firefox) render a classic ~15px scrollbar that a mobile-emulated overlay
+        // scrollbar doesn't, so comparing against vp.width directly is scrollbar-blind and would false-
+        // fail there. No horizontal page scroll either (1px fudge factor mirrors docs/responsive.spec.ts).
         const overflow = await page.evaluate(() => ({
           scrollWidth: document.documentElement.scrollWidth,
           clientWidth: document.documentElement.clientWidth,
         }));
         expect(overflow.scrollWidth, `document scrollWidth at ${vp.width}px`).toBeLessThanOrEqual(overflow.clientWidth + 1);
 
-        // Direct mechanism check: the element two levels up from the `profile-panel` testid (the
-        // <aside>) is the wrapper <div> carrying `lg:fixed` in profile-layout.component.html. Below lg
-        // it must NOT resolve to position: fixed — this is what actually distinguishes "inline in
-        // normal flow" from "fixed overlay pinned to the viewport"; bounding-box comparisons alone
-        // don't, since a fixed rail still sits above the nav and (once the content column is squeezed
-        // thin enough) may not geometrically overlap it either.
-        const wrapperPosition = await panel.evaluate((el) => getComputedStyle(el.parentElement!.parentElement!).position);
-        expect(wrapperPosition, `profile panel wrapper position at ${vp.width}px should not be fixed`).not.toBe('fixed');
+        // The content column must reclaim (close to) the full layout width — not be squeezed by an
+        // unconditional right gutter reserved for a rail that, below lg, no longer renders as a fixed
+        // overlay. Page padding is px-5 (40px total) below md, md:px-8 (64px total) at md and up.
+        const pagePadding = vp.width >= MD_BREAKPOINT ? 64 : 40;
+        const contentBox = await content.boundingBox();
+        expect(contentBox, 'content column should have a bounding box').not.toBeNull();
+        expect(contentBox!.width, `content column width at ${vp.width}px viewport`).toBeGreaterThanOrEqual(overflow.clientWidth - pagePadding - 8);
+
+        // Direct mechanism check on the dedicated profile-panel-rail testid (not a DOM-position hop
+        // off profile-panel, which would silently start reading the wrong ancestor and pass vacuously
+        // if a wrapper element is ever inserted between them): below lg it must NOT resolve to
+        // position: fixed — this is what actually distinguishes "inline in normal flow" from "fixed
+        // overlay pinned to the viewport"; bounding-box comparisons alone don't, since a fixed rail
+        // still sits above the nav and (once the content column is squeezed thin enough) may not
+        // geometrically overlap it either.
+        await expect(panelRail, 'profile panel rail wrapper should render').toBeVisible({ timeout: LOAD_TIMEOUT });
+        const wrapperPosition = await panelRail.evaluate((el) => getComputedStyle(el).position);
+        expect(wrapperPosition, `profile panel rail position at ${vp.width}px should not be fixed`).not.toBe('fixed');
 
         // Inline placement: the panel should be left-aligned with the content column (both children of
         // the same padded container) rather than offset toward the right edge like a fixed rail would be.

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -44,9 +44,10 @@
  * via <main>'s lg:ml-[348px], and the content column itself is capped at max-w-[1024px] on the inner
  * wrapper in profile-layout.component.html, so it stops growing well before `2xl`.
  *
- * A separate desktop-control test at 1440px asserts the OPPOSITE of the main matrix — the rail
- * wrapper IS `position: fixed` and IS 300px wide — as a regression guard for the rail disappearing
- * entirely if the breakpoint or its classes ever get dropped instead of moved.
+ * A separate desktop-control test above 2xl (TWO_XL_BREAKPOINT + 40, not exactly 1440px — see the
+ * DESKTOP_VIEWPORT comment for why) asserts the OPPOSITE of the main matrix — the rail wrapper IS
+ * `position: fixed` and IS 300px wide — as a regression guard for the rail disappearing entirely
+ * if the breakpoint or its classes ever get dropped instead of moved.
  *
  * The rail wrapper carries its own `profile-panel-rail` testid (added alongside the original spec)
  * specifically so the CSS-position mechanism check below doesn't rely on a DOM-position hop off

--- a/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
+++ b/apps/lfx-one/e2e/profile-mobile-layout.spec.ts
@@ -81,18 +81,26 @@ const TWO_XL_BREAKPOINT = 1440;
 // column stops growing here even once the sidebar's 348px and the page padding are accounted for.
 const CONTENT_MAX = 1024;
 
-// Sub-2xl matrix: narrow phone, the mobile-chrome project's own size (Pixel 5), the tablet band,
-// iPad landscape, a split-screen laptop window, and just under the 2xl breakpoint itself — every
-// band the inline-card layout now needs to hold up across.
+// Sub-2xl matrix: narrow phone, the mobile-chrome project's own size (Pixel 5), a landscape-phone
+// band between 393 and the sm breakpoint (see MAX_MD_WIDTH below — this is the one viewport where
+// the panel's own max-w-md cap is load-bearing; regressed and reinstated twice on this branch
+// without a dedicated assertion before this entry was added), the tablet band, iPad landscape, a
+// split-screen laptop window, and just under the 2xl breakpoint itself — every band the inline-card
+// layout now needs to hold up across.
 const VIEWPORTS = [
   { name: 'mobile-narrow', width: 360, height: 640 },
   { name: 'mobile', width: 393, height: 727 },
+  { name: 'mobile-landscape', width: 550, height: 400 },
   { name: 'tablet', width: 768, height: 1024 },
   { name: 'tablet-lg', width: 1023, height: 768 },
   { name: 'tablet-landscape', width: 1194, height: 834 },
   { name: 'laptop-split', width: 1280, height: 800 },
   { name: 'desktop-narrow', width: 1439, height: 900 },
 ] as const;
+
+// The panel's own max-w-md cap (below sm only) — sm:max-w-none removes it from sm up.
+const SM_BREAKPOINT = 640;
+const MAX_MD_WIDTH = 448;
 
 // Desktop control: at and above 2xl, the rail must be the fixed overlay again — the regression
 // guard for the rail disappearing entirely rather than just moving breakpoints. Requested a margin
@@ -196,6 +204,17 @@ test.describe('Profile & Account hub — mobile/tablet/laptop layout (LFXV2-3285
         await expect(panelRail, 'profile panel rail wrapper should render').toBeVisible({ timeout: LOAD_TIMEOUT });
         const wrapperPosition = await panelRail.evaluate((el) => getComputedStyle(el).position);
         expect(wrapperPosition, `profile panel rail position at ${vp.width}px should not be fixed`).not.toBe('fixed');
+
+        // Below sm, the rail wrapper is capped at max-w-md (448px) so it stays a proportioned stacked
+        // card instead of stretching wide while its internals are still fully stacked (a content
+        // column can exceed 448px below the 640px sm breakpoint once page padding is this small, e.g.
+        // ~510px at a 550px viewport). This regression was introduced and reverted twice on this
+        // branch before this assertion existed.
+        if (vp.width < SM_BREAKPOINT) {
+          const railBox = await panelRail.boundingBox();
+          expect(railBox, 'profile panel rail should have a bounding box').not.toBeNull();
+          expect(railBox!.width, `profile panel rail width at ${vp.width}px should be capped at max-w-md`).toBeLessThanOrEqual(MAX_MD_WIDTH + 1);
+        }
 
         // Inline placement: the panel should be left-aligned with the content column (both children of
         // the same padded container) rather than offset toward the right edge like a fixed rail would be.

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -74,8 +74,8 @@
   }
 
   <!-- Main Content Area -->
-  <!-- On the profile hub, reserve a right gutter (lg:pr-[300px]) so content and the footer clear the fixed profile rail at lg and up; below lg the panel renders inline instead. -->
-  <main class="flex-1 min-w-0 lg:ml-[348px] flex flex-col" [ngClass]="{ 'lg:pr-[300px]': isProfileHub() }" data-testid="main-content">
+  <!-- On the profile hub, reserve a right gutter (2xl:pr-[300px]) so content and the footer clear the fixed profile rail at 2xl and up; below 2xl the panel renders inline instead. -->
+  <main class="flex-1 min-w-0 lg:ml-[348px] flex flex-col" [ngClass]="{ '2xl:pr-[300px]': isProfileHub() }" data-testid="main-content">
     <!-- Mobile Menu Button -->
     <div
       class="lg:hidden sticky z-30 bg-white border-b border-gray-200 px-5 py-3"

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.html
@@ -74,8 +74,8 @@
   }
 
   <!-- Main Content Area -->
-  <!-- On the profile hub, reserve a right gutter (pr-[300px]) so content and the footer clear the fixed profile rail. -->
-  <main class="flex-1 min-w-0 lg:ml-[348px] flex flex-col" [ngClass]="{ 'pr-[300px]': isProfileHub() }" data-testid="main-content">
+  <!-- On the profile hub, reserve a right gutter (lg:pr-[300px]) so content and the footer clear the fixed profile rail at lg and up; below lg the panel renders inline instead. -->
+  <main class="flex-1 min-w-0 lg:ml-[348px] flex flex-col" [ngClass]="{ 'lg:pr-[300px]': isProfileHub() }" data-testid="main-content">
     <!-- Mobile Menu Button -->
     <div
       class="lg:hidden sticky z-30 bg-white border-b border-gray-200 px-5 py-3"

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -47,8 +47,9 @@ export class MainLayoutComponent {
   // Lens-aware sidebar items (built by SidebarNavService; shared with the docs shell).
   protected readonly sidebarItems = this.sidebarNavService.sidebarItems;
 
-  // True on the /profile hub — drives the pr-[300px] right gutter on <main> so content/footer
-  // clear the fixed rail. Only the me-lens /profile route uses ProfileLayoutComponent.
+  // True on the /profile hub — drives the lg:pr-[300px] right gutter on <main> at lg and up so
+  // content/footer clear the fixed rail; below lg the panel renders inline instead. Only the
+  // me-lens /profile route uses ProfileLayoutComponent.
   protected readonly isProfileHub = signal(false);
 
   /**

--- a/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/main-layout/main-layout.component.ts
@@ -47,8 +47,8 @@ export class MainLayoutComponent {
   // Lens-aware sidebar items (built by SidebarNavService; shared with the docs shell).
   protected readonly sidebarItems = this.sidebarNavService.sidebarItems;
 
-  // True on the /profile hub — drives the lg:pr-[300px] right gutter on <main> at lg and up so
-  // content/footer clear the fixed rail; below lg the panel renders inline instead. Only the
+  // True on the /profile hub — drives the 2xl:pr-[300px] right gutter on <main> at 2xl and up so
+  // content/footer clear the fixed rail; below 2xl the panel renders inline instead. Only the
   // me-lens /profile route uses ProfileLayoutComponent.
   protected readonly isProfileHub = signal(false);
 

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -7,11 +7,12 @@
   never changes width, and always sits above page content (z-40). MainLayoutComponent reserves a
   matching right gutter (2xl:pr-[300px]) on the profile hub so the content and the shared footer
   stay clear of the rail. The rail's `top` matches the impersonation banner offset. Below 2xl, the
-  panel renders inline in the content column above the subtabs instead, capped at max-w-md so it
-  keeps rail-like proportions rather than stretching to the full column width. The 2xl threshold
-  (not lg) accounts for the 348px left sidebar (lg:ml-[348px] on <main>) plus 64px page padding
-  (md:px-8) that also apply once the sidebar shows — at lg that leaves only a 312px content column
-  next to a 300px rail; at 2xl it leaves 728px.
+  panel renders inline in the content column above the subtabs instead, full width — the panel's
+  own internal layout (profile-panel.component.html) reflows across three states: a stacked card
+  below sm, a full-width horizontal layout from sm up to just under 2xl, and the vertical rail at
+  2xl and up. The 2xl threshold (not lg) accounts for the 348px left sidebar (lg:ml-[348px] on
+  <main>) plus 64px page padding (md:px-8) that also apply once the sidebar shows — at lg that
+  leaves only a 312px content column next to a 300px rail; at 2xl it leaves 728px.
 -->
 <div class="flex flex-col" data-testid="profile-layout">
   <!-- Left column -->
@@ -34,9 +35,9 @@
         <p class="mt-1 text-sm text-slate-500">Manage your profile and account settings.</p>
       </div>
 
-      <!-- Profile panel — inline below 2xl (capped at max-w-md); fixed full-height right rail at 2xl and up (out of normal flow) -->
+      <!-- Profile panel — full-width inline below 2xl (reflows internally at sm+); fixed full-height right rail at 2xl and up (out of normal flow) -->
       <div
-        class="max-w-md 2xl:max-w-none 2xl:fixed 2xl:bottom-0 2xl:right-0 2xl:z-40 2xl:w-[300px]"
+        class="2xl:fixed 2xl:bottom-0 2xl:right-0 2xl:z-40 2xl:w-[300px]"
         [ngClass]="{ '2xl:top-12': impersonating(), '2xl:top-0': !impersonating() }"
         data-testid="profile-panel-rail">
         <lfx-profile-panel

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -36,10 +36,12 @@
       </div>
 
       <!-- Profile panel — capped at max-w-md below sm (stacked card, matches the design's "stacked
-           card below sm" state — the content column can exceed 448px there, e.g. ~510px at a 550px
-           viewport, so without the cap the card would stretch wide while still fully stacked
-           internally); full width from sm up to 2xl (reflows internally); fixed full-height right
-           rail at 2xl and up (out of normal flow). -->
+           card below sm" state — the content column can exceed the cap there, e.g. ~515px at a 550px
+           viewport against a 392px cap (this app sets html { font-size: 14px } in styles.scss, so
+           max-w-md's 28rem renders at 392px here, not the browser-default-root 448px), so without the
+           cap the card would stretch wide while still fully stacked internally); full width from sm
+           up to 2xl (reflows internally); fixed full-height right rail at 2xl and up (out of normal
+           flow). -->
       <div
         class="max-w-md sm:max-w-none 2xl:fixed 2xl:bottom-0 2xl:right-0 2xl:z-40 2xl:w-[300px]"
         [ngClass]="{ '2xl:top-12': impersonating(), '2xl:top-0': !impersonating() }"

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -11,8 +11,9 @@
   sm (a stacked card), full width from sm up to just under 2xl (where the panel's own internal
   layout, profile-panel.component.html, reflows into a header row + metadata grid + side-by-side
   social rows). The 2xl threshold (not lg) accounts for the 348px left sidebar (lg:ml-[348px] on
-  <main>) plus 64px page padding (md:px-8) that also apply once the sidebar shows — at lg that
-  leaves only a 312px content column next to a 300px rail; at 2xl it leaves 728px.
+  <main>) plus 56px page padding (md:px-8, which is 2rem per side at this app's 14px root — not the
+  64px a 16px-root assumption would give) that also apply once the sidebar shows — at lg that leaves
+  only a 320px content column next to a 300px rail; at 2xl it leaves 736px.
 -->
 <div class="flex flex-col" data-testid="profile-layout">
   <!-- Left column -->

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -2,12 +2,13 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Profile & Account hub. The profile panel is a fixed, full-height 300px rail pinned to the right
-  edge of the viewport at lg and up — mirroring the left menu. It never stacks above the content,
-  never changes width, and always sits above page content (z-40) at that breakpoint.
-  MainLayoutComponent reserves a matching right gutter (lg:pr-[300px]) on the profile hub so the
-  content and the shared footer stay clear of the rail. The rail's `top` matches the impersonation
-  banner offset. Below lg, the panel renders inline in the content column above the subtabs instead.
+  Profile & Account hub. At lg and up, the profile panel is a fixed, full-height 300px rail pinned
+  to the right edge of the viewport — mirroring the left menu: it never stacks above the content,
+  never changes width, and always sits above page content (z-40). MainLayoutComponent reserves a
+  matching right gutter (lg:pr-[300px]) on the profile hub so the content and the shared footer
+  stay clear of the rail. The rail's `top` matches the impersonation banner offset. Below lg, the
+  panel renders inline in the content column above the subtabs instead, capped at max-w-md so it
+  keeps rail-like proportions rather than stretching to the full column width.
 -->
 <div class="flex flex-col" data-testid="profile-layout">
   <!-- Left column -->
@@ -30,9 +31,9 @@
         <p class="mt-1 text-sm text-slate-500">Manage your profile and account settings.</p>
       </div>
 
-      <!-- Profile panel — inline below lg; fixed full-height right rail at lg and up (out of normal flow) -->
+      <!-- Profile panel — inline below lg (capped at max-w-md); fixed full-height right rail at lg and up (out of normal flow) -->
       <div
-        class="lg:fixed lg:bottom-0 lg:right-0 lg:z-40 lg:w-[300px]"
+        class="max-w-md lg:max-w-none lg:fixed lg:bottom-0 lg:right-0 lg:z-40 lg:w-[300px]"
         [ngClass]="{ 'lg:top-12': impersonating(), 'lg:top-0': !impersonating() }">
         <lfx-profile-panel
           [loading]="loading()"

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -34,7 +34,8 @@
       <!-- Profile panel — inline below lg (capped at max-w-md); fixed full-height right rail at lg and up (out of normal flow) -->
       <div
         class="max-w-md lg:max-w-none lg:fixed lg:bottom-0 lg:right-0 lg:z-40 lg:w-[300px]"
-        [ngClass]="{ 'lg:top-12': impersonating(), 'lg:top-0': !impersonating() }">
+        [ngClass]="{ 'lg:top-12': impersonating(), 'lg:top-0': !impersonating() }"
+        data-testid="profile-panel-rail">
         <lfx-profile-panel
           [loading]="loading()"
           [impersonating]="impersonating()"

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -3,33 +3,13 @@
 
 <!--
   Profile & Account hub. The profile panel is a fixed, full-height 300px rail pinned to the right
-  edge of the viewport at every screen size — mirroring the left menu. It never stacks above the
-  content, never changes width, and always sits above page content (z-40). MainLayoutComponent
-  reserves a matching right gutter (pr-[300px]) on the profile hub so the content and the shared
-  footer stay clear of the rail. The rail's `top` matches the impersonation banner offset.
+  edge of the viewport at lg and up — mirroring the left menu. It never stacks above the content,
+  never changes width, and always sits above page content (z-40) at that breakpoint.
+  MainLayoutComponent reserves a matching right gutter (lg:pr-[300px]) on the profile hub so the
+  content and the shared footer stay clear of the rail. The rail's `top` matches the impersonation
+  banner offset. Below lg, the panel renders inline in the content column above the subtabs instead.
 -->
 <div class="flex flex-col" data-testid="profile-layout">
-  <!-- Profile panel — fixed full-height right rail at all widths (out of normal flow) -->
-  <div class="fixed bottom-0 right-0 z-40 w-[300px]" [class.top-12]="impersonating()" [class.top-0]="!impersonating()">
-    <lfx-profile-panel
-      [loading]="loading()"
-      [impersonating]="impersonating()"
-      [avatarUrl]="avatarUrl()"
-      [displayName]="displayName()"
-      [initials]="initials()"
-      [username]="displayUsername() ?? ''"
-      [jobTitle]="jobTitle()"
-      [organization]="organization()"
-      [email]="emailInfo()"
-      [addressLines]="fullAddress()"
-      [phone]="phoneInfo()"
-      [tshirtSize]="tshirtSizeLabel()"
-      [aboutMe]="aboutMe()"
-      [githubHandle]="githubHandle()"
-      (editRequested)="openEditDrawer()"
-      (visibilityRequested)="openVisibilityDrawer()" />
-  </div>
-
   <!-- Left column -->
   <div class="min-w-0 flex-1">
     <div class="mx-auto flex max-w-[1024px] flex-col gap-6">
@@ -48,6 +28,29 @@
       <div>
         <h1 class="text-[22px] font-bold tracking-tight text-slate-900" data-testid="profile-page-title">Profile &amp; Account</h1>
         <p class="mt-1 text-sm text-slate-500">Manage your profile and account settings.</p>
+      </div>
+
+      <!-- Profile panel — inline below lg; fixed full-height right rail at lg and up (out of normal flow) -->
+      <div
+        class="lg:fixed lg:bottom-0 lg:right-0 lg:z-40 lg:w-[300px]"
+        [ngClass]="{ 'lg:top-12': impersonating(), 'lg:top-0': !impersonating() }">
+        <lfx-profile-panel
+          [loading]="loading()"
+          [impersonating]="impersonating()"
+          [avatarUrl]="avatarUrl()"
+          [displayName]="displayName()"
+          [initials]="initials()"
+          [username]="displayUsername() ?? ''"
+          [jobTitle]="jobTitle()"
+          [organization]="organization()"
+          [email]="emailInfo()"
+          [addressLines]="fullAddress()"
+          [phone]="phoneInfo()"
+          [tshirtSize]="tshirtSizeLabel()"
+          [aboutMe]="aboutMe()"
+          [githubHandle]="githubHandle()"
+          (editRequested)="openEditDrawer()"
+          (visibilityRequested)="openVisibilityDrawer()" />
       </div>
 
       <!-- Subtab navigation — horizontally scrollable on small screens -->

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -7,10 +7,10 @@
   never changes width, and always sits above page content (z-40). MainLayoutComponent reserves a
   matching right gutter (2xl:pr-[300px]) on the profile hub so the content and the shared footer
   stay clear of the rail. The rail's `top` matches the impersonation banner offset. Below 2xl, the
-  panel renders inline in the content column above the subtabs instead, full width — the panel's
-  own internal layout (profile-panel.component.html) reflows across three states: a stacked card
-  below sm, a full-width horizontal layout from sm up to just under 2xl, and the vertical rail at
-  2xl and up. The 2xl threshold (not lg) accounts for the 348px left sidebar (lg:ml-[348px] on
+  panel renders inline in the content column above the subtabs instead — capped at max-w-md below
+  sm (a stacked card), full width from sm up to just under 2xl (where the panel's own internal
+  layout, profile-panel.component.html, reflows into a header row + metadata grid + side-by-side
+  social rows). The 2xl threshold (not lg) accounts for the 348px left sidebar (lg:ml-[348px] on
   <main>) plus 64px page padding (md:px-8) that also apply once the sidebar shows — at lg that
   leaves only a 312px content column next to a 300px rail; at 2xl it leaves 728px.
 -->
@@ -35,9 +35,13 @@
         <p class="mt-1 text-sm text-slate-500">Manage your profile and account settings.</p>
       </div>
 
-      <!-- Profile panel — full-width inline below 2xl (reflows internally at sm+); fixed full-height right rail at 2xl and up (out of normal flow) -->
+      <!-- Profile panel — capped at max-w-md below sm (stacked card, matches the design's "stacked
+           card below sm" state — the content column can exceed 448px there, e.g. ~510px at a 550px
+           viewport, so without the cap the card would stretch wide while still fully stacked
+           internally); full width from sm up to 2xl (reflows internally); fixed full-height right
+           rail at 2xl and up (out of normal flow). -->
       <div
-        class="2xl:fixed 2xl:bottom-0 2xl:right-0 2xl:z-40 2xl:w-[300px]"
+        class="max-w-md sm:max-w-none 2xl:fixed 2xl:bottom-0 2xl:right-0 2xl:z-40 2xl:w-[300px]"
         [ngClass]="{ '2xl:top-12': impersonating(), '2xl:top-0': !impersonating() }"
         data-testid="profile-panel-rail">
         <lfx-profile-panel

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.html
@@ -2,13 +2,16 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Profile & Account hub. At lg and up, the profile panel is a fixed, full-height 300px rail pinned
+  Profile & Account hub. At 2xl and up, the profile panel is a fixed, full-height 300px rail pinned
   to the right edge of the viewport — mirroring the left menu: it never stacks above the content,
   never changes width, and always sits above page content (z-40). MainLayoutComponent reserves a
-  matching right gutter (lg:pr-[300px]) on the profile hub so the content and the shared footer
-  stay clear of the rail. The rail's `top` matches the impersonation banner offset. Below lg, the
+  matching right gutter (2xl:pr-[300px]) on the profile hub so the content and the shared footer
+  stay clear of the rail. The rail's `top` matches the impersonation banner offset. Below 2xl, the
   panel renders inline in the content column above the subtabs instead, capped at max-w-md so it
-  keeps rail-like proportions rather than stretching to the full column width.
+  keeps rail-like proportions rather than stretching to the full column width. The 2xl threshold
+  (not lg) accounts for the 348px left sidebar (lg:ml-[348px] on <main>) plus 64px page padding
+  (md:px-8) that also apply once the sidebar shows — at lg that leaves only a 312px content column
+  next to a 300px rail; at 2xl it leaves 728px.
 -->
 <div class="flex flex-col" data-testid="profile-layout">
   <!-- Left column -->
@@ -31,10 +34,10 @@
         <p class="mt-1 text-sm text-slate-500">Manage your profile and account settings.</p>
       </div>
 
-      <!-- Profile panel — inline below lg (capped at max-w-md); fixed full-height right rail at lg and up (out of normal flow) -->
+      <!-- Profile panel — inline below 2xl (capped at max-w-md); fixed full-height right rail at 2xl and up (out of normal flow) -->
       <div
-        class="max-w-md lg:max-w-none lg:fixed lg:bottom-0 lg:right-0 lg:z-40 lg:w-[300px]"
-        [ngClass]="{ 'lg:top-12': impersonating(), 'lg:top-0': !impersonating() }"
+        class="max-w-md 2xl:max-w-none 2xl:fixed 2xl:bottom-0 2xl:right-0 2xl:z-40 2xl:w-[300px]"
+        [ngClass]="{ '2xl:top-12': impersonating(), '2xl:top-0': !impersonating() }"
         data-testid="profile-panel-rail">
         <lfx-profile-panel
           [loading]="loading()"

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -33,10 +33,10 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
 /**
  * ProfileLayoutComponent is the shell for the Profile & Account hub. It provides:
  * - Content column: page head, subtab navigation, and the router outlet for child pages
- * - A profile rail (lfx-profile-panel) that is inline in the content column below lg, and a fixed,
- *   full-height 300px rail pinned to the right edge at lg and up — never stacks above the content,
+ * - A profile rail (lfx-profile-panel) that is inline in the content column below 2xl, and a fixed,
+ *   full-height 300px rail pinned to the right edge at 2xl and up — never stacks above the content,
  *   never changes width, and sits above page content (z-40) at that breakpoint; MainLayoutComponent
- *   reserves a matching right gutter (lg and up only) so content/footer stay clear of it
+ *   reserves a matching right gutter (2xl and up only) so content/footer stay clear of it
  *
  * The layout owns the profile data fetch, optimistic updates, the edit drawer, and the
  * Flow C (management-token) auth-return handling; the panel is presentational and emits

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { isPlatformBrowser } from '@angular/common';
+import { isPlatformBrowser, NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
@@ -33,9 +33,10 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
 /**
  * ProfileLayoutComponent is the shell for the Profile & Account hub. It provides:
  * - Content column: page head, subtab navigation, and the router outlet for child pages
- * - A fixed, full-height 300px profile rail (lfx-profile-panel) pinned to the right edge at every
- *   screen size — never stacks above the content, never changes width, and sits above page content
- *   (z-40); MainLayoutComponent reserves a matching right gutter so content/footer stay clear of it
+ * - A profile rail (lfx-profile-panel) that is inline in the content column below lg, and a fixed,
+ *   full-height 300px rail pinned to the right edge at lg and up — never stacks above the content,
+ *   never changes width, and sits above page content (z-40) at that breakpoint; MainLayoutComponent
+ *   reserves a matching right gutter (lg and up only) so content/footer stay clear of it
  *
  * The layout owns the profile data fetch, optimistic updates, the edit drawer, and the
  * Flow C (management-token) auth-return handling; the panel is presentational and emits
@@ -43,7 +44,7 @@ const PROFILE_AUTH_ERROR_CODES = new Set([
  */
 @Component({
   selector: 'lfx-profile-layout',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive, ProfilePanelComponent, ProfileEditDrawerComponent, ProfileVisibilityDrawerComponent],
+  imports: [NgClass, RouterOutlet, RouterLink, RouterLinkActive, ProfilePanelComponent, ProfileEditDrawerComponent, ProfileVisibilityDrawerComponent],
   // Drawer services are layout-scoped (not root) so their retained context is torn down when the hub
   // is left; each drawer child shares this injector instance via the providers below. MessageService
   // is deliberately NOT scoped here — the app's only <p-toast/> lives in AppComponent and reads from

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -2,13 +2,13 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Presentational summary card. Below lg it renders inline in the content column as a standalone
-  card (rounded, bordered, own padding). At lg and up the layout wraps this in a fixed full-height
+  Presentational summary card. Below 2xl it renders inline in the content column as a standalone
+  card (rounded, bordered, own padding). At 2xl and up the layout wraps this in a fixed full-height
   right rail; there we fill that rail (h-full) with a flush surface and a left border mirroring the
   left menu, scrolling its own content independently (overflow-y-auto) when the viewport is short.
 -->
 <aside
-  class="flex flex-col rounded-xl border border-gray-200 bg-white px-5 py-6 lg:h-full lg:overflow-y-auto lg:rounded-none lg:border-0 lg:border-l lg:px-6 lg:py-7"
+  class="flex flex-col rounded-xl border border-gray-200 bg-white px-5 py-6 2xl:h-full 2xl:overflow-y-auto 2xl:rounded-none 2xl:border-0 2xl:border-l 2xl:px-6 2xl:py-7"
   aria-label="Profile summary"
   data-testid="profile-panel">
   @if (loading()) {

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -2,11 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Presentational summary card. The layout wraps this in a fixed full-height right rail; here we
-  fill that rail (h-full) with a white, flush surface and a left border mirroring the left menu,
-  scrolling its own content independently (overflow-y-auto) when the viewport is short.
+  Presentational summary card. Below lg it renders inline in the content column as a standalone
+  card (rounded, bordered, own padding). At lg and up the layout wraps this in a fixed full-height
+  right rail; there we fill that rail (h-full) with a flush surface and a left border mirroring the
+  left menu, scrolling its own content independently (overflow-y-auto) when the viewport is short.
 -->
-<aside class="flex h-full flex-col overflow-y-auto border-l border-gray-200 bg-white px-6 py-7" aria-label="Profile summary" data-testid="profile-panel">
+<aside
+  class="flex flex-col rounded-xl border border-gray-200 bg-white px-5 py-6 lg:h-full lg:overflow-y-auto lg:rounded-none lg:border-0 lg:border-l lg:px-6 lg:py-7"
+  aria-label="Profile summary"
+  data-testid="profile-panel">
   @if (loading()) {
     <div class="flex items-center justify-center py-8" role="status" aria-live="polite">
       <i class="fa-light fa-circle-notch fa-spin text-3xl text-blue-400" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -2,11 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Presentational summary card. Below 2xl it renders inline in the content column, full width, as a
-  standalone card (rounded, bordered, own padding) — its internal layout reflows across three
-  states: a single stacked column below sm, a full-width horizontal layout (header row + 2/3-col
-  metadata grid + side-by-side social rows) from sm up to just under 2xl, so it doesn't sit as a
-  narrow left-aligned card with blank space beside it. At 2xl and up the layout wraps this in a
+  Presentational summary card. Below 2xl it renders inline in the content column as a standalone
+  card (rounded, bordered, own padding) — capped at max-w-md below sm (parent wrapper, see
+  profile-layout.component.html) and full width from sm up. Its own internal layout reflows across
+  three states: a single stacked column below sm, a full-width horizontal layout (header row +
+  2/3-col metadata grid + side-by-side social rows) from sm up to just under 2xl, so it doesn't sit
+  as a narrow left-aligned card with blank space beside it. At 2xl and up the layout wraps this in a
   fixed full-height right rail, and every sm:/md: reflow class collapses back to the original
   single-column layout there; we fill that rail (h-full) with a flush surface and a left border
   mirroring the left menu, scrolling its own content independently (overflow-y-auto) when the
@@ -26,8 +27,9 @@
          panel is full width in that band, not a narrow rail); back to stacked block flow at 2xl,
          matching the fixed rail's narrow column. -->
     <div class="sm:flex sm:items-start sm:gap-5 2xl:block">
-      <!-- Avatar + edit-pencil badge (rounded, not circle) -->
-      <div class="relative mb-3.5 w-24">
+      <!-- Avatar + edit-pencil badge (rounded, not circle). mb-3.5 only applies below sm and at 2xl
+           (stacked states) — in the sm-2xl row it would leave 14px of dead space under the avatar. -->
+      <div class="relative mb-3.5 w-24 sm:mb-0 2xl:mb-3.5">
         <div
           class="flex h-24 w-24 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-blue-500 to-violet-600 text-xl font-semibold text-white"
           data-testid="profile-avatar">
@@ -60,17 +62,21 @@
         </span>
       </div>
 
-      <!-- Name + handle -->
-      <div>
-        <p class="text-left text-[17px] font-bold text-slate-900" data-testid="profile-display-name">{{ displayName() }}</p>
+      <!-- Name + handle. min-w-0 lets this flex item shrink below its content's min-content width in
+           the sm-2xl row (the flex default is min-width: auto, which would instead force the row to
+           overflow if displayName() falls back to a long, unbreakable username); break-words lets a
+           long name wrap instead of pushing the fixed-width pills container past the card edge. -->
+      <div class="min-w-0">
+        <p class="break-words text-left text-[17px] font-bold text-slate-900" data-testid="profile-display-name">{{ displayName() }}</p>
         @if (username()) {
-          <p class="mb-4 text-left text-xs text-slate-500" data-testid="profile-panel-handle">&#64;{{ username() }}</p>
+          <p class="mb-4 break-words text-left text-xs text-slate-500" data-testid="profile-panel-handle">&#64;{{ username() }}</p>
         }
       </div>
 
       <!-- Action pills — pushed to the row's trailing edge at sm+ (ml-auto), fixed-width so they don't
-           stretch to fill the row; back to full-width stacked at 2xl. -->
-      <div class="sm:ml-auto sm:flex sm:w-auto sm:flex-col sm:gap-2.5 2xl:ml-0 2xl:w-full">
+           stretch to fill the row; sm:shrink-0 keeps them at their full sm:w-56 even if the name above
+           is long enough to want the space; back to full-width stacked at 2xl. -->
+      <div class="sm:ml-auto sm:flex sm:flex-col sm:shrink-0 sm:gap-2.5 2xl:ml-0 2xl:w-full">
         <!-- Edit profile pill -->
         <button
           type="button"
@@ -105,7 +111,7 @@
          to fit the fixed rail's width. -->
     <div class="flex flex-col gap-5 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:gap-y-5 md:grid-cols-3 2xl:flex 2xl:flex-col">
       @if (aboutMe()) {
-        <div class="sm:col-span-2 md:col-span-3 2xl:col-span-1" data-testid="profile-panel-about">
+        <div class="sm:col-span-2 md:col-span-3" data-testid="profile-panel-about">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-file-lines"></i>
             <span>About me</span>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.html
@@ -2,10 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <!--
-  Presentational summary card. Below 2xl it renders inline in the content column as a standalone
-  card (rounded, bordered, own padding). At 2xl and up the layout wraps this in a fixed full-height
-  right rail; there we fill that rail (h-full) with a flush surface and a left border mirroring the
-  left menu, scrolling its own content independently (overflow-y-auto) when the viewport is short.
+  Presentational summary card. Below 2xl it renders inline in the content column, full width, as a
+  standalone card (rounded, bordered, own padding) — its internal layout reflows across three
+  states: a single stacked column below sm, a full-width horizontal layout (header row + 2/3-col
+  metadata grid + side-by-side social rows) from sm up to just under 2xl, so it doesn't sit as a
+  narrow left-aligned card with blank space beside it. At 2xl and up the layout wraps this in a
+  fixed full-height right rail, and every sm:/md: reflow class collapses back to the original
+  single-column layout there; we fill that rail (h-full) with a flush surface and a left border
+  mirroring the left menu, scrolling its own content independently (overflow-y-auto) when the
+  viewport is short.
 -->
 <aside
   class="flex flex-col rounded-xl border border-gray-200 bg-white px-5 py-6 2xl:h-full 2xl:overflow-y-auto 2xl:rounded-none 2xl:border-0 2xl:border-l 2xl:px-6 2xl:py-7"
@@ -17,76 +22,90 @@
       <span class="sr-only">Loading profile summary</span>
     </div>
   } @else {
-    <!-- Avatar + edit-pencil badge (rounded, not circle) -->
-    <div class="relative mb-3.5 w-24">
-      <div
-        class="flex h-24 w-24 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-blue-500 to-violet-600 text-xl font-semibold text-white"
-        data-testid="profile-avatar">
-        @if (showAvatarImage()) {
-          <img
-            [src]="avatarUrl()"
-            [alt]="displayName()"
-            (error)="onAvatarError()"
-            class="h-full w-full rounded-2xl object-cover"
-            data-testid="profile-avatar-image" />
-        } @else {
-          {{ initials() }}
+    <!-- Header: avatar + name/handle + action pills. Row layout from sm up to just under 2xl (the
+         panel is full width in that band, not a narrow rail); back to stacked block flow at 2xl,
+         matching the fixed rail's narrow column. -->
+    <div class="sm:flex sm:items-start sm:gap-5 2xl:block">
+      <!-- Avatar + edit-pencil badge (rounded, not circle) -->
+      <div class="relative mb-3.5 w-24">
+        <div
+          class="flex h-24 w-24 items-center justify-center overflow-hidden rounded-2xl bg-gradient-to-br from-blue-500 to-violet-600 text-xl font-semibold text-white"
+          data-testid="profile-avatar">
+          @if (showAvatarImage()) {
+            <img
+              [src]="avatarUrl()"
+              [alt]="displayName()"
+              (error)="onAvatarError()"
+              class="h-full w-full rounded-2xl object-cover"
+              data-testid="profile-avatar-image" />
+          } @else {
+            {{ initials() }}
+          }
+        </div>
+        <!--
+          Decorative duplicate of the "Edit profile" pill below. A plain span (not a button) so it is
+          never focusable, keeping it out of both the a11y tree (aria-hidden) and tab/focus order:
+          screen-reader and keyboard users get a single actionable control (the labeled pill) for one
+          destination. Stays mouse-clickable; while impersonating, pointer-events-none blocks the click
+          (onEdit() is a no-op then anyway) and opacity-40 mirrors the disabled look.
+        -->
+        <span
+          (click)="onEdit()"
+          aria-hidden="true"
+          [class.pointer-events-none]="impersonating()"
+          [class.opacity-40]="impersonating()"
+          class="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition-colors hover:bg-slate-50"
+          data-testid="profile-panel-edit-badge">
+          <i class="fa-light fa-pencil text-xs"></i>
+        </span>
+      </div>
+
+      <!-- Name + handle -->
+      <div>
+        <p class="text-left text-[17px] font-bold text-slate-900" data-testid="profile-display-name">{{ displayName() }}</p>
+        @if (username()) {
+          <p class="mb-4 text-left text-xs text-slate-500" data-testid="profile-panel-handle">&#64;{{ username() }}</p>
         }
       </div>
-      <!--
-        Decorative duplicate of the "Edit profile" pill below. A plain span (not a button) so it is
-        never focusable, keeping it out of both the a11y tree (aria-hidden) and tab/focus order:
-        screen-reader and keyboard users get a single actionable control (the labeled pill) for one
-        destination. Stays mouse-clickable; while impersonating, pointer-events-none blocks the click
-        (onEdit() is a no-op then anyway) and opacity-40 mirrors the disabled look.
-      -->
-      <span
-        (click)="onEdit()"
-        aria-hidden="true"
-        [class.pointer-events-none]="impersonating()"
-        [class.opacity-40]="impersonating()"
-        class="absolute -right-1 -top-1 flex h-7 w-7 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 shadow-sm transition-colors hover:bg-slate-50"
-        data-testid="profile-panel-edit-badge">
-        <i class="fa-light fa-pencil text-xs"></i>
-      </span>
+
+      <!-- Action pills — pushed to the row's trailing edge at sm+ (ml-auto), fixed-width so they don't
+           stretch to fill the row; back to full-width stacked at 2xl. -->
+      <div class="sm:ml-auto sm:flex sm:w-auto sm:flex-col sm:gap-2.5 2xl:ml-0 2xl:w-full">
+        <!-- Edit profile pill -->
+        <button
+          type="button"
+          (click)="onEdit()"
+          [disabled]="impersonating()"
+          [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : null"
+          class="mb-2.5 flex w-full items-center justify-center gap-1.5 rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-800 transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 sm:mb-0 sm:w-56 2xl:w-full"
+          data-testid="profile-edit-button">
+          <i class="fa-light fa-pencil text-xs"></i>
+          Edit profile
+        </button>
+
+        <!-- Public profile visibility (LFXV2-2629) -->
+        <button
+          type="button"
+          (click)="onVisibility()"
+          [disabled]="impersonating()"
+          [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : null"
+          class="flex w-full items-center justify-center gap-1.5 rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-800 transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40 sm:w-56 2xl:w-full"
+          data-testid="profile-visibility-button">
+          <i class="fa-light fa-eye text-xs"></i>
+          Public profile settings
+        </button>
+      </div>
     </div>
-
-    <!-- Name + handle -->
-    <p class="text-left text-[17px] font-bold text-slate-900" data-testid="profile-display-name">{{ displayName() }}</p>
-    @if (username()) {
-      <p class="mb-4 text-left text-xs text-slate-500" data-testid="profile-panel-handle">&#64;{{ username() }}</p>
-    }
-
-    <!-- Edit profile pill -->
-    <button
-      type="button"
-      (click)="onEdit()"
-      [disabled]="impersonating()"
-      [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : null"
-      class="mb-2.5 flex w-full items-center justify-center gap-1.5 rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-800 transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
-      data-testid="profile-edit-button">
-      <i class="fa-light fa-pencil text-xs"></i>
-      Edit profile
-    </button>
-
-    <!-- Public profile visibility (LFXV2-2629) -->
-    <button
-      type="button"
-      (click)="onVisibility()"
-      [disabled]="impersonating()"
-      [attr.aria-label]="impersonating() ? 'This action is unavailable while impersonating another user' : null"
-      class="flex w-full items-center justify-center gap-1.5 rounded-full border border-slate-300 bg-white px-3 py-2 text-xs font-medium text-slate-800 transition-colors enabled:hover:bg-slate-50 disabled:cursor-not-allowed disabled:opacity-40"
-      data-testid="profile-visibility-button">
-      <i class="fa-light fa-eye text-xs"></i>
-      Public profile settings
-    </button>
 
     <div class="my-5 h-px bg-slate-200"></div>
 
-    <!-- Fields — each renders only when its value is present -->
-    <div class="flex flex-col gap-5">
+    <!-- Fields — each renders only when its value is present. Stacked below sm; a 2-col grid from sm,
+         3-col from md, so the reflowed panel doesn't leave a lone populated cell in a mostly-empty
+         row (grid auto-flow packs however many fields exist); back to a single stacked column at 2xl
+         to fit the fixed rail's width. -->
+    <div class="flex flex-col gap-5 sm:grid sm:grid-cols-2 sm:gap-x-8 sm:gap-y-5 md:grid-cols-3 2xl:flex 2xl:flex-col">
       @if (aboutMe()) {
-        <div data-testid="profile-panel-about">
+        <div class="sm:col-span-2 md:col-span-3 2xl:col-span-1" data-testid="profile-panel-about">
           <div class="mb-0.5 flex items-center gap-1.5 text-[11px] text-slate-500">
             <i class="fa-light fa-file-lines"></i>
             <span>About me</span>
@@ -154,10 +173,12 @@
       }
     </div>
 
-    <!-- Social rows — GitHub is wired from the user's connected identities; LinkedIn is stubbed. Each renders only when present. -->
+    <!-- Social rows — GitHub is wired from the user's connected identities; LinkedIn is stubbed. Each
+         renders only when present. Side by side at sm+ (the reflowed panel has the width for it);
+         back to stacked at 2xl to fit the fixed rail. -->
     @if (githubHandle() || linkedinHandle()) {
       <div class="my-1 h-px bg-slate-200"></div>
-      <div class="flex flex-col gap-2 pt-4">
+      <div class="flex flex-col gap-2 pt-4 sm:flex-row sm:gap-6 2xl:flex-col 2xl:gap-2">
         @if (githubHandle()) {
           <div class="flex items-center gap-2 text-[12.5px] text-slate-700" data-testid="profile-panel-github">
             <i class="fa-brands fa-github text-slate-800"></i>

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -4,8 +4,8 @@
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 
 /**
- * ProfilePanelComponent is the right-hand panel of the Profile & Account hub. Below lg, the layout
- * renders it inline in the content column as a standalone card; at lg and up, the layout wraps it
+ * ProfilePanelComponent is the right-hand panel of the Profile & Account hub. Below 2xl, the layout
+ * renders it inline in the content column as a standalone card; at 2xl and up, the layout wraps it
  * in a fixed, full-height 300px rail pinned to the right edge, and this component fills that rail
  * and scrolls its own content independently when the viewport is short.
  * It is purely presentational: all values arrive via signal inputs (sourced from the
@@ -13,9 +13,9 @@ import { ChangeDetectionStrategy, Component, computed, input, output, signal } f
  * `editRequested` so the parent — which owns the profile data, edit dialog, and
  * optimistic-update logic — handles the actual edit flow.
  *
- * The host is `block lg:h-full` so at lg and up the inner `aside`'s `h-full`/`overflow-y-auto`
+ * The host is `block 2xl:h-full` so at 2xl and up the inner `aside`'s `h-full`/`overflow-y-auto`
  * resolves against the fixed rail's height (mirrors lfx-sidebar's `:host { height: 100% }`);
- * below lg the height chain is unused since the card renders inline instead of in a fixed rail.
+ * below 2xl the height chain is unused since the card renders inline instead of in a fixed rail.
  *
  * Rows render only when their value is present. About me (from the profile bio) and GitHub
  * (from the user's connected identities) are sourced and bound by the parent; LinkedIn is
@@ -24,7 +24,7 @@ import { ChangeDetectionStrategy, Component, computed, input, output, signal } f
 @Component({
   selector: 'lfx-profile-panel',
   imports: [],
-  host: { class: 'block lg:h-full' },
+  host: { class: 'block 2xl:h-full' },
   templateUrl: './profile-panel.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-panel/profile-panel.component.ts
@@ -4,17 +4,18 @@
 import { ChangeDetectionStrategy, Component, computed, input, output, signal } from '@angular/core';
 
 /**
- * ProfilePanelComponent is the right-hand panel of the Profile & Account hub. The layout wraps it
- * in a fixed, full-height 300px rail pinned to the right edge at every screen size; this component
- * fills that rail and scrolls its own content independently when the viewport is short.
+ * ProfilePanelComponent is the right-hand panel of the Profile & Account hub. Below lg, the layout
+ * renders it inline in the content column as a standalone card; at lg and up, the layout wraps it
+ * in a fixed, full-height 300px rail pinned to the right edge, and this component fills that rail
+ * and scrolls its own content independently when the viewport is short.
  * It is purely presentational: all values arrive via signal inputs (sourced from the
  * parent ProfileLayoutComponent's CombinedProfile) and the edit affordances emit
  * `editRequested` so the parent — which owns the profile data, edit dialog, and
  * optimistic-update logic — handles the actual edit flow.
  *
- * The host is `block h-full` so the inner `aside`'s `h-full`/`overflow-y-auto` resolves against
- * the fixed rail's height (mirrors lfx-sidebar's `:host { height: 100% }`); without host sizing
- * the height chain breaks and the rail cannot scroll independently.
+ * The host is `block lg:h-full` so at lg and up the inner `aside`'s `h-full`/`overflow-y-auto`
+ * resolves against the fixed rail's height (mirrors lfx-sidebar's `:host { height: 100% }`);
+ * below lg the height chain is unused since the card renders inline instead of in a fixed rail.
  *
  * Rows render only when their value is present. About me (from the profile bio) and GitHub
  * (from the user's connected identities) are sourced and bound by the parent; LinkedIn is
@@ -23,7 +24,7 @@ import { ChangeDetectionStrategy, Component, computed, input, output, signal } f
 @Component({
   selector: 'lfx-profile-panel',
   imports: [],
-  host: { class: 'block h-full' },
+  host: { class: 'block lg:h-full' },
   templateUrl: './profile-panel.component.html',
   changeDetection: ChangeDetectionStrategy.OnPush,
 })

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
@@ -71,38 +71,40 @@
                   class="flex flex-wrap items-center gap-2 rounded-md px-2 py-1"
                   [class]="isOverlapping ? 'bg-amber-50/50' : ''"
                   [attr.data-testid]="'period-row-' + period.id">
-                  <!-- Start label — unconditional (not sm-gated), so the pair stays identifiable regardless of
-                       whether flex-wrap kicks in from the true viewport or from the dialog's own rendered width -->
-                  <span class="text-xs font-medium text-slate-500">Start</span>
-                  <!-- Start Month/Year — equal-width grid below sm so the pair wraps to two rows instead of
-                       overflowing; fixed 110px/100px columns at sm and up so w-full resolves to the original
-                       month/year widths instead of shrink-to-fit sizing -->
-                  <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">
-                    <p-select
-                      [options]="monthOptions"
-                      [ngModel]="period.startMonth"
-                      (ngModelChange)="updatePeriodField(org.organization, period.id, 'startMonth', $event)"
-                      optionLabel="label"
-                      optionValue="value"
-                      placeholder="Month"
-                      [ariaLabel]="'Start month, ' + org.organization + ' period ' + ($index + 1)"
-                      styleClass="w-full"
-                      size="small"
-                      appendTo="body"
-                      [attr.data-testid]="'period-start-month-' + period.id" />
+                  <!-- Start label + Start Month/Year, grouped into ONE flex item so flex-wrap on the row
+                       (below) can only move the whole pair to the next line, never orphan the label from
+                       its controls. Below sm the month/year grid keeps them equal-width side by side (2
+                       columns, not stacked); fixed 110px/100px columns at sm and up so w-full resolves to
+                       the original month/year widths instead of shrink-to-fit sizing. -->
+                  <div class="flex items-center gap-2">
+                    <span class="text-xs font-medium text-slate-500">Start</span>
+                    <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">
+                      <p-select
+                        [options]="monthOptions"
+                        [ngModel]="period.startMonth"
+                        (ngModelChange)="updatePeriodField(org.organization, period.id, 'startMonth', $event)"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Month"
+                        [ariaLabel]="'Start month, ' + org.organization + ' period ' + ($index + 1)"
+                        styleClass="w-full"
+                        size="small"
+                        appendTo="body"
+                        [attr.data-testid]="'period-start-month-' + period.id" />
 
-                    <p-select
-                      [options]="periodYearOptions"
-                      [ngModel]="period.startYear"
-                      (ngModelChange)="updatePeriodField(org.organization, period.id, 'startYear', $event)"
-                      optionLabel="label"
-                      optionValue="value"
-                      placeholder="Year"
-                      [ariaLabel]="'Start year, ' + org.organization + ' period ' + ($index + 1)"
-                      styleClass="w-full"
-                      size="small"
-                      appendTo="body"
-                      [attr.data-testid]="'period-start-year-' + period.id" />
+                      <p-select
+                        [options]="periodYearOptions"
+                        [ngModel]="period.startYear"
+                        (ngModelChange)="updatePeriodField(org.organization, period.id, 'startYear', $event)"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Year"
+                        [ariaLabel]="'Start year, ' + org.organization + ' period ' + ($index + 1)"
+                        styleClass="w-full"
+                        size="small"
+                        appendTo="body"
+                        [attr.data-testid]="'period-start-year-' + period.id" />
+                    </div>
                   </div>
 
                   <!-- Hidden below sm — reads as a stray dash between wrapped start/end pairs there -->
@@ -112,35 +114,37 @@
                   @if (period.isPresent) {
                     <span class="text-xs font-medium text-slate-500">End: Present</span>
                   } @else {
-                    <!-- End label — unconditional, see Start label comment above -->
-                    <span class="text-xs font-medium text-slate-500">End</span>
-                    <!-- End Month/Year — same equal-width-below-sm / fixed-columns-at-sm pattern as the start pair -->
-                    <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">
-                      <p-select
-                        [options]="monthOptions"
-                        [ngModel]="period.endMonth"
-                        (ngModelChange)="updatePeriodField(org.organization, period.id, 'endMonth', $event)"
-                        optionLabel="label"
-                        optionValue="value"
-                        placeholder="Month"
-                        [ariaLabel]="'End month, ' + org.organization + ' period ' + ($index + 1)"
-                        styleClass="w-full"
-                        size="small"
-                        appendTo="body"
-                        [attr.data-testid]="'period-end-month-' + period.id" />
+                    <!-- End label + End Month/Year, grouped into ONE flex item — see Start pair comment
+                         above (same flex-wrap-orphan concern, same fixed-column pattern). -->
+                    <div class="flex items-center gap-2">
+                      <span class="text-xs font-medium text-slate-500">End</span>
+                      <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">
+                        <p-select
+                          [options]="monthOptions"
+                          [ngModel]="period.endMonth"
+                          (ngModelChange)="updatePeriodField(org.organization, period.id, 'endMonth', $event)"
+                          optionLabel="label"
+                          optionValue="value"
+                          placeholder="Month"
+                          [ariaLabel]="'End month, ' + org.organization + ' period ' + ($index + 1)"
+                          styleClass="w-full"
+                          size="small"
+                          appendTo="body"
+                          [attr.data-testid]="'period-end-month-' + period.id" />
 
-                      <p-select
-                        [options]="periodYearOptions"
-                        [ngModel]="period.endYear"
-                        (ngModelChange)="updatePeriodField(org.organization, period.id, 'endYear', $event)"
-                        optionLabel="label"
-                        optionValue="value"
-                        placeholder="Year"
-                        [ariaLabel]="'End year, ' + org.organization + ' period ' + ($index + 1)"
-                        styleClass="w-full"
-                        size="small"
-                        appendTo="body"
-                        [attr.data-testid]="'period-end-year-' + period.id" />
+                        <p-select
+                          [options]="periodYearOptions"
+                          [ngModel]="period.endYear"
+                          (ngModelChange)="updatePeriodField(org.organization, period.id, 'endYear', $event)"
+                          optionLabel="label"
+                          optionValue="value"
+                          placeholder="Year"
+                          [ariaLabel]="'End year, ' + org.organization + ' period ' + ($index + 1)"
+                          styleClass="w-full"
+                          size="small"
+                          appendTo="body"
+                          [attr.data-testid]="'period-end-year-' + period.id" />
+                      </div>
                     </div>
                   }
 

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
@@ -85,7 +85,7 @@
                       optionLabel="label"
                       optionValue="value"
                       placeholder="Month"
-                      ariaLabel="Start month"
+                      [ariaLabel]="'Start month, ' + org.organization + ' period ' + ($index + 1)"
                       styleClass="w-full"
                       size="small"
                       appendTo="body"
@@ -98,7 +98,7 @@
                       optionLabel="label"
                       optionValue="value"
                       placeholder="Year"
-                      ariaLabel="Start year"
+                      [ariaLabel]="'Start year, ' + org.organization + ' period ' + ($index + 1)"
                       styleClass="w-full"
                       size="small"
                       appendTo="body"
@@ -123,7 +123,7 @@
                         optionLabel="label"
                         optionValue="value"
                         placeholder="Month"
-                        ariaLabel="End month"
+                        [ariaLabel]="'End month, ' + org.organization + ' period ' + ($index + 1)"
                         styleClass="w-full"
                         size="small"
                         appendTo="body"
@@ -136,7 +136,7 @@
                         optionLabel="label"
                         optionValue="value"
                         placeholder="Year"
-                        ariaLabel="End year"
+                        [ariaLabel]="'End year, ' + org.organization + ' period ' + ($index + 1)"
                         styleClass="w-full"
                         size="small"
                         appendTo="body"
@@ -150,6 +150,7 @@
                       [ngModel]="period.isPresent"
                       (ngModelChange)="updatePeriodField(org.organization, period.id, 'isPresent', $event)"
                       [binary]="true"
+                      [ariaLabel]="'Currently affiliated (present), ' + org.organization + ' period ' + ($index + 1)"
                       [attr.data-testid]="'period-present-' + period.id" />
                     <span class="text-xs font-medium text-slate-600">Present</span>
                   </div>
@@ -159,8 +160,9 @@
                     <button
                       class="ml-auto flex h-7 w-7 cursor-pointer items-center justify-center rounded text-slate-400 transition-colors hover:bg-red-50 hover:text-red-500"
                       (click)="removePeriod(org.organization, period.id)"
+                      [attr.aria-label]="'Remove period, ' + org.organization + ' period ' + ($index + 1)"
                       [attr.data-testid]="'period-remove-' + period.id">
-                      <i class="fa-light fa-trash-can text-xs"></i>
+                      <i class="fa-light fa-trash-can text-xs" aria-hidden="true"></i>
                     </button>
                   }
                 </div>

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
@@ -71,8 +71,10 @@
                   class="flex flex-wrap items-center gap-2 rounded-md px-2 py-1"
                   [class]="isOverlapping ? 'bg-amber-50/50' : ''"
                   [attr.data-testid]="'period-row-' + period.id">
-                  <!-- Start Month/Year — grid below sm so the pair wraps to two rows instead of overflowing; inline row at sm and up -->
-                  <div class="grid grid-cols-2 gap-2 sm:flex sm:gap-2">
+                  <!-- Start Month/Year — equal-width grid below sm so the pair wraps to two rows instead of
+                       overflowing; fixed 110px/100px columns at sm and up so w-full resolves to the original
+                       month/year widths instead of shrink-to-fit sizing -->
+                  <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">
                     <p-select
                       [options]="monthOptions"
                       [ngModel]="period.startMonth"
@@ -105,8 +107,8 @@
                   @if (period.isPresent) {
                     <span class="text-xs font-medium text-slate-500">Present</span>
                   } @else {
-                    <!-- End Month/Year — same grid-below-sm / inline-row-at-sm pattern as the start pair -->
-                    <div class="grid grid-cols-2 gap-2 sm:flex sm:gap-2">
+                    <!-- End Month/Year — same equal-width-below-sm / fixed-columns-at-sm pattern as the start pair -->
+                    <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">
                       <p-select
                         [options]="monthOptions"
                         [ngModel]="period.endMonth"

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
@@ -71,11 +71,12 @@
                   class="flex flex-wrap items-center gap-2 rounded-md px-2 py-1"
                   [class]="isOverlapping ? 'bg-amber-50/50' : ''"
                   [attr.data-testid]="'period-row-' + period.id">
-                  <!-- Start label + Start Month/Year, grouped into ONE flex item so flex-wrap on the row
-                       (below) can only move the whole pair to the next line, never orphan the label from
-                       its controls. Below sm the month/year grid keeps them equal-width side by side (2
-                       columns, not stacked); fixed 110px/100px columns at sm and up so w-full resolves to
-                       the original month/year widths instead of shrink-to-fit sizing. -->
+                  <!-- Start label + Start Month/Year, grouped into ONE flex item so flex-wrap on the
+                       enclosing period-row div above can only move the whole pair to the next line, never
+                       orphan the label from its controls. Below sm the month/year grid keeps them
+                       equal-width side by side (2 columns, not stacked); fixed 110px/100px columns at sm
+                       and up so w-full resolves to the original month/year widths instead of shrink-to-fit
+                       sizing. -->
                   <div class="flex items-center gap-2">
                     <span class="text-xs font-medium text-slate-500">Start</span>
                     <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
@@ -68,66 +68,69 @@
                 @let isOverlapping = overlappingPeriodIds().has(period.id);
                 @let periodYearOptions = availableYearsMap().get(period.id) ?? yearOptions;
                 <div
-                  class="flex items-center gap-2 rounded-md px-2 py-1"
+                  class="flex flex-wrap items-center gap-2 rounded-md px-2 py-1"
                   [class]="isOverlapping ? 'bg-amber-50/50' : ''"
                   [attr.data-testid]="'period-row-' + period.id">
-                  <!-- Start Month -->
-                  <p-select
-                    [options]="monthOptions"
-                    [ngModel]="period.startMonth"
-                    (ngModelChange)="updatePeriodField(org.organization, period.id, 'startMonth', $event)"
-                    optionLabel="label"
-                    optionValue="value"
-                    placeholder="Month"
-                    [style]="{ width: '110px' }"
-                    size="small"
-                    appendTo="body"
-                    [attr.data-testid]="'period-start-month-' + period.id" />
+                  <!-- Start Month/Year — grid below sm so the pair wraps to two rows instead of overflowing; inline row at sm and up -->
+                  <div class="grid grid-cols-2 gap-2 sm:flex sm:gap-2">
+                    <p-select
+                      [options]="monthOptions"
+                      [ngModel]="period.startMonth"
+                      (ngModelChange)="updatePeriodField(org.organization, period.id, 'startMonth', $event)"
+                      optionLabel="label"
+                      optionValue="value"
+                      placeholder="Month"
+                      styleClass="w-full"
+                      size="small"
+                      appendTo="body"
+                      [attr.data-testid]="'period-start-month-' + period.id" />
 
-                  <!-- Start Year -->
-                  <p-select
-                    [options]="periodYearOptions"
-                    [ngModel]="period.startYear"
-                    (ngModelChange)="updatePeriodField(org.organization, period.id, 'startYear', $event)"
-                    optionLabel="label"
-                    optionValue="value"
-                    placeholder="Year"
-                    [style]="{ width: '100px' }"
-                    size="small"
-                    appendTo="body"
-                    [attr.data-testid]="'period-start-year-' + period.id" />
+                    <p-select
+                      [options]="periodYearOptions"
+                      [ngModel]="period.startYear"
+                      (ngModelChange)="updatePeriodField(org.organization, period.id, 'startYear', $event)"
+                      optionLabel="label"
+                      optionValue="value"
+                      placeholder="Year"
+                      styleClass="w-full"
+                      size="small"
+                      appendTo="body"
+                      [attr.data-testid]="'period-start-year-' + period.id" />
+                  </div>
 
-                  <span class="text-xs text-slate-400">–</span>
+                  <!-- Hidden below sm — reads as a stray dash between wrapped start/end pairs there -->
+                  <span class="hidden text-xs text-slate-400 sm:inline">–</span>
 
                   <!-- End Date or Present -->
                   @if (period.isPresent) {
                     <span class="text-xs font-medium text-slate-500">Present</span>
                   } @else {
-                    <!-- End Month -->
-                    <p-select
-                      [options]="monthOptions"
-                      [ngModel]="period.endMonth"
-                      (ngModelChange)="updatePeriodField(org.organization, period.id, 'endMonth', $event)"
-                      optionLabel="label"
-                      optionValue="value"
-                      placeholder="Month"
-                      [style]="{ width: '110px' }"
-                      size="small"
-                      appendTo="body"
-                      [attr.data-testid]="'period-end-month-' + period.id" />
+                    <!-- End Month/Year — same grid-below-sm / inline-row-at-sm pattern as the start pair -->
+                    <div class="grid grid-cols-2 gap-2 sm:flex sm:gap-2">
+                      <p-select
+                        [options]="monthOptions"
+                        [ngModel]="period.endMonth"
+                        (ngModelChange)="updatePeriodField(org.organization, period.id, 'endMonth', $event)"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Month"
+                        styleClass="w-full"
+                        size="small"
+                        appendTo="body"
+                        [attr.data-testid]="'period-end-month-' + period.id" />
 
-                    <!-- End Year -->
-                    <p-select
-                      [options]="periodYearOptions"
-                      [ngModel]="period.endYear"
-                      (ngModelChange)="updatePeriodField(org.organization, period.id, 'endYear', $event)"
-                      optionLabel="label"
-                      optionValue="value"
-                      placeholder="Year"
-                      [style]="{ width: '100px' }"
-                      size="small"
-                      appendTo="body"
-                      [attr.data-testid]="'period-end-year-' + period.id" />
+                      <p-select
+                        [options]="periodYearOptions"
+                        [ngModel]="period.endYear"
+                        (ngModelChange)="updatePeriodField(org.organization, period.id, 'endYear', $event)"
+                        optionLabel="label"
+                        optionValue="value"
+                        placeholder="Year"
+                        styleClass="w-full"
+                        size="small"
+                        appendTo="body"
+                        [attr.data-testid]="'period-end-year-' + period.id" />
+                    </div>
                   }
 
                   <!-- Present Checkbox -->

--- a/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/affiliation-timeline-dialog/affiliation-timeline-dialog.component.html
@@ -71,6 +71,9 @@
                   class="flex flex-wrap items-center gap-2 rounded-md px-2 py-1"
                   [class]="isOverlapping ? 'bg-amber-50/50' : ''"
                   [attr.data-testid]="'period-row-' + period.id">
+                  <!-- Start label — unconditional (not sm-gated), so the pair stays identifiable regardless of
+                       whether flex-wrap kicks in from the true viewport or from the dialog's own rendered width -->
+                  <span class="text-xs font-medium text-slate-500">Start</span>
                   <!-- Start Month/Year — equal-width grid below sm so the pair wraps to two rows instead of
                        overflowing; fixed 110px/100px columns at sm and up so w-full resolves to the original
                        month/year widths instead of shrink-to-fit sizing -->
@@ -82,6 +85,7 @@
                       optionLabel="label"
                       optionValue="value"
                       placeholder="Month"
+                      ariaLabel="Start month"
                       styleClass="w-full"
                       size="small"
                       appendTo="body"
@@ -94,6 +98,7 @@
                       optionLabel="label"
                       optionValue="value"
                       placeholder="Year"
+                      ariaLabel="Start year"
                       styleClass="w-full"
                       size="small"
                       appendTo="body"
@@ -105,8 +110,10 @@
 
                   <!-- End Date or Present -->
                   @if (period.isPresent) {
-                    <span class="text-xs font-medium text-slate-500">Present</span>
+                    <span class="text-xs font-medium text-slate-500">End: Present</span>
                   } @else {
+                    <!-- End label — unconditional, see Start label comment above -->
+                    <span class="text-xs font-medium text-slate-500">End</span>
                     <!-- End Month/Year — same equal-width-below-sm / fixed-columns-at-sm pattern as the start pair -->
                     <div class="grid grid-cols-2 gap-2 sm:grid-cols-[110px_100px]">
                       <p-select
@@ -116,6 +123,7 @@
                         optionLabel="label"
                         optionValue="value"
                         placeholder="Month"
+                        ariaLabel="End month"
                         styleClass="w-full"
                         size="small"
                         appendTo="body"
@@ -128,6 +136,7 @@
                         optionLabel="label"
                         optionValue="value"
                         placeholder="Year"
+                        ariaLabel="End year"
                         styleClass="w-full"
                         size="small"
                         appendTo="body"

--- a/apps/lfx-one/src/app/modules/profile/components/work-experience-form-dialog/work-experience-form-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/profile/components/work-experience-form-dialog/work-experience-form-dialog.component.html
@@ -28,8 +28,8 @@
       <lfx-input-text [form]="form" control="role" placeholder="e.g. Senior Software Engineer" size="small" data-testid="we-form-role" />
     </div>
 
-    <!-- Dates: Two-column grid -->
-    <div class="grid grid-cols-2 gap-4">
+    <!-- Dates: single column below sm, two-column grid at sm and up -->
+    <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
       <!-- Start Date -->
       <div class="flex flex-col gap-1">
         <label class="text-xs font-bold text-slate-700">Start Date *</label>

--- a/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
+++ b/apps/lfx-one/src/app/modules/settings/account-settings/account-settings.component.html
@@ -23,9 +23,10 @@
   }
 
   <!-- Two Column Layout: TOC + Content -->
-  <div class="flex gap-8">
-    <!-- LEFT: Table of Contents (outer stretches to row height, inner sticks) -->
-    <div class="w-auto shrink-0 pr-10">
+  <div class="flex flex-col lg:flex-row lg:gap-8">
+    <!-- LEFT: Table of Contents (outer stretches to row height, inner sticks); hidden below lg — a
+         3-item jump list has little value on a phone where the sections are a short scroll apart -->
+    <div class="hidden lg:block w-auto shrink-0 pr-10">
       <div class="sticky top-24 flex flex-col gap-3">
         <p class="text-xs font-medium text-gray-400 uppercase tracking-wide">On this page</p>
 

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -66,6 +66,10 @@ export default {
     'bg-gray-100',
   ],
   theme: {
+    // `container.screens` only sizes the `.container` utility's max-width per breakpoint — it does
+    // NOT affect the `sm:`/`md:`/.../`2xl:` responsive variant prefixes used throughout the app
+    // (those come from `theme.screens` below, which Tailwind otherwise defaults independently).
+    // Kept in sync with `theme.screens` so both mean the same breakpoints.
     container: {
       center: true,
       screens: {
@@ -75,6 +79,17 @@ export default {
         xl: '1280px',
         '2xl': '1440px',
       },
+    },
+    // Overrides Tailwind's default `2xl` (1536px) to 1440px so `2xl:` variant classes — e.g. the
+    // Profile & Account hub's rail breakpoint (LFXV2-3285) — actually fire at 1440px. sm/md/lg/xl
+    // match Tailwind's own defaults, listed explicitly since `screens` fully replaces the defaults
+    // rather than merging with them.
+    screens: {
+      sm: '640px',
+      md: '768px',
+      lg: '1024px',
+      xl: '1280px',
+      '2xl': '1440px',
     },
     extend: {
       colors: lfxColors,

--- a/docs/architecture/frontend/styling-system.md
+++ b/docs/architecture/frontend/styling-system.md
@@ -242,15 +242,21 @@ options: {
 ### Breakpoint Strategy
 
 ```typescript
-// Tailwind breakpoints
+// Tailwind breakpoints — set via theme.screens in apps/lfx-one/tailwind.config.js.
+// `2xl` is overridden from Tailwind's 1536px default to 1440px; sm/md/lg/xl match the defaults.
 const breakpoints = {
   sm: '640px',
   md: '768px',
   lg: '1024px',
   xl: '1280px',
-  '2xl': '1536px',
+  '2xl': '1440px',
 };
 ```
+
+`theme.container.screens` is a separate config block that only sizes the `.container` utility
+class's max-width per breakpoint — it does not affect the `sm:`/`md:`/etc. responsive variant
+prefixes used everywhere else in templates. Those come from `theme.screens` above. Keep both in
+sync when changing a breakpoint value.
 
 ### Responsive Patterns
 


### PR DESCRIPTION
## Summary

**Profile hub layout (finding 1)**
- The Profile & Account hub's profile rail was `fixed` at 300px with no breakpoint guard, and `<main>` reserved a matching `pr-[300px]` gutter unconditionally — at a 390px viewport this left ~50px of usable content width.
- The rail now renders inline in the content column below `2xl` (1440px) and as a fixed full-height right rail at `2xl` and up — moved from the initial `lg` (1024px) threshold in a follow-up once review surfaced that `lg`–`xl` (1024–1439px) still only had a ~320–616px content column beside a 300px rail. `2xl` is the first breakpoint where the hub's 704px of fixed chrome (348px left sidebar + 300px rail + 56px page padding) leaves comfortable room (736px+) for both.
- Below `2xl`, the inline panel itself reflows across three states so it isn't a narrow left-aligned card with blank space beside it on tablet/laptop: a stacked card below `sm` (capped at `max-w-md`), a full-width horizontal layout (header row + 2/3-col metadata grid + side-by-side social rows) from `sm` up to just under `2xl`, and back to the fixed rail's single-column layout at `2xl`+.
- Single `<lfx-profile-panel>` instance kept throughout (its `data-testid`s are asserted by e2e specs) — only wrapper/host classes and the panel's own internal layout change per breakpoint.

**Three additional responsive breakages (findings 2-4, independent of the layout fix)**
- `account-settings`: the "On this page" TOC always claimed ~160-180px; now hidden below `lg` (little value on a phone where sections are a short scroll apart).
- `affiliation-timeline-dialog`: each period row (4 `p-select`s + separator + actions, ~450px min-width) overflowed on every phone; rows now wrap, with the month/year pairs gridding to 2 columns below `sm` and pinning to their original 110px/100px widths at `sm`+. Added Start/End labels and disambiguated `ariaLabel`s (interpolating org + period index) so wrapped/duplicate rows stay identifiable to screen readers.
- `work-experience-form-dialog`: the start/end date-picker grid was a fixed 2-column layout giving each field ~165px at 375px; now stacks below `sm`.

**e2e regression coverage (LFXV2-3285 follow-up)**
- Added `apps/lfx-one/e2e/profile-mobile-layout.spec.ts`: an 8-viewport matrix (360/393/550/768/1023/1194/1280/1439px, covering phone through just-under-`2xl` laptop widths) × 2 routes, plus a dedicated desktop-control test above `2xl` — 54 cases total across chromium/firefox/mobile-chrome. Asserts the content column's width (scrollbar-safe, via `document.documentElement.clientWidth`, and `matchMedia`-based rather than threshold comparisons where a matrix viewport lands exactly on a breakpoint, since browser engines disagree on which viewport metric a `min-width` query resolves against when a classic scrollbar is present), no horizontal scroll, and — via a dedicated `profile-panel-rail` testid's computed CSS `position` and `max-width` — that the rail is genuinely in normal document flow below `2xl` (not a `fixed` overlay), that the `max-w-md` stacked-card cap is present below `sm`, and that `sm:max-w-none` actually lifts it from `sm` up to `2xl`.
- Live-verified red/green repeatedly through the branch's iteration: red against `origin/main`'s pre-fix layout, red against each intermediate regression this spec caught before its own assertions were fixed (a tautological cap check, a scrollbar-blind width comparison, a fail-open DOM-traversal hop), green against the current tree across all three Playwright projects.

## Known trade-offs (flagged in review, deliberately not addressed in this PR)
- **e2e coverage scope**: this spec covers the profile-rail layout only. `/profile/settings` is loaded but the TOC's `hidden lg:block` isn't asserted, and neither the affiliation-timeline nor work-experience dialogs are opened to verify their wrap/stack behavior. Those three responsive fixes can regress silently. Deferred rather than added here — opening and populating those dialogs (work-experience/affiliation data prerequisites, PrimeNG dialog interaction) is a meaningfully larger addition than a rail-layout regression test; worth its own follow-up ticket.
- **`affiliation-timeline-dialog` still uses raw `p-select`/`p-checkbox`**: the LFX `lfx-select` wrapper exists but requires `FormGroup`/`FormControl`, while this dialog is `[ngModel]`-driven against plain period objects. Migrating is a reactive-forms rewrite, not a responsive fix — pre-existing debt, not introduced here.
- **`affiliation-timeline-dialog` dialog width vs. `sm` breakpoint**: the dialog opens at a fixed 720px width (PrimeNG-capped ~90-95vw on narrow viewports) with no `breakpoints` config, so the `sm:` Tailwind classes key off viewport width while the actual wrap point is governed by the dialog's own rendered width — a mismatch could still cause wrapping just above the `sm` boundary. Mitigated by making the Start/End labels unconditional (not `sm`-gated) so the row stays legible even if it wraps; the underlying dialog-width mismatch was not changed since it wasn't visually verified.
- **Dev-environment e2e auth gap discovered, not fixed here**: the shared `global-setup.ts`/`auth.helper.ts` login flow doesn't dismiss a Transcend consent banner on the dev Auth0 tenant's hosted login page, so `yarn e2e` against dev currently can't auto-authenticate out of the box (worked around locally with a throwaway script to verify this PR's spec). Worth a follow-up fix in the shared helper — out of scope here since it's cross-cutting test infra, not this PR's responsive fixes.

JIRA: LFXV2-3285

## Test plan
- [x] `yarn lint`
- [x] `yarn check-types`
- [x] `yarn build`
- [x] `apps/lfx-one/e2e/profile-mobile-layout.spec.ts` — 54/54 passing (chromium/firefox/mobile-chrome), live-verified red against pre-fix and against each intermediate regression caught during review iteration
- [x] Manual check at mobile viewports (390/768/1024/1500px) for both sparse (name+email only) and populated profiles — panel reflows correctly at each of the three states, no dead space or orphaned cells
- [x] Manual check at `2xl`+ (≥1440px) — fixed right rail still pins right exactly as before
- [ ] Manual check of account-settings TOC (hidden below `lg`, visible at `lg`+)
- [ ] Manual check of affiliation-timeline-dialog period rows at a mobile width — wraps without overflow, Start/End legible
- [ ] Manual check of work-experience-form-dialog date pickers at 375px — stacked, not squeezed
