### PR TITLE
docs(account): document work history, identities, and enrollment

### DIFF
--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-08-11
+last_updated: 2026-08-17
 intercom_collection: Account
 ---
 
@@ -32,9 +32,33 @@ Account settings (email, password, API token) are tied to your LFX account and a
 
 LFX Self Serve does not currently include a notification preferences section. Email and password settings are managed in the **Settings** tab (`/profile/settings`).
 
-## What are affiliations?
+## How do I add or edit my work history?
 
-Affiliations are the Linux Foundation projects and companies you are associated with. They appear on your profile and may affect your persona and the lenses available to you. Go to [**Profile & Account**](/profile) and select the **Work history & Affiliations** tab (`/profile/attributions`) to view and manage them.
+Go to [**Profile & Account**](/profile) and use the **Work history & Affiliations** tab (`/profile/attributions`, the default tab). Select **Add work experience**, enter the organization, role, and dates (or mark **I currently work here**), then select **Add experience**. Use the actions menu on an entry to **Edit** or **Delete** it. Your work history also populates the **Organization** choices in the Edit Profile drawer. See [Work History & Affiliations](../work-history/).
+
+## What are affiliations, and how are my contributions attributed?
+
+Affiliations are the Linux Foundation projects and organizations you are associated with. They are calculated automatically from your **verified identities**, your **work experience**, and the overlap between your contribution timestamps and your employment dates — you don't add projects manually. View and adjust them on the **Work history & Affiliations** tab (`/profile/attributions`); you can confirm your affiliation history and your maintainer/contributor role, and override anything the system gets wrong. See [Work History & Affiliations](../work-history/).
+
+## How do I link a GitHub or social account?
+
+Go to [**Profile & Account**](/profile) and open the **Identities** tab (`/profile/identities`). Select **Add identity**, then **Continue with _[provider]_** for a social account, or **Add email** to link and verify an email address. Linked identities attribute your contributions across projects. See [Identities](../identities/).
+
+## What is an unverified identity, and how do I verify it?
+
+An unverified identity is an account connected to your profile that hasn't been confirmed yet. On the **Identities** tab, find it under **Unverified identities** and select **Verify** (or **This is not me** if it isn't yours). Verifying keeps your project affiliations and work history accurate. See [Identities](../identities/).
+
+## What is the Linux.com email alias?
+
+The Linux.com email alias is a one-time add-on for Individual Supporters that gives you a personal `@linux.com` address forwarding to an inbox you choose. Manage it in the **Linux.com email** section of the [Identities](../identities/) tab — purchase, then claim an alias and a forward-to address. The alias can't be changed after claiming.
+
+## How do I enroll as an Individual Supporter?
+
+Go to [**Profile & Account**](/profile) and open the **Individual Enrollment** tab (`/profile/individual-enrollment`). Review the membership and its benefits, then select **Enroll**. See [Individual Enrollment](../individual-enrollment/).
+
+## How do I turn off auto-renew or stop my membership?
+
+On the **Individual Enrollment** tab, select **Disable auto-renew** and confirm. Your membership stays active until its expiration date, then lapses — there is no separate immediate-cancel step. See [Individual Enrollment](../individual-enrollment/).
 
 ## Where do I find My CLAs?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -58,7 +58,7 @@ Go to [**Profile & Account**](/profile) and open the **Individual Enrollment** t
 
 ## How do I turn off auto-renew or stop my membership?
 
-On the **Individual Enrollment** tab, select **Disable auto-renew** and confirm. Your membership stays active until its expiration date, then lapses — there is no separate immediate-cancel step. See [Individual Enrollment](../individual-enrollment/).
+If your membership supports automatic renewal, the **Individual Enrollment** tab shows a **Disable auto-renew** control — select it and confirm. Your membership then stays active until its expiration date and won't renew automatically; there is no separate immediate-cancel step. Memberships that renew manually don't show an auto-renew control. See [Individual Enrollment](../individual-enrollment/).
 
 ## Where do I find My CLAs?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -34,11 +34,11 @@ LFX Self Serve does not currently include a notification preferences section. Em
 
 ## How do I add or edit my work history?
 
-Go to [**Profile & Account**](/profile) and use the **Work history & Affiliations** tab (`/profile/attributions`, the default tab). Select **Add work experience**, enter the organization, role, and dates (or mark **I currently work here**), then select **Add experience**. Use the actions menu on an entry to **Edit** or **Delete** it. Your work history also populates the **Organization** choices in the Edit Profile drawer. See [Work History & Affiliations](../work-history/).
+Go to [**Profile & Account**](/profile) and use the **Work history & Affiliations** tab (`/profile/attributions`, the default tab). Select **Add work experience**, enter the organization, role, and dates (or mark **I currently work here**), then select **Add experience**. Use the actions menu on an entry to **Edit** or **Delete** it. Your work history also populates the **Organization** choices in the Edit Profile drawer. See [Work history & Affiliations](../work-history/).
 
 ## What are affiliations, and how are my contributions attributed?
 
-Affiliations are the Linux Foundation projects and organizations you are associated with. They are calculated automatically from your **verified identities**, your **work experience**, and the overlap between your contribution timestamps and your employment dates — you don't add projects manually. View and adjust them on the **Work history & Affiliations** tab (`/profile/attributions`); you can confirm your affiliation history and your maintainer/contributor role, and override anything the system gets wrong. See [Work History & Affiliations](../work-history/).
+Affiliations are the Linux Foundation projects and organizations you are associated with. They are calculated automatically from your **verified identities**, your **work experience**, and the overlap between your contribution timestamps and your employment dates — you don't add projects manually. View and adjust them on the **Work history & Affiliations** tab (`/profile/attributions`); you can confirm your affiliation history and your maintainer/contributor role, and override anything the system gets wrong. See [Work history & Affiliations](../work-history/).
 
 ## How do I link a GitHub or social account?
 

--- a/docs/user/account/identities/index.md
+++ b/docs/user/account/identities/index.md
@@ -36,7 +36,7 @@ Identities are grouped into two sections:
 
 1. Select **Add identity**.
 2. Choose a provider:
-   - For a social account (for example GitHub, Google, LinkedIn, or X), select **Continue with _[provider]_** and complete the provider's sign-in. This links the account and attributes its contributions to you.
+   - For a social account (for example GitHub, Google, or LinkedIn), select **Continue with _[provider]_** and complete the provider's sign-in. Linked identities are used to attribute contributions and participation across projects.
    - For an email address, select **Add email**, enter the address, and select **Send verification code**. Enter the 6-digit code sent to that address, then select **Verify email**. Use **Resend Code** if it does not arrive.
 
 ## Verify an unverified identity
@@ -53,7 +53,7 @@ If an unverified identity is not yours, select **This is not me** to reject it.
 1. Open the actions menu on a verified identity and select **Remove**.
 2. In **Remove verified identity**, acknowledge that removing it may affect your contribution attribution, then select **Remove identity**.
 
-Unverified identities can be removed the same way (**Remove** → **Remove**). Your **Primary** identity cannot be removed.
+To reject an unverified identity instead, use **This is not me** on its row (see [Verify an unverified identity](#verify-an-unverified-identity)). Your **Primary** identity cannot be removed.
 
 > **Note:** Removing an identity can't be undone. Some identity information may be retained to support project insights.
 

--- a/docs/user/account/identities/index.md
+++ b/docs/user/account/identities/index.md
@@ -57,7 +57,7 @@ To reject an unverified identity instead, use **This is not me** on its row (see
 
 > **Note:** Removing an identity can't be undone. As the removal dialog notes, identity information may be retained to help improve our services and support project insights — see the [Linux Foundation Privacy Policy](https://www.linuxfoundation.org/legal/privacy-policy) for what data is kept and why.
 
-## Your linux.com email alias
+## Your Linux.com email alias
 
 The **Linux.com email** section, at the bottom of the Identities tab, lets Individual Supporters set up a personal `@linux.com` address that forwards to an inbox you choose. The Lifetime Linux.com Email Alias is a one-time add-on.
 

--- a/docs/user/account/identities/index.md
+++ b/docs/user/account/identities/index.md
@@ -1,0 +1,75 @@
+---
+title: Identities
+description: Link, verify, and remove the GitHub, social, and email identities used to attribute your work in LFX Self Serve
+audience: [all]
+product_area: Account
+tags: [account, identities, github, email, verification, linux-com-alias]
+last_updated: 2026-08-17
+intercom_collection: Account
+---
+
+The **Identities** tab is where you manage the accounts used to identify you and attribute your contributions across Linux Foundation projects — your GitHub and social accounts and your verified email addresses. Keeping these linked and verified helps ensure accurate project affiliations and work history. It lives under the Profile & Account hub at `/profile/identities`.
+
+## What you can do
+
+- Link a new GitHub, social, or email identity to your account
+- Verify an identity that is connected but not yet confirmed
+- Remove an identity you no longer want linked
+- Claim and manage a personal **Linux.com email** alias (an Individual Supporter add-on)
+
+## Open Identities
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select [**Profile & Account**](/profile) from the left navigation sidebar.
+3. Open the **Identities** tab, or go directly to `/profile/identities`.
+
+## Verified vs unverified identities
+
+Identities are grouped into two sections:
+
+- **Verified identities** — accounts you have confirmed. A verified identity that is your primary shows a **Primary** badge.
+- **Unverified identities** — accounts connected to your profile that still need confirmation. You will see a reminder to verify them so your project affiliations and work history stay accurate.
+
+> **Note:** A single identity can only be linked to one LFX account. If an identity is already linked elsewhere, LFX shows a conflict message — contact support if you believe this is an error.
+
+## Add an identity
+
+1. Select **Add identity**.
+2. Choose a provider:
+   - For a social account (for example GitHub, Google, LinkedIn, or X), select **Continue with _[provider]_** and complete the provider's sign-in. This links the account and attributes its contributions to you.
+   - For an email address, select **Add email**, enter the address, and select **Send verification code**. Enter the 6-digit code sent to that address, then select **Verify email**. Use **Resend Code** if it does not arrive.
+
+## Verify an unverified identity
+
+1. Find the account under **Unverified identities**.
+2. Select **Verify**.
+   - For a social account, select **Continue with _[provider]_** to confirm through the provider.
+   - For an email address, select **Send verification code**, then enter the 6-digit code and select **Verify identity**.
+
+If an unverified identity is not yours, select **This is not me** to reject it.
+
+## Remove an identity
+
+1. Open the actions menu on a verified identity and select **Remove**.
+2. In **Remove verified identity**, acknowledge that removing it may affect your contribution attribution, then select **Remove identity**.
+
+Unverified identities can be removed the same way (**Remove** → **Remove**). Your **Primary** identity cannot be removed.
+
+> **Note:** Removing an identity can't be undone. Some identity information may be retained to support project insights.
+
+## Your linux.com email alias
+
+The **Linux.com email** section, at the bottom of the Identities tab, lets Individual Supporters set up a personal `@linux.com` address that forwards to an inbox you choose. The Lifetime Linux.com Email Alias is a one-time add-on.
+
+- **Purchase** — if you have not bought the add-on yet, select **Purchase Email** to complete the one-time purchase.
+- **Claim** — once purchased, choose **Your alias** and a **Forward to** address, then select **Claim alias**. Aliases use letters, numbers, dots, and hyphens (up to 64 characters) and **cannot be changed after claiming**.
+- **Manage forwarding** — after claiming, your alias shows an **Active** badge. To change where it forwards, pick a different verified address under **Forward to** and select **Save**.
+
+> **Note:** You need at least one verified email address to forward to. If you don't have one yet, add and verify an email first (see [Add an identity](#add-an-identity) or [Settings](../settings/)), then return here.
+
+## Related
+
+- [Account overview](../) — all account areas and navigation
+- [My CLAs](../my-clas/) — linked Email and GitHub identities are how signed CLAs are matched to you
+- [Settings](../settings/) — add and verify email addresses, manage your password and API token
+- [Account FAQ](../faq/) — short answers about identities, settings, and CLAs

--- a/docs/user/account/identities/index.md
+++ b/docs/user/account/identities/index.md
@@ -55,7 +55,7 @@ If an unverified identity is not yours, select **This is not me** to reject it.
 
 To reject an unverified identity instead, use **This is not me** on its row (see [Verify an unverified identity](#verify-an-unverified-identity)). Your **Primary** identity cannot be removed.
 
-> **Note:** Removing an identity can't be undone. Some identity information may be retained to support project insights.
+> **Note:** Removing an identity can't be undone. As the removal dialog notes, identity information may be retained to help improve our services and support project insights — see the [Linux Foundation Privacy Policy](https://www.linuxfoundation.org/legal/privacy-policy) for what data is kept and why.
 
 ## Your linux.com email alias
 

--- a/docs/user/account/index.md
+++ b/docs/user/account/index.md
@@ -4,7 +4,7 @@ description: Manage your LFX account — work history and affiliations, identiti
 audience: [all]
 product_area: Account
 tags: [account, settings, affiliations, identities, individual-enrollment, cla, transactions]
-last_updated: 2026-08-11
+last_updated: 2026-08-17
 intercom_collection: Account
 ---
 
@@ -29,20 +29,23 @@ All authenticated users have an account. Every user can view and manage their ow
 
 Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, select [**Profile & Account**](/profile) from the left navigation sidebar, and choose a tab:
 
-| Tab                         | Route                            | Description                                                    | Documentation                   |
-| --------------------------- | -------------------------------- | -------------------------------------------------------------- | ------------------------------- |
-| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     | —                               |
-| Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work    | —                               |
-| Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan       | —                               |
-| My CLAs                     | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [My CLAs](./my-clas/)           |
-| Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                         | [Transactions](./transactions/) |
-| Settings                    | `/profile/settings`              | Email addresses, password, and developer API token             | [Settings](./settings/)         |
+| Tab                         | Route                            | Description                                                    | Documentation                                     |
+| --------------------------- | -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------- |
+| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     | [Work History & Affiliations](./work-history/)    |
+| Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work    | [Identities](./identities/)                       |
+| Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan       | [Individual Enrollment](./individual-enrollment/) |
+| My CLAs                     | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [My CLAs](./my-clas/)                             |
+| Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                         | [Transactions](./transactions/)                   |
+| Settings                    | `/profile/settings`              | Email addresses, password, and developer API token             | [Settings](./settings/)                           |
 
 `/profile` opens the **Work history & Affiliations** tab by default.
 
 ## Related sections
 
 - [Profile](../profile/) — your name, photo, About Me, primary email, and location (Edit Profile drawer)
+- [Work History & Affiliations](./work-history/) — record your employment history and review how contributions are attributed
+- [Identities](./identities/) — link, verify, and remove GitHub, social, and email identities, and claim a Linux.com alias
+- [Individual Enrollment](./individual-enrollment/) — enroll in an Individual Supporter membership and manage auto-renew
 - [My CLAs](./my-clas/) — view your signed ICLAs and Employee CLA coverage
 - [Transactions](./transactions/) — your Linux Foundation purchase history
 - [Settings](./settings/) — email, password, and developer API token

--- a/docs/user/account/index.md
+++ b/docs/user/account/index.md
@@ -31,7 +31,7 @@ Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, s
 
 | Tab                         | Route                            | Description                                                    | Documentation                                     |
 | --------------------------- | -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------- |
-| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     | [Work History & Affiliations](./work-history/)    |
+| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     | [Work history & Affiliations](./work-history/)    |
 | Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work    | [Identities](./identities/)                       |
 | Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan       | [Individual Enrollment](./individual-enrollment/) |
 | My CLAs                     | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [My CLAs](./my-clas/)                             |
@@ -43,7 +43,7 @@ Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, s
 ## Related sections
 
 - [Profile](../profile/) — your name, photo, About Me, primary email, and location (Edit Profile drawer)
-- [Work History & Affiliations](./work-history/) — record your employment history and review how contributions are attributed
+- [Work history & Affiliations](./work-history/) — record your employment history and review how contributions are attributed
 - [Identities](./identities/) — link, verify, and remove GitHub, social, and email identities, and claim a Linux.com alias
 - [Individual Enrollment](./individual-enrollment/) — enroll in an Individual Supporter membership and manage auto-renew
 - [My CLAs](./my-clas/) — view your signed ICLAs and Employee CLA coverage

--- a/docs/user/account/individual-enrollment/index.md
+++ b/docs/user/account/individual-enrollment/index.md
@@ -41,6 +41,8 @@ Once you are enrolled, the membership card shows:
 
 ## Turn auto-renew on or off
 
+The **Disable auto-renew** / **Enable auto-renew** control appears on the membership card while your membership is active. If your membership doesn't support automatic renewal, this control isn't shown.
+
 1. On the membership card, select **Disable auto-renew** or **Enable auto-renew**.
 2. Confirm in the dialog:
    - **Enabling** shows: _This will enable auto-renew for your membership; your next payment will be charged on [date]._

--- a/docs/user/account/individual-enrollment/index.md
+++ b/docs/user/account/individual-enrollment/index.md
@@ -1,0 +1,62 @@
+---
+title: Individual Enrollment
+description: Enroll in a Linux Foundation Individual Supporter membership and manage auto-renew in LFX Self Serve
+audience: [all]
+product_area: Account
+tags: [account, individual-enrollment, membership, supporter, auto-renew]
+last_updated: 2026-08-17
+intercom_collection: Account
+---
+
+The **Individual Enrollment** tab is where you enroll in a Linux Foundation Individual Supporter membership and manage it — including auto-renew. Becoming an Individual Supporter is one way to support the Linux Foundation's work; some memberships also unlock add-ons such as the Linux.com email alias. It lives under the Profile & Account hub at `/profile/individual-enrollment`.
+
+## What you can do
+
+- Enroll in an available Individual Supporter membership
+- See your membership price, purchase date, and renewal or expiration date
+- Turn **auto-renew** on or off
+- Renew or repurchase a membership that is expiring or expired
+
+## Open Individual Enrollment
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select [**Profile & Account**](/profile) from the left navigation sidebar.
+3. Open the **Individual Enrollment** tab, or go directly to `/profile/individual-enrollment`.
+
+## Enroll in a membership
+
+1. Review the available membership, its **Benefits**, and its yearly price.
+2. Select **Enroll** and complete the checkout.
+
+If no memberships are available, the tab shows _There are no individual enrollment products at this time._
+
+## Your membership details
+
+Once you are enrolled, the membership card shows:
+
+- **Price** — the yearly cost
+- **Purchased** — when you enrolled
+- **Renews** — the next renewal date (for an active membership), or **Expired on** for a lapsed one
+- **Auto-renew** — whether renewal is **Enabled** or **Disabled**
+
+## Turn auto-renew on or off
+
+1. On the membership card, select **Disable auto-renew** or **Enable auto-renew**.
+2. Confirm in the dialog:
+   - **Enabling** shows: _This will enable auto-renew for your membership; your next payment will be charged on [date]._
+   - **Disabling** shows: _This will disable auto-renew for your membership; your current membership will expire on [date]._
+3. Select the matching **Enable auto-renew** / **Disable auto-renew** button to confirm, or **Cancel** to keep things as they are.
+
+> **Note:** To stop a membership, disable auto-renew. Your membership stays active until the expiration date shown, then lapses — there is no separate immediate-cancel step.
+
+## Renew or repurchase
+
+- If your membership is **expiring soon**, select **Renew My Enrollment**.
+- If it has already **expired**, select **Repurchase** to enroll again.
+
+## Related
+
+- [Account overview](../) — all account areas and navigation
+- [Transactions](../transactions/) — your membership purchase appears in your transaction history
+- [Identities](../identities/) — claim the Linux.com email alias add-on for Individual Supporters
+- [Account FAQ](../faq/) — short answers about account areas and billing

--- a/docs/user/account/work-history/index.md
+++ b/docs/user/account/work-history/index.md
@@ -52,7 +52,7 @@ This section shows your role and organizational affiliation for each open-source
 
 Your contributions are attributed based on three inputs (see the **How affiliations work** dialog on the tab):
 
-- **Verified identities** — your connected GitHub, GitLab, and email accounts link activity to you.
+- **Verified identities** — your connected accounts (such as GitHub) and verified email addresses link activity to you.
 - **Work experience** — tells us which organization you represented during each time period.
 - **Contribution timestamp overlap** — matching when you contributed against your employment dates attributes each contribution to the right organization.
 

--- a/docs/user/account/work-history/index.md
+++ b/docs/user/account/work-history/index.md
@@ -1,5 +1,5 @@
 ---
-title: Work History & Affiliations
+title: Work history & Affiliations
 description: Manage your work history and see how your project affiliations and contribution attribution are calculated in LFX Self Serve
 audience: [all]
 product_area: Account
@@ -30,10 +30,10 @@ Your employment history determines which organization your contributions are att
 ### Add a work experience
 
 1. Select **Add work experience**.
-2. Fill in the fields:
-   - **Organization** (required) — search and pick your employer (for example, `Google`, `Red Hat`).
+2. Fill in the fields (only **Role** is required):
+   - **Organization** — search and pick your employer (for example, `Google`, `Red Hat`).
    - **Role** (required) — your job title (for example, `Senior Software Engineer`).
-   - **Start Date** (required) — month and year.
+   - **Start Date** — month and year.
    - **End Date** — month and year, or select **I currently work here** to mark it as your current role (this hides the end date).
 3. Select **Add experience**.
 

--- a/docs/user/account/work-history/index.md
+++ b/docs/user/account/work-history/index.md
@@ -62,7 +62,7 @@ When the system attributes contributions from your employment timeline, you may 
 
 ### Confirm your maintainer or contributor role
 
-If the system detects you may be a maintainer, it asks you to verify: in the **Verify your role** dialog, choose **Yes, I'm a maintainer** or **No, I'm a contributor**. Some maintainer roles are defined in a project's repository configuration file and are shown as read-only.
+If the system detects you may be a maintainer, it asks you to verify: in the **Verify your role** dialog, choose **Yes, I'm a maintainer** or **No, I'm a contributor**. A role that comes from a project's repository configuration file is marked with a lock icon and the tooltip _Role defined in repository configuration file_; you can still open the role menu and change it to **Contributor** if it's wrong.
 
 If nothing is linked yet, the section shows _No project affiliations yet_ with prompts to **Verify identities** and **Add work experience**.
 

--- a/docs/user/account/work-history/index.md
+++ b/docs/user/account/work-history/index.md
@@ -1,0 +1,74 @@
+---
+title: Work History & Affiliations
+description: Manage your work history and see how your project affiliations and contribution attribution are calculated in LFX Self Serve
+audience: [all]
+product_area: Account
+tags: [account, work-history, affiliations, project-involvement, attribution, maintainer]
+last_updated: 2026-08-17
+intercom_collection: Account
+---
+
+The **Work history & Affiliations** tab is where you record your employment history and review how your open-source contributions are attributed to organizations. It has two sections — **Work history** and **Project Involvement** — and it is the tab that opens by default under the Profile & Account hub at `/profile/attributions`.
+
+## What you can do
+
+- Add, edit, and delete work experience entries, and mark your current employer
+- See how your project contributions are attributed to organizations over time
+- Confirm or adjust your affiliation history when the system needs it
+- Confirm whether you are a maintainer or a contributor on a project
+
+## Open Work history & Affiliations
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select [**Profile & Account**](/profile) from the left navigation sidebar.
+3. You land on the **Work history & Affiliations** tab by default, or go directly to `/profile/attributions`.
+
+## Work history
+
+Your employment history determines which organization your contributions are attributed to. Your work experience also populates the **Organization** choices in the [Edit Profile drawer](../../profile/edit-profile/#set-your-organization).
+
+### Add a work experience
+
+1. Select **Add work experience**.
+2. Fill in the fields:
+   - **Organization** (required) — search and pick your employer (for example, `Google`, `Red Hat`).
+   - **Role** (required) — your job title (for example, `Senior Software Engineer`).
+   - **Start Date** (required) — month and year.
+   - **End Date** — month and year, or select **I currently work here** to mark it as your current role (this hides the end date).
+3. Select **Add experience**.
+
+> **Note:** This information is used to compute your project affiliations.
+
+### Edit or delete a work experience
+
+- Open the actions menu on an entry and select **Edit**, change the fields, then select **Save changes**.
+- To remove an entry, select **Delete** and confirm with **Delete experience**. This can't be undone.
+
+If you have no entries yet, the section shows _No work experience added_ — use **Add work experience** to get started.
+
+## Project Involvement (affiliations)
+
+This section shows your role and organizational affiliation for each open-source project you contribute to. Affiliations are calculated automatically — you don't add projects manually.
+
+Your contributions are attributed based on three inputs (see the **How affiliations work** dialog on the tab):
+
+- **Verified identities** — your connected GitHub, GitLab, and email accounts link activity to you.
+- **Work experience** — tells us which organization you represented during each time period.
+- **Contribution timestamp overlap** — matching when you contributed against your employment dates attributes each contribution to the right organization.
+
+### Confirm or adjust your affiliation history
+
+When the system attributes contributions from your employment timeline, you may see a prompt: _We've attributed your project contributions based on your employment timeline. Confirm or adjust if needed._ Select **Confirm Affiliation History** (or **Edit Affiliation** on a project) to open the affiliation editor, where you can adjust the organization and dates per project and override anything the system got wrong.
+
+### Confirm your maintainer or contributor role
+
+If the system detects you may be a maintainer, it asks you to verify: in the **Verify your role** dialog, choose **Yes, I'm a maintainer** or **No, I'm a contributor**. Some maintainer roles are defined in a project's repository configuration file and are shown as read-only.
+
+If nothing is linked yet, the section shows _No project affiliations yet_ with prompts to **Verify identities** and **Add work experience**.
+
+## Related
+
+- [Account overview](../) — all account areas and navigation
+- [Identities](../identities/) — verified identities feed contribution attribution
+- [Edit your profile](../../profile/edit-profile/#set-your-organization) — the Organization field is populated from your work history
+- [Account FAQ](../faq/) — short answers about affiliations and account areas


### PR DESCRIPTION
## Summary

Documents the three previously-undocumented **Profile & Account** tabs migrated to LFX Self Serve, ahead of the legacy `docs.linuxfoundation.org/lfx/my-profile` cutover (epic LFXV2-1948):

- **Work history & Affiliations** (`/profile/attributions`) — new article covering work-experience CRUD and how project affiliations are calculated and confirmed.
- **Identities** (`/profile/identities`) — new article covering linking, verifying, and removing identities, plus the Linux.com email alias add-on.
- **Individual Enrollment** (`/profile/individual-enrollment`) — new article covering enrolling, managing auto-renew, and renew/repurchase.

Also fills the empty Documentation cells and Related links on the Account landing page, and adds matching FAQ entries. Closes the Account slice of the docs-parity effort; other topics are tracked separately.

Fixes LFXV2-3097