### PR TITLE
docs(committees): correct answer for missing groups in My Groups

### DIFF
--- a/docs/user/committees/faq/index.md
+++ b/docs/user/committees/faq/index.md
@@ -15,9 +15,9 @@ Users with a **maintainer**, **board-member**, or **executive-director** persona
 
 ## Why can't I see a group I should be in?
 
-Which group were you expecting to see? Tell us the name and we'll open a ticket and sort it out — we can see which account you're signed in with, so that's all we need.
+Contact LFX support through the Help Center and tell us which group you were expecting to see. If you're signed in, we can already see your account, so that's all we need from you.
 
-Two things cause this: either you're not currently on that group's list, or you are and our records haven't linked you to your login yet. We'll check which and come back to you. Your group's chair can also confirm your membership and send you meeting details directly in the meantime.
+Two things cause this: either you're not currently on that group's list, or you are and our records haven't linked you to your login yet. Support will check which and follow up. Your group's chair can also confirm your membership and send you meeting details directly in the meantime.
 
 ## How do I add members to a committee?
 

--- a/docs/user/committees/faq/index.md
+++ b/docs/user/committees/faq/index.md
@@ -5,7 +5,7 @@ audience: [maintainer, board-member, executive-director]
 product_area: Committees
 tags: [committees, faq, governance]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-17
 intercom_collection: Committees
 ---
 
@@ -13,9 +13,11 @@ intercom_collection: Committees
 
 Users with a **maintainer**, **board-member**, or **executive-director** persona can create committees. Contributors can view committee information but cannot create or manage committees.
 
-## Why can't I see any committees?
+## Why can't I see a group I should be in?
 
-Make sure you have the correct project or foundation selected in the lens switcher. Committees are scoped to a specific project context. If you switch to the **Foundation** lens, you see foundation-level committees; the **Project** lens shows project-level committees.
+Which group were you expecting to see? Tell us the name and we'll open a ticket and sort it out — we can see which account you're signed in with, so that's all we need.
+
+Two things cause this: either you're not currently on that group's list, or you are and our records haven't linked you to your login yet. We'll check which and come back to you. Your group's chair can also confirm your membership and send you meeting details directly in the meantime.
 
 ## How do I add members to a committee?
 


### PR DESCRIPTION
## What

Corrects the answer to "Why can't I see any committees?" in the Committees FAQ, and retitles it to match the question members actually ask.

## Why

The current answer says committees are scoped to the selected project or foundation and tells the member to check the lens switcher. That describes PCC. In Self Serve, the My Groups page states it shows "Groups you are a member of across all foundations and projects" and is not lens-scoped, so switching the lens changes nothing on that page.

Tested against the live help centre bot on 14 August 2026. It gave the lens answer, repeated it when told the context was already correct, then after a third turn said documentation was limited and offered to connect the member to support. The escalation works; the answer preceding it sends people to a dead end first.

This matters now because LFX Self Serve foundation activation begins 17 August. Some committee members are recorded in PCC but do not resolve in Self Serve (LFXV2-2521), so they see no groups at all. Around 90 members across the foundations being activated are expected to hit this. Wave 1 is deliberately small — roughly 4 expected — which makes it the right window to get the answer right before the larger waves.

## Approach

The new answer asks which group the member expected and hands off, rather than troubleshooting. Both causes — not being on the list, or being on it with an unlinked login — need a human to tell apart, so extra turns add delay without resolving anything.

It deliberately does not ask for an email address. Intercom identifies signed-in members already: contacts carry the LFID as `external_id` and the widget greets them by name. Asking suggests we don't know who they are.

It also does not assert whether the member is or isn't on the group, because the bot cannot tell those apart.

Terminology follows the product: "group", not "committee". The rest of the article still says committee throughout; not changed here to keep this PR to a single concern.

## Questions for review

**Is this file hand-editable, or regenerated?** The frontmatter carries `last_generated: 2026-05-22`, which suggests a generator. If it regenerates, this fix belongs upstream and this PR is only a stopgap. I bumped `last_updated` and left `last_generated` alone.

**What triggers the Intercom sync, and how long after merge does the article change?** The frontmatter has `intercom_collection: Committees`, so I assume a sync job pushes this to article 16154508. Timing determines whether the correction is live before 17 August.

**The heading change moves the anchor** from `#why-cant-i-see-any-committees` to `#why-cant-i-see-a-group-i-should-be-in`. Nothing in this file links to it. If anything external does, happy to keep the old heading and change only the body.

## Not in this PR

Two Intercom-side changes are needed alongside this and are configuration rather than content:

- Make the handoff automatic on this path. The answer promises a ticket; today the member has to accept an offer to be connected.
- Tag these conversations (suggested `selfserve-missing-group`) so the volume is countable during activation, and route them to the LFXV2-2521 remediation rather than closing as user error. Anyone checking PCC will see the member *is* on the committee and could reasonably conclude they are mistaken.