### PR TITLE
fix(dashboards): skip join-url fetch for past meetings on dashboard cards

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.html
@@ -188,7 +188,7 @@
               </div>
             </lfx-card>
           } @else if (lastMeeting(); as meeting) {
-            <lfx-dashboard-meeting-card [meeting]="meeting" [detailUrl]="'/meetings/' + meeting.id" />
+            <lfx-dashboard-meeting-card [meeting]="meeting" [detailUrl]="'/meetings/' + meeting.id" [pastMeeting]="true" />
           } @else {
             <lfx-card>
               <div class="flex flex-col items-center py-6">

--- a/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-overview/committee-overview.component.ts
@@ -297,8 +297,25 @@ export class CommitteeOverviewComponent {
   });
 
   public lastMeeting: Signal<PastMeeting | null> = computed(() => {
-    const past = [...this.pastMeetings()].sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''));
-    return past[0] ?? null;
+    // v1_past_meeting includes meetings as soon as they START, so filter to truly ended
+    // records before returning — same guard used in my-meetings.component.ts.
+    const now = Date.now();
+    return (
+      [...this.pastMeetings()]
+        .sort((a, b) => (b.start_time ?? '').localeCompare(a.start_time ?? ''))
+        .find((meeting) => {
+          if (meeting.scheduled_end_time) {
+            const scheduledEnd = new Date(meeting.scheduled_end_time).getTime();
+            if (!Number.isNaN(scheduledEnd)) return scheduledEnd < now;
+          }
+          const startIso = meeting.scheduled_start_time ?? meeting.start_time;
+          if (!startIso) return false;
+          const startMs = new Date(startIso).getTime();
+          const duration = Number(meeting.duration);
+          if (Number.isNaN(startMs) || Number.isNaN(duration)) return false;
+          return startMs + duration * 60 * 1000 < now;
+        }) ?? null
+    );
   });
 
   public constructor() {

--- a/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/dashboard-meeting-card/dashboard-meeting-card.component.ts
@@ -58,6 +58,8 @@ export class DashboardMeetingCardComponent {
   public readonly overlappingCount = input<number>(0);
   /** Optional recording URL override — when set, skips the API call and renders the "Watch recording" button directly. */
   public readonly recordingUrl = input<string | null>(null);
+  /** When true, suppresses the join-url fetch and hides the Join button. Pass for past-meeting contexts (e.g. Last Meeting card) where joining is never appropriate. */
+  public readonly pastMeeting = input<boolean>(false);
 
   public readonly joinUrl: Signal<string | null>;
 
@@ -177,6 +179,10 @@ export class DashboardMeetingCardComponent {
 
   private initCanJoinMeeting(): Signal<boolean> {
     return computed(() => {
+      if (this.pastMeeting()) {
+        return false;
+      }
+
       const meeting = this.meeting();
 
       if (meeting.restricted && !meeting.invited) {

--- a/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/my-meetings/my-meetings.component.html
@@ -41,7 +41,8 @@
           cardLabel="LAST MEETING"
           cardVariant="neutral"
           viewAllRouterLink="/meetings"
-          [viewAllQueryParams]="{ time: 'past' }" />
+          [viewAllQueryParams]="{ time: 'past' }"
+          [pastMeeting]="true" />
       } @else {
         <div
           class="rounded-2xl border border-gray-200 shadow-sm overflow-hidden flex-1 flex items-center justify-center gap-4 px-5 py-10"


### PR DESCRIPTION
## Summary

- Adds a `pastMeeting` input (default `false`) to `DashboardMeetingCardComponent` that short-circuits `canJoinMeeting()` to `false`, preventing the `POST /public/api/meetings/:id/join-url` BFF call from firing.
- Passes `[pastMeeting]="true"` in the two past-meeting card contexts: the **Last Meeting** card in `my-meetings` (all dashboard lenses) and the **Past Meeting** card in `committee-overview`.
- The "Join Meeting" button was never rendered in these contexts anyway — ITX always 403s for ended occurrences and `catchError(() => of(null))` collapses `joinUrl()` to null — but the failed request was logging a `console.error` on every dashboard load, inflating the RUM error count tracked in Datadog (app `eb09f2b2-2cd7-4a3b-9354-992278f8c43d`).
- Updated `committee-overview.lastMeeting` to filter truly ended records (same `scheduled_end_time < now` guard used in `my-meetings`) so an in-progress committee meeting is not passed `pastMeeting=true` and retains its Join button.

## Test plan

- [x] Load the dashboard while having a recent past meeting — confirm no `POST .../join-url` request fires in DevTools Network tab and no `Failed to load public meeting join url` console error appears.
- [x] Confirm the **Next Meeting** card still shows a "Join Meeting" button when a meeting is within the join window (the `pastMeeting` input defaults to `false` for that card).
- [ ] Load a committee overview with a past meeting in the "Past Meeting" section — confirm no join-url request fires.
- [ ] Load a committee overview **while a meeting is currently in-progress** — confirm the in-progress meeting does **not** appear in the "Past Meeting" card (it should still be reachable from the "Next Meeting" card while the join window is open).
- [x] Confirm "Meeting details" and "Watch recording" buttons still render and function correctly on past-meeting cards.

Fixes: LFXV2-3219