### PR TITLE
docs(faq): remove nonexistent Help Center references

### DIFF
--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-08-11
+last_updated: 2026-08-17
 intercom_collection: Account
 ---
 
@@ -74,8 +74,8 @@ You can only see your own transactions. Other users and project administrators c
 
 ## I was charged incorrectly. Who do I contact?
 
-Contact LFX support through the Help Center. Include the transaction date, amount, and item name so the support team can investigate.
+Contact LFX support via in-app messaging. Include the transaction date, amount, and item name so the support team can investigate.
 
 ## Who do I contact if a setting isn't working?
 
-Contact LFX support through the Help Center. Describe the setting you changed and the behavior you expected.
+Contact LFX support via in-app messaging. Describe the setting you changed and the behavior you expected.

--- a/docs/user/badges/faq/index.md
+++ b/docs/user/badges/faq/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Badges
 tags: [badges, faq, credentials]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-17
 intercom_collection: Badges
 ---
 
@@ -35,4 +35,4 @@ Some badges may have expiry dates. Check the badge detail view for expiry inform
 
 ## Who do I contact if a badge is incorrect?
 
-Contact LFX support through the Help Center. Include the badge name and the project it relates to so the support team can investigate.
+Contact LFX support via in-app messaging. Include the badge name and the project it relates to so the support team can investigate.

--- a/docs/user/committees/faq/index.md
+++ b/docs/user/committees/faq/index.md
@@ -15,7 +15,7 @@ Users with a **maintainer**, **board-member**, or **executive-director** persona
 
 ## Why can't I see a group I should be in?
 
-Contact LFX support through the Help Center and tell us which group you were expecting to see. If you're signed in, we can already see your account, so that's all we need from you.
+Contact LFX support via in-app messaging and tell us which group you were expecting to see. If you're signed in, we can already see your account, so that's all we need from you.
 
 Two things cause this: either you're not currently on that group's list, or you are and our records haven't linked you to your login yet. Support will check which and follow up. Your group's chair can also confirm your membership and send you meeting details directly in the meantime.
 
@@ -37,4 +37,4 @@ Contact your project administrator before deleting a committee, as this may affe
 
 ## Who do I contact if I need help with committees?
 
-Contact LFX support through the Help Center. Include your project name and the committee name in your request.
+Contact LFX support via in-app messaging. Include your project name and the committee name in your request.

--- a/docs/user/crowdfunding/faq/index.md
+++ b/docs/user/crowdfunding/faq/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, faq, initiatives, donations, recurring, refunds]
 last_generated: 2026-06-29
-last_updated: 2026-06-29
+last_updated: 2026-08-17
 intercom_collection: Crowdfunding
 ---
 
@@ -40,4 +40,4 @@ A charge fails when the linked payment method cannot be processed — for exampl
 
 ## Can I get a refund for a crowdfunding donation?
 
-Crowdfunding donations are contributions to open-source project funds and are generally non-refundable. If you believe a charge was made in error, contact LFX support through the Help Center with the donation date, amount, and initiative name so the support team can investigate.
+Crowdfunding donations are contributions to open-source project funds and are generally non-refundable. If you believe a charge was made in error, contact LFX support via in-app messaging with the donation date, amount, and initiative name so the support team can investigate.

--- a/docs/user/documents/faq/index.md
+++ b/docs/user/documents/faq/index.md
@@ -5,7 +5,7 @@ audience: [maintainer, board-member, executive-director]
 product_area: Documents
 tags: [documents, faq]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-17
 intercom_collection: Documents
 ---
 
@@ -27,7 +27,7 @@ Document upload availability depends on your project role. Contact your project 
 
 ## Who do I contact if a document is missing or incorrect?
 
-Contact your project administrator or LFX support through the Help Center. Include the document name and the project it belongs to.
+Contact your project administrator or LFX support via in-app messaging. Include the document name and the project it belongs to.
 
 ## Are documents shared across projects?
 

--- a/docs/user/events/faq/index.md
+++ b/docs/user/events/faq/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Events
 tags: [events, faq, attendance]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-17
 intercom_collection: Events
 ---
 
@@ -35,4 +35,4 @@ Check the My Events page regularly for new events. Contact your project administ
 
 ## Who do I contact about a specific event?
 
-Contact the event organizer listed on the event detail page, or reach out to LFX support through the Help Center.
+Contact the event organizer listed on the event detail page, or reach out to LFX support via in-app messaging.

--- a/docs/user/mailing-lists/faq/index.md
+++ b/docs/user/mailing-lists/faq/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Mailing Lists
 tags: [mailing-lists, faq, subscribe]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-17
 intercom_collection: Mailing Lists
 ---
 
@@ -35,4 +35,4 @@ Open the mailing list detail page and navigate to the manage or settings view. U
 
 ## Who do I contact if a mailing list is set up incorrectly?
 
-Contact LFX support through the Help Center. Include the list name and the project it belongs to.
+Contact LFX support via in-app messaging. Include the list name and the project it belongs to.

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Profile
 tags: [profile, faq, about-me, photo, public-profile, visibility]
 last_generated: 2026-05-22
-last_updated: 2026-08-12
+last_updated: 2026-08-17
 intercom_collection: Profile
 ---
 
@@ -35,4 +35,4 @@ Those live in the [Account](../../account/) section, not your personal profile. 
 
 ## Who do I contact if I cannot access my account?
 
-Contact LFX support through the Help Center. If you cannot sign in at all, use the login page's help or forgotten password link.
+Contact LFX support via in-app messaging. If you cannot sign in at all, use the login page's help or forgotten password link.

--- a/docs/user/votes/faq/index.md
+++ b/docs/user/votes/faq/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Votes
 tags: [votes, faq, polls, governance, elections]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-17
 intercom_collection: Votes
 ---
 
@@ -43,4 +43,4 @@ Make sure you have the correct project selected in the lens switcher. Polls are 
 
 ## Who do I contact if there is an error with a vote result?
 
-Contact LFX support through the Help Center. Include the poll name, the project, and a description of the discrepancy.
+Contact LFX support via in-app messaging. Include the poll name, the project, and a description of the discrepancy.


### PR DESCRIPTION
## What

Replaces "contact LFX support through the Help Center" with "contact LFX support via in-app messaging" across every FAQ doc that used it (11 occurrences, 9 files).

## Why

LFX doesn't have a "Help Center" product/page. The actual support path is the in-app messaging widget's **Contact Support** action (Intercom, `apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts`), which falls back to a JIRA service-desk link when Intercom isn't loaded. Flagged by Heather: "we don't have an LFX Help center, it's in-app messenging."

This surfaced from #1589, which introduced a new "Help Center" reference in `docs/user/committees/faq/index.md` — but #1589 was already merged by the time the correction came in, so that file's two occurrences plus the same pre-existing wording in 8 other FAQs are all fixed here together.

Closes #1593