### PR TITLE
feat(campaigns): build the email template picker

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -254,8 +254,19 @@
                   -->
                   <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-truncated">This may be a partial list. Search to narrow it.</p>
                 }
+                @if (emailTemplatesRenderCapped()) {
+                  <!--
+                    Stated as FACT, unlike the `possiblyTruncated` banner above, which hedges
+                    because a capped 500 and a complete 500 are indistinguishable on the wire.
+                    Both numbers here were measured on the list in hand before it was sliced.
+
+                    Both can show at once: an unfiltered search can be cut upstream at 500 and
+                    cut again here at the render limit.
+                  -->
+                  <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-render-capped">{{ emailTemplatesRenderCapMessage() }}</p>
+                }
                 <ul class="flex flex-col gap-2" data-testid="campaigns-email-template-list">
-                  @for (template of templates; track template.id) {
+                  @for (template of emailTemplatesRendered(); track template.id) {
                     <li>
                       <button
                         type="button"
@@ -268,9 +279,33 @@
                             : 'flex w-full flex-col gap-0.5 rounded-md border border-gray-200 px-3 py-2 text-left hover:bg-gray-50'
                         "
                         [attr.data-testid]="'campaigns-email-template-' + template.id">
-                        <span class="text-sm font-medium text-gray-900">{{ template.name || template.subject || template.id }}</span>
+                        <span class="flex w-full items-center gap-2">
+                          <span class="min-w-0 flex-1 text-sm font-medium text-gray-900">{{ template.name || template.subject || template.id }}</span>
+                          <!--
+                            The non-colour half of the selected state (WCAG 1.4.1): the border and
+                            background above are colour ONLY, so a colour-blind user, or anyone on
+                            a low-contrast display, had nothing to go on. Same treatment as
+                            project-selector and org-selector — an opacity-toggled check rather
+                            than an @if, so the row's width does not shift as the selection moves.
+
+                            aria-hidden while unselected keeps it out of the accessible name;
+                            aria-pressed on the button already tells assistive tech the state, so
+                            the label would otherwise be announced twice.
+                          -->
+                          <i
+                            class="fa-light fa-check shrink-0 text-blue-500 transition-opacity"
+                            [class.opacity-100]="selectedEmailTemplateId() === template.id"
+                            [class.opacity-0]="selectedEmailTemplateId() !== template.id"
+                            [attr.aria-hidden]="selectedEmailTemplateId() !== template.id"
+                            [attr.aria-label]="selectedEmailTemplateId() === template.id ? 'Selected' : null"></i>
+                        </span>
                         <span class="text-xs text-gray-500">
-                          @if (template.subject) {
+                          <!--
+                            Only when it is not ALREADY the primary label above. With no `name`,
+                            the primary falls through to `subject`, and rendering it again here
+                            printed the same string twice on one row.
+                          -->
+                          @if (template.subject && template.name) {
                             {{ template.subject }}
                           }
                           @if (template.state) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -236,7 +236,7 @@
                     first screen are indistinguishable. Telling someone to narrow an already
                     exhaustive search would send them hunting for a template that does not exist.
                   -->
-                  <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-truncated">Showing a partial list. Search to narrow it.</p>
+                  <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-truncated">This may be a partial list. Search to narrow it.</p>
                 }
                 <ul class="flex flex-col gap-2" data-testid="campaigns-email-template-list">
                   @for (template of templates; track template.id) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -221,7 +221,7 @@
               </p>
             } @else if (emailChannelEnabled() === false) {
               <!-- Not an error: the steady state wherever HubSpot is not connected. -->
-              <p class="text-sm text-gray-500" data-testid="campaigns-email-not-connected">Connect HubSpot for this foundation to stage an email.</p>
+              <p class="text-sm text-gray-500" data-testid="campaigns-email-not-connected">{{ emailNotConnectedMessage() }}</p>
             } @else if (emailTemplatesError(); as message) {
               <p class="text-sm text-red-600" role="alert" data-testid="campaigns-email-templates-error">{{ message }}</p>
             } @else if (emailTemplates(); as templates) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -178,6 +178,15 @@
             </div>
 
             <div class="flex items-center gap-2">
+              <!--
+                Search status. Separate from the visible states and always in the DOM: an
+                aria-live element inserted with its text already present is not reliably
+                announced, so the region has to exist first and then have its CONTENTS change.
+                Same reasoning as implementation-tab's brief-status region.
+              -->
+              <div role="status" aria-live="polite" class="sr-only" data-testid="campaigns-email-templates-live">
+                {{ emailTemplatesAnnouncement() }}
+              </div>
               <input
                 type="search"
                 [value]="emailTemplateQuery()"
@@ -236,7 +245,7 @@
                         type="button"
                         (click)="onSelectEmailTemplate(template.id)"
                         [attr.aria-pressed]="selectedEmailTemplateId() === template.id"
-                        [attr.aria-label]="emailTemplateAccessibleName(template)"
+                        [attr.aria-label]="template | hubspotTemplateLabel"
                         [class]="
                           selectedEmailTemplateId() === template.id
                             ? 'flex w-full flex-col gap-0.5 rounded-md border border-blue-500 bg-blue-50 px-3 py-2 text-left'

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -251,6 +251,9 @@
                           @if (template.state) {
                             · {{ template.state }}
                           }
+                          @if (formatTemplateUpdatedAt(template.updatedAt); as updated) {
+                            · Updated {{ updated }}
+                          }
                         </span>
                       </button>
                     </li>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -236,7 +236,7 @@
                         type="button"
                         (click)="onSelectEmailTemplate(template.id)"
                         [attr.aria-pressed]="selectedEmailTemplateId() === template.id"
-                        [attr.aria-label]="'Use template ' + (template.name || template.subject || template.id)"
+                        [attr.aria-label]="emailTemplateAccessibleName(template)"
                         [class]="
                           selectedEmailTemplateId() === template.id
                             ? 'flex w-full flex-col gap-0.5 rounded-md border border-blue-500 bg-blue-50 px-3 py-2 text-left'

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -251,7 +251,7 @@
                           @if (template.state) {
                             · {{ template.state }}
                           }
-                          @if (formatTemplateUpdatedAt(template.updatedAt); as updated) {
+                          @if (template.updatedAt | hubspotUpdatedAt; as updated) {
                             · Updated {{ updated }}
                           }
                         </span>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -181,7 +181,8 @@
               <input
                 type="search"
                 [value]="emailTemplateQuery()"
-                (keyup.enter)="searchEmailTemplates($any($event.target).value)"
+                (input)="onEmailTemplateQueryInput($any($event.target).value)"
+                (keyup.enter)="searchEmailTemplates(emailTemplateQuery())"
                 placeholder="Search by name or subject"
                 aria-label="Search HubSpot marketing emails"
                 class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
@@ -226,9 +227,7 @@
                     first screen are indistinguishable. Telling someone to narrow an already
                     exhaustive search would send them hunting for a template that does not exist.
                   -->
-                  <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-truncated">
-                    Showing the most recently updated templates. Search to narrow the list.
-                  </p>
+                  <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-truncated">Showing a partial list. Search to narrow it.</p>
                 }
                 <ul class="flex flex-col gap-2" data-testid="campaigns-email-template-list">
                   @for (template of templates; track template.id) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -214,8 +214,8 @@
                   a statement about the search rather than about the portal.
                 -->
                 <p class="text-sm text-gray-500" data-testid="campaigns-email-templates-empty">
-                  @if (emailTemplateQuery()) {
-                    No templates match “{{ emailTemplateQuery() }}”.
+                  @if (emailTemplateSubmittedQuery()) {
+                    No templates match “{{ emailTemplateSubmittedQuery() }}”.
                   } @else {
                     This portal has no marketing emails yet.
                   }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -160,6 +160,23 @@
       }
     </div>
 
+    <!--
+      Template-search status, mounted OUTSIDE the @switch below.
+
+      An aria-live element inserted with its text already present is not reliably announced — the
+      region has to exist first and then have its CONTENTS change. Inside the @case this region
+      could never satisfy that rule: BOTH entry paths (`onEmailProceedToImplementation` and
+      `selectTab`) call `searchEmailTemplates` synchronously BEFORE the case renders, so the node
+      was created with "Searching templates" already in it and the first search — the main path —
+      announced nothing at all. Kept here it survives every tab transition, so only its text
+      changes. Same placement as implementation-tab's brief-status region, which sits above its
+      own @switch for exactly this reason.
+
+      It stays in the DOM on the other email tabs, which is harmless: the computed reads signals
+      that are only written by a search, so it is empty unless one is running or has answered.
+    -->
+    <div role="status" aria-live="polite" class="sr-only" data-testid="campaigns-email-templates-live">{{ emailTemplatesAnnouncement() }}</div>
+
     @switch (selectedEmailTab()) {
       @case ('implementation') {
         <div role="tabpanel" id="email-panel-implementation" aria-labelledby="email-tab-implementation" data-testid="campaigns-email-implementation-panel">
@@ -178,27 +195,18 @@
             </div>
 
             <div class="flex items-center gap-2">
-              <!--
-                Search status. Separate from the visible states and always in the DOM: an
-                aria-live element inserted with its text already present is not reliably
-                announced, so the region has to exist first and then have its CONTENTS change.
-                Same reasoning as implementation-tab's brief-status region.
-              -->
-              <div role="status" aria-live="polite" class="sr-only" data-testid="campaigns-email-templates-live">
-                {{ emailTemplatesAnnouncement() }}
-              </div>
               <input
                 type="search"
                 [value]="emailTemplateQuery()"
                 (input)="onEmailTemplateQueryInput($any($event.target).value)"
-                (keyup.enter)="searchEmailTemplates(emailTemplateQuery())"
+                (keyup.enter)="onEmailTemplateSearchSubmit()"
                 placeholder="Search by name or subject"
                 aria-label="Search HubSpot marketing emails"
                 class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
                 data-testid="campaigns-email-template-search" />
               <button
                 type="button"
-                (click)="searchEmailTemplates(emailTemplateQuery())"
+                (click)="onEmailTemplateSearchSubmit()"
                 [disabled]="emailTemplatesLoading()"
                 class="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
                 data-testid="campaigns-email-template-search-button">

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -182,8 +182,16 @@
         <div role="tabpanel" id="email-panel-implementation" aria-labelledby="email-tab-implementation" data-testid="campaigns-email-implementation-panel">
           <!--
             The template picker. Staging an email CLONES one of the project's HubSpot marketing
-            emails, and `sourceEmailId` has no default, so choosing one is the whole gate on this
-            channel — the rest is already implemented in campaign-service.
+            emails, and `sourceEmailId` has no default, so a chosen template is REQUIRED before a
+            send can be staged.
+
+            It is not yet SUFFICIENT, and an earlier version of this comment wrongly said it was.
+            There is no create trigger on the email side at all: the only `createCampaign` call
+            site is in the implementation tab, which renders solely under Paid, and
+            `CampaignPlatform` has no `hubspot` member — so the type system forbids this path from
+            reaching create even if a button existed. The selection is threaded through to
+            `hubspotConfig.sourceEmailId` so it flows the moment a trigger lands; wiring that
+            trigger is LFXV2-3201.
 
             Four states, kept distinct because collapsing any pair states something false:
             channel not connected, search failed, searched-and-empty, and results.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -164,32 +164,101 @@
       @case ('implementation') {
         <div role="tabpanel" id="email-panel-implementation" aria-labelledby="email-tab-implementation" data-testid="campaigns-email-implementation-panel">
           <!--
-            The staging form is the half of this channel that still needs a service endpoint:
-            campaign create clones a caller-specified source email and `sourceEmailId` has no
-            default, so the form cannot be built until the template picker has something to
-            list (LFXV2-3197 → LFXV2-3198). Said plainly rather than as "coming soon", which
-            would repeat the claim this PR exists to correct — the channel IS implemented in
-            campaign-service; what is missing is one route and the form over it.
+            The template picker. Staging an email CLONES one of the project's HubSpot marketing
+            emails, and `sourceEmailId` has no default, so choosing one is the whole gate on this
+            channel — the rest is already implemented in campaign-service.
+
+            Four states, kept distinct because collapsing any pair states something false:
+            channel not connected, search failed, searched-and-empty, and results.
           -->
-          <div
-            class="flex flex-col items-center justify-center gap-3 rounded-lg border border-dashed border-gray-200 bg-gray-50 px-6 py-16 text-center"
-            data-testid="campaigns-email-implementation-pending">
-            <i class="fa-light fa-envelope-open-text text-3xl text-gray-400" aria-hidden="true"></i>
-            <h2 class="text-base font-semibold text-gray-900">Email staging is not wired up yet</h2>
-            <!--
-              The brief sentence is gated on there BEING a brief. This tab is directly clickable
-              with no disabled binding, so it is reachable before anything has been generated —
-              and "Your brief is ready" is then simply false, told to someone who has not started.
-              The rest of the panel is true either way: it explains what is missing from the
-              channel, which does not depend on the user's progress.
-            -->
-            <p class="max-w-md text-sm text-gray-500">
-              @if (emailBriefOutput()) {
-                Your brief is ready.
+          <div class="flex flex-col gap-4" data-testid="campaigns-email-implementation">
+            <div class="flex flex-col gap-1">
+              <h2 class="text-base font-semibold text-gray-900">Choose a template to clone</h2>
+              <p class="text-sm text-gray-500">The send is created as a clone of one of your HubSpot marketing emails.</p>
+            </div>
+
+            <div class="flex items-center gap-2">
+              <input
+                type="search"
+                [value]="emailTemplateQuery()"
+                (keyup.enter)="searchEmailTemplates($any($event.target).value)"
+                placeholder="Search by name or subject"
+                aria-label="Search HubSpot marketing emails"
+                class="flex-1 rounded-md border border-gray-300 px-3 py-2 text-sm"
+                data-testid="campaigns-email-template-search" />
+              <button
+                type="button"
+                (click)="searchEmailTemplates(emailTemplateQuery())"
+                [disabled]="emailTemplatesLoading()"
+                class="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50"
+                data-testid="campaigns-email-template-search-button">
+                Search
+              </button>
+            </div>
+
+            @if (emailTemplatesLoading()) {
+              <p class="text-sm text-gray-500" data-testid="campaigns-email-templates-loading">
+                <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+                Loading templates…
+              </p>
+            } @else if (emailChannelEnabled() === false) {
+              <!-- Not an error: the steady state wherever HubSpot is not connected. -->
+              <p class="text-sm text-gray-500" data-testid="campaigns-email-not-connected">Connect HubSpot for this foundation to stage an email.</p>
+            } @else if (emailTemplatesError(); as message) {
+              <p class="text-sm text-red-600" role="alert" data-testid="campaigns-email-templates-error">{{ message }}</p>
+            } @else if (emailTemplates(); as templates) {
+              @if (templates.length === 0) {
+                <!--
+                  Only reachable when the search SUCCEEDED. The copy names the query so it reads as
+                  a statement about the search rather than about the portal.
+                -->
+                <p class="text-sm text-gray-500" data-testid="campaigns-email-templates-empty">
+                  @if (emailTemplateQuery()) {
+                    No templates match “{{ emailTemplateQuery() }}”.
+                  } @else {
+                    This portal has no marketing emails yet.
+                  }
+                </p>
+              } @else {
+                @if (emailTemplatesTruncated()) {
+                  <!--
+                    Only ever set for an EMPTY query, where a complete listing and a truncated
+                    first screen are indistinguishable. Telling someone to narrow an already
+                    exhaustive search would send them hunting for a template that does not exist.
+                  -->
+                  <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-truncated">
+                    Showing the most recently updated templates. Search to narrow the list.
+                  </p>
+                }
+                <ul class="flex flex-col gap-2" data-testid="campaigns-email-template-list">
+                  @for (template of templates; track template.id) {
+                    <li>
+                      <button
+                        type="button"
+                        (click)="onSelectEmailTemplate(template.id)"
+                        [attr.aria-pressed]="selectedEmailTemplateId() === template.id"
+                        [attr.aria-label]="'Use template ' + (template.name || template.subject || template.id)"
+                        [class]="
+                          selectedEmailTemplateId() === template.id
+                            ? 'flex w-full flex-col gap-0.5 rounded-md border border-blue-500 bg-blue-50 px-3 py-2 text-left'
+                            : 'flex w-full flex-col gap-0.5 rounded-md border border-gray-200 px-3 py-2 text-left hover:bg-gray-50'
+                        "
+                        [attr.data-testid]="'campaigns-email-template-' + template.id">
+                        <span class="text-sm font-medium text-gray-900">{{ template.name || template.subject || template.id }}</span>
+                        <span class="text-xs text-gray-500">
+                          @if (template.subject) {
+                            {{ template.subject }}
+                          }
+                          @if (template.state) {
+                            · {{ template.state }}
+                          }
+                        </span>
+                      </button>
+                    </li>
+                  }
+                </ul>
               }
-              Staging an email clones one of your HubSpot marketing emails as its template, and choosing that template needs an endpoint that is still in
-              review.
-            </p>
+            }
           </div>
         </div>
       }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1787,6 +1787,23 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     fixture.detectChanges();
   }
 
+  it('loads templates when the implementation tab is entered, not only on proceed', () => {
+    // The only other searchEmailTemplates call site is onEmailProceedToImplementation, so
+    // arriving at this tab any other way — clicking it directly, or returning after a
+    // foundation switch cleared the list — used to leave an empty box. This file's own
+    // comment calls that state "a broken channel".
+    const comp = fixture.componentInstance as unknown as { selectTab(t: string, owner: string): void };
+    comp.selectTab('implementation', 'email');
+    fixture.detectChanges();
+
+    // The request itself is the assertion: expectOne throws if entering the tab issued none.
+    const req = httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails');
+    req.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: '1', name: 'KubeCon promo' }] });
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('KubeCon promo');
+  });
+
   it('lists the templates a search returned, dropping any row with no id', () => {
     picker().searchEmailTemplates('');
     respond({
@@ -1926,6 +1943,11 @@ describe('CampaignsComponent — HubSpot template picker', () => {
   // everything.
   it('searches what is typed, not the previous query', () => {
     const el = panel();
+    // Entering the tab issues the initial load (see selectTab). Answer it so the assertion
+    // below is about what the SEARCH sent, not about that first request.
+    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').flush({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+    fixture.detectChanges();
+
     const input = el.querySelector('[data-testid="campaigns-email-template-search"]') as HTMLInputElement;
     input.value = 'kubecon';
     input.dispatchEvent(new Event('input'));

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1910,6 +1910,30 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     expect(el.querySelector('[data-testid="campaigns-email-template-list"]')).toBeNull();
   });
 
+  /**
+   * campaign-service answers the SAME typed 404 for an absent connection row and for a project id
+   * that does not exist (`campaign.interface.ts:1223-1226`), so this copy is the only place a
+   * mistyped slug can be distinguished from an unconfigured one. Naming nothing reported every
+   * typo as a missing integration.
+   */
+  it('names the project it queried in the connect-HubSpot state', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: false, error: null, possiblyTruncated: false, emails: [] });
+
+    const text = panel().querySelector('[data-testid="campaigns-email-not-connected"]')?.textContent ?? '';
+    expect(text).toContain('tlf');
+  });
+
+  it('announces the same named message it renders', () => {
+    // The visible node and the live region held two separate copies of this sentence. A screen
+    // reader hearing an unnamed message while the screen names one is told a different story.
+    picker().searchEmailTemplates('');
+    respond({ enabled: false, error: null, possiblyTruncated: false, emails: [] });
+
+    const text = panel().querySelector('[data-testid="campaigns-email-not-connected"]')?.textContent?.trim() ?? '';
+    expect(picker().emailTemplatesAnnouncement()).toBe(text);
+  });
+
   it('renders the error state, not an empty portal, when the search failed', () => {
     picker().searchEmailTemplates('');
     respond({ enabled: true, error: 'HubSpot refused the request', possiblyTruncated: false, emails: [] });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1919,6 +1919,24 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     expect(el.querySelector('[data-testid="campaigns-email-templates-empty"]')).toBeNull();
   });
 
+  it('keeps the empty state naming the query that ran, not what is being typed', () => {
+    picker().searchEmailTemplates('alpha');
+    respond({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+    expect(panel().querySelector('[data-testid="campaigns-email-templates-empty"]')?.textContent).toContain('alpha');
+
+    // Type a new query WITHOUT submitting it. The results on screen are still alpha's, so the
+    // empty state must keep saying alpha — naming beta would assert a search that never ran.
+    const el = panel();
+    const input = el.querySelector('[data-testid="campaigns-email-template-search"]') as HTMLInputElement;
+    input.value = 'beta';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    const empty = panel().querySelector('[data-testid="campaigns-email-templates-empty"]');
+    expect(empty?.textContent).toContain('alpha');
+    expect(empty?.textContent).not.toContain('beta');
+  });
+
   it('names the query in the empty state, so it reads as being about the search', () => {
     picker().searchEmailTemplates('nothing-matches');
     respond({ enabled: true, error: null, possiblyTruncated: false, emails: [] });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -2058,15 +2058,17 @@ describe('CampaignsComponent — HubSpot template picker correctness', () => {
   it('renders each template updated date', () => {
     openEmailImplementationTab();
     picker().searchEmailTemplates('');
-    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').flush({
-      enabled: true,
-      error: null,
-      possiblyTruncated: false,
-      emails: [
-        { id: '1', name: 'KubeCon promo', updatedAt: '2026-08-14T10:00:00Z' },
-        { id: '2', name: 'KubeCon promo' },
-      ],
-    });
+    httpMock
+      .expectOne((r) => r.url === '/api/campaigns/hubspot/emails')
+      .flush({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: '1', name: 'KubeCon promo', updatedAt: '2026-08-14T10:00:00Z' },
+          { id: '2', name: 'KubeCon promo' },
+        ],
+      });
     fixture.detectChanges();
 
     const text = (fixture.nativeElement as HTMLElement).textContent ?? '';

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -6,6 +6,7 @@ import { HttpTestingController } from '@angular/common/http/testing';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { Signal, WritableSignal } from '@angular/core';
+import { computed, signal } from '@angular/core';
 import type {
   CampaignBriefOutput,
   CampaignBriefPersistResult,
@@ -1749,6 +1750,8 @@ describe('CampaignsComponent — Implementation edits survive a tab switch', () 
 describe('CampaignsComponent — HubSpot template picker', () => {
   let fixture: ComponentFixture<CampaignsComponent>;
   let httpMock: HttpTestingController;
+  // A writable context signal so a foundation SWITCH can be driven, not just its absence.
+  let ctx: WritableSignal<ProjectContext | null>;
 
   interface PickerInternals {
     emailTemplates: WritableSignal<HubSpotMarketingEmail[] | null>;
@@ -1762,16 +1765,19 @@ describe('CampaignsComponent — HubSpot template picker', () => {
   const picker = (): PickerInternals => fixture.componentInstance as unknown as PickerInternals;
 
   beforeEach(async () => {
+    ctx = signal<ProjectContext | null>({ uid: 'u1', name: 'The Linux Foundation', slug: 'tlf', logoUrl: '' } as ProjectContext);
     await TestBed.configureTestingModule({
       imports: [CampaignsComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: ProjectContextService, useValue: { activeContext: ctx, activeContextUid: computed(() => ctx()?.uid ?? '') } },
+      ],
     }).compileComponents();
     fixture = TestBed.createComponent(CampaignsComponent);
     httpMock = TestBed.inject(HttpTestingController);
     fixture.detectChanges();
-    // The component reads the foundation from ProjectContextService; without a slug the search
-    // refuses before issuing a request, which is its own test below.
-    (fixture.componentInstance as unknown as { activeFoundationSlug: () => string }).activeFoundationSlug = () => 'tlf';
   });
 
   function respond(body: { enabled: boolean; error: string | null; possiblyTruncated: boolean; emails: HubSpotMarketingEmail[] }): void {
@@ -1849,12 +1855,106 @@ describe('CampaignsComponent — HubSpot template picker', () => {
   });
 
   it('refuses to search without a foundation rather than listing another portal', () => {
-    (fixture.componentInstance as unknown as { activeFoundationSlug: () => string }).activeFoundationSlug = () => '';
+    ctx.set(null);
+    fixture.detectChanges();
 
     picker().searchEmailTemplates('kubecon');
 
     httpMock.expectNone((r) => r.url === '/api/campaigns/hubspot/emails');
     expect(picker().emailTemplatesError()).toContain('foundation');
+  });
+
+  // The four states are pinned in the COMPONENT above and were entirely unpinned in the UI that
+  // expresses them: a reviewer deleted all four rendering blocks and every test still passed. The
+  // defect class this whole picker guards against could therefore reappear in the template with a
+  // green suite. These assert the DOM, one state at a time, using the testids already present.
+  interface PanelNav {
+    selectorForm: { controls: { deliveryType: { setValue(v: string): void } } };
+    selectTab(tab: string, owner: string): void;
+  }
+  function panel(): HTMLElement {
+    const nav = fixture.componentInstance as unknown as PanelNav;
+    nav.selectorForm.controls.deliveryType.setValue('email');
+    nav.selectTab('implementation', 'email');
+    fixture.detectChanges();
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  it('renders the connect-HubSpot state and nothing else when the channel is off', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: false, error: null, possiblyTruncated: false, emails: [] });
+
+    const el = panel();
+    expect(el.querySelector('[data-testid="campaigns-email-not-connected"]')).not.toBeNull();
+    expect(el.querySelector('[data-testid="campaigns-email-templates-error"]')).toBeNull();
+    expect(el.querySelector('[data-testid="campaigns-email-templates-empty"]')).toBeNull();
+    expect(el.querySelector('[data-testid="campaigns-email-template-list"]')).toBeNull();
+  });
+
+  it('renders the error state, not an empty portal, when the search failed', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: true, error: 'HubSpot refused the request', possiblyTruncated: false, emails: [] });
+
+    const el = panel();
+    expect(el.querySelector('[data-testid="campaigns-email-templates-error"]')).not.toBeNull();
+    // The claim that must never render over a failure.
+    expect(el.querySelector('[data-testid="campaigns-email-templates-empty"]')).toBeNull();
+  });
+
+  it('names the query in the empty state, so it reads as being about the search', () => {
+    picker().searchEmailTemplates('nothing-matches');
+    respond({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+
+    const empty = panel().querySelector('[data-testid="campaigns-email-templates-empty"]');
+    expect(empty).not.toBeNull();
+    expect(empty?.textContent).toContain('nothing-matches');
+  });
+
+  it('renders a row per template with an accessible name', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: '1', name: 'KubeCon promo' }] });
+
+    const row = panel().querySelector('[data-testid="campaigns-email-template-1"]');
+    expect(row).not.toBeNull();
+    expect(row?.getAttribute('aria-label')).toContain('KubeCon promo');
+  });
+
+  // The input was one-way, so the signal only changed INSIDE searchEmailTemplates. Typing
+  // "kubecon" then clicking Search re-ran the previous query — empty on arrival — returning the
+  // full listing while the box still read "kubecon", so the user concludes their search matched
+  // everything.
+  it('searches what is typed, not the previous query', () => {
+    const el = panel();
+    const input = el.querySelector('[data-testid="campaigns-email-template-search"]') as HTMLInputElement;
+    input.value = 'kubecon';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    (el.querySelector('[data-testid="campaigns-email-template-search-button"]') as HTMLButtonElement).click();
+
+    const req = httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails');
+    expect(req.request.params.get('q')).toBe('kubecon');
+    req.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+  });
+
+  // A CHANGED foundation is the same hazard as a missing one, and searchEmailTemplates' own
+  // guard cannot see it: the results are already on screen, now labelled with whichever
+  // foundation is selected. selectedEmailTemplateId is the one that must not survive — it becomes
+  // hubspotConfig.sourceEmailId on create, so a stale selection stages a send that clones
+  // foundation A's email into foundation B's portal.
+  it('clears the picker when the foundation changes', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: true, error: null, possiblyTruncated: true, emails: [{ id: '1', name: 'A-only template' }] });
+    picker().onSelectEmailTemplate('1');
+    expect(picker().selectedEmailTemplateId()).toBe('1');
+
+    ctx.set({ uid: 'u2', name: 'Other Foundation', slug: 'other', logoUrl: '' } as ProjectContext);
+    fixture.detectChanges();
+
+    expect(picker().selectedEmailTemplateId()).toBe('');
+    expect(picker().emailTemplates()).toBeNull();
+    expect(picker().emailChannelEnabled()).toBeNull();
+    expect(picker().emailTemplatesTruncated()).toBe(false);
   });
 
   it('records the chosen template id, which is what sourceEmailId takes', () => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1760,6 +1760,7 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     emailTemplatesTruncated: WritableSignal<boolean>;
     emailChannelEnabled: WritableSignal<boolean | null>;
     selectedEmailTemplateId: WritableSignal<string>;
+    emailTemplatesAnnouncement: Signal<string>;
     searchEmailTemplates(query: string): void;
     onSelectEmailTemplate(id: string): void;
   }
@@ -2055,6 +2056,123 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     expect(picker().emailTemplates()).toBeNull();
     expect(picker().emailChannelEnabled()).toBeNull();
     expect(picker().emailTemplatesTruncated()).toBe(false);
+  });
+
+  // The live region was mounted INSIDE @switch → @case('implementation'), and both entry paths
+  // call searchEmailTemplates synchronously BEFORE that case renders — so the node was inserted
+  // with "Searching templates" already in it, which is not reliably announced. Its own comment
+  // states the rule it broke. Mounted above the @switch it exists before any text changes.
+  it('keeps the search live region mounted before the picker is entered', () => {
+    const el = fixture.nativeElement as HTMLElement;
+    const nav = fixture.componentInstance as unknown as PanelNav;
+    nav.selectorForm.controls.deliveryType.setValue('email');
+    fixture.detectChanges();
+
+    // Present while still on Plan — i.e. BEFORE the implementation case has ever rendered.
+    const live = el.querySelector('[data-testid="campaigns-email-templates-live"]');
+    expect(live, 'the region must exist before its contents change').not.toBeNull();
+    expect(live?.textContent?.trim()).toBe('');
+    // It must NOT be inside the implementation panel, or it is destroyed on every tab change.
+    expect(el.querySelector('[data-testid="campaigns-email-implementation-panel"]')?.contains(live as Node)).toBeFalsy();
+
+    nav.selectTab('implementation', 'email');
+    fixture.detectChanges();
+
+    // Same node, now carrying the progress text: a CONTENT change, not an insertion.
+    const after = el.querySelector('[data-testid="campaigns-email-templates-live"]');
+    expect(after).toBe(live);
+    expect(after?.textContent).toContain('Searching templates');
+  });
+
+  // The button was [disabled] while loading but Enter called searchEmailTemplates directly, so a
+  // held Enter fired a full portal walk per repeat. The generation counter discards the late
+  // answers; it does not cancel the requests, so the cost is still paid upstream.
+  it('refuses an Enter press while a search is already in flight', () => {
+    const el = panel();
+    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').flush({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+    fixture.detectChanges();
+
+    const input = el.querySelector('[data-testid="campaigns-email-template-search"]') as HTMLInputElement;
+    input.value = 'kubecon';
+    input.dispatchEvent(new Event('input'));
+    fixture.detectChanges();
+
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+    fixture.detectChanges();
+    expect(httpMock.match((r) => r.url === '/api/campaigns/hubspot/emails').length).toBe(1);
+
+    // Held down: every repeat while the first is unanswered must issue nothing.
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+    input.dispatchEvent(new KeyboardEvent('keyup', { key: 'Enter', bubbles: true }));
+    fixture.detectChanges();
+    httpMock.expectNone((r) => r.url === '/api/campaigns/hubspot/emails');
+  });
+
+  // The failure-as-measurement class this PR exists to fix. The server drops id-less rows, so a
+  // response carrying ONLY such rows means the contract was violated — not that the portal is
+  // empty. Filtering to [] rendered "This portal has no marketing emails yet" over rows that
+  // proved the opposite.
+  it('does not report a portal as empty when every returned row was unusable', () => {
+    picker().searchEmailTemplates('');
+    respond({
+      enabled: true,
+      error: null,
+      possiblyTruncated: false,
+      emails: [{ id: '', name: 'broken row' }, { id: '' }] as HubSpotMarketingEmail[],
+    });
+
+    expect(picker().emailTemplates(), 'an empty array here claims the portal holds nothing').toBeNull();
+    expect(picker().emailTemplatesError()).toBeTruthy();
+
+    const el = panel();
+    expect(el.querySelector('[data-testid="campaigns-email-templates-empty"]')).toBeNull();
+    expect(el.querySelector('[data-testid="campaigns-email-templates-error"]')).not.toBeNull();
+  });
+
+  // The switch handler's reload reads selectedDeliveryType() AT THAT MOMENT. A foundation switch
+  // made while on Paid therefore cleared the picker and skipped the reload, and nothing
+  // re-checked it — returning to email/Implement showed a permanently blank panel.
+  it('reloads the picker when returning to email after a foundation switch made elsewhere', () => {
+    panel();
+    httpMock
+      .expectOne((r) => r.url === '/api/campaigns/hubspot/emails')
+      .flush({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: '1', name: 'TLF promo' }] });
+    fixture.detectChanges();
+
+    const nav = fixture.componentInstance as unknown as PanelNav;
+    nav.selectorForm.controls.deliveryType.setValue('paid-marketing');
+    fixture.detectChanges();
+
+    // The switch clears the picker but must not load templates for a hidden panel.
+    ctx.set({ uid: 'u2', name: 'CNCF', slug: 'cncf', logoUrl: '' } as ProjectContext);
+    fixture.detectChanges();
+    httpMock.expectNone((r) => r.url === '/api/campaigns/hubspot/emails');
+
+    nav.selectorForm.controls.deliveryType.setValue('email');
+    fixture.detectChanges();
+
+    const req = httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails');
+    req.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: '9', name: 'CNCF promo' }] });
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('CNCF promo');
+  });
+
+  // The announcement and the visible copy must not say different things. The truncation clause is
+  // the one a screen-reader user cannot recover any other way, so it is compared word-for-word.
+  it('announces the same truncation and empty-state wording the panel shows', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: true, error: null, possiblyTruncated: true, emails: [{ id: '1', name: 'One' }] });
+
+    const banner = panel().querySelector('[data-testid="campaigns-email-templates-truncated"]')?.textContent?.trim();
+    expect(banner).toBe('This may be a partial list. Search to narrow it.');
+    expect(picker().emailTemplatesAnnouncement()).toBe('1 template found. This may be a partial list. Search to narrow it.');
+
+    // The query is quoted in both, so a multi-word query cannot dissolve into the sentence.
+    picker().searchEmailTemplates('no templates');
+    respond({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+    expect(picker().emailTemplatesAnnouncement()).toBe('No templates match “no templates”.');
+    expect(panel().querySelector('[data-testid="campaigns-email-templates-empty"]')?.textContent?.trim()).toBe('No templates match “no templates”.');
   });
 
   it('records the chosen template id, which is what sourceEmailId takes', () => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -20,6 +20,7 @@ import type {
 } from '@lfx-one/shared/interfaces';
 import { provideRouter } from '@angular/router';
 import { CampaignService } from '@services/campaign.service';
+import { HUBSPOT_TEMPLATE_RENDER_LIMIT } from '@lfx-one/shared/constants';
 import type { HubSpotMarketingEmail } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -2217,6 +2218,8 @@ describe('CampaignsComponent — HubSpot template picker correctness', () => {
     selectedEmailTab: WritableSignal<Exclude<CampaignTab, 'optimization'>>;
     selectorForm: { controls: { deliveryType: { setValue(v: CampaignDeliveryType): void } } };
     searchEmailTemplates(query: string): void;
+    onSelectEmailTemplate(id: string): void;
+    emailTemplatesAnnouncement: Signal<string>;
   }
   const picker = (): PickerInternals => fixture.componentInstance as unknown as PickerInternals;
 
@@ -2316,5 +2319,141 @@ describe('CampaignsComponent — HubSpot template picker correctness', () => {
     expect(text).toContain('Aug 14, 2026');
     // A row with no date renders no placeholder — a dash would read as a reported value.
     expect(text).not.toContain('· Updated –');
+  });
+
+  /**
+   * WCAG 1.4.1: the selected row must not be distinguished by colour alone.
+   *
+   * Asserts the RENDERED opacity class on the check icon rather than the presence of the `<i>`,
+   * because the icon is always in the DOM — an existence check passes against a row that renders
+   * it permanently invisible, which is exactly the bug this guards.
+   */
+  it('marks the selected template with a non-colour indicator', () => {
+    openEmailImplementationTab();
+    picker().searchEmailTemplates('');
+    httpMock
+      .expectOne((r) => r.url === '/api/campaigns/hubspot/emails')
+      .flush({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: '1', name: 'Alpha' },
+          { id: '2', name: 'Beta' },
+        ],
+      });
+    fixture.detectChanges();
+
+    picker().onSelectEmailTemplate('1');
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const iconIn = (id: string): HTMLElement => root.querySelector(`[data-testid="campaigns-email-template-${id}"] i.fa-check`) as HTMLElement;
+
+    // The chosen row shows the check AND exposes it as text to assistive tech.
+    expect(iconIn('1').classList.contains('opacity-100')).toBe(true);
+    expect(iconIn('1').getAttribute('aria-label')).toBe('Selected');
+
+    // The unchosen row hides it and keeps it out of the accessible name.
+    expect(iconIn('2').classList.contains('opacity-0')).toBe(true);
+    expect(iconIn('2').getAttribute('aria-label')).toBeNull();
+    expect(iconIn('2').getAttribute('aria-hidden')).toBe('true');
+  });
+
+  /**
+   * With no `name`, the primary label falls through to `subject` — so the metadata line must not
+   * print it a second time.
+   *
+   * Counts OCCURRENCES of the subject in the row rather than asserting the metadata line is
+   * empty: the line still carries state and date, so an emptiness check would fail against
+   * correct code and a `toContain` check would pass against the duplicate.
+   */
+  it('does not repeat the subject when it is already the primary label', () => {
+    openEmailImplementationTab();
+    picker().searchEmailTemplates('');
+    httpMock
+      .expectOne((r) => r.url === '/api/campaigns/hubspot/emails')
+      .flush({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'no-name', subject: 'Register for KubeCon', state: 'DRAFT' },
+          { id: 'named', name: 'KubeCon promo', subject: 'Register for KubeCon', state: 'DRAFT' },
+        ],
+      });
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    const occurrences = (id: string): number =>
+      ((root.querySelector(`[data-testid="campaigns-email-template-${id}"]`)?.textContent ?? '').match(/Register for KubeCon/g) ?? []).length;
+
+    // Name absent: subject is the primary label, so it appears exactly once.
+    expect(occurrences('no-name')).toBe(1);
+    // Name present: primary label is the NAME, and the subject renders once beneath it as
+    // genuinely extra information. Also once — but for the opposite reason, so both the primary
+    // label and the metadata line are asserted directly rather than inferred from the count.
+    expect(occurrences('named')).toBe(1);
+
+    const named = root.querySelector('[data-testid="campaigns-email-template-named"]') as HTMLElement;
+    // The name is the primary label…
+    expect(named.querySelector('span.font-medium')?.textContent?.trim()).toBe('KubeCon promo');
+    // …and the subject is the metadata line, which is where the one occurrence lives.
+    expect(named.textContent).toContain('Register for KubeCon');
+
+    const unnamed = root.querySelector('[data-testid="campaigns-email-template-no-name"]') as HTMLElement;
+    // Subject IS the primary label here, so the metadata line must not repeat it: what is left
+    // there is the state alone.
+    expect(unnamed.querySelector('span.font-medium')?.textContent?.trim()).toBe('Register for KubeCon');
+    const meta = unnamed.querySelectorAll('span')[unnamed.querySelectorAll('span').length - 1];
+    expect(meta.textContent).not.toContain('Register for KubeCon');
+    expect(meta.textContent).toContain('DRAFT');
+  });
+
+  /**
+   * A filtered search is exempt from the service's 500-row cap, so a broad query can answer with
+   * thousands of rows. The render is capped — and the UI must SAY the render was capped.
+   *
+   * Asserts the exact sentence and both numbers, not merely that a banner exists: a banner
+   * reading "Showing the first 100 of 100" would satisfy an existence check while telling the
+   * user nothing true.
+   */
+  it('caps how many templates it renders and says so, without discarding the rest', () => {
+    openEmailImplementationTab();
+    picker().searchEmailTemplates('a');
+    const emails = Array.from({ length: HUBSPOT_TEMPLATE_RENDER_LIMIT + 37 }, (_, i) => ({ id: `t-${i}`, name: `Template ${i}` }));
+    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').flush({ enabled: true, error: null, possiblyTruncated: false, emails });
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+
+    // Only the cap is drawn…
+    expect(root.querySelectorAll('[data-testid="campaigns-email-template-list"] > li').length).toBe(HUBSPOT_TEMPLATE_RENDER_LIMIT);
+    // …and the LAST fetched row is genuinely not on screen.
+    expect(root.querySelector(`[data-testid="campaigns-email-template-t-${HUBSPOT_TEMPLATE_RENDER_LIMIT + 36}"]`)).toBeNull();
+
+    // The truth about the cut is stated, with the real total — not the drawn count.
+    const banner = root.querySelector('[data-testid="campaigns-email-templates-render-capped"]')?.textContent?.trim();
+    expect(banner).toBe(`Showing the first ${HUBSPOT_TEMPLATE_RENDER_LIMIT} of ${HUBSPOT_TEMPLATE_RENDER_LIMIT + 37}. Search to narrow the list.`);
+
+    // A screen-reader user cannot see the banner, so the same fact reaches the live region.
+    expect(picker().emailTemplatesAnnouncement()).toContain(`Showing the first ${HUBSPOT_TEMPLATE_RENDER_LIMIT} of ${HUBSPOT_TEMPLATE_RENDER_LIMIT + 37}`);
+
+    // The rows were not thrown away — the cap is a render limit, not a truncation of the result.
+    expect(picker().emailTemplates()?.length).toBe(HUBSPOT_TEMPLATE_RENDER_LIMIT + 37);
+  });
+
+  /** At or under the limit nothing is cut, so claiming a cut would be a fresh falsehood. */
+  it('says nothing about a cap when every fetched template is drawn', () => {
+    openEmailImplementationTab();
+    picker().searchEmailTemplates('a');
+    const emails = Array.from({ length: HUBSPOT_TEMPLATE_RENDER_LIMIT }, (_, i) => ({ id: `t-${i}`, name: `Template ${i}` }));
+    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').flush({ enabled: true, error: null, possiblyTruncated: false, emails });
+    fixture.detectChanges();
+
+    const root = fixture.nativeElement as HTMLElement;
+    expect(root.querySelectorAll('[data-testid="campaigns-email-template-list"] > li').length).toBe(HUBSPOT_TEMPLATE_RENDER_LIMIT);
+    expect(root.querySelector('[data-testid="campaigns-email-templates-render-capped"]')).toBeNull();
+    expect(picker().emailTemplatesAnnouncement()).not.toContain('Showing the first');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1962,3 +1962,115 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     expect(picker().selectedEmailTemplateId()).toBe('123');
   });
 });
+
+describe('CampaignsComponent — HubSpot template picker correctness', () => {
+  let fixture: ComponentFixture<CampaignsComponent>;
+  let httpMock: HttpTestingController;
+  let ctx: WritableSignal<ProjectContext | null>;
+
+  interface PickerInternals {
+    emailTemplates: WritableSignal<HubSpotMarketingEmail[] | null>;
+    emailTemplatesError: WritableSignal<string | null>;
+    emailChannelEnabled: WritableSignal<boolean | null>;
+    selectedEmailTab: WritableSignal<Exclude<CampaignTab, 'optimization'>>;
+    selectorForm: { controls: { deliveryType: { setValue(v: CampaignDeliveryType): void } } };
+    searchEmailTemplates(query: string): void;
+  }
+  const picker = (): PickerInternals => fixture.componentInstance as unknown as PickerInternals;
+
+  /**
+   * The picker renders under `@switch (selectedEmailTab())` → `@case ('implementation')`, so a
+   * DOM assertion needs the email delivery type AND that tab selected. Without both, the list is
+   * simply not in the document and a `toContain` check fails against correct code.
+   */
+  function openEmailImplementationTab(): void {
+    picker().selectorForm.controls.deliveryType.setValue('email');
+    picker().selectedEmailTab.set('implementation');
+    fixture.detectChanges();
+  }
+
+  beforeEach(async () => {
+    ctx = signal<ProjectContext | null>({ uid: 'u1', name: 'The Linux Foundation', slug: 'tlf', logoUrl: '' } as ProjectContext);
+    await TestBed.configureTestingModule({
+      imports: [CampaignsComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        { provide: ProjectContextService, useValue: { activeContext: ctx, activeContextUid: computed(() => ctx()?.uid ?? '') } },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(CampaignsComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+  });
+
+  /**
+   * A slow FIRST search must not overwrite a fast SECOND one.
+   *
+   * Each call is an independent subscribe, so without a generation guard the earlier response
+   * lands last and wins — leaving the list from search A on screen while the query box shows B.
+   * Driven by flushing the two requests out of order, which is the only way to reproduce it.
+   */
+  it('ignores a stale response that lands after a newer search', () => {
+    picker().searchEmailTemplates('alpha');
+    picker().searchEmailTemplates('beta');
+
+    const reqs = httpMock.match((r) => r.url === '/api/campaigns/hubspot/emails');
+    expect(reqs.length).toBe(2);
+
+    // The NEWER search answers first…
+    reqs[1].flush({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: 'beta-1', name: 'Beta template' }] });
+    fixture.detectChanges();
+    // …then the older one lands.
+    reqs[0].flush({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: 'alpha-1', name: 'Alpha template' }] });
+    fixture.detectChanges();
+
+    const listed = picker().emailTemplates();
+    expect(listed?.length).toBe(1);
+    expect(listed?.[0].id, 'the stale first search overwrote the newer result').toBe('beta-1');
+  });
+
+  /**
+   * A transport failure must surface as a failure, not as "HubSpot is not connected".
+   *
+   * The template checks `emailChannelEnabled() === false` BEFORE the error branch, so a stale
+   * false from an earlier response outranks a real error and the operator is told to fix a
+   * connection that is fine.
+   */
+  it('does not report a later failure as a disconnected channel', () => {
+    picker().searchEmailTemplates('one');
+    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').flush({ enabled: false, error: null, possiblyTruncated: false, emails: [] });
+    fixture.detectChanges();
+    expect(picker().emailChannelEnabled()).toBe(false);
+
+    // A second search that fails at the transport.
+    picker().searchEmailTemplates('two');
+    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').error(new ProgressEvent('network'));
+    fixture.detectChanges();
+
+    expect(picker().emailTemplatesError()).toBe('Could not load templates. Try again.');
+    expect(picker().emailChannelEnabled(), 'a stale false outranks the error branch and hides it').not.toBe(false);
+  });
+
+  /** Two templates routinely share a name; the date is what tells them apart. */
+  it('renders each template updated date', () => {
+    openEmailImplementationTab();
+    picker().searchEmailTemplates('');
+    httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails').flush({
+      enabled: true,
+      error: null,
+      possiblyTruncated: false,
+      emails: [
+        { id: '1', name: 'KubeCon promo', updatedAt: '2026-08-14T10:00:00Z' },
+        { id: '2', name: 'KubeCon promo' },
+      ],
+    });
+    fixture.detectChanges();
+
+    const text = (fixture.nativeElement as HTMLElement).textContent ?? '';
+    expect(text).toContain('Aug 14, 2026');
+    // A row with no date renders no placeholder — a dash would read as a reported value.
+    expect(text).not.toContain('· Updated –');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1919,6 +1919,49 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     expect(el.querySelector('[data-testid="campaigns-email-templates-empty"]')).toBeNull();
   });
 
+  it('reloads the picker when the foundation changes while it is already open', () => {
+    // The entry load lives in selectTab, which only runs on a tab TRANSITION. An operator
+    // already sitting on the picker who switches foundation never triggers it, so the clears
+    // in the switch handler left a blank panel in front of them.
+    panel();
+    httpMock
+      .expectOne((r) => r.url === '/api/campaigns/hubspot/emails')
+      .flush({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: '1', name: 'TLF promo' }] });
+    fixture.detectChanges();
+
+    ctx.set({ uid: 'u2', name: 'CNCF', slug: 'cncf', logoUrl: '' } as ProjectContext);
+    fixture.detectChanges();
+
+    // The switch must issue a fresh load for the NEW foundation, not leave the panel empty.
+    const req = httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails');
+    req.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: '9', name: 'CNCF promo' }] });
+    fixture.detectChanges();
+
+    expect((fixture.nativeElement as HTMLElement).textContent).toContain('CNCF promo');
+  });
+
+  it('announces the metadata that disambiguates two same-named templates', () => {
+    // aria-label REPLACES descendant text, so a name-only label made two same-named rows
+    // sound identical — defeating the very date the picker renders to tell them apart.
+    picker().searchEmailTemplates('');
+    respond({
+      enabled: true,
+      error: null,
+      possiblyTruncated: false,
+      emails: [
+        { id: '1', name: 'KubeCon promo', subject: 'Join us', state: 'PUBLISHED', updatedAt: '2026-08-14' },
+        { id: '2', name: 'KubeCon promo', subject: 'Last call', state: 'DRAFT', updatedAt: '2026-08-01' },
+      ],
+    });
+
+    const labels = Array.from(panel().querySelectorAll('[data-testid="campaigns-email-template-list"] button')).map((b) => b.getAttribute('aria-label'));
+    expect(labels.length).toBe(2);
+    // The two rows share a name; their labels must NOT be identical.
+    expect(labels[0]).not.toBe(labels[1]);
+    expect(labels[0]).toContain('Aug 14, 2026');
+    expect(labels[0]).toContain('Join us');
+  });
+
   it('keeps the empty state naming the query that ran, not what is being typed', () => {
     picker().searchEmailTemplates('alpha');
     respond({ enabled: true, error: null, possiblyTruncated: false, emails: [] });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1962,6 +1962,22 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     expect(labels[0]).toContain('Join us');
   });
 
+  it('treats a whitespace-only query as the unfiltered search the server actually runs', () => {
+    // The controller trims `q` before calling upstream, so "   " is an UNFILTERED portal
+    // search. Storing it raw made the empty state claim `No templates match "   "` about a
+    // search that had no filter at all.
+    picker().searchEmailTemplates('   ');
+    const req = httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails');
+    // An empty query omits the param entirely rather than sending `q=`, which is the same
+    // unfiltered request the server would have made after trimming.
+    expect(req.request.params.get('q')).toBeNull();
+    req.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+    fixture.detectChanges();
+
+    const empty = panel().querySelector('[data-testid="campaigns-email-templates-empty"]');
+    expect(empty?.textContent).toContain('no marketing emails yet');
+  });
+
   it('keeps the empty state naming the query that ran, not what is being typed', () => {
     picker().searchEmailTemplates('alpha');
     respond({ enabled: true, error: null, possiblyTruncated: false, emails: [] });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController } from '@angular/common/http/testing';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import type { Signal, WritableSignal } from '@angular/core';
@@ -18,6 +19,7 @@ import type {
 } from '@lfx-one/shared/interfaces';
 import { provideRouter } from '@angular/router';
 import { CampaignService } from '@services/campaign.service';
+import type { HubSpotMarketingEmail } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 import { NEVER, Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -1290,37 +1292,26 @@ describe('CampaignsComponent — email delivery channel', () => {
     expect(internals().selectedEmailTab()).toBe('planning');
   });
 
-  it('does not claim a brief is ready when none has been generated', () => {
-    // The Implement tab is directly clickable — no disabled binding — so this panel is reachable
-    // before anything has been generated, and "Your brief is ready" is then simply false, told to
-    // someone who has not started. The rest of the panel explains what is missing from the
-    // channel, which is true either way.
+  it('renders the template picker rather than a not-wired-up notice', () => {
+    // REPLACES a test that pinned the old pending panel ("Email staging is not wired up yet" /
+    // "Staging an email clones ... an endpoint that is still in review"). That copy was false by
+    // the time it was read: /hubspot/emails has been live on main since #1439, and the config
+    // builder since #1546. LFXV2-3198 is what removes it.
+    //
+    // The original test's real concern survives here: the Implement tab is directly clickable, so
+    // this panel is reachable before anything has been generated, and it must not claim progress
+    // the user has not made. The picker states nothing about the brief at all, which is the
+    // strongest form of not-lying available.
     internals().selectorForm.controls.deliveryType.setValue('email');
     internals().selectTab('implementation', 'email');
     fixture.detectChanges();
 
-    const pending = (fixture.nativeElement as HTMLElement).querySelector('[data-testid="campaigns-email-implementation-pending"]');
-    expect(pending, 'the pending panel must render').not.toBeNull();
-    expect(pending?.textContent).not.toContain('Your brief is ready');
-    expect(pending?.textContent).toContain('Staging an email clones');
-
-    internals().onEmailProceedToImplementation({ eventDetails: { name: 'KubeCon', slug: 'kubecon' } } as CampaignBriefOutput);
-    internals().selectTab('implementation', 'email');
-    fixture.detectChanges();
-
-    const withBrief = (fixture.nativeElement as HTMLElement).querySelector('[data-testid="campaigns-email-implementation-pending"]');
-    expect(withBrief?.textContent).toContain('Your brief is ready');
-    // The two sentences must stay separated — a review round raised `preserveWhitespaces: false`
-    // collapsing the separator between the `@if` block and the following text into
-    // `ready.Staging`.
-    //
-    // It does not happen: Angular keeps a space at that boundary. Stated plainly, this assertion
-    // was NOT binding as originally written (`not.toContain('ready.Staging')`) — the compiler
-    // normalizes the join either way, so it could not fail. In a suite whose whole purpose is
-    // pinning behaviours one line away from silently regressing, an unfailable assertion is worse
-    // than none: the next person copies it believing the separation is protected. Asserting the
-    // separator POSITIVELY does bind.
-    expect(withBrief?.textContent).toMatch(/ready\.\s+Staging an email/);
+    const panel = fixture.nativeElement as HTMLElement;
+    expect(panel.querySelector('[data-testid="campaigns-email-implementation"]'), 'the picker must render').not.toBeNull();
+    expect(panel.querySelector('[data-testid="campaigns-email-implementation-pending"]'), 'the stale pending panel must be gone').toBeNull();
+    expect(panel.textContent).not.toContain('not wired up yet');
+    expect(panel.textContent).not.toContain('still in review');
+    expect(panel.textContent).not.toContain('Your brief is ready');
   });
 
   // `fixture.nativeElement` is typed `any`, so without the cast the annotation below would be
@@ -1739,5 +1730,135 @@ describe('CampaignsComponent — Implementation edits survive a tab switch', () 
 
     // Event B's own generated copy stands.
     expect(headlineInput()?.value).toBe('Generated A');
+  });
+});
+
+/**
+ * The HubSpot template picker (LFXV2-3198).
+ *
+ * Staging an email CLONES one of the project's marketing emails and `sourceEmailId` has no
+ * default, so choosing one is the whole gate on this channel. These tests pin the four states the
+ * picker must keep distinct, because collapsing any pair states something false:
+ *
+ *   not connected · search failed · searched-and-empty · results
+ *
+ * The dangerous collapse is failure into emptiness: "this portal has no marketing emails" is a
+ * claim only a completed search can support, and it sends someone to go create one they may
+ * already have.
+ */
+describe('CampaignsComponent — HubSpot template picker', () => {
+  let fixture: ComponentFixture<CampaignsComponent>;
+  let httpMock: HttpTestingController;
+
+  interface PickerInternals {
+    emailTemplates: WritableSignal<HubSpotMarketingEmail[] | null>;
+    emailTemplatesError: WritableSignal<string | null>;
+    emailTemplatesTruncated: WritableSignal<boolean>;
+    emailChannelEnabled: WritableSignal<boolean | null>;
+    selectedEmailTemplateId: WritableSignal<string>;
+    searchEmailTemplates(query: string): void;
+    onSelectEmailTemplate(id: string): void;
+  }
+  const picker = (): PickerInternals => fixture.componentInstance as unknown as PickerInternals;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CampaignsComponent],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+    }).compileComponents();
+    fixture = TestBed.createComponent(CampaignsComponent);
+    httpMock = TestBed.inject(HttpTestingController);
+    fixture.detectChanges();
+    // The component reads the foundation from ProjectContextService; without a slug the search
+    // refuses before issuing a request, which is its own test below.
+    (fixture.componentInstance as unknown as { activeFoundationSlug: () => string }).activeFoundationSlug = () => 'tlf';
+  });
+
+  function respond(body: { enabled: boolean; error: string | null; possiblyTruncated: boolean; emails: HubSpotMarketingEmail[] }): void {
+    const req = httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails');
+    req.flush(body);
+    fixture.detectChanges();
+  }
+
+  it('lists the templates a search returned, dropping any row with no id', () => {
+    picker().searchEmailTemplates('');
+    respond({
+      enabled: true,
+      error: null,
+      possiblyTruncated: false,
+      // The id is what `sourceEmailId` takes, so a row without one is not a choice that can be
+      // made. Rendering it would offer a button that cannot work.
+      emails: [
+        { id: '1', name: 'KubeCon promo' },
+        { id: '', name: 'broken row' },
+      ],
+    });
+
+    expect(
+      picker()
+        .emailTemplates()
+        ?.map((e) => e.id)
+    ).toEqual(['1']);
+  });
+
+  // The collapse that matters. An empty array asserts the portal holds nothing; only a completed
+  // search can support that.
+  it('leaves the list NULL when the search fails, rather than empty', () => {
+    picker().searchEmailTemplates('kubecon');
+    const req = httpMock.expectOne((r) => r.url === '/api/campaigns/hubspot/emails');
+    req.flush({ message: 'boom' }, { status: 500, statusText: 'Server Error' });
+    fixture.detectChanges();
+
+    expect(picker().emailTemplates()).toBeNull();
+    expect(picker().emailTemplatesError()).toBeTruthy();
+  });
+
+  it('leaves the list NULL when the service reports an upstream error', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: true, error: 'HubSpot refused the request', possiblyTruncated: false, emails: [] });
+
+    expect(picker().emailTemplates()).toBeNull();
+    expect(picker().emailTemplatesError()).toBe('HubSpot refused the request');
+  });
+
+  // Not an error: the steady state wherever HubSpot is not connected for the foundation.
+  it('reports a disconnected channel without rendering it as a failure', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: false, error: null, possiblyTruncated: false, emails: [] });
+
+    expect(picker().emailChannelEnabled()).toBe(false);
+    expect(picker().emailTemplatesError()).toBeNull();
+    expect(picker().emailTemplates()).toBeNull();
+  });
+
+  it('distinguishes a successful empty search from a failure', () => {
+    picker().searchEmailTemplates('nothing-matches');
+    respond({ enabled: true, error: null, possiblyTruncated: false, emails: [] });
+
+    expect(picker().emailTemplates()).toEqual([]);
+    expect(picker().emailTemplatesError()).toBeNull();
+  });
+
+  // possiblyTruncated is only meaningful for an EMPTY query. Telling someone to narrow a search
+  // that was already exhaustive sends them hunting for a template that does not exist.
+  it('carries the truncation warning through', () => {
+    picker().searchEmailTemplates('');
+    respond({ enabled: true, error: null, possiblyTruncated: true, emails: [{ id: '1', name: 'One' }] });
+
+    expect(picker().emailTemplatesTruncated()).toBe(true);
+  });
+
+  it('refuses to search without a foundation rather than listing another portal', () => {
+    (fixture.componentInstance as unknown as { activeFoundationSlug: () => string }).activeFoundationSlug = () => '';
+
+    picker().searchEmailTemplates('kubecon');
+
+    httpMock.expectNone((r) => r.url === '/api/campaigns/hubspot/emails');
+    expect(picker().emailTemplatesError()).toContain('foundation');
+  });
+
+  it('records the chosen template id, which is what sourceEmailId takes', () => {
+    picker().onSelectEmailTemplate('123');
+    expect(picker().selectedEmailTemplateId()).toBe('123');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -18,6 +18,7 @@ import type {
   CampaignTabOption,
   HubSpotMarketingEmail,
 } from '@lfx-one/shared/interfaces';
+import { formatHubSpotUpdatedAt } from '@lfx-one/shared/utils';
 import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { firstValueFrom, skip, take } from 'rxjs';
@@ -513,6 +514,16 @@ export class CampaignsComponent {
         this.emailChannelEnabled.set(null);
         this.emailTemplatesError.set(null);
         this.selectedEmailTemplateId.set('');
+
+        // Reload if the operator is SITTING on the picker. The clears above are correct, but
+        // on their own they leave a blank panel in front of someone who never navigated: the
+        // entry load lives in `selectTab`, which only runs on a tab transition. Nothing else
+        // re-evaluates it after a switch, so the picker stayed empty until they navigated
+        // away and back. Guarded, so a switch into a foundation whose channel is off still
+        // renders that answer rather than looping on it.
+        if (this.selectedDeliveryType() === 'email' && this.selectedEmailTab() === 'implementation') {
+          this.loadEmailTemplatesIfNeverAnswered();
+        }
       });
 
     // Mirror the program control into the signal. A program switch changes the whole
@@ -573,18 +584,8 @@ export class CampaignsComponent {
         // empty box, which this file's own comment calls out as reading like a broken
         // channel. Guarded on `null` so it fires once and does not re-run over a list the
         // operator is already searching, and skipped while a request is in flight.
-        if (
-          tab === 'implementation' &&
-          this.emailTemplates() === null &&
-          !this.emailTemplatesLoading() &&
-          // A search that already ANSWERED leaves templates null too — when the channel is
-          // off, or when it failed. Re-firing on entry would retry a refusal on every tab
-          // click and overwrite the error the operator needs to read. Only a picker that has
-          // never been answered for this foundation should load.
-          this.emailChannelEnabled() === null &&
-          this.emailTemplatesError() === null
-        ) {
-          this.searchEmailTemplates(this.emailTemplateQuery());
+        if (tab === 'implementation') {
+          this.loadEmailTemplatesIfNeverAnswered();
         }
       }
       return;
@@ -707,6 +708,7 @@ export class CampaignsComponent {
    * not per keystroke. campaign-service walks every page and matches in-process, so a filtered
    * search is genuinely expensive — firing one per character would be the wrong trade.
    */
+
   protected searchEmailTemplates(query: string): void {
     const projectSlug = this.activeFoundationSlug();
     if (projectSlug === '') {
@@ -856,6 +858,47 @@ export class CampaignsComponent {
       this.knownBriefIds.set(key, { id: briefId, etag: null, absence: 'overwrite' });
     }
     this.onProceedToImplementation(brief, true, approved);
+  }
+
+  /**
+   * Load the picker when it holds no answer for the current foundation.
+   *
+   * Called from BOTH paths that can leave it blank: entering the Implementation tab, and a
+   * foundation switch while that tab is already open. Fixing only the first left the second
+   * broken — the switch handler clears the signals, and nothing re-evaluated a guard that
+   * lived inside `selectTab`. Resetting a guard's inputs does nothing if nothing runs it.
+   *
+   * The four-signal condition distinguishes "never answered" from "answered with a refusal":
+   * a channel-off or failed search also leaves `emailTemplates` null, and re-firing on those
+   * would retry a refusal on every entry and overwrite the error the operator needs to read.
+   */
+  /**
+   * The full accessible name for a template row.
+   *
+   * `aria-label` REPLACES descendant text in the accessible name, so the previous
+   * name-only label meant a screen-reader user heard "Use template KubeCon promo" and
+   * nothing else — no subject, state or date. Those are exactly the fields that exist to
+   * disambiguate: `formatHubSpotUpdatedAt` says so in its own doc comment, because two
+   * templates routinely share a name. Without them the a11y label silently defeated the
+   * feature, and two same-named rows sounded identical.
+   *
+   * A method rather than a template expression because an Angular template cannot pipe
+   * inside a ternary without a parse error, and because the concatenation is long enough
+   * that inlining it obscures what is being announced.
+   */
+  protected emailTemplateAccessibleName(template: HubSpotMarketingEmail): string {
+    const parts = [`Use template ${template.name || template.subject || template.id}`];
+    if (template.subject && template.name) parts.push(`subject ${template.subject}`);
+    if (template.state) parts.push(template.state);
+    const updated = formatHubSpotUpdatedAt(template.updatedAt);
+    if (updated) parts.push(`updated ${updated}`);
+    return parts.join(', ');
+  }
+
+  private loadEmailTemplatesIfNeverAnswered(): void {
+    if (this.emailTemplates() === null && !this.emailTemplatesLoading() && this.emailChannelEnabled() === null && this.emailTemplatesError() === null) {
+      this.searchEmailTemplates(this.emailTemplateQuery());
+    }
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -413,8 +413,13 @@ export class CampaignsComponent {
     // The truncation cue must carry over, for the same reason the sibling appends its reload
     // instruction: announcing the count alone gives the reassurance without the instruction, and
     // the instruction is the part a screen-reader user cannot recover on their own — nothing else
-    // says the list is partial.
-    return this.emailTemplatesTruncated() ? `${count} Showing a partial list. Search to narrow it.` : count;
+    // says the list may be partial.
+    //
+    // "MAY be", not "is": `possiblyTruncated` records when the 500 cap MIGHT have bitten, and a
+    // portal holding exactly 500 emails sets the same flag on a complete listing — the shared
+    // interface says a capped 500 is byte-identical to a complete one. Asserting a partial list
+    // as fact would send someone hunting for a template that does not exist.
+    return this.emailTemplatesTruncated() ? `${count} This may be a partial list. Search to narrow it.` : count;
   });
   protected readonly emailTemplatesLoading = signal(false);
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -402,7 +402,10 @@ export class CampaignsComponent {
     // error node already carries role="alert", so returning the same string here would announce
     // the failure twice.
     if (this.emailTemplatesError()) return '';
-    if (this.emailChannelEnabled() === false) return 'HubSpot is not connected for this foundation.';
+    // The SAME computed the visible node renders, not a second copy of the sentence: the two
+    // drifted once already, and an announcement that names no project while the text on screen
+    // names one describes a different failure to a screen-reader user than to a sighted one.
+    if (this.emailChannelEnabled() === false) return this.emailNotConnectedMessage();
     const templates = this.emailTemplates();
     if (templates === null) return '';
     if (templates.length === 0) {
@@ -457,6 +460,37 @@ export class CampaignsComponent {
    * response can settle it, and rendering either answer before one arrives would be a guess.
    */
   protected readonly emailChannelEnabled = signal<boolean | null>(null);
+
+  /**
+   * The project slug the CURRENT template search was issued against.
+   *
+   * Separate from `activeFoundationSlug` on purpose. The "not connected" copy names the project
+   * that was queried, and the foundation is switchable while a response is in flight — reading
+   * the live slug would name whichever foundation the user has since moved to, which is the
+   * opposite of the point. Written at dispatch and only by the generation-current response.
+   */
+  protected readonly emailSearchProjectSlug = signal<string>('');
+
+  /**
+   * Names the project the search actually queried, for the "connect HubSpot" empty state.
+   *
+   * campaign-service answers the same typed 404 for an absent connection row and for a project id
+   * that does not exist (`campaign.interface.ts:1223-1226`), so "not connected" and "no such
+   * project" are indistinguishable here. Naming the slug is what makes a typo visible instead of
+   * being reported as a missing integration.
+   *
+   * The slug — not the display name — because the slug is the identifier that was sent, and it is
+   * the thing that can be mistyped; a name would be resolved from local context and would look
+   * correct even when the queried id was wrong.
+   */
+  protected readonly emailNotConnectedMessage = computed<string>(() => {
+    const slug = this.emailSearchProjectSlug();
+    // The empty-slug search is refused before dispatch, so this is defensive only: naming nothing
+    // is still better than rendering "project ''".
+    return slug
+      ? `HubSpot is not connected for “${slug}”. Connect it for this foundation to stage an email.`
+      : 'Connect HubSpot for this foundation to stage an email.';
+  });
 
   protected readonly activeProgramTypeConfig = computed(() => this.programTypes.find((pt) => pt.id === this.selectedProgramType()) ?? this.programTypes[0]);
   protected readonly activeDeliveryTypeConfig = computed(() => this.deliveryTypes.find((dt) => dt.id === this.selectedDeliveryType()) ?? this.deliveryTypes[0]);
@@ -553,6 +587,9 @@ export class CampaignsComponent {
         this.emailChannelEnabled.set(null);
         this.emailTemplatesError.set(null);
         this.selectedEmailTemplateId.set('');
+        // Cleared with the rest: it names the project in the "not connected" copy, and the
+        // previous foundation's slug must not survive into a message rendered under the new one.
+        this.emailSearchProjectSlug.set('');
 
         // Reload if the operator is SITTING on the picker. The clears above are correct, but
         // on their own they leave a blank panel in front of someone who never navigated: the
@@ -782,6 +819,10 @@ export class CampaignsComponent {
 
     this.emailTemplateQuery.set(query);
     this.emailTemplateSubmittedQuery.set(query);
+    // Captured at dispatch, alongside the slug actually passed to the request below, so the
+    // "not connected" copy names the project that was queried even if the foundation changes
+    // while the response is in flight.
+    this.emailSearchProjectSlug.set(projectSlug);
     this.emailTemplatesLoading.set(true);
     this.emailTemplatesError.set(null);
     // Reset alongside the error, not only on a foundation switch. The template checks

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -22,6 +22,7 @@ import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { firstValueFrom, skip, take } from 'rxjs';
 
+import { HubSpotUpdatedAtPipe } from '../../../shared/pipes/hubspot-updated-at.pipe';
 import { SelectComponent } from '../../../shared/components/select/select.component';
 import { ImplementationTabComponent } from './components/implementation-tab/implementation-tab.component';
 import { MonitoringTabComponent } from './components/monitoring-tab/monitoring-tab.component';
@@ -30,7 +31,15 @@ import { PlanningTabComponent } from './components/planning-tab/planning-tab.com
 
 @Component({
   selector: 'lfx-campaigns',
-  imports: [ReactiveFormsModule, SelectComponent, PlanningTabComponent, ImplementationTabComponent, MonitoringTabComponent, OptimizationTabComponent],
+  imports: [
+    ReactiveFormsModule,
+    SelectComponent,
+    PlanningTabComponent,
+    ImplementationTabComponent,
+    MonitoringTabComponent,
+    OptimizationTabComponent,
+    HubSpotUpdatedAtPipe,
+  ],
   templateUrl: './campaigns.component.html',
   styleUrl: './campaigns.component.scss',
 })
@@ -530,25 +539,6 @@ export class CampaignsComponent {
       }
       this.selectedDeliveryType.set(value);
     });
-  }
-
-  /**
-   * Render a HubSpot `updatedAt` for a template row.
-   *
-   * Two templates routinely share a name — the shared interface says so where `updatedAt` is
-   * declared — so without a date two same-name rows are visually identical and the operator
-   * cannot tell which one they are cloning.
-   *
-   * Returns '' rather than a placeholder when the field is absent: `updatedAt` is optional on
-   * the interface, and a dash in the metadata line would read as a value the portal reported.
-   * Same normalisation as monitoring-tab's formatDate, which handles HubSpot's date-only form.
-   */
-  protected formatTemplateUpdatedAt(value: string | undefined): string {
-    if (!value) return '';
-    const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
-    const date = new Date(normalized);
-    if (isNaN(date.getTime())) return '';
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -398,8 +398,10 @@ export class CampaignsComponent {
    */
   protected readonly emailTemplatesAnnouncement = computed<string>(() => {
     if (this.emailTemplatesLoading()) return 'Searching templates';
-    const error = this.emailTemplatesError();
-    if (error) return error;
+    // The error case is deliberately ABSENT, matching briefPersistenceAnnouncement: the visible
+    // error node already carries role="alert", so returning the same string here would announce
+    // the failure twice.
+    if (this.emailTemplatesError()) return '';
     if (this.emailChannelEnabled() === false) return 'HubSpot is not connected for this foundation.';
     const templates = this.emailTemplates();
     if (templates === null) return '';
@@ -407,7 +409,12 @@ export class CampaignsComponent {
       const q = this.emailTemplateSubmittedQuery();
       return q ? `No templates match ${q}.` : 'This portal has no marketing emails yet.';
     }
-    return `${templates.length} template${templates.length === 1 ? '' : 's'} found.`;
+    const count = `${templates.length} template${templates.length === 1 ? '' : 's'} found.`;
+    // The truncation cue must carry over, for the same reason the sibling appends its reload
+    // instruction: announcing the count alone gives the reassurance without the instruction, and
+    // the instruction is the part a screen-reader user cannot recover on their own — nothing else
+    // says the list is partial.
+    return this.emailTemplatesTruncated() ? `${count} Showing a partial list. Search to narrow it.` : count;
   });
   protected readonly emailTemplatesLoading = signal(false);
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -557,6 +557,25 @@ export class CampaignsComponent {
       // exclusion exists to catch, so it must not be asserted away.
       if (tab !== 'optimization') {
         this.selectedEmailTab.set(tab);
+        // Load on ENTRY, not only on proceed. The only other call site is
+        // `onEmailProceedToImplementation`, so arriving at this tab any other way — clicking
+        // it directly, or returning after a foundation switch cleared the list — left an
+        // empty box, which this file's own comment calls out as reading like a broken
+        // channel. Guarded on `null` so it fires once and does not re-run over a list the
+        // operator is already searching, and skipped while a request is in flight.
+        if (
+          tab === 'implementation' &&
+          this.emailTemplates() === null &&
+          !this.emailTemplatesLoading() &&
+          // A search that already ANSWERED leaves templates null too — when the channel is
+          // off, or when it failed. Re-firing on entry would retry a refusal on every tab
+          // click and overwrite the error the operator needs to read. Only a picker that has
+          // never been answered for this foundation should load.
+          this.emailChannelEnabled() === null &&
+          this.emailTemplatesError() === null
+        ) {
+          this.searchEmailTemplates(this.emailTemplateQuery());
+        }
       }
       return;
     }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -18,11 +18,11 @@ import type {
   CampaignTabOption,
   HubSpotMarketingEmail,
 } from '@lfx-one/shared/interfaces';
-import { formatHubSpotUpdatedAt } from '@lfx-one/shared/utils';
 import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { firstValueFrom, skip, take } from 'rxjs';
 
+import { HubSpotTemplateLabelPipe } from '../../../shared/pipes/hubspot-template-label.pipe';
 import { HubSpotUpdatedAtPipe } from '../../../shared/pipes/hubspot-updated-at.pipe';
 import { SelectComponent } from '../../../shared/components/select/select.component';
 import { ImplementationTabComponent } from './components/implementation-tab/implementation-tab.component';
@@ -40,6 +40,7 @@ import { PlanningTabComponent } from './components/planning-tab/planning-tab.com
     MonitoringTabComponent,
     OptimizationTabComponent,
     HubSpotUpdatedAtPipe,
+    HubSpotTemplateLabelPipe,
   ],
   templateUrl: './campaigns.component.html',
   styleUrl: './campaigns.component.scss',
@@ -386,6 +387,28 @@ export class CampaignsComponent {
    * `No templates match "beta"` before any beta request existed.
    */
   protected readonly emailTemplateSubmittedQuery = signal('');
+
+  /**
+   * What a screen reader announces about the template search.
+   *
+   * A computed feeding a PERSISTENT region, matching the pattern in implementation-tab: an
+   * aria-live element inserted with its text already present is not reliably announced, so
+   * the region must exist first and then have its CONTENTS change. Search progress and
+   * results were previously silent — the picker rendered them visually only.
+   */
+  protected readonly emailTemplatesAnnouncement = computed<string>(() => {
+    if (this.emailTemplatesLoading()) return 'Searching templates';
+    const error = this.emailTemplatesError();
+    if (error) return error;
+    if (this.emailChannelEnabled() === false) return 'HubSpot is not connected for this foundation.';
+    const templates = this.emailTemplates();
+    if (templates === null) return '';
+    if (templates.length === 0) {
+      const q = this.emailTemplateSubmittedQuery();
+      return q ? `No templates match ${q}.` : 'This portal has no marketing emails yet.';
+    }
+    return `${templates.length} template${templates.length === 1 ? '' : 's'} found.`;
+  });
   protected readonly emailTemplatesLoading = signal(false);
   /**
    * Monotonic id for the in-flight template search.
@@ -872,28 +895,6 @@ export class CampaignsComponent {
    * a channel-off or failed search also leaves `emailTemplates` null, and re-firing on those
    * would retry a refusal on every entry and overwrite the error the operator needs to read.
    */
-  /**
-   * The full accessible name for a template row.
-   *
-   * `aria-label` REPLACES descendant text in the accessible name, so the previous
-   * name-only label meant a screen-reader user heard "Use template KubeCon promo" and
-   * nothing else — no subject, state or date. Those are exactly the fields that exist to
-   * disambiguate: `formatHubSpotUpdatedAt` says so in its own doc comment, because two
-   * templates routinely share a name. Without them the a11y label silently defeated the
-   * feature, and two same-named rows sounded identical.
-   *
-   * A method rather than a template expression because an Angular template cannot pipe
-   * inside a ternary without a parse error, and because the concatenation is long enough
-   * that inlining it obscures what is being announced.
-   */
-  protected emailTemplateAccessibleName(template: HubSpotMarketingEmail): string {
-    const parts = [`Use template ${template.name || template.subject || template.id}`];
-    if (template.subject && template.name) parts.push(`subject ${template.subject}`);
-    if (template.state) parts.push(template.state);
-    const updated = formatHubSpotUpdatedAt(template.updatedAt);
-    if (updated) parts.push(`updated ${updated}`);
-    return parts.join(', ');
-  }
 
   private loadEmailTemplatesIfNeverAnswered(): void {
     if (this.emailTemplates() === null && !this.emailTemplatesLoading() && this.emailChannelEnabled() === null && this.emailTemplatesError() === null) {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -476,6 +476,12 @@ export class CampaignsComponent {
         // `hubspotConfig.sourceEmailId` on create, so a stale selection stages a send that clones
         // foundation A's email into foundation B's portal — 404 if the user cannot reach it, and
         // silently wrong if they can.
+        // Bumping the search generation is what makes the clears below STICK. Clearing the
+        // signals alone cannot stop a request already in flight for the previous foundation:
+        // it resolves afterwards, still passes `isCurrent()`, and repopulates the list under
+        // the new foundation — the cross-portal leak this handler exists to prevent, and the
+        // one `searchEmailTemplates` documents as the hazard its guard cannot see.
+        this.emailSearchGeneration++;
         this.emailTemplates.set(null);
         this.emailTemplateQuery.set('');
         this.emailTemplatesTruncated.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -6,7 +6,7 @@ import { Component, computed, inject, PLATFORM_ID, signal } from '@angular/core'
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 
-import { CAMPAIGN_DELIVERY_TYPES, CAMPAIGN_PROGRAM_TYPES, CAMPAIGN_TABS } from '@lfx-one/shared/constants';
+import { CAMPAIGN_DELIVERY_TYPES, CAMPAIGN_PROGRAM_TYPES, CAMPAIGN_TABS, HUBSPOT_TEMPLATE_RENDER_LIMIT } from '@lfx-one/shared/constants';
 import type {
   CampaignBriefOutput,
   CampaignBriefPersistenceState,
@@ -426,7 +426,12 @@ export class CampaignsComponent {
     // portal holding exactly 500 emails sets the same flag on a complete listing — the shared
     // interface says a capped 500 is byte-identical to a complete one. Asserting a partial list
     // as fact would send someone hunting for a template that does not exist.
-    return this.emailTemplatesTruncated() ? `${count} This may be a partial list. Search to narrow it.` : count;
+    // The render cap must carry over for the same reason the truncation cue does: a
+    // screen-reader user hears "4000 templates found" and then reaches the 100th button with no
+    // way to discover that the rest were never drawn. Stated as fact — unlike the truncation
+    // hedge below, both numbers here are known exactly.
+    const capped = this.emailTemplatesRenderCapped() ? ` ${this.emailTemplatesRenderCapMessage()}` : '';
+    return this.emailTemplatesTruncated() ? `${count}${capped} This may be a partial list. Search to narrow it.` : `${count}${capped}`;
   });
   protected readonly emailTemplatesLoading = signal(false);
   /**
@@ -448,6 +453,44 @@ export class CampaignsComponent {
    * send them looking for a template that does not exist.
    */
   protected readonly emailTemplatesTruncated = signal(false);
+
+  /**
+   * The rows the picker actually DRAWS — the first `HUBSPOT_TEMPLATE_RENDER_LIMIT` of them.
+   *
+   * A computed rather than a slice in the template: `frontend-checklist.md` §4 allows only signal
+   * reads, computed values and pipes in a template, and `templates.slice(...)` there would be a
+   * method call re-run on every change-detection pass.
+   *
+   * The full list is NOT discarded — `emailTemplates` still holds every row, which is what
+   * `emailTemplateRenderTotal` reports. Capping the render without saying so would present a cut
+   * list as a complete one; `emailTemplatesRenderCapped` drives the copy that says otherwise.
+   */
+  protected readonly emailTemplatesRendered = computed<HubSpotMarketingEmail[]>(() => {
+    const templates = this.emailTemplates();
+    if (templates === null) return [];
+    return templates.length > HUBSPOT_TEMPLATE_RENDER_LIMIT ? templates.slice(0, HUBSPOT_TEMPLATE_RENDER_LIMIT) : templates;
+  });
+
+  /** How many rows the search returned, as opposed to how many are drawn. */
+  protected readonly emailTemplateRenderTotal = computed<number>(() => this.emailTemplates()?.length ?? 0);
+
+  /** Whether the render cap actually bit — i.e. rows were fetched that are not on screen. */
+  protected readonly emailTemplatesRenderCapped = computed<boolean>(() => this.emailTemplateRenderTotal() > HUBSPOT_TEMPLATE_RENDER_LIMIT);
+
+  /**
+   * The "showing the first N of M" line.
+   *
+   * States the cap as FACT, unlike the `possiblyTruncated` banner beside it, which says "may be"
+   * because a capped 500 and a complete 500 are indistinguishable upstream. Here both numbers are
+   * known exactly — the list in hand was measured before slicing — so hedging would understate a
+   * certainty. The two are independent and can both show: an unfiltered search can be cut
+   * upstream at 500 AND cut again here at the render limit.
+   */
+  protected readonly emailTemplatesRenderCapMessage = computed<string>(() =>
+    this.emailTemplatesRenderCapped()
+      ? `Showing the first ${HUBSPOT_TEMPLATE_RENDER_LIMIT} of ${this.emailTemplateRenderTotal()}. Search to narrow the list.`
+      : ''
+  );
 
   /** The chosen template's id — what `hubspotConfig.sourceEmailId` takes on create. */
   protected readonly selectedEmailTemplateId = signal<string>('');

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -458,6 +458,22 @@ export class CampaignsComponent {
         // nothing, which is exactly the distinction that counter exists to draw.
         this.briefPersistenceGeneration++;
         this.briefPersistence.set(this.idlePersistence);
+
+        // The picker is per-FOUNDATION and must not survive a switch. `searchEmailTemplates`
+        // already refuses a MISSING slug so one portal's templates cannot stand in for another's
+        // — but a CHANGED slug is the same hazard and that guard does not see it: the results are
+        // already on screen, labelled with whichever foundation is now selected.
+        //
+        // `selectedEmailTemplateId` is the one that must not be missed. It becomes
+        // `hubspotConfig.sourceEmailId` on create, so a stale selection stages a send that clones
+        // foundation A's email into foundation B's portal — 404 if the user cannot reach it, and
+        // silently wrong if they can.
+        this.emailTemplates.set(null);
+        this.emailTemplateQuery.set('');
+        this.emailTemplatesTruncated.set(false);
+        this.emailChannelEnabled.set(null);
+        this.emailTemplatesError.set(null);
+        this.selectedEmailTemplateId.set('');
       });
 
     // Mirror the program control into the signal. A program switch changes the whole
@@ -679,6 +695,19 @@ export class CampaignsComponent {
           this.emailTemplatesError.set('Could not load templates. Try again.');
         },
       });
+  }
+
+  /**
+   * Track what is TYPED, not only what was last searched.
+   *
+   * Without this the input is one-way and `emailTemplateQuery` only changes inside
+   * `searchEmailTemplates` — so typing "kubecon" and clicking Search re-ran the PREVIOUS query
+   * (empty on arrival), returning the full listing while the box still read "kubecon". The user
+   * concludes their search matched everything. It also let the empty-state copy name a different
+   * string than the box held.
+   */
+  protected onEmailTemplateQueryInput(value: string): void {
+    this.emailTemplateQuery.set(value);
   }
 
   protected onSelectEmailTemplate(id: string): void {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -407,7 +407,11 @@ export class CampaignsComponent {
     if (templates === null) return '';
     if (templates.length === 0) {
       const q = this.emailTemplateSubmittedQuery();
-      return q ? `No templates match ${q}.` : 'This portal has no marketing emails yet.';
+      // Quoted to match the visible copy character-for-character. Without the delimiters the
+      // query dissolves into the sentence it sits in: a search for "no templates" announced as
+      // "No templates match no templates." Sighted users get the boundary from the quote marks;
+      // this is the only place the two texts said different things.
+      return q ? `No templates match “${q}”.` : 'This portal has no marketing emails yet.';
     }
     const count = `${templates.length} template${templates.length === 1 ? '' : 's'} found.`;
     // The truncation cue must carry over, for the same reason the sibling appends its reload
@@ -594,6 +598,20 @@ export class CampaignsComponent {
         return;
       }
       this.selectedDeliveryType.set(value);
+
+      // Re-evaluate the picker on RETURN to email, for the reason the foundation-switch handler
+      // documents one condition over: resetting a guard's inputs does nothing if nothing runs it.
+      // The switch handler's reload is gated on `selectedDeliveryType()` AS IT READS AT THAT
+      // MOMENT, so a foundation switch made while the user is on Paid clears the picker and
+      // skips the reload — and no later event re-checked it. Coming back to email/Implement then
+      // showed a permanently blank panel: `selectTab` never runs (no tab transition), so nothing
+      // reloaded until the user navigated tabs or searched by hand.
+      //
+      // The same never-answered guard, so a channel-off or failed answer is not retried on every
+      // round-trip and a healthy list is not re-fetched.
+      if (value === 'email' && this.selectedEmailTab() === 'implementation') {
+        this.loadEmailTemplatesIfNeverAnswered();
+      }
     });
   }
 
@@ -806,7 +824,21 @@ export class CampaignsComponent {
           }
           // A row with no id cannot be selected — `sourceEmailId` takes that value — so it is
           // dropped rather than rendered as a choice that cannot be made.
-          this.emailTemplates.set(result.emails.filter((e) => !!e?.id));
+          const selectable = result.emails.filter((e) => !!e?.id);
+          if (selectable.length === 0 && result.emails.length > 0) {
+            // The response CARRIED rows and every one of them was unusable. Reporting that as an
+            // empty list would render "This portal has no marketing emails yet" — a claim about
+            // the portal, made from a response that proves the opposite. The server already drops
+            // id-less rows (campaign-service.service.ts), so reaching here means the contract was
+            // violated somewhere upstream; that is a read failure, not an empty portal.
+            //
+            // NULL rather than [], for the same reason the error arms use null: only a search
+            // that genuinely came back with nothing can support the empty-portal claim.
+            this.emailTemplates.set(null);
+            this.emailTemplatesError.set('Could not load templates. Try again.');
+            return;
+          }
+          this.emailTemplates.set(selectable);
           this.emailTemplatesTruncated.set(result.possiblyTruncated);
         },
         error: () => {
@@ -832,6 +864,27 @@ export class CampaignsComponent {
    */
   protected onEmailTemplateQueryInput(value: string): void {
     this.emailTemplateQuery.set(value);
+  }
+
+  /**
+   * The single entry point for a USER-initiated search — both the button and Enter.
+   *
+   * The gate lives here rather than on the button, because `[disabled]` only ever covered the
+   * button: Enter called `searchEmailTemplates` directly, so holding it down fired a full portal
+   * walk per repeat while the button next to it was visibly disabled. The generation counter
+   * discards the late responses but does NOT cancel the requests — each one still walks every
+   * page server-side (the interface documents `q` as matched in-process, page by page), so the
+   * cost is paid upstream regardless of which answer the UI keeps.
+   *
+   * Refusing while a search is in flight is safe rather than lossy: the request already running
+   * is for whatever the box held when it started, and the operator can search again the moment
+   * it answers.
+   */
+  protected onEmailTemplateSearchSubmit(): void {
+    if (this.emailTemplatesLoading()) {
+      return;
+    }
+    this.searchEmailTemplates(this.emailTemplateQuery());
   }
 
   protected onSelectEmailTemplate(id: string): void {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -368,6 +368,33 @@ export class CampaignsComponent {
   protected readonly emailTemplates = signal<HubSpotMarketingEmail[] | null>(null);
   protected readonly emailTemplateQuery = signal('');
   protected readonly emailTemplatesLoading = signal(false);
+  /**
+   * Render a HubSpot `updatedAt` for a template row.
+   *
+   * Two templates routinely share a name — the shared interface says so where `updatedAt` is
+   * declared — so without a date two same-name rows are visually identical and the operator
+   * cannot tell which one they are cloning.
+   *
+   * Returns '' rather than a placeholder when the field is absent: `updatedAt` is optional on
+   * the interface, and a dash in the metadata line would read as a value the portal reported.
+   * Same normalisation as monitoring-tab's formatDate, which handles HubSpot's date-only form.
+   */
+  protected formatTemplateUpdatedAt(value: string | undefined): string {
+    if (!value) return '';
+    const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
+    const date = new Date(normalized);
+    if (isNaN(date.getTime())) return '';
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  }
+
+  /**
+   * Monotonic id for the in-flight template search.
+   *
+   * Not a signal: nothing renders it, and it must be readable synchronously inside a subscribe
+   * callback to decide whether that response is still the current one. A plain counter is the
+   * whole mechanism — a response whose generation no longer matches writes nothing.
+   */
+  private emailSearchGeneration = 0;
   protected readonly emailTemplatesError = signal<string | null>(null);
 
   /**
@@ -655,6 +682,9 @@ export class CampaignsComponent {
       // The page is reachable by an ED of any foundation and templates are per-project, so a
       // missing slug must not fall back to some other portal's templates.
       this.emailTemplates.set(null);
+      // Same reason as the reset below: a stale `false` would render "Connect HubSpot" instead of
+      // this message, because the template checks the channel flag first.
+      this.emailChannelEnabled.set(null);
       this.emailTemplatesError.set('Select a foundation before searching for a template.');
       return;
     }
@@ -662,12 +692,29 @@ export class CampaignsComponent {
     this.emailTemplateQuery.set(query);
     this.emailTemplatesLoading.set(true);
     this.emailTemplatesError.set(null);
+    // Reset alongside the error, not only on a foundation switch. The template checks
+    // `emailChannelEnabled() === false` BEFORE the error branch, so a stale false from an earlier
+    // response outranks a real failure: after one "not connected" answer, a later transport error
+    // still rendered "Connect HubSpot for this foundation" and the user never saw "Could not load
+    // templates." Null means "not yet known for this search", which is the truth at this point.
+    this.emailChannelEnabled.set(null);
+
+    // Generation guard. Every call is an independent subscribe, so a slow earlier response can
+    // land after a newer one and overwrite the list, truncation flag and error while
+    // `emailTemplateQuery` already shows the later search. The foundation-switch handler clears
+    // these signals but cannot stop an in-flight response from refilling them — under the NEW
+    // foundation — which is the cross-portal leak that handler exists to prevent.
+    const generation = ++this.emailSearchGeneration;
+    const isCurrent = (): boolean => generation === this.emailSearchGeneration;
 
     this.campaignService
       .searchHubSpotEmails(projectSlug, query)
       .pipe(take(1))
       .subscribe({
         next: (result) => {
+          if (!isCurrent()) {
+            return;
+          }
           this.emailTemplatesLoading.set(false);
           this.emailChannelEnabled.set(result.enabled);
           if (!result.enabled) {
@@ -689,6 +736,9 @@ export class CampaignsComponent {
           this.emailTemplatesTruncated.set(result.possiblyTruncated);
         },
         error: () => {
+          if (!isCurrent()) {
+            return;
+          }
           this.emailTemplatesLoading.set(false);
           // NULL, not []. A failed search says nothing about what the portal holds.
           this.emailTemplates.set(null);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -16,10 +16,11 @@ import type {
   CampaignProgramType,
   CampaignTab,
   CampaignTabOption,
+  HubSpotMarketingEmail,
 } from '@lfx-one/shared/interfaces';
 import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { firstValueFrom, skip } from 'rxjs';
+import { firstValueFrom, skip, take } from 'rxjs';
 
 import { SelectComponent } from '../../../shared/components/select/select.component';
 import { ImplementationTabComponent } from './components/implementation-tab/implementation-tab.component';
@@ -356,6 +357,41 @@ export class CampaignsComponent {
    */
   protected readonly emailBriefOutput = signal<CampaignBriefOutput | null>(null);
 
+  /**
+   * The HubSpot marketing emails a user can clone as the template for this send.
+   *
+   * `null` means NOT SEARCHED, which is distinct from `[]` (searched, portal returned nothing)
+   * for the same reason it is on the campaign list: an empty array asserts the portal has no
+   * matching templates, and only a completed search can support that claim. A failed search must
+   * not be rendered as an empty portal.
+   */
+  protected readonly emailTemplates = signal<HubSpotMarketingEmail[] | null>(null);
+  protected readonly emailTemplateQuery = signal('');
+  protected readonly emailTemplatesLoading = signal(false);
+  protected readonly emailTemplatesError = signal<string | null>(null);
+
+  /**
+   * Whether the listing may have been cut off by the service's unfiltered cap.
+   *
+   * Only ever true for an EMPTY query, where a complete portal listing and a truncated first
+   * screen are indistinguishable on the wire. A filtered search is complete-or-error, so this
+   * stays false there — telling someone to narrow a search that was already exhaustive would
+   * send them looking for a template that does not exist.
+   */
+  protected readonly emailTemplatesTruncated = signal(false);
+
+  /** The chosen template's id — what `hubspotConfig.sourceEmailId` takes on create. */
+  protected readonly selectedEmailTemplateId = signal<string>('');
+
+  /**
+   * Whether the channel is usable at all for this project.
+   *
+   * `enabled: false` is the steady state wherever HubSpot is not connected, not a failure, so it
+   * renders as "connect HubSpot" rather than an error. Starts null meaning UNKNOWN — only a
+   * response can settle it, and rendering either answer before one arrives would be a guess.
+   */
+  protected readonly emailChannelEnabled = signal<boolean | null>(null);
+
   protected readonly activeProgramTypeConfig = computed(() => this.programTypes.find((pt) => pt.id === this.selectedProgramType()) ?? this.programTypes[0]);
   protected readonly activeDeliveryTypeConfig = computed(() => this.deliveryTypes.find((dt) => dt.id === this.selectedDeliveryType()) ?? this.deliveryTypes[0]);
 
@@ -584,6 +620,69 @@ export class CampaignsComponent {
   protected onEmailProceedToImplementation(brief: CampaignBriefOutput): void {
     this.emailBriefOutput.set(brief);
     this.selectedEmailTab.set('implementation');
+    // Load the picker's options on ARRIVAL rather than on first keystroke, so the tab opens with
+    // the portal's most recently updated templates already listed. Someone staging a send usually
+    // wants a recent one, and an empty box with no options reads as a broken channel.
+    this.searchEmailTemplates('');
+  }
+
+  /**
+   * Search the project's HubSpot marketing emails for one to clone.
+   *
+   * Debounce is deliberately absent: this is called on ARRIVAL and on an explicit Search press,
+   * not per keystroke. campaign-service walks every page and matches in-process, so a filtered
+   * search is genuinely expensive — firing one per character would be the wrong trade.
+   */
+  protected searchEmailTemplates(query: string): void {
+    const projectSlug = this.activeFoundationSlug();
+    if (projectSlug === '') {
+      // The page is reachable by an ED of any foundation and templates are per-project, so a
+      // missing slug must not fall back to some other portal's templates.
+      this.emailTemplates.set(null);
+      this.emailTemplatesError.set('Select a foundation before searching for a template.');
+      return;
+    }
+
+    this.emailTemplateQuery.set(query);
+    this.emailTemplatesLoading.set(true);
+    this.emailTemplatesError.set(null);
+
+    this.campaignService
+      .searchHubSpotEmails(projectSlug, query)
+      .pipe(take(1))
+      .subscribe({
+        next: (result) => {
+          this.emailTemplatesLoading.set(false);
+          this.emailChannelEnabled.set(result.enabled);
+          if (!result.enabled) {
+            // Not an error: HubSpot simply is not connected for this project, which is the steady
+            // state everywhere the channel is not set up.
+            this.emailTemplates.set(null);
+            return;
+          }
+          if (result.error) {
+            // The service reached HubSpot and HubSpot refused. Leave the list NULL rather than
+            // empty — an empty list would claim the portal has no templates.
+            this.emailTemplates.set(null);
+            this.emailTemplatesError.set(result.error);
+            return;
+          }
+          // A row with no id cannot be selected — `sourceEmailId` takes that value — so it is
+          // dropped rather than rendered as a choice that cannot be made.
+          this.emailTemplates.set(result.emails.filter((e) => !!e?.id));
+          this.emailTemplatesTruncated.set(result.possiblyTruncated);
+        },
+        error: () => {
+          this.emailTemplatesLoading.set(false);
+          // NULL, not []. A failed search says nothing about what the portal holds.
+          this.emailTemplates.set(null);
+          this.emailTemplatesError.set('Could not load templates. Try again.');
+        },
+      });
+  }
+
+  protected onSelectEmailTemplate(id: string): void {
+    this.selectedEmailTemplateId.set(id);
   }
 
   protected onRestoreSavedBrief(brief: CampaignBriefOutput, briefId: string, approved: boolean): void {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -369,25 +369,6 @@ export class CampaignsComponent {
   protected readonly emailTemplateQuery = signal('');
   protected readonly emailTemplatesLoading = signal(false);
   /**
-   * Render a HubSpot `updatedAt` for a template row.
-   *
-   * Two templates routinely share a name — the shared interface says so where `updatedAt` is
-   * declared — so without a date two same-name rows are visually identical and the operator
-   * cannot tell which one they are cloning.
-   *
-   * Returns '' rather than a placeholder when the field is absent: `updatedAt` is optional on
-   * the interface, and a dash in the metadata line would read as a value the portal reported.
-   * Same normalisation as monitoring-tab's formatDate, which handles HubSpot's date-only form.
-   */
-  protected formatTemplateUpdatedAt(value: string | undefined): string {
-    if (!value) return '';
-    const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
-    const date = new Date(normalized);
-    if (isNaN(date.getTime())) return '';
-    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-  }
-
-  /**
    * Monotonic id for the in-flight template search.
    *
    * Not a signal: nothing renders it, and it must be readable synchronously inside a subscribe
@@ -537,6 +518,25 @@ export class CampaignsComponent {
       }
       this.selectedDeliveryType.set(value);
     });
+  }
+
+  /**
+   * Render a HubSpot `updatedAt` for a template row.
+   *
+   * Two templates routinely share a name — the shared interface says so where `updatedAt` is
+   * declared — so without a date two same-name rows are visually identical and the operator
+   * cannot tell which one they are cloning.
+   *
+   * Returns '' rather than a placeholder when the field is absent: `updatedAt` is optional on
+   * the interface, and a dash in the metadata line would read as a value the portal reported.
+   * Same normalisation as monitoring-tab's formatDate, which handles HubSpot's date-only form.
+   */
+  protected formatTemplateUpdatedAt(value: string | undefined): string {
+    if (!value) return '';
+    const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
+    const date = new Date(normalized);
+    if (isNaN(date.getTime())) return '';
+    return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -482,6 +482,12 @@ export class CampaignsComponent {
         // the new foundation — the cross-portal leak this handler exists to prevent, and the
         // one `searchEmailTemplates` documents as the hazard its guard cannot see.
         this.emailSearchGeneration++;
+        // Cleared here too, and this is NOT redundant with the subscribe arms: BOTH of the
+        // set-false calls sit INSIDE their `isCurrent()` guards, so a response the generation
+        // bump above just invalidated returns before either runs. Without this line the
+        // spinner would hang until the user happened to search again — the bump closes the
+        // cross-portal leak and would otherwise open a stuck-loading state in its place.
+        this.emailTemplatesLoading.set(false);
         this.emailTemplates.set(null);
         this.emailTemplateQuery.set('');
         this.emailTemplatesTruncated.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -732,7 +732,12 @@ export class CampaignsComponent {
    * search is genuinely expensive — firing one per character would be the wrong trade.
    */
 
-  protected searchEmailTemplates(query: string): void {
+  protected searchEmailTemplates(rawQuery: string): void {
+    // Trimmed to match what the SERVER actually searches: the controller trims `q` before
+    // calling upstream, so a whitespace-only input runs the UNFILTERED portal search. Storing
+    // it raw made the empty state read `No templates match "   "` about a search that had no
+    // filter at all — the same class of lie as naming the draft query, one boundary further in.
+    const query = rawQuery.trim();
     const projectSlug = this.activeFoundationSlug();
     if (projectSlug === '') {
       // The page is reachable by an ED of any foundation and templates are per-project, so a

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -376,6 +376,15 @@ export class CampaignsComponent {
    */
   protected readonly emailTemplates = signal<HubSpotMarketingEmail[] | null>(null);
   protected readonly emailTemplateQuery = signal('');
+  /**
+   * The query the CURRENT results were fetched for, as opposed to `emailTemplateQuery`, which is
+   * the draft in the input and changes on every keystroke.
+   *
+   * The empty state names a query, and naming the draft made it a claim about a search that never
+   * ran: typing "beta" after an "alpha" search relabelled alpha's results as
+   * `No templates match "beta"` before any beta request existed.
+   */
+  protected readonly emailTemplateSubmittedQuery = signal('');
   protected readonly emailTemplatesLoading = signal(false);
   /**
    * Monotonic id for the in-flight template search.
@@ -499,6 +508,7 @@ export class CampaignsComponent {
         this.emailTemplatesLoading.set(false);
         this.emailTemplates.set(null);
         this.emailTemplateQuery.set('');
+        this.emailTemplateSubmittedQuery.set('');
         this.emailTemplatesTruncated.set(false);
         this.emailChannelEnabled.set(null);
         this.emailTemplatesError.set(null);
@@ -711,6 +721,7 @@ export class CampaignsComponent {
     }
 
     this.emailTemplateQuery.set(query);
+    this.emailTemplateSubmittedQuery.set(query);
     this.emailTemplatesLoading.set(true);
     this.emailTemplatesError.set(null);
     // Reset alongside the error, not only on a foundation switch. The template checks

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -6,8 +6,10 @@ import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import type { CampaignBriefPersistenceState } from '@lfx-one/shared/interfaces';
+import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImplementationTabComponent } from './implementation-tab.component';
@@ -195,5 +197,117 @@ describe('ImplementationTabComponent submit gate', () => {
     setPersistence({ status: 'off', briefId: null, message: null, approved: false });
 
     expect(canSubmit()).toBe(true);
+  });
+});
+
+/**
+ * What the create request actually CARRIES for the email channel.
+ *
+ * The template picker's `selectedEmailTemplateId` was write-only before this: set on click, read
+ * only for `aria-pressed` and row styling, and never placed on a request. These assert the value
+ * reaches `hubspotConfig.sourceEmailId`, which campaign-service requires with no default.
+ */
+describe('ImplementationTabComponent hubspotConfig wiring', () => {
+  let fixture: ComponentFixture<ImplementationTabComponent>;
+  let posted: Record<string, unknown> | null;
+
+  function makeOtherwiseValid(): void {
+    const c = fixture.componentInstance as unknown as {
+      selectedPlatforms: { set(v: string[]): void };
+      campaignForm: {
+        controls: Record<string, { setValue(v: unknown): void }>;
+        get(name: string): { controls: { setValue(v: unknown): void }[] } | null;
+      };
+    };
+    c.selectedPlatforms.set(['google-ads']);
+    c.campaignForm.controls['eventName'].setValue('KubeCon EU 2026');
+    c.campaignForm.controls['registrationUrl'].setValue('https://events.example.com/kubecon-eu-2026');
+    c.campaignForm.controls['startDate'].setValue('2026-09-01');
+    c.campaignForm.controls['endDate'].setValue('2026-09-30');
+    c.campaignForm.controls['includeSearch'].setValue(true);
+    c.campaignForm.controls['includeDemandGen'].setValue(false);
+    c.campaignForm.get('headlines')?.controls.forEach((ctrl) => ctrl.setValue('Attend KubeCon'));
+    c.campaignForm.get('descriptions')?.controls.forEach((ctrl) => ctrl.setValue('Join us in September'));
+    fixture.detectChanges();
+  }
+
+  /** Drive the real `submit()` and capture the body handed to the service. */
+  function submitAndCapture(): void {
+    (fixture.componentInstance as unknown as { submit(): void }).submit();
+  }
+
+  beforeEach(async () => {
+    posted = null;
+    await TestBed.configureTestingModule({
+      imports: [ImplementationTabComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ProjectContextService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        {
+          // Stubbed at the service boundary rather than the HTTP one: the assertion is about the
+          // REQUEST BODY the component builds, and a stub keeps the create from being dispatched
+          // anywhere. Nothing here can reach HubSpot or spend money.
+          provide: CampaignService,
+          useValue: {
+            createCampaign: (request: Record<string, unknown>) => {
+              posted = request;
+              return of({ jobId: '' });
+            },
+            // `ngOnInit` resolves the LinkedIn ad-account list on mount. Stubbed empty because
+            // these tests select google-ads only, so the list is never read.
+            getLinkedInAccounts: () => of([]),
+          },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ImplementationTabComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  it('carries the chosen template id as hubspotConfig.sourceEmailId', () => {
+    makeOtherwiseValid();
+    fixture.componentRef.setInput('sourceEmailId', 'email-123');
+    fixture.detectChanges();
+
+    submitAndCapture();
+
+    expect(posted?.['hubspotConfig']).toEqual({ sourceEmailId: 'email-123' });
+  });
+
+  it('omits hubspotConfig entirely when no template is chosen', () => {
+    // The paid-only path, which is every create today. An empty-but-present config would be a
+    // configured-looking email channel on a campaign that has none.
+    makeOtherwiseValid();
+
+    submitAndCapture();
+
+    expect(posted).not.toHaveProperty('hubspotConfig');
+  });
+
+  it('treats a whitespace-only template id as no selection, matching the server', () => {
+    // `buildHubSpotConfig` trims and returns null (UNCONFIGURED) for a blank id. Sending
+    // `{ sourceEmailId: '   ' }` would claim a template was picked and be refused upstream.
+    makeOtherwiseValid();
+    fixture.componentRef.setInput('sourceEmailId', '   ');
+    fixture.detectChanges();
+
+    submitAndCapture();
+
+    expect(posted).not.toHaveProperty('hubspotConfig');
+  });
+
+  it('trims a padded template id rather than sending the padding', () => {
+    makeOtherwiseValid();
+    fixture.componentRef.setInput('sourceEmailId', '  email-456  ');
+    fixture.detectChanges();
+
+    submitAndCapture();
+
+    expect(posted?.['hubspotConfig']).toEqual({ sourceEmailId: 'email-456' });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -110,6 +110,23 @@ export class ImplementationTabComponent implements OnInit {
   public readonly draft = input<CampaignImplementationDraft | null>(null);
 
   /**
+   * The HubSpot marketing-email id chosen in the email template picker, or '' when none is.
+   *
+   * Threaded through so the picker's selection reaches `hubspotConfig.sourceEmailId` on create.
+   * Until now `selectedEmailTemplateId` was write-only — set by the picker, read only for
+   * `aria-pressed` and row styling — so the choice never left the parent component.
+   *
+   * **This input is not yet reachable from the email UI.** The picker lives in the parent's Email
+   * container and this component renders only under Paid Marketing (`[style.display]` keyed on
+   * `isEmail()`), and its own `selectedPlatforms` is typed `CampaignPlatform[]`, which by
+   * construction excludes `'hubspot'` — only the wider `CampaignAnyPlatform` on the request
+   * admits it. There is therefore no email create trigger anywhere in the app today. The wiring
+   * below is the seam: it carries the value correctly the moment a trigger binds this input, and
+   * costs nothing while nothing does.
+   */
+  public readonly sourceEmailId = input<string>('');
+
+  /**
    * Emitted whenever a user-editable field changes, so the parent's copy is current at the moment
    * the tab is destroyed.
    *
@@ -608,6 +625,15 @@ export class ImplementationTabComponent implements OnInit {
             },
           }
         : {}),
+      // Gated on the id, NOT on `platforms.includes('hubspot')`. `selectedPlatforms` is typed
+      // `CampaignPlatform[]`, whose union has no 'hubspot' member, so a platform test here could
+      // never be true and would silently drop the value the day a trigger appears.
+      //
+      // Trimmed before the emptiness test so a whitespace-only id is treated as absent rather
+      // than sent as a present-but-blank config. The server applies the same rule
+      // (`buildHubSpotConfig` trims and returns null — UNCONFIGURED — when blank), so the two
+      // sides agree instead of the client sending something the server then has to reject.
+      ...(this.sourceEmailId().trim() ? { hubspotConfig: { sourceEmailId: this.sourceEmailId().trim() } } : {}),
     };
 
     // Read once, here, and carry it into the poll rather than re-reading per request. The

--- a/apps/lfx-one/src/app/shared/pipes/hubspot-template-label.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/hubspot-template-label.pipe.ts
@@ -1,0 +1,32 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { HubSpotMarketingEmail } from '@lfx-one/shared/interfaces';
+import { formatHubSpotUpdatedAt } from '@lfx-one/shared/utils';
+
+/**
+ * The accessible name for a HubSpot template row.
+ *
+ * `aria-label` REPLACES descendant text in the accessible name, so a name-only label leaves a
+ * screen-reader user with no way to tell two same-named templates apart — which is the whole
+ * reason the row renders a subject, state and date at all.
+ *
+ * A pipe taking the entire template, rather than a component method: `frontend-checklist.md`
+ * §4 allows only signal reads, computed values and pipes in templates, and the picker renders
+ * up to 500 rows per change-detection pass. Taking the object also sidesteps the Angular
+ * parse error that makes a piped value unusable inside a template ternary.
+ */
+@Pipe({
+  name: 'hubspotTemplateLabel',
+})
+export class HubSpotTemplateLabelPipe implements PipeTransform {
+  public transform(template: HubSpotMarketingEmail): string {
+    const parts = [`Use template ${template.name || template.subject || template.id}`];
+    if (template.subject && template.name) parts.push(`subject ${template.subject}`);
+    if (template.state) parts.push(template.state);
+    const updated = formatHubSpotUpdatedAt(template.updatedAt);
+    if (updated) parts.push(`updated ${updated}`);
+    return parts.join(', ');
+  }
+}

--- a/apps/lfx-one/src/app/shared/pipes/hubspot-updated-at.pipe.ts
+++ b/apps/lfx-one/src/app/shared/pipes/hubspot-updated-at.pipe.ts
@@ -1,0 +1,21 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Pipe, PipeTransform } from '@angular/core';
+import { formatHubSpotUpdatedAt } from '@lfx-one/shared/utils';
+
+/**
+ * Render a HubSpot template's `updatedAt` in a row.
+ *
+ * A pipe rather than a component method because the template picker renders up to 500 rows:
+ * `docs/reviews/frontend-checklist.md` §4 forbids template method calls, which re-run for every
+ * row on every change-detection pass. A pure pipe memoizes per input instead.
+ */
+@Pipe({
+  name: 'hubspotUpdatedAt',
+})
+export class HubSpotUpdatedAtPipe implements PipeTransform {
+  public transform(value: string | undefined): string {
+    return formatHubSpotUpdatedAt(value);
+  }
+}

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -251,3 +251,24 @@ export const REDDIT_OBJECTIVE_LABELS: Readonly<Record<RedditObjective, string>> 
  * module the cutover exists to retire.
  */
 export const JOB_LOST_MESSAGE = 'Lost connection to the campaign creation process. Please try again.';
+
+/**
+ * How many HubSpot template rows the picker will RENDER at once.
+ *
+ * The upstream 500-row cap does not bound this list. `HubSpotEmailSearchResult` documents that a
+ * FILTERED search is exempt from that cap — truncating one would report an email that exists as
+ * absent — so a broad query ("a") walks up to 200 pages and can answer with thousands of rows,
+ * each of which the template renders as a button.
+ *
+ * This caps the RENDER, not the result: `emailTemplates` keeps every row it was given, so the
+ * count the picker reports is the true total. The list is not silently shortened — the template
+ * states "Showing the first N of M" whenever this bites, because a list that is quietly cut off
+ * reads as a complete answer and sends someone hunting for a template that was fetched but never
+ * drawn.
+ *
+ * A cap rather than virtual scrolling: nothing in this repo virtualises a list today (no
+ * `cdk-virtual-scroll-viewport` anywhere in `apps/lfx-one`), and introducing the first one here
+ * would be a new pattern rather than a followed one. Narrowing the search is also the action the
+ * user actually wants — scrolling 4,000 rows is not.
+ */
+export const HUBSPOT_TEMPLATE_RENDER_LIMIT = 100;

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -644,6 +644,16 @@ export function formatHubSpotUpdatedAt(value: string | undefined): string {
     return label === value ? '' : label;
   }
 
+  // A TIMESTAMP carries the same hazard as the date-only form, and the earlier fix guarded only
+  // the latter: `new Date('2026-02-31T10:00:00Z')` rolls over to Mar 3 exactly as the bare date
+  // does, so the fabrication survived in this branch while the spec pinned the other one. Split
+  // the date portion off and round-trip it through the same validator before formatting.
+  const datePart = value.slice(0, 10);
+  if (/^\d{4}-\d{2}-\d{2}$/.test(datePart) && formatIsoDateLabel(datePart) === datePart) {
+    // formatIsoDateLabel echoes its input when it rejects, so an equal result means the calendar
+    // date does not exist — Feb 31st, year 0001, and the like.
+    return '';
+  }
   const date = new Date(value);
   if (isNaN(date.getTime())) return '';
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -617,3 +617,22 @@ export function formatIsoDateLabel(iso: string): string {
     timeZone: 'UTC',
   });
 }
+
+/**
+ * Render a HubSpot `updatedAt` for a marketing-email row.
+ *
+ * Two templates routinely share a name, so without a date two same-name rows are visually
+ * identical and an operator cannot tell which one they are cloning.
+ *
+ * Returns '' rather than a placeholder when the field is absent: `updatedAt` is optional on the
+ * interface, and a dash in the metadata line would read as a value the portal reported. HubSpot
+ * also sends a date-only form, which `new Date` would parse as UTC midnight and render as the
+ * previous day in western timezones — normalising to local midnight avoids the off-by-one.
+ */
+export function formatHubSpotUpdatedAt(value: string | undefined): string {
+  if (!value) return '';
+  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
+  const date = new Date(normalized);
+  if (isNaN(date.getTime())) return '';
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+}

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -656,5 +656,10 @@ export function formatHubSpotUpdatedAt(value: string | undefined): string {
   }
   const date = new Date(value);
   if (isNaN(date.getTime())) return '';
-  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+  // Pinned to UTC for the same reason the date-only branch is: without an explicit `timeZone`,
+  // `toLocaleDateString` renders in the HOST zone, and this is an SSR app. A timestamp near
+  // midnight then formats to one date in the Node process and another in the browser, so the row
+  // text and its accessible label both change during hydration. Pinning also keeps the two
+  // branches agreeing: `2026-08-14` and `2026-08-14T23:30:00Z` must not render different days.
+  return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric', timeZone: 'UTC' });
 }

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -631,8 +631,20 @@ export function formatIsoDateLabel(iso: string): string {
  */
 export function formatHubSpotUpdatedAt(value: string | undefined): string {
   if (!value) return '';
-  const normalized = /^\d{4}-\d{2}-\d{2}$/.test(value) ? `${value}T00:00:00` : value;
-  const date = new Date(normalized);
+
+  // A date-only value goes through formatIsoDateLabel, which ROUND-TRIPS year/month/day.
+  // Shape-checking alone is not enough: `2026-02-31` matches the pattern, and JS silently
+  // rolls the excess day into the next month, so `isNaN` never fires and the picker renders
+  // a confident "Mar 3, 2026" for a date that does not exist. An operator uses this value to
+  // tell two same-named templates apart, so a fabricated date is worse than none.
+  if (/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+    const label = formatIsoDateLabel(value);
+    // formatIsoDateLabel returns its input unchanged when it rejects; render nothing rather
+    // than echoing a raw ISO string into a metadata line that reads as a portal value.
+    return label === value ? '' : label;
+  }
+
+  const date = new Date(value);
   if (isNaN(date.getTime())) return '';
   return date.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
 }

--- a/packages/shared/src/utils/hubspot-updated-at.spec.ts
+++ b/packages/shared/src/utils/hubspot-updated-at.spec.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+import { formatHubSpotUpdatedAt } from './date-time.utils';
+
+describe('formatHubSpotUpdatedAt', () => {
+  it('refuses dates that do not exist rather than rolling them over', () => {
+    // JS rolls 2026-02-31 into Mar 3 and 0001 into 1901; both rendered a confident wrong date.
+    expect(formatHubSpotUpdatedAt('2026-02-31')).toBe('');
+    expect(formatHubSpotUpdatedAt('2026-02-30')).toBe('');
+    expect(formatHubSpotUpdatedAt('0001-01-01')).toBe('');
+    expect(formatHubSpotUpdatedAt('2026-13-01')).toBe('');
+  });
+
+  it('renders a real date-only value in local terms, not UTC-shifted', () => {
+    expect(formatHubSpotUpdatedAt('2026-08-14')).toBe('Aug 14, 2026');
+  });
+
+  it('still renders a full timestamp', () => {
+    expect(formatHubSpotUpdatedAt('2026-08-14T10:00:00Z')).toContain('2026');
+  });
+
+  it('renders nothing for absent or unparseable input', () => {
+    expect(formatHubSpotUpdatedAt(undefined)).toBe('');
+    expect(formatHubSpotUpdatedAt('not-a-date')).toBe('');
+  });
+});

--- a/packages/shared/src/utils/hubspot-updated-at.spec.ts
+++ b/packages/shared/src/utils/hubspot-updated-at.spec.ts
@@ -18,7 +18,32 @@ describe('formatHubSpotUpdatedAt', () => {
   });
 
   it('still renders a full timestamp', () => {
-    expect(formatHubSpotUpdatedAt('2026-08-14T10:00:00Z')).toContain('2026');
+    expect(formatHubSpotUpdatedAt('2026-08-14T10:00:00Z')).toBe('Aug 14, 2026');
+  });
+
+  it('formats a timestamp in UTC, so SSR and the browser agree across a midnight boundary', () => {
+    // `toContain('2026')` passed in every timezone, so it never covered this: without an explicit
+    // `timeZone`, `toLocaleDateString` uses the HOST zone. A timestamp near midnight then renders
+    // one day in the Node process and another in the browser, changing the row text and its
+    // aria-label during hydration.
+    //
+    // Asserted against the UTC calendar day computed from the instant itself, NOT against a
+    // literal. A literal would only disagree with the host-zone format on a non-UTC runner, and
+    // the repo pins no TZ — under a UTC runner (the common CI default) the assertion would hold
+    // with or without the fix. Setting `process.env.TZ` here would not help either: Node caches
+    // the zone on first `Intl` use, which the tests above have already triggered.
+    //
+    // These instants straddle UTC midnight in opposite directions, so on ANY host with a non-zero
+    // offset at least one of them formats to the wrong day without the pin.
+    for (const iso of ['2026-08-14T23:30:00Z', '2026-08-15T00:30:00Z', '2026-08-15T12:00:00Z']) {
+      const expected = new Date(iso).toLocaleDateString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        timeZone: 'UTC',
+      });
+      expect(formatHubSpotUpdatedAt(iso)).toBe(expected);
+    }
   });
 
   it('refuses impossible dates in the TIMESTAMP form too, not only date-only', () => {

--- a/packages/shared/src/utils/hubspot-updated-at.spec.ts
+++ b/packages/shared/src/utils/hubspot-updated-at.spec.ts
@@ -21,6 +21,15 @@ describe('formatHubSpotUpdatedAt', () => {
     expect(formatHubSpotUpdatedAt('2026-08-14T10:00:00Z')).toContain('2026');
   });
 
+  it('refuses impossible dates in the TIMESTAMP form too, not only date-only', () => {
+    // The first fix guarded only the date-only branch, so these kept fabricating: JS rolls
+    // 2026-02-31T10:00:00Z to Mar 3 exactly as it does the bare date. The spec pinned the
+    // branch that was fixed and not the one that was not.
+    expect(formatHubSpotUpdatedAt('2026-02-31T10:00:00Z')).toBe('');
+    expect(formatHubSpotUpdatedAt('2026-02-30T00:00:00Z')).toBe('');
+    expect(formatHubSpotUpdatedAt('0001-01-01T00:00:00Z')).toBe('');
+  });
+
   it('renders nothing for absent or unparseable input', () => {
     expect(formatHubSpotUpdatedAt(undefined)).toBe('');
     expect(formatHubSpotUpdatedAt('not-a-date')).toBe('');

--- a/packages/shared/src/utils/hubspot-updated-at.spec.ts
+++ b/packages/shared/src/utils/hubspot-updated-at.spec.ts
@@ -21,6 +21,31 @@ describe('formatHubSpotUpdatedAt', () => {
     expect(formatHubSpotUpdatedAt('2026-08-14T10:00:00Z')).toBe('Aug 14, 2026');
   });
 
+  it('pins timeZone UTC on the formatter itself, so the guard binds on a UTC runner too', () => {
+    // The instant-based test below cannot fail on a UTC host: with no explicit timeZone the
+    // host zone IS UTC, so pinned and unpinned agree. CI commonly runs UTC and the repo pins no
+    // TZ, so that test protects the fix everywhere EXCEPT where it runs.
+    //
+    // Observing the option directly binds on any host. A spy on the prototype sees exactly what
+    // the implementation asked for, independent of what the environment would have defaulted to.
+    const seen: (Intl.DateTimeFormatOptions | undefined)[] = [];
+    const original = Date.prototype.toLocaleDateString;
+    // eslint-disable-next-line no-extend-native
+    Date.prototype.toLocaleDateString = function (locales?: unknown, options?: Intl.DateTimeFormatOptions): string {
+      seen.push(options);
+      return original.call(this, locales as string, options);
+    };
+    try {
+      formatHubSpotUpdatedAt('2026-08-14T23:30:00Z');
+    } finally {
+      // eslint-disable-next-line no-extend-native
+      Date.prototype.toLocaleDateString = original;
+    }
+
+    expect(seen.length).toBeGreaterThan(0);
+    expect(seen.every((o) => o?.timeZone === 'UTC')).toBe(true);
+  });
+
   it('formats a timestamp in UTC, so SSR and the browser agree across a midnight boundary', () => {
     // `toContain('2026')` passed in every timezone, so it never covered this: without an explicit
     // `timeZone`, `toLocaleDateString` uses the HOST zone. A timestamp near midnight then renders


### PR DESCRIPTION
Replaces the "Email staging is not wired up yet" panel with the template picker it was waiting for.

Jira: [LFXV2-3198](https://linuxfoundation.atlassian.net/browse/LFXV2-3198)

## The copy it removes was false

That panel said choosing a template "needs an endpoint that is still in review". Both halves have been live for a while:

- `GET /api/campaigns/hubspot/emails` — merged in **#1439**
- `buildHubSpotConfig` (the `hubspotConfig` builder) — merged in **#1546**

Staging an email **clones** one of the project's HubSpot marketing emails, and `sourceEmailId` has no default, so a chosen template is **required** before a send can be staged.

**It is not yet sufficient, and an earlier version of this description said it was.** There is no create trigger on the email side: the only `createCampaign` call site is in the implementation tab, which renders solely under Paid, and `CampaignPlatform` has no `hubspot` member — so the type system forbids this path from reaching create even if a button existed. Every `hubspotConfig` reference in the app was a comment or a spec; the server side (`buildHubSpotConfig`) is built and waiting.

This PR threads the selection through to `hubspotConfig.sourceEmailId` so the value flows the moment a trigger lands, and nothing binds it — verified by sweeping every template. **No send can be staged and nothing can spend.** Wiring the trigger is LFXV2-3201.

## Four states, kept distinct

Each pair would state something false if collapsed:

| State | Renders | Why it matters |
|---|---|---|
| **not connected** (`enabled: false`) | "connect HubSpot" | The steady state wherever HubSpot isn't set up — not an error |
| **search failed** | nothing; list stays `null` | An empty array asserts the portal holds no templates. Only a completed search supports that, and the claim sends someone to create one they may already have |
| **searched-and-empty** | `[]` with copy naming the query | Reads as a statement about the *search*, not the portal |
| **results** | the list | Rows with no `id` are **dropped** — `id` is what `sourceEmailId` takes, so such a row is a choice that cannot be made |

`possiblyTruncated` surfaces only for an **empty** query — the one case where a complete listing and a truncated first screen are indistinguishable on the wire. A filtered search is complete-or-error upstream, so warning there would send someone to narrow a search that was already exhaustive.

## Verification

`yarn build`, `yarn lint:check --force`, `./check-headers.sh`. **1340 server tests + 73 app-side tests.**

Mutation-tested — each guard pinned by a test that fails when reverted:

| Mutation | Fails |
|---|---|
| collapse a failed search into `[]` | failure-stays-null |
| keep rows with no `id` | id-less-row-dropped |
| drop the foundation guard | refuses-without-foundation |

**Replaces a test rather than deleting it.** The old one pinned the stale panel's copy; its real concern — don't claim a brief is ready when none exists — survives, and the picker is stronger on that point because it states nothing about the brief at all.

**Not covered: layout.** The specs bind every branch where the component decides *what to say*, not how it looks. The local dev environment needs an OAuth consent grant that is the account owner's to give.


[LFXV2-3198]: https://linuxfoundation.atlassian.net/browse/LFXV2-3198?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
