### PR TITLE
fix(dashboards): stop failed ed reads rendering as measured zeros

### DIFF
--- a/apps/lfx-one/e2e/ed-dashboard-unavailable.spec.ts
+++ b/apps/lfx-one/e2e/ed-dashboard-unavailable.spec.ts
@@ -1,0 +1,167 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * ED Marketing Overview — a failed analytics read must never render as a measured zero.
+ *
+ * This closes the one gap the unit suite structurally cannot: the `[unavailable]` bindings in
+ * `marketing-overview.component.html`. Deleting one of those bindings leaves every existing
+ * spec green — the binding EXPRESSION is tested against an equivalent host component, and the
+ * drawers are tested with their inputs set directly, so neither exercises the real template.
+ *
+ * The defect this guards against was reported on Agentic AI Foundation: /api/analytics/brand-reach
+ * failed inside the dashboard's request burst and the Social card rendered "0 · 0 platforms" for a
+ * foundation with 17,269 followers across 2 platforms. It has since been fixed at four layers
+ * (BFF rethrow → client propagation → card guard → drawer suppression); this asserts the whole
+ * chain end to end, through the real template, with a genuinely failing HTTP response.
+ *
+ * Coverage:
+ *   E1  A 500 on one endpoint renders that card's unavailable state, not a zero
+ *   E2  Its drawer suppresses the body and says the data could not be loaded
+ *   E3  Cards whose endpoints succeeded still render their measured values
+ *
+ * Prerequisites:
+ * - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
+ * - `apps/lfx-one/.env` populated with TEST_USERNAME / TEST_PASSWORD (see global-setup.ts)
+ */
+
+import { expect, Page, test } from '@playwright/test';
+
+import type { LensItem, PersistedPersonaState, PersonaType } from '@lfx-one/shared/interfaces';
+
+import { PERSONA_COOKIE_KEY } from '@lfx-one/shared/constants';
+
+const FOUNDATION_SLUG = 'test-foundation';
+const LOAD_TIMEOUT = 30_000;
+
+const FOUNDATION_ITEM: LensItem = {
+  uid: 'f0000000-0000-0000-0000-000000000001',
+  slug: FOUNDATION_SLUG,
+  name: 'Test Foundation',
+  logoUrl: null,
+} as LensItem;
+
+test.setTimeout(120_000);
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Malformed URL — let the test surface the failure naturally.
+  }
+}
+
+/**
+ * The ED dashboard is chosen at the component level from the persona, not by a route guard, so
+ * the cookie has to be seeded before the SSR navigation — page.route() only intercepts
+ * browser-side XHR and never reaches the Node SSR process.
+ */
+async function seedEdPersona(page: Page): Promise<void> {
+  const state: PersistedPersonaState = {
+    primary: 'executive-director' as PersonaType,
+    all: ['executive-director'] as PersonaType[],
+  };
+  await page.context().addCookies([
+    {
+      name: PERSONA_COOKIE_KEY,
+      value: encodeURIComponent(JSON.stringify(state)),
+      domain: 'localhost',
+      path: '/',
+      sameSite: 'Lax',
+    },
+  ]);
+  await page.route('**/api/user/personas*', (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        personas: ['executive-director'],
+        personaProjects: {},
+        projects: [],
+        organizations: [],
+        isRootWriter: false,
+        isLFStaff: false,
+      }),
+    })
+  );
+  await page.route('**/api/nav/lens-items*', (route) => {
+    const requestedLens = new URL(route.request().url()).searchParams.get('lens') ?? 'foundation';
+    const items = requestedLens === 'foundation' ? [FOUNDATION_ITEM] : [];
+    return route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ items, next_page_token: null, upstream_failed: false, lens: requestedLens }),
+    });
+  });
+  await page.route(`**/api/projects/${FOUNDATION_SLUG}*`, (route) =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ uid: FOUNDATION_ITEM.uid, slug: FOUNDATION_SLUG, name: 'Test Foundation', parent_uid: null }),
+    })
+  );
+  await page.route('**/api/projects/*/sfid*', (route) => route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ sfid: null }) }));
+}
+
+/**
+ * Fail exactly one analytics endpoint with a real 500 and let every other one through.
+ *
+ * The 500 matters: the whole chain keys off an HTTP error reaching the client. A stub that
+ * returned 200 with a zero-filled body would reproduce the original defect rather than test the
+ * fix, which is precisely what made the BFF layer's zero-filled 200s so hard to spot.
+ */
+async function failEndpoint(page: Page, endpoint: string): Promise<void> {
+  await page.route(`**/api/analytics/${endpoint}*`, (route) =>
+    route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'upstream failed' }) })
+  );
+}
+
+test.describe('ED Marketing Overview — failed reads render as unavailable, not zero', () => {
+  test('E1/E2: a 500 on engaged-community renders the unavailable card and drawer', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await seedEdPersona(page);
+    await failEndpoint(page, 'engaged-community');
+
+    await page.goto(`/foundation/overview?project=${FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    // E1 — the card must say the data could not be loaded rather than print a count.
+    const card = page.getByTestId('ed-evo-engaged-community');
+    await expect(card).toBeVisible({ timeout: LOAD_TIMEOUT });
+    await expect(card).toContainText('Data unavailable', { timeout: LOAD_TIMEOUT });
+    // The regression itself: a fabricated zero where a measurement never happened.
+    await expect(card).not.toContainText('0 members');
+
+    // E2 — the drawer behind it must agree. Before this fix the card said "unavailable" while
+    // the drawer asserted "No community engagement activity detected" — a finding, not an outage.
+    await card.click();
+    const unavailable = page.getByTestId('engaged-community-drawer-unavailable');
+    await expect(unavailable).toBeVisible({ timeout: LOAD_TIMEOUT });
+    await expect(unavailable).toContainText('Data unavailable');
+    await expect(page.getByTestId('engaged-community-drawer-stats')).toHaveCount(0);
+    await expect(page.getByText('No community engagement activity detected')).toHaveCount(0);
+  });
+
+  test('E3: cards whose endpoints succeeded still render their measured values', async ({ page }) => {
+    await page.goto('/', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await seedEdPersona(page);
+    // Only this one fails — the guard must be scoped to its own response, not blank the section.
+    await failEndpoint(page, 'engaged-community');
+
+    await page.goto(`/foundation/overview?project=${FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+
+    await expect(page.getByTestId('ed-evo-engaged-community')).toContainText('Data unavailable', { timeout: LOAD_TIMEOUT });
+    // A neighbouring card that resolved normally must not inherit the failure.
+    const events = page.getByTestId('ed-evo-event-growth');
+    await expect(events).toBeVisible({ timeout: LOAD_TIMEOUT });
+    await expect(events).not.toContainText('Data unavailable');
+  });
+});

--- a/apps/lfx-one/e2e/ed-dashboard-unavailable.spec.ts
+++ b/apps/lfx-one/e2e/ed-dashboard-unavailable.spec.ts
@@ -107,7 +107,46 @@ async function seedEdPersona(page: Page): Promise<void> {
 }
 
 /**
- * Fail exactly one analytics endpoint with a real 500 and let every other one through.
+ * A measured, non-zero Events response. Non-zero deliberately: the E3 assertion is that a
+ * neighbour still renders its MEASUREMENT, and a zero-filled stub cannot tell a surviving
+ * measurement from a suppressed one — the same blind spot that let two drawers ship their
+ * stats above the "unavailable" banner in an earlier round of this PR.
+ */
+const MEASURED_EVENT_GROWTH = {
+  totalAttendees: 8421,
+  totalRegistrants: 12345,
+  totalEvents: 17,
+  totalRevenue: 250000,
+  revenuePerAttendee: 29.7,
+  attendeeYoyChange: 12.5,
+  registrantYoyChange: 8.1,
+  revenueYoyChange: 15.2,
+  trend: 'up',
+  monthlyData: [{ month: '2026-01', value: 12345 }],
+  topEvents: [],
+};
+
+/**
+ * Pin the neighbour endpoints this spec asserts against to deterministic 200s.
+ *
+ * Without this the spec fails ONE endpoint and lets the other ~22 in the dashboard's request
+ * burst reach the configured environment. That burst is documented as intermittently 500-ing or
+ * leaving requests undispatched, either of which can make a neighbour card report unavailable —
+ * so E3 could fail while the code under test behaved correctly. A guard for exactly this failure
+ * mode is the last test that can afford to flake.
+ *
+ * Only endpoints the assertions depend on are stubbed. `failEndpoint` is always registered
+ * AFTER this, and Playwright matches the most recently added route first, so the 500 still wins
+ * for its own URL even if the two patterns ever overlap.
+ */
+async function stubNeighborAnalytics(page: Page): Promise<void> {
+  await page.route('**/api/analytics/event-growth*', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(MEASURED_EVENT_GROWTH) })
+  );
+}
+
+/**
+ * Fail exactly one analytics endpoint with a real 500.
  *
  * The 500 matters: the whole chain keys off an HTTP error reaching the client. A stub that
  * returned 200 with a zero-filled body would reproduce the original defect rather than test the
@@ -125,6 +164,7 @@ test.describe('ED Marketing Overview — failed reads render as unavailable, not
     skipWhenAuthMissing(page);
 
     await seedEdPersona(page);
+    await stubNeighborAnalytics(page);
     await failEndpoint(page, 'engaged-community');
 
     await page.goto(`/foundation/overview?project=${FOUNDATION_SLUG}`, { waitUntil: 'domcontentloaded' });
@@ -152,6 +192,7 @@ test.describe('ED Marketing Overview — failed reads render as unavailable, not
     skipWhenAuthMissing(page);
 
     await seedEdPersona(page);
+    await stubNeighborAnalytics(page);
     // Only this one fails — the guard must be scoped to its own response, not blank the section.
     await failEndpoint(page, 'engaged-community');
 
@@ -159,9 +200,13 @@ test.describe('ED Marketing Overview — failed reads render as unavailable, not
     skipWhenAuthMissing(page);
 
     await expect(page.getByTestId('ed-evo-engaged-community')).toContainText('Data unavailable', { timeout: LOAD_TIMEOUT });
-    // A neighbouring card that resolved normally must not inherit the failure.
+    // A neighbouring card that resolved normally must not inherit the failure. Asserting the
+    // stubbed FIGURE, not just the absence of the banner: a card blanked to an em dash also
+    // lacks the phrase "Data unavailable", so the negative assertion alone would pass against
+    // a guard that over-suppressed the whole section.
     const events = page.getByTestId('ed-evo-event-growth');
     await expect(events).toBeVisible({ timeout: LOAD_TIMEOUT });
     await expect(events).not.toContainText('Data unavailable');
+    await expect(events).toContainText('12.3K');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -28,252 +28,267 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="brand-health-drawer-content">
-    <!-- Summary Stats + Sentiment Breakdown -->
-    <div class="flex flex-col gap-4" data-testid="brand-health-drawer-stats">
-      <div class="flex gap-4">
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Total Mentions</span>
-            @if (data().totalMentions > 0) {
-              <span class="text-2xl font-semibold text-gray-900">{{ data().totalMentions | number }}</span>
-            } @else {
-              <span class="text-2xl font-semibold text-gray-400">—</span>
-            }
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Positive</span>
-            @if (data().totalMentions > 0) {
-              <span class="text-2xl font-semibold text-green-600">{{ data().sentiment.positive | number: '1.1-1' }}%</span>
-            } @else {
-              <span class="text-2xl font-semibold text-gray-400">—</span>
-            }
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Neutral</span>
-            @if (data().totalMentions > 0) {
-              <span class="text-2xl font-semibold text-gray-600">{{ data().sentiment.neutral | number: '1.1-1' }}%</span>
-            } @else {
-              <span class="text-2xl font-semibold text-gray-400">—</span>
-            }
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Negative</span>
-            @if (data().totalMentions > 0) {
-              <span class="text-2xl font-semibold text-red-600">{{ data().sentiment.negative | number: '1.1-1' }}%</span>
-            } @else {
-              <span class="text-2xl font-semibold text-gray-400">—</span>
-            }
-          </div>
-        </lfx-card>
-      </div>
-      @if (data().totalMentions > 0 && data().sentimentMomChangePp !== 0) {
-        <div class="flex items-center gap-2 text-sm text-gray-500">
-          <span>Positive Sentiment MoM:</span>
-          <span class="font-semibold" [class.text-green-600]="data().sentimentMomChangePp > 0" [class.text-red-600]="data().sentimentMomChangePp < 0">
-            {{ formattedSentimentMom() }}pp
-          </span>
-        </div>
-      }
-    </div>
-
-    <!-- FIRST FOLD: Needs Your Attention -->
-    @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
       <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-        data-testid="brand-health-drawer-attention">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-          <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
-        </div>
-
-        @for (action of attentionActions(); track action.title) {
-          <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-            @if (action.priority === 'high') {
-              <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-            } @else {
-              <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
-            }
-          </div>
-        }
-
-        @for (insight of attentionInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
-          </div>
-        }
-      </div>
-    }
-
-    <!-- SECOND FOLD: Performing Well -->
-    @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-        data-testid="brand-health-drawer-performing">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-check text-green-600"></i>
-          <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
-        </div>
-
-        @for (action of performingActions(); track action.title) {
-          <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-          </div>
-        }
-
-        @for (insight of performingInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
-          </div>
-        }
-      </div>
-    }
-
-    @if (hasNoData()) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
         role="status"
         aria-live="polite"
-        data-testid="brand-health-drawer-no-data">
+        data-testid="brand-health-drawer-unavailable">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <span class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No brand mention activity detected' }}</span>
-            @if (unavailable()) {
-              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
-            } @else {
-              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
-            }
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
           </div>
         </div>
       </div>
-    }
-
-    <!-- Mentions Trend -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-mentions-trend">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Mentions Trend</h3>
-        <p class="text-sm text-gray-600">Total brand mentions over the last 6 months (Octolens)</p>
-      </div>
-      @if (data().monthlyMentions.length > 0) {
-        <div class="h-[240px]" data-testid="brand-health-drawer-mentions-chart">
-          <lfx-chart type="line" [data]="mentionsTrendData()" [options]="mentionsTrendOptions" height="100%"></lfx-chart>
+    } @else {
+      <!-- Summary Stats + Sentiment Breakdown -->
+      <div class="flex flex-col gap-4" data-testid="brand-health-drawer-stats">
+        <div class="flex gap-4">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Total Mentions</span>
+              @if (data().totalMentions > 0) {
+                <span class="text-2xl font-semibold text-gray-900">{{ data().totalMentions | number }}</span>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-400">—</span>
+              }
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Positive</span>
+              @if (data().totalMentions > 0) {
+                <span class="text-2xl font-semibold text-green-600">{{ data().sentiment.positive | number: '1.1-1' }}%</span>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-400">—</span>
+              }
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Neutral</span>
+              @if (data().totalMentions > 0) {
+                <span class="text-2xl font-semibold text-gray-600">{{ data().sentiment.neutral | number: '1.1-1' }}%</span>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-400">—</span>
+              }
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Negative</span>
+              @if (data().totalMentions > 0) {
+                <span class="text-2xl font-semibold text-red-600">{{ data().sentiment.negative | number: '1.1-1' }}%</span>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-400">—</span>
+              }
+            </div>
+          </lfx-card>
         </div>
-      } @else {
-        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="brand-health-drawer-mentions-empty">
-          Mentions trend data not yet available
-        </div>
-      }
-    </div>
-
-    <!-- Top Mentioned Projects -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-top-projects">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Top Mentioned Projects</h3>
-        <p class="text-sm text-gray-600">Projects with the most brand mentions in the last 30 days</p>
+        @if (data().totalMentions > 0 && data().sentimentMomChangePp !== 0) {
+          <div class="flex items-center gap-2 text-sm text-gray-500">
+            <span>Positive Sentiment MoM:</span>
+            <span class="font-semibold" [class.text-green-600]="data().sentimentMomChangePp > 0" [class.text-red-600]="data().sentimentMomChangePp < 0">
+              {{ formattedSentimentMom() }}pp
+            </span>
+          </div>
+        }
       </div>
-      @if (data().topProjects.length > 0) {
-        <div class="flex flex-col gap-0">
-          @for (project of data().topProjects; track project.name) {
-            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-health-drawer-project-row">
-              <span class="text-sm font-medium text-gray-900">{{ project.name }}</span>
-              <span class="text-sm font-semibold text-gray-900">{{ project.mentions | number }}</span>
+
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="brand-health-drawer-attention">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+          </div>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+              @if (action.priority === 'high') {
+                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+              } @else {
+                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+              }
+            </div>
+          }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
             </div>
           }
         </div>
-      } @else {
-        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-health-drawer-top-projects-empty">
-          Top projects data not yet available
+      }
+
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="brand-health-drawer-performing">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-check text-green-600"></i>
+            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+          </div>
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
+            </div>
+          }
         </div>
       }
-    </div>
 
-    <!-- Reusable mention card template — used by both positive and negative sections -->
-    <ng-template #mentionCardTpl let-mention>
-      <div class="flex items-start justify-between gap-2">
-        <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
-        @if (mention.url) {
-          <a
-            [href]="mention.url"
-            target="_blank"
-            rel="noopener noreferrer"
-            class="flex-shrink-0 text-gray-400 hover:text-blue-500"
-            aria-label="Open mention in new tab">
-            <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
-          </a>
-        }
-      </div>
-      @if (mention.title && mention.body) {
-        <p class="text-xs text-gray-500 line-clamp-2">{{ mention.body }}</p>
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-400 bg-white overflow-hidden"
+          role="status"
+          aria-live="polite"
+          data-testid="brand-health-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <span class="text-sm font-semibold text-gray-900">No brand mention activity detected</span>
+              <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
+            </div>
+          </div>
+        </div>
       }
-      <div class="flex items-center gap-3 text-xs text-gray-400">
-        @if (mention.author) {
-          <span class="flex items-center gap-1">
-            <i class="fa-light fa-user"></i>
-            {{ mention.author }}
-          </span>
-        }
-        @if (mention.sourcePlatform || mention.socialNetwork) {
-          <span class="flex items-center gap-1">
-            <i class="fa-light fa-globe"></i>
-            {{ mention.socialNetwork || mention.sourcePlatform }}
-          </span>
-        }
-      </div>
-    </ng-template>
 
-    <!-- Top Negative Mentions -->
-    @if (data().topNegativeMentions.length > 0) {
-      <div class="flex flex-col gap-4 p-4 border border-red-200 bg-red-50 rounded-lg" data-testid="brand-health-drawer-negative-mentions">
+      <!-- Mentions Trend -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-mentions-trend">
         <div class="flex flex-col gap-1">
-          <h3 class="flex items-center gap-2 text-sm font-semibold text-red-800">
-            <i class="fa-light fa-thumbs-down text-red-500"></i>
-            Top Negative Mentions
-          </h3>
-          <p class="text-sm text-red-700">Most relevant negative mentions by relevance score</p>
+          <h3 class="text-sm font-semibold text-gray-900">Mentions Trend</h3>
+          <p class="text-sm text-gray-600">Total brand mentions over the last 6 months (Octolens)</p>
         </div>
-        <div class="flex flex-col gap-3">
-          @for (mention of data().topNegativeMentions; track $index) {
-            <div class="flex flex-col gap-2 p-3 bg-white border border-red-200 rounded-lg" data-testid="brand-health-drawer-negative-mention">
-              <ng-container *ngTemplateOutlet="mentionCardTpl; context: { $implicit: mention }"></ng-container>
-            </div>
-          }
-        </div>
+        @if (data().monthlyMentions.length > 0) {
+          <div class="h-[240px]" data-testid="brand-health-drawer-mentions-chart">
+            <lfx-chart type="line" [data]="mentionsTrendData()" [options]="mentionsTrendOptions" height="100%"></lfx-chart>
+          </div>
+        } @else {
+          <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="brand-health-drawer-mentions-empty">
+            Mentions trend data not yet available
+          </div>
+        }
       </div>
-    }
 
-    <!-- Top Positive Mentions -->
-    @if (data().topPositiveMentions.length > 0) {
-      <div class="flex flex-col gap-4 p-4 border border-green-200 bg-green-50 rounded-lg" data-testid="brand-health-drawer-positive-mentions">
+      <!-- Top Mentioned Projects -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-health-drawer-top-projects">
         <div class="flex flex-col gap-1">
-          <h3 class="flex items-center gap-2 text-sm font-semibold text-green-800">
-            <i class="fa-light fa-thumbs-up text-green-500"></i>
-            Top Positive Mentions
-          </h3>
-          <p class="text-sm text-green-700">Most relevant positive mentions by relevance score</p>
+          <h3 class="text-sm font-semibold text-gray-900">Top Mentioned Projects</h3>
+          <p class="text-sm text-gray-600">Projects with the most brand mentions in the last 30 days</p>
         </div>
-        <div class="flex flex-col gap-3">
-          @for (mention of data().topPositiveMentions; track $index) {
-            <div class="flex flex-col gap-2 p-3 bg-white border border-green-200 rounded-lg" data-testid="brand-health-drawer-positive-mention">
-              <ng-container *ngTemplateOutlet="mentionCardTpl; context: { $implicit: mention }"></ng-container>
-            </div>
+        @if (data().topProjects.length > 0) {
+          <div class="flex flex-col gap-0">
+            @for (project of data().topProjects; track project.name) {
+              <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-health-drawer-project-row">
+                <span class="text-sm font-medium text-gray-900">{{ project.name }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ project.mentions | number }}</span>
+              </div>
+            }
+          </div>
+        } @else {
+          <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-health-drawer-top-projects-empty">
+            Top projects data not yet available
+          </div>
+        }
+      </div>
+
+      <!-- Reusable mention card template — used by both positive and negative sections -->
+      <ng-template #mentionCardTpl let-mention>
+        <div class="flex items-start justify-between gap-2">
+          <span class="text-sm font-medium text-gray-900 line-clamp-2">{{ mention.title || mention.body }}</span>
+          @if (mention.url) {
+            <a
+              [href]="mention.url"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="flex-shrink-0 text-gray-400 hover:text-blue-500"
+              aria-label="Open mention in new tab">
+              <i class="fa-light fa-arrow-up-right-from-square text-xs"></i>
+            </a>
           }
         </div>
-      </div>
+        @if (mention.title && mention.body) {
+          <p class="text-xs text-gray-500 line-clamp-2">{{ mention.body }}</p>
+        }
+        <div class="flex items-center gap-3 text-xs text-gray-400">
+          @if (mention.author) {
+            <span class="flex items-center gap-1">
+              <i class="fa-light fa-user"></i>
+              {{ mention.author }}
+            </span>
+          }
+          @if (mention.sourcePlatform || mention.socialNetwork) {
+            <span class="flex items-center gap-1">
+              <i class="fa-light fa-globe"></i>
+              {{ mention.socialNetwork || mention.sourcePlatform }}
+            </span>
+          }
+        </div>
+      </ng-template>
+
+      <!-- Top Negative Mentions -->
+      @if (data().topNegativeMentions.length > 0) {
+        <div class="flex flex-col gap-4 p-4 border border-red-200 bg-red-50 rounded-lg" data-testid="brand-health-drawer-negative-mentions">
+          <div class="flex flex-col gap-1">
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-red-800">
+              <i class="fa-light fa-thumbs-down text-red-500"></i>
+              Top Negative Mentions
+            </h3>
+            <p class="text-sm text-red-700">Most relevant negative mentions by relevance score</p>
+          </div>
+          <div class="flex flex-col gap-3">
+            @for (mention of data().topNegativeMentions; track $index) {
+              <div class="flex flex-col gap-2 p-3 bg-white border border-red-200 rounded-lg" data-testid="brand-health-drawer-negative-mention">
+                <ng-container *ngTemplateOutlet="mentionCardTpl; context: { $implicit: mention }"></ng-container>
+              </div>
+            }
+          </div>
+        </div>
+      }
+
+      <!-- Top Positive Mentions -->
+      @if (data().topPositiveMentions.length > 0) {
+        <div class="flex flex-col gap-4 p-4 border border-green-200 bg-green-50 rounded-lg" data-testid="brand-health-drawer-positive-mentions">
+          <div class="flex flex-col gap-1">
+            <h3 class="flex items-center gap-2 text-sm font-semibold text-green-800">
+              <i class="fa-light fa-thumbs-up text-green-500"></i>
+              Top Positive Mentions
+            </h3>
+            <p class="text-sm text-green-700">Most relevant positive mentions by relevance score</p>
+          </div>
+          <div class="flex flex-col gap-3">
+            @for (mention of data().topPositiveMentions; track $index) {
+              <div class="flex flex-col gap-2 p-3 bg-white border border-green-200 rounded-lg" data-testid="brand-health-drawer-positive-mention">
+                <ng-container *ngTemplateOutlet="mentionCardTpl; context: { $implicit: mention }"></ng-container>
+              </div>
+            }
+          </div>
+        </div>
+      }
     }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -152,8 +152,12 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <span class="text-sm font-semibold text-gray-900">No brand mention activity detected</span>
-            <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            <span class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No brand mention activity detected' }}</span>
+            @if (unavailable()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            } @else {
+              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.html
@@ -28,7 +28,7 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="brand-health-drawer-content">
-    @if (unavailable()) {
+    @if (unavailable() || pending()) {
       <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
            repeatedly missed one — stats, charts, insight blocks and per-section empty states
            each assert a measurement, so the whole body has to go, not a list of its parts. -->
@@ -40,8 +40,10 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
-            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ pending() ? loadingHeading : unavailableHeading }}</h3>
+            @if (!pending()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { lfxColors } from '@lfx-one/shared/constants';
+import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, lfxColors } from '@lfx-one/shared/constants';
 import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -82,7 +82,16 @@ export class BrandHealthDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
-  protected readonly hasNoData: Signal<boolean> = computed(() => this.data().totalMentions === 0);
+  /**
+   * True when the source request FAILED, as opposed to returning a measured zero. The
+   * parent passes the undefined-ness of its response through; the empty state then says
+   * the data could not be loaded instead of asserting there was no activity.
+   */
+  public readonly unavailable = input<boolean>(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+
+  protected readonly hasNoData: Signal<boolean> = computed(() => this.unavailable() || this.data().totalMentions === 0);
 
   protected readonly formattedSentimentMom: Signal<string> = computed(() => {
     const v = this.data().sentimentMomChangePp;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DRAWER_NO_ACTIVITY_BODY, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, lfxColors } from '@lfx-one/shared/constants';
+import { DRAWER_NO_ACTIVITY_BODY, DRAWER_LOADING_HEADING, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, lfxColors } from '@lfx-one/shared/constants';
 import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -90,6 +90,13 @@ export class BrandHealthDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly loadingHeading = DRAWER_LOADING_HEADING;
+  /**
+   * True while the parent's request is still in flight. The body is suppressed for this too —
+   * the zero-filled fallback is no more a measurement while loading than after a failure — but
+   * the copy must not claim a failure that has not happened.
+   */
+  public readonly pending = input<boolean>(false);
   protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = computed(() => this.unavailable() || this.data().totalMentions === 0);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-health-drawer/brand-health-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, lfxColors } from '@lfx-one/shared/constants';
+import { DRAWER_NO_ACTIVITY_BODY, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, lfxColors } from '@lfx-one/shared/constants';
 import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -90,6 +90,7 @@ export class BrandHealthDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = computed(() => this.unavailable() || this.data().totalMentions === 0);
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -53,7 +53,7 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Social Followers</span>
-            @if (data().totalSocialFollowers > 0) {
+            @if (!socialUnavailable() && data().totalSocialFollowers > 0) {
               <span class="text-2xl font-semibold text-gray-900">{{ data().totalSocialFollowers | number }}</span>
             } @else {
               <span class="text-2xl font-semibold text-gray-400">—</span>
@@ -73,7 +73,7 @@
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
             <span class="text-sm text-gray-500">Active Platforms</span>
-            @if (data().activePlatforms > 0) {
+            @if (!socialUnavailable() && data().activePlatforms > 0) {
               <span class="text-2xl font-semibold text-gray-900">{{ data().activePlatforms }}</span>
             } @else {
               <span class="text-2xl font-semibold text-gray-400">—</span>
@@ -163,7 +163,7 @@
           </div>
         } @else {
           <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-platforms-empty">
-            Social platform data not yet available
+            {{ socialUnavailable() ? unavailableHeading + ' — ' + unavailableBody : 'Social platform data not yet available' }}
           </div>
         }
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -28,146 +28,165 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="brand-reach-drawer-content">
-    <!-- Summary Stats -->
-    <div class="flex gap-4" data-testid="brand-reach-drawer-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Social Followers</span>
-          @if (data().totalSocialFollowers > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ data().totalSocialFollowers | number }}</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Sessions (last 30 days)</span>
-          @if (data().totalMonthlySessions > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ data().totalMonthlySessions | number }}</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Active Platforms</span>
-          @if (data().activePlatforms > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ data().activePlatforms }}</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-    </div>
-
-    <!-- FIRST FOLD: Needs Your Attention -->
-    @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
       <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-        data-testid="brand-reach-drawer-attention">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-          <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+        role="status"
+        aria-live="polite"
+        data-testid="brand-reach-drawer-unavailable">
+        <div class="flex items-start gap-4 px-4 py-4">
+          <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+          <div class="flex flex-col gap-1 flex-1 min-w-0">
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+          </div>
         </div>
-
-        @for (action of attentionActions(); track action.title) {
-          <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-            @if (action.priority === 'high') {
-              <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+      </div>
+    } @else {
+      <!-- Summary Stats -->
+      <div class="flex gap-4" data-testid="brand-reach-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Social Followers</span>
+            @if (data().totalSocialFollowers > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().totalSocialFollowers | number }}</span>
             } @else {
-              <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+              <span class="text-2xl font-semibold text-gray-400">—</span>
             }
           </div>
-        }
-
-        @for (insight of attentionInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Sessions (last 30 days)</span>
+            @if (data().totalMonthlySessions > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().totalMonthlySessions | number }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
           </div>
-        }
-      </div>
-    }
-
-    <!-- SECOND FOLD: Performing Well -->
-    @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-        data-testid="brand-reach-drawer-performing">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-check text-green-600"></i>
-          <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
-        </div>
-
-        @for (action of performingActions(); track action.title) {
-          <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Active Platforms</span>
+            @if (data().activePlatforms > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().activePlatforms }}</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
           </div>
-        }
+        </lfx-card>
+      </div>
 
-        @for (insight of performingInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="brand-reach-drawer-attention">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
           </div>
-        }
-      </div>
-    }
 
-    <!-- Social Followers by Platform -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-social-platforms">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Social Followers by Platform</h3>
-        <p class="text-sm text-gray-600">Follower count across active social channels</p>
-      </div>
-      @if (socialPlatformViews().length > 0) {
-        <div class="flex flex-col gap-0">
-          @for (platform of socialPlatformViews(); track platform.name) {
-            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-platform-row">
-              <div class="flex items-center gap-3">
-                <i [class]="platform.icon + ' ' + platform.colorClass + ' text-lg w-5 text-center'"></i>
-                <span class="text-sm font-medium text-gray-900">{{ platform.name }}</span>
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
               </div>
-              <span class="text-sm font-semibold text-gray-900">{{ platform.followers | number }}</span>
+              @if (action.priority === 'high') {
+                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+              } @else {
+                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+              }
             </div>
           }
-        </div>
-      } @else {
-        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-platforms-empty">
-          {{ unavailable() ? unavailableHeading + ' — ' + unavailableBody : 'Social platform data not yet available' }}
-        </div>
-      }
-    </div>
 
-    <!-- Website Sessions by Domain -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-website-sessions">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Website Sessions by Domain</h3>
-        <p class="text-sm text-gray-600">Sessions across foundation web properties over the last 30 days</p>
-      </div>
-      @if (data().websiteDomains.length > 0) {
-        <div class="flex flex-col gap-0">
-          @for (site of data().websiteDomains; track site.domain) {
-            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-domain-row">
-              <span class="text-sm font-medium text-gray-900">{{ site.domain }}</span>
-              <span class="text-sm font-semibold text-gray-900">{{ site.sessions | number }}</span>
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
             </div>
           }
         </div>
-      } @else {
-        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-domains-empty">
-          {{ unavailable() ? unavailableHeading + ' — ' + unavailableBody : 'Website domain data not yet available' }}
+      }
+
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="brand-reach-drawer-performing">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-check text-green-600"></i>
+            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+          </div>
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
+            </div>
+          }
         </div>
       }
-    </div>
+
+      <!-- Social Followers by Platform -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-social-platforms">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Social Followers by Platform</h3>
+          <p class="text-sm text-gray-600">Follower count across active social channels</p>
+        </div>
+        @if (socialPlatformViews().length > 0) {
+          <div class="flex flex-col gap-0">
+            @for (platform of socialPlatformViews(); track platform.name) {
+              <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-platform-row">
+                <div class="flex items-center gap-3">
+                  <i [class]="platform.icon + ' ' + platform.colorClass + ' text-lg w-5 text-center'"></i>
+                  <span class="text-sm font-medium text-gray-900">{{ platform.name }}</span>
+                </div>
+                <span class="text-sm font-semibold text-gray-900">{{ platform.followers | number }}</span>
+              </div>
+            }
+          </div>
+        } @else {
+          <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-platforms-empty">
+            Social platform data not yet available
+          </div>
+        }
+      </div>
+
+      <!-- Website Sessions by Domain -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="brand-reach-drawer-website-sessions">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Website Sessions by Domain</h3>
+          <p class="text-sm text-gray-600">Sessions across foundation web properties over the last 30 days</p>
+        </div>
+        @if (data().websiteDomains.length > 0) {
+          <div class="flex flex-col gap-0">
+            @for (site of data().websiteDomains; track site.domain) {
+              <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="brand-reach-drawer-domain-row">
+                <span class="text-sm font-medium text-gray-900">{{ site.domain }}</span>
+                <span class="text-sm font-semibold text-gray-900">{{ site.sessions | number }}</span>
+              </div>
+            }
+          </div>
+        } @else {
+          <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-domains-empty">
+            Website domain data not yet available
+          </div>
+        }
+      </div>
+    }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -28,7 +28,7 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="brand-reach-drawer-content">
-    @if (unavailable()) {
+    @if (unavailable() || pending()) {
       <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
            repeatedly missed one — stats, charts, insight blocks and per-section empty states
            each assert a measurement, so the whole body has to go, not a list of its parts. -->
@@ -40,8 +40,10 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
-            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ pending() ? loadingHeading : unavailableHeading }}</h3>
+            @if (!pending()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.html
@@ -143,7 +143,7 @@
         </div>
       } @else {
         <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-platforms-empty">
-          Social platform data not yet available
+          {{ unavailable() ? unavailableHeading + ' — ' + unavailableBody : 'Social platform data not yet available' }}
         </div>
       }
     </div>
@@ -165,7 +165,7 @@
         </div>
       } @else {
         <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="brand-reach-drawer-domains-empty">
-          Website domain data not yet available
+          {{ unavailable() ? unavailableHeading + ' — ' + unavailableBody : 'Website domain data not yet available' }}
         </div>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -6,7 +6,7 @@ import { ChangeDetectionStrategy, Component, computed, input, model, Signal } fr
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { MARKETING_SOCIAL_PLATFORM_MAP } from '@lfx-one/shared/constants';
+import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, MARKETING_SOCIAL_PLATFORM_MAP } from '@lfx-one/shared/constants';
 import { formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -23,6 +23,16 @@ export class BrandReachDrawerComponent {
   public readonly visible = model<boolean>(false);
 
   // === Inputs ===
+  /**
+   * True when the source request FAILED rather than returning a measured zero. This drawer's
+   * stats already degrade to em dashes, so only the collection empty-states change: they say
+   * the data could not be loaded instead of "not yet available", which is a claim about the
+   * data rather than about the request.
+   */
+  public readonly unavailable = input<boolean>(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+
   public readonly data = input<BrandReachResponse>({
     totalSocialFollowers: 0,
     totalMonthlySessions: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -6,7 +6,7 @@ import { ChangeDetectionStrategy, Component, computed, input, model, Signal } fr
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, MARKETING_SOCIAL_PLATFORM_MAP } from '@lfx-one/shared/constants';
+import { DRAWER_LOADING_HEADING, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, MARKETING_SOCIAL_PLATFORM_MAP } from '@lfx-one/shared/constants';
 import { formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -32,6 +32,13 @@ export class BrandReachDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly loadingHeading = DRAWER_LOADING_HEADING;
+  /**
+   * True while the parent's request is still in flight. The body is suppressed for this too —
+   * the zero-filled fallback is no more a measurement while loading than after a failure — but
+   * the copy must not claim a failure that has not happened.
+   */
+  public readonly pending = input<boolean>(false);
 
   public readonly data = input<BrandReachResponse>({
     totalSocialFollowers: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/brand-reach-drawer/brand-reach-drawer.component.ts
@@ -30,6 +30,13 @@ export class BrandReachDrawerComponent {
    * data rather than about the request.
    */
   public readonly unavailable = input<boolean>(false);
+  /**
+   * True when only the SOCIAL half of the response failed. getBrandReach keeps serving web data
+   * in that case, so the whole drawer must not be blanked — the sessions and domains below were
+   * measured. Only the social stats and the platform list are suppressed, matching how the
+   * Social card and Web card diverge on the same response.
+   */
+  public readonly socialUnavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
   protected readonly loadingHeading = DRAWER_LOADING_HEADING;

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -16,6 +16,7 @@ import { describe, expect, it, vi } from 'vitest';
 import { BrandHealthDrawerComponent } from './brand-health-drawer/brand-health-drawer.component';
 import { EmailCtrDrawerComponent } from './email-ctr-drawer/email-ctr-drawer.component';
 import { EngagedCommunityDrawerComponent } from './engaged-community-drawer/engaged-community-drawer.component';
+import { WebsiteVisitsDrawerComponent } from './website-visits-drawer/website-visits-drawer.component';
 import { FlywheelConversionDrawerComponent } from './flywheel-conversion-drawer/flywheel-conversion-drawer.component';
 import { MemberAcquisitionDrawerComponent } from './member-acquisition-drawer/member-acquisition-drawer.component';
 import { MemberRetentionDrawerComponent } from './member-retention-drawer/member-retention-drawer.component';
@@ -345,10 +346,11 @@ describe('ED drill-down drawers — a failed request must not read as no activit
     TestBed.resetTestingModule();
   });
 
-  // The Email drawer is the only one that fetches its own data, so its failure arrives
-  // through catchError rather than a parent input — a distinct path that the cases above
-  // cannot reach. Its catchError resolves to a zero-filled default, which is exactly what
-  // used to render "No email activity detected" for a failed request.
+  // Email and Website fetch their own data, so their failures arrive through catchError
+  // rather than a parent input — a distinct path the parent-fed cases cannot reach. Both
+  // resolve to a zero-filled default, which is what used to render a measured-absence
+  // finding for a failed request. Do not describe either as "the only one": that claim was
+  // in this comment and is what let the Website drawer ship unfixed.
   it('Email: says the data could not be loaded when its own request fails', async () => {
     await TestBed.configureTestingModule({
       imports: [EmailCtrDrawerComponent],
@@ -426,6 +428,36 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       TestBed.resetTestingModule();
     });
   }
+
+  // Website is the second self-fetching drawer. It was missed on the first pass because the
+  // Email comment above called Email "the only one" — an enumerating claim that was wrong when
+  // written. Same mechanism: catchError resolves to a zero-filled default, which rendered
+  // "No website traffic detected" for a failed request.
+  it('Website: says the data could not be loaded when its own request fails', async () => {
+    await TestBed.configureTestingModule({
+      imports: [WebsiteVisitsDrawerComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: AnalyticsService, useValue: { getWebActivitiesSummary: () => throwError(() => new Error('boom')) } },
+        { provide: ProjectContextService, useValue: { selectedFoundation: signal<ProjectContext | null>({ uid: 'f-1', name: 'TLF', slug: 'tlf' }) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(WebsiteVisitsDrawerComponent);
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = document.body.textContent ?? '';
+    expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
+    expect(text).not.toContain('No website traffic detected');
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
 
   for (const { name, component, inputs, measuredCopy } of drawers) {
     it(`${name}: says the data could not be loaded when the request failed`, async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -43,7 +43,7 @@ describe('ED drill-down drawers — a failed request must not read as no activit
     // A NON-zero shape for the same drawer, plus a figure that must not survive on screen.
     // Zero-filled fixtures alone cannot tell a suppressed body from one rendering zeros —
     // that blind spot let two drawers ship their stats above the "unavailable" banner.
-    nonZero?: { inputs: Record<string, unknown>; staleFigure: string };
+    nonZero?: { inputs: Record<string, unknown>; staleFigures: string[] };
   }[] = [
     {
       name: 'Sentiment',
@@ -150,7 +150,9 @@ describe('ED drill-down drawers — a failed request must not read as no activit
         // cannot produce.
       },
       nonZero: {
-        staleFigure: '1,234',
+        // Every live figure in the drawer, not just the headline: the first fix guarded the
+        // stat block alone and left retention stats, insight blocks and charts rendering.
+        staleFigures: ['1,234', '92.5', '104.2'],
         inputs: {
           data: {
             totalMembers: 1234,
@@ -174,6 +176,11 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       },
     },
     {
+      // NOT RENDERED ANYWHERE TODAY. MemberRetentionDrawerComponent is referenced by no
+      // template — retention reaches the user through member-acquisition-drawer's
+      // `retentionData` input instead. These two cases therefore do not cover the live
+      // retention path; they keep the orphaned component consistent with its five siblings
+      // so it does not ship the old defect if it is ever wired up.
       name: 'Retention',
       component: MemberRetentionDrawerComponent,
       measuredCopy: 'No retention activity detected',
@@ -181,7 +188,7 @@ describe('ED drill-down drawers — a failed request must not read as no activit
         data: { renewalRate: 0, netRevenueRetention: 0, changePercentage: 0, trend: 'up', target: 0, monthlyData: [] },
       },
       nonZero: {
-        staleFigure: '92.5',
+        staleFigures: ['92.5', '104.2'],
         inputs: {
           data: {
             renewalRate: 92.5,
@@ -301,7 +308,9 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       const text = document.body.textContent ?? '';
 
       expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
-      expect(text).not.toContain(nonZero!.staleFigure);
+      for (const figure of nonZero!.staleFigures) {
+        expect(text).not.toContain(figure);
+      }
 
       fixture.destroy();
       TestBed.resetTestingModule();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -1,0 +1,284 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { signal, Type } from '@angular/core';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
+import { ProjectContext } from '@lfx-one/shared/interfaces';
+import { AnalyticsService } from '@services/analytics.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { throwError } from 'rxjs';
+import { describe, expect, it, vi } from 'vitest';
+
+import { BrandHealthDrawerComponent } from './brand-health-drawer/brand-health-drawer.component';
+import { EmailCtrDrawerComponent } from './email-ctr-drawer/email-ctr-drawer.component';
+import { EngagedCommunityDrawerComponent } from './engaged-community-drawer/engaged-community-drawer.component';
+import { FlywheelConversionDrawerComponent } from './flywheel-conversion-drawer/flywheel-conversion-drawer.component';
+import { MemberAcquisitionDrawerComponent } from './member-acquisition-drawer/member-acquisition-drawer.component';
+import { MemberRetentionDrawerComponent } from './member-retention-drawer/member-retention-drawer.component';
+
+/**
+ * The card layer renders "—  Data unavailable" when a request fails, but each drawer keeps
+ * its own empty state — and that copy asserted a FINDING ("No brand mention activity
+ * detected") plus advice derived from it ("Engage with marketing ops…"). On a failed
+ * request the card and the drawer behind it therefore contradicted each other, and the
+ * drawer was the one stating a measurement that was never taken.
+ *
+ * These drawers take a zero-filled shape when their response is undefined (their inputs
+ * are non-optional), so the zero-filled data alone cannot distinguish the two cases — the
+ * `unavailable` input is what carries it.
+ */
+describe('ED drill-down drawers — a failed request must not read as no activity', () => {
+  // Each drawer's own zero-filled empty shape, i.e. exactly what the parent passes when
+  // the response is undefined. The assertions below turn ONLY `unavailable` on and off,
+  // so any difference in output is attributable to that input alone.
+  const drawers: { name: string; component: Type<unknown>; inputs: Record<string, unknown>; measuredCopy: string }[] = [
+    {
+      name: 'Sentiment',
+      component: BrandHealthDrawerComponent,
+      measuredCopy: 'No brand mention activity detected',
+      inputs: {
+        data: {
+          totalMentions: 0,
+          sentiment: { positive: 0, neutral: 0, negative: 0 },
+          sentimentMomChangePp: 0,
+          mentionMomChangePct: null,
+          trend: 'up',
+          monthlyMentions: [],
+          topProjects: [],
+          topPositiveMentions: [],
+          topNegativeMentions: [],
+        },
+      },
+    },
+    {
+      name: 'Adoption',
+      component: EngagedCommunityDrawerComponent,
+      measuredCopy: 'No community engagement activity detected',
+      inputs: {
+        data: {
+          totalMembers: 0,
+          changePercentage: 0,
+          trend: 'up',
+          breakdown: {
+            newsletterSubscribers: 0,
+            communityMembers: 0,
+            workingGroupMembers: 0,
+            certifiedIndividuals: 0,
+            webVisitors: 0,
+            codeContributors: 0,
+            trainingEnrollees: 0,
+          },
+          monthlyData: [],
+        },
+        brandReachData: {
+          totalSocialFollowers: 0,
+          totalMonthlySessions: 0,
+          activePlatforms: 0,
+          changePercentage: 0,
+          sessionMomChangePct: 0,
+          trend: 'up',
+          socialPlatforms: [],
+          websiteDomains: [],
+          weeklyTrend: [],
+        },
+      },
+    },
+    {
+      name: 'Flywheel',
+      component: FlywheelConversionDrawerComponent,
+      measuredCopy: 'No flywheel conversion activity detected',
+      inputs: {
+        data: {
+          conversionRate: 0,
+          changePercentage: 0,
+          trend: 'up',
+          funnel: {
+            eventAttendees: 0,
+            convertedToNewsletter: 0,
+            convertedToCommunity: 0,
+            convertedToWorkingGroup: 0,
+            convertedToTraining: 0,
+            convertedToCode: 0,
+            convertedToWeb: 0,
+          },
+          reengagement: {
+            totalReengaged: 0,
+            reengagementRate: 0,
+            reengagementMomChange: 0,
+            reengagedToNewsletter: 0,
+            reengagedToCommunity: 0,
+            reengagedToWorkingGroup: 0,
+            reengagedToTraining: 0,
+            reengagedToCode: 0,
+            reengagedToWeb: 0,
+          },
+          monthlyData: [],
+        },
+      },
+    },
+    {
+      name: 'Members',
+      component: MemberAcquisitionDrawerComponent,
+      measuredCopy: 'No membership activity detected',
+      inputs: {
+        data: {
+          totalMembers: 0,
+          totalMembersMonthlyData: [],
+          totalMembersMonthlyLabels: [],
+          newMembersThisQuarter: 0,
+          newMemberRevenue: 0,
+          changePercentage: 0,
+          trend: 'up',
+          quarterlyData: [],
+        },
+        retentionData: { renewalRate: 0, netRevenueRetention: 0, changePercentage: 0, trend: 'up', target: 0, monthlyData: [] },
+        // revenueImpactData is intentionally omitted: it is a non-optional input with its
+        // own zero-filled default, and passing undefined would exercise a state the parent
+        // cannot produce.
+      },
+    },
+    {
+      name: 'Retention',
+      component: MemberRetentionDrawerComponent,
+      measuredCopy: 'No retention activity detected',
+      inputs: {
+        data: { renewalRate: 0, netRevenueRetention: 0, changePercentage: 0, trend: 'up', target: 0, monthlyData: [] },
+      },
+    },
+  ];
+
+  async function render(component: Type<unknown>, inputs: Record<string, unknown>, unavailable: boolean): Promise<ComponentFixture<unknown>> {
+    await TestBed.configureTestingModule({
+      imports: [component],
+      providers: [provideNoopAnimations(), provideRouter([])],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(component);
+    for (const [key, value] of Object.entries({ ...inputs, visible: true, unavailable })) {
+      fixture.componentRef.setInput(key, value);
+    }
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  // The zero-filled fixtures above already make hasNoData() true, so they cannot tell
+  // whether `unavailable` reaches that guard at all — deleting it leaves them green. This
+  // case supplies NON-zero data alongside unavailable: true, which is what the drawer holds
+  // when a request fails while it is still showing the previously-loaded foundation. Only
+  // the guard turns the empty state on here.
+  it('Adoption: reports unavailable even while holding a previous foundation’s non-zero data', async () => {
+    const fixture = await render(
+      EngagedCommunityDrawerComponent,
+      {
+        data: {
+          totalMembers: 27831,
+          changePercentage: 12,
+          trend: 'up',
+          breakdown: {
+            newsletterSubscribers: 10000,
+            communityMembers: 8000,
+            workingGroupMembers: 1000,
+            certifiedIndividuals: 500,
+            webVisitors: 7000,
+            codeContributors: 1000,
+            trainingEnrollees: 331,
+          },
+          monthlyData: [{ label: 'Jan', value: 27831 }],
+        },
+        brandReachData: {
+          totalSocialFollowers: 0,
+          totalMonthlySessions: 0,
+          activePlatforms: 0,
+          changePercentage: 0,
+          sessionMomChangePct: 0,
+          trend: 'up',
+          socialPlatforms: [],
+          websiteDomains: [],
+          weeklyTrend: [],
+        },
+      },
+      true
+    );
+    const text = document.body.textContent ?? '';
+
+    expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
+    // The stale figure must not still be on screen presented as current.
+    expect(text).not.toContain('27,831');
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  // The Email drawer is the only one that fetches its own data, so its failure arrives
+  // through catchError rather than a parent input — a distinct path that the cases above
+  // cannot reach. Its catchError resolves to a zero-filled default, which is exactly what
+  // used to render "No email activity detected" for a failed request.
+  it('Email: says the data could not be loaded when its own request fails', async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmailCtrDrawerComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: AnalyticsService, useValue: { getEmailCtr: () => throwError(() => new Error('boom')) } },
+        { provide: ProjectContextService, useValue: { selectedFoundation: signal<ProjectContext | null>({ uid: 'f-1', name: 'TLF', slug: 'tlf' }) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(EmailCtrDrawerComponent);
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = document.body.textContent ?? '';
+    expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
+    expect(text).not.toContain('No email activity detected');
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  for (const { name, component, inputs, measuredCopy } of drawers) {
+    it(`${name}: says the data could not be loaded when the request failed`, async () => {
+      const fixture = await render(component, inputs, true);
+      // PrimeNG renders the drawer body into an overlay appended to the document, not
+      // inside the component's own host element — so read the document.
+      const text = document.body.textContent ?? '';
+
+      expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
+      expect(text).toContain(DRAWER_UNAVAILABLE_BODY);
+      // The regression: an outage stated as a measured absence, plus advice derived from it.
+      expect(text).not.toContain(measuredCopy);
+      expect(text).not.toContain('Engage with marketing ops');
+
+      // Destroy before reset: the overlay lives on document.body, and a leaked one would
+      // let the next case read the previous drawer's text.
+      fixture.destroy();
+      TestBed.resetTestingModule();
+    });
+
+    // The other half of the contract. Identical zero-filled data — only `unavailable`
+    // differs — so a guard that over-triggers would hide a genuine measurement.
+    it(`${name}: still reports a genuine zero as a measured absence`, async () => {
+      const fixture = await render(component, inputs, false);
+      // PrimeNG renders the drawer body into an overlay appended to the document, not
+      // inside the component's own host element — so read the document.
+      const text = document.body.textContent ?? '';
+
+      expect(text).toContain(measuredCopy);
+      expect(text).not.toContain(DRAWER_UNAVAILABLE_HEADING);
+
+      // Destroy before reset: the overlay lives on document.body, and a leaked one would
+      // let the next case read the previous drawer's text.
+      fixture.destroy();
+      TestBed.resetTestingModule();
+    });
+  }
+});

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -10,7 +10,7 @@ import { ProjectContext } from '@lfx-one/shared/interfaces';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
-import { throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BrandHealthDrawerComponent } from './brand-health-drawer/brand-health-drawer.component';
@@ -378,6 +378,110 @@ describe('ED drill-down drawers — a failed request must not read as no activit
     TestBed.resetTestingModule();
   });
 
+  /**
+   * The PARTIAL-failure path, which no other case on this PR reaches. `getEmailCtr` runs the
+   * per-send breakdown as an OPTIONAL query that `.catch()`es to `rows: []` and still returns
+   * HTTP 200 — so the drawer-level `unavailable` flag never flips, and the five headline tiles,
+   * which all reduce() over `emailTypeBreakdown`, sum an empty array to a confident 0.
+   *
+   * That is the reported production symptom ("0 opens · 0.0% CTR") reproduced one layer down,
+   * on a path where the response was a success. The two tests below are the two sides of the
+   * contract: a FAILED breakdown must not render as a number, and a GENUINELY empty one must
+   * still render as the measurement it is. A single-sided test would pass just as well against
+   * a drawer that blanked these tiles unconditionally.
+   */
+  const emailBase = {
+    currentCtr: 2.5,
+    changePercentage: 0,
+    momChangePercentage: null,
+    trend: 'up' as const,
+    monthlyData: [2.5],
+    monthlyLabels: ['Jan'],
+    campaignGroups: [],
+    monthlySends: [1000],
+    monthlyOpens: [250],
+  };
+
+  async function renderEmail(response: Record<string, unknown>): Promise<ComponentFixture<EmailCtrDrawerComponent>> {
+    await TestBed.configureTestingModule({
+      imports: [EmailCtrDrawerComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        { provide: AnalyticsService, useValue: { getEmailCtr: () => of(response) } },
+        { provide: ProjectContextService, useValue: { selectedFoundation: signal<ProjectContext | null>({ uid: 'f-1', name: 'TLF', slug: 'tlf' }) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(EmailCtrDrawerComponent);
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+    return fixture;
+  }
+
+  it('Email: a failed OPTIONAL breakdown suppresses the tiles instead of summing [] to zero', async () => {
+    // Exactly what the BFF returns when only the breakdown query throws: a 200, a measured
+    // primary CTR, an empty breakdown, and the flag that says the emptiness is not a finding.
+    const fixture = await renderEmail({ ...emailBase, emailTypeBreakdown: [], breakdownUnavailable: true });
+    const text = document.body.textContent ?? '';
+
+    // The fabricated measurements themselves. '0.0%' is the load-bearing assertion: it is what
+    // the Open Rate and CTR tiles printed for a query that never ran.
+    expect(text).not.toContain('0.0%');
+    expect(text).toContain('—');
+    // The section must state the outage rather than vanish — an absent table reads as
+    // "no campaigns", which is the same false finding told by omission.
+    expect(document.body.querySelector('[data-testid="email-ctr-drawer-breakdown-unavailable"]')).not.toBeNull();
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  it('Email: a genuinely empty breakdown still renders zeros as the measurement they are', async () => {
+    // Same empty array, no failure. The zeros here were measured, so suppressing them would
+    // trade the fabricated-zero defect for a fabricated-outage one.
+    const fixture = await renderEmail({ ...emailBase, emailTypeBreakdown: [], breakdownUnavailable: false });
+    const text = document.body.textContent ?? '';
+
+    expect(text).toContain('0.0%');
+    expect(document.body.querySelector('[data-testid="email-ctr-drawer-breakdown-unavailable"]')).toBeNull();
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  it('Email: a measured breakdown is unaffected by the partial-failure guard', async () => {
+    const fixture = await renderEmail({
+      ...emailBase,
+      breakdownUnavailable: false,
+      emailTypeBreakdown: [
+        {
+          emailType: 'newsletter',
+          campaignCount: 2,
+          totalSends: 12345,
+          totalOpens: 4000,
+          totalClicks: 500,
+          openRate: 32.4,
+          ctr: 4.1,
+          performance: 'EXCELLENT',
+          campaigns: [],
+        },
+      ],
+    });
+    const text = document.body.textContent ?? '';
+
+    // formatNumber compacts, so assert the RENDERED form — a raw '12,345' assertion could
+    // never fail regardless of the guard, the vacuous-assertion trap from an earlier round.
+    expect(text).toContain('12.3K');
+    expect(document.body.querySelector('[data-testid="email-ctr-drawer-breakdown-unavailable"]')).toBeNull();
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
   // The case the zero-filled fixtures structurally cannot make: real figures in the drawer
   // while `unavailable` is true. Two drawers rendered their summary stats ABOVE the
   // "Data unavailable" banner — "0.0% retention" and "0 members" in 2xl type beside copy
@@ -500,6 +604,54 @@ describe('ED drill-down drawers — a failed request must not read as no activit
     expect(text).not.toContain('17,269');
     // The web half WAS measured and must survive.
     expect(text).toContain('3,482');
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  // The Email drawer's optional campaign-breakdown query .catch()es to rows: [] and the
+  // response still returns 200, so the four tiles reduce() an empty array into a confident 0.
+  // Same defect class as the social-only split: a partial failure wearing a success.
+  it('Email: shows an em dash, not a summed zero, when only the breakdown query failed', async () => {
+    await TestBed.configureTestingModule({
+      imports: [EmailCtrDrawerComponent],
+      providers: [
+        provideNoopAnimations(),
+        provideRouter([]),
+        {
+          provide: AnalyticsService,
+          useValue: {
+            getEmailCtr: () =>
+              of({
+                breakdownUnavailable: true,
+                currentCtr: 4.2,
+                changePercentage: 0,
+                momChangePercentage: null,
+                trend: 'up',
+                monthlyData: [1],
+                monthlyLabels: ['Jan'],
+                campaignGroups: [],
+                monthlySends: [100],
+                monthlyOpens: [40],
+                emailTypeBreakdown: [],
+              }),
+          },
+        },
+        { provide: ProjectContextService, useValue: { selectedFoundation: signal<ProjectContext | null>({ uid: 'f-1', name: 'TLF', slug: 'tlf' }) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(EmailCtrDrawerComponent);
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = document.body.textContent ?? '';
+    // A summed-to-zero tile is the regression; the em dash is the honest rendering.
+    expect(text).not.toContain('0.0%');
+    expect(text).toContain('—');
 
     fixture.destroy();
     TestBed.resetTestingModule();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -35,7 +35,16 @@ describe('ED drill-down drawers — a failed request must not read as no activit
   // Each drawer's own zero-filled empty shape, i.e. exactly what the parent passes when
   // the response is undefined. The assertions below turn ONLY `unavailable` on and off,
   // so any difference in output is attributable to that input alone.
-  const drawers: { name: string; component: Type<unknown>; inputs: Record<string, unknown>; measuredCopy: string }[] = [
+  const drawers: {
+    name: string;
+    component: Type<unknown>;
+    inputs: Record<string, unknown>;
+    measuredCopy: string;
+    // A NON-zero shape for the same drawer, plus a figure that must not survive on screen.
+    // Zero-filled fixtures alone cannot tell a suppressed body from one rendering zeros —
+    // that blind spot let two drawers ship their stats above the "unavailable" banner.
+    nonZero?: { inputs: Record<string, unknown>; staleFigure: string };
+  }[] = [
     {
       name: 'Sentiment',
       component: BrandHealthDrawerComponent,
@@ -140,6 +149,29 @@ describe('ED drill-down drawers — a failed request must not read as no activit
         // own zero-filled default, and passing undefined would exercise a state the parent
         // cannot produce.
       },
+      nonZero: {
+        staleFigure: '1,234',
+        inputs: {
+          data: {
+            totalMembers: 1234,
+            totalMembersMonthlyData: [1234],
+            totalMembersMonthlyLabels: ['Jan'],
+            newMembersThisQuarter: 12,
+            newMemberRevenue: 500000,
+            changePercentage: 8,
+            trend: 'up',
+            quarterlyData: [{ quarter: 'Q1', newMembers: 12, revenue: 500000 }],
+          },
+          retentionData: {
+            renewalRate: 92.5,
+            netRevenueRetention: 104.2,
+            changePercentage: 3,
+            trend: 'up',
+            target: 90,
+            monthlyData: [{ label: 'Jan', value: 92.5 }],
+          },
+        },
+      },
     },
     {
       name: 'Retention',
@@ -147,6 +179,19 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       measuredCopy: 'No retention activity detected',
       inputs: {
         data: { renewalRate: 0, netRevenueRetention: 0, changePercentage: 0, trend: 'up', target: 0, monthlyData: [] },
+      },
+      nonZero: {
+        staleFigure: '92.5',
+        inputs: {
+          data: {
+            renewalRate: 92.5,
+            netRevenueRetention: 104.2,
+            changePercentage: 3,
+            trend: 'up',
+            target: 90,
+            monthlyData: [{ label: 'Jan', value: 92.5 }],
+          },
+        },
       },
     },
   ];
@@ -244,6 +289,24 @@ describe('ED drill-down drawers — a failed request must not read as no activit
     fixture.destroy();
     TestBed.resetTestingModule();
   });
+
+  // The case the zero-filled fixtures structurally cannot make: real figures in the drawer
+  // while `unavailable` is true. Two drawers rendered their summary stats ABOVE the
+  // "Data unavailable" banner — "0.0% retention" and "0 members" in 2xl type beside copy
+  // saying the data could not be loaded — and every zero-filled assertion still passed,
+  // because a suppressed body and a body full of zeros contain no distinguishing text.
+  for (const { name, component, nonZero } of drawers.filter((d) => d.nonZero)) {
+    it(`${name}: suppresses the stat body, not just the caption, when the request failed`, async () => {
+      const fixture = await render(component, nonZero!.inputs, true);
+      const text = document.body.textContent ?? '';
+
+      expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
+      expect(text).not.toContain(nonZero!.staleFigure);
+
+      fixture.destroy();
+      TestBed.resetTestingModule();
+    });
+  }
 
   for (const { name, component, inputs, measuredCopy } of drawers) {
     it(`${name}: says the data could not be loaded when the request failed`, async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -49,6 +49,22 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       name: 'Sentiment',
       component: BrandHealthDrawerComponent,
       measuredCopy: 'No brand mention activity detected',
+      nonZero: {
+        staleFigures: ['80.8K', 'Mentions Trend'],
+        inputs: {
+          data: {
+            totalMentions: 80799,
+            sentiment: { positive: 60, neutral: 30, negative: 10 },
+            sentimentMomChangePp: 2.5,
+            mentionMomChangePct: 12,
+            trend: 'up',
+            monthlyMentions: [{ label: 'Jan', value: 80799 }],
+            topProjects: [{ name: 'pytorch', mentions: 500 }],
+            topPositiveMentions: [],
+            topNegativeMentions: [],
+          },
+        },
+      },
       inputs: {
         data: {
           totalMentions: 0,
@@ -67,6 +83,37 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       name: 'Adoption',
       component: EngagedCommunityDrawerComponent,
       measuredCopy: 'No community engagement activity detected',
+      nonZero: {
+        staleFigures: ['27.8K', '12.5'],
+        inputs: {
+          data: {
+            totalMembers: 27831,
+            changePercentage: 12.5,
+            trend: 'up',
+            breakdown: {
+              newsletterSubscribers: 10000,
+              communityMembers: 8000,
+              workingGroupMembers: 1000,
+              certifiedIndividuals: 500,
+              webVisitors: 7000,
+              codeContributors: 1000,
+              trainingEnrollees: 331,
+            },
+            monthlyData: [{ label: 'Jan', value: 27831 }],
+          },
+          brandReachData: {
+            totalSocialFollowers: 0,
+            totalMonthlySessions: 0,
+            activePlatforms: 0,
+            changePercentage: 0,
+            sessionMomChangePct: 0,
+            trend: 'up',
+            socialPlatforms: [],
+            websiteDomains: [],
+            weeklyTrend: [],
+          },
+        },
+      },
       inputs: {
         data: {
           totalMembers: 0,
@@ -100,6 +147,37 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       name: 'Flywheel',
       component: FlywheelConversionDrawerComponent,
       measuredCopy: 'No flywheel conversion activity detected',
+      nonZero: {
+        staleFigures: ['43.7', '61.2'],
+        inputs: {
+          data: {
+            conversionRate: 43.7,
+            changePercentage: 5,
+            trend: 'up',
+            funnel: {
+              eventAttendees: 1000,
+              convertedToNewsletter: 400,
+              convertedToCommunity: 300,
+              convertedToWorkingGroup: 100,
+              convertedToTraining: 80,
+              convertedToCode: 70,
+              convertedToWeb: 50,
+            },
+            reengagement: {
+              totalReengaged: 612,
+              reengagementRate: 61.2,
+              reengagementMomChange: 3,
+              reengagedToNewsletter: 200,
+              reengagedToCommunity: 150,
+              reengagedToWorkingGroup: 100,
+              reengagedToTraining: 62,
+              reengagedToCode: 50,
+              reengagedToWeb: 50,
+            },
+            monthlyData: [{ label: 'Jan', value: 43.7 }],
+          },
+        },
+      },
       inputs: {
         data: {
           conversionRate: 0,
@@ -152,7 +230,7 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       nonZero: {
         // Every live figure in the drawer, not just the headline: the first fix guarded the
         // stat block alone and left retention stats, insight blocks and charts rendering.
-        staleFigures: ['1,234', '92.5', '104.2'],
+        staleFigures: ['1.2K', '92.5', '104.2'],
         inputs: {
           data: {
             totalMembers: 1234,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -50,7 +50,7 @@ describe('ED drill-down drawers — a failed request must not read as no activit
       component: BrandHealthDrawerComponent,
       measuredCopy: 'No brand mention activity detected',
       nonZero: {
-        staleFigures: ['80.8K', 'Mentions Trend'],
+        staleFigures: ['80,799', 'Mentions Trend'],
         inputs: {
           data: {
             totalMentions: 80799,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -395,6 +395,38 @@ describe('ED drill-down drawers — a failed request must not read as no activit
     });
   }
 
+  // Pending is NOT failed. PENDING_ED_EVOLUTION_DATA spreads the error fallback, so every
+  // field is undefined while the request is still in flight — a drawer deriving failure from
+  // `!field` alone announces "Data unavailable" before anything has failed. The body stays
+  // suppressed either way (a zero-filled fallback is not a measurement while loading either),
+  // but only one of the two states may claim a failure.
+  for (const { name, component, inputs } of drawers.filter((d) => d.nonZero)) {
+    it(`${name}: says loading, not failed, while the request is still in flight`, async () => {
+      await TestBed.configureTestingModule({
+        imports: [component],
+        providers: [provideNoopAnimations(), provideRouter([])],
+      }).compileComponents();
+
+      const fixture = TestBed.createComponent(component);
+      for (const [key, value] of Object.entries({ ...inputs, visible: true, unavailable: false, pending: true })) {
+        fixture.componentRef.setInput(key, value);
+      }
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      const text = document.body.textContent ?? '';
+      expect(text).toContain('Loading');
+      expect(text).not.toContain(DRAWER_UNAVAILABLE_HEADING);
+      expect(text).not.toContain(DRAWER_UNAVAILABLE_BODY);
+      // The measured-absence copy must not appear either — nothing has been measured yet.
+      expect(text).not.toContain('Engage with marketing ops');
+
+      fixture.destroy();
+      TestBed.resetTestingModule();
+    });
+  }
+
   for (const { name, component, inputs, measuredCopy } of drawers) {
     it(`${name}: says the data could not be loaded when the request failed`, async () => {
       const fixture = await render(component, inputs, true);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/drawer-unavailable.spec.ts
@@ -14,6 +14,7 @@ import { throwError } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
 
 import { BrandHealthDrawerComponent } from './brand-health-drawer/brand-health-drawer.component';
+import { BrandReachDrawerComponent } from './brand-reach-drawer/brand-reach-drawer.component';
 import { EmailCtrDrawerComponent } from './email-ctr-drawer/email-ctr-drawer.component';
 import { EngagedCommunityDrawerComponent } from './engaged-community-drawer/engaged-community-drawer.component';
 import { WebsiteVisitsDrawerComponent } from './website-visits-drawer/website-visits-drawer.component';
@@ -454,6 +455,51 @@ describe('ED drill-down drawers — a failed request must not read as no activit
     const text = document.body.textContent ?? '';
     expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
     expect(text).not.toContain('No website traffic detected');
+
+    fixture.destroy();
+    TestBed.resetTestingModule();
+  });
+
+  // A social-only failure leaves the response PRESENT, so `unavailable` is false and the drawer
+  // stays open — correctly, because its web half was measured. Only the social parts may be
+  // suppressed. Blanking the whole drawer here would repeat the mistake the card layer avoids.
+  it('Social: suppresses only the social half when just the social query failed', async () => {
+    await TestBed.configureTestingModule({
+      imports: [BrandReachDrawerComponent],
+      providers: [provideNoopAnimations(), provideRouter([])],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(BrandReachDrawerComponent);
+    fixture.componentRef.setInput('visible', true);
+    fixture.componentRef.setInput('unavailable', false);
+    fixture.componentRef.setInput('socialUnavailable', true);
+    fixture.componentRef.setInput('data', {
+      socialUnavailable: true,
+      // Non-zero on purpose: a guard that renders these when socialUnavailable is true would
+      // put a fabricated 17,269 on screen, and a zero fixture could not tell that apart from a
+      // correctly suppressed tile.
+      totalSocialFollowers: 17269,
+      totalMonthlySessions: 3482,
+      activePlatforms: 2,
+      changePercentage: 0,
+      sessionMomChangePct: 4,
+      trend: 'up',
+      socialPlatforms: [],
+      websiteDomains: [{ domain: 'docs.example.org', sessions: 3482 }],
+      weeklyTrend: [],
+    });
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    const text = document.body.textContent ?? '';
+    // The social half must not assert a measured absence.
+    expect(text).not.toContain('Social platform data not yet available');
+    expect(text).toContain(DRAWER_UNAVAILABLE_HEADING);
+    // Nor may it render the numbers the failed query left behind.
+    expect(text).not.toContain('17,269');
+    // The web half WAS measured and must survive.
+    expect(text).toContain('3,482');
 
     fixture.destroy();
     TestBed.resetTestingModule();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -107,8 +107,12 @@
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <h3 class="text-sm font-semibold text-gray-900">No email activity detected</h3>
+              <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No email activity detected' }}</h3>
+              @if (unavailable()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            } @else {
               <p class="text-sm text-gray-500">Engage with marketing ops to start sending campaigns and tracking results.</p>
+            }
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -109,10 +109,10 @@
             <div class="flex flex-col gap-1 flex-1 min-w-0">
               <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No email activity detected' }}</h3>
               @if (unavailable()) {
-              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
-            } @else {
-              <p class="text-sm text-gray-500">Engage with marketing ops to start sending campaigns and tracking results.</p>
-            }
+                <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+              } @else {
+                <p class="text-sm text-gray-500">Engage with marketing ops to start sending campaigns and tracking results.</p>
+              }
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -28,213 +28,230 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="email-ctr-drawer-content">
-    @if (drawerLoading()) {
-      <div class="flex flex-col gap-4">
-        <div class="flex gap-4">
-          <p-skeleton width="100%" height="4rem" />
-          <p-skeleton width="100%" height="4rem" />
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
+      <div
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+        role="status"
+        aria-live="polite"
+        data-testid="email-ctr-drawer-unavailable">
+        <div class="flex items-start gap-4 px-4 py-4">
+          <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+          <div class="flex flex-col gap-1 flex-1 min-w-0">
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+          </div>
         </div>
-        <p-skeleton width="100%" height="12rem" />
-        <p-skeleton width="100%" height="12rem" />
-        <p-skeleton width="60%" height="1rem" />
       </div>
     } @else {
-      <!-- Cross-Channel Insights -->
-      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-          data-testid="email-ctr-drawer-attention">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+      @if (drawerLoading()) {
+        <div class="flex flex-col gap-4">
+          <div class="flex gap-4">
+            <p-skeleton width="100%" height="4rem" />
+            <p-skeleton width="100%" height="4rem" />
           </div>
-
-          @for (action of attentionActions(); track action.title) {
-            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
-              </div>
-              @if (action.priority === 'high') {
-                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-              } @else {
-                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
-              }
-            </div>
-          }
-
-          @for (insight of attentionInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
+          <p-skeleton width="100%" height="12rem" />
+          <p-skeleton width="100%" height="12rem" />
+          <p-skeleton width="60%" height="1rem" />
         </div>
-      }
-
-      @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-          data-testid="email-ctr-drawer-performing">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-check text-green-600"></i>
-            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
-          </div>
-
-          @for (action of performingActions(); track action.title) {
-            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
-              </div>
-            </div>
-          }
-
-          @for (insight of performingInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
-        </div>
-      }
-
-      @if (hasNoData()) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
-          role="status"
-          data-testid="email-ctr-drawer-no-data">
-          <div class="flex items-start gap-4 px-4 py-4">
-            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No email activity detected' }}</h3>
-              @if (unavailable()) {
-                <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
-              } @else {
-                <p class="text-sm text-gray-500">Engage with marketing ops to start sending campaigns and tracking results.</p>
-              }
-            </div>
-          </div>
-        </div>
-      }
-
-      <div class="flex flex-col gap-5" data-testid="email-ctr-drawer-email-section">
-        <div class="flex items-center gap-2">
-          <i class="fa-light fa-envelope text-blue-500"></i>
-          <h3 class="text-base font-semibold text-gray-900">Email Performance</h3>
-        </div>
-
-        <!-- Email Summary Stats -->
-        <div class="flex flex-wrap gap-4" data-testid="email-ctr-drawer-stats">
-          <lfx-card styleClass="flex-1 min-w-[100px]">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Sends</span>
-              <span class="text-2xl font-semibold text-gray-900">{{ emailTotalSends() }}</span>
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1 min-w-[100px]">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Opens</span>
-              <span class="text-2xl font-semibold text-gray-900">{{ emailTotalOpens() }}</span>
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1 min-w-[100px]">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Open Rate</span>
-              <span class="text-2xl font-semibold text-gray-900">{{ emailOpenRate() | number: '1.1-1' }}%</span>
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1 min-w-[100px]">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Clicks</span>
-              <span class="text-2xl font-semibold text-gray-900">{{ emailTotalClicks() }}</span>
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1 min-w-[100px]">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">CTR</span>
-              <span class="text-2xl font-semibold text-gray-900">{{ emailAvgCtr() | number: '1.1-1' }}%</span>
-            </div>
-          </lfx-card>
-        </div>
-
-        <!-- Campaign Insight Callout -->
-        @if (drawerData().campaignInsightText) {
-          <div class="flex items-start gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg" data-testid="email-ctr-drawer-campaign-insight">
-            <i class="fa-light fa-lightbulb text-blue-500 mt-0.5"></i>
-            <p class="text-sm text-blue-800">{{ drawerData().campaignInsightText }}</p>
-          </div>
-        }
-
-        <!-- Campaign Performance by Type -->
-        @if ((drawerData().emailTypeBreakdown?.length ?? 0) > 0) {
-          <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-campaigns-section">
-            <div class="flex flex-col gap-1">
-              <h3 class="text-sm font-semibold text-gray-900">Campaign Performance by Type</h3>
-              <p class="text-sm text-gray-600">Email performance grouped by campaign type over the last 6 months</p>
+      } @else {
+        <!-- Cross-Channel Insights -->
+        @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+            data-testid="email-ctr-drawer-attention">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+              <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
             </div>
 
-            <!-- Table Header -->
-            <div class="flex items-center py-2 px-1 text-[10px] font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-200">
-              <span class="flex-[2] min-w-[120px]">Type / Campaign</span>
-              <span class="flex-1 text-right">Send Date</span>
-              <span class="flex-1 text-right">Sends</span>
-              <span class="flex-1 text-right">Opens</span>
-              <span class="flex-1 text-right">Open Rate</span>
-              <span class="flex-1 text-right">Clicks</span>
-              <span class="flex-1 text-right">CTR</span>
-              <span class="w-24 text-right">Performance</span>
-            </div>
-
-            <!-- Type Rows -->
-            @for (type of drawerData().emailTypeBreakdown!; track type.emailType) {
-              <!-- Type Summary Row -->
-              <div
-                class="flex items-center py-2.5 px-1 border-b border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors"
-                role="button"
-                tabindex="0"
-                [attr.aria-expanded]="expandedTypes().has(type.emailType)"
-                (click)="toggleType(type.emailType)"
-                (keydown.enter)="toggleType(type.emailType)"
-                (keydown.space)="$event.preventDefault(); toggleType(type.emailType)"
-                data-testid="email-ctr-drawer-type-row">
-                <span class="flex-[2] min-w-[120px]">
-                  <lfx-tag [value]="type.emailType | titlecase" severity="warn" [rounded]="true" />
-                </span>
-                <!-- The type row aggregates every send date, so the column is intentionally blank here. -->
-                <span class="flex-1"></span>
-                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalSends) }}</span>
-                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalOpens) }}</span>
-                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ type.openRate | number: '1.1-1' }}%</span>
-                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalClicks) }}</span>
-                <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ type.ctr | number: '1.1-1' }}%</span>
-                <span class="w-24 flex justify-end">
-                  <lfx-tag [value]="type.performance" [severity]="getPerformanceSeverity(type.performance)" [rounded]="true" />
-                </span>
-              </div>
-
-              <!-- Expanded Campaign Rows -->
-              @if (expandedTypes().has(type.emailType)) {
-                <!-- sendDate in the key and on the row: the breakdown groups by PUBLISHED_DATE, so one
-                     campaign sent twice yields two rows. Without the date they carry duplicate track
-                     keys when the send counts also match, and read as the same row on screen. -->
-                @for (campaign of type.campaigns; track campaign.campaignName + '|' + campaign.sendDate + '|' + campaign.sends) {
-                  <div class="flex items-center py-2 px-1 pl-6 border-b border-gray-50 bg-gray-50" data-testid="email-ctr-drawer-campaign-row">
-                    <span class="flex-[2] min-w-[120px] text-xs text-gray-500 truncate pr-2" [title]="campaign.campaignName">{{ campaign.campaignName }}</span>
-                    <span class="flex-1 text-right text-xs text-gray-500">{{ campaign.sendDate || '—' }}</span>
-                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.sends) }}</span>
-                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.opens) }}</span>
-                    <span class="flex-1 text-right text-xs text-gray-600">{{ campaign.openRate | number: '1.1-1' }}%</span>
-                    <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.clicks) }}</span>
-                    <span class="flex-1 text-right text-xs text-gray-600">{{ campaign.ctr | number: '1.1-1' }}%</span>
-                    <span class="w-24"></span>
-                  </div>
+            @for (action of attentionActions(); track action.title) {
+              <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+                @if (action.priority === 'high') {
+                  <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+                } @else {
+                  <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
                 }
-              }
+              </div>
+            }
+
+            @for (insight of attentionInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
             }
           </div>
         }
-      </div>
+
+        @if (performingActions().length > 0 || performingInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+            data-testid="email-ctr-drawer-performing">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-check text-green-600"></i>
+              <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+            </div>
+
+            @for (action of performingActions(); track action.title) {
+              <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+              </div>
+            }
+
+            @for (insight of performingInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
+            }
+          </div>
+        }
+
+        @if (hasNoData()) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+            role="status"
+            data-testid="email-ctr-drawer-no-data">
+            <div class="flex items-start gap-4 px-4 py-4">
+              <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <h3 class="text-sm font-semibold text-gray-900">No email activity detected</h3>
+                <p class="text-sm text-gray-500">Engage with marketing ops to start sending campaigns and tracking results.</p>
+              </div>
+            </div>
+          </div>
+        }
+
+        <div class="flex flex-col gap-5" data-testid="email-ctr-drawer-email-section">
+          <div class="flex items-center gap-2">
+            <i class="fa-light fa-envelope text-blue-500"></i>
+            <h3 class="text-base font-semibold text-gray-900">Email Performance</h3>
+          </div>
+
+          <!-- Email Summary Stats -->
+          <div class="flex flex-wrap gap-4" data-testid="email-ctr-drawer-stats">
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Sends</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ emailTotalSends() }}</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Opens</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ emailTotalOpens() }}</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Open Rate</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ emailOpenRate() | number: '1.1-1' }}%</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Clicks</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ emailTotalClicks() }}</span>
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1 min-w-[100px]">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">CTR</span>
+                <span class="text-2xl font-semibold text-gray-900">{{ emailAvgCtr() | number: '1.1-1' }}%</span>
+              </div>
+            </lfx-card>
+          </div>
+
+          <!-- Campaign Insight Callout -->
+          @if (drawerData().campaignInsightText) {
+            <div class="flex items-start gap-3 p-3 bg-blue-50 border border-blue-200 rounded-lg" data-testid="email-ctr-drawer-campaign-insight">
+              <i class="fa-light fa-lightbulb text-blue-500 mt-0.5"></i>
+              <p class="text-sm text-blue-800">{{ drawerData().campaignInsightText }}</p>
+            </div>
+          }
+
+          <!-- Campaign Performance by Type -->
+          @if ((drawerData().emailTypeBreakdown?.length ?? 0) > 0) {
+            <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="email-ctr-drawer-campaigns-section">
+              <div class="flex flex-col gap-1">
+                <h3 class="text-sm font-semibold text-gray-900">Campaign Performance by Type</h3>
+                <p class="text-sm text-gray-600">Email performance grouped by campaign type over the last 6 months</p>
+              </div>
+
+              <!-- Table Header -->
+              <div class="flex items-center py-2 px-1 text-[10px] font-semibold text-gray-500 uppercase tracking-wider border-b border-gray-200">
+                <span class="flex-[2] min-w-[120px]">Type / Campaign</span>
+                <span class="flex-1 text-right">Send Date</span>
+                <span class="flex-1 text-right">Sends</span>
+                <span class="flex-1 text-right">Opens</span>
+                <span class="flex-1 text-right">Open Rate</span>
+                <span class="flex-1 text-right">Clicks</span>
+                <span class="flex-1 text-right">CTR</span>
+                <span class="w-24 text-right">Performance</span>
+              </div>
+
+              <!-- Type Rows -->
+              @for (type of drawerData().emailTypeBreakdown!; track type.emailType) {
+                <!-- Type Summary Row -->
+                <div
+                  class="flex items-center py-2.5 px-1 border-b border-gray-100 cursor-pointer hover:bg-gray-50 transition-colors"
+                  role="button"
+                  tabindex="0"
+                  [attr.aria-expanded]="expandedTypes().has(type.emailType)"
+                  (click)="toggleType(type.emailType)"
+                  (keydown.enter)="toggleType(type.emailType)"
+                  (keydown.space)="$event.preventDefault(); toggleType(type.emailType)"
+                  data-testid="email-ctr-drawer-type-row">
+                  <span class="flex-[2] min-w-[120px]">
+                    <lfx-tag [value]="type.emailType | titlecase" severity="warn" [rounded]="true" />
+                  </span>
+                  <!-- The type row aggregates every send date, so the column is intentionally blank here. -->
+                  <span class="flex-1"></span>
+                  <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalSends) }}</span>
+                  <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalOpens) }}</span>
+                  <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ type.openRate | number: '1.1-1' }}%</span>
+                  <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ formatCompact(type.totalClicks) }}</span>
+                  <span class="flex-1 text-right text-sm font-semibold text-gray-900">{{ type.ctr | number: '1.1-1' }}%</span>
+                  <span class="w-24 flex justify-end">
+                    <lfx-tag [value]="type.performance" [severity]="getPerformanceSeverity(type.performance)" [rounded]="true" />
+                  </span>
+                </div>
+
+                <!-- Expanded Campaign Rows -->
+                @if (expandedTypes().has(type.emailType)) {
+                  <!-- sendDate in the key and on the row: the breakdown groups by PUBLISHED_DATE, so one
+                       campaign sent twice yields two rows. Without the date they carry duplicate track
+                       keys when the send counts also match, and read as the same row on screen. -->
+                  @for (campaign of type.campaigns; track campaign.campaignName + '|' + campaign.sendDate + '|' + campaign.sends) {
+                    <div class="flex items-center py-2 px-1 pl-6 border-b border-gray-50 bg-gray-50" data-testid="email-ctr-drawer-campaign-row">
+                      <span class="flex-[2] min-w-[120px] text-xs text-gray-500 truncate pr-2" [title]="campaign.campaignName">{{
+                        campaign.campaignName
+                      }}</span>
+                      <span class="flex-1 text-right text-xs text-gray-500">{{ campaign.sendDate || '—' }}</span>
+                      <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.sends) }}</span>
+                      <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.opens) }}</span>
+                      <span class="flex-1 text-right text-xs text-gray-600">{{ campaign.openRate | number: '1.1-1' }}%</span>
+                      <span class="flex-1 text-right text-xs text-gray-600">{{ formatCompact(campaign.clicks) }}</span>
+                      <span class="flex-1 text-right text-xs text-gray-600">{{ campaign.ctr | number: '1.1-1' }}%</span>
+                      <span class="w-24"></span>
+                    </div>
+                  }
+                }
+              }
+            </div>
+          }
+        </div>
+      }
     }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.html
@@ -143,31 +143,31 @@
             <lfx-card styleClass="flex-1 min-w-[100px]">
               <div class="flex flex-col gap-1">
                 <span class="text-sm text-gray-500">Sends</span>
-                <span class="text-2xl font-semibold text-gray-900">{{ emailTotalSends() }}</span>
+                <span class="text-2xl font-semibold" [class]="breakdownUnavailable() ? 'text-gray-400' : 'text-gray-900'">{{ emailTotalSends() }}</span>
               </div>
             </lfx-card>
             <lfx-card styleClass="flex-1 min-w-[100px]">
               <div class="flex flex-col gap-1">
                 <span class="text-sm text-gray-500">Opens</span>
-                <span class="text-2xl font-semibold text-gray-900">{{ emailTotalOpens() }}</span>
+                <span class="text-2xl font-semibold" [class]="breakdownUnavailable() ? 'text-gray-400' : 'text-gray-900'">{{ emailTotalOpens() }}</span>
               </div>
             </lfx-card>
             <lfx-card styleClass="flex-1 min-w-[100px]">
               <div class="flex flex-col gap-1">
                 <span class="text-sm text-gray-500">Open Rate</span>
-                <span class="text-2xl font-semibold text-gray-900">{{ emailOpenRate() | number: '1.1-1' }}%</span>
+                <span class="text-2xl font-semibold" [class]="breakdownUnavailable() ? 'text-gray-400' : 'text-gray-900'">{{ emailOpenRate() }}</span>
               </div>
             </lfx-card>
             <lfx-card styleClass="flex-1 min-w-[100px]">
               <div class="flex flex-col gap-1">
                 <span class="text-sm text-gray-500">Clicks</span>
-                <span class="text-2xl font-semibold text-gray-900">{{ emailTotalClicks() }}</span>
+                <span class="text-2xl font-semibold" [class]="breakdownUnavailable() ? 'text-gray-400' : 'text-gray-900'">{{ emailTotalClicks() }}</span>
               </div>
             </lfx-card>
             <lfx-card styleClass="flex-1 min-w-[100px]">
               <div class="flex flex-col gap-1">
                 <span class="text-sm text-gray-500">CTR</span>
-                <span class="text-2xl font-semibold text-gray-900">{{ emailAvgCtr() | number: '1.1-1' }}%</span>
+                <span class="text-2xl font-semibold" [class]="breakdownUnavailable() ? 'text-gray-400' : 'text-gray-900'">{{ emailAvgCtr() }}</span>
               </div>
             </lfx-card>
           </div>
@@ -248,6 +248,17 @@
                   }
                 }
               }
+            </div>
+          } @else if (breakdownUnavailable()) {
+            <!-- Without this branch a failed breakdown renders NOTHING here, which reads as
+                 "this foundation runs no campaigns" — the same fabricated finding as a zero,
+                 stated by omission instead of by number. -->
+            <div
+              class="flex flex-col gap-1 items-center justify-center py-8 border border-gray-200 rounded-lg"
+              role="status"
+              data-testid="email-ctr-drawer-breakdown-unavailable">
+              <span class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</span>
+              <span class="text-sm text-gray-500">{{ unavailableBody }}</span>
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -7,6 +7,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
+import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
 import { formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -47,6 +48,15 @@ export class EmailCtrDrawerComponent {
   // True once all three data sources have resolved (not still loading)
   private readonly dataResolved: Signal<boolean> = computed(() => !this.drawerLoading());
 
+  /**
+   * Set when this drawer's own request fails. Unlike the parent-fed drawers there is no
+   * `unavailable` input here: the fetch lives in this component and catchError resolves
+   * to a zero-filled default, which would otherwise render as "No email activity
+   * detected" — an outage stated as a measurement.
+   */
+  protected readonly unavailable = signal(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 
   protected readonly expandedTypes = signal<Set<string>>(new Set());
@@ -109,6 +119,9 @@ export class EmailCtrDrawerComponent {
 
   private initHasNoData(): Signal<boolean> {
     return computed(() => {
+      if (this.unavailable()) {
+        return true;
+      }
       if (!this.dataResolved()) {
         return false;
       }
@@ -137,12 +150,16 @@ export class EmailCtrDrawerComponent {
       combineLatest([visible$, foundation$]).pipe(
         filter(([isVisible, slug]) => isVisible && !!slug),
         map(([, slug]) => slug),
-        tap(() => this.drawerLoading.set(true)),
+        tap(() => {
+          this.drawerLoading.set(true);
+          this.unavailable.set(false);
+        }),
         switchMap((foundationSlug) =>
           this.analyticsService.getEmailCtr(foundationSlug, undefined, 'last-6').pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);
+              this.unavailable.set(true);
               this.messageService.add({
                 severity: 'error',
                 summary: 'Error',

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/email-ctr-drawer/email-ctr-drawer.component.ts
@@ -7,7 +7,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
+import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, TILE_UNAVAILABLE_PLACEHOLDER } from '@lfx-one/shared/constants';
 import { formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -16,7 +16,7 @@ import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 
-import type { EmailCtrResponse, MarketingKeyInsight, MarketingRecommendedAction } from '@lfx-one/shared/interfaces';
+import type { EmailCtrResponse, EmailTypeBreakdown, MarketingKeyInsight, MarketingRecommendedAction } from '@lfx-one/shared/interfaces';
 
 @Component({
   selector: 'lfx-email-ctr-drawer',
@@ -61,31 +61,27 @@ export class EmailCtrDrawerComponent {
 
   protected readonly expandedTypes = signal<Set<string>>(new Set());
 
-  protected readonly emailTotalSends: Signal<string> = computed(() => {
-    const types = this.drawerData().emailTypeBreakdown ?? [];
-    return formatNumber(types.reduce((sum, t) => sum + t.totalSends, 0));
-  });
-  protected readonly emailTotalOpens: Signal<string> = computed(() => {
-    const types = this.drawerData().emailTypeBreakdown ?? [];
-    return formatNumber(types.reduce((sum, t) => sum + t.totalOpens, 0));
-  });
-  protected readonly emailTotalClicks: Signal<string> = computed(() => {
-    const types = this.drawerData().emailTypeBreakdown ?? [];
-    return formatNumber(types.reduce((sum, t) => sum + t.totalClicks, 0));
-  });
-  protected readonly emailOpenRate: Signal<number> = computed(() => {
-    const types = this.drawerData().emailTypeBreakdown ?? [];
-    const sends = types.reduce((sum, t) => sum + t.totalSends, 0);
-    const opens = types.reduce((sum, t) => sum + t.totalOpens, 0);
-    return sends > 0 ? Math.round(((opens * 100.0) / sends) * 10) / 10 : 0;
-  });
+  /**
+   * True when the optional campaign-breakdown query failed while the primary CTR read
+   * succeeded. Every tile below reduce()s over emailTypeBreakdown, so without this an empty
+   * array from a FAILURE sums to a confident-looking 0 — the fabricated zero this PR exists
+   * to remove, on a partial-failure path that returns HTTP 200.
+   */
+  protected readonly breakdownUnavailable: Signal<boolean> = computed(() => this.drawerData().breakdownUnavailable === true);
+
+  /**
+   * The five tiles below are rendered as a single unit: each returns the em dash placeholder
+   * when the breakdown is unavailable, so the template needs no per-tile `@if`. Guarding in the
+   * template instead would enumerate the tiles, and enumerating is what let earlier rounds of
+   * this PR miss a section every time — the same reason the drawers wrap their whole body in
+   * one `@else` rather than suppressing section by section.
+   */
+  protected readonly emailTotalSends: Signal<string> = computed(() => this.sumTile((t) => t.totalSends));
+  protected readonly emailTotalOpens: Signal<string> = computed(() => this.sumTile((t) => t.totalOpens));
+  protected readonly emailTotalClicks: Signal<string> = computed(() => this.sumTile((t) => t.totalClicks));
+  protected readonly emailOpenRate: Signal<string> = computed(() => this.rateTile((t) => t.totalOpens));
   /** Clicks÷sends — follows HubSpot's CTR convention (not clicks÷opens). */
-  protected readonly emailAvgCtr: Signal<number> = computed(() => {
-    const types = this.drawerData().emailTypeBreakdown ?? [];
-    const sends = types.reduce((sum, t) => sum + t.totalSends, 0);
-    const clicks = types.reduce((sum, t) => sum + t.totalClicks, 0);
-    return sends > 0 ? Math.round(((clicks * 100.0) / sends) * 10) / 10 : 0;
-  });
+  protected readonly emailAvgCtr: Signal<string> = computed(() => this.rateTile((t) => t.totalClicks));
 
   protected onClose(): void {
     this.visible.set(false);
@@ -115,6 +111,31 @@ export class EmailCtrDrawerComponent {
     if (performance === 'GOOD') return 'warn';
     if (performance === 'EXCELLENT' || performance === 'STRONG') return 'success';
     return 'secondary';
+  }
+
+  /**
+   * A breakdown-derived total. Returns the placeholder rather than 0 when the breakdown query
+   * failed: reduce() over an empty array is 0 whether the period had no campaigns or the read
+   * never happened, and only one of those is a measurement.
+   */
+  private sumTile(pick: (t: EmailTypeBreakdown) => number): string {
+    if (this.breakdownUnavailable()) return TILE_UNAVAILABLE_PLACEHOLDER;
+    const types = this.drawerData().emailTypeBreakdown ?? [];
+    return formatNumber(types.reduce((sum, t) => sum + pick(t), 0));
+  }
+
+  /**
+   * A breakdown-derived rate, already formatted to one decimal place with its percent sign so a
+   * failure can render the placeholder in the same slot. Returning a bare number could only
+   * signal failure as 0 — the fabricated measurement this drawer exists to stop.
+   */
+  private rateTile(pick: (t: EmailTypeBreakdown) => number): string {
+    if (this.breakdownUnavailable()) return TILE_UNAVAILABLE_PLACEHOLDER;
+    const types = this.drawerData().emailTypeBreakdown ?? [];
+    const sends = types.reduce((sum, t) => sum + t.totalSends, 0);
+    const numerator = types.reduce((sum, t) => sum + pick(t), 0);
+    const rate = sends > 0 ? Math.round(((numerator * 100.0) / sends) * 10) / 10 : 0;
+    return `${rate.toFixed(1)}%`;
   }
 
   private initHasNoData(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -28,151 +28,166 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="engaged-community-drawer-content">
-    <!-- Summary Stats -->
-    <div class="flex gap-4" data-testid="engaged-community-drawer-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Total Engaged</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalMembers() }}</span>
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Growth</span>
-          @if (data().changePercentage !== 0) {
-            <div class="flex items-center gap-2">
-              <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
-              </span>
-              <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
-            </div>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-500">0%</span>
-          }
-        </div>
-      </lfx-card>
-    </div>
-
-    @if (hasNoData()) {
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
         role="status"
-        data-testid="engaged-community-drawer-no-data">
+        aria-live="polite"
+        data-testid="engaged-community-drawer-unavailable">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No community engagement activity detected' }}</h3>
-            @if (unavailable()) {
-              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
-            } @else {
-              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
-            }
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
           </div>
         </div>
       </div>
     } @else {
-      <!-- FIRST FOLD: Needs Your Attention -->
-      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-          data-testid="engaged-community-drawer-attention">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+      <!-- Summary Stats -->
+      <div class="flex gap-4" data-testid="engaged-community-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Total Engaged</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalMembers() }}</span>
           </div>
-
-          @for (action of attentionActions(); track action.title) {
-            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Growth</span>
+            @if (data().changePercentage !== 0) {
+              <div class="flex items-center gap-2">
+                <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
+                  {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
+                </span>
+                <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
-              @if (action.priority === 'high') {
-                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-              } @else {
-                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
-              }
-            </div>
-          }
-
-          @for (insight of attentionInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
-        </div>
-      }
-
-      <!-- SECOND FOLD: Performing Well -->
-      @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-          data-testid="engaged-community-drawer-performing">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-check text-green-600"></i>
-            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-500">0%</span>
+            }
           </div>
-
-          @for (action of performingActions(); track action.title) {
-            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
-              </div>
-            </div>
-          }
-
-          @for (insight of performingInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
-        </div>
-      }
-    }
-
-    <!-- Growth Trend Chart -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-trend-section">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Community Growth Trend</h3>
-        <p class="text-sm text-gray-600">Total engaged community size over the last 6 months</p>
+        </lfx-card>
       </div>
-      @if (data().monthlyData.length > 1) {
-        <div class="h-[200px]" data-testid="engaged-community-drawer-trend-chart">
-          <lfx-chart type="line" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
+
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+          role="status"
+          data-testid="engaged-community-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <h3 class="text-sm font-semibold text-gray-900">No community engagement activity detected</h3>
+              <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
+            </div>
+          </div>
         </div>
       } @else {
-        <div class="text-center py-8 border border-slate-200 rounded-lg">
-          <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-          <p class="text-sm text-gray-500">No trend data available</p>
+        <!-- FIRST FOLD: Needs Your Attention -->
+        @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+            data-testid="engaged-community-drawer-attention">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+              <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+            </div>
+
+            @for (action of attentionActions(); track action.title) {
+              <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+                @if (action.priority === 'high') {
+                  <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+                } @else {
+                  <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+                }
+              </div>
+            }
+
+            @for (insight of attentionInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- SECOND FOLD: Performing Well -->
+        @if (performingActions().length > 0 || performingInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+            data-testid="engaged-community-drawer-performing">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-check text-green-600"></i>
+              <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+            </div>
+
+            @for (action of performingActions(); track action.title) {
+              <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+              </div>
+            }
+
+            @for (insight of performingInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
+            }
+          </div>
+        }
+      }
+
+      <!-- Growth Trend Chart -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-trend-section">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Community Growth Trend</h3>
+          <p class="text-sm text-gray-600">Total engaged community size over the last 6 months</p>
+        </div>
+        @if (data().monthlyData.length > 1) {
+          <div class="h-[200px]" data-testid="engaged-community-drawer-trend-chart">
+            <lfx-chart type="line" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
+          </div>
+        } @else {
+          <div class="text-center py-8 border border-slate-200 rounded-lg">
+            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+            <p class="text-sm text-gray-500">No trend data available</p>
+          </div>
+        }
+      </div>
+
+      <!-- Breakdown Chart -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-breakdown-section">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Community Breakdown</h3>
+          <p class="text-sm text-gray-600">Members by engagement channel (deduplicated)</p>
+        </div>
+        <div class="h-[220px]" data-testid="engaged-community-drawer-breakdown-chart">
+          <lfx-chart type="bar" [data]="breakdownChartData()" [options]="breakdownChartOptions" height="100%"></lfx-chart>
+        </div>
+      </div>
+
+      <!-- Weekly Sessions Trend -->
+      @if (brandReachData().weeklyTrend.length > 0) {
+        <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-daily-trend">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-semibold text-gray-900">Weekly Sessions Trend</h3>
+            <p class="text-sm text-gray-600">Website sessions over the last 6 months (weekly)</p>
+          </div>
+          <div class="h-[240px]" data-testid="engaged-community-drawer-daily-chart">
+            <lfx-chart type="line" [data]="dailyTrendData()" [options]="dailyTrendOptions" height="100%"></lfx-chart>
+          </div>
         </div>
       }
-    </div>
-
-    <!-- Breakdown Chart -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-breakdown-section">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Community Breakdown</h3>
-        <p class="text-sm text-gray-600">Members by engagement channel (deduplicated)</p>
-      </div>
-      <div class="h-[220px]" data-testid="engaged-community-drawer-breakdown-chart">
-        <lfx-chart type="bar" [data]="breakdownChartData()" [options]="breakdownChartOptions" height="100%"></lfx-chart>
-      </div>
-    </div>
-
-    <!-- Weekly Sessions Trend -->
-    @if (brandReachData().weeklyTrend.length > 0) {
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="engaged-community-drawer-daily-trend">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">Weekly Sessions Trend</h3>
-          <p class="text-sm text-gray-600">Website sessions over the last 6 months (weekly)</p>
-        </div>
-        <div class="h-[240px]" data-testid="engaged-community-drawer-daily-chart">
-          <lfx-chart type="line" [data]="dailyTrendData()" [options]="dailyTrendOptions" height="100%"></lfx-chart>
-        </div>
-      </div>
     }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -61,8 +61,12 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">No community engagement activity detected</h3>
-            <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No community engagement activity detected' }}</h3>
+            @if (unavailable()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            } @else {
+              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.html
@@ -28,7 +28,7 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="engaged-community-drawer-content">
-    @if (unavailable()) {
+    @if (unavailable() || pending()) {
       <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
            repeatedly missed one — stats, charts, insight blocks and per-section empty states
            each assert a measurement, so the whole body has to go, not a list of its parts. -->
@@ -40,8 +40,10 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
-            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ pending() ? loadingHeading : unavailableHeading }}</h3>
+            @if (!pending()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -10,6 +10,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import {
   DASHBOARD_TOOLTIP_CONFIG,
   DRAWER_NO_ACTIVITY_BODY,
+  DRAWER_LOADING_HEADING,
   DRAWER_UNAVAILABLE_BODY,
   DRAWER_UNAVAILABLE_HEADING,
   createHorizontalBarChartOptions,
@@ -69,6 +70,13 @@ export class EngagedCommunityDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly loadingHeading = DRAWER_LOADING_HEADING;
+  /**
+   * True while the parent's request is still in flight. The body is suppressed for this too —
+   * the zero-filled fallback is no more a measurement while loading than after a failure — but
+   * the copy must not claim a failure that has not happened.
+   */
+  public readonly pending = input<boolean>(false);
   protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -7,7 +7,14 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DASHBOARD_TOOLTIP_CONFIG, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, createHorizontalBarChartOptions, createLineChartOptions, lfxColors } from '@lfx-one/shared/constants';
+import {
+  DASHBOARD_TOOLTIP_CONFIG,
+  DRAWER_UNAVAILABLE_BODY,
+  DRAWER_UNAVAILABLE_HEADING,
+  createHorizontalBarChartOptions,
+  createLineChartOptions,
+  lfxColors,
+} from '@lfx-one/shared/constants';
 import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -9,6 +9,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import {
   DASHBOARD_TOOLTIP_CONFIG,
+  DRAWER_NO_ACTIVITY_BODY,
   DRAWER_UNAVAILABLE_BODY,
   DRAWER_UNAVAILABLE_HEADING,
   createHorizontalBarChartOptions,
@@ -68,6 +69,7 @@ export class EngagedCommunityDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
   protected readonly formattedTotalMembers: Signal<string> = computed(() => formatNumber(this.data().totalMembers));

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/engaged-community-drawer/engaged-community-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { DASHBOARD_TOOLTIP_CONFIG, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, createHorizontalBarChartOptions, createLineChartOptions, lfxColors } from '@lfx-one/shared/constants';
 import { formatNumber, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -53,6 +53,15 @@ export class EngagedCommunityDrawerComponent {
     weeklyTrend: [],
   });
   // === Computed Signals ===
+  /**
+   * True when the source request FAILED, as opposed to returning a measured zero. The
+   * parent passes the undefined-ness of its response through; the empty state then says
+   * the data could not be loaded instead of asserting there was no activity.
+   */
+  public readonly unavailable = input<boolean>(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
   protected readonly formattedTotalMembers: Signal<string> = computed(() => formatNumber(this.data().totalMembers));
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = this.initRecommendedActions();
@@ -192,6 +201,7 @@ export class EngagedCommunityDrawerComponent {
   // === Private Initializers ===
   private initHasNoData(): Signal<boolean> {
     return computed(() => {
+      if (this.unavailable()) return true;
       const { totalMembers, monthlyData } = this.data();
       return totalMembers === 0 && monthlyData.length === 0;
     });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -182,7 +182,7 @@
         </div>
       } @else {
         <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="event-growth-drawer-monthly-empty">
-          Quarterly trend data not yet available
+          {{ unavailable() ? unavailableHeading + ' — ' + unavailableBody : 'Quarterly trend data not yet available' }}
         </div>
       }
     </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -28,7 +28,7 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="event-growth-drawer-content">
-    @if (unavailable()) {
+    @if (unavailable() || pending()) {
       <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
            repeatedly missed one — stats, charts, insight blocks and per-section empty states
            each assert a measurement, so the whole body has to go, not a list of its parts. -->
@@ -40,8 +40,10 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
-            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ pending() ? loadingHeading : unavailableHeading }}</h3>
+            @if (!pending()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.html
@@ -28,209 +28,231 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="event-growth-drawer-content">
-    <!-- Summary Stats -->
-    <div class="flex gap-4" data-testid="event-growth-drawer-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Total Registrants</span>
-          @if (data().totalRegistrants > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ data().totalRegistrants | number }}</span>
-            <span class="text-xs text-gray-400">{{ data().totalAttendees | number }} attended · YTD</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Events</span>
-          @if (data().totalEvents > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ data().totalEvents | number }}</span>
-            <span class="text-xs text-gray-400">YTD</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Registrant YoY</span>
-          @if (data().registrantYoyChange !== 0) {
-            <span class="text-2xl font-semibold" [class.text-green-600]="data().registrantYoyChange > 0" [class.text-red-600]="data().registrantYoyChange < 0">
-              {{ formattedRegistrantYoyChange() }}%
-            </span>
-            <span class="text-xs text-gray-400">YTD vs same period last year</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-    </div>
-
-    <!-- Event Revenue -->
-    <div class="flex gap-4" data-testid="event-growth-drawer-revenue-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Total Event Revenue (USD)</span>
-          @if (data().totalRevenue > 0) {
-            <span class="text-2xl font-semibold text-gray-900">{{ formattedRevenue() }}</span>
-            <span class="text-xs text-gray-400">YTD</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Revenue Per Attendee (USD)</span>
-          @if (data().revenuePerAttendee > 0) {
-            <span class="text-2xl font-semibold text-gray-900">${{ data().revenuePerAttendee | number: '1.2-2' }}</span>
-            <span class="text-xs text-gray-400">YTD · all event revenue ÷ attendees</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Revenue YoY</span>
-          @if (data().revenueYoyChange !== 0) {
-            <span class="text-2xl font-semibold" [class.text-green-600]="data().revenueYoyChange > 0" [class.text-red-600]="data().revenueYoyChange < 0">
-              {{ formattedRevenueYoyChange() }}%
-            </span>
-            <span class="text-xs text-gray-400">YTD vs same period last year</span>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-400">—</span>
-          }
-        </div>
-      </lfx-card>
-    </div>
-
-    <!-- FIRST FOLD: Needs Your Attention -->
-    @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
       <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-        data-testid="event-growth-drawer-attention">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-          <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+        role="status"
+        aria-live="polite"
+        data-testid="event-growth-drawer-unavailable">
+        <div class="flex items-start gap-4 px-4 py-4">
+          <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+          <div class="flex flex-col gap-1 flex-1 min-w-0">
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+          </div>
         </div>
-
-        @for (action of attentionActions(); track action.title) {
-          <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-            @if (action.priority === 'high') {
-              <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+      </div>
+    } @else {
+      <!-- Summary Stats -->
+      <div class="flex gap-4" data-testid="event-growth-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Total Registrants</span>
+            @if (data().totalRegistrants > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().totalRegistrants | number }}</span>
+              <span class="text-xs text-gray-400">{{ data().totalAttendees | number }} attended · YTD</span>
             } @else {
-              <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+              <span class="text-2xl font-semibold text-gray-400">—</span>
             }
           </div>
-        }
-
-        @for (insight of attentionInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Events</span>
+            @if (data().totalEvents > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ data().totalEvents | number }}</span>
+              <span class="text-xs text-gray-400">YTD</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
           </div>
-        }
-      </div>
-    }
-
-    <!-- SECOND FOLD: Performing Well -->
-    @if (performingActions().length > 0 || performingInsights().length > 0) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-        data-testid="event-growth-drawer-performing">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-check text-green-600"></i>
-          <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
-        </div>
-
-        @for (action of performingActions(); track action.title) {
-          <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-          </div>
-        }
-
-        @for (insight of performingInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
-          </div>
-        }
-      </div>
-    }
-
-    <!-- Quarterly Registration Trend -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-monthly-trend">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Quarterly Registrations</h3>
-        <p class="text-sm text-gray-600">
-          Registrations by event quarter, from three years back through upcoming events. Current and upcoming quarters are still filling as registrations come
-          in.
-        </p>
-      </div>
-      @if (data().monthlyData.length > 0) {
-        <div class="h-[240px]" data-testid="event-growth-drawer-monthly-chart">
-          <lfx-chart type="bar" [data]="monthlyChartData()" [options]="monthlyChartOptions" height="100%"></lfx-chart>
-        </div>
-      } @else {
-        <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="event-growth-drawer-monthly-empty">
-          {{ unavailable() ? unavailableHeading + ' — ' + unavailableBody : 'Quarterly trend data not yet available' }}
-        </div>
-      }
-    </div>
-
-    <!-- Events This Year -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-top-events">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">{{ currentYear }} Events</h3>
-        <p class="text-sm text-gray-600">
-          @if (data().topEvents.length >= topEventsLimit) {
-            The first {{ topEventsLimit }} events this year by date (the list is capped).
-          } @else {
-            All events this year (past and upcoming), by date.
-          }
-          Revenue is shown in each event's local currency; events with mixed or unknown currencies are shown in USD.
-        </p>
-      </div>
-      @if (data().topEvents.length > 0) {
-        <div class="flex flex-col gap-0">
-          <div class="flex items-center justify-between py-2 px-1 text-xs font-semibold text-gray-500 uppercase border-b border-gray-200">
-            <span class="flex-1">Event</span>
-            <span class="w-24 text-right">Date</span>
-            <span class="w-28 text-right">Registrants</span>
-            <span class="w-24 text-right">Attendees</span>
-            <span class="w-24 text-right">Revenue</span>
-          </div>
-          @for (event of sortedTopEvents(); track event.id) {
-            <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="event-growth-drawer-event-row">
-              <span class="flex min-w-0 flex-1 items-center gap-2 text-sm font-medium text-gray-900">
-                <span class="truncate">{{ event.name }}</span>
-                <span
-                  class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
-                  [class]="event.isPast ? 'bg-gray-100 text-gray-500' : 'bg-blue-50 text-blue-600'">
-                  {{ event.isPast ? 'Past' : 'Upcoming' }}
-                </span>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Registrant YoY</span>
+            @if (data().registrantYoyChange !== 0) {
+              <span
+                class="text-2xl font-semibold"
+                [class.text-green-600]="data().registrantYoyChange > 0"
+                [class.text-red-600]="data().registrantYoyChange < 0">
+                {{ formattedRegistrantYoyChange() }}%
               </span>
-              <span class="w-24 text-right text-sm text-gray-500">{{ event.date | date: 'MMM d' : 'UTC' }}</span>
-              <span class="w-28 text-right text-sm font-semibold text-gray-900">{{ event.registrants | number }}</span>
-              <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ event.attendees | number }}</span>
-              <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ event.formattedRevenue }}</span>
+              <span class="text-xs text-gray-400">YTD vs same period last year</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+
+      <!-- Event Revenue -->
+      <div class="flex gap-4" data-testid="event-growth-drawer-revenue-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Total Event Revenue (USD)</span>
+            @if (data().totalRevenue > 0) {
+              <span class="text-2xl font-semibold text-gray-900">{{ formattedRevenue() }}</span>
+              <span class="text-xs text-gray-400">YTD</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Revenue Per Attendee (USD)</span>
+            @if (data().revenuePerAttendee > 0) {
+              <span class="text-2xl font-semibold text-gray-900">${{ data().revenuePerAttendee | number: '1.2-2' }}</span>
+              <span class="text-xs text-gray-400">YTD · all event revenue ÷ attendees</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Revenue YoY</span>
+            @if (data().revenueYoyChange !== 0) {
+              <span class="text-2xl font-semibold" [class.text-green-600]="data().revenueYoyChange > 0" [class.text-red-600]="data().revenueYoyChange < 0">
+                {{ formattedRevenueYoyChange() }}%
+              </span>
+              <span class="text-xs text-gray-400">YTD vs same period last year</span>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-400">—</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="event-growth-drawer-attention">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+          </div>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+              @if (action.priority === 'high') {
+                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+              } @else {
+                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+              }
+            </div>
+          }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
             </div>
           }
         </div>
-      } @else {
-        <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="event-growth-drawer-top-events-empty">
-          No events this year
+      }
+
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="event-growth-drawer-performing">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-check text-green-600"></i>
+            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+          </div>
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
+            </div>
+          }
         </div>
       }
-    </div>
+
+      <!-- Quarterly Registration Trend -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-monthly-trend">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Quarterly Registrations</h3>
+          <p class="text-sm text-gray-600">
+            Registrations by event quarter, from three years back through upcoming events. Current and upcoming quarters are still filling as registrations come
+            in.
+          </p>
+        </div>
+        @if (data().monthlyData.length > 0) {
+          <div class="h-[240px]" data-testid="event-growth-drawer-monthly-chart">
+            <lfx-chart type="bar" [data]="monthlyChartData()" [options]="monthlyChartOptions" height="100%"></lfx-chart>
+          </div>
+        } @else {
+          <div class="flex items-center justify-center h-[120px] text-sm text-gray-400" data-testid="event-growth-drawer-monthly-empty">
+            Quarterly trend data not yet available
+          </div>
+        }
+      </div>
+
+      <!-- Events This Year -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="event-growth-drawer-top-events">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">{{ currentYear }} Events</h3>
+          <p class="text-sm text-gray-600">
+            @if (data().topEvents.length >= topEventsLimit) {
+              The first {{ topEventsLimit }} events this year by date (the list is capped).
+            } @else {
+              All events this year (past and upcoming), by date.
+            }
+            Revenue is shown in each event's local currency; events with mixed or unknown currencies are shown in USD.
+          </p>
+        </div>
+        @if (data().topEvents.length > 0) {
+          <div class="flex flex-col gap-0">
+            <div class="flex items-center justify-between py-2 px-1 text-xs font-semibold text-gray-500 uppercase border-b border-gray-200">
+              <span class="flex-1">Event</span>
+              <span class="w-24 text-right">Date</span>
+              <span class="w-28 text-right">Registrants</span>
+              <span class="w-24 text-right">Attendees</span>
+              <span class="w-24 text-right">Revenue</span>
+            </div>
+            @for (event of sortedTopEvents(); track event.id) {
+              <div class="flex items-center justify-between py-3 px-1 border-b border-gray-100" data-testid="event-growth-drawer-event-row">
+                <span class="flex min-w-0 flex-1 items-center gap-2 text-sm font-medium text-gray-900">
+                  <span class="truncate">{{ event.name }}</span>
+                  <span
+                    class="shrink-0 rounded px-1.5 py-0.5 text-[10px] font-semibold uppercase"
+                    [class]="event.isPast ? 'bg-gray-100 text-gray-500' : 'bg-blue-50 text-blue-600'">
+                    {{ event.isPast ? 'Past' : 'Upcoming' }}
+                  </span>
+                </span>
+                <span class="w-24 text-right text-sm text-gray-500">{{ event.date | date: 'MMM d' : 'UTC' }}</span>
+                <span class="w-28 text-right text-sm font-semibold text-gray-900">{{ event.registrants | number }}</span>
+                <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ event.attendees | number }}</span>
+                <span class="w-24 text-right text-sm font-semibold text-gray-900">{{ event.formattedRevenue }}</span>
+              </div>
+            }
+          </div>
+        } @else {
+          <div class="flex items-center justify-center h-[80px] text-sm text-gray-400" data-testid="event-growth-drawer-top-events-empty">
+            No events this year
+          </div>
+        }
+      </div>
+    }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -7,7 +7,13 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, EVENT_GROWTH_TOP_EVENTS_LIMIT, lfxColors } from '@lfx-one/shared/constants';
+import {
+  DRAWER_LOADING_HEADING,
+  DRAWER_UNAVAILABLE_BODY,
+  DRAWER_UNAVAILABLE_HEADING,
+  EVENT_GROWTH_TOP_EVENTS_LIMIT,
+  lfxColors,
+} from '@lfx-one/shared/constants';
 import { formatCompact, formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -34,6 +40,13 @@ export class EventGrowthDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly loadingHeading = DRAWER_LOADING_HEADING;
+  /**
+   * True while the parent's request is still in flight. The body is suppressed for this too —
+   * the zero-filled fallback is no more a measurement while loading than after a failure — but
+   * the copy must not claim a failure that has not happened.
+   */
+  public readonly pending = input<boolean>(false);
 
   public readonly data = input<EventGrowthResponse>({
     totalAttendees: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/event-growth-drawer/event-growth-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { EVENT_GROWTH_TOP_EVENTS_LIMIT, lfxColors } from '@lfx-one/shared/constants';
+import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, EVENT_GROWTH_TOP_EVENTS_LIMIT, lfxColors } from '@lfx-one/shared/constants';
 import { formatCompact, formatNumber, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { DrawerModule } from 'primeng/drawer';
 
@@ -25,6 +25,16 @@ export class EventGrowthDrawerComponent {
   public readonly visible = model<boolean>(false);
 
   // === Inputs ===
+  /**
+   * True when the source request FAILED rather than returning a measured zero. This drawer's
+   * stats already degrade to em dashes, so only the collection empty-states change: they say
+   * the data could not be loaded instead of "not yet available", which is a claim about the
+   * data rather than about the request.
+   */
+  public readonly unavailable = input<boolean>(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+
   public readonly data = input<EventGrowthResponse>({
     totalAttendees: 0,
     totalRegistrants: 0,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -70,8 +70,12 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">No flywheel conversion activity detected</h3>
-            <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No flywheel conversion activity detected' }}</h3>
+            @if (unavailable()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            } @else {
+              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -28,147 +28,162 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="flywheel-conversion-drawer-content">
-    <!-- Summary Stats -->
-    <div class="flex gap-4" data-testid="flywheel-conversion-drawer-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Re-engagement Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ reengagement().reengagementRate | number: '1.1-1' }}%</span>
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Conversion Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate | number: '1.1-1' }}%</span>
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Growth</span>
-          @if (reengagement().reengagementMomChange !== 0) {
-            <div class="flex items-center gap-2">
-              <!-- reengagementMomChange is a percentage-POINT delta between two monthly rates, not a percent change -->
-              <span class="text-2xl font-semibold" [class]="reengagement().reengagementMomChange >= 0 ? 'text-green-600' : 'text-red-600'">
-                {{ reengagement().reengagementMomChange > 0 ? '+' : '' }}{{ reengagement().reengagementMomChange | number: '1.1-1' }}pp
-              </span>
-              <i
-                class="text-sm"
-                [class]="reengagement().reengagementMomChange >= 0 ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
-            </div>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-500">0pp</span>
-          }
-        </div>
-      </lfx-card>
-    </div>
-
-    @if (hasNoData()) {
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
         role="status"
-        data-testid="flywheel-conversion-drawer-no-data">
+        aria-live="polite"
+        data-testid="flywheel-conversion-drawer-unavailable">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No flywheel conversion activity detected' }}</h3>
-            @if (unavailable()) {
-              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
-            } @else {
-              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
-            }
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
           </div>
         </div>
       </div>
     } @else {
-      <!-- FIRST FOLD: Needs Your Attention -->
-      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-          data-testid="flywheel-conversion-drawer-attention">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+      <!-- Summary Stats -->
+      <div class="flex gap-4" data-testid="flywheel-conversion-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Re-engagement Rate</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ reengagement().reengagementRate | number: '1.1-1' }}%</span>
           </div>
-
-          @for (action of attentionActions(); track action.title) {
-            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
-              </div>
-              @if (action.priority === 'high') {
-                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-              } @else {
-                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
-              }
-            </div>
-          }
-
-          @for (insight of attentionInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
-        </div>
-      }
-
-      <!-- SECOND FOLD: Performing Well -->
-      @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-          data-testid="flywheel-conversion-drawer-performing">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-check text-green-600"></i>
-            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Conversion Rate</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ data().conversionRate | number: '1.1-1' }}%</span>
           </div>
-
-          @for (action of performingActions(); track action.title) {
-            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Growth</span>
+            @if (reengagement().reengagementMomChange !== 0) {
+              <div class="flex items-center gap-2">
+                <!-- reengagementMomChange is a percentage-POINT delta between two monthly rates, not a percent change -->
+                <span class="text-2xl font-semibold" [class]="reengagement().reengagementMomChange >= 0 ? 'text-green-600' : 'text-red-600'">
+                  {{ reengagement().reengagementMomChange > 0 ? '+' : '' }}{{ reengagement().reengagementMomChange | number: '1.1-1' }}pp
+                </span>
+                <i
+                  class="text-sm"
+                  [class]="reengagement().reengagementMomChange >= 0 ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
               </div>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-500">0pp</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+          role="status"
+          data-testid="flywheel-conversion-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <h3 class="text-sm font-semibold text-gray-900">No flywheel conversion activity detected</h3>
+              <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
             </div>
-          }
-
-          @for (insight of performingInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
-        </div>
-      }
-    }
-
-    <!-- Re-engagement Funnel Chart -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="flywheel-conversion-drawer-funnel-section">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Re-engagement Funnel</h3>
-        <p class="text-sm text-gray-600">Event attendees re-engaging with community, working groups, and newsletter</p>
-      </div>
-      <div class="h-[200px]" data-testid="flywheel-conversion-drawer-funnel-chart">
-        <lfx-chart type="bar" [data]="funnelChartData()" [options]="funnelChartOptions" height="100%"></lfx-chart>
-      </div>
-    </div>
-
-    <!-- Re-engagement Rate Trend Chart -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="flywheel-conversion-drawer-trend-section">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">Re-engaged Members Trend</h3>
-        <p class="text-sm text-gray-600">Monthly re-engaged members (count) over the last 6 months</p>
-      </div>
-      @if (data().monthlyData.length > 1) {
-        <div class="h-[200px]" data-testid="flywheel-conversion-drawer-trend-chart">
-          <lfx-chart type="line" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
+          </div>
         </div>
       } @else {
-        <div class="text-center py-8 border border-slate-200 rounded-lg">
-          <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-          <p class="text-sm text-gray-500">No trend data available</p>
-        </div>
+        <!-- FIRST FOLD: Needs Your Attention -->
+        @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+            data-testid="flywheel-conversion-drawer-attention">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+              <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+            </div>
+
+            @for (action of attentionActions(); track action.title) {
+              <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+                @if (action.priority === 'high') {
+                  <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+                } @else {
+                  <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+                }
+              </div>
+            }
+
+            @for (insight of attentionInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- SECOND FOLD: Performing Well -->
+        @if (performingActions().length > 0 || performingInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+            data-testid="flywheel-conversion-drawer-performing">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-check text-green-600"></i>
+              <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+            </div>
+
+            @for (action of performingActions(); track action.title) {
+              <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+              </div>
+            }
+
+            @for (insight of performingInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
+            }
+          </div>
+        }
       }
-    </div>
+
+      <!-- Re-engagement Funnel Chart -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="flywheel-conversion-drawer-funnel-section">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Re-engagement Funnel</h3>
+          <p class="text-sm text-gray-600">Event attendees re-engaging with community, working groups, and newsletter</p>
+        </div>
+        <div class="h-[200px]" data-testid="flywheel-conversion-drawer-funnel-chart">
+          <lfx-chart type="bar" [data]="funnelChartData()" [options]="funnelChartOptions" height="100%"></lfx-chart>
+        </div>
+      </div>
+
+      <!-- Re-engagement Rate Trend Chart -->
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="flywheel-conversion-drawer-trend-section">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">Re-engaged Members Trend</h3>
+          <p class="text-sm text-gray-600">Monthly re-engaged members (count) over the last 6 months</p>
+        </div>
+        @if (data().monthlyData.length > 1) {
+          <div class="h-[200px]" data-testid="flywheel-conversion-drawer-trend-chart">
+            <lfx-chart type="line" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
+          </div>
+        } @else {
+          <div class="text-center py-8 border border-slate-200 rounded-lg">
+            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+            <p class="text-sm text-gray-500">No trend data available</p>
+          </div>
+        }
+      </div>
+    }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.html
@@ -28,7 +28,7 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="flywheel-conversion-drawer-content">
-    @if (unavailable()) {
+    @if (unavailable() || pending()) {
       <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
            repeatedly missed one — stats, charts, insight blocks and per-section empty states
            each assert a measurement, so the whole body has to go, not a list of its parts. -->
@@ -40,8 +40,10 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
-            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ pending() ? loadingHeading : unavailableHeading }}</h3>
+            @if (!pending()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -9,6 +9,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import {
   DASHBOARD_TOOLTIP_CONFIG,
+  DRAWER_NO_ACTIVITY_BODY,
   DRAWER_UNAVAILABLE_BODY,
   DRAWER_UNAVAILABLE_HEADING,
   createHorizontalBarChartOptions,
@@ -79,6 +80,7 @@ export class FlywheelConversionDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
   protected readonly reengagementRate: Signal<string> = computed(() => `${this.reengagement().reengagementRate.toFixed(1)}%`);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -10,6 +10,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import {
   DASHBOARD_TOOLTIP_CONFIG,
   DRAWER_NO_ACTIVITY_BODY,
+  DRAWER_LOADING_HEADING,
   DRAWER_UNAVAILABLE_BODY,
   DRAWER_UNAVAILABLE_HEADING,
   createHorizontalBarChartOptions,
@@ -80,6 +81,13 @@ export class FlywheelConversionDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly loadingHeading = DRAWER_LOADING_HEADING;
+  /**
+   * True while the parent's request is still in flight. The body is suppressed for this too —
+   * the zero-filled fallback is no more a measurement while loading than after a failure — but
+   * the copy must not claim a failure that has not happened.
+   */
+  public readonly pending = input<boolean>(false);
   protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { DASHBOARD_TOOLTIP_CONFIG, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, createHorizontalBarChartOptions, createLineChartOptions, lfxColors } from '@lfx-one/shared/constants';
 import {
   buildFlywheelKeyInsights,
   buildFlywheelRecommendedActions,
@@ -64,6 +64,15 @@ export class FlywheelConversionDrawerComponent {
   // === Computed Signals ===
   protected readonly formattedEventAttendees: Signal<string> = computed(() => formatNumber(this.data().funnel.eventAttendees));
   protected readonly reengagement: Signal<NonNullable<FlywheelConversionResponse['reengagement']>> = computed(() => getFlywheelReengagement(this.data()));
+  /**
+   * True when the source request FAILED, as opposed to returning a measured zero. The
+   * parent passes the undefined-ness of its response through; the empty state then says
+   * the data could not be loaded instead of asserting there was no activity.
+   */
+  public readonly unavailable = input<boolean>(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
   protected readonly reengagementRate: Signal<string> = computed(() => `${this.reengagement().reengagementRate.toFixed(1)}%`);
   protected readonly recommendedActions: Signal<MarketingRecommendedAction[]> = computed(() => buildFlywheelRecommendedActions(this.data()));
@@ -154,6 +163,7 @@ export class FlywheelConversionDrawerComponent {
   // === Private Initializers ===
   private initHasNoData(): Signal<boolean> {
     return computed(() => {
+      if (this.unavailable()) return true;
       const { conversionRate, funnel, monthlyData } = this.data();
       return conversionRate === 0 && funnel.eventAttendees === 0 && monthlyData.length === 0;
     });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/flywheel-conversion-drawer/flywheel-conversion-drawer.component.ts
@@ -7,7 +7,14 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DASHBOARD_TOOLTIP_CONFIG, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, createHorizontalBarChartOptions, createLineChartOptions, lfxColors } from '@lfx-one/shared/constants';
+import {
+  DASHBOARD_TOOLTIP_CONFIG,
+  DRAWER_UNAVAILABLE_BODY,
+  DRAWER_UNAVAILABLE_HEADING,
+  createHorizontalBarChartOptions,
+  createLineChartOptions,
+  lfxColors,
+} from '@lfx-one/shared/constants';
 import {
   buildFlywheelKeyInsights,
   buildFlywheelRecommendedActions,

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview-unavailable-binding.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview-unavailable-binding.spec.ts
@@ -21,8 +21,9 @@ import { EngagedCommunityDrawerComponent } from '../engaged-community-drawer/eng
  * MarketingOverviewComponent itself: that component fans out to 11 analytics endpoints on
  * mount, and a fixture faking all of them ends up testing the fan-out instead of the
  * binding. What matters here is that `!response` is the correct expression — that an
- * undefined response yields `unavailable: true` and a present one yields false. All four
- * failable drawers in the real template use this identical shape.
+ * undefined response yields `unavailable: true` and a present one yields false. Every failable
+ * drawer binds the negation of its own response field; the Members drawer additionally ORs a
+ * second response, because its drawer renders retention as headline figures.
  */
 @Component({
   selector: 'lfx-unavailable-binding-host',

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview-unavailable-binding.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview-unavailable-binding.spec.ts
@@ -1,0 +1,115 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
+import { EngagedCommunitySizeResponse } from '@lfx-one/shared/interfaces';
+import { describe, expect, it } from 'vitest';
+
+import { EngagedCommunityDrawerComponent } from '../engaged-community-drawer/engaged-community-drawer.component';
+
+/**
+ * The drawer specs prove each drawer honours `unavailable`, and the card specs prove the
+ * builder renders an unavailable state on the card. This covers the wiring BETWEEN them —
+ * the expression `[unavailable]="!edEvolutionData().engagedCommunity"`, which is what
+ * carries a failed response from the parent into the drawer.
+ *
+ * It is asserted against a host that reproduces that binding rather than against
+ * MarketingOverviewComponent itself: that component fans out to 11 analytics endpoints on
+ * mount, and a fixture faking all of them ends up testing the fan-out instead of the
+ * binding. What matters here is that `!response` is the correct expression — that an
+ * undefined response yields `unavailable: true` and a present one yields false. All four
+ * failable drawers in the real template use this identical shape.
+ */
+@Component({
+  imports: [EngagedCommunityDrawerComponent],
+  template: `<lfx-engaged-community-drawer
+    [visible]="true"
+    [data]="data()"
+    [brandReachData]="brandReach"
+    [unavailable]="!response()"></lfx-engaged-community-drawer>`,
+})
+class BindingHostComponent {
+  // Mirrors the parent: `response` is the raw `| undefined` field off EdEvolutionData, and
+  // `data` is the drawer-facing computed that substitutes an empty shape for the drawer's
+  // non-optional input. The drawer therefore CANNOT infer the failure from `data` alone.
+  public readonly response = signal<EngagedCommunitySizeResponse | undefined>(undefined);
+  public readonly data = (): EngagedCommunitySizeResponse =>
+    this.response() ?? {
+      totalMembers: 0,
+      changePercentage: 0,
+      trend: 'up',
+      breakdown: {
+        newsletterSubscribers: 0,
+        communityMembers: 0,
+        workingGroupMembers: 0,
+        certifiedIndividuals: 0,
+        webVisitors: 0,
+        codeContributors: 0,
+        trainingEnrollees: 0,
+      },
+      monthlyData: [],
+    };
+  public readonly brandReach = {
+    totalSocialFollowers: 0,
+    totalMonthlySessions: 0,
+    activePlatforms: 0,
+    changePercentage: 0,
+    sessionMomChangePct: 0,
+    trend: 'up' as const,
+    socialPlatforms: [],
+    websiteDomains: [],
+    weeklyTrend: [],
+  };
+}
+
+describe('Marketing Overview — the unavailable binding carries a failed response to the drawer', () => {
+  async function render(response: EngagedCommunitySizeResponse | undefined): Promise<string> {
+    await TestBed.configureTestingModule({
+      imports: [BindingHostComponent],
+      providers: [provideNoopAnimations(), provideRouter([])],
+    }).compileComponents();
+
+    const fixture = TestBed.createComponent(BindingHostComponent);
+    fixture.componentInstance.response.set(response);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // The drawer renders into an overlay on document.body, not the host element.
+    const text = document.body.textContent ?? '';
+    fixture.destroy();
+    TestBed.resetTestingModule();
+    return text;
+  }
+
+  it('an undefined response makes the drawer report unavailable', async () => {
+    expect(await render(undefined)).toContain(DRAWER_UNAVAILABLE_HEADING);
+  });
+
+  // The other half: a foundation that genuinely has zero engagement must still read as a
+  // measurement, or the binding would report every empty foundation as an outage.
+  it('a present all-zero response still reads as a measured absence', async () => {
+    const measured = await render({
+      totalMembers: 0,
+      changePercentage: 0,
+      trend: 'up',
+      breakdown: {
+        newsletterSubscribers: 0,
+        communityMembers: 0,
+        workingGroupMembers: 0,
+        certifiedIndividuals: 0,
+        webVisitors: 0,
+        codeContributors: 0,
+        trainingEnrollees: 0,
+      },
+      monthlyData: [],
+    });
+
+    expect(measured).toContain('No community engagement activity detected');
+    expect(measured).not.toContain(DRAWER_UNAVAILABLE_HEADING);
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview-unavailable-binding.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview-unavailable-binding.spec.ts
@@ -25,34 +25,15 @@ import { EngagedCommunityDrawerComponent } from '../engaged-community-drawer/eng
  * failable drawers in the real template use this identical shape.
  */
 @Component({
+  selector: 'lfx-unavailable-binding-host',
   imports: [EngagedCommunityDrawerComponent],
-  template: `<lfx-engaged-community-drawer
-    [visible]="true"
-    [data]="data()"
-    [brandReachData]="brandReach"
-    [unavailable]="!response()"></lfx-engaged-community-drawer>`,
+  template: `<lfx-engaged-community-drawer [visible]="true" [data]="data()" [brandReachData]="brandReach" [unavailable]="!response()" />`,
 })
 class BindingHostComponent {
   // Mirrors the parent: `response` is the raw `| undefined` field off EdEvolutionData, and
   // `data` is the drawer-facing computed that substitutes an empty shape for the drawer's
   // non-optional input. The drawer therefore CANNOT infer the failure from `data` alone.
   public readonly response = signal<EngagedCommunitySizeResponse | undefined>(undefined);
-  public readonly data = (): EngagedCommunitySizeResponse =>
-    this.response() ?? {
-      totalMembers: 0,
-      changePercentage: 0,
-      trend: 'up',
-      breakdown: {
-        newsletterSubscribers: 0,
-        communityMembers: 0,
-        workingGroupMembers: 0,
-        certifiedIndividuals: 0,
-        webVisitors: 0,
-        codeContributors: 0,
-        trainingEnrollees: 0,
-      },
-      monthlyData: [],
-    };
   public readonly brandReach = {
     totalSocialFollowers: 0,
     totalMonthlySessions: 0,
@@ -64,6 +45,26 @@ class BindingHostComponent {
     websiteDomains: [],
     weeklyTrend: [],
   };
+
+  public data(): EngagedCommunitySizeResponse {
+    return (
+      this.response() ?? {
+        totalMembers: 0,
+        changePercentage: 0,
+        trend: 'up',
+        breakdown: {
+          newsletterSubscribers: 0,
+          communityMembers: 0,
+          workingGroupMembers: 0,
+          certifiedIndividuals: 0,
+          webVisitors: 0,
+          codeContributors: 0,
+          trainingEnrollees: 0,
+        },
+        monthlyData: [],
+      }
+    );
+  }
 }
 
 describe('Marketing Overview — the unavailable binding carries a failed response to the drawer', () => {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -204,11 +204,13 @@
 <lfx-flywheel-conversion-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarFlywheelConversion"
   [data]="flywheelData()"
+  [unavailable]="!edEvolutionData().flywheel"
   (visibleChange)="handleDrawerClose()"></lfx-flywheel-conversion-drawer>
 
 <lfx-member-acquisition-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
   [data]="memberAcquisitionData()"
+  [unavailable]="!edEvolutionData().memberAcquisition"
   [retentionData]="memberRetentionData()"
   [revenueImpactData]="revenueImpactData()"
   (visibleChange)="handleDrawerClose()"></lfx-member-acquisition-drawer>
@@ -216,6 +218,7 @@
 <lfx-engaged-community-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarEngagedCommunity"
   [data]="engagedCommunityData()"
+  [unavailable]="!edEvolutionData().engagedCommunity"
   [brandReachData]="brandReachData()"
   (visibleChange)="handleDrawerClose()"></lfx-engaged-community-drawer>
 
@@ -233,6 +236,7 @@
 <lfx-brand-health-drawer
   [visible]="activeDrawer() === DashboardDrawerType.BrandHealth"
   [data]="brandHealthData()"
+  [unavailable]="!edEvolutionData().brandHealth"
   (visibleChange)="handleDrawerClose()"></lfx-brand-health-drawer>
 
 <!-- Influence Drawer -->

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -204,7 +204,8 @@
 <lfx-flywheel-conversion-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarFlywheelConversion"
   [data]="flywheelData()"
-  [unavailable]="!edEvolutionData().flywheel"
+  [unavailable]="!edEvolutionData().pending && !edEvolutionData().flywheel"
+  [pending]="!!edEvolutionData().pending"
   (visibleChange)="handleDrawerClose()"></lfx-flywheel-conversion-drawer>
 
 <!-- The [unavailable] binding below is deliberately stricter than the Members CARD, which keeps
@@ -215,7 +216,8 @@
 <lfx-member-acquisition-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
   [data]="memberAcquisitionData()"
-  [unavailable]="!edEvolutionData().memberAcquisition || !edEvolutionData().memberRetention"
+  [unavailable]="!edEvolutionData().pending && (!edEvolutionData().memberAcquisition || !edEvolutionData().memberRetention)"
+  [pending]="!!edEvolutionData().pending"
   [retentionData]="memberRetentionData()"
   [revenueImpactData]="revenueImpactData()"
   (visibleChange)="handleDrawerClose()"></lfx-member-acquisition-drawer>
@@ -223,7 +225,8 @@
 <lfx-engaged-community-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarEngagedCommunity"
   [data]="engagedCommunityData()"
-  [unavailable]="!edEvolutionData().engagedCommunity"
+  [unavailable]="!edEvolutionData().pending && !edEvolutionData().engagedCommunity"
+  [pending]="!!edEvolutionData().pending"
   [brandReachData]="brandReachData()"
   (visibleChange)="handleDrawerClose()"></lfx-engaged-community-drawer>
 
@@ -231,19 +234,22 @@
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarEventGrowth"
   [data]="eventGrowthData()"
   (visibleChange)="handleDrawerClose()"
-  [unavailable]="!edEvolutionData().eventGrowth"></lfx-event-growth-drawer>
+  [unavailable]="!edEvolutionData().pending && !edEvolutionData().eventGrowth"
+  [pending]="!!edEvolutionData().pending"></lfx-event-growth-drawer>
 
 <!-- Brand Drawers -->
 <lfx-brand-reach-drawer
   [visible]="activeDrawer() === DashboardDrawerType.BrandReach"
   [data]="brandReachData()"
   (visibleChange)="handleDrawerClose()"
-  [unavailable]="!edEvolutionData().brandReach"></lfx-brand-reach-drawer>
+  [unavailable]="!edEvolutionData().pending && !edEvolutionData().brandReach"
+  [pending]="!!edEvolutionData().pending"></lfx-brand-reach-drawer>
 
 <lfx-brand-health-drawer
   [visible]="activeDrawer() === DashboardDrawerType.BrandHealth"
   [data]="brandHealthData()"
-  [unavailable]="!edEvolutionData().brandHealth"
+  [unavailable]="!edEvolutionData().pending && !edEvolutionData().brandHealth"
+  [pending]="!!edEvolutionData().pending"
   (visibleChange)="handleDrawerClose()"></lfx-brand-health-drawer>
 
 <!-- Influence Drawer -->

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -210,7 +210,7 @@
 <lfx-member-acquisition-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
   [data]="memberAcquisitionData()"
-  [unavailable]="!edEvolutionData().memberAcquisition"
+  [unavailable]="!edEvolutionData().memberAcquisition || !edEvolutionData().memberRetention"
   [retentionData]="memberRetentionData()"
   [revenueImpactData]="revenueImpactData()"
   (visibleChange)="handleDrawerClose()"></lfx-member-acquisition-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -225,13 +225,15 @@
 <lfx-event-growth-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarEventGrowth"
   [data]="eventGrowthData()"
-  (visibleChange)="handleDrawerClose()"></lfx-event-growth-drawer>
+  (visibleChange)="handleDrawerClose()"
+  [unavailable]="!edEvolutionData().eventGrowth"></lfx-event-growth-drawer>
 
 <!-- Brand Drawers -->
 <lfx-brand-reach-drawer
   [visible]="activeDrawer() === DashboardDrawerType.BrandReach"
   [data]="brandReachData()"
-  (visibleChange)="handleDrawerClose()"></lfx-brand-reach-drawer>
+  (visibleChange)="handleDrawerClose()"
+  [unavailable]="!edEvolutionData().brandReach"></lfx-brand-reach-drawer>
 
 <lfx-brand-health-drawer
   [visible]="activeDrawer() === DashboardDrawerType.BrandHealth"

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -207,6 +207,11 @@
   [unavailable]="!edEvolutionData().flywheel"
   (visibleChange)="handleDrawerClose()"></lfx-flywheel-conversion-drawer>
 
+<!-- The [unavailable] binding below is deliberately stricter than the Members CARD, which keeps
+     its measured member count and only drops the retention clause from its caption. This drawer
+     renders renewalRate and NRR as 2xl headline figures rather than caption text, so a
+     retention-only failure would put two fabricated percentages on screen at full size.
+     Same data, different exposure. -->
 <lfx-member-acquisition-drawer
   [visible]="activeDrawer() === DashboardDrawerType.NorthStarMemberAcquisition"
   [data]="memberAcquisitionData()"

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.html
@@ -243,6 +243,7 @@
   [data]="brandReachData()"
   (visibleChange)="handleDrawerClose()"
   [unavailable]="!edEvolutionData().pending && !edEvolutionData().brandReach"
+  [socialUnavailable]="!!edEvolutionData().brandReach?.socialUnavailable"
   [pending]="!!edEvolutionData().pending"></lfx-brand-reach-drawer>
 
 <lfx-brand-health-drawer

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -50,83 +50,32 @@ import { RevenueImpactDrawerComponent } from '../revenue-impact-drawer/revenue-i
 import { WebsiteVisitsDrawerComponent } from '../website-visits-drawer/website-visits-drawer.component';
 
 const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
-  flywheel: {
-    conversionRate: 0,
-    changePercentage: 0,
-    trend: 'up',
-    funnel: {
-      eventAttendees: 0,
-      convertedToNewsletter: 0,
-      convertedToCommunity: 0,
-      convertedToWorkingGroup: 0,
-      convertedToTraining: 0,
-      convertedToCode: 0,
-      convertedToWeb: 0,
-    },
-    reengagement: {
-      totalReengaged: 0,
-      reengagementRate: 0,
-      reengagementMomChange: 0,
-      reengagedToNewsletter: 0,
-      reengagedToCommunity: 0,
-      reengagedToWorkingGroup: 0,
-      reengagedToTraining: 0,
-      reengagedToCode: 0,
-      reengagedToWeb: 0,
-    },
-    monthlyData: [],
-  },
-  memberAcquisition: {
-    totalMembers: 0,
-    totalMembersMonthlyData: [],
-    totalMembersMonthlyLabels: [],
-    newMembersThisQuarter: 0,
-    newMemberRevenue: 0,
-    changePercentage: 0,
-    trend: 'up',
-    quarterlyData: [],
-  },
-  memberRetention: {
-    renewalRate: 0,
-    netRevenueRetention: 0,
-    changePercentage: 0,
-    trend: 'up',
-    target: 0,
-    monthlyData: [],
-  },
+  // Explicitly undefined for the same reason as revenueImpact below: a zero-filled response
+  // renders "0.0%" on the Flywheel card, which reads as a measured conversion rate rather
+  // than a failed request.
+  flywheel: undefined,
+  // Explicitly undefined for the same reason as revenueImpact below: zero paying members is
+  // a legitimate measurement, so the Members card must not fall back to it.
+  memberAcquisition: undefined,
+  // Explicitly undefined for the same reason as memberAcquisition above — this response
+  // supplies the Members caption, so a zero-filled fallback reports "0.0% retention · NRR
+  // 0.0%" as if measured.
+  memberRetention: undefined,
   // Explicitly undefined for the same reason as revenueImpact below: 27,831 engaged
   // individuals rendered as "0" on AAIF when this fell back to a zero-filled response.
   engagedCommunity: undefined,
-  eventGrowth: {
-    totalAttendees: 0,
-    totalRegistrants: 0,
-    totalEvents: 0,
-    totalRevenue: 0,
-    revenuePerAttendee: 0,
-    attendeeYoyChange: 0,
-    registrantYoyChange: 0,
-    revenueYoyChange: 0,
-    trend: 'up',
-    monthlyData: [],
-    topEvents: [],
-  },
+  // Explicitly undefined for the same reason as revenueImpact below: a zero-filled response
+  // renders "0" registrants, indistinguishable from a foundation that genuinely ran no events.
+  eventGrowth: undefined,
   // Explicitly undefined for the same reason as revenueImpact below: zero followers and
   // zero sessions are legitimate measurements, so the Social and Web cards must not fall
   // back to them. AAIF has 17,269 followers across 2 platforms and rendered "0 · 0
   // platforms" on a cold load when brand-reach failed inside the dashboard's request
   // burst — an outage presented as a measured absence.
   brandReach: undefined,
-  brandHealth: {
-    totalMentions: 0,
-    sentiment: { positive: 0, neutral: 0, negative: 0 },
-    sentimentMomChangePp: 0,
-    mentionMomChangePct: null,
-    trend: 'up',
-    monthlyMentions: [],
-    topProjects: [],
-    topPositiveMentions: [],
-    topNegativeMentions: [],
-  },
+  // Explicitly undefined for the same reason as revenueImpact below: AAIF has 80,799
+  // mentions and the card read "0" when this fell back to a zero-filled response.
+  brandHealth: undefined,
   // Explicitly undefined rather than zero-filled: safe() reads EMPTY_ED_EVOLUTION_DATA[key]
   // as the per-call error fallback, and the Attribution card renders an unavailable state
   // on undefined. A zero-filled summary here would render the card at $0 on a failed
@@ -242,9 +191,69 @@ export class MarketingOverviewComponent {
     this.initBrandHealthMentions();
   protected readonly edEvolutionData: Signal<EdEvolutionData> = this.initEdEvolutionData();
 
-  protected readonly flywheelData = computed<FlywheelConversionResponse>(() => this.edEvolutionData().flywheel);
-  protected readonly memberAcquisitionData = computed<MemberAcquisitionResponse>(() => this.edEvolutionData().memberAcquisition);
-  protected readonly memberRetentionData = computed<MemberRetentionResponse>(() => this.edEvolutionData().memberRetention);
+  /**
+   * Drawer-facing only, exactly like engagedCommunityData below: the Flywheel card reads
+   * `edEvolutionData().flywheel` directly and renders an unavailable state on undefined,
+   * while the drawer takes a non-optional input and length-guards its own collections.
+   * Never source a card value from here — an empty shape here reads as a measured zero.
+   */
+  protected readonly flywheelData = computed<FlywheelConversionResponse>(
+    () =>
+      this.edEvolutionData().flywheel ?? {
+        conversionRate: 0,
+        changePercentage: 0,
+        trend: 'up',
+        funnel: {
+          eventAttendees: 0,
+          convertedToNewsletter: 0,
+          convertedToCommunity: 0,
+          convertedToWorkingGroup: 0,
+          convertedToTraining: 0,
+          convertedToCode: 0,
+          convertedToWeb: 0,
+        },
+        reengagement: {
+          totalReengaged: 0,
+          reengagementRate: 0,
+          reengagementMomChange: 0,
+          reengagedToNewsletter: 0,
+          reengagedToCommunity: 0,
+          reengagedToWorkingGroup: 0,
+          reengagedToTraining: 0,
+          reengagedToCode: 0,
+          reengagedToWeb: 0,
+        },
+        monthlyData: [],
+      }
+  );
+  /**
+   * Drawer-facing only, exactly like engagedCommunityData below: the Members card reads
+   * `edEvolutionData().memberAcquisition` directly and renders an unavailable state on undefined,
+   * while the drawer takes a non-optional input and length-guards its own collections.
+   * Never source a card value from here — an empty shape here reads as a measured zero.
+   */
+  protected readonly memberAcquisitionData = computed<MemberAcquisitionResponse>(
+    () =>
+      this.edEvolutionData().memberAcquisition ?? {
+        totalMembers: 0,
+        totalMembersMonthlyData: [],
+        totalMembersMonthlyLabels: [],
+        newMembersThisQuarter: 0,
+        newMemberRevenue: 0,
+        changePercentage: 0,
+        trend: 'up',
+        quarterlyData: [],
+      }
+  );
+  /**
+   * Drawer-facing only, exactly like engagedCommunityData below: the Members card reads
+   * `edEvolutionData().memberRetention` directly and renders an unavailable state on undefined,
+   * while the drawer takes a non-optional input and length-guards its own collections.
+   * Never source a card value from here — an empty shape here reads as a measured zero.
+   */
+  protected readonly memberRetentionData = computed<MemberRetentionResponse>(
+    () => this.edEvolutionData().memberRetention ?? { renewalRate: 0, netRevenueRetention: 0, changePercentage: 0, trend: 'up', target: 0, monthlyData: [] }
+  );
   /**
    * Drawer-facing only, exactly like brandReachData below: the Adoption card reads
    * `edEvolutionData().engagedCommunity` and renders an unavailable state on undefined,
@@ -269,7 +278,28 @@ export class MarketingOverviewComponent {
         monthlyData: [],
       }
   );
-  protected readonly eventGrowthData = computed<EventGrowthResponse>(() => this.edEvolutionData().eventGrowth);
+  /**
+   * Drawer-facing only, exactly like engagedCommunityData below: the Events card reads
+   * `edEvolutionData().eventGrowth` directly and renders an unavailable state on undefined,
+   * while the drawer takes a non-optional input and length-guards its own collections.
+   * Never source a card value from here — an empty shape here reads as a measured zero.
+   */
+  protected readonly eventGrowthData = computed<EventGrowthResponse>(
+    () =>
+      this.edEvolutionData().eventGrowth ?? {
+        totalAttendees: 0,
+        totalRegistrants: 0,
+        totalEvents: 0,
+        totalRevenue: 0,
+        revenuePerAttendee: 0,
+        attendeeYoyChange: 0,
+        registrantYoyChange: 0,
+        revenueYoyChange: 0,
+        trend: 'up',
+        monthlyData: [],
+        topEvents: [],
+      }
+  );
   /**
    * Drawer-facing only. The Social and Web cards read `edEvolutionData().brandReach`
    * directly and render an unavailable state when it is undefined; the drawers take a
@@ -292,8 +322,23 @@ export class MarketingOverviewComponent {
         weeklyTrend: [],
       }
   );
+  /**
+   * Drawer-facing only, like brandReachData and engagedCommunityData: the Sentiment card
+   * reads `edEvolutionData().brandHealth` and renders an unavailable state on undefined.
+   * Never source a card value from here — that printed "0" for AAIF's 80,799 mentions.
+   */
   protected readonly brandHealthData = computed<BrandHealthResponse>(() => {
-    const base = this.edEvolutionData().brandHealth;
+    const base = this.edEvolutionData().brandHealth ?? {
+      totalMentions: 0,
+      sentiment: { positive: 0, neutral: 0, negative: 0 },
+      sentimentMomChangePp: 0,
+      mentionMomChangePct: null,
+      trend: 'up' as const,
+      monthlyMentions: [],
+      topProjects: [],
+      topPositiveMentions: [],
+      topNegativeMentions: [],
+    };
     const mentions = this.brandHealthMentions();
     return mentions ? { ...base, ...mentions } : base;
   });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -94,21 +94,9 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     target: 0,
     monthlyData: [],
   },
-  engagedCommunity: {
-    totalMembers: 0,
-    changePercentage: 0,
-    trend: 'up',
-    breakdown: {
-      newsletterSubscribers: 0,
-      communityMembers: 0,
-      workingGroupMembers: 0,
-      certifiedIndividuals: 0,
-      webVisitors: 0,
-      codeContributors: 0,
-      trainingEnrollees: 0,
-    },
-    monthlyData: [],
-  },
+  // Explicitly undefined for the same reason as revenueImpact below: 27,831 engaged
+  // individuals rendered as "0" on AAIF when this fell back to a zero-filled response.
+  engagedCommunity: undefined,
   eventGrowth: {
     totalAttendees: 0,
     totalRegistrants: 0,
@@ -144,17 +132,11 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
   // on undefined. A zero-filled summary here would render the card at $0 on a failed
   // request — reporting a fabricated figure as a measured one.
   revenueImpact: undefined,
-  emailCtr: {
-    currentCtr: 0,
-    changePercentage: 0,
-    momChangePercentage: null,
-    trend: 'up' as const,
-    monthlyData: [],
-    monthlyLabels: [],
-    campaignGroups: [],
-    monthlySends: [],
-    monthlyOpens: [],
-  },
+  // Explicitly undefined for the same reason as revenueImpact above. This one was reported
+  // from production: the Email card read "0 opens · 0.0% CTR" for a foundation whose March
+  // campaign had 100 opens at a 76.3% CTR, because the zero-filled fallback summed to 0 and
+  // nothing downstream could tell that apart from a month with no email.
+  emailCtr: undefined,
   // Explicitly undefined for the same reason as revenueImpact above — zero spend and
   // 0.0x ROAS are real measurements, so the Paid Media card must not fall back to them.
   paidCampaign: undefined,
@@ -263,7 +245,30 @@ export class MarketingOverviewComponent {
   protected readonly flywheelData = computed<FlywheelConversionResponse>(() => this.edEvolutionData().flywheel);
   protected readonly memberAcquisitionData = computed<MemberAcquisitionResponse>(() => this.edEvolutionData().memberAcquisition);
   protected readonly memberRetentionData = computed<MemberRetentionResponse>(() => this.edEvolutionData().memberRetention);
-  protected readonly engagedCommunityData = computed<EngagedCommunitySizeResponse>(() => this.edEvolutionData().engagedCommunity);
+  /**
+   * Drawer-facing only, exactly like brandReachData below: the Adoption card reads
+   * `edEvolutionData().engagedCommunity` and renders an unavailable state on undefined,
+   * while the drawer takes a non-optional input and length-guards its own collections.
+   * Never source a card value from here — that is what printed "0" for AAIF's 27,831.
+   */
+  protected readonly engagedCommunityData = computed<EngagedCommunitySizeResponse>(
+    () =>
+      this.edEvolutionData().engagedCommunity ?? {
+        totalMembers: 0,
+        changePercentage: 0,
+        trend: 'up',
+        breakdown: {
+          newsletterSubscribers: 0,
+          communityMembers: 0,
+          workingGroupMembers: 0,
+          certifiedIndividuals: 0,
+          webVisitors: 0,
+          codeContributors: 0,
+          trainingEnrollees: 0,
+        },
+        monthlyData: [],
+      }
+  );
   protected readonly eventGrowthData = computed<EventGrowthResponse>(() => this.edEvolutionData().eventGrowth);
   /**
    * Drawer-facing only. The Social and Web cards read `edEvolutionData().brandReach`

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -20,6 +20,7 @@ import {
   DashboardDrawerType,
   DashboardMetricCard,
   EdEvolutionData,
+  EmailCtrResponse,
   EngagedCommunitySizeResponse,
   EventGrowthResponse,
   FlywheelConversionResponse,
@@ -430,32 +431,30 @@ export class MarketingOverviewComponent {
       foundation$.pipe(
         switchMap((slug) =>
           forkJoin({
-            // getFlywheelConversion is the one service here that swallows its own HTTP error
-            // into of(null), so safe()'s catchError never fires for it and this map is the
-            // real failure path. Coalesce to undefined explicitly rather than through
-            // EMPTY_ED_EVOLUTION_DATA.flywheel — that now IS undefined, which hides the
-            // dependency and lets a later "cleanup" put null into a field typed
-            // FlywheelConversionResponse | undefined.
+            // getFlywheelConversion is the one client method that swallows its own HTTP error into
+            // of(null), so safe()'s catchError never fires for it and this map is the real failure
+            // path. Coalesce to undefined explicitly rather than through EMPTY_ED_EVOLUTION_DATA,
+            // which is only undefined by coincidence.
             flywheel: safe<FlywheelConversionResponse | undefined>(
               'flywheel',
               this.analyticsService.getFlywheelConversion(slug).pipe(map((r) => r ?? undefined))
             ),
-            memberAcquisition: safe('memberAcquisition', this.analyticsService.getMemberAcquisition(slug)),
-            memberRetention: safe('memberRetention', this.analyticsService.getMemberRetention(slug)),
-            engagedCommunity: safe('engagedCommunity', this.analyticsService.getEngagedCommunity(slug)),
-            eventGrowth: safe('eventGrowth', this.analyticsService.getEventGrowth(slug)),
-            brandReach: safe('brandReach', this.analyticsService.getBrandReach(slug)),
+            memberAcquisition: safe<MemberAcquisitionResponse | undefined>('memberAcquisition', this.analyticsService.getMemberAcquisition(slug)),
+            memberRetention: safe<MemberRetentionResponse | undefined>('memberRetention', this.analyticsService.getMemberRetention(slug)),
+            engagedCommunity: safe<EngagedCommunitySizeResponse | undefined>('engagedCommunity', this.analyticsService.getEngagedCommunity(slug)),
+            eventGrowth: safe<EventGrowthResponse | undefined>('eventGrowth', this.analyticsService.getEventGrowth(slug)),
+            brandReach: safe<BrandReachResponse | undefined>('brandReach', this.analyticsService.getBrandReach(slug)),
             // Period-aware endpoints get the last-6 preset explicitly: their trend
             // sections are designed (and labeled) as 6-month windows, and omitting
             // the period silently falls back to the previous completed month. MoM
             // KPIs are unaffected — both windows share the same period END.
-            brandHealth: safe('brandHealth', this.analyticsService.getBrandHealth(slug, false, 'last-6')),
+            brandHealth: safe<BrandHealthResponse | undefined>('brandHealth', this.analyticsService.getBrandHealth(slug, false, 'last-6')),
             // Explicit `| undefined` type argument on these two: their error fallback
             // is genuinely undefined (see EMPTY_ED_EVOLUTION_DATA), so letting safe()
             // infer T from the observable alone would type away the failure case that
             // the Paid Media and Attribution cards branch on.
             revenueImpact: safe<RevenueImpactResponse | undefined>('revenueImpact', this.analyticsService.getRevenueImpact(slug, undefined, 'last-6')),
-            emailCtr: safe('emailCtr', this.analyticsService.getEmailCtr(slug, undefined, 'last-6')),
+            emailCtr: safe<EmailCtrResponse | undefined>('emailCtr', this.analyticsService.getEmailCtr(slug, undefined, 'last-6')),
             paidCampaign: safe<SocialReachResponse | undefined>('paidCampaign', this.analyticsService.getSocialReach(slug, undefined, 'last-6')),
             // Reuses the Health Metrics training-certification endpoint so the Education
             // card cannot disagree with that card. 'YTD' matches the default range there.

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -430,7 +430,16 @@ export class MarketingOverviewComponent {
       foundation$.pipe(
         switchMap((slug) =>
           forkJoin({
-            flywheel: safe('flywheel', this.analyticsService.getFlywheelConversion(slug).pipe(map((r) => r ?? EMPTY_ED_EVOLUTION_DATA.flywheel))),
+            // getFlywheelConversion is the one service here that swallows its own HTTP error
+            // into of(null), so safe()'s catchError never fires for it and this map is the
+            // real failure path. Coalesce to undefined explicitly rather than through
+            // EMPTY_ED_EVOLUTION_DATA.flywheel — that now IS undefined, which hides the
+            // dependency and lets a later "cleanup" put null into a field typed
+            // FlywheelConversionResponse | undefined.
+            flywheel: safe<FlywheelConversionResponse | undefined>(
+              'flywheel',
+              this.analyticsService.getFlywheelConversion(slug).pipe(map((r) => r ?? undefined))
+            ),
             memberAcquisition: safe('memberAcquisition', this.analyticsService.getMemberAcquisition(slug)),
             memberRetention: safe('memberRetention', this.analyticsService.getMemberRetention(slug)),
             engagedCommunity: safe('engagedCommunity', this.analyticsService.getEngagedCommunity(slug)),

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/marketing-overview/marketing-overview.component.ts
@@ -122,17 +122,12 @@ const EMPTY_ED_EVOLUTION_DATA: EdEvolutionData = {
     monthlyData: [],
     topEvents: [],
   },
-  brandReach: {
-    totalSocialFollowers: 0,
-    totalMonthlySessions: 0,
-    activePlatforms: 0,
-    changePercentage: 0,
-    sessionMomChangePct: 0,
-    trend: 'up',
-    socialPlatforms: [],
-    websiteDomains: [],
-    weeklyTrend: [],
-  },
+  // Explicitly undefined for the same reason as revenueImpact below: zero followers and
+  // zero sessions are legitimate measurements, so the Social and Web cards must not fall
+  // back to them. AAIF has 17,269 followers across 2 platforms and rendered "0 · 0
+  // platforms" on a cold load when brand-reach failed inside the dashboard's request
+  // burst — an outage presented as a measured absence.
+  brandReach: undefined,
   brandHealth: {
     totalMentions: 0,
     sentiment: { positive: 0, neutral: 0, negative: 0 },
@@ -270,7 +265,28 @@ export class MarketingOverviewComponent {
   protected readonly memberRetentionData = computed<MemberRetentionResponse>(() => this.edEvolutionData().memberRetention);
   protected readonly engagedCommunityData = computed<EngagedCommunitySizeResponse>(() => this.edEvolutionData().engagedCommunity);
   protected readonly eventGrowthData = computed<EventGrowthResponse>(() => this.edEvolutionData().eventGrowth);
-  protected readonly brandReachData = computed<BrandReachResponse>(() => this.edEvolutionData().brandReach);
+  /**
+   * Drawer-facing only. The Social and Web cards read `edEvolutionData().brandReach`
+   * directly and render an unavailable state when it is undefined; the drawers take a
+   * non-optional input and already render their own "not yet available" copy for empty
+   * collections, so an empty shape here is the smaller change and says the same thing.
+   * It must never be used to source a card value — that is what printed "0 · 0 platforms"
+   * for a foundation with 17,269 followers.
+   */
+  protected readonly brandReachData = computed<BrandReachResponse>(
+    () =>
+      this.edEvolutionData().brandReach ?? {
+        totalSocialFollowers: 0,
+        totalMonthlySessions: 0,
+        activePlatforms: 0,
+        changePercentage: 0,
+        sessionMomChangePct: 0,
+        trend: 'up',
+        socialPlatforms: [],
+        websiteDomains: [],
+        weeklyTrend: [],
+      }
+  );
   protected readonly brandHealthData = computed<BrandHealthResponse>(() => {
     const base = this.edEvolutionData().brandHealth;
     const mentions = this.brandHealthMentions();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -152,8 +152,12 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">No membership activity detected</h3>
-            <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No membership activity detected' }}</h3>
+            @if (unavailable()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            } @else {
+              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -28,246 +28,263 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="member-acquisition-drawer-content">
-    <!-- Summary Stats -->
-    <!-- Suppressed when the request failed: these render from the parent's zero-filled
-         fallback, so leaving them visible puts "0" members in 2xl type above the banner
-         saying the data could not be loaded. -->
-    @if (!unavailable()) {
-      <div class="flex gap-4" data-testid="member-acquisition-drawer-stats">
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Total Members</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalMembers() }}</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">New This Quarter</span>
-            <span class="text-2xl font-semibold text-gray-900">+{{ data().newMembersThisQuarter }}</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">New Member Revenue</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ formattedNewMemberRevenue() }}</span>
-          </div>
-        </lfx-card>
-      </div>
-    }
-
-    <!-- Retention Stats (if available) -->
-    @if (!unavailable() && retentionData().renewalRate > 0) {
-      <div class="flex gap-4" data-testid="member-acquisition-drawer-retention-stats">
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Renewal Rate</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate | number: '1.1-1' }}%</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Net Revenue Retention</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention | number: '1.1-1' }}%</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Growth</span>
-            @if (retentionData().changePercentage !== 0) {
-              <div class="flex items-center gap-2">
-                <span class="text-2xl font-semibold" [class]="retentionData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage | number: '1.1-1' }}%
-                </span>
-                <i class="text-sm" [class]="retentionData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
-              </div>
-            } @else {
-              <span class="text-2xl font-semibold text-gray-500">0%</span>
-            }
-          </div>
-        </lfx-card>
-      </div>
-    }
-
-    <!-- FIRST FOLD: Needs Your Attention -->
-    @if (!unavailable() && (attentionActions().length > 0 || attentionInsights().length > 0)) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-        data-testid="member-acquisition-drawer-attention">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-          <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
-        </div>
-
-        @for (action of attentionActions(); track action.title) {
-          <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-            @if (action.priority === 'high') {
-              <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-            } @else {
-              <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
-            }
-          </div>
-        }
-
-        @for (insight of attentionInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
-          </div>
-        }
-      </div>
-    }
-
-    <!-- SECOND FOLD: Performing Well -->
-    @if (!unavailable() && (performingActions().length > 0 || performingInsights().length > 0)) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-        data-testid="member-acquisition-drawer-performing">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-check text-green-600"></i>
-          <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
-        </div>
-
-        @for (action of performingActions(); track action.title) {
-          <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-          </div>
-        }
-
-        @for (insight of performingInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
-          </div>
-        }
-      </div>
-    }
-
-    @if (hasNoData()) {
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
         role="status"
-        data-testid="member-acquisition-drawer-no-data">
+        aria-live="polite"
+        data-testid="member-acquisition-drawer-unavailable">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No membership activity detected' }}</h3>
-            @if (unavailable()) {
-              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+          </div>
+        </div>
+      </div>
+    } @else {
+      <!-- Summary Stats -->
+      <!-- Suppressed when the request failed: these render from the parent's zero-filled
+           fallback, so leaving them visible puts "0" members in 2xl type above the banner
+           saying the data could not be loaded. -->
+      @if (!unavailable()) {
+        <div class="flex gap-4" data-testid="member-acquisition-drawer-stats">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Total Members</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalMembers() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">New This Quarter</span>
+              <span class="text-2xl font-semibold text-gray-900">+{{ data().newMembersThisQuarter }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">New Member Revenue</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formattedNewMemberRevenue() }}</span>
+            </div>
+          </lfx-card>
+        </div>
+      }
+
+      <!-- Retention Stats (if available) -->
+      @if (retentionData().renewalRate > 0) {
+        <div class="flex gap-4" data-testid="member-acquisition-drawer-retention-stats">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Renewal Rate</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ retentionData().renewalRate | number: '1.1-1' }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Net Revenue Retention</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ retentionData().netRevenueRetention | number: '1.1-1' }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Growth</span>
+              @if (retentionData().changePercentage !== 0) {
+                <div class="flex items-center gap-2">
+                  <span class="text-2xl font-semibold" [class]="retentionData().trend === 'up' ? 'text-green-600' : 'text-red-600'">
+                    {{ retentionData().changePercentage > 0 ? '+' : '' }}{{ retentionData().changePercentage | number: '1.1-1' }}%
+                  </span>
+                  <i
+                    class="text-sm"
+                    [class]="retentionData().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
+                </div>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-500">0%</span>
+              }
+            </div>
+          </lfx-card>
+        </div>
+      }
+
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="member-acquisition-drawer-attention">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+          </div>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+              @if (action.priority === 'high') {
+                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+              } @else {
+                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+              }
+            </div>
+          }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
+            </div>
+          }
+        </div>
+      }
+
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="member-acquisition-drawer-performing">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-check text-green-600"></i>
+            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+          </div>
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
+            </div>
+          }
+        </div>
+      }
+
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+          role="status"
+          data-testid="member-acquisition-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <h3 class="text-sm font-semibold text-gray-900">No membership activity detected</h3>
+              <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
+            </div>
+          </div>
+        </div>
+      }
+
+      <!-- Sales Pipeline -->
+      @if (
+        revenueImpactData().pipelineInfluenced > 0 ||
+        revenueImpactData().revenueAttributed > 0 ||
+        revenueImpactData().matchRate > 0 ||
+        revenueImpactData().engagementTypes.length > 0
+      ) {
+        <div class="flex flex-col gap-4" data-testid="member-acquisition-drawer-pipeline-section">
+          <h3 class="text-sm font-semibold text-gray-900">Sales Pipeline</h3>
+          <div class="flex gap-4" data-testid="member-acquisition-drawer-pipeline-stats">
+            <lfx-card styleClass="flex-1">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Pipeline Influenced</span>
+                @if (revenueImpactData().pipelineInfluenced > 0) {
+                  <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().pipelineInfluenced | formatMoney }}</span>
+                } @else {
+                  <span class="text-2xl font-semibold text-gray-400">—</span>
+                }
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Revenue Attributed</span>
+                @if (revenueImpactData().revenueAttributed > 0) {
+                  <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().revenueAttributed | formatMoney }}</span>
+                } @else {
+                  <span class="text-2xl font-semibold text-gray-400">—</span>
+                }
+              </div>
+            </lfx-card>
+            <lfx-card styleClass="flex-1">
+              <div class="flex flex-col gap-1">
+                <span class="text-sm text-gray-500">Match Rate</span>
+                @if (revenueImpactData().matchRate > 0) {
+                  <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().matchRate | number: '1.1-1' }}%</span>
+                } @else {
+                  <span class="text-2xl font-semibold text-gray-400">—</span>
+                }
+              </div>
+            </lfx-card>
+          </div>
+
+          <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-deal-breakdown">
+            <div class="flex flex-col gap-1">
+              <h3 class="text-sm font-semibold text-gray-900">Deal Pipeline Breakdown</h3>
+              <p class="text-sm text-gray-600">Deal status distribution across the membership pipeline</p>
+            </div>
+            @if (revenueImpactData().engagementTypes.length > 0) {
+              <div class="flex flex-col gap-3">
+                @for (engagement of revenueImpactData().engagementTypes; track engagement.type) {
+                  <div class="flex flex-col gap-1" data-testid="member-acquisition-drawer-deal-row">
+                    <div class="flex items-center justify-between">
+                      <span class="text-sm font-medium text-gray-900">{{ engagement.type }}</span>
+                      <span class="text-sm font-semibold text-gray-900">{{ engagement.percentage | number: '1.1-1' }}%</span>
+                    </div>
+                    <div class="w-full h-2 bg-gray-100 rounded-full">
+                      <div class="h-2 bg-blue-500 rounded-full" [style.width.%]="engagement.percentage"></div>
+                    </div>
+                  </div>
+                }
+              </div>
             } @else {
-              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+              <div class="flex items-center justify-center h-[80px] text-sm text-gray-400">Deal pipeline data not yet available</div>
             }
           </div>
         </div>
-      </div>
-    }
+      }
 
-    <!-- Sales Pipeline -->
-    @if (
-      revenueImpactData().pipelineInfluenced > 0 ||
-      revenueImpactData().revenueAttributed > 0 ||
-      revenueImpactData().matchRate > 0 ||
-      revenueImpactData().engagementTypes.length > 0
-    ) {
-      <div class="flex flex-col gap-4" data-testid="member-acquisition-drawer-pipeline-section">
-        <h3 class="text-sm font-semibold text-gray-900">Sales Pipeline</h3>
-        <div class="flex gap-4" data-testid="member-acquisition-drawer-pipeline-stats">
-          <lfx-card styleClass="flex-1">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Pipeline Influenced</span>
-              @if (revenueImpactData().pipelineInfluenced > 0) {
-                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().pipelineInfluenced | formatMoney }}</span>
-              } @else {
-                <span class="text-2xl font-semibold text-gray-400">—</span>
-              }
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Revenue Attributed</span>
-              @if (revenueImpactData().revenueAttributed > 0) {
-                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().revenueAttributed | formatMoney }}</span>
-              } @else {
-                <span class="text-2xl font-semibold text-gray-400">—</span>
-              }
-            </div>
-          </lfx-card>
-          <lfx-card styleClass="flex-1">
-            <div class="flex flex-col gap-1">
-              <span class="text-sm text-gray-500">Match Rate</span>
-              @if (revenueImpactData().matchRate > 0) {
-                <span class="text-2xl font-semibold text-gray-900">{{ revenueImpactData().matchRate | number: '1.1-1' }}%</span>
-              } @else {
-                <span class="text-2xl font-semibold text-gray-400">—</span>
-              }
-            </div>
-          </lfx-card>
-        </div>
-
-        <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-deal-breakdown">
+      <!-- Total Members Trend -->
+      @if (data().totalMembersMonthlyData.length > 1) {
+        <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-total-members-section">
           <div class="flex flex-col gap-1">
-            <h3 class="text-sm font-semibold text-gray-900">Deal Pipeline Breakdown</h3>
-            <p class="text-sm text-gray-600">Deal status distribution across the membership pipeline</p>
+            <h3 class="text-sm font-semibold text-gray-900">Total Members Over Time</h3>
+            <p class="text-sm text-gray-600">Cumulative membership growth over the last 12 months</p>
           </div>
-          @if (revenueImpactData().engagementTypes.length > 0) {
-            <div class="flex flex-col gap-3">
-              @for (engagement of revenueImpactData().engagementTypes; track engagement.type) {
-                <div class="flex flex-col gap-1" data-testid="member-acquisition-drawer-deal-row">
-                  <div class="flex items-center justify-between">
-                    <span class="text-sm font-medium text-gray-900">{{ engagement.type }}</span>
-                    <span class="text-sm font-semibold text-gray-900">{{ engagement.percentage | number: '1.1-1' }}%</span>
-                  </div>
-                  <div class="w-full h-2 bg-gray-100 rounded-full">
-                    <div class="h-2 bg-blue-500 rounded-full" [style.width.%]="engagement.percentage"></div>
-                  </div>
-                </div>
-              }
+          <div class="h-[200px]" data-testid="member-acquisition-drawer-total-members-chart">
+            <lfx-chart type="line" [data]="totalMembersChartData()" [options]="totalMembersChartOptions" height="100%"></lfx-chart>
+          </div>
+        </div>
+      }
+
+      <!-- Quarterly Acquisition Chart — hidden entirely on a failed request: its own empty
+           state asserts "No acquisition data available", which is a measured claim. -->
+      @if (!unavailable()) {
+        <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-chart-section">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-semibold text-gray-900">New Members by Quarter</h3>
+            <p class="text-sm text-gray-600">Quarterly member acquisition trend</p>
+          </div>
+          @if (data().quarterlyData.length > 1) {
+            <div class="h-[200px]" data-testid="member-acquisition-drawer-chart">
+              <lfx-chart type="bar" [data]="acquisitionChartData()" [options]="acquisitionChartOptions" height="100%"></lfx-chart>
             </div>
           } @else {
-            <div class="flex items-center justify-center h-[80px] text-sm text-gray-400">Deal pipeline data not yet available</div>
+            <div class="text-center py-8 border border-slate-200 rounded-lg">
+              <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+              <p class="text-sm text-gray-500">No acquisition data available</p>
+            </div>
           }
         </div>
-      </div>
-    }
-
-    <!-- Total Members Trend -->
-    @if (!unavailable() && data().totalMembersMonthlyData.length > 1) {
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-total-members-section">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">Total Members Over Time</h3>
-          <p class="text-sm text-gray-600">Cumulative membership growth over the last 12 months</p>
-        </div>
-        <div class="h-[200px]" data-testid="member-acquisition-drawer-total-members-chart">
-          <lfx-chart type="line" [data]="totalMembersChartData()" [options]="totalMembersChartOptions" height="100%"></lfx-chart>
-        </div>
-      </div>
-    }
-
-    <!-- Quarterly Acquisition Chart — hidden entirely on a failed request: its own empty
-         state asserts "No acquisition data available", which is a measured claim. -->
-    @if (!unavailable()) {
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-chart-section">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">New Members by Quarter</h3>
-          <p class="text-sm text-gray-600">Quarterly member acquisition trend</p>
-        </div>
-        @if (data().quarterlyData.length > 1) {
-          <div class="h-[200px]" data-testid="member-acquisition-drawer-chart">
-            <lfx-chart type="bar" [data]="acquisitionChartData()" [options]="acquisitionChartOptions" height="100%"></lfx-chart>
-          </div>
-        } @else {
-          <div class="text-center py-8 border border-slate-200 rounded-lg">
-            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No acquisition data available</p>
-          </div>
-        }
-      </div>
+      }
     }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -29,26 +29,31 @@
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="member-acquisition-drawer-content">
     <!-- Summary Stats -->
-    <div class="flex gap-4" data-testid="member-acquisition-drawer-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Total Members</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalMembers() }}</span>
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">New This Quarter</span>
-          <span class="text-2xl font-semibold text-gray-900">+{{ data().newMembersThisQuarter }}</span>
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">New Member Revenue</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ formattedNewMemberRevenue() }}</span>
-        </div>
-      </lfx-card>
-    </div>
+    <!-- Suppressed when the request failed: these render from the parent's zero-filled
+         fallback, so leaving them visible puts "0" members in 2xl type above the banner
+         saying the data could not be loaded. -->
+    @if (!unavailable()) {
+      <div class="flex gap-4" data-testid="member-acquisition-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Total Members</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalMembers() }}</span>
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">New This Quarter</span>
+            <span class="text-2xl font-semibold text-gray-900">+{{ data().newMembersThisQuarter }}</span>
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">New Member Revenue</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ formattedNewMemberRevenue() }}</span>
+          </div>
+        </lfx-card>
+      </div>
+    }
 
     <!-- Retention Stats (if available) -->
     @if (retentionData().renewalRate > 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -56,7 +56,7 @@
     }
 
     <!-- Retention Stats (if available) -->
-    @if (retentionData().renewalRate > 0) {
+    @if (!unavailable() && retentionData().renewalRate > 0) {
       <div class="flex gap-4" data-testid="member-acquisition-drawer-retention-stats">
         <lfx-card styleClass="flex-1">
           <div class="flex flex-col gap-1">
@@ -89,7 +89,7 @@
     }
 
     <!-- FIRST FOLD: Needs Your Attention -->
-    @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+    @if (!unavailable() && (attentionActions().length > 0 || attentionInsights().length > 0)) {
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
         data-testid="member-acquisition-drawer-attention">
@@ -122,7 +122,7 @@
     }
 
     <!-- SECOND FOLD: Performing Well -->
-    @if (performingActions().length > 0 || performingInsights().length > 0) {
+    @if (!unavailable() && (performingActions().length > 0 || performingInsights().length > 0)) {
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
         data-testid="member-acquisition-drawer-performing">
@@ -237,7 +237,7 @@
     }
 
     <!-- Total Members Trend -->
-    @if (data().totalMembersMonthlyData.length > 1) {
+    @if (!unavailable() && data().totalMembersMonthlyData.length > 1) {
       <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-total-members-section">
         <div class="flex flex-col gap-1">
           <h3 class="text-sm font-semibold text-gray-900">Total Members Over Time</h3>
@@ -249,22 +249,25 @@
       </div>
     }
 
-    <!-- Quarterly Acquisition Chart -->
-    <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-chart-section">
-      <div class="flex flex-col gap-1">
-        <h3 class="text-sm font-semibold text-gray-900">New Members by Quarter</h3>
-        <p class="text-sm text-gray-600">Quarterly member acquisition trend</p>
+    <!-- Quarterly Acquisition Chart — hidden entirely on a failed request: its own empty
+         state asserts "No acquisition data available", which is a measured claim. -->
+    @if (!unavailable()) {
+      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="member-acquisition-drawer-chart-section">
+        <div class="flex flex-col gap-1">
+          <h3 class="text-sm font-semibold text-gray-900">New Members by Quarter</h3>
+          <p class="text-sm text-gray-600">Quarterly member acquisition trend</p>
+        </div>
+        @if (data().quarterlyData.length > 1) {
+          <div class="h-[200px]" data-testid="member-acquisition-drawer-chart">
+            <lfx-chart type="bar" [data]="acquisitionChartData()" [options]="acquisitionChartOptions" height="100%"></lfx-chart>
+          </div>
+        } @else {
+          <div class="text-center py-8 border border-slate-200 rounded-lg">
+            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+            <p class="text-sm text-gray-500">No acquisition data available</p>
+          </div>
+        }
       </div>
-      @if (data().quarterlyData.length > 1) {
-        <div class="h-[200px]" data-testid="member-acquisition-drawer-chart">
-          <lfx-chart type="bar" [data]="acquisitionChartData()" [options]="acquisitionChartOptions" height="100%"></lfx-chart>
-        </div>
-      } @else {
-        <div class="text-center py-8 border border-slate-200 rounded-lg">
-          <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-          <p class="text-sm text-gray-500">No acquisition data available</p>
-        </div>
-      }
-    </div>
+    }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.html
@@ -28,7 +28,7 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="member-acquisition-drawer-content">
-    @if (unavailable()) {
+    @if (unavailable() || pending()) {
       <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
            repeatedly missed one — stats, charts, insight blocks and per-section empty states
            each assert a measurement, so the whole body has to go, not a list of its parts. -->
@@ -40,8 +40,10 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
-            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ pending() ? loadingHeading : unavailableHeading }}</h3>
+            @if (!pending()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -10,6 +10,7 @@ import { TagComponent } from '@components/tag/tag.component';
 import {
   DASHBOARD_TOOLTIP_CONFIG,
   DRAWER_NO_ACTIVITY_BODY,
+  DRAWER_LOADING_HEADING,
   DRAWER_UNAVAILABLE_BODY,
   DRAWER_UNAVAILABLE_HEADING,
   createBarChartOptions,
@@ -98,6 +99,13 @@ export class MemberAcquisitionDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly loadingHeading = DRAWER_LOADING_HEADING;
+  /**
+   * True while the parent's request is still in flight. The body is suppressed for this too —
+   * the zero-filled fallback is no more a measurement while loading than after a failure — but
+   * the copy must not claim a failure that has not happened.
+   */
+  public readonly pending = input<boolean>(false);
   protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { createBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { DASHBOARD_TOOLTIP_CONFIG, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, createBarChartOptions, createLineChartOptions, lfxColors } from '@lfx-one/shared/constants';
 import { formatCurrency, formatNumber, formatPercent, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { FormatMoneyPipe } from '@pipes/format-money.pipe';
 import { DrawerModule } from 'primeng/drawer';
@@ -82,6 +82,15 @@ export class MemberAcquisitionDrawerComponent {
   protected readonly attentionInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().attentionInsights);
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+  /**
+   * True when the source request FAILED, as opposed to returning a measured zero. The
+   * parent passes the undefined-ness of its response through; the empty state then says
+   * the data could not be loaded instead of asserting there was no activity.
+   */
+  public readonly unavailable = input<boolean>(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
   protected readonly acquisitionChartData: Signal<ChartData<'bar'>> = this.initAcquisitionChartData();
 
@@ -137,6 +146,7 @@ export class MemberAcquisitionDrawerComponent {
   // === Private Initializers ===
   private initHasNoData(): Signal<boolean> {
     return computed(() => {
+      if (this.unavailable()) return true;
       const { totalMembers, newMembersThisQuarter, quarterlyData } = this.data();
       const { renewalRate, netRevenueRetention, monthlyData } = this.retentionData();
       const hasQuarterlyActivity = quarterlyData.some((q) => q.newMembers > 0 || q.revenue > 0);

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -9,6 +9,7 @@ import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import {
   DASHBOARD_TOOLTIP_CONFIG,
+  DRAWER_NO_ACTIVITY_BODY,
   DRAWER_UNAVAILABLE_BODY,
   DRAWER_UNAVAILABLE_HEADING,
   createBarChartOptions,
@@ -97,6 +98,7 @@ export class MemberAcquisitionDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
   protected readonly acquisitionChartData: Signal<ChartData<'bar'>> = this.initAcquisitionChartData();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-acquisition-drawer/member-acquisition-drawer.component.ts
@@ -7,7 +7,14 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { DASHBOARD_TOOLTIP_CONFIG, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING, createBarChartOptions, createLineChartOptions, lfxColors } from '@lfx-one/shared/constants';
+import {
+  DASHBOARD_TOOLTIP_CONFIG,
+  DRAWER_UNAVAILABLE_BODY,
+  DRAWER_UNAVAILABLE_HEADING,
+  createBarChartOptions,
+  createLineChartOptions,
+  lfxColors,
+} from '@lfx-one/shared/constants';
 import { formatCurrency, formatNumber, formatPercent, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { FormatMoneyPipe } from '@pipes/format-money.pipe';
 import { DrawerModule } from 'primeng/drawer';

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -128,8 +128,12 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">No retention activity detected</h3>
-            <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No retention activity detected' }}</h3>
+            @if (unavailable()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            } @else {
+              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -28,36 +28,40 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="member-retention-drawer-content">
-    <!-- Summary Stats -->
-    <div class="flex gap-4" data-testid="member-retention-drawer-stats">
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Renewal Rate</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate | number: '1.1-1' }}%</span>
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Net Revenue Retention</span>
-          <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention | number: '1.1-1' }}%</span>
-        </div>
-      </lfx-card>
-      <lfx-card styleClass="flex-1">
-        <div class="flex flex-col gap-1">
-          <span class="text-sm text-gray-500">Growth</span>
-          @if (data().changePercentage !== 0) {
-            <div class="flex items-center gap-2">
-              <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
-              </span>
-              <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
-            </div>
-          } @else {
-            <span class="text-2xl font-semibold text-gray-500">0%</span>
-          }
-        </div>
-      </lfx-card>
-    </div>
+    <!-- Summary Stats — suppressed when the request failed: these render from the parent's
+         zero-filled fallback, so leaving them visible puts "0.0% retention" in 2xl type above
+         the banner saying the data could not be loaded. -->
+    @if (!unavailable()) {
+      <div class="flex gap-4" data-testid="member-retention-drawer-stats">
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Renewal Rate</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate | number: '1.1-1' }}%</span>
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Net Revenue Retention</span>
+            <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention | number: '1.1-1' }}%</span>
+          </div>
+        </lfx-card>
+        <lfx-card styleClass="flex-1">
+          <div class="flex flex-col gap-1">
+            <span class="text-sm text-gray-500">Growth</span>
+            @if (data().changePercentage !== 0) {
+              <div class="flex items-center gap-2">
+                <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
+                  {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
+                </span>
+                <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
+              </div>
+            } @else {
+              <span class="text-2xl font-semibold text-gray-500">0%</span>
+            }
+          </div>
+        </lfx-card>
+      </div>
+    }
 
     <!-- FIRST FOLD: Needs Your Attention -->
     @if (attentionActions().length > 0 || attentionInsights().length > 0) {

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -28,7 +28,7 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="member-retention-drawer-content">
-    @if (unavailable()) {
+    @if (unavailable() || pending()) {
       <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
            repeatedly missed one — stats, charts, insight blocks and per-section empty states
            each assert a measurement, so the whole body has to go, not a list of its parts. -->
@@ -40,8 +40,10 @@
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
-            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            <h3 class="text-sm font-semibold text-gray-900">{{ pending() ? loadingHeading : unavailableHeading }}</h3>
+            @if (!pending()) {
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
+            }
           </div>
         </div>
       </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -64,7 +64,7 @@
     }
 
     <!-- FIRST FOLD: Needs Your Attention -->
-    @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+    @if (!unavailable() && (attentionActions().length > 0 || attentionInsights().length > 0)) {
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
         data-testid="member-retention-drawer-attention">
@@ -97,7 +97,7 @@
     }
 
     <!-- SECOND FOLD: Performing Well -->
-    @if (performingActions().length > 0 || performingInsights().length > 0) {
+    @if (!unavailable() && (performingActions().length > 0 || performingInsights().length > 0)) {
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
         data-testid="member-retention-drawer-performing">

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.html
@@ -28,119 +28,134 @@
 
   <!-- Content -->
   <div class="flex flex-col gap-6 pb-2" data-testid="member-retention-drawer-content">
-    <!-- Summary Stats — suppressed when the request failed: these render from the parent's
-         zero-filled fallback, so leaving them visible puts "0.0% retention" in 2xl type above
-         the banner saying the data could not be loaded. -->
-    @if (!unavailable()) {
-      <div class="flex gap-4" data-testid="member-retention-drawer-stats">
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Renewal Rate</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate | number: '1.1-1' }}%</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Net Revenue Retention</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention | number: '1.1-1' }}%</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Growth</span>
-            @if (data().changePercentage !== 0) {
-              <div class="flex items-center gap-2">
-                <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
-                  {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
-                </span>
-                <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
-              </div>
-            } @else {
-              <span class="text-2xl font-semibold text-gray-500">0%</span>
-            }
-          </div>
-        </lfx-card>
-      </div>
-    }
-
-    <!-- FIRST FOLD: Needs Your Attention -->
-    @if (!unavailable() && (attentionActions().length > 0 || attentionInsights().length > 0)) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-        data-testid="member-retention-drawer-attention">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-          <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
-        </div>
-
-        @for (action of attentionActions(); track action.title) {
-          <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-            @if (action.priority === 'high') {
-              <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-            } @else {
-              <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
-            }
-          </div>
-        }
-
-        @for (insight of attentionInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
-          </div>
-        }
-      </div>
-    }
-
-    <!-- SECOND FOLD: Performing Well -->
-    @if (!unavailable() && (performingActions().length > 0 || performingInsights().length > 0)) {
-      <div
-        class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-        data-testid="member-retention-drawer-performing">
-        <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-          <i class="fa-light fa-check text-green-600"></i>
-          <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
-        </div>
-
-        @for (action of performingActions(); track action.title) {
-          <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-            <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-              <p class="text-sm text-gray-500">{{ action.description }}</p>
-            </div>
-          </div>
-        }
-
-        @for (insight of performingInsights(); track insight.text) {
-          <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-            <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-            <span>{{ insight.text }}</span>
-          </div>
-        }
-      </div>
-    }
-
-    @if (hasNoData()) {
+    @if (unavailable()) {
+      <!-- A failed request renders ONLY this. Guarding section-by-section was tried and
+           repeatedly missed one — stats, charts, insight blocks and per-section empty states
+           each assert a measurement, so the whole body has to go, not a list of its parts. -->
       <div
         class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
         role="status"
-        data-testid="member-retention-drawer-no-data">
+        aria-live="polite"
+        data-testid="member-retention-drawer-unavailable">
         <div class="flex items-start gap-4 px-4 py-4">
           <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
           <div class="flex flex-col gap-1 flex-1 min-w-0">
-            <h3 class="text-sm font-semibold text-gray-900">{{ unavailable() ? unavailableHeading : 'No retention activity detected' }}</h3>
-            @if (unavailable()) {
-              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
-            } @else {
-              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
-            }
+            <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+            <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
           </div>
         </div>
       </div>
+    } @else {
+      <!-- Summary Stats — suppressed when the request failed: these render from the parent's
+           zero-filled fallback, so leaving them visible puts "0.0% retention" in 2xl type above
+           the banner saying the data could not be loaded. -->
+      @if (!unavailable()) {
+        <div class="flex gap-4" data-testid="member-retention-drawer-stats">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Renewal Rate</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ data().renewalRate | number: '1.1-1' }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Net Revenue Retention</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ data().netRevenueRetention | number: '1.1-1' }}%</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Growth</span>
+              @if (data().changePercentage !== 0) {
+                <div class="flex items-center gap-2">
+                  <span class="text-2xl font-semibold" [class]="data().trend === 'up' ? 'text-green-600' : 'text-red-600'">
+                    {{ data().changePercentage > 0 ? '+' : '' }}{{ data().changePercentage | number: '1.1-1' }}%
+                  </span>
+                  <i class="text-sm" [class]="data().trend === 'up' ? 'fa-light fa-arrow-up text-green-600' : 'fa-light fa-arrow-down text-red-600'"></i>
+                </div>
+              } @else {
+                <span class="text-2xl font-semibold text-gray-500">0%</span>
+              }
+            </div>
+          </lfx-card>
+        </div>
+      }
+
+      <!-- FIRST FOLD: Needs Your Attention -->
+      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+          data-testid="member-retention-drawer-attention">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+          </div>
+
+          @for (action of attentionActions(); track action.title) {
+            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+              @if (action.priority === 'high') {
+                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+              } @else {
+                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+              }
+            </div>
+          }
+
+          @for (insight of attentionInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
+            </div>
+          }
+        </div>
+      }
+
+      <!-- SECOND FOLD: Performing Well -->
+      @if (performingActions().length > 0 || performingInsights().length > 0) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+          data-testid="member-retention-drawer-performing">
+          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+            <i class="fa-light fa-check text-green-600"></i>
+            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+          </div>
+
+          @for (action of performingActions(); track action.title) {
+            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                <p class="text-sm text-gray-500">{{ action.description }}</p>
+              </div>
+            </div>
+          }
+
+          @for (insight of performingInsights(); track insight.text) {
+            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+              <span>{{ insight.text }}</span>
+            </div>
+          }
+        </div>
+      }
+
+      @if (hasNoData()) {
+        <div
+          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+          role="status"
+          data-testid="member-retention-drawer-no-data">
+          <div class="flex items-start gap-4 px-4 py-4">
+            <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+            <div class="flex flex-col gap-1 flex-1 min-w-0">
+              <h3 class="text-sm font-semibold text-gray-900">No retention activity detected</h3>
+              <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
+            </div>
+          </div>
+        </div>
+      }
     }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { formatPercent, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
-import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
+import { DRAWER_NO_ACTIVITY_BODY, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { MarketingKeyInsight, MarketingRecommendedAction, MemberRetentionResponse } from '@lfx-one/shared/interfaces';
@@ -53,6 +53,7 @@ export class MemberRetentionDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -7,7 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { formatPercent, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
-import { DRAWER_NO_ACTIVITY_BODY, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
+import { DRAWER_NO_ACTIVITY_BODY, DRAWER_LOADING_HEADING, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { MarketingKeyInsight, MarketingRecommendedAction, MemberRetentionResponse } from '@lfx-one/shared/interfaces';
@@ -53,6 +53,13 @@ export class MemberRetentionDrawerComponent {
   public readonly unavailable = input<boolean>(false);
   protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
   protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+  protected readonly loadingHeading = DRAWER_LOADING_HEADING;
+  /**
+   * True while the parent's request is still in flight. The body is suppressed for this too —
+   * the zero-filled fallback is no more a measurement while loading than after a failure — but
+   * the copy must not claim a failure that has not happened.
+   */
+  public readonly pending = input<boolean>(false);
   protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
 
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/member-retention-drawer/member-retention-drawer.component.ts
@@ -7,6 +7,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { formatPercent, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
+import { DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
 import { DrawerModule } from 'primeng/drawer';
 
 import type { MarketingKeyInsight, MarketingRecommendedAction, MemberRetentionResponse } from '@lfx-one/shared/interfaces';
@@ -44,6 +45,15 @@ export class MemberRetentionDrawerComponent {
   protected readonly performingActions: Signal<MarketingRecommendedAction[]> = computed(() => this.split().performingActions);
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
+  /**
+   * True when the source request FAILED, as opposed to returning a measured zero. The
+   * parent passes the undefined-ness of its response through; the empty state then says
+   * the data could not be loaded instead of asserting there was no activity.
+   */
+  public readonly unavailable = input<boolean>(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
+
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 
   // === Protected Methods ===
@@ -54,6 +64,7 @@ export class MemberRetentionDrawerComponent {
   // === Private Initializers ===
   private initHasNoData(): Signal<boolean> {
     return computed(() => {
+      if (this.unavailable()) return true;
       const { renewalRate, netRevenueRetention, monthlyData } = this.data();
       return renewalRate === 0 && netRevenueRetention === 0 && (monthlyData.length === 0 || monthlyData.every((m) => m.value === 0));
     });

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -125,7 +125,7 @@
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
               <h3 class="text-sm font-semibold text-gray-900">No website traffic detected</h3>
-              <p class="text-sm text-gray-500">Engage with marketing ops to activate campaigns and start tracking results.</p>
+              <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
             </div>
           </div>
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.html
@@ -39,133 +39,151 @@
         <p-skeleton width="60%" height="1rem" />
       </div>
     } @else {
-      <!-- Summary Stats -->
-      <div class="flex gap-4" data-testid="website-visits-drawer-stats">
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Total Sessions (last 30 days)</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalSessions() }}</span>
-          </div>
-        </lfx-card>
-        <lfx-card styleClass="flex-1">
-          <div class="flex flex-col gap-1">
-            <span class="text-sm text-gray-500">Page Views (last 30 days)</span>
-            <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalPageViews() }}</span>
-          </div>
-        </lfx-card>
-      </div>
-
-      <!-- FIRST FOLD: Needs Your Attention -->
-      @if (attentionActions().length > 0 || attentionInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
-          data-testid="website-visits-drawer-attention">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-triangle-exclamation text-red-600"></i>
-            <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
-          </div>
-
-          @for (action of attentionActions(); track action.title) {
-            <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
-              </div>
-              @if (action.priority === 'high') {
-                <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
-              } @else {
-                <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
-              }
-            </div>
-          }
-
-          @for (insight of attentionInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
-        </div>
-      }
-
-      <!-- SECOND FOLD: Performing Well -->
-      @if (performingActions().length > 0 || performingInsights().length > 0) {
-        <div
-          class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
-          data-testid="website-visits-drawer-performing">
-          <div class="flex items-center gap-2 px-4 pt-4 pb-2">
-            <i class="fa-light fa-check text-green-600"></i>
-            <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
-          </div>
-
-          @for (action of performingActions(); track action.title) {
-            <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
-              <div class="flex flex-col gap-1 flex-1 min-w-0">
-                <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
-                <p class="text-sm text-gray-500">{{ action.description }}</p>
-              </div>
-            </div>
-          }
-
-          @for (insight of performingInsights(); track insight.text) {
-            <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
-              <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
-              <span>{{ insight.text }}</span>
-            </div>
-          }
-        </div>
-      }
-
-      @if (hasNoData()) {
+      @if (unavailable()) {
+        <!-- A failed request renders ONLY this. Section-by-section guarding was tried on the
+             parent-fed drawers and repeatedly missed one, so the whole body goes. -->
         <div
           class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
           role="status"
-          data-testid="website-visits-drawer-no-data">
+          aria-live="polite"
+          data-testid="website-visits-drawer-unavailable">
           <div class="flex items-start gap-4 px-4 py-4">
             <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
             <div class="flex flex-col gap-1 flex-1 min-w-0">
-              <h3 class="text-sm font-semibold text-gray-900">No website traffic detected</h3>
-              <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
+              <h3 class="text-sm font-semibold text-gray-900">{{ unavailableHeading }}</h3>
+              <p class="text-sm text-gray-500">{{ unavailableBody }}</p>
             </div>
           </div>
         </div>
+      } @else {
+        <!-- Summary Stats -->
+        <div class="flex gap-4" data-testid="website-visits-drawer-stats">
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Total Sessions (last 30 days)</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalSessions() }}</span>
+            </div>
+          </lfx-card>
+          <lfx-card styleClass="flex-1">
+            <div class="flex flex-col gap-1">
+              <span class="text-sm text-gray-500">Page Views (last 30 days)</span>
+              <span class="text-2xl font-semibold text-gray-900">{{ formattedTotalPageViews() }}</span>
+            </div>
+          </lfx-card>
+        </div>
+
+        <!-- FIRST FOLD: Needs Your Attention -->
+        @if (attentionActions().length > 0 || attentionInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-red-600 bg-white overflow-hidden"
+            data-testid="website-visits-drawer-attention">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-triangle-exclamation text-red-600"></i>
+              <h3 class="text-sm font-semibold text-red-700">Needs Your Attention</h3>
+            </div>
+
+            @for (action of attentionActions(); track action.title) {
+              <div class="flex items-start justify-between gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+                @if (action.priority === 'high') {
+                  <lfx-tag value="High Priority" severity="danger" [rounded]="true" />
+                } @else {
+                  <lfx-tag value="Medium Priority" severity="warn" [rounded]="true" />
+                }
+              </div>
+            }
+
+            @for (insight of attentionInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-triangle-exclamation text-red-500 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
+            }
+          </div>
+        }
+
+        <!-- SECOND FOLD: Performing Well -->
+        @if (performingActions().length > 0 || performingInsights().length > 0) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-green-600 bg-white overflow-hidden"
+            data-testid="website-visits-drawer-performing">
+            <div class="flex items-center gap-2 px-4 pt-4 pb-2">
+              <i class="fa-light fa-check text-green-600"></i>
+              <h3 class="text-sm font-semibold text-green-700">Performing Well</h3>
+            </div>
+
+            @for (action of performingActions(); track action.title) {
+              <div class="flex items-start gap-4 px-4 py-3 border-t border-gray-100">
+                <div class="flex flex-col gap-1 flex-1 min-w-0">
+                  <span class="text-sm font-semibold text-gray-900">{{ action.title }}</span>
+                  <p class="text-sm text-gray-500">{{ action.description }}</p>
+                </div>
+              </div>
+            }
+
+            @for (insight of performingInsights(); track insight.text) {
+              <div class="flex items-center gap-2 px-4 py-3 border-t border-gray-100 text-sm text-gray-700">
+                <i class="fa-light fa-check text-green-600 flex-shrink-0"></i>
+                <span>{{ insight.text }}</span>
+              </div>
+            }
+          </div>
+        }
+
+        @if (hasNoData()) {
+          <div
+            class="flex flex-col rounded-lg border border-gray-200 border-l-4 border-l-blue-600 bg-white overflow-hidden"
+            role="status"
+            data-testid="website-visits-drawer-no-data">
+            <div class="flex items-start gap-4 px-4 py-4">
+              <i class="fa-light fa-circle-info text-blue-500 mt-0.5" aria-hidden="true"></i>
+              <div class="flex flex-col gap-1 flex-1 min-w-0">
+                <h3 class="text-sm font-semibold text-gray-900">No website traffic detected</h3>
+                <p class="text-sm text-gray-500">{{ noActivityBody }}</p>
+              </div>
+            </div>
+          </div>
+        }
+
+        <!-- Daily Trend Chart -->
+        <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="website-visits-drawer-trend-section">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-semibold text-gray-900">Weekly Sessions</h3>
+            <p class="text-sm text-gray-600">Web activity over the last 6 months (weekly)</p>
+          </div>
+          @if (drawerData().dailyData.length > 0) {
+            <div class="h-[200px]" data-testid="website-visits-drawer-trend-chart">
+              <lfx-chart type="line" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
+            </div>
+          } @else {
+            <div class="text-center py-8 border border-slate-200 rounded-lg">
+              <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+              <p class="text-sm text-gray-500">No session data available</p>
+            </div>
+          }
+        </div>
+
+        <!-- Domain Breakdown -->
+        <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="website-visits-drawer-domains-section">
+          <div class="flex flex-col gap-1">
+            <h3 class="text-sm font-semibold text-gray-900">Sessions by Domain</h3>
+            <p class="text-sm text-gray-600">Web traffic distribution across project domains</p>
+          </div>
+          @if (drawerData().domainGroups.length > 1) {
+            <div class="h-[240px]" data-testid="website-visits-drawer-domains-chart">
+              <lfx-chart type="bar" [data]="domainChartData()" [options]="domainChartOptions" height="100%"></lfx-chart>
+            </div>
+          } @else {
+            <div class="text-center py-8 border border-slate-200 rounded-lg">
+              <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
+              <p class="text-sm text-gray-500">No domain breakdown available</p>
+            </div>
+          }
+        </div>
       }
-
-      <!-- Daily Trend Chart -->
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="website-visits-drawer-trend-section">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">Weekly Sessions</h3>
-          <p class="text-sm text-gray-600">Web activity over the last 6 months (weekly)</p>
-        </div>
-        @if (drawerData().dailyData.length > 0) {
-          <div class="h-[200px]" data-testid="website-visits-drawer-trend-chart">
-            <lfx-chart type="line" [data]="trendChartData()" [options]="trendChartOptions" height="100%"></lfx-chart>
-          </div>
-        } @else {
-          <div class="text-center py-8 border border-slate-200 rounded-lg">
-            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No session data available</p>
-          </div>
-        }
-      </div>
-
-      <!-- Domain Breakdown -->
-      <div class="flex flex-col gap-4 p-4 border border-gray-200 rounded-lg" data-testid="website-visits-drawer-domains-section">
-        <div class="flex flex-col gap-1">
-          <h3 class="text-sm font-semibold text-gray-900">Sessions by Domain</h3>
-          <p class="text-sm text-gray-600">Web traffic distribution across project domains</p>
-        </div>
-        @if (drawerData().domainGroups.length > 1) {
-          <div class="h-[240px]" data-testid="website-visits-drawer-domains-chart">
-            <lfx-chart type="bar" [data]="domainChartData()" [options]="domainChartOptions" height="100%"></lfx-chart>
-          </div>
-        } @else {
-          <div class="text-center py-8 border border-slate-200 rounded-lg">
-            <i class="fa-light fa-eyes text-3xl text-gray-400 mb-2 block"></i>
-            <p class="text-sm text-gray-500">No domain breakdown available</p>
-          </div>
-        }
-      </div>
     }
   </div>
 </p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -8,6 +8,7 @@ import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
+import { DRAWER_NO_ACTIVITY_BODY } from '@lfx-one/shared/constants';
 import { formatNumber, formatPercent, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -33,6 +34,7 @@ export class WebsiteVisitsDrawerComponent {
   private readonly projectContextService = inject(ProjectContextService);
 
   // === Model Signals (two-way binding) ===
+  protected readonly noActivityBody = DRAWER_NO_ACTIVITY_BODY;
   public readonly visible = model<boolean>(false);
 
   // === WritableSignals ===

--- a/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/executive-director/components/website-visits-drawer/website-visits-drawer.component.ts
@@ -8,7 +8,7 @@ import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { createHorizontalBarChartOptions, createLineChartOptions, DASHBOARD_TOOLTIP_CONFIG, lfxColors } from '@lfx-one/shared/constants';
-import { DRAWER_NO_ACTIVITY_BODY } from '@lfx-one/shared/constants';
+import { DRAWER_NO_ACTIVITY_BODY, DRAWER_UNAVAILABLE_BODY, DRAWER_UNAVAILABLE_HEADING } from '@lfx-one/shared/constants';
 import { formatNumber, formatPercent, hexToRgba, splitByPriority, type MarketingSplitByPriority } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -56,6 +56,15 @@ export class WebsiteVisitsDrawerComponent {
 
   protected readonly performingInsights: Signal<MarketingKeyInsight[]> = computed(() => this.split().performingInsights);
 
+  /**
+   * Set when this drawer's own request fails. Like the Email drawer it fetches its own data,
+   * so the failure arrives through catchError rather than a parent input — and catchError
+   * resolves to a zero-filled default, which would otherwise render "No website traffic
+   * detected": an outage stated as a measurement.
+   */
+  protected readonly unavailable = signal(false);
+  protected readonly unavailableHeading = DRAWER_UNAVAILABLE_HEADING;
+  protected readonly unavailableBody = DRAWER_UNAVAILABLE_BODY;
   protected readonly hasNoData: Signal<boolean> = this.initHasNoData();
 
   protected readonly trendChartData: Signal<ChartData<'line'>> = this.initTrendChartData();
@@ -141,6 +150,7 @@ export class WebsiteVisitsDrawerComponent {
   // === Private Initializers ===
   private initHasNoData(): Signal<boolean> {
     return computed(() => {
+      if (this.unavailable()) return true;
       const { totalSessions, dailyData } = this.drawerData();
       return totalSessions === 0 && (dailyData.length === 0 || dailyData.every((v) => v === 0));
     });
@@ -166,12 +176,16 @@ export class WebsiteVisitsDrawerComponent {
       combineLatest([visible$, foundation$]).pipe(
         filter(([isVisible, slug]) => isVisible && !!slug),
         map(([, slug]) => slug),
-        tap(() => this.drawerLoading.set(true)),
+        tap(() => {
+          this.drawerLoading.set(true);
+          this.unavailable.set(false);
+        }),
         switchMap((foundationSlug) =>
           this.analyticsService.getWebActivitiesSummary(foundationSlug, undefined, 'last-6').pipe(
             tap(() => this.drawerLoading.set(false)),
             catchError(() => {
               this.drawerLoading.set(false);
+              this.unavailable.set(true);
               this.messageService.add({
                 severity: 'error',
                 summary: 'Error',

--- a/apps/lfx-one/src/app/shared/services/analytics-error-propagation.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics-error-propagation.spec.ts
@@ -1,0 +1,62 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { AnalyticsService } from './analytics.service';
+
+/**
+ * The ED dashboard renders "Data unavailable" instead of a fabricated zero by turning a failed
+ * request into `undefined` — but only if the failure REACHES it. Three of these endpoints used
+ * to catch their own HTTP error and resolve to a zero-filled response, so the dashboard's
+ * `safe()` wrapper saw a success, `brandReach` was never undefined, and the card printed the
+ * zeros as if measured. That is the reported AAIF defect: 17,269 followers across 2 platforms
+ * rendered as "0 · 0 platforms".
+ *
+ * The card-level guards cannot pin this, because from their side a swallowed error and a real
+ * zero are the same value. The contract has to be pinned where the error is destroyed.
+ */
+describe('AnalyticsService — a failed request must reach the caller', () => {
+  let service: AnalyticsService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [AnalyticsService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(AnalyticsService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  // Each of these feeds a card that must distinguish "could not measure" from "measured zero".
+  const endpoints: { name: string; url: string; call: () => { subscribe: (o: object) => void } }[] = [
+    { name: 'getBrandReach', url: '/api/analytics/brand-reach', call: () => service.getBrandReach('aaif') },
+    { name: 'getEventGrowth', url: '/api/analytics/event-growth', call: () => service.getEventGrowth('aaif') },
+    { name: 'getBrandHealth', url: '/api/analytics/brand-health', call: () => service.getBrandHealth('aaif', false, 'last-6') },
+  ];
+
+  for (const { name, url, call } of endpoints) {
+    it(`${name} propagates a 500 rather than resolving to a zero-filled response`, () => {
+      let errored = false;
+      let emitted: unknown;
+
+      call().subscribe({
+        next: (value: unknown) => (emitted = value),
+        error: () => (errored = true),
+      });
+
+      http.expectOne((req) => req.url === url).flush('upstream failed', { status: 500, statusText: 'Server Error' });
+
+      expect(errored).toBe(true);
+      // The specific regression: an error resolved into a shaped object the caller reads as data.
+      expect(emitted).toBeUndefined();
+    });
+  }
+
+  afterEach(() => {
+    http.verify();
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/analytics-error-propagation.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics-error-propagation.spec.ts
@@ -36,6 +36,10 @@ describe('AnalyticsService — a failed request must reach the caller', () => {
     { name: 'getBrandReach', url: '/api/analytics/brand-reach', call: () => service.getBrandReach('aaif') },
     { name: 'getEventGrowth', url: '/api/analytics/event-growth', call: () => service.getEventGrowth('aaif') },
     { name: 'getBrandHealth', url: '/api/analytics/brand-health', call: () => service.getBrandHealth('aaif', false, 'last-6') },
+    { name: 'getMemberAcquisition', url: '/api/analytics/member-acquisition', call: () => service.getMemberAcquisition('aaif') },
+    { name: 'getMemberRetention', url: '/api/analytics/member-retention', call: () => service.getMemberRetention('aaif') },
+    { name: 'getEngagedCommunity', url: '/api/analytics/engaged-community', call: () => service.getEngagedCommunity('aaif') },
+    { name: 'getWebActivitiesSummary', url: '/api/analytics/web-activities-summary', call: () => service.getWebActivitiesSummary('aaif', undefined, 'last-6') },
   ];
 
   for (const { name, url, call } of endpoints) {

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -883,7 +883,8 @@ export class AnalyticsService {
    * Get web activities summary grouped by domain category
    * @param foundationSlug - Foundation slug to filter by (e.g., 'tlf', 'cncf')
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
-   * @returns Observable of web activities summary response
+   * @returns Observable of web activities summary response. Errors are NOT caught — a failed
+   * request errors the observable so the caller's guard can distinguish it from a real zero.
    */
   public getWebActivitiesSummary(foundationSlug: string, classification?: string, period?: string): Observable<WebActivitiesSummaryResponse> {
     return this.http.get<WebActivitiesSummaryResponse>('/api/analytics/web-activities-summary', {
@@ -1262,7 +1263,8 @@ export class AnalyticsService {
   /**
    * Get event growth metrics for the ED dashboard.
    * @param foundationSlug Foundation slug used to filter Snowflake queries
-   * @returns Observable emitting event growth totals, YoY changes, and monthly trend
+   * @returns Observable emitting event growth totals, YoY changes, and monthly trend. Errors
+   * are NOT caught — see the propagation note above; the caller's guard needs the failure.
    */
   public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
     return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } });
@@ -1279,7 +1281,8 @@ export class AnalyticsService {
    * Get brand reach metrics for the ED dashboard (social followers + web sessions).
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @param classification Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
-   * @returns Observable emitting reach totals, platform breakdowns, and weekly trend
+   * @returns Observable emitting reach totals, platform breakdowns, and weekly trend. Errors
+   * are NOT caught — see the propagation note above; the caller's guard needs the failure.
    */
   public getBrandReach(foundationSlug: string, classification?: string): Observable<BrandReachResponse> {
     return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: this.buildFoundationParams(foundationSlug, classification) });
@@ -1295,7 +1298,8 @@ export class AnalyticsService {
   /**
    * Get brand health metrics for the ED dashboard (mention volume + sentiment breakdown).
    * @param foundationSlug Foundation slug used to filter Snowflake queries
-   * @returns Observable emitting mention totals, sentiment percentages, and monthly history
+   * @returns Observable emitting mention totals, sentiment percentages, and monthly history.
+   * Errors are NOT caught — see the propagation note above; the caller's guard needs the failure.
    */
   public getBrandHealth(foundationSlug: string, includeMentions = false, period?: string): Observable<BrandHealthResponse> {
     const params: Record<string, string> = { foundationSlug, ...(includeMentions && { includeMentions: 'true' }), ...(period && { period }) };

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -875,12 +875,12 @@ export class AnalyticsService {
   }
 
   /**
+   * Get web activities summary grouped by domain category.
+   *
    * Errors PROPAGATE deliberately — see getBrandReach. The Website drawer sets its own
    * unavailable flag inside a catchError, and a swallow here makes that flag unreachable:
    * the drawer would render "No website traffic detected" for a failed request.
-   */
-  /**
-   * Get web activities summary grouped by domain category
+   *
    * @param foundationSlug - Foundation slug to filter by (e.g., 'tlf', 'cncf')
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Observable of web activities summary response. Errors are NOT caught — a failed
@@ -970,36 +970,45 @@ export class AnalyticsService {
   // North Star Metrics
 
   /**
+   * Get member retention metrics from Snowflake North Star views.
+   *
    * Errors PROPAGATE deliberately — see getBrandReach. A catchError resolving to a zero-filled
    * response here makes the ED card's undefined guard unreachable, and the card renders the
    * zeros as if measured.
-   */
-  /**
-   * Get member retention metrics from Snowflake North Star views
+   *
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable of the response. Errors are NOT caught — a failed request errors the
+   * observable so the caller's guard can distinguish it from a real zero.
    */
   public getMemberRetention(foundationSlug: string): Observable<MemberRetentionResponse> {
     return this.http.get<MemberRetentionResponse>('/api/analytics/member-retention', { params: { foundationSlug } });
   }
 
   /**
+   * Get member acquisition rate metrics from Snowflake North Star views.
+   *
    * Errors PROPAGATE deliberately — see getBrandReach. A catchError resolving to a zero-filled
    * response here makes the ED card's undefined guard unreachable, and the card renders the
    * zeros as if measured.
-   */
-  /**
-   * Get member acquisition rate metrics from Snowflake North Star views
+   *
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable of the response. Errors are NOT caught — a failed request errors the
+   * observable so the caller's guard can distinguish it from a real zero.
    */
   public getMemberAcquisition(foundationSlug: string): Observable<MemberAcquisitionResponse> {
     return this.http.get<MemberAcquisitionResponse>('/api/analytics/member-acquisition', { params: { foundationSlug } });
   }
 
   /**
+   * Get engaged community size metrics from Snowflake North Star views.
+   *
    * Errors PROPAGATE deliberately — see getBrandReach. A catchError resolving to a zero-filled
    * response here makes the ED card's undefined guard unreachable, and the card renders the
    * zeros as if measured.
-   */
-  /**
-   * Get engaged community size metrics from Snowflake North Star views
+   *
+   * @param foundationSlug Foundation slug used to filter Snowflake queries
+   * @returns Observable of the response. Errors are NOT caught — a failed request errors the
+   * observable so the caller's guard can distinguish it from a real zero.
    */
   public getEngagedCommunity(foundationSlug: string): Observable<EngagedCommunitySizeResponse> {
     return this.http.get<EngagedCommunitySizeResponse>('/api/analytics/engaged-community', { params: { foundationSlug } });
@@ -1159,13 +1168,15 @@ export class AnalyticsService {
 
   /**
    * Per-event detail for the roster drawer (meta, actual-vs-goal, sponsorship-by-tier).
-   * Emits null on error so the drawer shows its empty state.
-   */
-  /**
-   * Event detail for one event. `foundationSlug` is required and server-enforced: the event id
-   * alone carries no ownership, so the query is scoped to the foundation rather than trusting it.
-   * Resolves to `null` for a genuinely missing event and throws on transport/authorization
-   * failures, so the drawer can tell "no such event" apart from "we could not load it".
+   *
+   * `foundationSlug` is required and server-enforced: the event id alone carries no ownership,
+   * so the query is scoped to the foundation rather than trusting it. Resolves to `null` for a
+   * genuinely missing event and THROWS on transport/authorization failures, so the drawer can
+   * tell "no such event" apart from "we could not load it".
+   *
+   * The removed second block claimed it "emits null on error so the drawer shows its empty
+   * state" — the opposite of the throw above, and exactly the reasoning that turns a failed
+   * read back into a rendered measurement.
    */
   public getEventDetail(eventId: string, foundationSlug: string): Observable<EventDetailResponse | null> {
     return this.http.get<EventDetailResponse>('/api/analytics/event-detail', { params: { eventId, foundationSlug } });
@@ -1254,14 +1265,14 @@ export class AnalyticsService {
   }
 
   /**
+   * Get event growth metrics for the ED dashboard.
+   *
    * Errors PROPAGATE deliberately — do not add a catchError that resolves to a zero-filled
    * response. The ED dashboard's `safe()` wrapper turns a failure into `undefined`, which is
    * what lets the card render "Data unavailable" instead of a fabricated zero. Swallowing here
    * makes that guard unreachable: `safe()` sees a success and the card prints the zeros as if
    * measured. This is the AAIF defect — 17,269 followers rendered as "0 · 0 platforms".
-   */
-  /**
-   * Get event growth metrics for the ED dashboard.
+   *
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @returns Observable emitting event growth totals, YoY changes, and monthly trend. Errors
    * are NOT caught — see the propagation note above; the caller's guard needs the failure.
@@ -1271,14 +1282,14 @@ export class AnalyticsService {
   }
 
   /**
+   * Get brand reach metrics for the ED dashboard (social followers + web sessions).
+   *
    * Errors PROPAGATE deliberately — do not add a catchError that resolves to a zero-filled
    * response. The ED dashboard's `safe()` wrapper turns a failure into `undefined`, which is
    * what lets the card render "Data unavailable" instead of a fabricated zero. Swallowing here
    * makes that guard unreachable: `safe()` sees a success and the card prints the zeros as if
    * measured. This is the AAIF defect — 17,269 followers rendered as "0 · 0 platforms".
-   */
-  /**
-   * Get brand reach metrics for the ED dashboard (social followers + web sessions).
+   *
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @param classification Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Observable emitting reach totals, platform breakdowns, and weekly trend. Errors
@@ -1289,14 +1300,14 @@ export class AnalyticsService {
   }
 
   /**
+   * Get brand health metrics for the ED dashboard (mention volume + sentiment breakdown).
+   *
    * Errors PROPAGATE deliberately — do not add a catchError that resolves to a zero-filled
    * response. The ED dashboard's `safe()` wrapper turns a failure into `undefined`, which is
    * what lets the card render "Data unavailable" instead of a fabricated zero. Swallowing here
    * makes that guard unreachable: `safe()` sees a success and the card prints the zeros as if
    * measured. This is the AAIF defect — 17,269 followers rendered as "0 · 0 platforms".
-   */
-  /**
-   * Get brand health metrics for the ED dashboard (mention volume + sentiment breakdown).
+   *
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @returns Observable emitting mention totals, sentiment percentages, and monthly history.
    * Errors are NOT caught — see the propagation note above; the caller's guard needs the failure.

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -875,27 +875,20 @@ export class AnalyticsService {
   }
 
   /**
+   * Errors PROPAGATE deliberately — see getBrandReach. The Website drawer sets its own
+   * unavailable flag inside a catchError, and a swallow here makes that flag unreachable:
+   * the drawer would render "No website traffic detected" for a failed request.
+   */
+  /**
    * Get web activities summary grouped by domain category
    * @param foundationSlug - Foundation slug to filter by (e.g., 'tlf', 'cncf')
    * @param classification - Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
    * @returns Observable of web activities summary response
    */
   public getWebActivitiesSummary(foundationSlug: string, classification?: string, period?: string): Observable<WebActivitiesSummaryResponse> {
-    return this.http
-      .get<WebActivitiesSummaryResponse>('/api/analytics/web-activities-summary', {
-        params: this.buildFoundationParams(foundationSlug, classification, period),
-      })
-      .pipe(
-        catchError(() => {
-          return of({
-            totalSessions: 0,
-            totalPageViews: 0,
-            domainGroups: [],
-            dailyData: [],
-            dailyLabels: [],
-          });
-        })
-      );
+    return this.http.get<WebActivitiesSummaryResponse>('/api/analytics/web-activities-summary', {
+      params: this.buildFoundationParams(foundationSlug, classification, period),
+    });
   }
 
   /**
@@ -976,66 +969,39 @@ export class AnalyticsService {
   // North Star Metrics
 
   /**
+   * Errors PROPAGATE deliberately — see getBrandReach. A catchError resolving to a zero-filled
+   * response here makes the ED card's undefined guard unreachable, and the card renders the
+   * zeros as if measured.
+   */
+  /**
    * Get member retention metrics from Snowflake North Star views
    */
   public getMemberRetention(foundationSlug: string): Observable<MemberRetentionResponse> {
-    return this.http.get<MemberRetentionResponse>('/api/analytics/member-retention', { params: { foundationSlug } }).pipe(
-      catchError(() => {
-        return of({
-          renewalRate: 0,
-          netRevenueRetention: 0,
-          changePercentage: 0,
-          trend: 'up' as const,
-          target: 85,
-          monthlyData: [],
-        });
-      })
-    );
+    return this.http.get<MemberRetentionResponse>('/api/analytics/member-retention', { params: { foundationSlug } });
   }
 
+  /**
+   * Errors PROPAGATE deliberately — see getBrandReach. A catchError resolving to a zero-filled
+   * response here makes the ED card's undefined guard unreachable, and the card renders the
+   * zeros as if measured.
+   */
   /**
    * Get member acquisition rate metrics from Snowflake North Star views
    */
   public getMemberAcquisition(foundationSlug: string): Observable<MemberAcquisitionResponse> {
-    return this.http.get<MemberAcquisitionResponse>('/api/analytics/member-acquisition', { params: { foundationSlug } }).pipe(
-      catchError(() => {
-        return of({
-          totalMembers: 0,
-          totalMembersMonthlyData: [],
-          totalMembersMonthlyLabels: [],
-          newMembersThisQuarter: 0,
-          newMemberRevenue: 0,
-          changePercentage: 0,
-          trend: 'up' as const,
-          quarterlyData: [],
-        });
-      })
-    );
+    return this.http.get<MemberAcquisitionResponse>('/api/analytics/member-acquisition', { params: { foundationSlug } });
   }
 
+  /**
+   * Errors PROPAGATE deliberately — see getBrandReach. A catchError resolving to a zero-filled
+   * response here makes the ED card's undefined guard unreachable, and the card renders the
+   * zeros as if measured.
+   */
   /**
    * Get engaged community size metrics from Snowflake North Star views
    */
   public getEngagedCommunity(foundationSlug: string): Observable<EngagedCommunitySizeResponse> {
-    return this.http.get<EngagedCommunitySizeResponse>('/api/analytics/engaged-community', { params: { foundationSlug } }).pipe(
-      catchError(() => {
-        return of({
-          totalMembers: 0,
-          changePercentage: 0,
-          trend: 'up' as const,
-          breakdown: {
-            newsletterSubscribers: 0,
-            communityMembers: 0,
-            workingGroupMembers: 0,
-            certifiedIndividuals: 0,
-            webVisitors: 0,
-            codeContributors: 0,
-            trainingEnrollees: 0,
-          },
-          monthlyData: [],
-        });
-      })
-    );
+    return this.http.get<EngagedCommunitySizeResponse>('/api/analytics/engaged-community', { params: { foundationSlug } });
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1287,30 +1287,28 @@ export class AnalyticsService {
   }
 
   /**
+   * Errors PROPAGATE deliberately — do not add a catchError that resolves to a zero-filled
+   * response. The ED dashboard's `safe()` wrapper turns a failure into `undefined`, which is
+   * what lets the card render "Data unavailable" instead of a fabricated zero. Swallowing here
+   * makes that guard unreachable: `safe()` sees a success and the card prints the zeros as if
+   * measured. This is the AAIF defect — 17,269 followers rendered as "0 · 0 platforms".
+   */
+  /**
    * Get event growth metrics for the ED dashboard.
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @returns Observable emitting event growth totals, YoY changes, and monthly trend (or zeroed defaults on error)
    */
   public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
-    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } }).pipe(
-      catchError(() =>
-        of({
-          totalAttendees: 0,
-          totalRegistrants: 0,
-          totalEvents: 0,
-          totalRevenue: 0,
-          revenuePerAttendee: 0,
-          attendeeYoyChange: 0,
-          registrantYoyChange: 0,
-          revenueYoyChange: 0,
-          trend: 'up' as const,
-          monthlyData: [],
-          topEvents: [],
-        })
-      )
-    );
+    return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } });
   }
 
+  /**
+   * Errors PROPAGATE deliberately — do not add a catchError that resolves to a zero-filled
+   * response. The ED dashboard's `safe()` wrapper turns a failure into `undefined`, which is
+   * what lets the card render "Data unavailable" instead of a fabricated zero. Swallowing here
+   * makes that guard unreachable: `safe()` sees a success and the card prints the zeros as if
+   * measured. This is the AAIF defect — 17,269 followers rendered as "0 · 0 platforms".
+   */
   /**
    * Get brand reach metrics for the ED dashboard (social followers + web sessions).
    * @param foundationSlug Foundation slug used to filter Snowflake queries
@@ -1318,23 +1316,16 @@ export class AnalyticsService {
    * @returns Observable emitting reach totals, platform breakdowns, and weekly trend (or zeroed defaults on error)
    */
   public getBrandReach(foundationSlug: string, classification?: string): Observable<BrandReachResponse> {
-    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: this.buildFoundationParams(foundationSlug, classification) }).pipe(
-      catchError(() =>
-        of({
-          totalSocialFollowers: 0,
-          totalMonthlySessions: 0,
-          activePlatforms: 0,
-          changePercentage: 0,
-          sessionMomChangePct: 0,
-          trend: 'up' as const,
-          socialPlatforms: [],
-          websiteDomains: [],
-          weeklyTrend: [],
-        })
-      )
-    );
+    return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: this.buildFoundationParams(foundationSlug, classification) });
   }
 
+  /**
+   * Errors PROPAGATE deliberately — do not add a catchError that resolves to a zero-filled
+   * response. The ED dashboard's `safe()` wrapper turns a failure into `undefined`, which is
+   * what lets the card render "Data unavailable" instead of a fabricated zero. Swallowing here
+   * makes that guard unreachable: `safe()` sees a success and the card prints the zeros as if
+   * measured. This is the AAIF defect — 17,269 followers rendered as "0 · 0 platforms".
+   */
   /**
    * Get brand health metrics for the ED dashboard (mention volume + sentiment breakdown).
    * @param foundationSlug Foundation slug used to filter Snowflake queries
@@ -1342,21 +1333,7 @@ export class AnalyticsService {
    */
   public getBrandHealth(foundationSlug: string, includeMentions = false, period?: string): Observable<BrandHealthResponse> {
     const params: Record<string, string> = { foundationSlug, ...(includeMentions && { includeMentions: 'true' }), ...(period && { period }) };
-    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params }).pipe(
-      catchError(() =>
-        of({
-          totalMentions: 0,
-          sentiment: { positive: 0, neutral: 0, negative: 0 },
-          sentimentMomChangePp: 0,
-          mentionMomChangePct: null,
-          trend: 'up' as const,
-          monthlyMentions: [],
-          topProjects: [],
-          topPositiveMentions: [],
-          topNegativeMentions: [],
-        })
-      )
-    );
+    return this.http.get<BrandHealthResponse>('/api/analytics/brand-health', { params });
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -1262,7 +1262,7 @@ export class AnalyticsService {
   /**
    * Get event growth metrics for the ED dashboard.
    * @param foundationSlug Foundation slug used to filter Snowflake queries
-   * @returns Observable emitting event growth totals, YoY changes, and monthly trend (or zeroed defaults on error)
+   * @returns Observable emitting event growth totals, YoY changes, and monthly trend
    */
   public getEventGrowth(foundationSlug: string): Observable<EventGrowthResponse> {
     return this.http.get<EventGrowthResponse>('/api/analytics/event-growth', { params: { foundationSlug } });
@@ -1279,7 +1279,7 @@ export class AnalyticsService {
    * Get brand reach metrics for the ED dashboard (social followers + web sessions).
    * @param foundationSlug Foundation slug used to filter Snowflake queries
    * @param classification Optional LF_SUB_DOMAIN_CLASSIFICATION filter (e.g., 'LF Events', 'LF Corporate')
-   * @returns Observable emitting reach totals, platform breakdowns, and weekly trend (or zeroed defaults on error)
+   * @returns Observable emitting reach totals, platform breakdowns, and weekly trend
    */
   public getBrandReach(foundationSlug: string, classification?: string): Observable<BrandReachResponse> {
     return this.http.get<BrandReachResponse>('/api/analytics/brand-reach', { params: this.buildFoundationParams(foundationSlug, classification) });
@@ -1295,7 +1295,7 @@ export class AnalyticsService {
   /**
    * Get brand health metrics for the ED dashboard (mention volume + sentiment breakdown).
    * @param foundationSlug Foundation slug used to filter Snowflake queries
-   * @returns Observable emitting mention totals, sentiment percentages, and monthly history (or zeroed defaults on error)
+   * @returns Observable emitting mention totals, sentiment percentages, and monthly history
    */
   public getBrandHealth(foundationSlug: string, includeMentions = false, period?: string): Observable<BrandHealthResponse> {
     const params: Record<string, string> = { foundationSlug, ...(includeMentions && { includeMentions: 'true' }), ...(period && { period }) };

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -939,3 +939,37 @@ describe('ProjectService — a Snowflake failure must not become a zero-filled 2
     });
   }
 });
+
+/**
+ * getBrandReach runs two independent queries. A WEB failure fails the whole request (covered
+ * above), but a SOCIAL failure is deliberately non-fatal so the measured web half still reaches
+ * the user. Without a flag that partial success is indistinguishable from a foundation with no
+ * followers — the reported AAIF defect, behind an HTTP 200 no undefined sentinel can catch.
+ */
+describe('ProjectService — a social-only failure is flagged, not silently zeroed', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    execute.mockReset();
+    service = new ProjectService();
+  });
+
+  it('sets socialUnavailable and still returns the measured web half', async () => {
+    // Both WEB queries (domains + daily trend) run in parallel first and must succeed; every
+    // social query after them rejects. Getting this order wrong fails the whole method and the
+    // assertion below would pass for the wrong reason.
+    execute
+      .mockResolvedValueOnce({ rows: [{ LF_SUB_DOMAIN_CLASSIFICATION: 'Docs', TOTAL_SESSIONS: 3482 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValue(new Error('social query failed'));
+
+    const result = await service.getBrandReach('aaif');
+
+    expect(result.socialUnavailable).toBe(true);
+    // The fabricated half must be flagged rather than presented as measured.
+    expect(result.totalSocialFollowers).toBe(0);
+    // The half that DID resolve must survive — blanking it would trade a false zero for a
+    // false outage.
+    expect(result.totalMonthlySessions).toBeGreaterThan(0);
+  });
+});

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -973,3 +973,70 @@ describe('ProjectService — a social-only failure is flagged, not silently zero
     expect(result.totalMonthlySessions).toBeGreaterThan(0);
   });
 });
+
+describe('ProjectService — a failed OPTIONAL email breakdown is flagged, not silently zeroed', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    execute.mockReset();
+    service = new ProjectService();
+  });
+
+  const EMAIL_CTR_PERIOD: ResolvedPeriodRange = { type: 'month', startDate: '2026-03-01', endDate: '2026-04-01', label: 'March 2026' };
+
+  /**
+   * `getEmailCtr` fires four queries in one Promise.all — summary, monthly, campaign, then the
+   * per-send breakdown. Only the LAST is optional: it `.catch()`es to `rows: []` so a breakdown
+   * outage does not blank the CTR that was genuinely measured. But an unflagged empty array is
+   * indistinguishable from a period with no campaigns, and the drawer reduce()s over it — so the
+   * degradation has to be reported, not just survived.
+   *
+   * Mock order is load-bearing: rejecting an earlier query would fail the whole method and the
+   * assertions below would pass for the wrong reason rather than binding the optional path.
+   */
+  it('sets breakdownUnavailable and still returns the measured primary CTR', async () => {
+    execute
+      .mockResolvedValueOnce({ rows: [{ PROJECT_NAME: 'TLF', CTR_LAST_COMPLETED_MONTH: 2.5 }] })
+      .mockResolvedValueOnce({ rows: [{ PUBLISHED_MONTH: 'Mar', PUBLISHED_MONTH_DATE: '2026-03-01', TOTAL_SENDS: 1000, TOTAL_OPENS: 250 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('breakdown query failed'));
+
+    const result = await service.getEmailCtr('tlf', undefined, EMAIL_CTR_PERIOD);
+
+    expect(result.breakdownUnavailable).toBe(true);
+    // The breakdown is empty because it FAILED, and the flag is the only thing that says so.
+    expect(result.emailTypeBreakdown ?? []).toEqual([]);
+    // The independent primary read must survive — rethrowing here would trade a partial
+    // outage for a total one and blank a figure that was actually measured.
+    expect(result.currentCtr).toBeGreaterThan(0);
+  });
+
+  it('leaves breakdownUnavailable false when every query succeeds', async () => {
+    // The other side of the contract: an empty breakdown that was genuinely READ must not be
+    // reported as an outage, or the fix trades a fabricated zero for a fabricated failure.
+    execute
+      .mockResolvedValueOnce({ rows: [{ PROJECT_NAME: 'TLF', CTR_LAST_COMPLETED_MONTH: 2.5 }] })
+      .mockResolvedValueOnce({ rows: [{ PUBLISHED_MONTH: 'Mar', PUBLISHED_MONTH_DATE: '2026-03-01', TOTAL_SENDS: 1000, TOTAL_OPENS: 250 }] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] });
+
+    const result = await service.getEmailCtr('tlf', undefined, EMAIL_CTR_PERIOD);
+
+    expect(result.breakdownUnavailable).toBe(false);
+  });
+
+  it('reports the breakdown failure even when the primary reads come back genuinely empty', async () => {
+    // The early-return path: `summaryResult`/`monthlyResult` empty short-circuits before the
+    // breakdown is ever mapped. The flag has to be carried there too — otherwise a period whose
+    // breakdown was never read reports as a confident "no campaigns".
+    execute
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockResolvedValueOnce({ rows: [] })
+      .mockRejectedValueOnce(new Error('breakdown query failed'));
+
+    const result = await service.getEmailCtr('tlf', undefined, EMAIL_CTR_PERIOD);
+
+    expect(result.breakdownUnavailable).toBe(true);
+  });
+});

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -898,3 +898,44 @@ describe('ProjectService — paid ads compatibility', () => {
     expect(execute.mock.calls.some(([sql]) => String(sql).includes('SUM(CONV)'))).toBe(true);
   });
 });
+
+/**
+ * The ED dashboard distinguishes "could not measure" from "measured zero" by turning a failed
+ * request into `undefined`, which the card renders as "Data unavailable". That only works if the
+ * failure reaches the client as an HTTP error.
+ *
+ * These five methods used to catch a Snowflake failure and return a zero-filled body with a 200,
+ * so the client saw a success, the undefined sentinel was never reached, and the card printed the
+ * zeros as if measured — the reported AAIF defect, one layer below where it was first fixed.
+ * getEventGrowth / getBrandReach / getBrandHealth already rethrew; these now match.
+ *
+ * A genuine no-data result (`rows.length === 0`) still returns its zero-filled shape — that is a
+ * measurement, and it must stay distinguishable from an outage.
+ */
+describe('ProjectService — a Snowflake failure must not become a zero-filled 200', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    execute.mockReset();
+    service = new ProjectService();
+  });
+
+  const methods: { name: string; call: (s: ProjectService) => Promise<unknown> }[] = [
+    {
+      name: 'getWebActivitiesSummary',
+      call: (s) => s.getWebActivitiesSummary('aaif', undefined, { type: 'trailing', startDate: '2026-01-01', endDate: '2026-06-30', label: 'Last 6 months' }),
+    },
+    { name: 'getMemberRetention', call: (s) => s.getMemberRetention('aaif') },
+    { name: 'getMemberAcquisition', call: (s) => s.getMemberAcquisition('aaif') },
+    { name: 'getEngagedCommunity', call: (s) => s.getEngagedCommunity('aaif') },
+    { name: 'getFlywheelConversion', call: (s) => s.getFlywheelConversion('aaif') },
+  ];
+
+  for (const { name, call } of methods) {
+    it(`${name} rethrows instead of returning zeros`, async () => {
+      execute.mockRejectedValue(new Error('snowflake unavailable'));
+
+      await expect(call(service)).rejects.toThrow('snowflake unavailable');
+    });
+  }
+});

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -6007,6 +6007,9 @@ export class ProjectService {
         this.snowflakeService.execute<{ ACTIVITY_DATE: string; DAILY_SESSIONS: number }>(dailyQuery, foundationParams),
       ]);
 
+      // Tracks whether the social half failed, so a partial success cannot be mistaken for a
+      // measured zero. See BrandReachResponse.socialUnavailable.
+      let socialUnavailable = false;
       let totalSocialFollowers = 0;
       let followerGrowthPct = 0;
       let socialPlatforms: BrandReachResponse['socialPlatforms'] = [];
@@ -6049,6 +6052,10 @@ export class ProjectService {
           followers: row.FOLLOWERS ?? 0,
         }));
       } catch (socialError) {
+        // Deliberately non-fatal: the web half is independent and was measured fine, so
+        // blanking it would trade a false zero for a false outage. Flag it instead, so the
+        // Social card can say "unavailable" while the Web card keeps its real figure.
+        socialUnavailable = true;
         logger.debug(undefined, 'get_brand_reach', 'Social media query failed, returning web-only data', {
           err: socialError instanceof Error ? socialError : new Error(String(socialError)),
         });
@@ -6080,6 +6087,7 @@ export class ProjectService {
       }
 
       return {
+        socialUnavailable,
         totalSocialFollowers,
         totalMonthlySessions,
         activePlatforms: socialPlatforms.length,

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2479,6 +2479,8 @@ export class ProjectService {
       // email is published once per month — it is not one row per recipient delivery.
       // Filtered on PUBLISHED_DATE rather than PUBLISHED_MONTH_DATE so a mid-month range boundary
       // includes only the sends that actually fall inside it, instead of every send in that month.
+      // See EmailCtrResponse.breakdownUnavailable — set when the optional query below fails.
+      let breakdownUnavailable = false;
       const campaignPerfQuery = `
         SELECT
           MARKETING_EMAIL_NAME,
@@ -2521,6 +2523,13 @@ export class ProjectService {
             CTR: number;
           }>(campaignPerfQuery, [resolved.startDate, resolved.endDate, ...foundationParams])
           .catch((error) => {
+            // Non-fatal by design — the primary CTR read is independent, so rethrowing here would
+            // trade a partial outage for a total one and blank a measurement that did succeed.
+            // But the empty array below is NOT a measurement: the drawer's Sends/Opens/Open Rate/
+            // CTR tiles reduce() over it, so an unflagged failure renders as a confident 0. The
+            // flag is what keeps a failed read distinguishable from a genuinely campaign-less
+            // period — the same contract the rethrowing methods above enforce with an HTTP error.
+            breakdownUnavailable = true;
             logger.warning(undefined, 'get_email_ctr', 'Optional campaign breakdown query failed, degrading gracefully', {
               foundation_slug: foundationSlug,
               err: error,
@@ -2551,6 +2560,10 @@ export class ProjectService {
           campaignGroups: [],
           monthlySends: [],
           monthlyOpens: [],
+          // Carried on this path too: the breakdown query runs before this branch, so it can
+          // have failed even when the primary reads came back genuinely empty. Omitting it here
+          // would report "no campaigns" for a period whose breakdown was never actually read.
+          breakdownUnavailable,
         };
       }
 
@@ -2767,6 +2780,7 @@ export class ProjectService {
         campaignGroups,
         monthlySends,
         monthlyOpens,
+        breakdownUnavailable,
         emailTypeBreakdown,
         campaignInsightText,
       };

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -3815,11 +3815,7 @@ export class ProjectService {
         year,
         err: error,
       });
-      // Rethrow rather than returning a zero-filled body: a 200 carrying zeros is
-      // indistinguishable from a genuine measurement, and the ED card's undefined guard
-      // only fires on an HTTP error. Matches getEventGrowth/getBrandReach/getBrandHealth.
-      // A genuine no-data result (rows.length === 0) still returns its zero shape above.
-      throw error;
+      return { year, platforms: [] };
     }
   }
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -2397,7 +2397,11 @@ export class ProjectService {
         foundation_slug: foundationSlug,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      return { totalSessions: 0, totalPageViews: 0, domainGroups: [], dailyData: [], dailyLabels: [] };
+      // Rethrow rather than returning a zero-filled body: a 200 carrying zeros is
+      // indistinguishable from a genuine measurement, and the ED card's undefined guard
+      // only fires on an HTTP error. Matches getEventGrowth/getBrandReach/getBrandHealth.
+      // A genuine no-data result (rows.length === 0) still returns its zero shape above.
+      throw error;
     }
   }
 
@@ -3811,7 +3815,11 @@ export class ProjectService {
         year,
         err: error,
       });
-      return { year, platforms: [] };
+      // Rethrow rather than returning a zero-filled body: a 200 carrying zeros is
+      // indistinguishable from a genuine measurement, and the ED card's undefined guard
+      // only fires on an HTTP error. Matches getEventGrowth/getBrandReach/getBrandHealth.
+      // A genuine no-data result (rows.length === 0) still returns its zero shape above.
+      throw error;
     }
   }
 
@@ -3894,14 +3902,11 @@ export class ProjectService {
         foundation_slug: foundationSlug,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      return {
-        renewalRate: 0,
-        netRevenueRetention: 0,
-        changePercentage: 0,
-        trend: 'up',
-        target: 85,
-        monthlyData: [],
-      };
+      // Rethrow rather than returning a zero-filled body: a 200 carrying zeros is
+      // indistinguishable from a genuine measurement, and the ED card's undefined guard
+      // only fires on an HTTP error. Matches getEventGrowth/getBrandReach/getBrandHealth.
+      // A genuine no-data result (rows.length === 0) still returns its zero shape above.
+      throw error;
     }
   }
 
@@ -3998,7 +4003,11 @@ export class ProjectService {
         foundation_slug: foundationSlug,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      return defaultResponse;
+      // Rethrow rather than returning a zero-filled body: a 200 carrying zeros is
+      // indistinguishable from a genuine measurement, and the ED card's undefined guard
+      // only fires on an HTTP error. Matches getEventGrowth/getBrandReach/getBrandHealth.
+      // A genuine no-data result (rows.length === 0) still returns its zero shape above.
+      throw error;
     }
   }
 
@@ -4130,21 +4139,11 @@ export class ProjectService {
         foundation_slug: foundationSlug,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      return {
-        totalMembers: 0,
-        changePercentage: 0,
-        trend: 'up',
-        breakdown: {
-          newsletterSubscribers: 0,
-          communityMembers: 0,
-          workingGroupMembers: 0,
-          certifiedIndividuals: 0,
-          webVisitors: 0,
-          codeContributors: 0,
-          trainingEnrollees: 0,
-        },
-        monthlyData: [],
-      };
+      // Rethrow rather than returning a zero-filled body: a 200 carrying zeros is
+      // indistinguishable from a genuine measurement, and the ED card's undefined guard
+      // only fires on an HTTP error. Matches getEventGrowth/getBrandReach/getBrandHealth.
+      // A genuine no-data result (rows.length === 0) still returns its zero shape above.
+      throw error;
     }
   }
 
@@ -4316,22 +4315,11 @@ export class ProjectService {
         foundation_slug: foundationSlug,
         error: error instanceof Error ? error.message : 'Unknown error',
       });
-      return {
-        conversionRate: 0,
-        changePercentage: 0,
-        trend: 'up',
-        funnel: {
-          eventAttendees: 0,
-          convertedToNewsletter: 0,
-          convertedToCommunity: 0,
-          convertedToWorkingGroup: 0,
-          convertedToTraining: 0,
-          convertedToCode: 0,
-          convertedToWeb: 0,
-        },
-        reengagement: emptyReengagement,
-        monthlyData: [],
-      };
+      // Rethrow rather than returning a zero-filled body: a 200 carrying zeros is
+      // indistinguishable from a genuine measurement, and the ED card's undefined guard
+      // only fires on an HTTP error. Matches getEventGrowth/getBrandReach/getBrandHealth.
+      // A genuine no-data result (rows.length === 0) still returns its zero shape above.
+      throw error;
     }
   }
 

--- a/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
@@ -1,0 +1,216 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import type { DashboardMetricCard, EdEvolutionData } from '../interfaces';
+
+import { buildEdEvolutionMetrics } from './dashboard-metrics.constants';
+
+/**
+ * The ED Marketing Overview swallows each card's request error and substitutes a fallback,
+ * so the fallback's SHAPE is what decides whether a failure reads as an outage or as a
+ * measurement. A zero-filled fallback renders "0" — indistinguishable from a real zero once
+ * the error is gone.
+ *
+ * Reproduced on Agentic AI Foundation: /api/analytics/brand-reach failed inside the
+ * dashboard's ~22-request burst on a cold load, and the Social card rendered "0 · 0
+ * platforms" for a foundation with 17,269 followers across 2 platforms.
+ */
+describe('buildEdEvolutionMetrics — a failed request must not render as a measurement', () => {
+  /**
+   * Only the fields these assertions read are populated; the rest of EdEvolutionData is cast
+   * in. A fixture spelling out every response would obscure which field drives each card, and
+   * would need editing whenever an unrelated response gains a field.
+   */
+  function dataWith(overrides: Partial<EdEvolutionData>): EdEvolutionData {
+    return {
+      // Present because the builder dereferences them unconditionally while computing other
+      // cards; none of the assertions below read them.
+      flywheel: {
+        conversionRate: 0,
+        changePercentage: 0,
+        trend: 'up',
+        funnel: {
+          eventAttendees: 0,
+          convertedToNewsletter: 0,
+          convertedToCommunity: 0,
+          convertedToWorkingGroup: 0,
+          convertedToTraining: 0,
+          convertedToCode: 0,
+          convertedToWeb: 0,
+        },
+        reengagement: {
+          totalReengaged: 0,
+          reengagementRate: 0,
+          reengagementMomChange: 0,
+          reengagedToNewsletter: 0,
+          reengagedToCommunity: 0,
+          reengagedToWorkingGroup: 0,
+          reengagedToTraining: 0,
+          reengagedToCode: 0,
+          reengagedToWeb: 0,
+        },
+        monthlyData: [],
+      },
+      revenueImpact: undefined,
+      paidCampaign: undefined,
+      education: undefined,
+      memberAcquisition: {
+        totalMembers: 0,
+        totalMembersMonthlyData: [],
+        totalMembersMonthlyLabels: [],
+        newMembersThisQuarter: 0,
+        newMemberRevenue: 0,
+        changePercentage: 0,
+        trend: 'up',
+        quarterlyData: [],
+      },
+      memberRetention: { renewalRate: 0, netRevenueRetention: 0, changePercentage: 0, trend: 'up', target: 0, monthlyData: [] },
+      engagedCommunity: {
+        totalMembers: 0,
+        changePercentage: 0,
+        trend: 'up',
+        breakdown: {
+          newsletterSubscribers: 0,
+          communityMembers: 0,
+          workingGroupMembers: 0,
+          certifiedIndividuals: 0,
+          webVisitors: 0,
+          codeContributors: 0,
+          trainingEnrollees: 0,
+        },
+        monthlyData: [],
+      },
+      eventGrowth: {
+        totalAttendees: 0,
+        totalRegistrants: 0,
+        totalEvents: 0,
+        totalRevenue: 0,
+        revenuePerAttendee: 0,
+        attendeeYoyChange: 0,
+        registrantYoyChange: 0,
+        revenueYoyChange: 0,
+        trend: 'up',
+        monthlyData: [],
+        topEvents: [],
+      },
+      brandHealth: {
+        totalMentions: 0,
+        sentiment: { positive: 0, neutral: 0, negative: 0 },
+        sentimentMomChangePp: 0,
+        mentionMomChangePct: null,
+        trend: 'up',
+        monthlyMentions: [],
+        topProjects: [],
+        topPositiveMentions: [],
+        topNegativeMentions: [],
+      },
+      emailCtr: {
+        currentCtr: 0,
+        changePercentage: 0,
+        momChangePercentage: null,
+        trend: 'up',
+        monthlyData: [],
+        monthlyLabels: [],
+        campaignGroups: [],
+        monthlySends: [],
+        monthlyOpens: [],
+      },
+      brandReach: {
+        totalSocialFollowers: 17269,
+        totalMonthlySessions: 3482,
+        activePlatforms: 2,
+        changePercentage: 28.18,
+        sessionMomChangePct: 0,
+        trend: 'up',
+        socialPlatforms: [],
+        websiteDomains: [],
+        weeklyTrend: [],
+      },
+      pending: false,
+      ...overrides,
+    } as EdEvolutionData;
+  }
+
+  const card = (cards: DashboardMetricCard[], testId: string): DashboardMetricCard | undefined => cards.find((c) => c.testId === testId);
+
+  // The cards below prove the BUILDER handles undefined. This proves the caller can actually
+  // produce it: EdEvolutionData must permit undefined for brandReach, so the component's
+  // error fallback can be undefined rather than a zero-filled response. Typed at compile
+  // time — if the field is narrowed back to a required BrandReachResponse, this stops
+  // compiling and the build fails, which is the layer a runtime assertion cannot reach.
+  it('permits an undefined brand-reach on the data contract', () => {
+    const failed: Pick<EdEvolutionData, 'brandReach'> = { brandReach: undefined };
+
+    expect(failed.brandReach).toBeUndefined();
+  });
+
+  it('renders the measured figures when the request succeeded', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({}));
+
+    expect(card(cards, 'ed-evo-brand-reach')?.value).toBe('17.3K');
+    expect(card(cards, 'ed-evo-brand-reach')?.subtitle).toBe('2 platforms');
+    expect(card(cards, 'ed-evo-web-sessions')?.value).toBe('3.5K');
+  });
+
+  // The regression itself: undefined is "the request failed", and the card must say so
+  // rather than print a zero a reader would take as a count.
+  it('says the data is unavailable when the brand-reach request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ brandReach: undefined }));
+
+    const social = card(cards, 'ed-evo-brand-reach');
+    expect(social?.value).toBe('—');
+    expect(social?.value).not.toBe('0');
+    expect(social?.subtitle).toContain('could not be loaded');
+    // A change indicator beside an em dash implies a measured movement.
+    expect(social?.changePercentage).toBeUndefined();
+    expect(social?.trend).toBeUndefined();
+  });
+
+  // Both cards read the same response, so both regress together — fixing only the Social
+  // card would leave Web printing "0" from the identical failure.
+  it('says the data is unavailable on the Web card too', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ brandReach: undefined }));
+
+    const web = card(cards, 'ed-evo-web-sessions');
+    expect(web?.value).toBe('—');
+    expect(web?.subtitle).toContain('could not be loaded');
+    expect(web?.changePercentage).toBeUndefined();
+  });
+
+  // While the request is still in flight nothing has failed yet, so the copy must not
+  // claim it did — the em dash is shared, the caption is not.
+  it('does not claim a failure while the request is still pending', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ brandReach: undefined, pending: true }));
+
+    const social = card(cards, 'ed-evo-brand-reach');
+    expect(social?.value).toBe('—');
+    expect(social?.subtitle).not.toContain('could not be loaded');
+  });
+
+  // The other half of the contract: a foundation that genuinely has nothing must still
+  // read as zero. Rendering an em dash here would hide a real measurement.
+  it('renders a genuine zero as zero, not as unavailable', () => {
+    const cards = buildEdEvolutionMetrics(
+      dataWith({
+        brandReach: {
+          totalSocialFollowers: 0,
+          totalMonthlySessions: 0,
+          activePlatforms: 0,
+          changePercentage: 0,
+          sessionMomChangePct: 0,
+          trend: 'up',
+          socialPlatforms: [],
+          websiteDomains: [],
+          weeklyTrend: [],
+        },
+      })
+    );
+
+    const social = card(cards, 'ed-evo-brand-reach');
+    expect(social?.value).toBe('0');
+    expect(social?.subtitle).toBe('0 platforms');
+    expect(social?.subtitle).not.toContain('could not be loaded');
+  });
+});

--- a/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
@@ -189,6 +189,40 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(social?.subtitle).not.toContain('could not be loaded');
   });
 
+  // The Email card was the one reported from production: AAIF's March campaign had 100 opens
+  // at a 76.3% CTR, and a failed request rendered "0 opens · 0.0% CTR" because summing an
+  // absent response yields 0. Its signals are dual-signal rows rather than a single value.
+  it('says the data is unavailable when the email request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ emailCtr: undefined }));
+
+    const email = card(cards, 'ed-evo-campaign-performance');
+    expect(email?.dualSignals?.map((row) => row.value)).toEqual(['—', '—']);
+    expect(email?.dualSignals?.some((row) => String(row.value).includes('0 opens'))).toBe(false);
+    expect(email?.caption).toContain('could not be loaded');
+  });
+
+  // The Adoption card, whose drawer additionally asserts "No community engagement activity
+  // detected" — copy that states a finding rather than an outage. AAIF has 27,831 engaged.
+  it('says the data is unavailable when the engaged-community request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ engagedCommunity: undefined }));
+
+    const adoption = card(cards, 'ed-evo-engaged-community');
+    expect(adoption?.value).toBe('—');
+    expect(adoption?.value).not.toBe('0');
+    expect(adoption?.subtitle).toContain('could not be loaded');
+    expect(adoption?.changePercentage).toBeUndefined();
+  });
+
+  // A foundation that genuinely sent nothing must still read as a measured zero, or the fix
+  // trades one wrong answer for another.
+  it('renders a genuinely empty email month as zero, not as unavailable', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({}));
+
+    const email = card(cards, 'ed-evo-campaign-performance');
+    expect(email?.dualSignals?.[0]?.value).toBe('0 opens');
+    expect(email?.caption).not.toContain('could not be loaded');
+  });
+
   // The other half of the contract: a foundation that genuinely has nothing must still
   // read as zero. Rendering an em dash here would hide a real measurement.
   it('renders a genuine zero as zero, not as unavailable', () => {

--- a/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
@@ -259,6 +259,25 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(web?.subtitle).not.toContain('could not be loaded');
   });
 
+  // Attribution and Paid Media are the two cards whose fields were ALREADY undefined-sentinel
+  // before this branch, so their guards predate the rest and had no assertions at all — the
+  // highest-risk gap, because a regression there looks exactly like the original defect.
+  it('says the data is unavailable when the attribution request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ revenueImpact: undefined }));
+
+    const attribution = card(cards, 'ed-evo-attribution');
+    expect(attribution?.dualSignals?.map((row) => row.value)).toEqual(['—', '—']);
+    expect(attribution?.caption).toContain('could not be loaded');
+  });
+
+  it('says the data is unavailable when the paid-media request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ paidCampaign: undefined }));
+
+    const paid = card(cards, 'ed-evo-paid-media');
+    expect(paid?.dualSignals?.map((row) => row.value)).toEqual(['—', '—']);
+    expect(paid?.caption).toContain('could not be loaded');
+  });
+
   // A foundation that genuinely sent nothing must still read as a measured zero, or the fix
   // trades one wrong answer for another.
   it('renders a genuinely empty email month as zero, not as unavailable', () => {
@@ -355,5 +374,66 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     for (const testId of ['ed-evo-event-growth', 'ed-evo-member-growth', 'ed-evo-flywheel-conversion', 'ed-evo-engaged-community']) {
       expect(card(cards, testId)?.subtitle).not.toContain('could not be loaded');
     }
+  });
+
+  /**
+   * Attribution and Paid Media are the two self-guarded cards: they are special-cased out of
+   * `withPendingPlaceholder` and build their own unavailable arm inline, which makes them the
+   * highest-risk guards here and — until now — the only regression-relevant ones with no
+   * assertion on either side. The base fixture pins both to `undefined`, so every other case in
+   * this file renders them in their unavailable arm incidentally without ever asserting it;
+   * reverting either guard to emit zeros left the whole suite green.
+   */
+  const ZERO_PAID_CAMPAIGN = {
+    totalReach: 0,
+    roas: 0,
+    totalSpend: 0,
+    totalRevenue: 0,
+    changePercentage: 0,
+    trend: 'up' as const,
+    monthlyData: [0],
+    monthlyLabels: ['Jan'],
+    monthlyRoas: [0],
+    monthlySpend: [0],
+    channelGroups: [],
+  };
+
+  const ZERO_REVENUE_IMPACT = {
+    pipelineInfluenced: 0,
+    revenueAttributed: 0,
+    matchRate: 0,
+    changePercentage: 0,
+    trend: 'up' as const,
+    attributionModels: { linear: 0, firstTouch: 0, lastTouch: 0 },
+    engagementTypes: [],
+    paidMedia: { roas: 0, impressions: 0, adSpend: 0, adRevenue: 0, monthlyTrend: [] },
+    attributionChannels: [],
+    projectBreakdown: [],
+    eventRegistrationAttribution: { channelBreakdown: [], monthlyTrend: [] },
+  };
+
+  it('reports a failed Attribution and Paid Media read as unavailable, not as $0', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ revenueImpact: undefined, paidCampaign: undefined }));
+
+    // Both cards are dual-signal, so the em dash must reach EVERY row — a guard that blanked
+    // only the headline would still fabricate the second figure.
+    expect(card(cards, 'ed-evo-attribution')?.dualSignals?.map((row) => row.value)).toEqual(['—', '—']);
+    expect(card(cards, 'ed-evo-paid-media')?.dualSignals?.map((row) => row.value)).toEqual(['—', '—']);
+    expect(card(cards, 'ed-evo-attribution')?.caption).toContain('could not be loaded');
+    expect(card(cards, 'ed-evo-paid-media')?.caption).toContain('could not be loaded');
+  });
+
+  it('renders genuinely zero Attribution and Paid Media as the measurements they are', () => {
+    // The counter-assertion. Without it, a guard that suppressed these cards unconditionally
+    // would pass the test above — reporting a foundation that genuinely spent nothing as an
+    // outage, which is the same defect inverted.
+    const cards = buildEdEvolutionMetrics(dataWith({ revenueImpact: ZERO_REVENUE_IMPACT, paidCampaign: ZERO_PAID_CAMPAIGN }));
+
+    expect(card(cards, 'ed-evo-attribution')?.dualSignals?.every((row) => row.value !== '—')).toBe(true);
+    expect(card(cards, 'ed-evo-paid-media')?.dualSignals?.every((row) => row.value !== '—')).toBe(true);
+    // ROAS is the figure that must read as a measured 0.0x rather than a dash.
+    expect(card(cards, 'ed-evo-paid-media')?.dualSignals?.[1]?.value).toBe('0.0x');
+    expect(card(cards, 'ed-evo-attribution')?.caption).not.toContain('could not be loaded');
+    expect(card(cards, 'ed-evo-paid-media')?.caption).not.toContain('could not be loaded');
   });
 });

--- a/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
@@ -224,6 +224,41 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(sentiment?.caption).toContain('could not be loaded');
   });
 
+  // getBrandReach runs two independent queries and keeps serving web data when only the social
+  // one fails — so the response is PRESENT while its social half is fabricated. That partial
+  // success is the last live path of the original AAIF defect: 17,269 followers rendering as
+  // "0 · 0 platforms" behind an HTTP 200 that no undefined sentinel can catch.
+  it('says the social data is unavailable when only the social query failed', () => {
+    const cards = buildEdEvolutionMetrics(
+      dataWith({
+        brandReach: {
+          socialUnavailable: true,
+          totalSocialFollowers: 0,
+          totalMonthlySessions: 3482,
+          activePlatforms: 0,
+          changePercentage: 0,
+          sessionMomChangePct: 4,
+          trend: 'up',
+          socialPlatforms: [],
+          websiteDomains: [],
+          weeklyTrend: [],
+        },
+      })
+    );
+
+    const social = card(cards, 'ed-evo-brand-reach');
+    expect(social?.value).toBe('—');
+    expect(social?.value).not.toBe('0');
+    expect(social?.subtitle).toContain('could not be loaded');
+    expect(social?.changePercentage).toBeUndefined();
+
+    // The other half of the partial success: web sessions WERE measured, so blanking them
+    // would trade a false zero for a false outage.
+    const web = card(cards, 'ed-evo-web-sessions');
+    expect(web?.value).toBe('3.5K');
+    expect(web?.subtitle).not.toContain('could not be loaded');
+  });
+
   // A foundation that genuinely sent nothing must still read as a measured zero, or the fix
   // trades one wrong answer for another.
   it('renders a genuinely empty email month as zero, not as unavailable', () => {

--- a/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
@@ -213,6 +213,17 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(adoption?.changePercentage).toBeUndefined();
   });
 
+  // The Sentiment card's unavailable arm had no assertion at all: reverting its guard left the
+  // whole shared suite green. Like Email it is a dual-signal card, so its state lives in
+  // dualSignals/caption rather than in `value`.
+  it('says the data is unavailable when the brand-health request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ brandHealth: undefined }));
+
+    const sentiment = card(cards, 'ed-evo-brand-health');
+    expect(sentiment?.dualSignals?.map((row) => row.value)).toEqual(['—', '—']);
+    expect(sentiment?.caption).toContain('could not be loaded');
+  });
+
   // A foundation that genuinely sent nothing must still read as a measured zero, or the fix
   // trades one wrong answer for another.
   it('renders a genuinely empty email month as zero, not as unavailable', () => {

--- a/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
@@ -266,7 +266,7 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(members?.changePercentage).toBeUndefined();
   });
 
-  // The Members card is the only one reading two responses. Retention supplies the caption
+  // Members reads two responses, so its two halves degrade separately. Retention supplies the caption
   // alone, so its failure leaves the value measured while the caption must stop claiming a
   // retention rate it never received.
   it('drops the retention caption when only the retention request failed', () => {
@@ -312,7 +312,12 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(card(cards, 'ed-evo-event-growth')?.value).toBe('0');
     expect(card(cards, 'ed-evo-member-growth')?.value).toBe('0');
     expect(card(cards, 'ed-evo-flywheel-conversion')?.value).toBe('0.0%');
-    for (const testId of ['ed-evo-event-growth', 'ed-evo-member-growth', 'ed-evo-flywheel-conversion']) {
+    // Adoption and Sentiment need the same pin: a guard written as a truthiness test on
+    // totalMembers/totalMentions would keep every failure case green while reporting a real
+    // zero as an outage — the inverse defect, and just as wrong.
+    expect(card(cards, 'ed-evo-engaged-community')?.value).toBe('0');
+    expect(card(cards, 'ed-evo-brand-health')?.dualSignals?.every((row) => row.value !== '—')).toBe(true);
+    for (const testId of ['ed-evo-event-growth', 'ed-evo-member-growth', 'ed-evo-flywheel-conversion', 'ed-evo-engaged-community']) {
       expect(card(cards, testId)?.subtitle).not.toContain('could not be loaded');
     }
   });

--- a/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.spec.ts
@@ -223,6 +223,50 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(email?.caption).not.toContain('could not be loaded');
   });
 
+  it('says the data is unavailable when the event-growth request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ eventGrowth: undefined }));
+
+    const events = card(cards, 'ed-evo-event-growth');
+    expect(events?.value).toBe('—');
+    expect(events?.value).not.toBe('0');
+    expect(events?.subtitle).toContain('could not be loaded');
+    expect(events?.changePercentage).toBeUndefined();
+    expect(events?.trend).toBeUndefined();
+  });
+
+  it('says the data is unavailable when the flywheel request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ flywheel: undefined }));
+
+    const conversion = card(cards, 'ed-evo-flywheel-conversion');
+    expect(conversion?.value).toBe('—');
+    // The failure mode this replaces: a zero-filled response rendered a plausible rate.
+    expect(conversion?.value).not.toBe('0.0%');
+    expect(conversion?.subtitle).toContain('could not be loaded');
+    expect(conversion?.changePercentage).toBeUndefined();
+  });
+
+  it('says the data is unavailable when the member-acquisition request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ memberAcquisition: undefined }));
+
+    const members = card(cards, 'ed-evo-member-growth');
+    expect(members?.value).toBe('—');
+    expect(members?.value).not.toBe('0');
+    expect(members?.subtitle).toContain('could not be loaded');
+    expect(members?.changePercentage).toBeUndefined();
+  });
+
+  // The Members card is the only one reading two responses. Retention supplies the caption
+  // alone, so its failure leaves the value measured while the caption must stop claiming a
+  // retention rate it never received.
+  it('drops the retention caption when only the retention request failed', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({ memberRetention: undefined }));
+
+    const members = card(cards, 'ed-evo-member-growth');
+    expect(members?.value).toBe('0');
+    expect(members?.subtitle).toContain('could not be loaded');
+    expect(members?.subtitle).not.toContain('retention');
+  });
+
   // The other half of the contract: a foundation that genuinely has nothing must still
   // read as zero. Rendering an em dash here would hide a real measurement.
   it('renders a genuine zero as zero, not as unavailable', () => {
@@ -246,5 +290,19 @@ describe('buildEdEvolutionMetrics — a failed request must not render as a meas
     expect(social?.value).toBe('0');
     expect(social?.subtitle).toBe('0 platforms');
     expect(social?.subtitle).not.toContain('could not be loaded');
+  });
+
+  // The same half of the contract for the four cards guarded above. The base fixture is
+  // all-zeros and every response present, which is exactly a foundation that ran nothing —
+  // so each of these must read as a measurement, not as an outage.
+  it('renders genuine zeros as measurements on the events, members, and flywheel cards', () => {
+    const cards = buildEdEvolutionMetrics(dataWith({}));
+
+    expect(card(cards, 'ed-evo-event-growth')?.value).toBe('0');
+    expect(card(cards, 'ed-evo-member-growth')?.value).toBe('0');
+    expect(card(cards, 'ed-evo-flywheel-conversion')?.value).toBe('0.0%');
+    for (const testId of ['ed-evo-event-growth', 'ed-evo-member-growth', 'ed-evo-flywheel-conversion']) {
+      expect(card(cards, testId)?.subtitle).not.toContain('could not be loaded');
+    }
   });
 });

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -743,6 +743,14 @@ export const DRAWER_UNAVAILABLE_BODY = 'Please try again.';
 export const DRAWER_LOADING_HEADING = 'Loading…';
 
 /**
+ * The placeholder a single tile renders when its own source could not be read, while the rest
+ * of the drawer stays measured. Used for PARTIAL failures — where blanking the whole drawer
+ * would trade a real outage for a false one — so it deliberately matches the em dash the card
+ * layer already uses for an unmeasured value rather than introducing a second vocabulary.
+ */
+export const TILE_UNAVAILABLE_PLACEHOLDER = '—';
+
+/**
  * A dual-signal row for a card whose data could not be fetched.
  *
  * Renders an em-dash instead of a number, with no sparkline and no trend pill, so a

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -913,7 +913,7 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
     : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD${eventGrowth.monthlyData.length > 0 ? ' · Trend: quarterly, 3 yrs + upcoming' : ''}`;
   const eventsSparkline =
     eventGrowth && eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth?.totalRegistrants ?? 0);
-  // The Members card is the only one reading two responses: the value comes from
+  // Members reads TWO responses, which is why it needs a combined guard: the value comes from
   // memberAcquisition and the caption from memberRetention, so either failing makes the card
   // no longer a measurement.
   // Note the Members DRAWER binds `unavailable` on either response failing, which is stricter

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -867,6 +867,13 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   // arm it would otherwise be a nested ternary, which .claude/rules/styling.md forbids.
   const webSessionsSubtitle = brandReach && brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Trend: last 6 months' : 'Sessions (30d)';
 
+  // Same reason: the Adoption sparkline picks between a real series and a flat placeholder,
+  // and that choice nested inside the engagedCommunity-undefined arm would be a third level.
+  const adoptionSparkline =
+    engagedCommunity && engagedCommunity.monthlyData.length > 0
+      ? monthlyValues(engagedCommunity.monthlyData)
+      : flatSparklineData(engagedCommunity?.totalMembers ?? 0);
+
   // Education totals. edX is counted in enrollments but has no revenue column in
   // COURSE_PURCHASES, so it is intentionally absent from the revenue sum — adding a 0
   // would be harmless here but the omission is deliberate and mirrored in the drawer.
@@ -884,17 +891,19 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
     ? education.enrollment.instructorLed + education.enrollment.eLearning + education.enrollment.certExams > 0
     : false;
 
-  // Pre-compute email open rate for the Campaign Performance card
-  const emailTotalSends = emailCtr.monthlySends.reduce((sum, v) => sum + v, 0);
-  const emailTotalOpens = emailCtr.monthlyOpens.reduce((sum, v) => sum + v, 0);
+  // Pre-compute email open rate for the Campaign Performance card. These stay computable on a
+  // failed request (summing nothing gives 0) — the card guards on `emailCtr` itself rather than
+  // on these totals, because a summed 0 is exactly the fabricated measurement to avoid showing.
+  const emailTotalSends = emailCtr ? emailCtr.monthlySends.reduce((sum, v) => sum + v, 0) : 0;
+  const emailTotalOpens = emailCtr ? emailCtr.monthlyOpens.reduce((sum, v) => sum + v, 0) : 0;
   const emailOpenRate = emailTotalSends > 0 ? (emailTotalOpens / emailTotalSends) * 100 : 0;
 
   // Per-month open RATE, not send volume. Charting sends here would report an
   // improving trend whenever sends grow faster than opens — the opposite of the
   // truth. Months with no sends contribute 0 and are suppressed by the sends
   // activity guard passed alongside.
-  const emailMonthlyOpenRate = emailCtr.monthlyOpens.map((opens, i) => {
-    const sends = emailCtr.monthlySends[i] ?? 0;
+  const emailMonthlyOpenRate = (emailCtr?.monthlyOpens ?? []).map((opens, i) => {
+    const sends = emailCtr?.monthlySends[i] ?? 0;
     return sends > 0 ? (opens / sends) * 100 : 0;
   });
 
@@ -1003,14 +1012,13 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       testId: 'ed-evo-engaged-community',
       description:
         'Unique individuals active across 7 channels — community, working groups, newsletter, training, code, web, and certified — in the last 90 days.',
-      value: formatNumber(engagedCommunity.totalMembers),
-      changePercentage: formatMomChange(engagedCommunity.changePercentage),
-      trend: normalizeTrend(engagedCommunity.changePercentage, engagedCommunity.trend),
-      subtitle: trendWindow(engagedCommunity.monthlyData.length),
-      chartData: protoSparkline(
-        engagedCommunity.monthlyData.length > 0 ? monthlyValues(engagedCommunity.monthlyData) : flatSparklineData(engagedCommunity.totalMembers),
-        lfxColors.blue[500]
-      ),
+      // undefined means the request failed, not that nobody engaged. AAIF has 27,831 engaged
+      // individuals and rendered "0" here when this fell back to a zero-filled response.
+      value: engagedCommunity ? formatNumber(engagedCommunity.totalMembers) : '—',
+      changePercentage: engagedCommunity ? formatMomChange(engagedCommunity.changePercentage) : undefined,
+      trend: engagedCommunity ? normalizeTrend(engagedCommunity.changePercentage, engagedCommunity.trend) : undefined,
+      subtitle: engagedCommunity ? trendWindow(engagedCommunity.monthlyData.length) : placeholderCaption,
+      chartData: engagedCommunity ? protoSparkline(adoptionSparkline, lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Unique individuals active across community, working groups, newsletter, training, code, web, and certified in the last 90 days.',
       drawerType: DashboardDrawerType.NorthStarEngagedCommunity,
@@ -1086,30 +1094,36 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       testId: 'ed-evo-campaign-performance',
       description: 'Email opens with click-through and open rate, and MoM trend.',
       customContentType: 'dual-signal',
-      dualSignals: [
-        protoDualSignal(
-          // withPendingPlaceholder overrides value/color while pending, but the label
-          // is built here — embedding the live CTR unconditionally would leave a
-          // fabricated "0.0% CTR" on screen next to an em-dash value.
-          pending ? 'Opens' : `Opens · ${emailCtr.currentCtr.toFixed(1)}% CTR`,
-          formatNumber(emailTotalOpens) + ' opens',
-          emailCtr.monthlyOpens,
-          lfxColors.blue[500],
-          seriesMomChange(emailCtr.monthlyOpens, emailCtr.monthlySends),
-          seriesTrendDirection(emailCtr.monthlyOpens, emailCtr.monthlySends)
-        ),
-        protoDualSignal(
-          `Open rate · 6 mo`,
-          `${emailOpenRate.toFixed(0)}%`,
-          emailMonthlyOpenRate,
-          lfxColors.violet[500],
-          // Guard on sends, not on the rate itself: a zero-send month has a 0% rate
-          // that would otherwise read as a real collapse.
-          seriesMomChange(emailMonthlyOpenRate, emailCtr.monthlySends),
-          seriesTrendDirection(emailMonthlyOpenRate, emailCtr.monthlySends)
-        ),
-      ],
-      caption: trendWindow(emailCtr.monthlyOpens.length),
+      // undefined means the request failed, not that nobody opened anything. Summing an
+      // absent response gives 0, so falling through would render "0 opens · 0.0% CTR" as a
+      // measurement — which is exactly what AAIF showed while its March campaign sat at 100
+      // opens and a 76.3% CTR.
+      dualSignals: emailCtr
+        ? [
+            protoDualSignal(
+              // withPendingPlaceholder overrides value/color while pending, but the label
+              // is built here — embedding the live CTR unconditionally would leave a
+              // fabricated "0.0% CTR" on screen next to an em-dash value.
+              pending ? 'Opens' : `Opens · ${emailCtr.currentCtr.toFixed(1)}% CTR`,
+              formatNumber(emailTotalOpens) + ' opens',
+              emailCtr.monthlyOpens,
+              lfxColors.blue[500],
+              seriesMomChange(emailCtr.monthlyOpens, emailCtr.monthlySends),
+              seriesTrendDirection(emailCtr.monthlyOpens, emailCtr.monthlySends)
+            ),
+            protoDualSignal(
+              `Open rate · 6 mo`,
+              `${emailOpenRate.toFixed(0)}%`,
+              emailMonthlyOpenRate,
+              lfxColors.violet[500],
+              // Guard on sends, not on the rate itself: a zero-send month has a 0% rate
+              // that would otherwise read as a real collapse.
+              seriesMomChange(emailMonthlyOpenRate, emailCtr.monthlySends),
+              seriesTrendDirection(emailMonthlyOpenRate, emailCtr.monthlySends)
+            ),
+          ]
+        : [unavailableDualSignal('Opens', lfxColors.blue[500]), unavailableDualSignal('Open rate · 6 mo', lfxColors.violet[500])],
+      caption: emailCtr ? trendWindow(emailCtr.monthlyOpens.length) : placeholderCaption,
       tooltipText: 'Email opens with click-through rate, plus sends and the six-month open rate.',
       drawerType: DashboardDrawerType.MarketingEmailCtr,
     } as DashboardMetricCard,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -710,6 +710,25 @@ const DATA_UNAVAILABLE_CAPTION = 'Data unavailable — could not be loaded';
 const DATA_LOADING_CAPTION = 'Loading…';
 
 /**
+ * Drawer empty-state copy for a FAILED request, as opposed to a measured absence.
+ *
+ * Each ED drill-down drawer's existing empty state asserts a finding ("No brand mention
+ * activity detected") and advises acting on it ("Engage with marketing ops…"). That copy
+ * is correct for a foundation that genuinely has no activity and wrong for one whose
+ * request failed — it reports an outage as a measurement and then recommends work based
+ * on it. The drawers pick between the two on their `unavailable` input.
+ *
+ * Deliberately terse: this is an executive dashboard, and the failure needs to be honest
+ * rather than loud. The body is a retry instruction and NOT a cause — the failure is
+ * intermittent under the dashboard's concurrent request burst, but that has not been
+ * confirmed as the mechanism, and naming an unproven cause in the UI would repeat the
+ * original defect one level up. The drawer suppresses its own advice paragraph in this
+ * state: advice derived from data that never arrived is the defect, not just its wording.
+ */
+export const DRAWER_UNAVAILABLE_HEADING = 'Data unavailable';
+export const DRAWER_UNAVAILABLE_BODY = 'Please try again.';
+
+/**
  * A dual-signal row for a card whose data could not be fetched.
  *
  * Renders an em-dash instead of a number, with no sparkline and no trend pill, so a

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -735,11 +735,17 @@ function attributionCaption(revenueImpact: RevenueImpactResponse): string {
  * Overrides a single-value or dual-signal card's value-bearing fields with the same
  * em-dash placeholder used by unavailableDualSignal, while pending is true.
  *
- * Only Paid Media and Attribution carry an `undefined` sentinel for a failed/pending
- * request — every other card's source field is a non-optional zero-filled object, so
- * without this the pending window renders each of their real-looking values (member
- * counts, session totals, mention counts, etc.) as if they were measured zeros for the
- * newly-selected foundation, the exact defect this PR exists to remove elsewhere.
+ * Now largely redundant, and kept as defence in depth rather than for a known live case.
+ * Every response field on EdEvolutionData is `| undefined`; each card guards on its own
+ * field and renders `placeholderCaption`, which already resolves to "Loading…" while
+ * pending. The pending emission itself (PENDING_ED_EVOLUTION_DATA) carries every field
+ * as undefined and is re-emitted synchronously on each foundation switch, so no card can
+ * be holding a resolved value when pending is true.
+ *
+ * It stays because it is the only enforcement point that does not depend on each card
+ * remembering to consult `pending`: a future card that reads a field without routing its
+ * caption through `placeholderCaption` is still blanked here. Do not narrow it to a list
+ * of card names — that list is what went stale last time.
  */
 function withPendingPlaceholder(card: DashboardMetricCard, pending: boolean): DashboardMetricCard {
   if (!pending) return card;
@@ -940,10 +946,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   // unavailable state in that case and never reads this.
   const paidActivity = paidCampaign ? paidCampaign.monthlyData.map((v, i) => v + (paidCampaign.monthlySpend?.[i] ?? 0)) : [];
 
-  // Paid Media and Attribution already carry their own undefined-sentinel pending
-  // handling above (paidCampaign/revenueImpact), so they're excluded here to avoid
-  // double-applying the placeholder — everything else has no such sentinel and would
-  // otherwise render its zero-filled PENDING_ED_EVOLUTION_DATA fields as measured data.
+  // Paid Media and Attribution build their pending copy inline rather than through a
+  // shared placeholder, so running withPendingPlaceholder over them would overwrite it.
+  // Every other card tolerates the override because it writes the same em dash and
+  // "Loading…" caption those cards already render for an absent field.
   const selfGuardedDrawerTypes = new Set([DashboardDrawerType.MarketingPaidSocialReach, DashboardDrawerType.RevenueImpact]);
 
   return [

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -735,6 +735,12 @@ export const DRAWER_UNAVAILABLE_HEADING = 'Data unavailable';
  */
 export const DRAWER_NO_ACTIVITY_BODY = 'Engage with marketing ops to activate campaigns and start tracking results.';
 export const DRAWER_UNAVAILABLE_BODY = 'Please try again.';
+/**
+ * Shown while the request is still in flight. Distinct from the unavailable copy because
+ * nothing has failed yet — the drawer suppresses its body in BOTH states (the zero-filled
+ * fallback is not a measurement in either), but only one of them may claim a failure.
+ */
+export const DRAWER_LOADING_HEADING = 'Loading…';
 
 /**
  * A dual-signal row for a card whose data could not be fetched.

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -902,6 +902,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   // else reports a failure during the initial in-flight window.
   const placeholderCaption = data.pending ? DATA_LOADING_CAPTION : DATA_UNAVAILABLE_CAPTION;
 
+  // The Social card needs BOTH the response and its social half: getBrandReach keeps serving
+  // web data when only the social query fails, so `brandReach` being present does not mean
+  // followers were measured. The Web card deliberately does NOT consult this — its sessions
+  // were measured fine, and blanking them would trade a false zero for a false outage.
+  const socialMeasured = brandReach && !brandReach.socialUnavailable;
+
   // Lifted out of the Web card's subtitle binding: combined with the brandReach-undefined
   // arm it would otherwise be a nested ternary, which .claude/rules/styling.md forbids.
   const webSessionsSubtitle = brandReach && brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Trend: last 6 months' : 'Sessions (30d)';
@@ -1095,15 +1101,15 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       description: 'Social followers across all platforms.',
       // undefined means the request failed, not that the foundation has no followers —
       // "0 · 0 platforms" would report an outage as a measurement.
-      value: brandReach ? formatNumber(brandReach.totalSocialFollowers) : '—',
-      changePercentage: brandReach ? formatMomChange(brandReach.changePercentage) : undefined,
-      trend: brandReach ? normalizeTrend(brandReach.changePercentage, brandReach.trend) : undefined,
-      subtitle: brandReach ? `${brandReach.activePlatforms} platform${brandReach.activePlatforms === 1 ? '' : 's'}` : placeholderCaption,
+      value: socialMeasured ? formatNumber(brandReach.totalSocialFollowers) : '—',
+      changePercentage: socialMeasured ? formatMomChange(brandReach.changePercentage) : undefined,
+      trend: socialMeasured ? normalizeTrend(brandReach.changePercentage, brandReach.trend) : undefined,
+      subtitle: socialMeasured ? `${brandReach.activePlatforms} platform${brandReach.activePlatforms === 1 ? '' : 's'}` : placeholderCaption,
       // No historical follower series available. flatSparklineData renders a nearly
       // flat line at the current total (a constant array collapses Chart.js's Y range
       // and hides the line entirely) — it is a placeholder, not a trend. Website
       // sessions are deliberately not reused here: different metric, different card.
-      chartData: brandReach ? protoSparkline(flatSparklineData(brandReach.totalSocialFollowers), lfxColors.blue[500]) : EMPTY_CHART_DATA,
+      chartData: socialMeasured ? protoSparkline(flatSparklineData(brandReach.totalSocialFollowers), lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Social followers across all platforms, with month-over-month change.',
       drawerType: DashboardDrawerType.BrandReach,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -867,6 +867,34 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   // arm it would otherwise be a nested ternary, which .claude/rules/styling.md forbids.
   const webSessionsSubtitle = brandReach && brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Trend: last 6 months' : 'Sessions (30d)';
 
+  // Same reason for these three: each already branches on whether a real series exists, so
+  // nesting that inside the undefined arm would add a second level.
+  const eventsSubtitle = !eventGrowth
+    ? ''
+    : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD${eventGrowth.monthlyData.length > 0 ? ' · Trend: quarterly, 3 yrs + upcoming' : ''}`;
+  const eventsSparkline =
+    eventGrowth && eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth?.totalRegistrants ?? 0);
+  // The Members card is the only one reading two responses: the value comes from
+  // memberAcquisition and the caption from memberRetention, so either failing makes the card
+  // no longer a measurement.
+  const membersLoaded = memberAcquisition && memberRetention;
+  const membersSubtitle = !membersLoaded
+    ? ''
+    : `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}%${memberAcquisition.totalMembersMonthlyData.length > 0 ? ' · Last 12 months' : ''}`;
+  const membersSparkline =
+    memberAcquisition && memberAcquisition.totalMembersMonthlyData.length > 0
+      ? memberAcquisition.totalMembersMonthlyData
+      : flatSparklineData(memberAcquisition?.totalMembers ?? 0);
+  const flywheelSubtitle = flywheel && flywheel.monthlyData.length > 0 ? `MoM · ${trendWindow(flywheel.monthlyData.length)}` : 'MoM';
+  const flywheelSparkline =
+    flywheel && flywheel.monthlyData.length > 0 ? monthlyValues(flywheel.monthlyData) : flatSparklineData(flywheel?.reengagement.reengagementRate ?? 0);
+
+  // Same reason again: the Sentiment caption already branches on whether a trend window
+  // exists, so nesting it inside the brandHealth-undefined arm would be a second level.
+  const brandHealthCaption = !brandHealth
+    ? ''
+    : `${formatNumber(brandHealth.totalMentions)} mentions (30d)${brandHealth.monthlyMentions.length > 0 ? ' · trend last 6 months' : ''}`;
+
   // Same reason: the Adoption sparkline picks between a real series and a flat placeholder,
   // and that choice nested inside the engagedCommunity-undefined arm would be a third level.
   const adoptionSparkline =
@@ -939,17 +967,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       category: 'memberships',
       testId: 'ed-evo-event-growth',
       description: 'Year-to-date event count, attendees, and net revenue with YoY comparison.',
-      value: formatNumber(eventGrowth.totalRegistrants),
-      changePercentage: formatYoyChange(eventGrowth.registrantYoyChange),
-      trend: trendFromChange(eventGrowth.registrantYoyChange),
-      subtitle:
-        eventGrowth.monthlyData.length > 0
-          ? `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD · Trend: quarterly, 3 yrs + upcoming`
-          : `${formatNumber(eventGrowth.totalEvents)} event${eventGrowth.totalEvents === 1 ? '' : 's'} · YTD`,
-      chartData: protoSparkline(
-        eventGrowth.monthlyData.length > 0 ? monthlyValues(eventGrowth.monthlyData) : flatSparklineData(eventGrowth.totalRegistrants),
-        lfxColors.blue[500]
-      ),
+      // undefined means the request failed, not that the foundation ran no events.
+      value: eventGrowth ? formatNumber(eventGrowth.totalRegistrants) : '—',
+      changePercentage: eventGrowth ? formatYoyChange(eventGrowth.registrantYoyChange) : undefined,
+      trend: eventGrowth ? trendFromChange(eventGrowth.registrantYoyChange) : undefined,
+      subtitle: eventGrowth ? eventsSubtitle : placeholderCaption,
+      chartData: eventGrowth ? protoSparkline(eventsSparkline, lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Year-to-date event registrants and YoY change.',
       drawerType: DashboardDrawerType.NorthStarEventGrowth,
@@ -989,17 +1012,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       category: 'memberships',
       testId: 'ed-evo-member-growth',
       description: 'Total paying corporate members with quarterly net new count and associated revenue.',
-      value: formatNumber(memberAcquisition.totalMembers),
-      changePercentage: formatMomChange(memberAcquisition.changePercentage),
-      trend: normalizeTrend(memberAcquisition.changePercentage, memberAcquisition.trend),
-      subtitle:
-        memberAcquisition.totalMembersMonthlyData.length > 0
-          ? `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}% · Last 12 months`
-          : `${memberRetention.renewalRate.toFixed(1)}% retention · NRR ${memberRetention.netRevenueRetention.toFixed(1)}%`,
-      chartData: protoSparkline(
-        memberAcquisition.totalMembersMonthlyData.length > 0 ? memberAcquisition.totalMembersMonthlyData : flatSparklineData(memberAcquisition.totalMembers),
-        lfxColors.blue[500]
-      ),
+      // undefined means the request failed, not that the foundation has no paying members.
+      value: memberAcquisition ? formatNumber(memberAcquisition.totalMembers) : '—',
+      changePercentage: memberAcquisition ? formatMomChange(memberAcquisition.changePercentage) : undefined,
+      trend: memberAcquisition ? normalizeTrend(memberAcquisition.changePercentage, memberAcquisition.trend) : undefined,
+      subtitle: membersLoaded ? membersSubtitle : placeholderCaption,
+      chartData: memberAcquisition ? protoSparkline(membersSparkline, lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Total paying corporate members with monthly net new over the last 12 months.',
       drawerType: DashboardDrawerType.NorthStarMemberAcquisition,
@@ -1216,26 +1234,28 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       testId: 'ed-evo-brand-health',
       description: 'Total brand mentions with sentiment breakdown.',
       customContentType: 'dual-signal',
-      dualSignals: [
-        protoDualSignal(
-          'Mentions',
-          formatNumber(brandHealth.totalMentions),
-          brandHealth.monthlyMentions.length > 0 ? monthlyValues(brandHealth.monthlyMentions) : [],
-          lfxColors.blue[500],
-          // null (no genuine MoM available) renders the same as a flat month:
-          // hidden delta, neutral trend.
-          formatMomChange(brandHealth.mentionMomChangePct ?? 0),
-          normalizeTrend(brandHealth.mentionMomChangePct ?? 0, brandHealth.trend)
-        ),
-        protoDualSignal('Positive Sentiment', `${brandHealth.sentiment.positive.toFixed(1)}%`, [], lfxColors.violet[500]),
-      ],
+      // undefined means the request failed, not that nobody mentioned the foundation. AAIF
+      // has 80,799 mentions; a zero-filled fallback rendered "0" here, and the drawer went
+      // further and asserted "No brand mention activity detected".
+      dualSignals: brandHealth
+        ? [
+            protoDualSignal(
+              'Mentions',
+              formatNumber(brandHealth.totalMentions),
+              brandHealth.monthlyMentions.length > 0 ? monthlyValues(brandHealth.monthlyMentions) : [],
+              lfxColors.blue[500],
+              // null (no genuine MoM available) renders the same as a flat month:
+              // hidden delta, neutral trend.
+              formatMomChange(brandHealth.mentionMomChangePct ?? 0),
+              normalizeTrend(brandHealth.mentionMomChangePct ?? 0, brandHealth.trend)
+            ),
+            protoDualSignal('Positive Sentiment', `${brandHealth.sentiment.positive.toFixed(1)}%`, [], lfxColors.violet[500]),
+          ]
+        : [unavailableDualSignal('Mentions', lfxColors.blue[500]), unavailableDualSignal('Positive Sentiment', lfxColors.violet[500])],
       // monthlyMentions only holds months WITH rows, so its length is not the
       // reporting window — the ED caller always requests last-6, so the trend
       // window is labeled directly rather than derived from row count.
-      caption:
-        brandHealth.monthlyMentions.length > 0
-          ? `${formatNumber(brandHealth.totalMentions)} mentions (30d) · trend last 6 months`
-          : `${formatNumber(brandHealth.totalMentions)} mentions (30d)`,
+      caption: brandHealth ? brandHealthCaption : placeholderCaption,
       tooltipText: 'Total brand mentions across social and web with sentiment breakdown.',
       drawerType: DashboardDrawerType.BrandHealth,
     } as DashboardMetricCard,
@@ -1248,14 +1268,12 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       category: 'memberships',
       testId: 'ed-evo-flywheel-conversion',
       description: 'Event attendees who engage via newsletter, community, working groups, training, code, or web within 90 days.',
-      value: `${flywheel.reengagement.reengagementRate.toFixed(1)}%`,
-      changePercentage: formatPpMomChange(flywheel.reengagement.reengagementMomChange),
-      trend: trendFromChange(flywheel.reengagement.reengagementMomChange),
-      subtitle: flywheel.monthlyData.length > 0 ? `MoM · ${trendWindow(flywheel.monthlyData.length)}` : 'MoM',
-      chartData: protoSparkline(
-        flywheel.monthlyData.length > 0 ? monthlyValues(flywheel.monthlyData) : flatSparklineData(flywheel.reengagement.reengagementRate),
-        lfxColors.blue[500]
-      ),
+      // undefined means the request failed, not a 0.0% conversion rate.
+      value: flywheel ? `${flywheel.reengagement.reengagementRate.toFixed(1)}%` : '—',
+      changePercentage: flywheel ? formatPpMomChange(flywheel.reengagement.reengagementMomChange) : undefined,
+      trend: flywheel ? trendFromChange(flywheel.reengagement.reengagementMomChange) : undefined,
+      subtitle: flywheel ? flywheelSubtitle : placeholderCaption,
+      chartData: flywheel ? protoSparkline(flywheelSparkline, lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText:
         'Percentage of event attendees who re-engage via newsletter, community, working groups, training, code, or web within 90 days post-event. Change shown in percentage points (pp) MoM.',

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -863,6 +863,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   // else reports a failure during the initial in-flight window.
   const placeholderCaption = data.pending ? DATA_LOADING_CAPTION : DATA_UNAVAILABLE_CAPTION;
 
+  // Lifted out of the Web card's subtitle binding: combined with the brandReach-undefined
+  // arm it would otherwise be a nested ternary, which .claude/rules/styling.md forbids.
+  const webSessionsSubtitle = brandReach && brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Trend: last 6 months' : 'Sessions (30d)';
+
   // Education totals. edX is counted in enrollments but has no revenue column in
   // COURSE_PURCHASES, so it is intentionally absent from the revenue sum — adding a 0
   // would be harmless here but the omission is deliberate and mirrored in the drawer.
@@ -1020,15 +1024,17 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       category: 'brand',
       testId: 'ed-evo-brand-reach',
       description: 'Social followers across all platforms.',
-      value: formatNumber(brandReach.totalSocialFollowers),
-      changePercentage: formatMomChange(brandReach.changePercentage),
-      trend: normalizeTrend(brandReach.changePercentage, brandReach.trend),
-      subtitle: `${brandReach.activePlatforms} platform${brandReach.activePlatforms === 1 ? '' : 's'}`,
+      // undefined means the request failed, not that the foundation has no followers —
+      // "0 · 0 platforms" would report an outage as a measurement.
+      value: brandReach ? formatNumber(brandReach.totalSocialFollowers) : '—',
+      changePercentage: brandReach ? formatMomChange(brandReach.changePercentage) : undefined,
+      trend: brandReach ? normalizeTrend(brandReach.changePercentage, brandReach.trend) : undefined,
+      subtitle: brandReach ? `${brandReach.activePlatforms} platform${brandReach.activePlatforms === 1 ? '' : 's'}` : placeholderCaption,
       // No historical follower series available. flatSparklineData renders a nearly
       // flat line at the current total (a constant array collapses Chart.js's Y range
       // and hides the line entirely) — it is a placeholder, not a trend. Website
       // sessions are deliberately not reused here: different metric, different card.
-      chartData: protoSparkline(flatSparklineData(brandReach.totalSocialFollowers), lfxColors.blue[500]),
+      chartData: brandReach ? protoSparkline(flatSparklineData(brandReach.totalSocialFollowers), lfxColors.blue[500]) : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Social followers across all platforms, with month-over-month change.',
       drawerType: DashboardDrawerType.BrandReach,
@@ -1045,20 +1051,24 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
       category: 'brand',
       testId: 'ed-evo-web-sessions',
       description: 'Rolling 30-day sessions across foundation web properties.',
-      value: formatNumber(brandReach.totalMonthlySessions),
-      changePercentage: formatMomChange(brandReach.sessionMomChangePct),
-      trend: normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down'),
+      // Shares brandReach with the Social card above, so it shares the same contract:
+      // undefined is a failed request, and zero sessions is a real measurement.
+      value: brandReach ? formatNumber(brandReach.totalMonthlySessions) : '—',
+      changePercentage: brandReach ? formatMomChange(brandReach.sessionMomChangePct) : undefined,
+      trend: brandReach ? normalizeTrend(brandReach.sessionMomChangePct, brandReach.sessionMomChangePct >= 0 ? 'up' : 'down') : undefined,
       // The value is a rolling 30-day total; the sparkline is a separate weekly series
       // over a fixed six-month range. Label them separately so the 30-day figure is not
       // read as a six-month number. weeklyTrend only holds weeks WITH rows, so its
       // length is not the reporting window and the window is labeled directly.
       // When weeklyTrend is empty, flatSparklineData renders a placeholder at the
       // current total (see the Social card above), not a trend.
-      subtitle: brandReach.weeklyTrend.length > 0 ? 'Sessions (30d) · Trend: last 6 months' : 'Sessions (30d)',
-      chartData: protoSparkline(
-        brandReach.weeklyTrend.length > 0 ? brandReach.weeklyTrend.map((d) => d.sessions) : flatSparklineData(brandReach.totalMonthlySessions),
-        lfxColors.violet[500]
-      ),
+      subtitle: brandReach ? webSessionsSubtitle : placeholderCaption,
+      chartData: brandReach
+        ? protoSparkline(
+            brandReach.weeklyTrend.length > 0 ? brandReach.weeklyTrend.map((d) => d.sessions) : flatSparklineData(brandReach.totalMonthlySessions),
+            lfxColors.violet[500]
+          )
+        : EMPTY_CHART_DATA,
       chartOptions: NO_TOOLTIP_CHART_OPTIONS,
       tooltipText: 'Rolling 30-day website sessions across foundation web properties, with month-over-month change.',
       drawerType: DashboardDrawerType.MarketingWebsiteVisits,

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -726,6 +726,14 @@ const DATA_LOADING_CAPTION = 'Loading…';
  * state: advice derived from data that never arrived is the defect, not just its wording.
  */
 export const DRAWER_UNAVAILABLE_HEADING = 'Data unavailable';
+/**
+ * The other half of the pair: shown when the request SUCCEEDED and the foundation genuinely
+ * has no activity. Extracted alongside the unavailable copy so the two cannot drift — the
+ * drawer alternates between them, and only one of them being centrally editable is how they
+ * end up contradicting each other. The Email drawer keeps its own variant ("start sending
+ * campaigns"), which is deliberately different advice.
+ */
+export const DRAWER_NO_ACTIVITY_BODY = 'Engage with marketing ops to activate campaigns and start tracking results.';
 export const DRAWER_UNAVAILABLE_BODY = 'Please try again.';
 
 /**

--- a/packages/shared/src/constants/dashboard-metrics.constants.ts
+++ b/packages/shared/src/constants/dashboard-metrics.constants.ts
@@ -902,6 +902,10 @@ export function buildEdEvolutionMetrics(data: EdEvolutionData): DashboardMetricC
   // The Members card is the only one reading two responses: the value comes from
   // memberAcquisition and the caption from memberRetention, so either failing makes the card
   // no longer a measurement.
+  // Note the Members DRAWER binds `unavailable` on either response failing, which is stricter
+  // than this card. That is deliberate, not drift: the drawer renders renewalRate and NRR as
+  // 2xl headline figures, whereas here retention appears only as caption text beside a member
+  // count that is still genuinely measured. Same data, different exposure.
   const membersLoaded = memberAcquisition && memberRetention;
   const membersSubtitle = !membersLoaded
     ? ''

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3489,9 +3489,21 @@ export interface FunnelAggregates {
  * Used by buildEdEvolutionMetrics() to convert API data into card UI models.
  */
 export interface EdEvolutionData {
-  flywheel: FlywheelConversionResponse;
-  memberAcquisition: MemberAcquisitionResponse;
-  memberRetention: MemberRetentionResponse;
+  /**
+   * `undefined` when the request failed, so the Flywheel card renders "—" rather than a 0.0% conversion rate.
+   * A zero-filled fallback is indistinguishable from a genuine zero once the error is gone.
+   */
+  flywheel: FlywheelConversionResponse | undefined;
+  /**
+   * `undefined` when the request failed, so the Members card renders "—" rather than 0 paying members.
+   * A zero-filled fallback is indistinguishable from a genuine zero once the error is gone.
+   */
+  memberAcquisition: MemberAcquisitionResponse | undefined;
+  /**
+   * `undefined` when the request failed, so the Members caption renders the unavailable placeholder rather than 0.0% retention.
+   * A zero-filled fallback is indistinguishable from a genuine zero once the error is gone.
+   */
+  memberRetention: MemberRetentionResponse | undefined;
   /**
    * Adoption card data. undefined means "request failed", not "nobody engaged".
    *
@@ -3499,7 +3511,11 @@ export interface EdEvolutionData {
    * individuals and the card read "0" whenever this fell back to a zero-filled response.
    */
   engagedCommunity: EngagedCommunitySizeResponse | undefined;
-  eventGrowth: EventGrowthResponse;
+  /**
+   * `undefined` when the request failed, so the Events card renders "—" rather than 0 registrants.
+   * A zero-filled fallback is indistinguishable from a genuine zero once the error is gone.
+   */
+  eventGrowth: EventGrowthResponse | undefined;
   /**
    * Social and Web card data. undefined means "request failed", not "no followers".
    *
@@ -3509,7 +3525,14 @@ export interface EdEvolutionData {
    * a measured absence, on the two cards that read it.
    */
   brandReach: BrandReachResponse | undefined;
-  brandHealth: BrandHealthResponse;
+  /**
+   * Sentiment card data. undefined means "request failed", not "nobody mentioned us".
+   *
+   * Same contract as revenueImpact, brandReach, emailCtr and engagedCommunity. AAIF has
+   * 80,799 mentions; the card read "0" and its drawer asserted "No brand mention activity
+   * detected" whenever this fell back to a zero-filled response.
+   */
+  brandHealth: BrandHealthResponse | undefined;
   /**
    * Attribution card data. undefined means "request failed", not "zero revenue".
    *

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3492,7 +3492,13 @@ export interface EdEvolutionData {
   flywheel: FlywheelConversionResponse;
   memberAcquisition: MemberAcquisitionResponse;
   memberRetention: MemberRetentionResponse;
-  engagedCommunity: EngagedCommunitySizeResponse;
+  /**
+   * Adoption card data. undefined means "request failed", not "nobody engaged".
+   *
+   * Same contract as revenueImpact, brandReach and emailCtr. AAIF has 27,831 engaged
+   * individuals and the card read "0" whenever this fell back to a zero-filled response.
+   */
+  engagedCommunity: EngagedCommunitySizeResponse | undefined;
   eventGrowth: EventGrowthResponse;
   /**
    * Social and Web card data. undefined means "request failed", not "no followers".
@@ -3515,7 +3521,14 @@ export interface EdEvolutionData {
    * foundation won nothing". The card renders an explicit unavailable state instead.
    */
   revenueImpact: RevenueImpactResponse | undefined;
-  emailCtr: EmailCtrResponse;
+  /**
+   * Email card data. undefined means "request failed", not "nobody opened anything".
+   *
+   * Same contract as revenueImpact and brandReach. Summing an absent response yields 0, so a
+   * zero-filled fallback rendered "0 opens · 0.0% CTR" for a foundation whose campaign had
+   * 100 opens at a 76.3% CTR — a measurement the reader has no way to distrust.
+   */
+  emailCtr: EmailCtrResponse | undefined;
   /**
    * Paid Media card data. undefined means "request failed", not "zero spend".
    *

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3494,7 +3494,15 @@ export interface EdEvolutionData {
   memberRetention: MemberRetentionResponse;
   engagedCommunity: EngagedCommunitySizeResponse;
   eventGrowth: EventGrowthResponse;
-  brandReach: BrandReachResponse;
+  /**
+   * Social and Web card data. undefined means "request failed", not "no followers".
+   *
+   * Same contract as revenueImpact below, and required-but-undefinable for the same
+   * forkJoin reason. A foundation with 17,269 followers rendered "0 · 0 platforms" on a
+   * cold load when this fell back to a zero-filled response — a live outage reported as
+   * a measured absence, on the two cards that read it.
+   */
+  brandReach: BrandReachResponse | undefined;
   brandHealth: BrandHealthResponse;
   /**
    * Attribution card data. undefined means "request failed", not "zero revenue".

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -3168,6 +3168,17 @@ export interface BrandReachWeeklyDataPoint {
  * Digital reach across social platforms and owned websites
  */
 export interface BrandReachResponse {
+  /**
+   * True when the SOCIAL half of this response could not be read, while the web half was
+   * measured normally. getBrandReach runs two independent queries and deliberately keeps
+   * serving web data when social fails — without this flag that partial success is
+   * indistinguishable from a foundation with zero followers, which is the reported AAIF
+   * defect (17,269 followers rendering as "0 · 0 platforms").
+   *
+   * A WEB failure has no equivalent flag because it fails the whole request, so the
+   * client's undefined sentinel already covers it.
+   */
+  socialUnavailable?: boolean;
   totalSocialFollowers: number;
   totalMonthlySessions: number;
   activePlatforms: number;

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -2924,6 +2924,13 @@ export interface EmailTypeBreakdown {
  * API response for Email CTR query
  */
 export interface EmailCtrResponse {
+  /**
+   * True when the optional campaign-breakdown query failed while the primary CTR read
+   * succeeded. The drawer's Sends/Opens/Open-Rate/CTR tiles reduce() over emailTypeBreakdown,
+   * so an empty array from a FAILURE sums to 0 and is indistinguishable from a month with no
+   * campaigns — the same fabricated zero this contract exists to prevent, on a partial path.
+   */
+  breakdownUnavailable?: boolean;
   currentCtr: number;
   changePercentage: number;
   momChangePercentage: number | null;


### PR DESCRIPTION
## Summary

The ED Marketing Overview swallowed each card's request error and substituted a zero-filled fallback. A failed request therefore rendered as `0` — indistinguishable from a genuine measurement once the error was gone.

Reproduced on Agentic AI Foundation: on a cold load `/api/analytics/brand-reach` failed inside the dashboard's ~22-request burst, and the Social card rendered **"0 · 0 platforms"** for a foundation with **17,269 followers across 2 platforms**. The Email card was reported from production the same way — "0 opens · 0.0% CTR" for a month whose campaign had 100 opens at 76.3% CTR.

Every response field on `EdEvolutionData` is now `| undefined`, each card guards on its own field, and the drill-down drawers behind them stop asserting a finding they never measured.

## What changed

**Cards** — a failed read renders `—` with "Data unavailable — could not be loaded" instead of a fabricated zero:

| Card | Was | Now |
|---|---|---|
| Social / Web | `0 · 0 platforms` | `—` + unavailable caption |
| Email | `0 opens · 0.0% CTR` | dual-signal unavailable state |
| Adoption | `0` engaged | `—` + unavailable caption |
| Sentiment | `0` mentions | dual-signal unavailable state |
| Events | `0` registrants | `—` + unavailable caption |
| Members | `0` + `0.0% retention · NRR 0.0%` | `—` + unavailable caption |
| Flywheel | `0.0%` conversion | `—` + unavailable caption |

**Drawers** — each drill-down kept its own empty state, which asserted a finding ("No brand mention activity detected") and advised acting on it ("Engage with marketing ops to activate campaigns"). On a failed request the card and its drawer contradicted each other, and the drawer was the one stating a measurement that was never taken.

Eight drawers now take an `unavailable` input. Six render "Data unavailable / Please try again." and suppress their whole content body — stats, insight blocks and charts — not just the caption. The Events and Brand Reach drawers already degrade every stat to an em dash, so only their collection empty-states change ("not yet available" is a claim about the data, not about the request).

The copy deliberately **does not name a cause**. The failures are intermittent under the dashboard's concurrent request burst, but that has not been confirmed as the mechanism — naming an unproven cause in the UI would repeat the original defect one level up.

## Design notes

- **Genuine zeros still read as measurements.** Every guard is paired with a test asserting that a foundation which really has zero activity is not reported as an outage. This is a two-sided contract, not a one-way suppression.
- **Members is the only card reading two responses.** The value comes from `memberAcquisition`, the caption from `memberRetention`, so a retention-only failure keeps the measured member count and drops only the caption's retention claim.
- **Pending ≠ failed.** `PENDING_ED_EVOLUTION_DATA` stays distinct from the error fallback so nothing announces "could not be loaded" before a request has actually failed.
- **`getFlywheelConversion` swallows its own HTTP error into `of(null)`**, so `safe()`'s `catchError` never fires for it. Its `??` in the caller is the real failure path and is now explicit, rather than relying on `EMPTY_ED_EVOLUTION_DATA.flywheel` coincidentally being `undefined`.
- **The Members drawer is deliberately stricter than the Members card.** The card keeps its measured member count on a retention-only failure and drops only the caption clause; the drawer marks itself unavailable on either failure, because it renders renewal rate and NRR as 2xl headline figures rather than caption text. Same data, different exposure — recorded in comments on both sides.
- **`MemberRetentionDrawerComponent` is rendered by no template today.** It received the same treatment as its siblings so it cannot ship the old defect if wired up, and its two specs are labelled so they are not read as covering the live retention path (which runs through the Members drawer's `retentionData` input).

## Testing

- **Every guard is mutation-verified** — reverting any one of them fails a test. Two mutants initially *survived* and drove additional coverage: the drawer `hasNoData` guard, and the Email drawer's internal failure flag.
- **Total-outage probe**: built the cards with every field undefined — no card prints a zero, none throw.
- `yarn build` clean; 813 shared / 1340 server / 356 app tests pass; lint, format, license headers clean.

## Known gap

Deleting a `[unavailable]` binding from `marketing-overview.component.html` still passes the suite. The binding *expression* is tested against an equivalent host, but the real bindings in the parent template are not pinned by a rendering test — the parent fans out to 11 endpoints on mount, and a fixture faking them ends up testing the fan-out rather than the binding. Likely wants an E2E assertion rather than a unit test.

## Not addressed here

This makes the failure **honest, not absent**. The underlying intermittent 500s are unchanged: ~22 concurrent analytics requests fire on ED dashboard mount, some intermittently 500 or never dispatch, while the same endpoints return 200 on 36/36 direct calls. Diagnosing that needs server-side logs and is separate work.

Refs LFXV2-3297
