### PR TITLE
fix(meetings): guard against stale project context on edit (GH-1579)

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
@@ -1,0 +1,179 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ApplicationRef, signal } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, convertToParamMap, NavigationEnd, Router } from '@angular/router';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { Meeting } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingManageComponent } from './meeting-manage.component';
+
+// Regression coverage for the relation-gated-null → uncached-detail context fallback (GH-1579):
+// when the by-uid project lookup is relation-gated into null for an organizer without a viewer
+// relation, the meeting detail is re-fetched uncached so its ungated enrichment can supply the
+// project the lookup withheld. Also pins the retry-once guard (a fresh fetch must not repeat on
+// every NavigationEnd step navigation) and the transient-error retry release.
+describe('MeetingManageComponent — context fallback', () => {
+  const MEETING_UID = 'meeting-uid-1';
+  const PROJECT_UID = 'project-uid-1';
+  const PROJECT_SLUG = 'test-project';
+
+  let getMeetingDetail: ReturnType<typeof vi.fn>;
+  let getProject: ReturnType<typeof vi.fn>;
+  let routerEvents$: BehaviorSubject<NavigationEnd>;
+  let setProject: ReturnType<typeof vi.fn>;
+
+  // Unenriched detail payload: project_uid only, no project_slug — the trigger condition for
+  // initMeetingContextFallback. Note `id` (not just `uid`): meetingEntityContext keys off
+  // `meeting.id`, so a stub without it never reaches the fallback.
+  const unenrichedMeeting = () =>
+    ({
+      id: MEETING_UID,
+      uid: MEETING_UID,
+      project_uid: PROJECT_UID,
+      committees: [],
+    }) as unknown as Meeting;
+
+  const enrichedMeeting = () =>
+    ({
+      ...unenrichedMeeting(),
+      project_slug: PROJECT_SLUG,
+      project_name: 'Test Project',
+      is_foundation: false,
+    }) as unknown as Meeting;
+
+  const createComponent = async () => {
+    const fixture = TestBed.createComponent(MeetingManageComponent);
+    // No fixture.detectChanges(): these tests exercise the constructor context-sync streams, not
+    // the template, and rendering would pull in the full PrimeNG stepper subtree for no signal.
+    await TestBed.inject(ApplicationRef).whenStable();
+    return fixture;
+  };
+
+  const emitNavigationEnd = async () => {
+    routerEvents$.next(new NavigationEnd(1, '/project/meetings/x/edit?step=2', '/project/meetings/x/edit?step=2'));
+    await TestBed.inject(ApplicationRef).whenStable();
+  };
+
+  const skipCacheCalls = () => getMeetingDetail.mock.calls.filter(([, opts]) => (opts as { skipCache?: boolean } | undefined)?.skipCache === true);
+
+  beforeEach(() => {
+    getMeetingDetail = vi.fn();
+    getProject = vi.fn();
+    setProject = vi.fn();
+    routerEvents$ = new BehaviorSubject<NavigationEnd>(new NavigationEnd(0, '/project/meetings/x/edit', '/project/meetings/x/edit'));
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Router,
+          useValue: {
+            events: routerEvents$.asObservable(),
+            url: '/project/meetings/x/edit',
+            parseUrl: vi.fn().mockReturnValue({ queryParams: {} }),
+            serializeUrl: vi.fn().mockReturnValue('/project/meetings/x/edit'),
+            navigate: vi.fn(),
+            createUrlTree: vi.fn(),
+          },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ id: MEETING_UID })),
+            queryParamMap: of(convertToParamMap({})),
+            snapshot: { queryParamMap: convertToParamMap({}), paramMap: convertToParamMap({ id: MEETING_UID }) },
+          },
+        },
+        {
+          provide: MeetingService,
+          useValue: {
+            // initializeMeeting probes via getMeeting; the fallback re-fetches via getMeetingDetail
+            // with skipCache — both land on the same mock so call ordering stays inspectable.
+            getMeeting: vi.fn().mockImplementation((id: string) => getMeetingDetail(id)),
+            getMeetingDetail,
+            getMeetingAttachments: vi.fn().mockReturnValue(of([])),
+          },
+        },
+        { provide: ProjectService, useValue: { getProject, project: signal(null) } },
+        {
+          provide: ProjectContextService,
+          useValue: {
+            activeContext: () => null,
+            activeContextUid: () => '',
+            isFoundationContext: () => false,
+            setProject,
+            setFoundation: vi.fn(),
+            setRouteLensKind: vi.fn(),
+          },
+        },
+        { provide: CommitteeService, useValue: { getCommittee: vi.fn().mockReturnValue(of(null)), fetchCommittee: vi.fn().mockReturnValue(of(null)) } },
+        // Transitive DI (LensService → PersonaService → HttpClient) — never called in these tests.
+        { provide: HttpClient, useValue: { get: vi.fn().mockReturnValue(of(null)), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
+        // PrimeNG stepper binds @content.start animation listeners when the template is compiled —
+        // required even without detectChanges(), since compilation alone wires the listener.
+        provideNoopAnimations(),
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+  });
+
+  it('resolves context from a fresh uncached detail fetch when the uid lookup is relation-gated to null', async () => {
+    getMeetingDetail.mockImplementation((_uid: string, opts?: { skipCache?: boolean }) => (opts?.skipCache ? of(enrichedMeeting()) : of(unenrichedMeeting())));
+    getProject.mockReturnValue(of(null));
+    await createComponent();
+
+    // The uid lookup returned null, so the fallback re-fetched the detail uncached and resolved
+    // the context from its (ungated) enrichment.
+    expect(getMeetingDetail).toHaveBeenCalledWith(MEETING_UID, { skipCache: true });
+    expect(setProject).toHaveBeenCalledWith({ uid: PROJECT_UID, name: 'Test Project', slug: PROJECT_SLUG }, false);
+  });
+
+  it('does not repeat the fresh fetch when NavigationEnd re-applies the fallback for the same meeting', async () => {
+    getMeetingDetail.mockImplementation((_uid: string, opts?: { skipCache?: boolean }) => (opts?.skipCache ? of(enrichedMeeting()) : of(unenrichedMeeting())));
+    getProject.mockReturnValue(of(null));
+    await createComponent();
+
+    const callsBefore = getMeetingDetail.mock.calls.length;
+    await emitNavigationEnd();
+    await emitNavigationEnd();
+
+    // The fallback already resolved the context for this meeting, so step navigations must not
+    // burn another uncached fetch.
+    expect(skipCacheCalls()).toHaveLength(1);
+    expect(getMeetingDetail.mock.calls.length).toBe(callsBefore);
+  });
+
+  it('releases the retry marker when the fresh fetch fails transiently, so a later navigation can retry', async () => {
+    let failFreshFetch = false;
+    getMeetingDetail.mockImplementation((_uid: string, opts?: { skipCache?: boolean }) => {
+      if (!opts?.skipCache) {
+        return of(unenrichedMeeting());
+      }
+      return failFreshFetch ? throwError(() => new Error('network')) : of(enrichedMeeting());
+    });
+    getProject.mockReturnValue(of(null));
+    failFreshFetch = true;
+    await createComponent();
+
+    // Every fresh fetch so far failed transiently (the seeded initial NavigationEnd plus the
+    // entity emission can each trigger one) — context untouched, marker released each time.
+    const failedAttempts = skipCacheCalls().length;
+    expect(failedAttempts).toBeGreaterThan(0);
+    expect(setProject).not.toHaveBeenCalled();
+
+    // …so the next NavigationEnd re-apply attempts the fresh fetch again and now resolves.
+    failFreshFetch = false;
+    await emitNavigationEnd();
+    expect(skipCacheCalls().length).toBeGreaterThan(failedAttempts);
+    expect(setProject).toHaveBeenCalledWith({ uid: PROJECT_UID, name: 'Test Project', slug: PROJECT_SLUG }, false);
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -965,6 +965,9 @@ export class MeetingManageComponent {
         return { context, isFoundation: meeting.is_foundation === true };
       }),
       catchError((error) => {
+        // Transient failures (network, 5xx) shouldn't burn the retry — release the uid so a later
+        // NavigationEnd re-apply can attempt the fresh fetch again.
+        this.contextFallbackRetried.delete(entity.uid);
         console.warn(`Unable to resolve project context for meeting ${entity.uid}:`, error);
         return of(null);
       })

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -959,7 +959,7 @@ export class MeetingManageComponent {
         }
         const context: ProjectContext = {
           uid: meeting.project_uid,
-          name: meeting.project_name ?? meeting.project_slug,
+          name: meeting.project_name || meeting.project_slug,
           slug: meeting.project_slug,
         };
         return { context, isFoundation: meeting.is_foundation === true };

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -90,6 +90,7 @@ import { MeetingResourcesSummaryComponent } from '../components/meeting-resource
 import { MeetingTypeSelectionComponent } from '../components/meeting-type-selection/meeting-type-selection.component';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
+import { hasMeetingWriteAccess, resolveMeetingWriteSlug } from '@shared/utils/write-access.util';
 
 @Component({
   selector: 'lfx-meeting-manage',
@@ -125,6 +126,9 @@ export class MeetingManageComponent {
   // Committee context — when navigated from a committee tab with ?committee_uid=
   public readonly committeeContext = signal<Committee | null>(null);
   private readonly committeeUidFromUrl = this.route.snapshot.queryParamMap.get('committee_uid');
+  // Meetings whose context fallback already retried the ungated detail fetch — the NavigationEnd
+  // re-apply would otherwise repeat the uncached request on every step navigation.
+  private readonly contextFallbackRetried = new Set<string>();
 
   // Mode and state signals
   public mode = signal<'create' | 'edit'>('create');
@@ -820,7 +824,7 @@ export class MeetingManageComponent {
             }
             // Mirror writerGuard's resolution order; the active-context fallback covers a meeting
             // carrying neither slug nor uid (the manage component owns that error path).
-            return meeting.project_slug ?? meeting.project_uid ?? this.projectContextService.activeContext()?.slug ?? null;
+            return resolveMeetingWriteSlug(meeting, this.projectContextService.activeContext()?.slug ?? null);
           })
         )
       : toObservable(this.projectContextService.activeContext).pipe(map((ctx) => ctx?.slug ?? null));
@@ -834,7 +838,7 @@ export class MeetingManageComponent {
             return of(false);
           }
           return this.projectService.getProject(key, false, { meetingCoordinator: true }).pipe(
-            map((project) => project?.writer === true || project?.meetingCoordinator === true),
+            map((project) => hasMeetingWriteAccess(project)),
             catchError(() => of(false))
           );
         })
@@ -899,6 +903,12 @@ export class MeetingManageComponent {
    * mismatch. As in syncEntityProjectContext, NavigationEnd re-applies the correction: query-param
    * step navigations re-assert the route's declared kind via syncLensFromRoute without re-running
    * guards. The re-apply hits the shareReplay-cached getProject, so it costs no extra request.
+   *
+   * When the uid lookup resolves null — the project GET is relation-gated, so an organizer without
+   * a direct viewer relation gets nothing back — the meeting detail is re-fetched uncached: its
+   * enrichment is query-service backed and not relation-gated, so a fresh payload can carry the
+   * `project_slug` the cached one lacked. Only if that also comes back unenriched is the context
+   * left alone (it self-corrects on the next navigation).
    */
   private initMeetingContextFallback(): void {
     const unresolvedEntity$ = toObservable(this.meetingEntityContext).pipe(
@@ -911,18 +921,54 @@ export class MeetingManageComponent {
     merge(unresolvedEntity$, navigationReapply$)
       .pipe(
         filter((entity): entity is EntityWithProject => !!entity?.project_uid && !entity.project_slug),
-        switchMap((entity) => this.projectService.getProject(entity.project_uid, false)),
+        switchMap((entity) =>
+          this.projectService.getProject(entity.project_uid, false).pipe(
+            switchMap((project) => {
+              if (!project) {
+                return this.resolveContextFromFreshMeeting(entity);
+              }
+              const context: ProjectContext = { uid: project.uid, name: project.name, slug: project.slug };
+              return of({ context, isFoundation: computeIsFoundation(project) });
+            })
+          )
+        ),
         takeUntilDestroyed(this.destroyRef)
       )
-      .subscribe((project) => {
-        if (!project) {
+      .subscribe((resolved) => {
+        if (!resolved) {
           return;
         }
-        const context: ProjectContext = { uid: project.uid, name: project.name, slug: project.slug };
         // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
         const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
-        applyEntityProjectContext(this.projectContextService, context, computeIsFoundation(project), syncUrl);
+        applyEntityProjectContext(this.projectContextService, resolved.context, resolved.isFoundation, syncUrl);
       });
+  }
+
+  // Last resort for initMeetingContextFallback: the ungated detail enrichment can supply the
+  // project the relation-gated lookup withheld. Emits null when it can't, leaving context untouched.
+  private resolveContextFromFreshMeeting(entity: EntityWithProject): Observable<{ context: ProjectContext; isFoundation: boolean } | null> {
+    if (this.contextFallbackRetried.has(entity.uid)) {
+      return of(null);
+    }
+    this.contextFallbackRetried.add(entity.uid);
+    return this.meetingService.getMeetingDetail(entity.uid, { skipCache: true }).pipe(
+      map((meeting) => {
+        if (!meeting?.project_slug) {
+          console.warn(`Unable to resolve project context for meeting ${entity.uid}: detail payload carries no project_slug`);
+          return null;
+        }
+        const context: ProjectContext = {
+          uid: meeting.project_uid,
+          name: meeting.project_name ?? meeting.project_slug,
+          slug: meeting.project_slug,
+        };
+        return { context, isFoundation: meeting.is_foundation === true };
+      }),
+      catchError((error) => {
+        console.warn(`Unable to resolve project context for meeting ${entity.uid}:`, error);
+        return of(null);
+      })
+    );
   }
 
   private initializeMeeting() {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -33,6 +33,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
+import { hasMeetingWriteAccess } from '@shared/utils/write-access.util';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import {
@@ -355,7 +356,7 @@ export class MeetingsDashboardComponent {
         switchMap((ctx) => {
           if (!ctx?.slug) return of(false);
           return this.projectService.getProject(ctx.slug, false, { meetingCoordinator: true }).pipe(
-            map((project) => project?.writer === true || project?.meetingCoordinator === true),
+            map((project) => hasMeetingWriteAccess(project)),
             catchError(() => of(false))
           );
         })

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -1,0 +1,138 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpErrorResponse } from '@angular/common/http';
+import { signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { ActivatedRouteSnapshot, convertToParamMap, Router, RouterStateSnapshot, UrlTree } from '@angular/router';
+import { CommitteeService } from '@shared/services/committee.service';
+import { MeetingService } from '@shared/services/meeting.service';
+import { PersonaService } from '@shared/services/persona.service';
+import { ProjectContextService } from '@shared/services/project-context.service';
+import { ProjectService } from '@shared/services/project.service';
+import { Meeting } from '@lfx-one/shared/interfaces';
+import { firstValueFrom, of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { writerGuard } from './writer.guard';
+
+// Pins the fail-closed contract of the meeting edit slug resolution (GH-1579): only a 404
+// on the meeting read may fall back to the stale active context — every other failure must
+// resolve no slug at all so the guard redirects instead of authorizing against an unrelated
+// project. A future broadened catch would silently restore the cross-project authorization bug.
+// Also covers the non-meetings early-returns (ED fast path, non-entity-scoped features) so the
+// file isn't a false sense of coverage for the guard's default flow.
+describe('writerGuard', () => {
+  const MEETING_UID = 'meeting-uid-1';
+  const MEETING_SLUG = 'meeting-project';
+  const STALE_SLUG = 'stale-project';
+
+  let getMeetingDetail: ReturnType<typeof vi.fn>;
+  let getProject: ReturnType<typeof vi.fn>;
+  let getCommittee: ReturnType<typeof vi.fn>;
+  let router: { parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
+  let currentPersona: ReturnType<typeof signal<string>>;
+
+  const httpError = (status: number) => new HttpErrorResponse({ status });
+
+  const meetingRoute = (data: Record<string, unknown> = { writeFeature: 'meetings', entityScopedSlug: true }): ActivatedRouteSnapshot =>
+    ({
+      queryParamMap: convertToParamMap({}),
+      paramMap: convertToParamMap({ id: MEETING_UID }),
+      data,
+      parent: null,
+    }) as unknown as ActivatedRouteSnapshot;
+
+  const runGuard = async (route: ActivatedRouteSnapshot = meetingRoute()) => {
+    // The guard returns `true` synchronously for the ED fast path, an Observable otherwise —
+    // never a bare UrlTree (redirects are always wrapped in `of(...)`).
+    const result = TestBed.runInInjectionContext(() => writerGuard(route, {} as RouterStateSnapshot));
+    return typeof result === 'boolean' ? result : firstValueFrom(result as import('rxjs').Observable<boolean | UrlTree>);
+  };
+
+  beforeEach(() => {
+    getMeetingDetail = vi.fn();
+    getProject = vi.fn().mockReturnValue(of(null));
+    getCommittee = vi.fn();
+    currentPersona = signal('maintainer');
+    router = {
+      parseUrl: vi.fn().mockImplementation((url: string) => ({ redirect: url }) as unknown as UrlTree),
+      createUrlTree: vi.fn().mockImplementation((commands: string[], opts: unknown) => ({ denied: commands[0], opts }) as unknown as UrlTree),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: PersonaService, useValue: { currentPersona } },
+        { provide: ProjectContextService, useValue: { activeContext: () => ({ uid: 'stale-uid', slug: STALE_SLUG, name: 'Stale' }) } },
+        { provide: ProjectService, useValue: { getProject } },
+        { provide: CommitteeService, useValue: { getCommittee } },
+        { provide: MeetingService, useValue: { getMeetingDetail } },
+        { provide: Router, useValue: router },
+      ],
+    });
+  });
+
+  it('falls back to the active context only on a 404 meeting read', async () => {
+    getMeetingDetail.mockReturnValue(throwError(() => httpError(404)));
+    getProject.mockReturnValue(of({ uid: 'stale-uid', slug: STALE_SLUG, writer: true }));
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: true });
+  });
+
+  it('fails closed on a 500 meeting read without probing the stale project', async () => {
+    getMeetingDetail.mockReturnValue(throwError(() => httpError(500)));
+
+    const result = await runGuard();
+
+    // The interaction is the contract: fail-closed means a redirect with NO downstream
+    // authorization probe — not a specific UrlTree stub shape.
+    expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
+    expect(result).toEqual({ redirect: '/project/overview' });
+    expect(getProject).not.toHaveBeenCalled();
+    expect(getCommittee).not.toHaveBeenCalled();
+  });
+
+  it('authorizes against the meeting’s own project when the read succeeds', async () => {
+    getMeetingDetail.mockReturnValue(of({ uid: MEETING_UID, project_uid: 'p-uid', project_slug: MEETING_SLUG } as unknown as Meeting));
+    getProject.mockReturnValue(of({ uid: 'p-uid', slug: MEETING_SLUG, writer: true }));
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith(MEETING_SLUG, false, { meetingCoordinator: true });
+  });
+
+  it('resolves the uid when the payload lacks an enriched slug, never the stale context', async () => {
+    getMeetingDetail.mockReturnValue(of({ uid: MEETING_UID, project_uid: 'p-uid', project_slug: null } as unknown as Meeting));
+    getProject.mockReturnValue(of({ uid: 'p-uid', slug: MEETING_SLUG, writer: true }));
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('p-uid', false, { meetingCoordinator: true });
+  });
+
+  it('allows the executive-director persona synchronously with no HTTP calls', async () => {
+    currentPersona.set('executive-director');
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).not.toHaveBeenCalled();
+    expect(getCommittee).not.toHaveBeenCalled();
+  });
+
+  it('resolves the slug from the active context without probing the meeting for non-meetings features', async () => {
+    getProject.mockReturnValue(of({ uid: 'stale-uid', slug: STALE_SLUG, writer: true }));
+
+    const result = await runGuard(meetingRoute({ writeFeature: 'surveys' }));
+
+    expect(result).toBe(true);
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
+  });
+});

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 import { COMMITTEE_WRITE_FEATURES } from '@lfx-one/shared/constants';
+import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
 import { catchError, map, Observable, of, switchMap } from 'rxjs';
@@ -10,6 +11,7 @@ import { MeetingService } from '../services/meeting.service';
 import { PersonaService } from '../services/persona.service';
 import { ProjectContextService } from '../services/project-context.service';
 import { ProjectService } from '../services/project.service';
+import { hasMeetingWriteAccess, resolveMeetingWriteSlug } from '../utils/write-access.util';
 
 /**
  * Protects create/edit/admin routes that require project write permission.
@@ -27,7 +29,8 @@ import { ProjectService } from '../services/project.service';
  *
  * Slug resolution: on routes flagged `data.entityScopedSlug` (meeting edit), resolves
  * the slug from the meeting itself first — the active context can belong to a different project
- * when the edit link carried no `?project=`; otherwise prefers the `?project=` query param
+ * when the edit link carried no `?project=`. A non-404 failure on that read resolves no slug at all,
+ * so the guard redirects instead of authorizing against a stale context. Otherwise prefers the `?project=` query param
  * (authoritative for the navigation target, works before the lens has synced), then falls back
  * to the active context's slug. The flag lives in route data — not a routeConfig.path check — so
  * a route rename/restructure can't silently disable the entity-scoped resolution.
@@ -67,8 +70,8 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   // `/meetings/:id/edit` links redirect by active lens and carry no project param). Authorizing
   // against that stale context intermittently denied legitimate organizers — or worse, could
   // authorize against the wrong project. Resolve the slug from the meeting itself first; fall
-  // back to the active context when the meeting can't be read (it may simply not exist — the
-  // manage component handles that error path).
+  // back to the active context only on a 404 (it may simply not exist — the manage component
+  // handles that error path), and fail closed on any other read failure.
   const writeFeature: string | undefined = route.data?.['writeFeature'];
   const resolveSlug = (): Observable<string | null> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
@@ -84,13 +87,14 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
     // getProject access check resolves either identifier. Never fall back to the active context
     // while the meeting is readable: doing so would authorize against a stale, unrelated project.
     // A failed project probe now denies against the meeting's own project instead of
-    // silently switching to that stale context. Only a meeting that can't be read at all falls
-    // back — it may simply not exist; the manage component handles that error path.
+    // silently switching to that stale context. Only a 404 falls back — the meeting may simply not
+    // exist and the manage component owns that error path; every other failure resolves null and
+    // fails closed via the `if (!slug)` redirect, so no check runs against a stale project.
     // Probe-friendly: getMeetingDetail is tap-free and short-TTL-cached, sharing the request with
     // MeetingManageComponent's fetch on the same navigation.
     return meetingService.getMeetingDetail(meetingId).pipe(
-      map((meeting) => meeting?.project_slug ?? meeting?.project_uid ?? fromContext),
-      catchError(() => of(fromContext))
+      map((meeting) => resolveMeetingWriteSlug(meeting, fromContext)),
+      catchError((error) => of(error instanceof HttpErrorResponse && error.status === 404 ? fromContext : null))
     );
   };
 
@@ -129,7 +133,7 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
             return of(true as const);
           }
           // meeting_coordinator can create meetings but not other write features
-          if (writeFeature === 'meetings' && project.meetingCoordinator === true) {
+          if (writeFeature === 'meetings' && hasMeetingWriteAccess(project)) {
             return of(true as const);
           }
           if (committeeUid && supportsCommitteeWriter) {

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -207,7 +207,10 @@ export class MeetingService {
    * within one navigation — sharing the request avoids a duplicate fetch on every edit-page
    * load. Probe-friendly: no `meeting` signal side-effect. Entries evict on error and on
    * write (updateMeeting/deleteMeeting). Pass `skipCache` to force a fresh fetch when a caller
-   * needs enrichment that a cached payload may predate.
+   * needs enrichment that a cached payload may predate. `skipCache` replaces the cache entry with
+   * the new `request$` rather than invalidating — callers already subscribed to the prior
+   * `shareReplay(1)` observable continue to completion with the old payload, so racing
+   * `skipCache` callers can still observe a stale result.
    */
   public getMeetingDetail(id: string, options?: { skipCache?: boolean }): Observable<Meeting> {
     const cached = this.meetingDetailCache.get(id);

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -206,11 +206,12 @@ export class MeetingService {
    * resolution and MeetingManageComponent's initializeMeeting both need the same payload
    * within one navigation — sharing the request avoids a duplicate fetch on every edit-page
    * load. Probe-friendly: no `meeting` signal side-effect. Entries evict on error and on
-   * write (updateMeeting/deleteMeeting).
+   * write (updateMeeting/deleteMeeting). Pass `skipCache` to force a fresh fetch when a caller
+   * needs enrichment that a cached payload may predate.
    */
-  public getMeetingDetail(id: string): Observable<Meeting> {
+  public getMeetingDetail(id: string, options?: { skipCache?: boolean }): Observable<Meeting> {
     const cached = this.meetingDetailCache.get(id);
-    if (cached && Date.now() - cached.cachedAt < MEETING_DETAIL_CACHE_TTL_MS) {
+    if (!options?.skipCache && cached && Date.now() - cached.cachedAt < MEETING_DETAIL_CACHE_TTL_MS) {
       return cached.observable;
     }
     if (cached) {
@@ -224,6 +225,7 @@ export class MeetingService {
       }),
       shareReplay(1)
     );
+    this.pruneExpiredMeetingDetailCache();
     this.meetingDetailCache.set(id, { observable: request$, cachedAt: Date.now() });
     return request$;
   }
@@ -636,6 +638,16 @@ export class MeetingService {
         return throwError(() => error);
       })
     );
+  }
+
+  // Opportunistic sweep on insert: entries otherwise linger for the whole session once their TTL lapses.
+  private pruneExpiredMeetingDetailCache(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.meetingDetailCache) {
+      if (now - entry.cachedAt >= MEETING_DETAIL_CACHE_TTL_MS) {
+        this.meetingDetailCache.delete(key);
+      }
+    }
   }
 
   private pruneExpiredPastMeetingRecordingCache(): void {

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -74,23 +74,23 @@ export class ProjectContextService {
     this.projectSelection.set(this.loadFromCookie(this.projectStorageKey));
   }
 
+  // The URL sync runs outside the same-context early return: a stale `?project=` left by a prior
+  // selection must still be corrected when the incoming selection already matches the current one.
   public setFoundation(foundation: ProjectContext, syncUrl = true): void {
-    if (isSameProjectContext(this.foundationSelection(), foundation)) {
-      return;
+    if (!isSameProjectContext(this.foundationSelection(), foundation)) {
+      this.foundationSelection.set(foundation);
+      this.persistToCookie(this.foundationStorageKey, foundation);
     }
-    this.foundationSelection.set(foundation);
-    this.persistToCookie(this.foundationStorageKey, foundation);
     if (syncUrl) {
       this.syncProjectQueryParam(foundation.slug);
     }
   }
 
   public setProject(project: ProjectContext, syncUrl = true): void {
-    if (isSameProjectContext(this.projectSelection(), project)) {
-      return;
+    if (!isSameProjectContext(this.projectSelection(), project)) {
+      this.projectSelection.set(project);
+      this.persistToCookie(this.projectStorageKey, project);
     }
-    this.projectSelection.set(project);
-    this.persistToCookie(this.projectStorageKey, project);
     if (syncUrl) {
       this.syncProjectQueryParam(project.slug);
     }

--- a/apps/lfx-one/src/app/shared/utils/write-access.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/write-access.util.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Meeting, Project } from '@lfx-one/shared/interfaces';
+
+// Single definition of the meetings write predicate: when writerGuard and the two reactive
+// access signals each carried their own copy, drift denied or evicted meeting coordinators.
+export function hasMeetingWriteAccess(project: Project | null): boolean {
+  return project?.writer === true || project?.meetingCoordinator === true;
+}
+
+// Prefers the BFF-enriched slug, falling back to the uid — `GET /api/projects/:slug` sniffs UUIDs,
+// so either resolves. `fallback` covers a meeting carrying neither.
+export function resolveMeetingWriteSlug(meeting: Pick<Meeting, 'project_slug' | 'project_uid'> | null, fallback: string | null): string | null {
+  return meeting?.project_slug ?? meeting?.project_uid ?? fallback;
+}


### PR DESCRIPTION
## Summary

This PR hardens the meetings edit flow against stale project context. Previously, when a meeting read failed for a non-404 reason, the writer guard silently fell back to the active lens and could authorize (or deny) against an unrelated project; when the relation-gated project GET returned nothing for an organizer without a direct viewer relation, the manage component gave up on context resolution; and a stale `?project=` query param could persist even after the user selected a different project. Each path is now corrected, and the meetings write predicate and slug resolver are centralized in a shared util so the guard and the reactive access signals can no longer drift.

Resolves #1579

## Behavior changes

### Stale-context authorization on edit

| Before | After |
|---|---|
| If reading a meeting failed for any reason, the edit guard silently fell back to whichever project the user happened to have open, so a legitimate organizer could be denied — or worse, the access check could run against the wrong project. | Only a genuinely missing meeting (404) falls back to the open project. Any other read failure fails closed and redirects, so no access check runs against a stale, unrelated project. |

### Context resolution for organizers without a direct viewer relation

| Before | After |
|---|---|
| When the project lookup returned nothing for an organizer who has meeting access but no direct viewer relation, the edit page left the project context unresolved and never self-corrected. | The edit page retries resolution from a fresh (uncached) meeting detail payload whose project enrichment is not relation-gated, so the organizer's project context is recovered when the enrichment is available. The retry runs at most once per meeting. |

### Stale `?project=` query param after a same-project selection

| Before | After |
|---|---|
| Selecting the same project that was already active skipped the URL sync, so a stale `?project=` left by a prior selection lingered in the URL. | The URL sync runs regardless of whether the selection matches, so a stale `?project=` is corrected whenever a selection is reasserted. |

## Technical changes

`apps/lfx-one/src/app/shared/utils/write-access.util.ts` — Shared write-access helpers
- Adds `hasMeetingWriteAccess(project)` as the single definition of the meetings write predicate (`writer` OR `meetingCoordinator`), replacing the inline copies that had drifted across the guard and the reactive access signals.
- Adds `resolveMeetingWriteSlug(meeting, fallback)` — prefers the BFF-enriched `project_slug`, falls back to `project_uid` (the project GET sniffs UUIDs), then to the supplied active-context fallback.

`apps/lfx-one/src/app/shared/guards/writer.guard.ts` — Route guard
- Fails closed on any non-404 meeting read failure: the `catchError` now returns `null` (triggering the `if (!slug)` redirect) for non-404 errors and only falls back to the active context on a 404.
- Replaces the inline slug-resolution and write-predicate logic with `resolveMeetingWriteSlug` and `hasMeetingWriteAccess`.
- Adds `HttpErrorResponse` import to distinguish 404 from other failures.
- Updates the doc comments to describe the fail-closed behavior.

`apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts` — Meeting edit/manage component
- In `initMeetingContextFallback`, when the relation-gated project GET returns null, retries resolution via `resolveContextFromFreshMeeting`, which calls `meetingService.getMeetingDetail(entity.uid, { skipCache: true })` and builds the `ProjectContext` from the freshly enriched payload.
- Adds a `contextFallbackRetried` Set keyed by meeting uid so the NavigationEnd re-apply (which re-emits the entity on every step navigation) does not repeat the uncached fetch.
- Emits `null` (leaving context untouched) when the fresh payload still carries no `project_slug`, with a `console.warn` for diagnostics; errors are caught and logged.
- Replaces the inline slug-resolution and write-predicate logic with the shared helpers.

`apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts` — Meetings dashboard
- Replaces the inline `project?.writer === true || project?.meetingCoordinator === true` check with `hasMeetingWriteAccess(project)` in the reactive access signal.

`apps/lfx-one/src/app/shared/services/meeting.service.ts` — Meeting service
- Adds an optional `options.skipCache` parameter to `getMeetingDetail` so callers can force a fresh fetch when they need enrichment that a cached payload may predate.
- Adds `pruneExpiredMeetingDetailCache`, an opportunistic sweep invoked on every insert, so TTL-lapsed entries no longer linger for the whole session.

`apps/lfx-one/src/app/shared/services/project-context.service.ts` — Project context service
- Restructures `setFoundation` and `setProject` so the URL sync runs outside the same-context early return, correcting a stale `?project=` query param even when the incoming selection already matches the current one. The signal write and cookie persist remain gated by the same-context check.
