### PR TITLE
fix(projects): stop protected project calls on anonymous routes

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -19,6 +19,7 @@ import type {
 import { provideRouter } from '@angular/router';
 import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
 import { NEVER, Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -84,7 +85,7 @@ describe('CampaignsComponent brief persistence', () => {
       // calls a new one. Their requests simply stay pending here, which is the loading state.
       // A router is needed because a child tab renders a RouterLink — stubbing the children
       // instead would stop this spec from proving the handoff really mounts the tab.
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([]), { provide: MessageService, useValue: { add: vi.fn() } }],
     }).compileComponents();
     persistBrief = vi.fn();
     vi.spyOn(TestBed.inject(CampaignService), 'persistBrief').mockImplementation(persistBrief);
@@ -1157,7 +1158,7 @@ describe('CampaignsComponent — email delivery channel', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CampaignsComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([]), { provide: MessageService, useValue: { add: vi.fn() } }],
     }).compileComponents();
     fixture = TestBed.createComponent(CampaignsComponent);
     fixture.detectChanges();
@@ -1529,7 +1530,7 @@ describe('CampaignsComponent — Implementation edits survive a tab switch', () 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [CampaignsComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([])],
+      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([]), { provide: MessageService, useValue: { add: vi.fn() } }],
     }).compileComponents();
     fixture = TestBed.createComponent(CampaignsComponent);
     fixture.detectChanges();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -7,7 +7,8 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
 import type { CampaignBriefPersistenceState } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
-import { beforeEach, describe, expect, it } from 'vitest';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImplementationTabComponent } from './implementation-tab.component';
 
@@ -61,7 +62,13 @@ describe('ImplementationTabComponent submit gate', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [ImplementationTabComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([]), ProjectContextService],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ProjectContextService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(ImplementationTabComponent);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/planning-tab/planning-tab.component.spec.ts
@@ -9,6 +9,7 @@ import { provideRouter } from '@angular/router';
 import type { CampaignBriefLoadResult, CampaignBriefOutput, CampaignProgramTypeOption } from '@lfx-one/shared/interfaces';
 import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
 import { Observable, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -97,7 +98,13 @@ describe('PlanningTabComponent brief read-back', () => {
       imports: [PlanningTabComponent],
       // Real CampaignService against HTTP testing backend, with only `loadBrief` spied.
       // Other methods stay pending, representing the "loading" state.
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([]), ProjectContextService],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ProjectContextService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
     }).compileComponents();
 
     campaignService = { loadBrief: vi.fn() };
@@ -679,7 +686,13 @@ describe('PlanningTabComponent delivery-type mode', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [PlanningTabComponent],
-      providers: [provideHttpClient(), provideHttpClientTesting(), provideRouter([]), ProjectContextService],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ProjectContextService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
     }).compileComponents();
 
     // Never completes: generate() stays in flight, so the request argument is observable without

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -48,10 +48,10 @@ import {
   PastMeetingParticipant,
   PastMeetingRecording,
   PastMeetingSummary,
-  Project,
   PublicMeetingOccurrencesResponse,
+  PublicMeetingParentProject,
+  PublicMeetingProject,
   PublicPastMeetingResponse,
-  ROOT_PROJECT_SLUG,
   TagSeverity,
   User,
 } from '@lfx-one/shared';
@@ -63,7 +63,6 @@ import { RecurrenceSummaryPipe } from '@pipes/recurrence-summary.pipe';
 import { MeetingService } from '@services/meeting.service';
 import { PlausibleService } from '@services/plausible.service';
 import { ProjectContextService } from '@services/project-context.service';
-import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
@@ -134,7 +133,6 @@ export class MeetingJoinComponent implements OnInit {
   private readonly activatedRoute = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly meetingService = inject(MeetingService);
-  private readonly projectService = inject(ProjectService);
   protected readonly userService = inject(UserService);
   private readonly clipboard = inject(Clipboard);
   private readonly projectContextService = inject(ProjectContextService);
@@ -147,8 +145,8 @@ export class MeetingJoinComponent implements OnInit {
   public authenticated: WritableSignal<boolean>;
   public user: Signal<User | null> = this.userService.user;
   public joinForm: FormGroup;
-  public project: WritableSignal<Partial<Project> | null> = signal<Partial<Project> | null>(null);
-  public meeting: Signal<Meeting & { project: Partial<Project> }>;
+  public project: WritableSignal<PublicMeetingProject | null> = signal<PublicMeetingProject | null>(null);
+  public meeting: Signal<Meeting & { project: PublicMeetingProject }>;
   public currentOccurrence: Signal<MeetingOccurrence | null>;
   // Recurrence rule that drives the cadence badge: the displayed occurrence's own override when
   // present (cadence changed at/after it — LFXV2-2112), otherwise the series rule. NOTE: the
@@ -251,8 +249,9 @@ export class MeetingJoinComponent implements OnInit {
   // Null on the server and until hydration resolves the browser timezone — the badge shows a skeleton while null.
   protected userTimezone = signal<string | null>(null);
   protected drawerPosition = computed(() => (this.isMobileViewport() ? 'bottom' : 'right') as 'bottom' | 'right');
-  // Parent project (foundation) for context display
-  protected parentProject: Signal<Project | null>;
+  // Parent project (foundation) for context display — read straight off the response (LFXV2-3266),
+  // resolved server-side rather than fetched here.
+  protected parentProject: Signal<PublicMeetingParentProject | null>;
   // Registrant list, fetched only when the user is the meeting organizer or invited.
   // Pre-loaded with the meeting so the Show Members drawer renders instantly from cache.
   protected registrants: Signal<MeetingRegistrant[]>;
@@ -684,7 +683,7 @@ export class MeetingJoinComponent implements OnInit {
   }
 
   private initializeMeeting() {
-    return toSignal<Meeting & { project: Partial<Project> }>(
+    return toSignal<Meeting & { project: PublicMeetingProject }>(
       combineLatest([this.activatedRoute.paramMap, this.activatedRoute.queryParamMap, this.refreshTrigger$]).pipe(
         debounceTime(0), // Coalesce rapid SSR hydration emissions so the fallback chain isn't canceled
         switchMap(([params, queryParams]) => {
@@ -705,7 +704,7 @@ export class MeetingJoinComponent implements OnInit {
               }),
               map((res: PublicPastMeetingResponse) => ({
                 meeting: res.meeting,
-                project: res.project as Partial<Project>,
+                project: res.project,
               })),
               catchError((error) => {
                 if ([404, 403, 400].includes(error.status)) {
@@ -729,7 +728,7 @@ export class MeetingJoinComponent implements OnInit {
                   }),
                   map((res: PublicPastMeetingResponse) => ({
                     meeting: res.meeting,
-                    project: res.project as Partial<Project>,
+                    project: res.project,
                   })),
                   catchError(() => {
                     this.router.navigate(['/meetings/not-found']);
@@ -749,7 +748,7 @@ export class MeetingJoinComponent implements OnInit {
           this.project.set(res.project);
         })
       )
-    ) as Signal<Meeting & { project: Partial<Project> }>;
+    ) as Signal<Meeting & { project: PublicMeetingProject }>;
   }
 
   private initializeCurrentOccurrence(): Signal<MeetingOccurrence | null> {
@@ -1338,25 +1337,10 @@ export class MeetingJoinComponent implements OnInit {
     );
   }
 
-  private initializeParentProject(): Signal<Project | null> {
-    return toSignal(
-      toObservable(this.project).pipe(
-        map((p) => p?.parent_uid ?? null),
-        distinctUntilChanged(),
-        switchMap((parentUid) => {
-          if (!parentUid) {
-            // Top-level (or unknown) project — explicitly clear any stale foundation context
-            // instead of suppressing the emission, which would leave the previous parent cached.
-            return of(null);
-          }
-          return this.projectService.getProject(parentUid, false).pipe(
-            map((parent) => (parent?.slug === ROOT_PROJECT_SLUG ? null : parent)),
-            catchError(() => of(null))
-          );
-        })
-      ),
-      { initialValue: null }
-    );
+  // The server resolves the foundation project and maps root-level projects to null (LFXV2-3266) —
+  // no client fetch needed here anymore.
+  private initializeParentProject(): Signal<PublicMeetingParentProject | null> {
+    return computed(() => this.project()?.parent ?? null);
   }
 
   // PlausibleService defers the auto-pageview for /meetings/:id — fire it here once context lands.
@@ -1364,27 +1348,11 @@ export class MeetingJoinComponent implements OnInit {
     if (isPlatformServer(this.platformId)) {
       return;
     }
-    // Caps the parent foundation fetch so ROOT_PROJECT_SLUG → null (mapped in initializeParentProject)
-    // doesn't block the pageview forever. Sub-projects whose parent doesn't land in time record
-    // project_* correctly and leave foundation_* empty (see buildPageviewContext callsite below).
-    const PARENT_FETCH_TIMEOUT_MS = 2000;
-    // Created here (injection context) rather than inside the switchMap below — toObservable()
-    // calls inject() internally and throws NG0203 when invoked from an async stream callback.
-    const parentProject$ = toObservable(this.parentProject);
+    // The parent (foundation) now arrives in the same payload as the project (LFXV2-3266), so no
+    // race against a separate fetch is needed here anymore — just wait for the project itself.
     const pageviewContext$ = toObservable(this.project).pipe(
-      filter((p): p is Partial<Project> => !!p?.slug),
-      switchMap((project) => {
-        if (!project.parent_uid) {
-          return of({ project, parent: null as Project | null });
-        }
-        return merge(
-          parentProject$.pipe(
-            filter((parent): parent is Project => !!parent),
-            map((parent) => ({ project, parent: parent as Project | null }))
-          ),
-          timer(PARENT_FETCH_TIMEOUT_MS).pipe(map(() => ({ project, parent: null as Project | null })))
-        );
-      }),
+      filter((p): p is PublicMeetingProject => !!p?.slug),
+      map((project) => ({ project, parent: project.parent })),
       take(1)
     );
     // trackPage() silently drops calls made before the Plausible script executes, and this route's

--- a/apps/lfx-one/src/app/shared/services/project-context.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project-context.service.ts
@@ -9,12 +9,13 @@ import { SELECTED_FOUNDATION_COOKIE_KEY, SELECTED_PROJECT_COOKIE_KEY } from '@lf
 import { ProjectContext } from '@lfx-one/shared/interfaces';
 import { isBoardScopedPersona, isSameProjectContext } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
-import { catchError, map, of, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, map, of, startWith, switchMap } from 'rxjs';
 
 import { CookieRegistryService } from './cookie-registry.service';
 import { LensService } from './lens.service';
 import { PersonaService } from './persona.service';
 import { ProjectService } from './project.service';
+import { UserService } from './user.service';
 
 @Injectable({
   providedIn: 'root',
@@ -27,6 +28,7 @@ export class ProjectContextService {
   private readonly personaService = inject(PersonaService);
   private readonly projectService = inject(ProjectService);
   private readonly router = inject(Router);
+  private readonly userService = inject(UserService);
 
   private readonly foundationStorageKey = SELECTED_FOUNDATION_COOKIE_KEY;
   private readonly projectStorageKey = SELECTED_PROJECT_COOKIE_KEY;
@@ -213,9 +215,10 @@ export class ProjectContextService {
 
   private initCanWrite(): Signal<boolean> {
     return toSignal(
-      toObservable(this.activeContext).pipe(
-        switchMap((ctx) => {
-          if (!ctx?.slug) {
+      combineLatest([toObservable(this.activeContext), toObservable(this.userService.authenticated)]).pipe(
+        switchMap(([ctx, authenticated]) => {
+          // Anonymous/public routes have no session — /api/projects/:slug would just 401 (LFXV2-3266).
+          if (!ctx?.slug || !authenticated) {
             return of(false);
           }
           return this.projectService.getProject(ctx.slug, false).pipe(
@@ -230,9 +233,10 @@ export class ProjectContextService {
 
   private initSelectedFoundationSfid(): Signal<string | null> {
     return toSignal(
-      toObservable(this.selectedFoundation).pipe(
-        switchMap((foundation) => {
-          if (!foundation?.uid) {
+      combineLatest([toObservable(this.selectedFoundation), toObservable(this.userService.authenticated)]).pipe(
+        switchMap(([foundation, authenticated]) => {
+          // Anonymous/public routes have no session — /api/projects/:uid/sfid would just 401 (LFXV2-3266).
+          if (!foundation?.uid || !authenticated) {
             return of(null);
           }
           return this.projectService.getProjectSfid(foundation.uid).pipe(startWith(null));

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.spec.ts
@@ -1,0 +1,65 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ApplicationRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { HttpClient } from '@angular/common/http';
+import { WriterSummary } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectService } from './project.service';
+import { UserService } from './user.service';
+import { WriterGrantsService } from './writer-grants.service';
+
+/**
+ * Covers the auth gate added for LFXV2-3266: on an anonymous/public route (e.g. a `/meetings/:id`
+ * invite page) there's no session, so `getWriterSummary`/`getProjects` would just 401. Both
+ * signals default `false`, which is already the correct answer for that visitor, so the gate must
+ * skip the calls entirely rather than let them fire and fail closed.
+ */
+describe('WriterGrantsService', () => {
+  let getWriterSummary: ReturnType<typeof vi.fn>;
+  let getProjects: ReturnType<typeof vi.fn>;
+  let userService: UserService;
+
+  beforeEach(() => {
+    getWriterSummary = vi.fn().mockReturnValue(of({ hasWriterFoundation: false, hasWriterProject: false } as WriterSummary));
+    getProjects = vi.fn().mockReturnValue(of([]));
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ProjectService, useValue: { getWriterSummary, getProjects } },
+        { provide: HttpClient, useValue: { get: vi.fn().mockReturnValue(of({})), post: vi.fn(), patch: vi.fn(), put: vi.fn(), delete: vi.fn() } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    });
+
+    userService = TestBed.inject(UserService);
+  });
+
+  it('skips both calls and leaves both signals false when unauthenticated', () => {
+    userService.authenticated.set(false);
+    const service = TestBed.inject(WriterGrantsService);
+
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(getWriterSummary).not.toHaveBeenCalled();
+    expect(getProjects).not.toHaveBeenCalled();
+    expect(service.hasWriterFoundation()).toBe(false);
+    expect(service.hasWriterProject()).toBe(false);
+  });
+
+  it('calls getWriterSummary and widens the signals when authenticated', () => {
+    userService.authenticated.set(true);
+    getWriterSummary.mockReturnValue(of({ hasWriterFoundation: true, hasWriterProject: false } as WriterSummary));
+    const service = TestBed.inject(WriterGrantsService);
+
+    TestBed.inject(ApplicationRef).tick();
+
+    expect(getWriterSummary).toHaveBeenCalledTimes(1);
+    expect(service.hasWriterFoundation()).toBe(true);
+    expect(service.hasWriterProject()).toBe(false);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
+++ b/apps/lfx-one/src/app/shared/services/writer-grants.service.ts
@@ -7,6 +7,7 @@ import { IDLE_SWEEP_FALLBACK_DELAY_MS, IDLE_SWEEP_MIN_DELAY_MS, IDLE_SWEEP_TIMEO
 import { WriterSummary } from '@lfx-one/shared/interfaces';
 import { summarizeWriterGrants } from '@lfx-one/shared/utils';
 import { ProjectService } from '@services/project.service';
+import { UserService } from '@services/user.service';
 import { finalize, map } from 'rxjs';
 
 /**
@@ -14,6 +15,11 @@ import { finalize, map } from 'rxjs';
  * the same authorization `writerGuard` enforces. The only consumer is {@link LensService}, which
  * OR's these into its allowed-lens set (LFXV2-2754): a `writer` grant is authority over that
  * project, so the lens that reaches it must be available regardless of which persona was detected.
+ *
+ * Gated on `UserService.authenticated()` (LFXV2-3266) — on public/anonymous routes (e.g. a
+ * `/meetings/:id` invite page) there's no session, so both calls would just 401. `authenticated`
+ * is seeded from `TransferState`/`REQUEST_CONTEXT` in `AppComponent`'s constructor, which runs
+ * before `afterNextRender` callbacks fire, so the check below always sees the settled value.
  *
  * Two-phase, kicked off post-hydration in `afterNextRender` (LFXV2-2857):
  *  - **Fast path** — `ProjectService.getWriterSummary()` hits a `filter_grants=direct`-scoped
@@ -45,6 +51,7 @@ import { finalize, map } from 'rxjs';
 })
 export class WriterGrantsService {
   private readonly projectService = inject(ProjectService);
+  private readonly userService = inject(UserService);
   private readonly destroyRef = inject(DestroyRef);
 
   private readonly hasWriterFoundationInternal: WritableSignal<boolean> = signal(false);
@@ -60,6 +67,12 @@ export class WriterGrantsService {
     // Runs browser-only, once the first render is committed — see the class doc for why both
     // calls live here rather than at construction.
     afterNextRender(() => {
+      // Anonymous/public routes have no session — both signals' default `false` is already the
+      // correct answer, so skip the calls rather than let them 401 (LFXV2-3266).
+      if (!this.userService.authenticated()) {
+        return;
+      }
+
       this.projectService
         .getWriterSummary()
         .pipe(

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { MeetingVisibility } from '@lfx-one/shared/enums';
-import type { Meeting } from '@lfx-one/shared/interfaces';
+import type { Meeting, PastMeeting } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const MEETING_ID = 'meeting-1111';
@@ -36,6 +36,7 @@ const {
     // Called by enrichMeetingsWithCreatedBy (#1155); empty map => enrich is a no-op.
     resolveCreatedByForMeetings: vi.fn().mockResolvedValue(new Map()),
     getMeetingHostKey: vi.fn(),
+    getPastMeetingById: vi.fn(),
     getPastOccurrencesForMeeting: vi.fn(),
     addMeetingRegistrantSelf: vi.fn(),
   },
@@ -52,7 +53,12 @@ vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public',
 vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null) }));
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.
-vi.mock('@lfx-one/shared/constants', () => ({ HOST_KEY_EARLY_MINUTES: 70, HOST_KEY_LATE_MINUTES: 40, MEETING_PASSWORD_HEADER: 'x-meeting-password' }));
+vi.mock('@lfx-one/shared/constants', () => ({
+  HOST_KEY_EARLY_MINUTES: 70,
+  HOST_KEY_LATE_MINUTES: 40,
+  MEETING_PASSWORD_HEADER: 'x-meeting-password',
+  ROOT_PROJECT_SLUG: 'ROOT',
+}));
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: validateUidParameterMock }));
 
 vi.mock('../services/meeting.service', () => ({
@@ -119,8 +125,31 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Meeting {
   } as Meeting;
 }
 
-function buildProject() {
-  return { name: 'Proj', slug: 'proj', logo_url: 'logo', uid: PROJECT_UID, parent_uid: 'parent' };
+function buildPastMeeting(overrides: Partial<PastMeeting> = {}): PastMeeting {
+  return {
+    id: MEETING_ID,
+    project_uid: PROJECT_UID,
+    visibility: MeetingVisibility.PUBLIC,
+    restricted: false,
+    committees: [],
+    start_time: new Date(Date.now() - 60 * 60_000).toISOString(),
+    duration: 60,
+    scheduled_start_time: new Date(Date.now() - 60 * 60_000).toISOString(),
+    scheduled_end_time: new Date(Date.now() - 30 * 60_000).toISOString(),
+    meeting_id: 'meeting-orig-1111',
+    occurrence_id: 'occurrence-1',
+    platform_meeting_id: 'zoom-1111',
+    sessions: [],
+    ...overrides,
+  } as PastMeeting;
+}
+
+function buildProject(overrides: Record<string, unknown> = {}) {
+  return { name: 'Proj', slug: 'proj', logo_url: 'logo', uid: PROJECT_UID, parent_uid: 'parent', ...overrides };
+}
+
+function buildParentProject(overrides: Record<string, unknown> = {}) {
+  return { name: 'Foundation', slug: 'foundation', logo_url: 'flogo', uid: 'parent', parent_uid: '', ...overrides };
 }
 
 function buildReqRes(authenticated: boolean, hasUserToken = true) {
@@ -288,6 +317,139 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.invited).toBe(true);
     expect(payload.meeting.host_key).toBeUndefined();
+  });
+});
+
+describe('PublicMeetingController.getMeetingById parent project resolution (LFXV2-3266)', () => {
+  let controller: PublicMeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicMeetingController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    getEffectiveUsernameMock.mockReturnValue('user');
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
+    meetingSvc.getMeetingHostKey.mockResolvedValue(null);
+    addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: Meeting) => ({ ...meeting, invited: false }));
+    checkAccessMock.mockResolvedValue(accessMap([]));
+  });
+
+  it('resolves and returns the foundation project', async () => {
+    projectSvc.getProjectById.mockImplementation(async (_req: any, uid: string) => (uid === PROJECT_UID ? buildProject() : buildParentProject()));
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toEqual({ uid: 'parent', name: 'Foundation', slug: 'foundation' });
+  });
+
+  it('returns parent: null when the project has no parent_uid', async () => {
+    projectSvc.getProjectById.mockResolvedValue(buildProject({ parent_uid: '' }));
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toBeNull();
+    // Only the project's own lookup should have run — no parent lookup to skip.
+    expect(projectSvc.getProjectById).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns parent: null and still responds 200 when the parent lookup throws', async () => {
+    projectSvc.getProjectById.mockImplementation(async (_req: any, uid: string) => {
+      if (uid === PROJECT_UID) return buildProject();
+      throw new Error('upstream 500');
+    });
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toBeNull();
+  });
+
+  it('maps a root-slug parent to null', async () => {
+    projectSvc.getProjectById.mockImplementation(async (_req: any, uid: string) =>
+      uid === PROJECT_UID ? buildProject() : buildParentProject({ slug: 'ROOT' })
+    );
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toBeNull();
+  });
+});
+
+describe('PublicMeetingController.getPublicPastMeetingById parent project resolution (LFXV2-3266)', () => {
+  let controller: PublicMeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicMeetingController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    getEffectiveUsernameMock.mockReturnValue('user');
+    meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting());
+    checkAccessMock.mockResolvedValue(accessMap([]));
+  });
+
+  it('resolves and returns the foundation project', async () => {
+    projectSvc.getProjectById.mockImplementation(async (_req: any, uid: string) => (uid === PROJECT_UID ? buildProject() : buildParentProject()));
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getPublicPastMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toEqual({ uid: 'parent', name: 'Foundation', slug: 'foundation' });
+  });
+
+  it('returns parent: null when the project has no parent_uid', async () => {
+    projectSvc.getProjectById.mockResolvedValue(buildProject({ parent_uid: '' }));
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getPublicPastMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toBeNull();
+    // Only the project's own lookup should have run — no parent lookup to skip.
+    expect(projectSvc.getProjectById).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns parent: null and still responds 200 when the parent lookup throws', async () => {
+    projectSvc.getProjectById.mockImplementation(async (_req: any, uid: string) => {
+      if (uid === PROJECT_UID) return buildProject();
+      throw new Error('upstream 500');
+    });
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getPublicPastMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toBeNull();
+  });
+
+  it('maps a root-slug parent to null', async () => {
+    projectSvc.getProjectById.mockImplementation(async (_req: any, uid: string) =>
+      uid === PROJECT_UID ? buildProject() : buildParentProject({ slug: 'ROOT' })
+    );
+    const { req, res, next } = buildReqRes(false);
+
+    await controller.getPublicPastMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.project.parent).toBeNull();
   });
 });
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -2,9 +2,16 @@
 // SPDX-License-Identifier: MIT
 
 import { Meeting } from '@lfx-one/shared';
-import { MEETING_PASSWORD_HEADER } from '@lfx-one/shared/constants';
+import { MEETING_PASSWORD_HEADER, ROOT_PROJECT_SLUG } from '@lfx-one/shared/constants';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
-import { CreateMeetingRegistrantRequest, MeetingOccurrenceSummary, MeetingRegistrant, PublicMeetingOccurrencesResponse } from '@lfx-one/shared/interfaces';
+import {
+  CreateMeetingRegistrantRequest,
+  MeetingOccurrenceSummary,
+  MeetingRegistrant,
+  Project,
+  PublicMeetingOccurrencesResponse,
+  PublicMeetingProject,
+} from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
@@ -84,6 +91,12 @@ export class PublicMeetingController {
           path: `/projects/${meeting.project_uid}`,
         });
       }
+
+      // Resolves the foundation project server-side (LFXV2-3266) so anonymous visitors get
+      // breadcrumb/attribution data without an authenticated /api/projects/:uid call from the
+      // client. m2mToken is still active here — the user-token swap below happens later and is
+      // restored before this response is sent.
+      const parent = await this.resolveParentProject(req, project);
 
       // Resolve host-key visibility (organizer OR project writer OR committee writer). This sets
       // meeting.organizer (used for the registrant counts below) and meeting.can_view_host_key,
@@ -172,7 +185,7 @@ export class PublicMeetingController {
       if (meeting.visibility === MeetingVisibility.PUBLIC && !meeting.restricted) {
         res.json({
           meeting,
-          project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+          project: this.toPublicMeetingProject(project, parent),
         });
         return;
       }
@@ -186,7 +199,7 @@ export class PublicMeetingController {
       if (meeting.invited || meeting.organizer) {
         res.json({
           meeting,
-          project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+          project: this.toPublicMeetingProject(project, parent),
         });
         return;
       }
@@ -206,7 +219,7 @@ export class PublicMeetingController {
               meeting.invited = true;
               res.json({
                 meeting,
-                project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+                project: this.toPublicMeetingProject(project, parent),
               });
               return;
             }
@@ -226,7 +239,7 @@ export class PublicMeetingController {
       }
 
       // Send the meeting and project data to the client
-      res.json({ meeting, project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid } });
+      res.json({ meeting, project: this.toPublicMeetingProject(project, parent) });
     } catch (error) {
       // Error handler will log
       next(error);
@@ -269,6 +282,9 @@ export class PublicMeetingController {
           path: `/projects/${meeting.project_uid}`,
         });
       }
+
+      // Resolves the foundation project server-side (LFXV2-3266) — see getMeetingById for why.
+      const parent = await this.resolveParentProject(req, project);
 
       // Check organizer status for authenticated users using user token
       let isOrganizer = false;
@@ -349,7 +365,7 @@ export class PublicMeetingController {
 
       res.json({
         meeting: meetingResponse,
-        project: { name: project.name, slug: project.slug, logo_url: project.logo_url, uid: project.uid, parent_uid: project.parent_uid },
+        project: this.toPublicMeetingProject(project, parent),
         full_access: fullAccess,
       });
     } catch (error) {
@@ -581,6 +597,46 @@ export class PublicMeetingController {
       // Error handler will log
       next(error);
     }
+  }
+
+  /**
+   * Resolves a project's foundation (parent) for public meeting responses (LFXV2-3266), so the
+   * client never needs its own authenticated `/api/projects/:uid` call to show it. Root-level
+   * projects have no meaningful parent — `ROOT_PROJECT_SLUG` maps to `null`, mirroring the
+   * client-side rule this replaces. Never throws: a missing/unresolvable parent degrades to
+   * `null` rather than failing the whole meeting response.
+   */
+  private async resolveParentProject(req: Request, project: Pick<Project, 'parent_uid'>): Promise<Project | null> {
+    if (!project.parent_uid) {
+      return null;
+    }
+
+    try {
+      const parent = await this.projectService.getProjectById(req, project.parent_uid, false);
+      return parent?.slug === ROOT_PROJECT_SLUG ? null : parent;
+    } catch (error) {
+      logger.warning(req, 'resolve_parent_project', 'Failed to resolve parent project, continuing without it', {
+        parent_uid: project.parent_uid,
+        err: error,
+      });
+      return null;
+    }
+  }
+
+  /**
+   * Builds the slim `PublicMeetingProject` payload shared by every public meeting response
+   * branch — kept as one helper so `parent` (LFXV2-3266) can't be added to some call sites and
+   * missed on others.
+   */
+  private toPublicMeetingProject(project: Project, parent: Project | null): PublicMeetingProject {
+    return {
+      name: project.name,
+      slug: project.slug,
+      logo_url: project.logo_url,
+      uid: project.uid,
+      parent_uid: project.parent_uid,
+      parent: parent ? { uid: parent.uid, name: parent.name, slug: parent.slug } : null,
+    };
   }
 
   /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1254,6 +1254,17 @@ export interface UrlMetadataResponse {
 }
 
 /**
+ * Slim parent (foundation) project context nested in {@link PublicMeetingProject} — resolved
+ * server-side (LFXV2-3266) so anonymous visitors on public meeting pages get foundation
+ * attribution without the client needing an authenticated `/api/projects/:uid` call.
+ */
+export type PublicMeetingParentProject = {
+  uid: string;
+  name: string;
+  slug: string;
+};
+
+/**
  * Slim project context returned alongside public meeting endpoints.
  * Only the fields needed for the join page — callers must not assume
  * any other project fields are present.
@@ -1264,6 +1275,8 @@ export type PublicMeetingProject = {
   logo_url: string;
   uid: string;
   parent_uid: string;
+  /** Resolved foundation project, or `null` when top-level or unresolvable (LFXV2-3266). */
+  parent: PublicMeetingParentProject | null;
 };
 
 /**


### PR DESCRIPTION
## Summary

- 93% of the `AUTHENTICATION_REQUIRED` 401s in Datadog RUM (89% on public `/meetings/:id` invite pages) come from anonymous sessions hitting protected `/api/*` endpoints — the server is correctly rejecting them; the client shouldn't be calling them at all.
- `WriterGrantsService` and `ProjectContextService`'s project lookups now gate on `UserService.authenticated()`, so anonymous visitors no longer fire `/api/projects*` calls that were always going to 401.
- The public meeting endpoint now resolves and returns the parent/foundation project server-side (via the existing M2M-authenticated `getProjectById` call), so anonymous visitors still get foundation attribution in the breadcrumb and pageview tracking without needing their own authenticated fetch.

Issue: LFXV2-3266