### PR TITLE
fix(nav): merge lenses for all hybrid grant sources

### DIFF
--- a/apps/lfx-one/src/app/shared/services/lens.service.ts
+++ b/apps/lfx-one/src/app/shared/services/lens.service.ts
@@ -12,8 +12,8 @@ import {
   NAV_LENS_COOKIE_KEY,
   ORG_LENS_ENABLED_FLAG,
 } from '@lfx-one/shared/constants';
-import { Lens, LensOption, NavLens } from '@lfx-one/shared/interfaces';
-import { deriveAllowedLenses } from '@lfx-one/shared/utils';
+import { Lens, LensGrantInputs, LensOption, NavLens } from '@lfx-one/shared/interfaces';
+import { deriveAllowedLenses, isHybridLensUser } from '@lfx-one/shared/utils';
 import { SsrCookieService } from 'ngx-cookie-service-ssr';
 import { filter, take } from 'rxjs';
 
@@ -56,8 +56,15 @@ export class LensService {
   public readonly availableLenses: Signal<LensOption[]> = this.initAvailableLenses();
   /** Lenses shown in the sidebar switcher. Mirrors {@link availableLenses} except for hybrid personas, who get a merged project entry instead of separate foundation + project buttons. */
   public readonly displayLenses: Signal<LensOption[]> = this.initDisplayLenses();
-  /** True when the user holds both a board role (ED/Board Member) AND a project role (Maintainer/Contributor). */
-  public readonly isHybridPersona: Signal<boolean> = computed(() => this.personaService.hasBoardRole() && this.personaService.hasProjectRole());
+  /** Single source of the persona/grant booleans, so lens visibility and the hybrid merge always agree. */
+  private readonly lensGrantInputs: Signal<LensGrantInputs> = this.initLensGrantInputs();
+  /**
+   * True when the user can reach both the foundation and project lenses, from any grant source —
+   * a board+project role pair, LF staff membership, a root-writer grant, or `writer` grants.
+   * Shares {@link lensGrantInputs} with {@link getAllowedLensIds} so the merged switcher entry
+   * cannot disagree with which lenses actually render.
+   */
+  public readonly isHybridPersona: Signal<boolean> = computed(() => isHybridLensUser(this.lensGrantInputs()));
   /** Lens to highlight in the switcher UI. Hybrid personas merge foundation + project into the 'project' entry, so a foundation-scoped active lens highlights 'project'. */
   public readonly displayActiveLens: Signal<Lens> = computed(() => {
     const active = this.activeLens();
@@ -186,7 +193,11 @@ export class LensService {
    * `MainLayoutComponent.syncLensFromRoute` is the one caller that re-asserts.
    */
   private getAllowedLensIds(): readonly Lens[] {
-    return deriveAllowedLenses({
+    return deriveAllowedLenses(this.lensGrantInputs());
+  }
+
+  private initLensGrantInputs(): Signal<LensGrantInputs> {
+    return computed(() => ({
       hasBoardRole: this.personaService.hasBoardRole(),
       hasProjectRole: this.personaService.hasProjectRole(),
       isRootWriter: this.personaService.isRootWriter(),
@@ -194,7 +205,7 @@ export class LensService {
       hasWriterProject: this.writerGrantsService.hasWriterProject(),
       isOrgLensEnabled: this.isOrgLensEnabled(),
       isLFStaff: this.personaService.isLFStaff(),
-    });
+    }));
   }
 
   private persistToCookie(lens: Lens): void {

--- a/packages/shared/src/utils/lens.utils.spec.ts
+++ b/packages/shared/src/utils/lens.utils.spec.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { LensGrantInputs } from '../interfaces/lens.interface';
-import { deriveAllowedLenses } from './lens.utils';
+import { deriveAllowedLenses, isHybridLensUser } from './lens.utils';
 
 const NO_GRANTS: LensGrantInputs = {
   hasBoardRole: false,
@@ -13,6 +13,7 @@ const NO_GRANTS: LensGrantInputs = {
   hasWriterFoundation: false,
   hasWriterProject: false,
   isOrgLensEnabled: false,
+  isLFStaff: false,
 };
 
 const inputs = (overrides: Partial<LensGrantInputs>): LensGrantInputs => ({ ...NO_GRANTS, ...overrides });
@@ -82,5 +83,48 @@ describe('deriveAllowedLenses', () => {
     it('orders org last alongside other grants', () => {
       expect(deriveAllowedLenses(inputs({ isRootWriter: true, isOrgLensEnabled: true }))).toEqual(['me', 'foundation', 'project', 'org']);
     });
+  });
+
+  describe('lf staff', () => {
+    it('grants foundation without a board role', () => {
+      expect(deriveAllowedLenses(inputs({ isLFStaff: true }))).toEqual(['me', 'foundation']);
+    });
+
+    it('does not grant project', () => {
+      expect(deriveAllowedLenses(inputs({ isLFStaff: true }))).not.toContain('project');
+    });
+  });
+});
+
+describe('isHybridLensUser', () => {
+  // Every combination that renders both lens buttons must merge them. Before this was derived
+  // from deriveAllowedLenses, only the board+project role pair did, so LF staff, root writers,
+  // and writer-granted users kept a separate foundation button.
+  it.each([
+    ['board role and project role', { hasBoardRole: true, hasProjectRole: true }],
+    ['lf staff and project role', { isLFStaff: true, hasProjectRole: true }],
+    ['lf staff and a project writer grant', { isLFStaff: true, hasWriterProject: true }],
+    ['a foundation writer grant and project role', { hasWriterFoundation: true, hasProjectRole: true }],
+    ['writer grants on both kinds', { hasWriterFoundation: true, hasWriterProject: true }],
+    ['a root writer alone', { isRootWriter: true }],
+    ['board role and a project writer grant', { hasBoardRole: true, hasWriterProject: true }],
+  ])('is true for %s', (_label, overrides: Partial<LensGrantInputs>) => {
+    expect(isHybridLensUser(inputs(overrides))).toBe(true);
+  });
+
+  it.each([
+    ['no grants at all', {}],
+    ['foundation only, from a board role', { hasBoardRole: true }],
+    ['foundation only, from lf staff', { isLFStaff: true }],
+    ['foundation only, from a writer grant', { hasWriterFoundation: true }],
+    ['project only, from a project role', { hasProjectRole: true }],
+    ['project only, from a writer grant', { hasWriterProject: true }],
+  ])('is false for %s', (_label, overrides: Partial<LensGrantInputs>) => {
+    expect(isHybridLensUser(inputs(overrides))).toBe(false);
+  });
+
+  it('is unaffected by the org lens flag', () => {
+    expect(isHybridLensUser(inputs({ isOrgLensEnabled: true }))).toBe(false);
+    expect(isHybridLensUser(inputs({ isRootWriter: true, isOrgLensEnabled: true }))).toBe(true);
   });
 });

--- a/packages/shared/src/utils/lens.utils.ts
+++ b/packages/shared/src/utils/lens.utils.ts
@@ -39,3 +39,17 @@ export function deriveAllowedLenses(inputs: LensGrantInputs): Lens[] {
   }
   return lenses;
 }
+
+/**
+ * True when the user can reach both the foundation and project lenses, from any grant source.
+ *
+ * Drives the sidebar's merged 'Projects' entry. Derived from {@link deriveAllowedLenses} rather
+ * than from persona roles directly so the merge rule cannot disagree with the visibility rule:
+ * foundation access also comes from LF staff membership, a root-writer grant, and a `writer`
+ * grant on a foundation, none of which a role-only check sees. Any grant source added later is
+ * picked up here for free.
+ */
+export function isHybridLensUser(inputs: LensGrantInputs): boolean {
+  const lenses = deriveAllowedLenses(inputs);
+  return lenses.includes('foundation') && lenses.includes('project');
+}


### PR DESCRIPTION
## Summary

Fixes #1600.

The sidebar merges Foundation into a single "Projects" entry for users who can reach both lenses, but the merge condition only recognised one of the four ways Foundation access is granted:

```ts
// visibility — four sources
const showFoundation = hasBoardRole || isRootWriter || hasWriterFoundation || isLFStaff;
const showProject    = hasProjectRole || isRootWriter || hasWriterProject;

// merge — one source
isHybridPersona = hasBoardRole && hasProjectRole;
```

So LF staff, root writers, and writer-granted users saw two separate lens buttons, and got the non-hybrid single-list selector instead of the All / Foundations / Projects tabs. Root writer is the starkest case: it confers both lenses on its own yet could never satisfy the merge condition.

## What changed

- **`isHybridLensUser(inputs)`** added to `packages/shared/src/utils/lens.utils.ts`, derived from `deriveAllowedLenses` so the merge rule is defined as "both lens buttons would render" rather than a hand-maintained restatement of the grant sources. Any grant source added later is covered for free.
- **`LensService`** now builds the persona/grant booleans once into a `lensGrantInputs` signal shared by `getAllowedLensIds()` and `isHybridPersona`, making the two rules structurally unable to drift.
- **Tests** — 16 new cases covering all seven hybrid combinations from the issue plus the single-lens negatives, and `isLFStaff` added to the spec's `NO_GRANTS` fixture (it was missing since #1327).

No behaviour change for users already treated as hybrid. `initDisplayLenses`, `displayActiveLens`, and `switchLens` are untouched — they read `isHybridPersona()` and inherit the wider definition.

## Blast radius

`isHybridPersona` also drives the tabbed selector in `ProjectSelectorComponent`, the sibling-lens preload in `NavigationService`, the merged-button highlight, and `switchLens`'s return-to-`lastNavLens`. Those now activate for LF staff and root writers, which is the intent, but it is more than hiding a button.

## Test plan

- [x] `yarn check-types`
- [x] `yarn test` (347 passing; `lens.utils.spec.ts` 29 passing)
- [x] `yarn lint:check` (only a pre-existing warning in `user.service.ts`)
- [x] `yarn build`
- [ ] LF staff account with a project role: one merged "Projects" lens with All / Foundations / Projects tabs
- [ ] Project-only user: foundations still selectable in the project list (the path #713 iterated on several times)
- [ ] Board + project role user: unchanged from today
- [ ] Hybrid state flipping mid-session once `refreshFromApi()` resolves `isLFStaff` (covered by `hybridTransitionPreloader`)
