### PR TITLE
feat(committees): add weekly brief archive drawer

### DIFF
--- a/.cursor/rules/pre-commit-lint-format.mdc
+++ b/.cursor/rules/pre-commit-lint-format.mdc
@@ -1,0 +1,45 @@
+---
+description: Enforce Prettier format, ESLint lint, and unit tests before every commit in lfx-self-serve
+alwaysApply: true
+---
+
+# Pre-commit: format, lint, and unit tests before every commit
+
+Always run all three checks on the changed files before staging and committing. A missed step is the most common cause of a red CI check.
+
+## 1. Format
+
+```bash
+# Format changed files
+npx prettier --write "<path(s) to changed files>"
+
+# Verify formatting passes CI check
+yarn format:check "<path(s) to changed files>"
+```
+
+The CI "Code Quality Checks" job runs `yarn format:check` over all files and fails if any file has Prettier diffs.
+
+## 2. Lint
+
+```bash
+# Lint (repo-wide; use --filter to scope when faster)
+yarn lint
+```
+
+## 3. Unit tests
+
+```bash
+# Full test suite (server vitest + Angular builder)
+yarn test
+```
+
+The CI "Code Quality Checks" job runs `yarn test` across all packages. Always run this locally before committing — the most common test failures are:
+
+- A new method added to a service but **not added to the service mock** in the component spec (causes `TypeError: this.fooService.newMethod is not a function` as an unhandled exception at runtime, which CI counts as a test failure even if the assertion tests all pass)
+- A shared constant renamed without updating the spec that imports it
+
+When adding a method to a service that already has a spec and a mock provider, always add the method to the mock's `useValue` object in the spec.
+
+## Run order
+
+Format → lint → test. If any step fails, fix before committing.

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.html
@@ -6,7 +6,7 @@
   position="right"
   [modal]="true"
   [showCloseIcon]="false"
-  styleClass="xl:w-[45%] lg:w-[55%] md:w-[75%] sm:w-[92%] w-full"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full"
   data-testid="weekly-brief-archive-drawer">
   <ng-template #header>
     <div class="flex items-center justify-between w-full pr-4" data-testid="weekly-brief-archive-drawer-header">

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.html
@@ -1,0 +1,92 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  [showCloseIcon]="false"
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[75%] sm:w-[92%] w-full"
+  data-testid="weekly-brief-archive-drawer">
+  <ng-template #header>
+    <div class="flex items-center justify-between w-full pr-4" data-testid="weekly-brief-archive-drawer-header">
+      <div class="flex flex-col gap-0.5">
+        <h2 class="text-lg font-semibold text-slate-900">Past Briefs</h2>
+        <p class="text-xs text-slate-500">Previously generated weekly briefs for this committee</p>
+      </div>
+      <button
+        type="button"
+        (click)="onClose()"
+        class="p-2 text-slate-400 hover:text-slate-600 hover:bg-slate-100 rounded-md transition-colors"
+        data-testid="weekly-brief-archive-drawer-close"
+        aria-label="Close panel">
+        <i class="fa-light fa-xmark text-xl"></i>
+      </button>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-4 py-2" data-testid="weekly-brief-archive-drawer-body">
+    @if (loading()) {
+      <div class="flex flex-col gap-4">
+        @for (n of [1, 2, 3]; track n) {
+          <div class="flex flex-col gap-2 p-4 rounded-lg border border-slate-200">
+            <p-skeleton width="40%" height="1rem" />
+            <p-skeleton width="100%" height="0.875rem" />
+            <p-skeleton width="90%" height="0.875rem" />
+            <p-skeleton width="80%" height="0.875rem" />
+          </div>
+        }
+      </div>
+    } @else if (error()) {
+      <div class="flex flex-col items-center justify-center gap-3 py-12" data-testid="weekly-brief-archive-drawer-error">
+        <i class="fa-light fa-triangle-exclamation text-2xl text-slate-400"></i>
+        <span class="text-sm text-slate-600">Failed to load past briefs.</span>
+        <lfx-button
+          label="Retry"
+          severity="secondary"
+          [outlined]="true"
+          size="small"
+          (onClick)="onRetry()"
+          data-testid="weekly-brief-archive-drawer-retry-button" />
+      </div>
+    } @else if (briefs().length === 0) {
+      <div class="flex flex-col items-center justify-center gap-3 py-12" data-testid="weekly-brief-archive-drawer-empty">
+        <i class="fa-light fa-clock-rotate-left text-2xl text-slate-400"></i>
+        <span class="text-sm text-slate-600">No past briefs yet.</span>
+      </div>
+    } @else {
+      @for (brief of briefs(); track brief.uid) {
+        <div class="flex flex-col gap-2 p-4 rounded-lg border border-slate-200" [attr.data-testid]="'weekly-brief-archive-entry-' + brief.uid">
+          <div class="flex items-center justify-between gap-2">
+            <span class="text-sm font-semibold text-slate-800" [attr.data-testid]="'weekly-brief-archive-date-' + brief.uid">
+              {{ formatDateRange(brief.window_start, brief.window_end) }}
+            </span>
+            <lfx-tag [value]="stateLabel(brief.state)" [severity]="stateSeverity(brief.state)" [attr.data-testid]="'weekly-brief-archive-state-' + brief.uid" />
+          </div>
+          <p class="text-sm text-slate-600 whitespace-pre-wrap leading-relaxed m-0" [attr.data-testid]="'weekly-brief-archive-text-' + brief.uid">
+            {{ brief.brief_text }}
+          </p>
+        </div>
+      }
+
+      @if (hasMore()) {
+        <div class="flex justify-center pt-2">
+          <lfx-button
+            label="Load more"
+            severity="secondary"
+            [text]="true"
+            [loading]="loadingMore()"
+            size="small"
+            (onClick)="onLoadMore()"
+            data-testid="weekly-brief-archive-load-more-button" />
+        </div>
+      }
+    }
+  </div>
+
+  <ng-template #footer>
+    <div class="flex items-center justify-end gap-3 w-full px-1 py-3 border-t border-slate-200" data-testid="weekly-brief-archive-drawer-footer">
+      <lfx-button label="Close" severity="secondary" [text]="true" size="small" (onClick)="onClose()" data-testid="weekly-brief-archive-drawer-close-button" />
+    </div>
+  </ng-template>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.scss
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.scss
@@ -1,0 +1,2 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
@@ -41,7 +41,10 @@ export class WeeklyBriefArchiveDrawerComponent {
 
   public constructor() {
     // Lazy fetch: load on first open; clear on close so a reopened drawer always starts fresh.
+    // committeeId() is read here so Angular tracks it — a change while visible re-triggers load()
+    // and cancels any stale in-flight request for the previous committee.
     effect(() => {
+      this.committeeId(); // track as dependency
       if (this.visible()) {
         this.load();
       } else {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
@@ -75,8 +75,10 @@ export class WeeklyBriefArchiveDrawerComponent {
           this.hasMore.set(!!response.page_token);
         },
         error: () => {
-          // A load-more failure only surfaces via the console — the existing briefs remain visible.
+          // A load-more failure hides the button so the user is not left in a retry loop.
+          // The existing briefs remain visible.
           console.error('[weekly-brief-archive-drawer] failed to load more briefs');
+          this.hasMore.set(false);
         },
       });
   }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
@@ -5,15 +5,13 @@ import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input, 
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { WEEKLY_BRIEF_SHAREABLE_STATES } from '@lfx-one/shared/constants';
+import { WEEKLY_BRIEF_ARCHIVE_PAGE_SIZE, WEEKLY_BRIEF_SHAREABLE_STATES } from '@lfx-one/shared/constants';
 import { WeeklyBrief } from '@lfx-one/shared/interfaces';
 import { formatUtcDateRangeLabel } from '@lfx-one/shared/utils';
 import { WeeklyBriefService } from '@services/weekly-brief.service';
 import { DrawerModule } from 'primeng/drawer';
 import { SkeletonModule } from 'primeng/skeleton';
 import { finalize } from 'rxjs';
-
-const ARCHIVE_PAGE_SIZE = 10;
 
 @Component({
   selector: 'lfx-weekly-brief-archive-drawer',
@@ -64,7 +62,7 @@ export class WeeklyBriefArchiveDrawerComponent {
     if (this.loadingMore() || !this.hasMore()) return;
     this.loadingMore.set(true);
     this.weeklyBriefService
-      .listWeeklyBriefs(this.committeeId(), { limit: ARCHIVE_PAGE_SIZE, page_token: this.nextCursor })
+      .listWeeklyBriefs(this.committeeId(), { limit: WEEKLY_BRIEF_ARCHIVE_PAGE_SIZE, page_token: this.nextCursor })
       .pipe(
         finalize(() => this.loadingMore.set(false)),
         takeUntilDestroyed(this.destroyRef)
@@ -113,7 +111,7 @@ export class WeeklyBriefArchiveDrawerComponent {
     this.reset();
     this.loading.set(true);
     this.weeklyBriefService
-      .listWeeklyBriefs(this.committeeId(), { limit: ARCHIVE_PAGE_SIZE })
+      .listWeeklyBriefs(this.committeeId(), { limit: WEEKLY_BRIEF_ARCHIVE_PAGE_SIZE })
       .pipe(
         finalize(() => this.loading.set(false)),
         takeUntilDestroyed(this.destroyRef)

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-archive-drawer/weekly-brief-archive-drawer.component.ts
@@ -1,0 +1,142 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, DestroyRef, effect, inject, input, model, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { ButtonComponent } from '@components/button/button.component';
+import { TagComponent } from '@components/tag/tag.component';
+import { WEEKLY_BRIEF_SHAREABLE_STATES } from '@lfx-one/shared/constants';
+import { WeeklyBrief } from '@lfx-one/shared/interfaces';
+import { formatUtcDateRangeLabel } from '@lfx-one/shared/utils';
+import { WeeklyBriefService } from '@services/weekly-brief.service';
+import { DrawerModule } from 'primeng/drawer';
+import { SkeletonModule } from 'primeng/skeleton';
+import { finalize } from 'rxjs';
+
+const ARCHIVE_PAGE_SIZE = 10;
+
+@Component({
+  selector: 'lfx-weekly-brief-archive-drawer',
+  imports: [DrawerModule, ButtonComponent, TagComponent, SkeletonModule],
+  templateUrl: './weekly-brief-archive-drawer.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class WeeklyBriefArchiveDrawerComponent {
+  // === Services ===
+  private readonly weeklyBriefService = inject(WeeklyBriefService);
+  private readonly destroyRef = inject(DestroyRef);
+
+  // === Inputs ===
+  public readonly committeeId = input.required<string>();
+
+  // === Model (two-way) ===
+  public readonly visible = model<boolean>(false);
+
+  // === State ===
+  public readonly loading = signal(false);
+  public readonly loadingMore = signal(false);
+  public readonly error = signal(false);
+  public readonly briefs = signal<WeeklyBrief[]>([]);
+  public readonly hasMore = signal(false);
+
+  private nextCursor: string | undefined;
+
+  public constructor() {
+    // Lazy fetch: load on first open; clear on close so a reopened drawer always starts fresh.
+    effect(() => {
+      if (this.visible()) {
+        this.load();
+      } else {
+        this.reset();
+      }
+    });
+  }
+
+  public onClose(): void {
+    this.visible.set(false);
+  }
+
+  public onRetry(): void {
+    this.load();
+  }
+
+  public onLoadMore(): void {
+    if (this.loadingMore() || !this.hasMore()) return;
+    this.loadingMore.set(true);
+    this.weeklyBriefService
+      .listWeeklyBriefs(this.committeeId(), { limit: ARCHIVE_PAGE_SIZE, page_token: this.nextCursor })
+      .pipe(
+        finalize(() => this.loadingMore.set(false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: (response) => {
+          const filtered = (response.data ?? []).filter((b) => WEEKLY_BRIEF_SHAREABLE_STATES.includes(b.state));
+          this.briefs.update((prev) => [...prev, ...filtered]);
+          this.nextCursor = response.page_token;
+          this.hasMore.set(!!response.page_token);
+        },
+        error: () => {
+          // A load-more failure only surfaces via the console — the existing briefs remain visible.
+          console.error('[weekly-brief-archive-drawer] failed to load more briefs');
+        },
+      });
+  }
+
+  protected formatDateRange(windowStart: string, windowEnd: string): string {
+    return formatUtcDateRangeLabel(windowStart, windowEnd);
+  }
+
+  protected stateLabel(state: WeeklyBrief['state']): string {
+    switch (state) {
+      case 'approved':
+        return 'Approved';
+      case 'edited':
+        return 'Edited';
+      default:
+        return 'Generated';
+    }
+  }
+
+  protected stateSeverity(state: WeeklyBrief['state']): 'success' | 'info' | 'secondary' {
+    switch (state) {
+      case 'approved':
+        return 'success';
+      case 'edited':
+        return 'info';
+      default:
+        return 'secondary';
+    }
+  }
+
+  private load(): void {
+    this.reset();
+    this.loading.set(true);
+    this.weeklyBriefService
+      .listWeeklyBriefs(this.committeeId(), { limit: ARCHIVE_PAGE_SIZE })
+      .pipe(
+        finalize(() => this.loading.set(false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe({
+        next: (response) => {
+          const filtered = (response.data ?? []).filter((b) => WEEKLY_BRIEF_SHAREABLE_STATES.includes(b.state));
+          this.briefs.set(filtered);
+          this.nextCursor = response.page_token;
+          this.hasMore.set(!!response.page_token);
+          this.error.set(false);
+        },
+        error: () => {
+          console.error('[weekly-brief-archive-drawer] failed to load brief archive');
+          this.error.set(true);
+        },
+      });
+  }
+
+  private reset(): void {
+    this.briefs.set([]);
+    this.nextCursor = undefined;
+    this.hasMore.set(false);
+    this.error.set(false);
+  }
+}

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -209,6 +209,19 @@
                 data-testid="weekly-brief-card-share-slack-button" />
             }
           </div>
+
+          @if (hasArchiveBriefs()) {
+            <div class="flex">
+              <button
+                type="button"
+                class="text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+                (click)="onOpenArchive()"
+                data-testid="weekly-brief-card-past-briefs-button">
+                View past briefs
+              </button>
+            </div>
+          }
+
           <!-- Visible hints rather than tooltips on these disabled buttons: a
                disabled native <button> never receives focus/hover, so a
                tooltip-only explanation would be unreachable by keyboard and
@@ -263,3 +276,5 @@
 
   <p-confirmDialog />
 }
+
+<lfx-weekly-brief-archive-drawer [(visible)]="archiveVisible" [committeeId]="committee().uid" />

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -75,6 +75,7 @@ describe('WeeklyBriefCardComponent — Share to Slack (LFXV2-3080)', () => {
           useValue: {
             getWeeklyBrief: vi.fn(() => of(BRIEF_RESPONSE)),
             shareWeeklyBriefToSlack,
+            listWeeklyBriefs: vi.fn(() => of({ data: [] })),
           },
         },
         { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(true)) } },

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -16,6 +16,7 @@ import {
   WEEKLY_BRIEF_ERROR_REASON,
   WEEKLY_BRIEF_MAX_POLL_ATTEMPTS,
   WEEKLY_BRIEF_POLL_INTERVAL_MS,
+  WEEKLY_BRIEF_SHAREABLE_STATES,
   WEEKLY_BRIEF_TERMINAL_STATES,
   WEEKLY_BRIEF_TEXT_MAX_LENGTH,
   WG_WEEKLY_BRIEF_SLACK_FLAG,
@@ -585,7 +586,8 @@ export class WeeklyBriefCardComponent {
         takeUntilDestroyed(this.destroyRef)
       )
       .subscribe((response) => {
-        this.hasArchiveBriefs.set((response?.data?.length ?? 0) > 0);
+        const shareable = (response?.data ?? []).filter((b) => WEEKLY_BRIEF_SHAREABLE_STATES.includes(b.state));
+        this.hasArchiveBriefs.set(shareable.length > 0);
       });
     combineLatest([committeeUid$, this.refresh$])
       .pipe(

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -11,6 +11,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { TextareaComponent } from '@components/textarea/textarea.component';
+import { WeeklyBriefArchiveDrawerComponent } from '../weekly-brief-archive-drawer/weekly-brief-archive-drawer.component';
 import {
   WEEKLY_BRIEF_ERROR_REASON,
   WEEKLY_BRIEF_MAX_POLL_ATTEMPTS,
@@ -21,6 +22,7 @@ import {
 } from '@lfx-one/shared/constants';
 import {
   Committee,
+  PaginatedResponse,
   ShareWeeklyBriefResult,
   ValidationError,
   WeeklyBrief,
@@ -61,7 +63,16 @@ import {
 
 @Component({
   selector: 'lfx-weekly-brief-card',
-  imports: [CardComponent, ButtonComponent, SkeletonModule, ReactiveFormsModule, TextareaComponent, ConfirmDialogModule, TagComponent],
+  imports: [
+    CardComponent,
+    ButtonComponent,
+    SkeletonModule,
+    ReactiveFormsModule,
+    TextareaComponent,
+    ConfirmDialogModule,
+    TagComponent,
+    WeeklyBriefArchiveDrawerComponent,
+  ],
   templateUrl: './weekly-brief-card.component.html',
   styleUrl: './weekly-brief-card.component.scss',
   changeDetection: ChangeDetectionStrategy.OnPush,
@@ -126,6 +137,14 @@ export class WeeklyBriefCardComponent {
   // racing the first before the optimistic state has settled.
   public readonly ratingPending = signal(false);
 
+  // Archive drawer visibility and availability signals.
+  // `hasArchiveBriefs` starts false and is set by a limit=1 preflight that fires once
+  // the current brief becomes available — avoids showing a "Past Briefs" button that
+  // opens to an empty drawer (LFXV2-3046 requirement: hide the affordance when < 2 briefs
+  // total exist, i.e. no archived past weeks).
+  public readonly archiveVisible = signal(false);
+  public readonly hasArchiveBriefs = signal(false);
+
   // Written by both the initial-load pipeline and the post-generate poll (see
   // initBriefResponseSubscription / pollUntilTerminal) — a plain signal rather than
   // toSignal(), since the poll needs to push updates outside that pipeline's own stream.
@@ -154,6 +173,10 @@ export class WeeklyBriefCardComponent {
   // a fresh, never-cleaned-up effect (Angular releases it only on component destroy) on
   // every single generate/regenerate/load-into-generating call, not just once.
   private readonly committee$ = toObservable(this.committee);
+
+  // Observable mirror of briefResponse for use in reactive pipelines that need to react
+  // to the brief loading (e.g. the archive-available preflight).
+  private readonly briefResponse$ = toObservable(this.briefResponse);
 
   // Guards against starting a second concurrent poll — pollUntilTerminal is reachable
   // both from onGenerate and from the initial-load pipeline (a page load / navigation
@@ -226,6 +249,10 @@ export class WeeklyBriefCardComponent {
   }
 
   // Public actions
+  public onOpenArchive(): void {
+    this.archiveVisible.set(true);
+  }
+
   public onGenerate(): void {
     if (this.generating()) return;
     const committeeUid = this.committee()?.uid;
@@ -536,7 +563,30 @@ export class WeeklyBriefCardComponent {
       this.editForm.reset({ briefText: '' });
       this.ratingPending.set(false);
       this.optimisticRating.set(null);
+      // Reset archive state when navigating between committees.
+      this.hasArchiveBriefs.set(false);
+      this.archiveVisible.set(false);
     });
+
+    // Archive preflight — fires once per committee when the current brief first becomes
+    // available. A limit=1 fetch confirms at least one past brief exists before the
+    // "Past Briefs" button is shown, per LFXV2-3046's "< 2 total → hide affordance" rule.
+    committeeUid$
+      .pipe(
+        switchMap((uid) =>
+          this.briefResponse$.pipe(
+            filter((r): r is WeeklyBriefCurrentResponse => !!r?.brief),
+            take(1),
+            switchMap(() =>
+              this.weeklyBriefService.listWeeklyBriefs(uid, { limit: 1 }).pipe(catchError(() => of(null as PaginatedResponse<WeeklyBrief> | null)))
+            )
+          )
+        ),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((response) => {
+        this.hasArchiveBriefs.set((response?.data?.length ?? 0) > 0);
+      });
     combineLatest([committeeUid$, this.refresh$])
       .pipe(
         switchMap(([uid]) => {

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -143,6 +143,8 @@ export class WeeklyBriefService {
    * errors itself and surfaces a retry affordance.
    */
   public listWeeklyBriefs(committeeId: string, params?: { limit?: number; page_token?: string }): Observable<PaginatedResponse<WeeklyBrief>> {
-    return this.http.get<PaginatedResponse<WeeklyBrief>>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs`, { params: { ...(params ?? {}) } });
+    return this.http
+      .get<PaginatedResponse<WeeklyBrief>>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs`, { params: { ...(params ?? {}) } })
+      .pipe(take(1));
   }
 }

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -7,6 +7,7 @@ import {
   GenerateWeeklyBriefRequest,
   GenerateWeeklyBriefResponse,
   GetWeeklyBriefActionItemsResponse,
+  PaginatedResponse,
   RateWeeklyBriefRequest,
   RateWeeklyBriefResponse,
   SaveWeeklyBriefRequest,
@@ -132,5 +133,16 @@ export class WeeklyBriefService {
     return this.http
       .delete<void>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs/${encodeURIComponent(briefUid)}/rating`, { body: { revision } })
       .pipe(take(1));
+  }
+
+  /**
+   * GET /api/committees/:committeeId/weekly-briefs
+   *
+   * Paginated archive list of past briefs for the committee, sourced from the
+   * query-service `group_weekly_brief` index. No `catchError` — the drawer classifies
+   * errors itself and surfaces a retry affordance.
+   */
+  public listWeeklyBriefs(committeeId: string, params?: { limit?: number; page_token?: string }): Observable<PaginatedResponse<WeeklyBrief>> {
+    return this.http.get<PaginatedResponse<WeeklyBrief>>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs`, { params: { ...(params ?? {}) } });
   }
 }

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -193,6 +193,45 @@ export class WeeklyBriefController {
   }
 
   /**
+   * GET /api/committees/:committeeId/weekly-briefs
+   *
+   * Paginated archive list of past briefs for the committee, sourced from the query-service
+   * `group_weekly_brief` index. Gated by `assertCommitteeRead` — same access contract as
+   * getCurrentBrief (committee#auditor). Returns `{ data: WeeklyBrief[], page_token? }`.
+   */
+  public async listBriefs(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { committeeId } = req.params;
+    const startTime = logger.startOperation(req, 'list_weekly_briefs', {
+      committee_id: committeeId,
+    });
+
+    try {
+      if (
+        !validateUidParameter(committeeId, req, next, {
+          operation: 'list_weekly_briefs',
+          service: 'weekly_brief_controller',
+        })
+      ) {
+        return;
+      }
+
+      await assertCommitteeRead(req, committeeId, 'list_weekly_briefs');
+
+      const { data, page_token } = await this.weeklyBriefService.listBriefs(req, committeeId, req.query as Record<string, string>);
+
+      logger.success(req, 'list_weekly_briefs', startTime, {
+        committee_id: committeeId,
+        count: data.length,
+        has_more_pages: !!page_token,
+      });
+
+      res.json({ data, page_token });
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /api/committees/:committeeId/weekly-briefs/action-items
    *
    * Gated by `assertCommitteeRead` (committee#auditor) — same gate as getCurrentBrief, since

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -218,7 +218,8 @@ export class WeeklyBriefController {
       await assertCommitteeRead(req, committeeId, 'list_weekly_briefs');
 
       const limit = typeof req.query['limit'] === 'string' ? req.query['limit'] : undefined;
-      const pageToken = typeof req.query['page_token'] === 'string' ? req.query['page_token'] : undefined;
+      const rawPageToken = req.query['page_token'];
+      const pageToken = typeof rawPageToken === 'string' && rawPageToken.length <= 512 ? rawPageToken : undefined;
       const { data, page_token } = await this.weeklyBriefService.listBriefs(req, committeeId, {
         ...(limit && { limit }),
         ...(pageToken && { page_token: pageToken }),

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -217,7 +217,12 @@ export class WeeklyBriefController {
 
       await assertCommitteeRead(req, committeeId, 'list_weekly_briefs');
 
-      const { data, page_token } = await this.weeklyBriefService.listBriefs(req, committeeId, req.query as Record<string, string>);
+      const limit = typeof req.query['limit'] === 'string' ? req.query['limit'] : undefined;
+      const pageToken = typeof req.query['page_token'] === 'string' ? req.query['page_token'] : undefined;
+      const { data, page_token } = await this.weeklyBriefService.listBriefs(req, committeeId, {
+        ...(limit && { limit }),
+        ...(pageToken && { page_token: pageToken }),
+      });
 
       logger.success(req, 'list_weekly_briefs', startTime, {
         committee_id: committeeId,

--- a/apps/lfx-one/src/server/routes/weekly-brief.route.ts
+++ b/apps/lfx-one/src/server/routes/weekly-brief.route.ts
@@ -11,7 +11,8 @@ const router = Router();
 const weeklyBriefController = new WeeklyBriefController();
 
 // GET /committees/:committeeId/weekly-briefs - paginated archive list via query-service
-// Registered before /current to avoid Express treating "current" as a :briefSegment wildcard.
+// Registered before /current so any future /:committeeId/weekly-briefs/:subpath routes
+// are not shadowed by a later-added wildcard route at this depth.
 router.get('/:committeeId/weekly-briefs', (req, res, next) => weeklyBriefController.listBriefs(req, res, next));
 
 // GET /committees/:committeeId/weekly-briefs/current - get the current WG weekly brief

--- a/apps/lfx-one/src/server/routes/weekly-brief.route.ts
+++ b/apps/lfx-one/src/server/routes/weekly-brief.route.ts
@@ -10,6 +10,10 @@ const router = Router();
 
 const weeklyBriefController = new WeeklyBriefController();
 
+// GET /committees/:committeeId/weekly-briefs - paginated archive list via query-service
+// Registered before /current to avoid Express treating "current" as a :briefSegment wildcard.
+router.get('/:committeeId/weekly-briefs', (req, res, next) => weeklyBriefController.listBriefs(req, res, next));
+
 // GET /committees/:committeeId/weekly-briefs/current - get the current WG weekly brief
 router.get('/:committeeId/weekly-briefs/current', (req, res, next) => weeklyBriefController.getCurrentBrief(req, res, next));
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -264,18 +264,19 @@ export class WeeklyBriefService {
       logger.debug(req, 'list_weekly_briefs', 'Returning mock brief archive', { committee_id: committeeId });
       return {
         data: [buildMockWeeklyBrief(committeeId, -1), buildMockWeeklyBrief(committeeId, -2), buildMockWeeklyBrief(committeeId, -3)],
+        page_token: query['page_token'] ? undefined : 'mock-cursor-page-2',
       };
     }
 
     logger.debug(req, 'list_weekly_briefs', 'Querying group_weekly_brief index', { committee_id: committeeId });
 
     const rawLimit = parseInt(query['limit'] ?? '', 10);
-    const limit = !isNaN(rawLimit) && rawLimit > 0 ? String(Math.min(rawLimit, 50)) : undefined;
+    const limit = !isNaN(rawLimit) && rawLimit > 0 ? Math.min(rawLimit, 50) : 20;
 
     const params: Record<string, string | undefined> = {
       type: 'group_weekly_brief',
       tags: `committee_uid:${committeeId}`,
-      ...(limit && { limit }),
+      limit: String(limit),
       ...(query['page_token'] && { page_token: query['page_token'] }),
     };
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -262,9 +262,12 @@ export class WeeklyBriefService {
   public async listBriefs(req: Request, committeeId: string, query: { limit?: string; page_token?: string } = {}): Promise<PaginatedResponse<WeeklyBrief>> {
     if (!this.isLive(req)) {
       logger.debug(req, 'list_weekly_briefs', 'Returning mock brief archive', { committee_id: committeeId });
+      const isSecondPage = !!query['page_token'];
       return {
-        data: [buildMockWeeklyBrief(committeeId, -1), buildMockWeeklyBrief(committeeId, -2), buildMockWeeklyBrief(committeeId, -3)],
-        page_token: query['page_token'] ? undefined : 'mock-cursor-page-2',
+        data: isSecondPage
+          ? [buildMockWeeklyBrief(committeeId, -4), buildMockWeeklyBrief(committeeId, -5), buildMockWeeklyBrief(committeeId, -6)]
+          : [buildMockWeeklyBrief(committeeId, -1), buildMockWeeklyBrief(committeeId, -2), buildMockWeeklyBrief(committeeId, -3)],
+        page_token: isSecondPage ? undefined : 'mock-cursor-page-2',
       };
     }
 
@@ -276,7 +279,7 @@ export class WeeklyBriefService {
     const params: Record<string, string | undefined> = {
       type: 'group_weekly_brief',
       tags: `committee_uid:${committeeId}`,
-      limit: String(limit),
+      page_size: String(limit),
       ...(query['page_token'] && { page_token: query['page_token'] }),
     };
 
@@ -288,7 +291,9 @@ export class WeeklyBriefService {
       params
     );
 
-    return { data: resources.map((r) => r.data), page_token };
+    // Exclude the current week's brief (window hasn't closed yet) — the card already shows it.
+    const now = new Date();
+    return { data: resources.map((r) => r.data).filter((b) => new Date(b.window_end) < now), page_token };
   }
 
   /**

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -253,13 +253,13 @@ export class WeeklyBriefService {
    * GET /committees/:committeeId/weekly-briefs (paginated archive list)
    *
    * Live mode: queries the query-service `group_weekly_brief` index filtered by
-   * `committee_uid` tag. The query-service enforces the same `committee:{uid}#viewer`
-   * access check that `getCurrentBrief` relies on upstream — no separate FGA call needed.
+   * `committee_uid` tag. Access is gated at the controller layer via `assertCommitteeRead`
+   * before this method is called — do not invoke without a prior access check.
    *
    * Mock mode: returns three canned past briefs (previous three weeks) so the archive
    * drawer is fully exercisable locally without standing up the upstream index.
    */
-  public async listBriefs(req: Request, committeeId: string, query: Record<string, string> = {}): Promise<PaginatedResponse<WeeklyBrief>> {
+  public async listBriefs(req: Request, committeeId: string, query: { limit?: string; page_token?: string } = {}): Promise<PaginatedResponse<WeeklyBrief>> {
     if (!this.isLive(req)) {
       logger.debug(req, 'list_weekly_briefs', 'Returning mock brief archive', { committee_id: committeeId });
       return {
@@ -269,10 +269,13 @@ export class WeeklyBriefService {
 
     logger.debug(req, 'list_weekly_briefs', 'Querying group_weekly_brief index', { committee_id: committeeId });
 
+    const rawLimit = parseInt(query['limit'] ?? '', 10);
+    const limit = !isNaN(rawLimit) && rawLimit > 0 ? String(Math.min(rawLimit, 50)) : undefined;
+
     const params: Record<string, string | undefined> = {
       type: 'group_weekly_brief',
       tags: `committee_uid:${committeeId}`,
-      ...(query['limit'] && { limit: query['limit'] }),
+      ...(limit && { limit }),
       ...(query['page_token'] && { page_token: query['page_token'] }),
     };
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -17,6 +17,8 @@ import {
   GetWeeklyBriefActionItemsResponse,
   Newsletter,
   NewsletterSendResult,
+  PaginatedResponse,
+  QueryServiceResponse,
   RateWeeklyBriefResponse,
   SaveWeeklyBriefRequest,
   ShareWeeklyBriefResult,
@@ -141,14 +143,23 @@ export function __resetMockBriefStateForTesting(): void {
   mockBriefByCommittee.clear();
 }
 
-function buildMockBrief(committeeId: string, overrides: Partial<WeeklyBrief> = {}): WeeklyBrief {
+/**
+ * Builds a mock WeeklyBrief shifted by `windowOffsetWeeks` relative to the current window.
+ * Pass 0 for the current week, -1 for last week, -2 for two weeks ago, etc.
+ * Used by both `buildMockBrief` (current-week mock) and `listBriefs` (archive mocks).
+ */
+function buildMockWeeklyBrief(committeeId: string, windowOffsetWeeks: number, overrides: Partial<WeeklyBrief> = {}): WeeklyBrief {
   const nowIso = new Date().toISOString();
-  const { window_start, window_end } = briefWindow();
+  const base = briefWindow();
+  const offsetMs = windowOffsetWeeks * 7 * 24 * 60 * 60 * 1000;
+  const windowStart = new Date(new Date(base.window_start).getTime() + offsetMs).toISOString();
+  const windowEnd = new Date(new Date(base.window_end).getTime() + offsetMs).toISOString();
+  const indexSuffix = String(Math.abs(windowOffsetWeeks)).padStart(2, '0');
   return {
-    uid: 'wb_mock_00000000-0000-0000-0000-000000000001',
+    uid: `wb_mock_00000000-0000-0000-0000-0000000000${indexSuffix}`,
     committee_uid: committeeId,
-    window_start,
-    window_end,
+    window_start: windowStart,
+    window_end: windowEnd,
     state: 'generated',
     brief_text:
       'This week the working group made steady progress across collaboration and delivery streams. ' +
@@ -179,6 +190,10 @@ function buildMockBrief(committeeId: string, overrides: Partial<WeeklyBrief> = {
     revision: 1,
     ...overrides,
   };
+}
+
+function buildMockBrief(committeeId: string, overrides: Partial<WeeklyBrief> = {}): WeeklyBrief {
+  return buildMockWeeklyBrief(committeeId, 0, overrides);
 }
 
 /**
@@ -232,6 +247,44 @@ export class WeeklyBriefService {
       );
     }
     return this.withCallerRating(req, committeeId, response);
+  }
+
+  /**
+   * GET /committees/:committeeId/weekly-briefs (paginated archive list)
+   *
+   * Live mode: queries the query-service `group_weekly_brief` index filtered by
+   * `committee_uid` tag. The query-service enforces the same `committee:{uid}#viewer`
+   * access check that `getCurrentBrief` relies on upstream — no separate FGA call needed.
+   *
+   * Mock mode: returns three canned past briefs (previous three weeks) so the archive
+   * drawer is fully exercisable locally without standing up the upstream index.
+   */
+  public async listBriefs(req: Request, committeeId: string, query: Record<string, string> = {}): Promise<PaginatedResponse<WeeklyBrief>> {
+    if (!this.isLive(req)) {
+      logger.debug(req, 'list_weekly_briefs', 'Returning mock brief archive', { committee_id: committeeId });
+      return {
+        data: [buildMockWeeklyBrief(committeeId, -1), buildMockWeeklyBrief(committeeId, -2), buildMockWeeklyBrief(committeeId, -3)],
+      };
+    }
+
+    logger.debug(req, 'list_weekly_briefs', 'Querying group_weekly_brief index', { committee_id: committeeId });
+
+    const params: Record<string, string | undefined> = {
+      type: 'group_weekly_brief',
+      tags: `committee_uid:${committeeId}`,
+      ...(query['limit'] && { limit: query['limit'] }),
+      ...(query['page_token'] && { page_token: query['page_token'] }),
+    };
+
+    const { resources, page_token } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<WeeklyBrief>>(
+      req,
+      'LFX_V2_SERVICE',
+      '/query/resources',
+      'GET',
+      params
+    );
+
+    return { data: resources.map((r) => r.data), page_token };
   }
 
   /**

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -65,5 +65,5 @@ export const WEEKLY_BRIEF_TERMINAL_STATES: ReadonlySet<WeeklyBriefState> = new S
  */
 export const WEEKLY_BRIEF_ERROR_REASON = { NO_SOURCES: 'no_sources' } as const;
 
-/** Number of past briefs fetched per page in the archive drawer (LFXV2-3046). */
+/** Number of past briefs fetched per page in the archive drawer (LFXV2-3046). The BFF caps all limit values at 50. */
 export const WEEKLY_BRIEF_ARCHIVE_PAGE_SIZE = 10;

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -64,3 +64,6 @@ export const WEEKLY_BRIEF_TERMINAL_STATES: ReadonlySet<WeeklyBriefState> = new S
  * `WeeklyBriefErrorReason` in `weekly-brief.interface.ts` for the derived type.
  */
 export const WEEKLY_BRIEF_ERROR_REASON = { NO_SOURCES: 'no_sources' } as const;
+
+/** Number of past briefs fetched per page in the archive drawer (LFXV2-3046). */
+export const WEEKLY_BRIEF_ARCHIVE_PAGE_SIZE = 10;


### PR DESCRIPTION
## Summary

- Adds a paginated read-only archive drawer (`WeeklyBriefArchiveDrawerComponent`) for past weekly briefs on each committee
- New BFF endpoint `GET /api/committees/:committeeId/weekly-briefs` queries the `group_weekly_brief` query-service index with `committee_uid` tag filtering
- "View past briefs" affordance on the Weekly Brief card is shown only after a `limit=1` preflight confirms at least one shareable-state brief exists in the index

## Motivation

LFXV2-3046 — committee co-chairs and EDs need to review and reference past weekly briefs that have already been generated for prior weeks.

## What changed

| File | Change |
|---|---|
| `server/routes/weekly-brief.route.ts` | New `GET /:committeeId/weekly-briefs` route registered before `/current` |
| `server/controllers/weekly-brief.controller.ts` | `listBriefs()`: `validateUidParameter` + `assertCommitteeRead` + typed `PaginatedResponse<WeeklyBrief>` |
| `server/services/weekly-brief.service.ts` | `listBriefs()`: queries `/query/resources?type=group_weekly_brief&tags=committee_uid:<id>`, default limit 20, cap 50; mock returns 3 past weeks with a first-page cursor so Load More is exercisable locally |
| `app/shared/services/weekly-brief.service.ts` | `listWeeklyBriefs()` Angular client method |
| `committees/components/weekly-brief-archive-drawer/` *(new)* | `WeeklyBriefArchiveDrawerComponent`: right-side `p-drawer`, lazy-loads on `visible=true`, Load More pagination (10/page), client-side `WEEKLY_BRIEF_SHAREABLE_STATES` filter, skeleton/empty/error states |
| `committees/components/weekly-brief-card/` | `archiveVisible` + `hasArchiveBriefs` signals; `limit=1` preflight gated behind current-brief presence; "View past briefs" link and drawer embed |
| `packages/shared/src/constants/weekly-brief.constants.ts` | `WEEKLY_BRIEF_ARCHIVE_PAGE_SIZE = 10` |

## External references

The BFF `listBriefs` queries the existing query-service `/query/resources` endpoint under the `group_weekly_brief` resource type. No upstream committee-service changes are required — the `group_weekly_brief` index is already published by the committee-service indexer (see LFXV2-3048 indexer contract: `committee_uid` tag).

## Known trade-offs

- **Lazy-load pattern**: The archive drawer uses `effect()` + imperative `subscribe` rather than the canonical `toObservable + skip(1) + switchMap` from `drawer-pattern.md`. The `effect` approach is functionally equivalent and `takeUntilDestroyed` correctly bounds the subscription to component lifetime. The closing-animation state flash (resetting briefs while the drawer is still animating closed) is a UX edge case acknowledged by the review — planned for follow-up refactor after this ships.
- **Archive preflight per navigation**: The `limit=1` preflight fires once per committee when the current brief first loads. For users browsing many committees this adds one round-trip per viewed committee with a brief — acceptable given it gates the drawer affordance correctly. The `hasArchiveBriefs` signal is reset on navigation which briefly hides the button before the preflight resolves; this is expected behavior.
- **Build failure pre-existing**: `yarn build` fails on `chartjs-chart-sankey` — this is a pre-existing missing-dependency issue on `main`, not introduced by this PR.

## Test plan

- [ ] Navigate to a committee with ≥1 past weekly brief in generated/edited/approved state → "View past briefs" link appears
- [ ] Navigate to a committee with no past briefs → link does not appear
- [ ] Click "View past briefs" → drawer opens, shows brief entries with date range + state badge + text
- [ ] Click "Load more" in the drawer → next page appends
- [ ] Simulate load-more error (devtools network block) → "Load more" button disappears
- [ ] Navigate between committees → archive state resets, preflight re-runs
- [ ] Close drawer → state resets, reopening triggers a fresh load
- [ ] Mock mode: open drawer → 3 mock past-week briefs shown, "Load more" available (mock cursor)

Resolves [LFXV2-3046](https://linuxfoundation.atlassian.net/browse/LFXV2-3046)

Made with [Cursor](https://cursor.com)

[LFXV2-3046]: https://linuxfoundation.atlassian.net/browse/LFXV2-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ