### PR TITLE
fix(cla): rename my clas to clas

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -81,7 +81,7 @@ export class ProfileLayoutComponent {
   // the initial GET, so we stash it and re-apply once a GET lands (see reapplyPendingOptimisticUpdate).
   private pendingOptimisticMetadata: Partial<UserMetadata> | null = null;
 
-  // Tab configuration. The read-only "My CLAs" tab is appended (before Transactions/Settings)
+  // Tab configuration. The read-only "CLAs" tab is appended (before Transactions/Settings)
   // only when the `my-clas-enabled` flag is on — matching the route's CanMatch guard.
   private readonly myClasEnabled = this.featureFlagService.getBooleanFlag(MY_CLAS_ENABLED_FLAG, false);
   public readonly tabs: Signal<ProfileTab[]> = computed(() => buildProfileTabs(this.myClasEnabled()));

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -46,7 +46,7 @@ SPDX-License-Identifier: MIT
         title="No CLAs on file yet"
         subtitle="We haven't found any signed ICLAs or ECLAs for your linked identities."
         ctaLabel="Learn about CLAs"
-        [ctaRoute]="['/docs', 'profile', 'my-clas']"
+        [ctaRoute]="['/docs', 'account', 'my-clas']"
         data-testid="my-clas-empty-state" />
     } @else {
       <lfx-table

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 <section class="flex flex-col gap-4" data-testid="my-clas">
   <!-- Header -->
   <div class="flex items-start justify-between gap-4">
-    <h2 class="text-lg font-semibold text-slate-800">My CLAs</h2>
+    <h2 class="text-lg font-semibold text-slate-800">CLAs</h2>
 
     <!-- Page-level, not per-row: signing a new CLA has no row to act on yet. -->
     @if (canSign()) {
@@ -36,7 +36,7 @@ SPDX-License-Identifier: MIT
     <lfx-message severity="info" [attr.data-testid]="'my-clas-info-banner'">
       <p class="text-sm">
         Your signed ICLAs (Individual CLA) and ECLAs (Employee CLA), matched to your Identities. Missing one?
-        <a class="font-semibold text-blue-600 hover:underline" routerLink="/profile/identities">Link your Email, GitHub, or GitLab accounts →</a>
+        <a class="font-semibold text-blue-600 hover:underline" routerLink="/profile/identities">Link your Email or GitHub accounts →</a>
       </p>
     </lfx-message>
 
@@ -45,7 +45,7 @@ SPDX-License-Identifier: MIT
         icon="fa-light fa-file-signature"
         title="No CLAs on file yet"
         subtitle="We haven't found any signed ICLAs or ECLAs for your linked identities."
-        ctaLabel="Learn about My CLAs"
+        ctaLabel="Learn about CLAs"
         [ctaRoute]="['/docs', 'profile', 'my-clas']"
         data-testid="my-clas-empty-state" />
     } @else {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -6,7 +6,7 @@ import { PLATFORM_ID, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideRouter } from '@angular/router';
+import { provideRouter, Router, RouterLink } from '@angular/router';
 import type { ClaGroupOption, MyClaAgreement, MyClasResponse } from '@lfx-one/shared/interfaces';
 import { MenuComponent } from '@components/menu/menu.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -113,8 +113,10 @@ describe('ProfileClasComponent', () => {
 
     const emptyState = fixture.debugElement.query(By.css('[data-testid="my-clas-empty-state"]'));
     expect(emptyState).toBeTruthy();
-    const cta = emptyState.query(By.css('a[href]'));
-    expect(cta.nativeElement.getAttribute('href')).toBe('/docs/account/my-clas');
+    const link = emptyState.query(By.directive(RouterLink));
+    if (!link) throw new Error('empty state rendered no RouterLink');
+    const urlTree = link.injector.get(RouterLink).urlTree;
+    expect(urlTree && TestBed.inject(Router).serializeUrl(urlTree)).toBe('/docs/account/my-clas');
   });
 
   it('shows the mockup sentence only for a completed Approved List miss', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -115,8 +115,9 @@ describe('ProfileClasComponent', () => {
     const emptyState = fixture.debugElement.query(By.css('[data-testid="my-clas-empty-state"]'));
     expect(emptyState).toBeTruthy();
     // Scoped to the `lfx-button` host rather than `By.directive(RouterLink)`: the wrapped `<p-button>`
-    // also matches `[routerLink]`, so an unscoped query would depend on DOM traversal order between
-    // the two RouterLink instances.
+    // also matches `[routerLink]`, so an unscoped query is ambiguous about which of the two instances
+    // it means, even though preorder traversal happens to resolve the host one today. Querying the
+    // host directly says which instance we mean and survives a change in nesting.
     const ctaButton = emptyState.query(By.directive(ButtonComponent));
     if (!ctaButton) throw new Error('empty state rendered no lfx-button CTA');
     const urlTree = ctaButton.injector.get(RouterLink).urlTree;

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -8,6 +8,7 @@ import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, RouterLink } from '@angular/router';
 import type { ClaGroupOption, MyClaAgreement, MyClasResponse } from '@lfx-one/shared/interfaces';
+import { ButtonComponent } from '@components/button/button.component';
 import { MenuComponent } from '@components/menu/menu.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { MyClasService } from '@services/my-clas.service';
@@ -113,10 +114,14 @@ describe('ProfileClasComponent', () => {
 
     const emptyState = fixture.debugElement.query(By.css('[data-testid="my-clas-empty-state"]'));
     expect(emptyState).toBeTruthy();
-    const link = emptyState.query(By.directive(RouterLink));
-    if (!link) throw new Error('empty state rendered no RouterLink');
-    const urlTree = link.injector.get(RouterLink).urlTree;
-    expect(urlTree && TestBed.inject(Router).serializeUrl(urlTree)).toBe('/docs/account/my-clas');
+    // Scoped to the `lfx-button` host rather than `By.directive(RouterLink)`: the wrapped `<p-button>`
+    // also matches `[routerLink]`, so an unscoped query would depend on DOM traversal order between
+    // the two RouterLink instances.
+    const ctaButton = emptyState.query(By.directive(ButtonComponent));
+    if (!ctaButton) throw new Error('empty state rendered no lfx-button CTA');
+    const urlTree = ctaButton.injector.get(RouterLink).urlTree;
+    if (!urlTree) throw new Error('empty state CTA resolved no urlTree');
+    expect(TestBed.inject(Router).serializeUrl(urlTree)).toBe('/docs/account/my-clas');
   });
 
   it('shows the mockup sentence only for a completed Approved List miss', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -6,7 +6,7 @@ import { PLATFORM_ID, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideRouter } from '@angular/router';
+import { provideRouter, RouterLink } from '@angular/router';
 import type { ClaGroupOption, MyClaAgreement, MyClasResponse } from '@lfx-one/shared/interfaces';
 import { MenuComponent } from '@components/menu/menu.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -106,6 +106,14 @@ describe('ProfileClasComponent', () => {
 
     expect(fixture.nativeElement.querySelector('[data-testid="my-clas-empty-state"]')).toBeNull();
     expect(fixture.nativeElement.querySelector('[data-testid="agreement-row-s-inv"]')).toBeTruthy();
+  });
+
+  it('empty state CTA routes to the CLAs docs article, not the pre-rename slug', async () => {
+    await render([]);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="my-clas-empty-state"]')).toBeTruthy();
+    const link = fixture.debugElement.query(By.directive(RouterLink));
+    expect(link.injector.get(RouterLink).routerLink).toEqual(['/docs', 'account', 'my-clas']);
   });
 
   it('shows the mockup sentence only for a completed Approved List miss', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -6,7 +6,7 @@ import { PLATFORM_ID, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { provideRouter, RouterLink } from '@angular/router';
+import { provideRouter } from '@angular/router';
 import type { ClaGroupOption, MyClaAgreement, MyClasResponse } from '@lfx-one/shared/interfaces';
 import { MenuComponent } from '@components/menu/menu.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -111,9 +111,10 @@ describe('ProfileClasComponent', () => {
   it('empty state CTA routes to the CLAs docs article, not the pre-rename slug', async () => {
     await render([]);
 
-    expect(fixture.nativeElement.querySelector('[data-testid="my-clas-empty-state"]')).toBeTruthy();
-    const link = fixture.debugElement.query(By.directive(RouterLink));
-    expect(link.injector.get(RouterLink).routerLink).toEqual(['/docs', 'account', 'my-clas']);
+    const emptyState = fixture.debugElement.query(By.css('[data-testid="my-clas-empty-state"]'));
+    expect(emptyState).toBeTruthy();
+    const cta = emptyState.query(By.css('a[href]'));
+    expect(cta.nativeElement.getAttribute('href')).toBe('/docs/account/my-clas');
   });
 
   it('shows the mockup sentence only for a completed Approved List miss', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -36,7 +36,7 @@ interface ClaRowStatus {
 }
 
 /**
- * One My CLAs table row, fully resolved before the template sees it. The template binds these
+ * One CLAs table row, fully resolved before the template sees it. The template binds these
  * fields and calls nothing — per the frontend checklist's no-template-functions rule
  * (`docs/reviews/frontend-checklist.md`), which a per-cell `claStatusLabel(...)` /
  * `statusNote(...)` call would re-run on every change-detection pass.
@@ -51,7 +51,7 @@ interface ClaRow {
 }
 
 /**
- * "My CLAs" Profile tab (Me lens). Lists every signed agreement (ICLA + ECLA)
+ * "CLAs" Profile tab (Me lens). Lists every signed agreement (ICLA + ECLA)
  * from `/v4/my-clas` with a status column (Valid / Needs attention / Revoked /
  * unknown as plain-text —) and a per-row actions menu. Status and reason are
  * copied from the producer; this component does not derive standing from

--- a/apps/lfx-one/src/app/modules/profile/profile.routes.ts
+++ b/apps/lfx-one/src/app/modules/profile/profile.routes.ts
@@ -31,7 +31,7 @@ export const PROFILE_ROUTES: Routes = [
         loadComponent: () => import('./individual-enrollment/profile-individual-enrollment.component').then((m) => m.ProfileIndividualEnrollmentComponent),
       },
 
-      // My CLAs tab — read-only EasyCLA agreements, dark-launched behind `my-clas-enabled` (CanMatch).
+      // CLAs tab — read-only EasyCLA agreements, dark-launched behind `my-clas-enabled` (CanMatch).
       {
         path: 'clas',
         canMatch: [myClasEnabledGuard],

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -108,7 +108,7 @@ export class SidebarComponent {
   protected readonly showPersonaBadge: Signal<boolean> = computed(() => !this.personaService.isRootWriter());
 
   // Profile & Account tabs for the me-lens card overflow (⋯) dropdown → /profile/<route>.
-  // Computed (not static) so the read-only "My CLAs" tab appears here whenever `my-clas-enabled`
+  // Computed (not static) so the read-only "CLAs" tab appears here whenever `my-clas-enabled`
   // is on, keeping this menu in sync with the profile-layout subtab strip (both use buildProfileTabs).
   private readonly myClasEnabled = this.featureFlagService.getBooleanFlag(MY_CLAS_ENABLED_FLAG, false);
   protected readonly profileTabs: Signal<ProfileTab[]> = computed(() => buildProfileTabs(this.myClasEnabled()));

--- a/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
@@ -11,7 +11,7 @@ import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 import { FeatureFlagService } from '../services/feature-flag.service';
 
 /**
- * CanMatch guard for the Profile "My CLAs" tab (`/profile/clas`), gating the
+ * CanMatch guard for the Profile "CLAs" tab (`/profile/clas`), gating the
  * read-only EasyCLA view behind the `my-clas-enabled` flag. SSR defers to the
  * browser; the browser waits up to 5 s for the flag provider to be READY, then
  * fails open (allows the route) if LD is unreachable so users aren't silently

--- a/apps/lfx-one/src/app/shared/services/my-clas.service.ts
+++ b/apps/lfx-one/src/app/shared/services/my-clas.service.ts
@@ -9,7 +9,7 @@ import { map, Observable, take } from 'rxjs';
 
 import { environment } from '@environments/environment';
 
-/** Client for the read-only "My CLAs" server endpoints (Me lens → Profile tab). */
+/** Client for the read-only "CLAs" server endpoints (Me lens → Profile tab). */
 @Injectable({
   providedIn: 'root',
 })

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Read-only "My CLAs" controller (Milestone 1, Me lens).
+// Read-only "CLAs" controller (Milestone 1, Me lens).
 // The user identity is derived strictly from the session — request input never
 // selects whose CLAs are read (research R3). SS asserts the trusted identity keys;
 // EasyCLA re-verifies each key belongs to the caller and owns the signature, so the

--- a/apps/lfx-one/src/server/routes/clas.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/clas.route.spec.ts
@@ -117,7 +117,7 @@ describe('clas router — Sign CLA hand-off during impersonation', () => {
   });
 
   it.each([
-    ['My CLAs list', '/api/me/clas'],
+    ['CLAs list', '/api/me/clas'],
     ['PDF URL', '/api/me/clas/sig-1/pdf-url'],
     ['CLA group options', '/api/me/clas/sign-options'],
   ])('keeps %s readable while impersonating', async (_label, path) => {

--- a/apps/lfx-one/src/server/routes/clas.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/clas.route.spec.ts
@@ -18,7 +18,7 @@ import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vites
  * would keep passing if the middleware were dropped from the route — which is the regression that
  * matters, because the failure mode is a signature recorded against the wrong person.
  *
- * The read routes are asserted alongside it: impersonated *viewing* of My CLAs must keep working,
+ * The read routes are asserted alongside it: impersonated *viewing* of CLAs must keep working,
  * so a blanket `router.use` would be a bug, not a safer default.
  */
 

--- a/apps/lfx-one/src/server/routes/clas.route.ts
+++ b/apps/lfx-one/src/server/routes/clas.route.ts
@@ -9,7 +9,7 @@ import { blockDuringImpersonation } from '../middleware/impersonation-readonly.m
 const router = Router();
 const clasController = new ClasController();
 
-// Read-only "My CLAs" (Me lens). Feature gating is enforced Angular-side via the
+// Read-only "CLAs" (Me lens). Feature gating is enforced Angular-side via the
 // route guard + sidebar flag (T020), mirroring the crowdfunding module convention.
 router.get('/clas', (req, res, next) => clasController.getMyClas(req, res, next));
 router.get('/clas/:signatureId/pdf-url', (req, res, next) => clasController.getPdfUrl(req, res, next));

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Read-only "My CLAs" service (Milestone 1). Resolves the session identity to a
+// Read-only "CLAs" service (Milestone 1). Resolves the session identity to a
 // set of identity keys, then delegates listing, validity computation and PDF
 // retrieval to the EasyCLA `/v4/my-clas` endpoints via lfx-gateway.
 //

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -36,21 +36,21 @@ LFX Self Serve does not currently include a notification preferences section. Em
 
 Affiliations are the Linux Foundation projects and companies you are associated with. They appear on your profile and may affect your persona and the lenses available to you. Go to [**Profile & Account**](/profile) and select the **Work history & Affiliations** tab (`/profile/attributions`) to view and manage them.
 
-## Where do I find My CLAs?
+## Where do I find CLAs?
 
-Go to [**Profile & Account**](/profile) and open the **My CLAs** tab (`/profile/clas`). For full detail, see [My CLAs](../my-clas/).
+Go to [**Profile & Account**](/profile) and open the **CLAs** tab (`/profile/clas`). For full detail, see [CLAs](../my-clas/).
 
 ## What is the difference between an ICLA and an ECLA?
 
-An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from My CLAs when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; My CLAs lists it with the company name and no individual PDF. See [My CLAs](../my-clas/).
+An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from CLAs when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; CLAs lists it with the company name and no individual PDF. See [CLAs](../my-clas/).
 
-## Why don't my signed CLAs show up on My CLAs?
+## Why don't my signed CLAs show up on CLAs?
 
-My CLAs matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **My CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
+CLAs matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
 
-## Can I sign a CLA from the My CLAs tab?
+## Can I sign a CLA from the CLAs tab?
 
-No. My CLAs is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [My CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+No. CLAs is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## What purchases appear in my transaction history?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -42,15 +42,15 @@ Go to [**Profile & Account**](/profile) and open the **CLAs** tab (`/profile/cla
 
 ## What is the difference between an ICLA and an ECLA?
 
-An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from CLAs when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; CLAs lists it with the company name and no individual PDF. See [CLAs](../my-clas/).
+An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from the CLAs tab when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; the CLAs tab lists it with the company name and no individual PDF. See [CLAs](../my-clas/).
 
-## Why don't my signed CLAs show up on CLAs?
+## Why don't my signed CLAs show up on the CLAs tab?
 
-CLAs matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
+The CLAs tab matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
 
 ## Can I sign a CLA from the CLAs tab?
 
-No. CLAs is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+No. The CLAs tab is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## What purchases appear in my transaction history?
 

--- a/docs/user/account/index.md
+++ b/docs/user/account/index.md
@@ -34,7 +34,7 @@ Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, s
 | Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     | —                               |
 | Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work    | —                               |
 | Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan       | —                               |
-| My CLAs                     | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [My CLAs](./my-clas/)           |
+| CLAs                        | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [CLAs](./my-clas/)              |
 | Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                         | [Transactions](./transactions/) |
 | Settings                    | `/profile/settings`              | Email addresses, password, and developer API token             | [Settings](./settings/)         |
 
@@ -43,6 +43,6 @@ Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, s
 ## Related sections
 
 - [Profile](../profile/) — your name, photo, About Me, primary email, and location (Edit Profile drawer)
-- [My CLAs](./my-clas/) — view your signed ICLAs and Employee CLA coverage
+- [CLAs](./my-clas/) — view your signed ICLAs and Employee CLA coverage
 - [Transactions](./transactions/) — your Linux Foundation purchase history
 - [Settings](./settings/) — email, password, and developer API token

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -11,9 +11,9 @@ intercom_collection: Account
 
 These steps apply to any signed-in user on LFX Self Serve.
 
-**CLAs** is a read-only tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. CLAs answers: _which agreements have I signed, and under which projects am I covered?_
+**CLAs** is a read-only tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. The CLAs tab answers: _which agreements have I signed, and under which projects am I covered?_
 
-You cannot sign a CLA from this page. Signing happens outside CLAs, and the signing process may evolve; this page only shows agreements already on file.
+You cannot sign a CLA from this page. Signing happens outside the CLAs tab, and the signing process may evolve; this page only shows agreements already on file.
 
 For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
@@ -37,7 +37,7 @@ In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered und
 
 ## What does the CLAs list show?
 
-When agreements are found, CLAs shows a table with four columns:
+When agreements are found, the CLAs tab shows a table with four columns:
 
 | Column       | Contents                                                                                                            |
 | ------------ | ------------------------------------------------------------------------------------------------------------------- |
@@ -48,7 +48,7 @@ When agreements are found, CLAs shows a table with four columns:
 
 Only currently valid agreements appear on this list.
 
-### Why does CLAs say I have no CLAs?
+### Why does the CLAs tab say I have no CLAs?
 
 If nothing matches your linked identities, you see:
 
@@ -59,7 +59,7 @@ That does not always mean you never signed — see the next section.
 
 ## Why don't my signed CLAs show up?
 
-CLAs only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
+The CLAs tab only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
 
 - The **email** or **GitHub** account you used when signing is **not linked** to this LFX profile
 - You signed under a **work or secondary email** that is not among your verified / linked emails
@@ -81,9 +81,9 @@ Yes for an **ICLA**, when EasyCLA has the signed file — use **Download PDF** i
 
 No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. The Document column shows _Covered by Corporate CLA (CCLA)_.
 
-## Can I sign a CLA from CLAs?
+## Can I sign a CLA from the CLAs tab?
 
-No. CLAs is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+No. The CLAs tab is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## Related
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -1,5 +1,5 @@
 ---
-title: My CLAs
+title: CLAs
 description: View your signed Individual and Employee CLAs in LFX Self Serve, and understand why an agreement might not appear.
 audience: [all]
 product_area: Account
@@ -11,23 +11,23 @@ intercom_collection: Account
 
 These steps apply to any signed-in user on LFX Self Serve.
 
-**My CLAs** is a read-only tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. My CLAs answers: _which agreements have I signed, and under which projects am I covered?_
+**CLAs** is a read-only tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. CLAs answers: _which agreements have I signed, and under which projects am I covered?_
 
-You cannot sign a CLA from this page. Signing happens outside My CLAs, and the signing process may evolve; this page only shows agreements already on file.
+You cannot sign a CLA from this page. Signing happens outside CLAs, and the signing process may evolve; this page only shows agreements already on file.
 
 For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
-## Where do I find My CLAs?
+## Where do I find CLAs?
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Select [**Profile & Account**](/profile) from the left navigation sidebar.
-3. Open the **My CLAs** tab, or go directly to `/profile/clas`.
+3. Open the **CLAs** tab, or go directly to `/profile/clas`.
 
 Agreements are matched from your signed-in session and your linked [Email and GitHub identities](/profile/identities). You never search or type a project name here.
 
 ## What is the difference between ICLA and ECLA?
 
-| Type                      | What it means                                                                                                      | On My CLAs                                                               | Document                                                                        |
+| Type                      | What it means                                                                                                      | On CLAs                                                                  | Document                                                                        |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | **ICLA** (Individual CLA) | You signed as yourself for a project                                                                               | Listed                                                                   | **Download PDF** when EasyCLA has the signed file (otherwise _PDF unavailable_) |
 | **ECLA** (Employee CLA)   | You are covered because your employer holds a Corporate CLA (CCLA) and you are on that company's **Approved List** | Listed (shows the employer name)                                         | No individual PDF — shown as _Covered by Corporate CLA (CCLA)_                  |
@@ -35,9 +35,9 @@ Agreements are matched from your signed-in session and your linked [Email and Gi
 
 In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered under your company's **CCLA**.
 
-## What does the My CLAs list show?
+## What does the CLAs list show?
 
-When agreements are found, My CLAs shows a table with four columns:
+When agreements are found, CLAs shows a table with four columns:
 
 | Column       | Contents                                                                                                            |
 | ------------ | ------------------------------------------------------------------------------------------------------------------- |
@@ -48,7 +48,7 @@ When agreements are found, My CLAs shows a table with four columns:
 
 Only currently valid agreements appear on this list.
 
-### Why does My CLAs say I have no CLAs?
+### Why does CLAs say I have no CLAs?
 
 If nothing matches your linked identities, you see:
 
@@ -59,7 +59,7 @@ That does not always mean you never signed — see the next section.
 
 ## Why don't my signed CLAs show up?
 
-My CLAs only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
+CLAs only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
 
 - The **email** or **GitHub** account you used when signing is **not linked** to this LFX profile
 - You signed under a **work or secondary email** that is not among your verified / linked emails
@@ -69,11 +69,11 @@ My CLAs only finds agreements that match an identity linked to your LFX account.
 
 1. Open [Identities](/profile/identities).
 2. Link the Email or GitHub accounts you used when signing.
-3. Return to **My CLAs** — newly linked Email/GitHub identities are included on the next load.
+3. Return to **CLAs** — newly linked Email/GitHub identities are included on the next load.
 
 If an agreement is still missing after that, see [EasyCLA troubleshooting](https://docs.linuxfoundation.org/lfx/easycla/v2-current/getting-started/easycla-troubleshooting).
 
-The info banner on the My CLAs tab also points to the Identities flow (_Link your Email, GitHub, or GitLab accounts →_). Linking Email or GitHub is what recovers missing CLA matches today.
+The info banner on the CLAs tab also points to the Identities flow (_Link your Email or GitHub accounts →_). Linking Email or GitHub is what recovers missing CLA matches today.
 
 ## Can I download my signed CLA PDF?
 
@@ -81,13 +81,13 @@ Yes for an **ICLA**, when EasyCLA has the signed file — use **Download PDF** i
 
 No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. The Document column shows _Covered by Corporate CLA (CCLA)_.
 
-## Can I sign a CLA from My CLAs?
+## Can I sign a CLA from CLAs?
 
-No. My CLAs is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+No. CLAs is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## Related
 
 - [Account overview](../) — all account areas and navigation
-- [Account FAQ](../faq/) — short answers to common account questions, including My CLAs
+- [Account FAQ](../faq/) — short answers to common account questions, including CLAs
 - [Edit your profile](../../profile/edit-profile/) — name, photo, About Me, primary email, and location
 - [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) — CLA concepts, consoles, and troubleshooting outside Self Serve

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -31,7 +31,7 @@ Open [**Profile & Account**](/profile), select **Edit profile**, update your **F
 
 ## Where do I manage my email, password, affiliations, or CLAs?
 
-Those live in the [Account](../../account/) section, not your personal profile. See the [Account FAQ](../../account/faq/) for email and password changes, affiliations, My CLAs, transactions, and developer settings.
+Those live in the [Account](../../account/) section, not your personal profile. See the [Account FAQ](../../account/faq/) for email and password changes, affiliations, CLAs, transactions, and developer settings.
 
 ## Who do I contact if I cannot access my account?
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// UI-facing shapes for the read-only "My CLAs" view (Me lens → Profile tab).
+// UI-facing shapes for the read-only "CLAs" view (Me lens → Profile tab).
 // Normalized by the LFX One server from upstream EasyCLA signature records.
 // See specs/001-easycla-ss-integration-fable/m1-my-cla/data-model.md.
 
@@ -25,7 +25,7 @@ export type ClaStatus = 'valid' | 'needs_attention' | 'invalidated' | 'unknown' 
 
 export type ClaStatusReason = 'not_on_approval_list' | 'unknown';
 
-/** A single signed CLA shown in the My CLAs list. */
+/** A single signed CLA shown in the CLAs list. */
 export interface MyClaAgreement {
   /** EasyCLA signatureID — also the key for the PDF-URL endpoint. */
   id: string;
@@ -74,7 +74,7 @@ export interface MyClasResponse {
   identity: MyClasIdentitySummary;
 }
 
-/** View state for the My CLAs tab: the last response (or null), plus load/error flags. */
+/** View state for the CLAs tab: the last response (or null), plus load/error flags. */
 export interface MyClasState {
   data: MyClasResponse | null;
   error: boolean;

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -271,7 +271,7 @@ export * from './linux-email.interface';
 // Crowdfunding interfaces
 export * from './crowdfunding.interface';
 
-// EasyCLA "My CLAs" interfaces (Me lens)
+// EasyCLA "CLAs" interfaces (Me lens)
 export * from './cla.interface';
 
 // Country, state, t-shirt size, tag, and timezone interfaces

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -28,12 +28,12 @@ describe('buildProfileTabs', () => {
     expect(buildProfileTabs(false)).toBe(PROFILE_TABS);
   });
 
-  it('inserts the My CLAs tab immediately before Transactions when the flag is on', () => {
+  it('inserts the CLAs tab immediately before Transactions when the flag is on', () => {
     const tabs = buildProfileTabs(true);
     const ids = tabs.map((t) => t.id);
     expect(ids).toContain('clas');
     expect(ids.indexOf('clas')).toBe(ids.indexOf('transactions') - 1);
-    expect(tabs.find((t) => t.id === 'clas')).toEqual({ id: 'clas', label: 'My CLAs', route: 'clas' });
+    expect(tabs.find((t) => t.id === 'clas')).toEqual({ id: 'clas', label: 'CLAs', route: 'clas' });
   });
 
   it('does not mutate the shared PROFILE_TABS constant', () => {

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -18,7 +18,7 @@ import { ClaStatus, MyClaAgreement, MyClasIdentitySummary } from '../interfaces/
  */
 export function buildProfileTabs(myClasEnabled: boolean): ProfileTab[] {
   if (!myClasEnabled) return PROFILE_TABS;
-  const clasTab: ProfileTab = { id: 'clas', label: 'My CLAs', route: 'clas' };
+  const clasTab: ProfileTab = { id: 'clas', label: 'CLAs', route: 'clas' };
   const insertAt = PROFILE_TABS.findIndex((t) => t.id === 'transactions');
   if (insertAt === -1) return [...PROFILE_TABS, clasTab];
   return [...PROFILE_TABS.slice(0, insertAt), clasTab, ...PROFILE_TABS.slice(insertAt)];

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Pure presentation helpers for the read-only "My CLAs" view. Kept framework-free so the
+// Pure presentation helpers for the read-only "CLAs" view. Kept framework-free so the
 // branching logic (ICLA/ECLA split, empty/CTA rules, status labels) is unit-testable without
 // an Angular component-test harness.
 
@@ -11,7 +11,7 @@ import { ProfileTab } from '../interfaces';
 import { ClaStatus, MyClaAgreement, MyClasIdentitySummary } from '../interfaces/cla.interface';
 
 /**
- * Profile subtab list, with the read-only "My CLAs" tab appended (before Transactions)
+ * Profile subtab list, with the read-only "CLAs" tab appended (before Transactions)
  * when `my-clas-enabled` is on. Shared by both profile-hub nav entry points — the layout
  * subtab strip and the sidebar me-lens ⋯ menu — so they never disagree on whether the tab
  * is present. Returns the static PROFILE_TABS reference unchanged when the flag is off.


### PR DESCRIPTION
## Summary

- Renames "My CLAs" → "CLAs" throughout the self-serve CLA section UI (`/profile/clas`): nav tab label, page heading, empty-state CTA text.
- Drops the stray "GitLab" mention from the identity-linking banner.
- Updates corresponding user docs under `docs/user/account` and `docs/user/profile/faq`.
- Internal identifiers are intentionally left unchanged (service names, feature flag, guard, route segment, `data-testid` attributes, API path) — this is a visible-copy change only.

## Notable fixes picked up along the way (all `fix(review):` commits, driven by the mandatory post-commit reviewer trio)

- Fixed a broken docs CTA route and grammar issue introduced by the rename.
- Hardened the CTA-route unit test to assert the resolved `RouterLink` `urlTree` (via the `lfx-button` host, scoped with `By.directive(ButtonComponent)`) rather than a write-only `routerLink` input or an ambiguous `By.directive(RouterLink)` query — the wrapped `<p-button>` also carries a `RouterLink` instance from the same binding expression, so scoping to the host makes explicit which instance the test means.

## Trade-offs / out of scope (documented per review findings)

- **Pre-existing duplicate `RouterLink` instance on `lfx-button` CTAs** (`EmptyStateComponent` imports `RouterLink` directly *and* forwards to `ButtonComponent`'s own `routerLink` input, producing two directive instances bound to the same expression — each click fires two `navigateByUrl` calls, currently masked by the Router's `onSameUrlNavigation: 'ignore'` default). This is a pre-existing structural issue, not introduced here, and is tracked separately — not fixed in this PR to keep it scoped to the rename.
- A reviewer suggested adding a `data-testid` to the empty-state CTA for a less ambiguous test hook. Deferred: the eventual fix for the duplicate-`RouterLink` issue above will change this component's structure, so landing a `data-testid` now risks being reworked; the current host-scoped query is sufficient for this PR's purpose (asserting the target route).
- A full-branch sweep flagged the CTA test as asserting on the "wrong" (host) `RouterLink` instance rather than the one nested in `<p-button>`. Both instances derive from the same single binding expression (`[routerLink]="ctaRoute()!"`), so they always resolve identically — asserting on either is an equally valid proof of the target route. Not changed.

## Test plan

- [x] `yarn format` — clean
- [x] `yarn lint` — 0 errors
- [x] `yarn build` — succeeded (SSR bundle)
- [x] Unit tests — 285/285 app tests, 6/6 server tests passing (including the CTA-route regression test and the impersonation-gate server tests for `/api/me/clas/*`)
- [x] License headers — all present
- [x] No protected files touched
- [x] All commits DCO + GPG signed (`--signoff -S`)

Refs #1418