### PR TITLE
fix(cla): rename my clas to clas

### DIFF
--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -81,7 +81,7 @@ export class ProfileLayoutComponent {
   // the initial GET, so we stash it and re-apply once a GET lands (see reapplyPendingOptimisticUpdate).
   private pendingOptimisticMetadata: Partial<UserMetadata> | null = null;
 
-  // Tab configuration. The read-only "My CLAs" tab is appended (before Transactions/Settings)
+  // Tab configuration. The read-only "CLAs" tab is appended (before Transactions/Settings)
   // only when the `my-clas-enabled` flag is on — matching the route's CanMatch guard.
   private readonly myClasEnabled = this.featureFlagService.getBooleanFlag(MY_CLAS_ENABLED_FLAG, false);
   public readonly tabs: Signal<ProfileTab[]> = computed(() => buildProfileTabs(this.myClasEnabled()));

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -8,7 +8,7 @@ SPDX-License-Identifier: MIT
 <section class="flex flex-col gap-4" data-testid="my-clas">
   <!-- Header -->
   <div>
-    <h2 class="text-lg font-semibold text-slate-800">My CLAs</h2>
+    <h2 class="text-lg font-semibold text-slate-800">CLAs</h2>
   </div>
 
   @if (error()) {
@@ -25,7 +25,7 @@ SPDX-License-Identifier: MIT
     <lfx-message severity="info" [attr.data-testid]="'my-clas-info-banner'">
       <p class="text-sm">
         Your signed ICLAs (Individual CLA) and ECLAs (Employee CLA), matched to your Identities. Missing one?
-        <a class="font-semibold text-blue-600 hover:underline" routerLink="/profile/identities">Link your Email, GitHub, or GitLab accounts →</a>
+        <a class="font-semibold text-blue-600 hover:underline" routerLink="/profile/identities">Link your Email or GitHub accounts →</a>
       </p>
     </lfx-message>
 
@@ -34,8 +34,8 @@ SPDX-License-Identifier: MIT
         icon="fa-light fa-file-signature"
         title="No CLAs on file yet"
         subtitle="We haven't found any signed ICLAs or ECLAs for your linked identities."
-        ctaLabel="Learn about My CLAs"
-        [ctaRoute]="['/docs', 'profile', 'my-clas']"
+        ctaLabel="Learn about CLAs"
+        [ctaRoute]="['/docs', 'account', 'my-clas']"
         data-testid="my-clas-empty-state" />
     } @else {
       <lfx-table

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -19,7 +19,7 @@ import { TableComponent } from '@components/table/table.component';
 import { MyClasService } from '@services/my-clas.service';
 
 /**
- * Read-only "My CLAs" Profile tab (Me lens). Renders the user's currently-valid signed CLAs
+ * Read-only "CLAs" Profile tab (Me lens). Renders the user's currently-valid signed CLAs
  * (ICLA + ECLA) from `/v4/my-clas` in a single table (Project / Type / Signed / Document) per
  * the approved M1 mockup — no status column, because the BFF filters to valid-only so every row
  * is valid. Agreements are resolved server-side from the session identity; ICLA PDFs download via

--- a/apps/lfx-one/src/app/modules/profile/profile.routes.ts
+++ b/apps/lfx-one/src/app/modules/profile/profile.routes.ts
@@ -31,7 +31,7 @@ export const PROFILE_ROUTES: Routes = [
         loadComponent: () => import('./individual-enrollment/profile-individual-enrollment.component').then((m) => m.ProfileIndividualEnrollmentComponent),
       },
 
-      // My CLAs tab — read-only EasyCLA agreements, dark-launched behind `my-clas-enabled` (CanMatch).
+      // CLAs tab — read-only EasyCLA agreements, dark-launched behind `my-clas-enabled` (CanMatch).
       {
         path: 'clas',
         canMatch: [myClasEnabledGuard],

--- a/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
+++ b/apps/lfx-one/src/app/shared/components/sidebar/sidebar.component.ts
@@ -108,7 +108,7 @@ export class SidebarComponent {
   protected readonly showPersonaBadge: Signal<boolean> = computed(() => !this.personaService.isRootWriter());
 
   // Profile & Account tabs for the me-lens card overflow (⋯) dropdown → /profile/<route>.
-  // Computed (not static) so the read-only "My CLAs" tab appears here whenever `my-clas-enabled`
+  // Computed (not static) so the read-only "CLAs" tab appears here whenever `my-clas-enabled`
   // is on, keeping this menu in sync with the profile-layout subtab strip (both use buildProfileTabs).
   private readonly myClasEnabled = this.featureFlagService.getBooleanFlag(MY_CLAS_ENABLED_FLAG, false);
   protected readonly profileTabs: Signal<ProfileTab[]> = computed(() => buildProfileTabs(this.myClasEnabled()));

--- a/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/my-clas-enabled.guard.ts
@@ -11,7 +11,7 @@ import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 import { FeatureFlagService } from '../services/feature-flag.service';
 
 /**
- * CanMatch guard for the Profile "My CLAs" tab (`/profile/clas`), gating the
+ * CanMatch guard for the Profile "CLAs" tab (`/profile/clas`), gating the
  * read-only EasyCLA view behind the `my-clas-enabled` flag. SSR defers to the
  * browser; the browser waits up to 5 s for the flag provider to be READY, then
  * fails open (allows the route) if LD is unreachable so users aren't silently

--- a/apps/lfx-one/src/app/shared/services/my-clas.service.ts
+++ b/apps/lfx-one/src/app/shared/services/my-clas.service.ts
@@ -6,7 +6,7 @@ import { inject, Injectable } from '@angular/core';
 import { MyClasResponse, PdfUrlResponse } from '@lfx-one/shared/interfaces';
 import { Observable, take } from 'rxjs';
 
-/** Client for the read-only "My CLAs" server endpoints (Me lens → Profile tab). */
+/** Client for the read-only "CLAs" server endpoints (Me lens → Profile tab). */
 @Injectable({
   providedIn: 'root',
 })

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Read-only "My CLAs" controller (Milestone 1, Me lens).
+// Read-only "CLAs" controller (Milestone 1, Me lens).
 // The user identity is derived strictly from the session — request input never
 // selects whose CLAs are read (research R3). SS asserts the trusted identity keys;
 // EasyCLA re-verifies each key belongs to the caller and owns the signature, so the

--- a/apps/lfx-one/src/server/routes/clas.route.ts
+++ b/apps/lfx-one/src/server/routes/clas.route.ts
@@ -8,7 +8,7 @@ import { ClasController } from '../controllers/clas.controller';
 const router = Router();
 const clasController = new ClasController();
 
-// Read-only "My CLAs" (Me lens). Feature gating is enforced Angular-side via the
+// Read-only "CLAs" (Me lens). Feature gating is enforced Angular-side via the
 // route guard + sidebar flag (T020), mirroring the crowdfunding module convention.
 router.get('/clas', (req, res, next) => clasController.getMyClas(req, res, next));
 router.get('/clas/:signatureId/pdf-url', (req, res, next) => clasController.getPdfUrl(req, res, next));

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Read-only "My CLAs" service (Milestone 1). Resolves the session identity to a
+// Read-only "CLAs" service (Milestone 1). Resolves the session identity to a
 // set of identity keys, then delegates listing, validity computation and PDF
 // retrieval to the EasyCLA `/v4/my-clas` endpoints via lfx-gateway.
 //

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -60,21 +60,21 @@ Go to [**Profile & Account**](/profile) and open the **Individual Enrollment** t
 
 If your membership supports automatic renewal, the **Individual Enrollment** tab shows a **Disable auto-renew** control — select it and confirm. Your membership then stays active until its expiration date and won't renew automatically; there is no separate immediate-cancel step. Memberships that renew manually don't show an auto-renew control. See [Individual Enrollment](../individual-enrollment/).
 
-## Where do I find My CLAs?
+## Where do I find CLAs?
 
-Go to [**Profile & Account**](/profile) and open the **My CLAs** tab (`/profile/clas`). For full detail, see [My CLAs](../my-clas/).
+Go to [**Profile & Account**](/profile) and open the **CLAs** tab (`/profile/clas`). For full detail, see [CLAs](../my-clas/).
 
 ## What is the difference between an ICLA and an ECLA?
 
-An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from My CLAs when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; My CLAs lists it with the company name and no individual PDF. See [My CLAs](../my-clas/).
+An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from the CLAs tab when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; the CLAs tab lists it with the company name and no individual PDF. See [CLAs](../my-clas/).
 
-## Why don't my signed CLAs show up on My CLAs?
+## Why don't my signed CLAs show up on the CLAs tab?
 
-My CLAs matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **My CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
+The CLAs tab matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
 
-## Can I sign a CLA from the My CLAs tab?
+## Can I sign a CLA from the CLAs tab?
 
-No. My CLAs is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [My CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+No. The CLAs tab is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## What purchases appear in my transaction history?
 

--- a/docs/user/account/identities/index.md
+++ b/docs/user/account/identities/index.md
@@ -70,6 +70,6 @@ The **Linux.com email** section, at the bottom of the Identities tab, lets Indiv
 ## Related
 
 - [Account overview](../) — all account areas and navigation
-- [My CLAs](../my-clas/) — linked Email and GitHub identities are how signed CLAs are matched to you
+- [CLAs](../my-clas/) — linked Email and GitHub identities are how signed CLAs are matched to you
 - [Settings](../settings/) — add and verify email addresses, manage your password and API token
 - [Account FAQ](../faq/) — short answers about identities, settings, and CLAs

--- a/docs/user/account/index.md
+++ b/docs/user/account/index.md
@@ -34,7 +34,7 @@ Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, s
 | Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     | [Work history & Affiliations](./work-history/)    |
 | Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work    | [Identities](./identities/)                       |
 | Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan       | [Individual Enrollment](./individual-enrollment/) |
-| My CLAs                     | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [My CLAs](./my-clas/)                             |
+| CLAs                        | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [CLAs](./my-clas/)                                |
 | Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                         | [Transactions](./transactions/)                   |
 | Settings                    | `/profile/settings`              | Email addresses, password, and developer API token             | [Settings](./settings/)                           |
 
@@ -46,6 +46,6 @@ Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, s
 - [Work history & Affiliations](./work-history/) — record your employment history and review how contributions are attributed
 - [Identities](./identities/) — link, verify, and remove GitHub, social, and email identities, and claim a Linux.com alias
 - [Individual Enrollment](./individual-enrollment/) — enroll in an Individual Supporter membership and manage auto-renew
-- [My CLAs](./my-clas/) — view your signed ICLAs and Employee CLA coverage
+- [CLAs](./my-clas/) — view your signed ICLAs and Employee CLA coverage
 - [Transactions](./transactions/) — your Linux Foundation purchase history
 - [Settings](./settings/) — email, password, and developer API token

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -1,5 +1,5 @@
 ---
-title: My CLAs
+title: CLAs
 description: View your signed Individual and Employee CLAs in LFX Self Serve, and understand why an agreement might not appear.
 audience: [all]
 product_area: Account
@@ -11,23 +11,23 @@ intercom_collection: Account
 
 These steps apply to any signed-in user on LFX Self Serve.
 
-**My CLAs** is a read-only tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. My CLAs answers: _which agreements have I signed, and under which projects am I covered?_
+**CLAs** is a read-only tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. The CLAs tab answers: _which agreements have I signed, and under which projects am I covered?_
 
-You cannot sign a CLA from this page. Signing happens outside My CLAs, and the signing process may evolve; this page only shows agreements already on file.
+You cannot sign a CLA from this page. Signing happens outside the CLAs tab, and the signing process may evolve; this page only shows agreements already on file.
 
 For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
-## Where do I find My CLAs?
+## Where do I find CLAs?
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Select [**Profile & Account**](/profile) from the left navigation sidebar.
-3. Open the **My CLAs** tab, or go directly to `/profile/clas`.
+3. Open the **CLAs** tab, or go directly to `/profile/clas`.
 
 Agreements are matched from your signed-in session and your linked [Email and GitHub identities](/profile/identities). You never search or type a project name here.
 
 ## What is the difference between ICLA and ECLA?
 
-| Type                      | What it means                                                                                                      | On My CLAs                                                               | Document                                                                        |
+| Type                      | What it means                                                                                                      | On CLAs                                                                  | Document                                                                        |
 | ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
 | **ICLA** (Individual CLA) | You signed as yourself for a project                                                                               | Listed                                                                   | **Download PDF** when EasyCLA has the signed file (otherwise _PDF unavailable_) |
 | **ECLA** (Employee CLA)   | You are covered because your employer holds a Corporate CLA (CCLA) and you are on that company's **Approved List** | Listed (shows the employer name)                                         | No individual PDF — shown as _Covered by Corporate CLA (CCLA)_                  |
@@ -35,9 +35,9 @@ Agreements are matched from your signed-in session and your linked [Email and Gi
 
 In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered under your company's **CCLA**.
 
-## What does the My CLAs list show?
+## What does the CLAs list show?
 
-When agreements are found, My CLAs shows a table with four columns:
+When agreements are found, the CLAs tab shows a table with four columns:
 
 | Column       | Contents                                                                                                            |
 | ------------ | ------------------------------------------------------------------------------------------------------------------- |
@@ -48,7 +48,7 @@ When agreements are found, My CLAs shows a table with four columns:
 
 Only currently valid agreements appear on this list.
 
-### Why does My CLAs say I have no CLAs?
+### Why does the CLAs tab say I have no CLAs?
 
 If nothing matches your linked identities, you see:
 
@@ -59,7 +59,7 @@ That does not always mean you never signed — see the next section.
 
 ## Why don't my signed CLAs show up?
 
-My CLAs only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
+The CLAs tab only finds agreements that match an identity linked to your LFX account. Matching today uses your LF username, verified emails, and linked GitHub accounts. A CLA can be missing from the list when:
 
 - The **email** or **GitHub** account you used when signing is **not linked** to this LFX profile
 - You signed under a **work or secondary email** that is not among your verified / linked emails
@@ -69,11 +69,11 @@ My CLAs only finds agreements that match an identity linked to your LFX account.
 
 1. Open [Identities](/profile/identities).
 2. Link the Email or GitHub accounts you used when signing.
-3. Return to **My CLAs** — newly linked Email/GitHub identities are included on the next load.
+3. Return to **CLAs** — newly linked Email/GitHub identities are included on the next load.
 
 If an agreement is still missing after that, see [EasyCLA troubleshooting](https://docs.linuxfoundation.org/lfx/easycla/v2-current/getting-started/easycla-troubleshooting).
 
-The info banner on the My CLAs tab also points to the Identities flow (_Link your Email, GitHub, or GitLab accounts →_). Linking Email or GitHub is what recovers missing CLA matches today.
+The info banner on the CLAs tab also points to the Identities flow (_Link your Email or GitHub accounts →_). Linking Email or GitHub is what recovers missing CLA matches today.
 
 ## Can I download my signed CLA PDF?
 
@@ -81,13 +81,13 @@ Yes for an **ICLA**, when EasyCLA has the signed file — use **Download PDF** i
 
 No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. The Document column shows _Covered by Corporate CLA (CCLA)_.
 
-## Can I sign a CLA from My CLAs?
+## Can I sign a CLA from the CLAs tab?
 
-No. My CLAs is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+No. The CLAs tab is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
 
 ## Related
 
 - [Account overview](../) — all account areas and navigation
-- [Account FAQ](../faq/) — short answers to common account questions, including My CLAs
+- [Account FAQ](../faq/) — short answers to common account questions, including CLAs
 - [Edit your profile](../../profile/edit-profile/) — name, photo, About Me, primary email, and location
 - [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) — CLA concepts, consoles, and troubleshooting outside Self Serve

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -31,7 +31,7 @@ Open [**Profile & Account**](/profile), select **Edit profile**, update your **F
 
 ## Where do I manage my email, password, affiliations, or CLAs?
 
-Those live in the [Account](../../account/) section, not your personal profile. See the [Account FAQ](../../account/faq/) for email and password changes, affiliations, My CLAs, transactions, and developer settings.
+Those live in the [Account](../../account/) section, not your personal profile. See the [Account FAQ](../../account/faq/) for email and password changes, affiliations, CLAs, transactions, and developer settings.
 
 ## Who do I contact if I cannot access my account?
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// UI-facing shapes for the read-only "My CLAs" view (Me lens → Profile tab).
+// UI-facing shapes for the read-only "CLAs" view (Me lens → Profile tab).
 // Normalized by the LFX One server from upstream EasyCLA signature records.
 // See specs/001-easycla-ss-integration-fable/m1-my-cla/data-model.md.
 
@@ -18,7 +18,7 @@ export type ClaKind = 'ICLA' | 'ECLA';
  */
 export type ClaStatus = 'valid' | 'superseded' | 'inactive';
 
-/** A single signed CLA shown in the My CLAs list. */
+/** A single signed CLA shown in the CLAs list. */
 export interface MyClaAgreement {
   /** EasyCLA signatureID — also the key for the PDF-URL endpoint. */
   id: string;
@@ -66,7 +66,7 @@ export interface MyClasResponse {
   identity: MyClasIdentitySummary;
 }
 
-/** View state for the My CLAs tab: the last response (or null), plus load/error flags. */
+/** View state for the CLAs tab: the last response (or null), plus load/error flags. */
 export interface MyClasState {
   data: MyClasResponse | null;
   error: boolean;

--- a/packages/shared/src/interfaces/index.ts
+++ b/packages/shared/src/interfaces/index.ts
@@ -271,7 +271,7 @@ export * from './linux-email.interface';
 // Crowdfunding interfaces
 export * from './crowdfunding.interface';
 
-// EasyCLA "My CLAs" interfaces (Me lens)
+// EasyCLA "CLAs" interfaces (Me lens)
 export * from './cla.interface';
 
 // Country, state, t-shirt size, tag, and timezone interfaces

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -28,12 +28,12 @@ describe('buildProfileTabs', () => {
     expect(buildProfileTabs(false)).toBe(PROFILE_TABS);
   });
 
-  it('inserts the My CLAs tab immediately before Transactions when the flag is on', () => {
+  it('inserts the CLAs tab immediately before Transactions when the flag is on', () => {
     const tabs = buildProfileTabs(true);
     const ids = tabs.map((t) => t.id);
     expect(ids).toContain('clas');
     expect(ids.indexOf('clas')).toBe(ids.indexOf('transactions') - 1);
-    expect(tabs.find((t) => t.id === 'clas')).toEqual({ id: 'clas', label: 'My CLAs', route: 'clas' });
+    expect(tabs.find((t) => t.id === 'clas')).toEqual({ id: 'clas', label: 'CLAs', route: 'clas' });
   });
 
   it('does not mutate the shared PROFILE_TABS constant', () => {

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Pure presentation helpers for the read-only "My CLAs" view. Kept framework-free so the
+// Pure presentation helpers for the read-only "CLAs" view. Kept framework-free so the
 // branching logic (ICLA/ECLA split, empty/CTA rules, status labels) is unit-testable without
 // an Angular component-test harness.
 
@@ -11,14 +11,14 @@ import { ProfileTab } from '../interfaces';
 import { ClaStatus, MyClaAgreement, MyClasIdentitySummary } from '../interfaces/cla.interface';
 
 /**
- * Profile subtab list, with the read-only "My CLAs" tab appended (before Transactions)
+ * Profile subtab list, with the read-only "CLAs" tab appended (before Transactions)
  * when `my-clas-enabled` is on. Shared by both profile-hub nav entry points — the layout
  * subtab strip and the sidebar me-lens ⋯ menu — so they never disagree on whether the tab
  * is present. Returns the static PROFILE_TABS reference unchanged when the flag is off.
  */
 export function buildProfileTabs(myClasEnabled: boolean): ProfileTab[] {
   if (!myClasEnabled) return PROFILE_TABS;
-  const clasTab: ProfileTab = { id: 'clas', label: 'My CLAs', route: 'clas' };
+  const clasTab: ProfileTab = { id: 'clas', label: 'CLAs', route: 'clas' };
   const insertAt = PROFILE_TABS.findIndex((t) => t.id === 'transactions');
   if (insertAt === -1) return [...PROFILE_TABS, clasTab];
   return [...PROFILE_TABS.slice(0, insertAt), clasTab, ...PROFILE_TABS.slice(insertAt)];


### PR DESCRIPTION
## Summary

- Renames "My CLAs" → "CLAs" throughout the self-serve CLA section UI (`/profile/clas`): nav tab label, page heading, empty-state CTA text.
- Drops the stray "GitLab" mention from the identity-linking banner (CLA identity matching only uses LF username, verified emails, and linked GitHub accounts).
- Fixes the empty-state CTA's docs route, which pointed at `/docs/profile/my-clas` (404) instead of the actual article at `/docs/account/my-clas`.
- Updates corresponding user docs under `docs/user/account` and `docs/user/profile/faq`.
- Internal identifiers are intentionally left unchanged (service names, feature flag, guard, route segment, `data-testid` attributes, the `/v4/my-clas` upstream API path) — this is a visible-copy change only.

## Context

PR #1612 made this exact change but was accidentally merged into `feat/GH-1256` instead of `main`, so it never shipped on `main`. This PR reapplies the same rename directly against `main`'s current (simpler, pre-GH-1256) CLA implementation.

Two files from the original PR's diff — `profile-clas.component.spec.ts` and `clas.route.spec.ts` — don't exist on `main` yet; they cover Sign CLA / impersonation features that only exist on `feat/GH-1256`. They should get the equivalent rename once that feature work lands on `main`.

## Test plan

- [x] `yarn format` — clean, no changes needed
- [x] `yarn lint` — 0 errors (1 pre-existing unrelated warning)
- [x] `yarn build` — succeeded
- [x] `yarn test --filter=lfx-one-ui` — 356/356 passing
- [x] `yarn test --filter=@lfx-one/shared` — 808/808 passing
- [x] `yarn docs:check` — manifest/search-index/sitemap valid and idempotent
- [x] `markdownlint` on all changed docs files — clean
- [x] License headers — all present
- [x] No protected files touched
- [x] All commits DCO + GPG signed (`--signoff -S`)

Refs GH-1418