### PR TITLE
fix(profile): send deletedBy in CDP work-experience delete

### DIFF
--- a/apps/lfx-one/src/server/services/cdp.service.ts
+++ b/apps/lfx-one/src/server/services/cdp.service.ts
@@ -531,7 +531,7 @@ export class CdpService {
   /**
    * Delete a specific CDP work experience
    */
-  public async deleteWorkExperience(req: Request | undefined, memberId: string, workExperienceId: string): Promise<void> {
+  public async deleteWorkExperience(req: Request | undefined, memberId: string, workExperienceId: string, deletedBy: string): Promise<void> {
     const token = await this.generateToken(req);
     const url = `${this.cdpApiUrl}${CDP_CONFIG.ENDPOINTS.MEMBER_WORK_EXPERIENCES(memberId)}/${encodeURIComponent(workExperienceId)}`;
     const requestId = randomUUID();
@@ -539,14 +539,17 @@ export class CdpService {
     logger.debug(req, 'delete_cdp_work_experience', 'Deleting CDP work experience', {
       member_id: memberId,
       work_experience_id: workExperienceId,
+      deleted_by: deletedBy,
     });
 
     const response = await fetch(url, {
       method: 'DELETE',
       headers: {
+        'Content-Type': 'application/json',
         Authorization: `Bearer ${token}`,
         'X-LFX-Request-ID': requestId,
       },
+      body: JSON.stringify({ deletedBy }),
       signal: AbortSignal.timeout(10000),
     });
 
@@ -565,7 +568,7 @@ export class CdpService {
    */
   public async deleteWorkExperienceForUser(req: Request | undefined, sub: string, workExperienceId: string): Promise<void> {
     const memberId = await this.resolveMember(req, [sub]);
-    await this.deleteWorkExperience(req, memberId, workExperienceId);
+    await this.deleteWorkExperience(req, memberId, workExperienceId, sub);
   }
 
   /**


### PR DESCRIPTION
## Summary

- CDP is making `deletedBy` **required** in the body of `DELETE /members/:memberId/work-experiences/:workExperienceId`. It lets CDP track who initiated the deletion and prevents enrichment from recreating work experiences that were intentionally deleted — behaving like the `verifiedBy` field on the sibling create / update / confirm calls.
- Our delete previously sent **no body**, so it would start failing once CDP deploys the change.
- `deleteWorkExperience()` now accepts a `deletedBy` argument, sends `Content-Type: application/json`, and includes `{ "deletedBy": "<lfid>" }` in the request body — mirroring `confirmWorkExperience`'s `{ verified, verifiedBy }` shape.
- `deleteWorkExperienceForUser()` forwards its already-resolved identifier as `deletedBy` (the controller passes the effective `lfid`, the same value used for `verifiedBy` on create/update). No controller, client, or shared-type changes were needed.

## Related

- Upstream CDP / crowd.dev change requiring this field: linuxfoundation/crowd.dev#4487

Fixes #1628
