### PR TITLE
feat(cla): let contributors choose which GitHub account signs

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/cla-group-select.component.html
@@ -81,10 +81,4 @@ SPDX-License-Identifier: MIT
       (onClick)="onContinue()"
       data-testid="cla-group-select-continue" />
   </div>
-
-  @if (selected()) {
-    <p class="mt-3 text-xs text-slate-500" data-testid="cla-group-select-auth-note">
-      You'll be asked to authorize the account you want to use (GitHub or GitLab) before EasyCLA opens.
-    </p>
-  }
 </div>

--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.html
@@ -1,0 +1,33 @@
+<!--
+Copyright The Linux Foundation and each contributor to LFX.
+SPDX-License-Identifier: MIT
+-->
+
+<div class="flex flex-col" data-testid="github-account-select-dialog">
+  <p class="mb-4 text-sm text-slate-600">
+    Choose the GitHub account to sign with. Your signature will be recorded against the account you pick, and contributions from your other accounts won't be covered
+    by it.
+  </p>
+
+  <div role="listbox" aria-label="Linked GitHub accounts" class="flex flex-col gap-2">
+    @for (account of accounts(); track account.githubId) {
+      <lfx-selectable-card
+        [form]="selectForm"
+        control="githubId"
+        [value]="account.githubId"
+        [label]="accountLabel(account)"
+        [testId]="'github-account-select-' + account.githubId" />
+    }
+  </div>
+
+  <div class="mt-4 flex justify-end gap-2.5">
+    <lfx-button label="Cancel" [text]="true" (onClick)="onCancel()" data-testid="github-account-select-cancel" />
+    <lfx-button
+      label="Continue to sign"
+      icon="fa-light fa-arrow-right"
+      iconPos="right"
+      [disabled]="!selectedId()"
+      (onClick)="onContinue()"
+      data-testid="github-account-select-continue" />
+  </div>
+</div>

--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.spec.ts
@@ -1,0 +1,128 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import type { GithubAccountOption } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { GithubAccountSelectComponent } from './github-account-select.component';
+
+/**
+ * Covers the GitHub account step opened by DialogService (#1252).
+ *
+ * The dialog holds no authority — the backend re-derives the attested set from the caller's own
+ * token — so what these tests protect is the contributor's *choice*: that every linked account
+ * is offered, that nothing is chosen on their behalf, and that the dialog closes with exactly
+ * what they picked. Those three are what the parent depends on.
+ */
+describe('GithubAccountSelectComponent', () => {
+  const OCTOCAT: GithubAccountOption = { githubId: '12345', githubUsername: 'octocat' };
+  const HUBOT: GithubAccountOption = { githubId: '67890', githubUsername: 'hubot' };
+
+  let fixture: ComponentFixture<GithubAccountSelectComponent>;
+  let close: ReturnType<typeof vi.fn>;
+
+  async function setup(accounts: GithubAccountOption[] = [OCTOCAT, HUBOT]): Promise<void> {
+    TestBed.resetTestingModule();
+    close = vi.fn();
+
+    TestBed.configureTestingModule({
+      imports: [GithubAccountSelectComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: DynamicDialogRef, useValue: { close } },
+        { provide: DynamicDialogConfig, useValue: { data: { accounts } } },
+      ],
+    });
+
+    fixture = TestBed.createComponent(GithubAccountSelectComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  function query(testId: string): HTMLElement | null {
+    return fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  /** Picks a card the way a click does — the card writes the chosen value into the form. */
+  async function choose(githubId: string): Promise<void> {
+    query(`github-account-select-${githubId}`)?.click();
+    fixture.detectChanges();
+    await fixture.whenStable();
+  }
+
+  beforeEach(async () => {
+    await setup();
+  });
+
+  it('offers every linked account', async () => {
+    expect(query(`github-account-select-${OCTOCAT.githubId}`)).not.toBeNull();
+    expect(query(`github-account-select-${HUBOT.githubId}`)).not.toBeNull();
+  });
+
+  it('shows the handle, since an account number means nothing to the contributor', async () => {
+    expect(query(`github-account-select-${OCTOCAT.githubId}`)?.textContent).toContain('octocat');
+  });
+
+  it('falls back to the account number when the handle is blank, so the row is still identifiable', async () => {
+    // The server maps a missing Auth0 nickname to '' rather than guessing a handle. Rendered
+    // as-is that produces an unlabelled row, which is unusable in the one situation this
+    // dialog is shown at all — a contributor choosing between two accounts.
+    const NAMELESS: GithubAccountOption = { githubId: '55555', githubUsername: '' };
+    await setup([OCTOCAT, NAMELESS]);
+
+    expect(query(`github-account-select-${NAMELESS.githubId}`)?.textContent).toContain('55555');
+  });
+
+  it('preselects nothing', async () => {
+    // A preselection is indistinguishable from a choice once submitted, and this step exists
+    // precisely so the association stops being decided by list order.
+    expect((fixture.componentInstance as any).selectedId()).toBeNull();
+  });
+
+  it('does not close until an account is chosen', async () => {
+    (fixture.componentInstance as any).onContinue();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('closes with the account number the contributor picked', async () => {
+    await choose(HUBOT.githubId);
+    (fixture.componentInstance as any).onContinue();
+
+    // The number, not the handle: handles get renamed and reclaimed by other people, so a
+    // hand-off keyed on one could land on a different account than the one shown here.
+    expect(close).toHaveBeenCalledWith(HUBOT.githubId);
+  });
+
+  it('closes with the later choice when the contributor changes their mind', async () => {
+    await choose(OCTOCAT.githubId);
+    await choose(HUBOT.githubId);
+    (fixture.componentInstance as any).onContinue();
+
+    expect(close).toHaveBeenCalledWith(HUBOT.githubId);
+  });
+
+  it('closes with nothing when the contributor backs out', async () => {
+    await choose(OCTOCAT.githubId);
+    (fixture.componentInstance as any).onCancel();
+
+    // Null rather than the selection: the caller treats any account number as consent to
+    // record it, so a cancel that leaked one would bind an association nobody confirmed.
+    expect(close).toHaveBeenCalledWith(null);
+  });
+
+  it('renders without a choice when opened with no accounts', async () => {
+    // Should not happen — the caller routes an empty list into account linking — but an empty
+    // picker must not offer a Continue that could submit nothing.
+    await setup([]);
+
+    (fixture.componentInstance as any).onContinue();
+
+    expect(close).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
@@ -1,0 +1,80 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import type { GithubAccountOption } from '@lfx-one/shared/interfaces';
+import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
+
+import { ButtonComponent } from '@components/button/button.component';
+import { SelectableCardComponent } from '@components/selectable-card/selectable-card.component';
+
+/**
+ * "Which GitHub account are you signing as?" step, shown between the CLA-group picker and the
+ * Console hand-off (#1252) when the contributor has linked more than one GitHub account.
+ *
+ * It exists because the account a CLA is recorded against used to be decided by whichever
+ * record an identity search returned first, which is not a decision the contributor got to
+ * make and not one that is stable across signings.
+ *
+ * The list comes from the server, which reads it from the identity provider for this session,
+ * and the CLA service records the submitted account without re-deriving ownership. So the list
+ * is not merely display data: an account that should not be in it would be recorded. This
+ * component must present what it is given and nothing else — it must never accept an account
+ * from the URL, from user input, or from anywhere but `config.data`.
+ *
+ * Closes with the chosen account's `githubId`, or `null` if the contributor backs out. The id
+ * alone, because the parent already holds the list and resolves the rest from it rather than
+ * taking a handle from here.
+ */
+@Component({
+  selector: 'lfx-github-account-select',
+  imports: [ReactiveFormsModule, ButtonComponent, SelectableCardComponent],
+  templateUrl: './github-account-select.component.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class GithubAccountSelectComponent {
+  private readonly ref = inject(DynamicDialogRef);
+  private readonly config = inject<DynamicDialogConfig<{ accounts: GithubAccountOption[] }>>(DynamicDialogConfig);
+
+  /**
+   * Deliberately starts empty rather than preselecting the first account. A preselection is
+   * indistinguishable from a choice once submitted, and the whole point of this step is that
+   * the association stops being decided by list order.
+   */
+  protected readonly selectForm = new FormGroup({
+    githubId: new FormControl<string | null>(null),
+  });
+
+  protected readonly accounts = signal<GithubAccountOption[]>(this.config.data?.accounts ?? []);
+  protected readonly selectedId = signal<string | null>(null);
+
+  public constructor() {
+    this.selectForm
+      .get('githubId')!
+      .valueChanges.pipe(takeUntilDestroyed())
+      .subscribe((value) => this.selectedId.set(value));
+  }
+
+  /**
+   * The handle can be blank: the server maps a missing `profileData.nickname` to `''` rather
+   * than guessing one. Labelling that option with the account number keeps the two accounts
+   * distinguishable, which is the entire purpose of the step — an unnamed row asks the
+   * contributor to choose between two identical-looking things. The blank handle itself is
+   * left alone, because what gets recorded is not this component's to invent.
+   */
+  protected accountLabel(account: GithubAccountOption): string {
+    return account.githubUsername || `GitHub account ${account.githubId}`;
+  }
+
+  protected onContinue(): void {
+    const githubId = this.selectedId();
+    if (!githubId) return;
+    this.ref.close(githubId);
+  }
+
+  protected onCancel(): void {
+    this.ref.close(null);
+  }
+}

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -1,13 +1,17 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+// Injecting Router pulls in @angular/common's partially-compiled PlatformLocation, which needs
+// the JIT compiler under vitest. Same reason as clas.route.spec.ts.
+import '@angular/compiler';
+
 import { DOCUMENT } from '@angular/common';
 import { PLATFORM_ID, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter, Router, RouterLink } from '@angular/router';
-import type { ClaGroupOption, MyClaAgreement, MyClasResponse } from '@lfx-one/shared/interfaces';
+import type { ClaGroupOption, GithubAccountOptions, MyClaAgreement, MyClasResponse, SigningIdentityResponse } from '@lfx-one/shared/interfaces';
 import { ButtonComponent } from '@components/button/button.component';
 import { MenuComponent } from '@components/menu/menu.component';
 import { TagComponent } from '@components/tag/tag.component';
@@ -19,6 +23,7 @@ import { Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ClaGroupSelectComponent } from './cla-group-select.component';
+import { GithubAccountSelectComponent } from './github-account-select.component';
 import { ProfileClasComponent } from './profile-clas.component';
 
 describe('ProfileClasComponent', () => {
@@ -240,29 +245,65 @@ describe('ProfileClasComponent', () => {
 });
 
 /**
- * Covers the Sign CLA hand-off entry point (#1251).
+ * Covers the Sign CLA hand-off entry point (#1251) and the GitHub account step that now sits
+ * inside it (#1252).
  *
- * The picker itself is a dynamic dialog with its own spec; what matters here is that the action is
- * offered only when it can succeed, that opening it goes through DialogService, and that whatever
- * the dialog closes with drives the hand-off. The template is rendered rather than overridden,
- * because whether the action is offered at all is a template condition.
+ * Each picker is a dynamic dialog with its own spec; what matters here is the orchestration —
+ * that the action is offered only when it can succeed, that the number of linked accounts
+ * decides whether a choice is even presented, that the association is recorded before a URL is
+ * built from it, and that a refusal ends the flow rather than quietly picking another account.
+ * The template is rendered rather than overridden, because whether the action is offered at all
+ * is a template condition.
  */
-describe('ProfileClasComponent — Sign CLA hand-off (#1251)', () => {
+describe('ProfileClasComponent — Sign CLA hand-off and account selection (#1251, #1252)', () => {
   const CLA_GROUP: ClaGroupOption = { claGroupId: 'cg-1', projectName: 'Venus test' };
   const EMPTY_CLAS: MyClasResponse = { agreements: [], identity: { matchedUserIds: 1, unmatched: false, githubLinked: true } };
+  const HOME = 'https://app.dev.lfx.dev/profile/clas';
+  const CONSOLE_URL = 'https://easycla.dev.communitybridge.org/#/cla/project/cg-1/user/u-1?redirect=enc';
+
+  const ONE_ACCOUNT: GithubAccountOptions = { accounts: [{ githubId: '12345', githubUsername: 'octocat' }] };
+  const TWO_ACCOUNTS: GithubAccountOptions = {
+    accounts: [
+      { githubId: '12345', githubUsername: 'octocat' },
+      { githubId: '67890', githubUsername: 'hubot' },
+    ],
+  };
+  const BOUND: SigningIdentityResponse = { claUserId: 'u-1', githubId: '12345', githubUsername: 'octocat', redirectUrl: HOME };
 
   let location: { href: string };
   let messageAdd: ReturnType<typeof vi.fn>;
-  let getSignUrl: ReturnType<typeof vi.fn>;
+  let getGithubAccounts: ReturnType<typeof vi.fn>;
+  let bindSigningIdentity: ReturnType<typeof vi.fn>;
+  let buildSignUrlFor: ReturnType<typeof vi.fn>;
   let open: ReturnType<typeof vi.fn>;
+  let navigate: ReturnType<typeof vi.fn>;
+
+  /** Records dialog opens in order, so "which dialog, and was it opened at all" is assertable. */
+  let opened: unknown[];
 
   async function setup(
-    options: { impersonating?: boolean; signUrl?: () => Observable<string>; closesWith?: ClaGroupOption | null } = {}
+    options: {
+      impersonating?: boolean;
+      accounts?: () => Observable<GithubAccountOptions>;
+      bind?: () => Observable<SigningIdentityResponse>;
+      closesWith?: ClaGroupOption | null;
+      accountClosesWith?: string | null;
+    } = {}
   ): Promise<ComponentFixture<ProfileClasComponent>> {
-    location = { href: 'https://app.dev.lfx.dev/profile/clas' };
+    location = { href: HOME };
     messageAdd = vi.fn();
-    getSignUrl = vi.fn(options.signUrl ?? (() => of('https://easycla.dev.communitybridge.org/#/cla/project/cg-1/user/u-1?redirect=enc')));
-    open = vi.fn(() => ({ onClose: of('closesWith' in options ? options.closesWith : CLA_GROUP) }));
+    opened = [];
+    getGithubAccounts = vi.fn(options.accounts ?? (() => of(TWO_ACCOUNTS)));
+    bindSigningIdentity = vi.fn(options.bind ?? (() => of(BOUND)));
+    buildSignUrlFor = vi.fn(() => CONSOLE_URL);
+
+    open = vi.fn((component: unknown) => {
+      opened.push(component);
+      if (component === GithubAccountSelectComponent) {
+        return { onClose: of('accountClosesWith' in options ? options.accountClosesWith : '12345') };
+      }
+      return { onClose: of('closesWith' in options ? options.closesWith : CLA_GROUP) };
+    });
 
     TestBed.configureTestingModule({
       imports: [ProfileClasComponent],
@@ -288,7 +329,14 @@ describe('ProfileClasComponent — Sign CLA hand-off (#1251)', () => {
         { provide: UserService, useValue: { impersonating: signal(options.impersonating ?? false) } },
         {
           provide: MyClasService,
-          useValue: { getMyClas: vi.fn(() => of(EMPTY_CLAS)), getPdfUrl: vi.fn(), getClaGroupOptions: vi.fn(() => of([CLA_GROUP])), getSignUrl },
+          useValue: {
+            getMyClas: vi.fn(() => of(EMPTY_CLAS)),
+            getPdfUrl: vi.fn(),
+            getClaGroupOptions: vi.fn(() => of([CLA_GROUP])),
+            getGithubAccounts,
+            bindSigningIdentity,
+            buildSignUrlFor,
+          },
         },
       ],
     });
@@ -296,6 +344,8 @@ describe('ProfileClasComponent — Sign CLA hand-off (#1251)', () => {
     TestBed.overrideProvider(DialogService, { useValue: { open } });
 
     const fixture = TestBed.createComponent(ProfileClasComponent);
+    navigate = vi.fn(() => Promise.resolve(true));
+    TestBed.inject(Router).navigate = navigate as never;
     fixture.detectChanges();
     await fixture.whenStable();
     return fixture;
@@ -303,6 +353,17 @@ describe('ProfileClasComponent — Sign CLA hand-off (#1251)', () => {
 
   function query(fixture: ComponentFixture<ProfileClasComponent>, testId: string): HTMLElement | null {
     return fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
+  }
+
+  /** Runs the whole flow from the entry point, as a click would. */
+  async function sign(fixture: ComponentFixture<ProfileClasComponent>): Promise<void> {
+    (fixture.componentInstance as any).openSignDialog();
+    await fixture.whenStable();
+  }
+
+  /** Rejects the binding with the reason code shape the BFF forwards from upstream. */
+  function refusedWith(reason: string): () => Observable<SigningIdentityResponse> {
+    return () => throwError(() => ({ status: 403, error: { upstreamCode: reason } }));
   }
 
   beforeEach(() => {
@@ -315,7 +376,7 @@ describe('ProfileClasComponent — Sign CLA hand-off (#1251)', () => {
     expect(query(fixture, 'sign-cla-action')).not.toBeNull();
   });
 
-  it('withholds the action while impersonating, since the server refuses the hand-off', async () => {
+  it('withholds the action while impersonating, since the server refuses the write', async () => {
     const fixture = await setup({ impersonating: true });
 
     expect(query(fixture, 'sign-cla-action')).toBeNull();
@@ -329,61 +390,221 @@ describe('ProfileClasComponent — Sign CLA hand-off (#1251)', () => {
 
     // The frontend checklist forbids <p-dialog> in feature templates; a regression to one would
     // still open a dialog, so assert the mechanism rather than the visible result.
-    expect(open).toHaveBeenCalledTimes(1);
-    expect(open.mock.calls[0][0]).toBe(ClaGroupSelectComponent);
+    expect(open).toHaveBeenCalled();
+    expect(opened[0]).toBe(ClaGroupSelectComponent);
     expect(fixture.nativeElement.querySelector('p-dialog')).toBeNull();
   });
 
-  it('navigates to the resolved Console URL in the same tab', async () => {
-    const fixture = await setup();
-
-    (fixture.componentInstance as any).openSignDialog();
-    await fixture.whenStable();
-
-    expect(getSignUrl).toHaveBeenCalledWith('cg-1');
-    // Same tab, not a new one: the Console returns the contributor here afterwards.
-    expect(location.href).toBe('https://easycla.dev.communitybridge.org/#/cla/project/cg-1/user/u-1?redirect=enc');
-  });
-
-  it('never composes the URL client-side from a guessed identifier', async () => {
-    const fixture = await setup();
-
-    (fixture.componentInstance as any).openSignDialog();
-    await fixture.whenStable();
-
-    // The only source of the contributor id is the server round trip.
-    expect(getSignUrl).toHaveBeenCalledTimes(1);
-  });
-
-  it('does nothing when the contributor backs out of the picker', async () => {
+  it('does nothing when the contributor backs out of the project picker', async () => {
     const fixture = await setup({ closesWith: null });
 
-    (fixture.componentInstance as any).openSignDialog();
-    await fixture.whenStable();
+    await sign(fixture);
 
-    expect(getSignUrl).not.toHaveBeenCalled();
-    expect(location.href).toBe('https://app.dev.lfx.dev/profile/clas');
+    expect(getGithubAccounts).not.toHaveBeenCalled();
+    expect(bindSigningIdentity).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
   });
 
-  it('stays on the page and reports failure when the hand-off cannot be resolved', async () => {
-    const fixture = await setup({ signUrl: () => throwError(() => new Error('resolution failed')) });
+  // --- Cardinality (FR-002) -------------------------------------------------
 
-    (fixture.componentInstance as any).openSignDialog();
+  it('asks which account to sign as when several are linked', async () => {
+    const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS) });
+
+    await sign(fixture);
+
+    expect(opened).toContain(GithubAccountSelectComponent);
+    expect(open.mock.calls.at(-1)?.[1]).toMatchObject({ data: { accounts: TWO_ACCOUNTS.accounts } });
+    // The account number only. The handle is read from the session by the server, so sending
+    // one from here could only ever contradict it.
+    expect(bindSigningIdentity).toHaveBeenCalledWith('12345');
+  });
+
+  it('submits the account chosen, not the first one listed', async () => {
+    const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS), accountClosesWith: '67890' });
+
+    await sign(fixture);
+
+    expect(bindSigningIdentity).toHaveBeenCalledWith('67890');
+  });
+
+  it('does not submit an account that is not in the served list', async () => {
+    const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS), accountClosesWith: '99999' });
+
+    await sign(fixture);
+
+    // The served list is what establishes the account is the contributor's, since upstream
+    // records what it is sent. An account from anywhere else must never be submitted.
+    expect(bindSigningIdentity).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
+  });
+
+  it('skips the choice but still records it when exactly one account is linked', async () => {
+    const fixture = await setup({ accounts: () => of(ONE_ACCOUNT) });
+
+    await sign(fixture);
+
+    // "No picker" must not become "no binding" — dropping the write here would leave the
+    // single-account contributor on the old, order-dependent resolution.
+    expect(opened).not.toContain(GithubAccountSelectComponent);
+    expect(bindSigningIdentity).toHaveBeenCalledWith('12345');
+    expect(location.href).toBe(CONSOLE_URL);
+  });
+
+  it('routes to account linking rather than showing an empty picker when none are linked', async () => {
+    const fixture = await setup({ accounts: () => of({ accounts: [] }) });
+
+    await sign(fixture);
+
+    expect(opened).not.toContain(GithubAccountSelectComponent);
+    expect(bindSigningIdentity).not.toHaveBeenCalled();
+    expect(navigate).toHaveBeenCalledWith(['/profile/identities']);
+    expect(location.href).toBe(HOME);
+  });
+
+  it('treats an account-list failure as a failure, not as zero accounts', async () => {
+    const fixture = await setup({ accounts: () => throwError(() => new Error('identity lookup failed')) });
+
+    await sign(fixture);
+
+    // Routing this into account linking would tell a contributor who has a linked account to
+    // go connect one — sending them to fix something that is not broken.
+    expect(navigate).not.toHaveBeenCalled();
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }));
+    expect(location.href).toBe(HOME);
+  });
+
+  it('does nothing when the contributor backs out of the account picker', async () => {
+    const fixture = await setup({ accountClosesWith: null });
+
+    await sign(fixture);
+
+    expect(bindSigningIdentity).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
+  });
+
+  // --- Ordering and identifier provenance (FR-003, FR-007, FR-012) ----------
+
+  it('records the association before assembling the hand-off URL', async () => {
+    const pending = new Subject<SigningIdentityResponse>();
+    const fixture = await setup({ bind: () => pending.asObservable() });
+
+    await sign(fixture);
+
+    // A URL built from an identifier obtained beforehand could carry a record the binding then
+    // refuses, so nothing may be assembled while the write is still outstanding.
+    expect(buildSignUrlFor).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
+
+    pending.next(BOUND);
     await fixture.whenStable();
 
-    // A failed resolution must not navigate to a half-built URL — the Console would show
-    // "invalid user ID", which reads as a broken product rather than a failed lookup.
-    expect(location.href).toBe('https://app.dev.lfx.dev/profile/clas');
+    expect(location.href).toBe(CONSOLE_URL);
+  });
+
+  it('builds the URL from the binding answer, never from a locally held identifier', async () => {
+    const fixture = await setup();
+
+    await sign(fixture);
+
+    // The identifier's only source is what the binding settled on.
+    expect(buildSignUrlFor).toHaveBeenCalledWith('cg-1', BOUND);
+    // Same tab, not a new one: the Console returns the contributor here afterwards.
+    expect(location.href).toBe(CONSOLE_URL);
+  });
+
+  it('stops the hand-off when the recorded account is not the chosen one', async () => {
+    // The picker closes with 12345; the binding answers with a different account. Upstream is
+    // content — it confirmed the record holds the account it was sent — so nothing below this
+    // layer can notice. Only comparing what came back against what went in catches a
+    // signature about to be attributed to an account nobody chose.
+    const fixture = await setup({
+      accountClosesWith: '12345',
+      bind: () => of({ ...BOUND, githubId: '67890', githubUsername: 'hubot' }),
+    });
+
+    await sign(fixture);
+
+    expect(buildSignUrlFor).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', summary: 'Could not start signing' }));
+  });
+
+  it('proceeds when the recorded account matches, so the check is not merely blocking everything', async () => {
+    const fixture = await setup({ accountClosesWith: '67890', bind: () => of({ ...BOUND, githubId: '67890', githubUsername: 'hubot' }) });
+
+    await sign(fixture);
+
+    expect(location.href).toBe(CONSOLE_URL);
+  });
+
+  it('ignores a second hand-off while one is already in flight', async () => {
+    const pending = new Subject<GithubAccountOptions>();
+    const fixture = await setup({ accounts: () => pending.asObservable() });
+
+    (fixture.componentInstance as any).openSignDialog();
+    (fixture.componentInstance as any).openSignDialog();
+
+    expect(getGithubAccounts).toHaveBeenCalledTimes(1);
+  });
+
+  // --- Refusals (FR-013, FR-014) -------------------------------------------
+
+  it('refuses without retrying with a different account', async () => {
+    const fixture = await setup({ bind: refusedWith('record_conflict') });
+
+    await sign(fixture);
+
+    // Substituting an account the contributor did not choose is the exact failure this
+    // feature removes, so a second binding attempt must not happen.
+    expect(bindSigningIdentity).toHaveBeenCalledTimes(1);
+    expect(location.href).toBe(HOME);
     expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }));
   });
 
-  it('ignores a second hand-off while one is already resolving', async () => {
-    const pending = new Subject<string>();
-    const fixture = await setup({ signUrl: () => pending.asObservable() });
+  // Account linking is reached only from an empty account list, which is a fact about this
+  // session rather than an upstream answer. Routing a refusal there would send someone who does
+  // have a linked account to fix something that is not broken.
+  it.each(['identity_unavailable', 'record_conflict', 'record_unclaimed', 'lf_record_already_bound', 'recorded_mismatch'] as const)(
+    'does not route the %s refusal into account linking',
+    async (reason) => {
+      const fixture = await setup({ bind: refusedWith(reason) });
 
-    (fixture.componentInstance as any).openSignDialog();
-    (fixture.componentInstance as any).openSignDialog();
+      await sign(fixture);
 
-    expect(getSignUrl).toHaveBeenCalledTimes(1);
+      expect(navigate).not.toHaveBeenCalled();
+    }
+  );
+
+  it.each([
+    ['identity_unavailable', 'sign in again'],
+    ['identity_mismatch', 'sign in again'],
+    ['record_conflict', 'already associated'],
+    ['duplicate_github_id', 'already associated'],
+    // An unclaimed record needs a human to say whose it is, which is the same instruction as a
+    // contested one from the contributor's side, so it deliberately shares that message.
+    ['record_unclaimed', 'already associated'],
+    // Points the other way to the three above — the contributor's own record holds the other
+    // account — so it must not collapse into their message, nor into the generic retry copy for
+    // a refusal that retrying cannot clear.
+    ['lf_record_already_bound', 'second account is not supported'],
+    ['recorded_mismatch', 'stopped before signing'],
+  ])('explains the %s refusal in its own terms', async (reason, expected) => {
+    const fixture = await setup({ bind: refusedWith(reason) });
+
+    await sign(fixture);
+
+    expect(location.href).toBe(HOME);
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining(expected) }));
+  });
+
+  it('stays on the page when the binding fails without a reason code', async () => {
+    const fixture = await setup({ bind: () => throwError(() => new Error('network down')) });
+
+    await sign(fixture);
+
+    // Navigating on a failed binding would land the contributor on the Console's "invalid user
+    // ID" screen, which reads as a broken product rather than a failed write.
+    expect(location.href).toBe(HOME);
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }));
   });
 });

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -4,8 +4,17 @@
 import { DatePipe, DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATFORM_ID, signal } from '@angular/core';
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
-import { RouterLink } from '@angular/router';
-import type { ClaGroupOption, ClaStatus, MyClaAgreement, MyClasState, TagSeverity } from '@lfx-one/shared/interfaces';
+import { Router, RouterLink } from '@angular/router';
+import type {
+  ClaGroupOption,
+  ClaStatus,
+  GithubAccountOption,
+  MyClaAgreement,
+  MyClasState,
+  SigningIdentityRefusal,
+  SigningIdentityResponse,
+  TagSeverity,
+} from '@lfx-one/shared/interfaces';
 import { claStatusLabel, claStatusSeverity, downloadFromUrl, isMyClasEmpty } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -23,6 +32,7 @@ import { MyClasService } from '@services/my-clas.service';
 import { UserService } from '@services/user.service';
 
 import { ClaGroupSelectComponent } from './cla-group-select.component';
+import { GithubAccountSelectComponent } from './github-account-select.component';
 
 /** Precomputed status cell for one row. */
 interface ClaRowStatus {
@@ -87,6 +97,7 @@ export class ProfileClasComponent {
   private readonly document = inject(DOCUMENT);
   private readonly destroyRef = inject(DestroyRef);
   private readonly dialogService = inject(DialogService);
+  private readonly router = inject(Router);
 
   // signatureID currently resolving a PDF URL (drives the row's spinner + guards double-clicks).
   protected readonly downloadingId = signal<string | null>(null);
@@ -171,6 +182,12 @@ export class ProfileClasComponent {
    * dialog rule and the sibling profile tabs.
    */
   protected openSignDialog(): void {
+    // Guarded from the moment the picker opens, not from when a group is chosen. `starting` is
+    // only set once the hand-off begins, which leaves the button live for as long as the picker
+    // is open — long enough to open a second one and bind twice.
+    if (this.starting()) return;
+    this.starting.set(true);
+
     const dialogRef = this.dialogService.open(ClaGroupSelectComponent, {
       header: 'Sign a CLA',
       width: '32rem',
@@ -179,8 +196,12 @@ export class ProfileClasComponent {
       dismissableMask: true,
     }) as DynamicDialogRef;
 
-    dialogRef.onClose.pipe(take(1)).subscribe((option: ClaGroupOption | null | undefined) => {
-      if (option) this.handOffToConsole(option);
+    dialogRef.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((option: ClaGroupOption | null | undefined) => {
+      if (!option) {
+        this.starting.set(false);
+        return;
+      }
+      this.handOffToConsole(option);
     });
   }
 
@@ -212,30 +233,30 @@ export class ProfileClasComponent {
   }
 
   /**
-   * Resolves the Console URL for the chosen project and leaves the page.
+   * Settles which GitHub account the signature will be recorded against, then leaves for the
+   * Console (#1252).
    *
-   * A full navigation, not a new tab: the Console returns the contributor here afterwards, which
-   * only reads as one continuous flow if they never left this tab.
+   * The account step comes before the hand-off rather than after because the association is
+   * what the Console's signature is recorded against; deciding it afterwards would mean the
+   * contributor had already signed by the time anyone knew as whom.
    */
   private handOffToConsole(option: ClaGroupOption): void {
-    if (this.starting()) return;
-
-    this.starting.set(true);
-
+    // Already flagged as in flight by `openSignDialog`, which owns the guard because the window
+    // worth guarding opens with the picker rather than with this call.
     this.myClasService
-      .getSignUrl(option.claGroupId)
+      .getGithubAccounts()
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe({
-        next: (url) => {
-          this.starting.set(false);
-          this.document.location.href = url;
-        },
+        next: ({ accounts }) => this.chooseAccountThenSign(option, accounts),
         error: () => {
           this.starting.set(false);
+          // Explicitly not treated as "no accounts linked". The two are indistinguishable in
+          // the payload but not in consequence: sending someone who already linked an account
+          // into account-linking asks them to fix something that is not broken.
           this.messageService.add({
             severity: 'error',
             summary: 'Could not start signing',
-            detail: 'We could not open the CLA signing page. Please try again.',
+            detail: 'We could not check your linked GitHub accounts. Please try again.',
           });
         },
       });
@@ -255,6 +276,155 @@ export class ProfileClasComponent {
       case 'superseded':
         return 'fa-light fa-clock-rotate-left';
     }
+  }
+
+  /**
+   * Routes on how many accounts are linked.
+   *
+   * One account skips the dialog but still binds — the screen is what is unnecessary when
+   * there is nothing to choose between, not the confirmation. Dropping the binding too would
+   * leave exactly the contributors this feature was built for on the old unpredictable path.
+   */
+  private chooseAccountThenSign(option: ClaGroupOption, accounts: GithubAccountOption[]): void {
+    if (accounts.length === 0) {
+      this.starting.set(false);
+      this.sendToAccountLinking();
+      return;
+    }
+
+    if (accounts.length === 1) {
+      this.bindThenHandOff(option, accounts[0]);
+      return;
+    }
+
+    const dialogRef = this.dialogService.open(GithubAccountSelectComponent, {
+      header: 'Choose a GitHub account',
+      width: '32rem',
+      modal: true,
+      closable: true,
+      dismissableMask: true,
+      data: { accounts },
+    }) as DynamicDialogRef;
+
+    dialogRef.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((githubId: string | null | undefined) => {
+      if (!githubId) {
+        this.starting.set(false);
+        return;
+      }
+
+      // Resolved from the list the server served rather than taken from the dialog, so the
+      // account submitted is always one of the accounts linked to this session. The upstream
+      // records what it is sent, which is what makes where this value came from matter.
+      const chosen = accounts.find((account) => account.githubId === githubId);
+      if (!chosen) {
+        this.starting.set(false);
+        this.reportRecordedMismatch();
+        return;
+      }
+
+      this.bindThenHandOff(option, chosen);
+    });
+  }
+
+  /**
+   * Records the choice, then navigates with the identifier that came back from it.
+   *
+   * A full navigation, not a new tab: the Console returns the contributor here afterwards, which
+   * only reads as one continuous flow if they never left this tab.
+   */
+  private bindThenHandOff(option: ClaGroupOption, account: GithubAccountOption): void {
+    this.starting.set(true);
+
+    this.myClasService
+      .bindSigningIdentity(account.githubId)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        next: (identity: SigningIdentityResponse) => {
+          this.starting.set(false);
+
+          // The account that came back must be the account that went in. Upstream confirms
+          // the record holds the account it was sent, which cannot detect this layer having
+          // sent the wrong one of the contributor's accounts in the first place. This
+          // comparison is the only one that answers "did we sign as the account they
+          // picked", and it is the reason the response carries the account at all.
+          if (identity.githubId !== account.githubId) {
+            this.reportRecordedMismatch();
+            return;
+          }
+
+          this.document.location.href = this.myClasService.buildSignUrlFor(option.claGroupId, identity);
+        },
+        error: (error: unknown) => {
+          this.starting.set(false);
+          this.reportBindingRefusal(error);
+        },
+      });
+  }
+
+  /**
+   * Turns a refusal into the message that fits it.
+   *
+   * Each reason calls for a different response from the contributor, so they are not collapsed
+   * into one failure notice. In particular no refusal is ever recovered from by submitting a
+   * different account — that would record the signature against an account they did not
+   * choose, which is the failure this feature exists to stop.
+   */
+  private reportBindingRefusal(error: unknown): void {
+    const reason = (error as { error?: { upstreamCode?: SigningIdentityRefusal } } | undefined)?.error?.upstreamCode;
+
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Could not start signing',
+      detail: this.refusalDetail(reason),
+    });
+  }
+
+  /**
+   * Stops the hand-off when the recorded account is not the chosen one.
+   *
+   * Deliberately the same message the service's own mismatch refusal produces: from the
+   * contributor's side it is the same event, and the difference — which layer noticed —
+   * belongs in the logs rather than on screen.
+   */
+  private reportRecordedMismatch(): void {
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Could not start signing',
+      detail: this.refusalDetail('recorded_mismatch'),
+    });
+  }
+
+  private refusalDetail(reason: SigningIdentityRefusal | undefined): string {
+    switch (reason) {
+      case 'identity_unavailable':
+      case 'identity_mismatch':
+        return 'We could not confirm who is signed in. Please sign in again and retry.';
+      case 'record_conflict':
+      case 'duplicate_github_id':
+      case 'record_unclaimed':
+        // Distinct upstream, deliberately one message here. All three mean an existing CLA
+        // record stands in the way and only a human can say whose it is; the contributor can
+        // do nothing differently, so naming the difference would only ask them to.
+        return 'That GitHub account is already associated with a different CLA record. Please contact support.';
+      case 'lf_record_already_bound':
+        // Kept apart from the three above even though it also ends in support, because it points
+        // the opposite way: there the account belongs to another record, here the contributor's
+        // own record already holds a different account. Only one is recordable at a time.
+        return 'Your CLA record already has a different GitHub account. Signing with a second account is not supported yet — please contact support.';
+      case 'recorded_mismatch':
+        return "We couldn't confirm the account was recorded correctly, so we stopped before signing. Please try again.";
+      default:
+        return 'We could not open the CLA signing page. Please try again.';
+    }
+  }
+
+  private sendToAccountLinking(): void {
+    this.messageService.add({
+      severity: 'info',
+      summary: 'Link a GitHub account',
+      detail: 'Connect the GitHub account you contribute with, then start signing again.',
+    });
+    void this.router.navigate(['/profile/identities']);
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/my-clas.service.ts
+++ b/apps/lfx-one/src/app/shared/services/my-clas.service.ts
@@ -3,9 +3,9 @@
 
 import { HttpClient } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { ClaGroupOption, ClaSignHandoff, MyClasResponse, PdfUrlResponse } from '@lfx-one/shared/interfaces';
+import { ClaGroupOption, GithubAccountOptions, MyClasResponse, PdfUrlResponse, SigningIdentityRequest, SigningIdentityResponse } from '@lfx-one/shared/interfaces';
 import { buildConsoleHandoffUrl } from '@lfx-one/shared/utils';
-import { map, Observable, take } from 'rxjs';
+import { Observable, take } from 'rxjs';
 
 import { environment } from '@environments/environment';
 
@@ -39,17 +39,38 @@ export class MyClasService {
   }
 
   /**
-   * Resolves the Contributor Console URL for signing the given CLA Group.
+   * The GitHub accounts the contributor has already linked (#1252).
    *
-   * The URL is composed across the boundary: the server supplies the contributor's EasyCLA
-   * identifier and the absolute return address (neither may be client-influenced), and this
-   * layer adds the Console base, which lives in the Angular environment the server never
-   * imports. Composing it here is what keeps the Console base from becoming a fourth
-   * server-side environment variable.
+   * A failure here is a failure, never an empty list: the caller routes an empty list into
+   * account-linking, and doing that to someone who does have a linked account sends them to
+   * fix something that is not broken.
    */
-  public getSignUrl(claGroupId: string): Observable<string> {
-    return this.http
-      .get<ClaSignHandoff>('/api/me/clas/sign-handoff')
-      .pipe(map((handoff) => buildConsoleHandoffUrl(environment.urls.contributorConsole, claGroupId, handoff.claUserId, handoff.redirectUrl)));
+  public getGithubAccounts(): Observable<GithubAccountOptions> {
+    return this.http.get<GithubAccountOptions>('/api/me/clas/github-accounts').pipe(take(1));
+  }
+
+  /**
+   * Records the contributor's chosen GitHub account, returning the EasyCLA record identifier
+   * the hand-off uses.
+   *
+   * Only the account number is sent. The server matches it against the accounts linked to this
+   * session and reads the handle from the match, so an account that did not come from
+   * `getGithubAccounts` above is refused there rather than recorded.
+   */
+  public bindSigningIdentity(githubId: string): Observable<SigningIdentityResponse> {
+    const body: SigningIdentityRequest = { githubId };
+    return this.http.post<SigningIdentityResponse>('/api/me/clas/signing-identity', body).pipe(take(1));
+  }
+
+  /**
+   * Resolves the Console URL from an association the binding has already confirmed.
+   *
+   * Takes both server-supplied halves from the binding response rather than re-fetching
+   * them, which is what makes it impossible to hand off with an identifier the binding did
+   * not settle on — including the case the older path could not serve at all, a first-time
+   * signer with no record to find yet.
+   */
+  public buildSignUrlFor(claGroupId: string, identity: SigningIdentityResponse): string {
+    return buildConsoleHandoffUrl(environment.urls.contributorConsole, claGroupId, identity.claUserId, identity.redirectUrl);
   }
 }

--- a/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
@@ -8,11 +8,12 @@ import '@angular/compiler';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const { getUsernameFromAuth } = vi.hoisted(() => ({ getUsernameFromAuth: vi.fn<() => Promise<string | null>>() }));
-const { getMyClas, resolveIdentity, getPdfUrl, getSignHandoff } = vi.hoisted(() => ({
+const { getMyClas, resolveIdentity, getPdfUrl, listGithubAccounts, bindSigningIdentity } = vi.hoisted(() => ({
   getMyClas: vi.fn(),
   resolveIdentity: vi.fn(),
   getPdfUrl: vi.fn(),
-  getSignHandoff: vi.fn(),
+  listGithubAccounts: vi.fn(),
+  bindSigningIdentity: vi.fn(),
 }));
 const { listClaGroupOptions } = vi.hoisted(() => ({ listClaGroupOptions: vi.fn() }));
 
@@ -23,7 +24,8 @@ vi.mock('../services/cla.service', () => ({
     public getMyClas = getMyClas;
     public resolveIdentity = resolveIdentity;
     public getPdfUrl = getPdfUrl;
-    public getSignHandoff = getSignHandoff;
+    public listGithubAccounts = listGithubAccounts;
+    public bindSigningIdentity = bindSigningIdentity;
   },
 }));
 vi.mock('../services/logger.service', () => ({
@@ -128,58 +130,6 @@ describe('ClasController.getPdfUrl', () => {
   });
 });
 
-// ---------------------------------------------------------------------------
-// Sign CLA hand-off (#1251)
-// ---------------------------------------------------------------------------
-
-describe('ClasController.getSignHandoff', () => {
-  const handoff = { claUserId: 'u-1', redirectUrl: 'https://app.dev.lfx.dev/profile/clas' };
-
-  it('returns the server-resolved identifier and return URL', async () => {
-    getSignHandoff.mockResolvedValue(handoff);
-    const res = buildRes();
-
-    await new ClasController().getSignHandoff({ params: {}, query: {}, body: {} } as any, res, vi.fn());
-
-    expect(res.json).toHaveBeenCalledWith(handoff);
-  });
-
-  it('ignores a client-supplied identifier — the session is the only source (FR-003)', async () => {
-    getSignHandoff.mockResolvedValue(handoff);
-    const res = buildRes();
-    // An attempt to have the hand-off carry someone else's EasyCLA record.
-    const req = { params: {}, query: { claUserId: 'someone-else' }, body: { claUserId: 'someone-else' } } as any;
-
-    await new ClasController().getSignHandoff(req, res, vi.fn());
-
-    // The service receives only (req) — no identifier is threaded through from input.
-    expect(getSignHandoff).toHaveBeenCalledWith(req);
-    expect(res.json).toHaveBeenCalledWith(handoff);
-    expect(res.json).not.toHaveBeenCalledWith(expect.objectContaining({ claUserId: 'someone-else' }));
-  });
-
-  it('returns 401 (via next) when unauthenticated', async () => {
-    getUsernameFromAuth.mockResolvedValue(null);
-    const next = vi.fn();
-
-    await new ClasController().getSignHandoff({ params: {}, query: {}, body: {} } as any, buildRes(), next);
-
-    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
-    expect(getSignHandoff).not.toHaveBeenCalled();
-  });
-
-  it('forwards a failed resolution instead of returning a partial payload', async () => {
-    getSignHandoff.mockRejectedValue(new MicroserviceError('no user id', 502, 'UPSTREAM_ERROR', { service: 'cla_service' }));
-    const res = buildRes();
-    const next = vi.fn();
-
-    await new ClasController().getSignHandoff({ params: {}, query: {}, body: {} } as any, res, next);
-
-    expect(next.mock.calls[0][0]).toBeInstanceOf(MicroserviceError);
-    expect(res.json).not.toHaveBeenCalled();
-  });
-});
-
 describe('ClasController.getClaGroupOptions', () => {
   it('returns the stubbed selection options', async () => {
     listClaGroupOptions.mockReturnValue([{ claGroupId: 'cg-1', projectName: 'Venus test' }]);
@@ -216,5 +166,124 @@ describe('ClasController.getClaGroupOptions', () => {
     await new ClasController().getClaGroupOptions({ params: {}, query: {} } as any, buildRes(), next);
 
     expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// GitHub account selection and binding (#1252)
+// ---------------------------------------------------------------------------
+
+describe('ClasController.getGithubAccounts', () => {
+  const options = { accounts: [{ githubId: '12345', githubUsername: 'octocat' }] };
+
+  it('returns the linked accounts for the picker', async () => {
+    listGithubAccounts.mockResolvedValue(options);
+    const res = buildRes();
+
+    await new ClasController().getGithubAccounts({ params: {}, query: {} } as any, res, vi.fn());
+
+    expect(res.json).toHaveBeenCalledWith(options);
+  });
+
+  it('forwards a lookup failure instead of answering with zero accounts', async () => {
+    listGithubAccounts.mockRejectedValue(new MicroserviceError('identity lookup failed', 502, 'UPSTREAM_ERROR', { service: 'cla_service' }));
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new ClasController().getGithubAccounts({ params: {}, query: {} } as any, res, next);
+
+    // An empty list routes the contributor into account-linking. A failure reported that way
+    // would send someone who already linked an account to go fix nothing.
+    expect(next.mock.calls[0][0]).toBeInstanceOf(MicroserviceError);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 (via next) when unauthenticated', async () => {
+    getUsernameFromAuth.mockResolvedValue(null);
+    const next = vi.fn();
+
+    await new ClasController().getGithubAccounts({ params: {}, query: {} } as any, buildRes(), next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
+    expect(listGithubAccounts).not.toHaveBeenCalled();
+  });
+});
+
+describe('ClasController.bindSigningIdentity', () => {
+  const bound = { claUserId: 'u-1', githubId: '12345', githubUsername: 'octocat', redirectUrl: 'https://app.dev.lfx.dev/profile/clas' };
+
+  it('returns the recorded association and the return address', async () => {
+    bindSigningIdentity.mockResolvedValue(bound);
+    const res = buildRes();
+
+    await new ClasController().bindSigningIdentity({ params: {}, query: {}, body: { githubId: '12345' } } as any, res, vi.fn());
+
+    expect(res.json).toHaveBeenCalledWith(bound);
+  });
+
+  it('takes the record identifier from the upstream answer, never from the request', async () => {
+    bindSigningIdentity.mockResolvedValue(bound);
+    const res = buildRes();
+    // An attempt to have the association land on someone else's EasyCLA record.
+    const req = { params: {}, query: { claUserId: 'someone-else' }, body: { githubId: '12345', claUserId: 'someone-else' } } as any;
+
+    await new ClasController().bindSigningIdentity(req, res, vi.fn());
+
+    // Only the chosen account number crosses the boundary. The record identifier is resolved
+    // upstream from the authenticated caller and is never client input.
+    expect(bindSigningIdentity).toHaveBeenCalledWith(req, '12345');
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ claUserId: 'u-1' }));
+  });
+
+  it('ignores a handle sent alongside the account number', async () => {
+    bindSigningIdentity.mockResolvedValue(bound);
+
+    // The service reads the handle from the session's own accounts. Accepting one here would
+    // let a caller pair an account number they own with a handle they do not.
+    const withHandle = { params: {}, query: {}, body: { githubId: '12345', githubUsername: 'someone-else' } } as any;
+    await new ClasController().bindSigningIdentity(withHandle, buildRes(), vi.fn());
+
+    expect(bindSigningIdentity).toHaveBeenCalledWith(withHandle, '12345');
+  });
+
+  it.each([undefined, '', '   ', 'abc', '12a', '-1', '0', '1.5'])('rejects %p as an account number', async (githubId) => {
+    const res = buildRes();
+
+    await new ClasController().bindSigningIdentity({ params: {}, query: {}, body: { githubId } } as any, res, vi.fn());
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(bindSigningIdentity).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    'identity_unavailable',
+    'identity_mismatch',
+    'record_conflict',
+    'record_unclaimed',
+    'duplicate_github_id',
+    'recorded_mismatch',
+  ] as const)('forwards the %s refusal rather than falling back', async (reason) => {
+    bindSigningIdentity.mockRejectedValue(
+      new MicroserviceError(`refused: ${reason}`, 403, 'UPSTREAM_ERROR', { service: 'cla_service', errorBody: { error: reason } })
+    );
+    const res = buildRes();
+    const next = vi.fn();
+
+    await new ClasController().bindSigningIdentity({ params: {}, query: {}, body: { githubId: '12345' } } as any, res, next);
+
+    // No alternative account is chosen on the contributor's behalf. Silently signing as a
+    // different account than the one picked is exactly the outcome this feature removes.
+    expect(next.mock.calls[0][0]).toMatchObject({ errorBody: { error: reason } });
+    expect(res.json).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 (via next) when unauthenticated', async () => {
+    getUsernameFromAuth.mockResolvedValue(null);
+    const next = vi.fn();
+
+    await new ClasController().bindSigningIdentity({ params: {}, query: {}, body: { githubId: '12345' } } as any, buildRes(), next);
+
+    expect(next.mock.calls[0][0]).toBeInstanceOf(AuthenticationError);
+    expect(bindSigningIdentity).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -90,23 +90,61 @@ export class ClasController {
     }
   }
 
-  // GET /api/me/clas/sign-handoff
-  // Server-owned halves of the Contributor Console URL. Blocked during impersonation at the
-  // route (signing is a write), so this handler has no impersonation branch of its own.
-  public async getSignHandoff(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const startTime = logger.startOperation(req, 'get_cla_sign_handoff');
+  // GET /api/me/clas/github-accounts
+  // The accounts the contributor has already linked, for the selection step (#1252).
+  // A lookup failure surfaces as a failure rather than as an empty list: routing someone
+  // who has a linked account into account-linking is worse than telling them the choice is
+  // unavailable right now.
+  public async getGithubAccounts(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_cla_github_accounts');
 
     try {
       if (!(await getUsernameFromAuth(req))) {
-        throw new AuthenticationError('User authentication required', { operation: 'get_cla_sign_handoff' });
+        throw new AuthenticationError('User authentication required', { operation: 'get_cla_github_accounts' });
       }
 
-      // Nothing is read from the query or body: whose CLA is being signed is a property of the
-      // session, never of request input (FR-003).
-      const handoff = await this.claService.getSignHandoff(req);
+      const options = await this.claService.listGithubAccounts(req);
 
-      logger.success(req, 'get_cla_sign_handoff', startTime);
-      res.json(handoff);
+      logger.success(req, 'get_cla_github_accounts', startTime, { account_count: options.accounts.length });
+      res.json(options);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  // POST /api/me/clas/signing-identity
+  // Forwards the contributor's choice and returns the record identifier the hand-off uses.
+  //
+  // Deliberately performs no resolution, no check of the selection against the list this
+  // controller served, and no fallback on refusal. Those judgements belong to the layer
+  // holding the identity provider's attestation; duplicating them here would mean deciding
+  // on weaker evidence, and the only thing a pre-check could achieve is hiding a refusal
+  // that has to stay visible.
+  //
+  // Blocked during impersonation at the route, so there is no impersonation branch here.
+  public async bindSigningIdentity(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'bind_cla_signing_identity');
+
+    try {
+      if (!(await getUsernameFromAuth(req))) {
+        throw new AuthenticationError('User authentication required', { operation: 'bind_cla_signing_identity' });
+      }
+
+      // The account number is the only thing taken from the body. The handle that accompanies
+      // it is read from the session's own accounts by the service, so there is nothing here for
+      // a caller to influence beyond which of their own accounts they name.
+      const body = req.body as { githubId?: unknown } | undefined;
+
+      const githubId = String(body?.githubId ?? '').trim();
+      if (!/^[1-9][0-9]*$/.test(githubId)) {
+        res.status(400).json({ message: 'A GitHub account number is required' });
+        return;
+      }
+
+      const result = await this.claService.bindSigningIdentity(req, githubId);
+
+      logger.success(req, 'bind_cla_signing_identity', startTime);
+      res.json(result);
     } catch (error) {
       next(error);
     }

--- a/apps/lfx-one/src/server/routes/clas.route.spec.ts
+++ b/apps/lfx-one/src/server/routes/clas.route.spec.ts
@@ -10,23 +10,24 @@ import type { Server } from 'node:http';
 import { afterAll, beforeAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
 /**
- * Router-level coverage for the read-only-impersonation gate on the Sign CLA hand-off (#1251).
+ * Router-level coverage for the read-only-impersonation gate on the signing-identity write (#1252).
  *
- * The middleware has its own behaviour; what these tests protect is the *registration*. Signing
- * is a binding legal act with no way to attribute it back to an impersonator, so the hand-off is
- * exactly the class of write `blockDuringImpersonation` exists for. A unit test of the controller
- * would keep passing if the middleware were dropped from the route — which is the regression that
- * matters, because the failure mode is a signature recorded against the wrong person.
+ * The middleware has its own behaviour; what these tests protect is the *registration*. A unit
+ * test of the controller would keep passing if the middleware were dropped from the route — which
+ * is the regression that matters, because the failure mode is a GitHub account recorded onto the
+ * impersonated person's EasyCLA record, attributed to them rather than to the administrator who
+ * caused it, with no in-payload trace of who did.
  *
- * The read routes are asserted alongside it: impersonated *viewing* of CLAs must keep working,
- * so a blanket `router.use` would be a bug, not a safer default.
+ * The read routes are asserted alongside it: impersonated *viewing* of CLAs and of the linked
+ * accounts must keep working, so a blanket `router.use` would be a bug, not a safer default.
  */
 
-const { getMyClas, getPdfUrl, getSignHandoff, getClaGroupOptions } = vi.hoisted(() => ({
+const { getMyClas, getPdfUrl, getClaGroupOptions, getGithubAccounts, bindSigningIdentity } = vi.hoisted(() => ({
   getMyClas: vi.fn(),
   getPdfUrl: vi.fn(),
-  getSignHandoff: vi.fn(),
   getClaGroupOptions: vi.fn(),
+  getGithubAccounts: vi.fn(),
+  bindSigningIdentity: vi.fn(),
 }));
 const { isImpersonating } = vi.hoisted(() => ({ isImpersonating: vi.fn<() => boolean>(() => false) }));
 
@@ -34,8 +35,9 @@ vi.mock('../controllers/clas.controller', () => ({
   ClasController: class {
     public getMyClas = getMyClas;
     public getPdfUrl = getPdfUrl;
-    public getSignHandoff = getSignHandoff;
     public getClaGroupOptions = getClaGroupOptions;
+    public getGithubAccounts = getGithubAccounts;
+    public bindSigningIdentity = bindSigningIdentity;
   },
 }));
 vi.mock('../utils/auth-helper', () => ({ isImpersonating }));
@@ -85,41 +87,52 @@ beforeEach(() => {
   isImpersonating.mockReturnValue(false);
   getMyClas.mockImplementation(ok);
   getPdfUrl.mockImplementation(ok);
-  getSignHandoff.mockImplementation(ok);
   getClaGroupOptions.mockImplementation(ok);
+  getGithubAccounts.mockImplementation(ok);
+  bindSigningIdentity.mockImplementation(ok);
 });
 
-describe('clas router — Sign CLA hand-off during impersonation', () => {
-  it('refuses the hand-off while impersonating', async () => {
+describe('clas router — signing-identity write during impersonation', () => {
+  /** POST helper — the guarded route is a write, so it cannot be reached with a bare fetch. */
+  function bind(): Promise<Response> {
+    return fetch(`${baseUrl}/api/me/clas/signing-identity`, {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({ githubId: '12345' }),
+    });
+  }
+
+  it('refuses to record an association while impersonating', async () => {
     isImpersonating.mockReturnValue(true);
 
-    const res = await fetch(`${baseUrl}/api/me/clas/sign-handoff`);
+    const res = await bind();
 
     expect(res.status).toBe(403);
     // Asserted together with the status: a downstream failure could also produce 403, so the
     // status alone would not prove the gate produced it.
-    expect(getSignHandoff).not.toHaveBeenCalled();
+    expect(bindSigningIdentity).not.toHaveBeenCalled();
   });
 
   it('reports the read-only impersonation code, so the UI can explain it', async () => {
     isImpersonating.mockReturnValue(true);
 
-    const res = await fetch(`${baseUrl}/api/me/clas/sign-handoff`);
+    const res = await bind();
 
     expect((await res.json()).code).toBe('IMPERSONATION_READ_ONLY');
   });
 
-  it('allows the hand-off in a normal session', async () => {
-    const res = await fetch(`${baseUrl}/api/me/clas/sign-handoff`);
+  it('allows the write in a normal session', async () => {
+    const res = await bind();
 
     expect(res.status).toBe(200);
-    expect(getSignHandoff).toHaveBeenCalled();
+    expect(bindSigningIdentity).toHaveBeenCalled();
   });
 
   it.each([
     ['CLAs list', '/api/me/clas'],
     ['PDF URL', '/api/me/clas/sig-1/pdf-url'],
     ['CLA group options', '/api/me/clas/sign-options'],
+    ['linked GitHub accounts', '/api/me/clas/github-accounts'],
   ])('keeps %s readable while impersonating', async (_label, path) => {
     isImpersonating.mockReturnValue(true);
 

--- a/apps/lfx-one/src/server/routes/clas.route.ts
+++ b/apps/lfx-one/src/server/routes/clas.route.ts
@@ -14,12 +14,16 @@ const clasController = new ClasController();
 router.get('/clas', (req, res, next) => clasController.getMyClas(req, res, next));
 router.get('/clas/:signatureId/pdf-url', (req, res, next) => clasController.getPdfUrl(req, res, next));
 
-// Sign CLA hand-off (#1251). Selection is a read and stays available while impersonating; the
-// hand-off is guarded, because starting a signature is a real, externally-visible act that would
-// be attributed to the target rather than the impersonator who performed it. Registered before
-// `/clas/:signatureId/pdf-url` would not matter (distinct final segments), but both sign routes
-// are kept together so the guard is visible next to what it protects.
+// Sign CLA hand-off (#1251). Project selection is a read and stays available while
+// impersonating.
 router.get('/clas/sign-options', (req, res, next) => clasController.getClaGroupOptions(req, res, next));
-router.get('/clas/sign-handoff', blockDuringImpersonation, (req, res, next) => clasController.getSignHandoff(req, res, next));
+
+// GitHub account selection before the hand-off (#1252). Listing the linked accounts is a
+// read and stays available while impersonating; recording the choice is guarded, and more
+// plainly than the hand-off is — this route causes an identity attribute to be written to
+// an EasyCLA record, which is literally the hard-to-retract, externally-visible act with no
+// in-payload caller identity that the read-only rule exists for.
+router.get('/clas/github-accounts', (req, res, next) => clasController.getGithubAccounts(req, res, next));
+router.post('/clas/signing-identity', blockDuringImpersonation, (req, res, next) => clasController.bindSigningIdentity(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -611,149 +611,229 @@ describe('ClaService.getPdfUrl', () => {
   });
 });
 
+
 // ---------------------------------------------------------------------------
-// resolveContributorId — userIds from /v4/my-clas (Sign CLA hand-off, #1251)
+// listGithubAccounts — the picker's options (#1252)
 // ---------------------------------------------------------------------------
 
-describe('ClaService.resolveContributorId', () => {
-  /** Rejects the /v2/user-from-token probe so the userIds bridge behind it is exercised. */
-  function probeUnavailable(): void {
-    gatewayFetch.mockRejectedValueOnce(new MicroserviceError('probe rejected', 401, 'UPSTREAM_ERROR', { service: 'cla_service' }));
-  }
-
-  it('prefers the resolve-or-create endpoint when it accepts our token', async () => {
-    gatewayFetch.mockResolvedValueOnce({ user_id: 'u-created' });
-
-    // Preferred because it mints a record for a first-time signer, which the bridge cannot.
-    expect(await new ClaService().resolveContributorId(req)).toBe('u-created');
-    expect(gatewayFetch).toHaveBeenCalledTimes(1);
+describe('ClaService.listGithubAccounts', () => {
+  beforeEach(() => {
+    getEffectiveSub.mockReturnValue('auth0|abc');
   });
 
-  it('reads the snake_case user_id the legacy backend returns', async () => {
-    // /v2 returns the raw DynamoDB item, not v4's camelCase model — userID would read as absent.
-    gatewayFetch.mockResolvedValueOnce({ userID: 'wrong-case' });
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['from-bridge'] });
+  it('returns the linked GitHub accounts with their numbers and handles', async () => {
+    getUserIdentities.mockResolvedValueOnce([
+      { provider: 'github', user_id: '12345', profileData: { nickname: 'octocat' } },
+      { provider: 'github', user_id: 'github|67890', profileData: { nickname: 'hubot' } },
+    ]);
 
-    expect(await new ClaService().resolveContributorId(req)).toBe('from-bridge');
+    expect(await new ClaService().listGithubAccounts(req)).toEqual({
+      accounts: [
+        { githubId: '12345', githubUsername: 'octocat' },
+        { githubId: '67890', githubUsername: 'hubot' },
+      ],
+    });
   });
 
-  it('falls back to the bridge when the probe is rejected', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['from-bridge'] });
+  it('excludes identities from other providers', async () => {
+    getUserIdentities.mockResolvedValueOnce([
+      { provider: 'google-oauth2', user_id: '999', profileData: { nickname: 'someone' } },
+      { provider: 'github', user_id: '12345', profileData: { nickname: 'octocat' } },
+    ]);
 
-    // A rejected probe must not break the hand-off for a contributor who already has a record.
-    expect(await new ClaService().resolveContributorId(req)).toBe('from-bridge');
+    const { accounts } = await new ClaService().listGithubAccounts(req);
+
+    expect(accounts).toEqual([{ githubId: '12345', githubUsername: 'octocat' }]);
   });
 
-  it('resolves the EasyCLA user UUID from the identity search', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['40dc8def-e014-11ec-8750-4225fa2d71d7'] });
+  it('returns an empty list when nothing is linked', async () => {
+    getUserIdentities.mockResolvedValueOnce([]);
 
-    expect(await new ClaService().resolveContributorId(req)).toBe('40dc8def-e014-11ec-8750-4225fa2d71d7');
+    // Genuinely none linked — the caller routes this into account-linking, which is only
+    // correct because the failure case below is NOT reported this way.
+    expect(await new ClaService().listGithubAccounts(req)).toEqual({ accounts: [] });
   });
 
-  it('reads the fallback from /v4/my-clas, never /v4/user-from-token', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1'] });
+  it('surfaces an identity-lookup failure instead of reporting zero accounts', async () => {
+    getUserIdentities.mockRejectedValueOnce(new Error('auth service timed out'));
 
-    await new ClaService().resolveContributorId(req);
-
-    // The v4 namesake is an unauthenticated passthrough on the gateway, so it never receives the
-    // X-ACL header the CLA backend's security scheme is keyed on and always 401s.
-    const urls = gatewayFetch.mock.calls.map((call) => (call as [unknown, string])[1]);
-    expect(urls.some((url) => url.includes('/v4/my-clas'))).toBe(true);
-    expect(urls.some((url) => url.includes('/v4/user-from-token'))).toBe(false);
+    // The read path degrades to "no GitHub keys" here and is right to. This path must not:
+    // an empty list sends the contributor into account-linking, and doing that to someone
+    // who has a linked account asks them to fix something that is not broken.
+    await expect(new ClaService().listGithubAccounts(req)).rejects.toThrow();
   });
 
-  it('runs on the default gateway token', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1'] });
+  it('drops an identity whose account number cannot be read', async () => {
+    getUserIdentities.mockResolvedValueOnce([
+      { provider: 'github', user_id: 'not-a-number', profileData: { nickname: 'ghost' } },
+      { provider: 'github', user_id: '12345', profileData: { nickname: 'octocat' } },
+    ]);
 
-    await new ClaService().resolveContributorId(req);
+    // Dropped rather than refused: an unreadable number could never be selected anyway,
+    // because the backend would not attest it either.
+    const { accounts } = await new ClaService().listGithubAccounts(req);
 
-    // apiGatewayToken already carries the signed-in contributor (their own refresh token
-    // exchanged for the gateway audience). Overriding it would resolve someone else.
-    for (const call of gatewayFetch.mock.calls) {
-      const [, , opts] = call as [unknown, string, { bearerToken?: string }];
-      expect(opts.bearerToken).toBeUndefined();
-    }
+    expect(accounts).toEqual([{ githubId: '12345', githubUsername: 'octocat' }]);
   });
 
-  it('refuses to hand off when no record matches the session', async () => {
-    // A first-time signer has no EasyCLA record yet, and with the probe unavailable there is
-    // nothing to mint one. The Console renders "invalid user ID in the URL" for an absent id, so
-    // this must fail here rather than dead-end there (FR-009).
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: [] });
+  it('refuses when the session carries no identity subject', async () => {
+    getEffectiveSub.mockReturnValue(null);
 
-    await expect(new ClaService().resolveContributorId(req)).rejects.toThrow(MicroserviceError);
-  });
-
-  it('refuses when the field is missing entirely', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ resultCount: 0 });
-
-    await expect(new ClaService().resolveContributorId(req)).rejects.toThrow(MicroserviceError);
-  });
-
-  it('refuses when the upstream returns no body', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce(null);
-
-    await expect(new ClaService().resolveContributorId(req)).rejects.toThrow(MicroserviceError);
-  });
-
-  it('ignores blank identifiers rather than handing one off', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['  ', ''] });
-
-    await expect(new ClaService().resolveContributorId(req)).rejects.toThrow(MicroserviceError);
-  });
-
-  it('trims a padded identifier', async () => {
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['  u-1  '] });
-
-    expect(await new ClaService().resolveContributorId(req)).toBe('u-1');
-  });
-
-  it('takes the first of several matched records rather than failing', async () => {
-    // An identity can match several EasyCLA records and nothing here can tell which one a
-    // signature belongs against. Refusing a returning contributor helps nobody; the ambiguity is
-    // logged instead, and the resolve-or-create endpoint returns one record.
-    probeUnavailable();
-    gatewayFetch.mockResolvedValueOnce({ userIds: ['u-1', 'u-2', 'u-3'] });
-
-    expect(await new ClaService().resolveContributorId(req)).toBe('u-1');
-  });
-
-  it('propagates a failure of the fallback itself', async () => {
-    probeUnavailable();
-    gatewayFetch.mockRejectedValueOnce(new MicroserviceError('boom', 502, 'UPSTREAM_ERROR', { service: 'cla_service' }));
-
-    await expect(new ClaService().resolveContributorId(req)).rejects.toThrow(MicroserviceError);
+    await expect(new ClaService().listGithubAccounts(req)).rejects.toThrow(MicroserviceError);
   });
 });
 
 // ---------------------------------------------------------------------------
-// getSignHandoff — server-owned halves of the Console URL (#1251)
+// bindSigningIdentity — recording the chosen account (#1252)
 // ---------------------------------------------------------------------------
 
-describe('ClaService.getSignHandoff', () => {
-  const handoffReq = { protocol: 'https', get: (n: string) => (n === 'host' ? 'app.dev.lfx.dev' : undefined) } as unknown as Request;
+describe('ClaService.bindSigningIdentity', () => {
+  const bindReq = reqWithHost('app.dev.lfx.dev');
 
-  it('returns the resolved identifier and an absolute return URL', async () => {
-    gatewayFetch.mockResolvedValueOnce({ user_id: 'u-1' });
+  // The submitted account is matched against the session's linked accounts before anything is
+  // sent upstream, so every test here needs a session that actually has the account it names.
+  beforeEach(() => {
+    getEffectiveSub.mockReturnValue('auth0|abc');
+    getUserIdentities.mockResolvedValue([
+      { provider: 'github', user_id: 'github|12345', connection: 'github', profileData: { nickname: 'octocat' } },
+    ]);
+  });
 
-    expect(await new ClaService().getSignHandoff(handoffReq)).toEqual({
+  it('refuses an account that is not linked to this session', async () => {
+    // The upstream records what it is sent without re-deriving ownership, so this is the check
+    // that keeps a caller from naming somebody else's account by calling the endpoint directly.
+    await expect(new ClaService().bindSigningIdentity(bindReq, '99999')).rejects.toMatchObject({ code: 'CLA_ACCOUNT_NOT_LINKED' });
+
+    expect(gatewayFetch).not.toHaveBeenCalled();
+  });
+
+  it('refuses rather than proceeding when the linked accounts cannot be read', async () => {
+    // A failure must not read as "no accounts", which would refuse every account including the
+    // contributor's own — but more importantly must never fall through to recording one.
+    getUserIdentities.mockRejectedValueOnce(new Error('NATS TIMEOUT'));
+
+    await expect(new ClaService().bindSigningIdentity(bindReq, '12345')).rejects.toThrow();
+
+    expect(gatewayFetch).not.toHaveBeenCalled();
+  });
+
+  it('sends the handle from the session, not one supplied by the caller', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 12345 });
+
+    await new ClaService().bindSigningIdentity(bindReq, '12345');
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      bindReq,
+      expect.stringContaining('/v4/my-clas/signing-identity'),
+      expect.objectContaining({ body: { githubId: 12345, githubUsername: 'octocat' } })
+    );
+  });
+
+  it('returns the recorded association and the return address together', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 12345, githubUsername: 'octocat', outcome: 'created' });
+
+    expect(await new ClaService().bindSigningIdentity(bindReq, '12345')).toEqual({
       claUserId: 'u-1',
+      githubId: '12345',
+      githubUsername: 'octocat',
+      // Both halves come back from the binding, so a hand-off URL cannot be assembled
+      // before the association exists.
       redirectUrl: 'https://app.dev.lfx.dev/profile/clas',
     });
   });
 
-  it('does not resolve an identifier when the return URL cannot be derived', async () => {
-    const hostless = { protocol: 'https', get: () => undefined } as unknown as Request;
+  it('posts the account as a number to the signing-identity endpoint', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 12345 });
 
-    await expect(new ClaService().getSignHandoff(hostless)).rejects.toThrow(MicroserviceError);
+    await new ClaService().bindSigningIdentity(bindReq, '12345');
+
+    expect(gatewayFetch).toHaveBeenCalledWith(
+      bindReq,
+      expect.stringContaining('/v4/my-clas/signing-identity'),
+      expect.objectContaining({ method: 'POST', body: { githubId: 12345, githubUsername: 'octocat' } })
+    );
+  });
+
+  it('omits the handle rather than sending an empty one', async () => {
+    // A linked account the identity provider has no nickname for.
+    getUserIdentities.mockResolvedValueOnce([{ provider: 'github', user_id: 'github|12345', connection: 'github', profileData: {} }]);
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 12345 });
+
+    await new ClaService().bindSigningIdentity(bindReq, '12345');
+
+    // An empty string would be recorded as the contributor's handle, replacing whatever the
+    // record already held with nothing.
+    const [, , opts] = gatewayFetch.mock.calls[0] as [unknown, string, { body?: Record<string, unknown> }];
+    expect(opts.body).not.toHaveProperty('githubUsername');
+  });
+
+  it('runs on the default gateway token, which is what identifies the caller upstream', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 12345 });
+
+    await new ClaService().bindSigningIdentity(bindReq, '12345');
+
+    const [, , opts] = gatewayFetch.mock.calls[0] as [unknown, string, { bearerToken?: string }];
+    expect(opts.bearerToken).toBeUndefined();
+  });
+
+  it('returns the account the backend recorded, not the one submitted', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 999, githubUsername: 'recorded' });
+
+    // The caller checks this against what was chosen, so echoing the request back would
+    // defeat the only check that what was recorded is what was picked.
+    const result = await new ClaService().bindSigningIdentity(bindReq, '12345');
+
+    expect(result.githubId).toBe('999');
+  });
+
+  it.each([
+    'identity_unavailable',
+    'identity_mismatch',
+    'record_conflict',
+    'record_unclaimed',
+    'duplicate_github_id',
+    'recorded_mismatch',
+  ] as const)('keeps the %s refusal reason distinguishable to the caller', async (reason) => {
+    gatewayFetch.mockRejectedValueOnce(
+      new MicroserviceError(`refused: ${reason}`, 403, 'UPSTREAM_ERROR', { service: 'cla_service', errorBody: { error: reason } })
+    );
+
+    // Collapsing these into one failure would lose the only thing that tells the contributor
+    // what to do next — sign in again, choose again, or contact support.
+    await expect(new ClaService().bindSigningIdentity(bindReq, '12345')).rejects.toMatchObject({
+      errorBody: { error: reason },
+    });
+  });
+
+  it('resolves the account list again rather than trusting the caller to have used it', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 12345 });
+
+    await new ClaService().bindSigningIdentity(bindReq, '12345');
+
+    // The browser resolves the choice against the served list too, but nothing obliges a caller
+    // to go through the browser. Skipping this to save a lookup would leave the account number
+    // unchecked on the one path that records it.
+    expect(getUserIdentities).toHaveBeenCalled();
+  });
+
+  it('refuses an upstream answer with no recorded identifier', async () => {
+    gatewayFetch.mockResolvedValueOnce({ githubId: 12345 });
+
+    await expect(new ClaService().bindSigningIdentity(bindReq, '12345')).rejects.toThrow(MicroserviceError);
+  });
+
+  it('refuses an upstream answer with no recorded account', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1' });
+
+    await expect(new ClaService().bindSigningIdentity(bindReq, '12345')).rejects.toThrow(MicroserviceError);
+  });
+
+  it('does not write an association it could never hand off', async () => {
+    gatewayFetch.mockResolvedValueOnce({ userId: 'u-1', githubId: 12345 });
+
+    await expect(new ClaService().bindSigningIdentity(reqWithHost(undefined), '12345')).rejects.toThrow(MicroserviceError);
+    // An unusable origin dead-ends the flow regardless, so the identity attribute must not
+    // have been recorded on the way to finding that out.
+    expect(gatewayFetch).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -10,10 +10,21 @@
 // authenticated user before searching and reports unverifiable keys in
 // `skippedIdentities` — SS surfaces that as identity-gap telemetry.
 
-import { Auth0Identity, ClaSignHandoff, EmailManagementData, MyClaAgreement, MyClasResponse, PdfUrlResponse, type ClaStatus } from '@lfx-one/shared/interfaces';
+import {
+  Auth0Identity,
+  EmailManagementData,
+  GithubAccountOption,
+  GithubAccountOptions,
+  MyClaAgreement,
+  MyClasResponse,
+  PdfUrlResponse,
+  SigningIdentityRefusal,
+  SigningIdentityResponse,
+  type ClaStatus,
+} from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
-import { EasyClaMyCla, EasyClaMyClaList, EasyClaMyClaPdf, EasyClaUserFromTokenV2, ResolvedClaIdentity } from '../types/cla.types';
+import { EasyClaMyCla, EasyClaMyClaList, EasyClaMyClaPdf, EasyClaSigningIdentity, ResolvedClaIdentity } from '../types/cla.types';
 import { MicroserviceError } from '../errors';
 import { gatewayFetch } from '../helpers/gateway-fetch.helper';
 import { getEffectiveEmail, getEffectiveSub, getEffectiveUsername, isImpersonating } from '../utils/auth-helper';
@@ -216,6 +227,57 @@ export function toMyClaAgreement(cla: EasyClaMyCla): MyClaAgreement {
   };
 }
 
+/**
+ * The refusal reasons the CLA service can answer a binding request with. A closed set, in
+ * the order they are tested — no reason is a substring of another, so a match is exact
+ * even though the search is not anchored.
+ */
+const SIGNING_IDENTITY_REFUSALS: readonly SigningIdentityRefusal[] = [
+  'identity_unavailable',
+  'identity_mismatch',
+  'record_conflict',
+  'record_unclaimed',
+  'duplicate_github_id',
+  'lf_record_already_bound',
+  'recorded_mismatch',
+];
+
+/**
+ * Finds the refusal reason in an upstream error body.
+ *
+ * The reason has to be recovered from the message text because the CLA service's shared
+ * error shape carries only `code`, `message` and a request id, and adding a field to it
+ * would change every endpoint that uses it. Searching a closed set of known reasons keeps
+ * that safe: an unrecognised body yields null and the error passes through untouched,
+ * rather than being guessed into the nearest reason.
+ */
+export function signingIdentityRefusalFrom(errorBody: unknown): SigningIdentityRefusal | null {
+  if (!errorBody) return null;
+  const text = typeof errorBody === 'string' ? errorBody : JSON.stringify(errorBody);
+  return SIGNING_IDENTITY_REFUSALS.find((reason) => text.includes(reason)) ?? null;
+}
+
+/**
+ * Re-labels an upstream failure with its refusal reason, so the reason survives to the
+ * browser rather than being flattened into a single "conflict".
+ *
+ * Carried on `errorBody.error`, which the error response already forwards as
+ * `upstreamCode` — the existing route for exactly this, since `code` is derived from the
+ * HTTP status and collapses every 409 together.
+ */
+function withSigningIdentityRefusal(error: unknown): unknown {
+  if (!(error instanceof MicroserviceError)) return error;
+
+  const reason = signingIdentityRefusalFrom(error.errorBody);
+  if (!reason) return error;
+
+  return new MicroserviceError(error.message, error.statusCode, error.code, {
+    operation: 'cla_bind_signing_identity',
+    service: SERVICE,
+    errorBody: { error: reason },
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Service
 // ---------------------------------------------------------------------------
@@ -365,114 +427,121 @@ export class ClaService {
   }
 
   /**
-   * Resolves the contributor's EasyCLA user-record UUID for the Sign CLA hand-off (#1251), from
-   * the `userIds` the identity search already returns.
+   * Lists the GitHub accounts the contributor has already linked, so the picker can render
+   * and so the flow can tell whether a picker is needed at all (#1252).
    *
-   * TEMPORARY BRIDGE. The intended source is a resolve-or-create "current user" endpoint, which
-   * `GET /v4/user-from-token` would be — except it is not reachable authenticated. The CLA
-   * backend's security scheme is an API key on the `X-ACL` header, injected by the platform
-   * gateway on authenticated routes; `/v4/user-from-token` is configured as an unauthenticated
-   * passthrough, so nothing injects it and go-swagger rejects the call before the authenticator
-   * runs. The BFF cannot supply `X-ACL` itself — the backend trusts that header precisely because
-   * only the gateway can set it. `/v4/my-clas` is an authenticated route, so its `userIds` are
-   * the same records, obtained through a door that is actually open.
+   * This list carries no authority. The CLA service re-derives the attested set from the
+   * caller's own token and refuses anything outside it, so a stale or over-broad list here
+   * can only cause a refusal downstream, never an incorrect association. That independence
+   * is what makes it safe to read from the same convenient source the My CLAs page uses.
    *
-   * Two gaps this bridge cannot close, both of which the proper endpoint fixes:
-   *
-   * - It is a pure read. A contributor with no EasyCLA record yet — a first-time signer, the very
-   *   person this feature exists for — resolves to nothing and is refused below.
-   * - It can match several records, and nothing here can tell which one a signature ought to be
-   *   attributed to. We take the first and log the ambiguity rather than fail, because refusing a
-   *   returning contributor helps nobody; the proper endpoint returns one canonical record.
-   *
-   * No impersonation branch, on purpose: the hand-off route is blocked outright while
-   * impersonating, because a signature must never be attributed to the wrong person.
+   * One behaviour differs from that read path on purpose: `resolveIdentity` degrades when
+   * the identity lookup fails, continuing without GitHub keys, which is right for a list
+   * where a partial answer beats an error. It is wrong here, because an empty list is
+   * indistinguishable from "no accounts linked" and would send a contributor who does have
+   * a linked account into an account-linking flow they do not need. A failure surfaces.
    */
-  public async resolveContributorId(req: Request): Promise<string> {
-    const startTime = logger.startOperation(req, 'cla_resolve_contributor_id');
+  public async listGithubAccounts(req: Request): Promise<GithubAccountOptions> {
+    const startTime = logger.startOperation(req, 'cla_list_github_accounts');
 
-    const resolvedOrCreated = await this.tryResolveOrCreateContributor(req);
-    if (resolvedOrCreated) {
-      logger.success(req, 'cla_resolve_contributor_id', startTime);
-      return resolvedOrCreated;
+    const auth0Sub = getEffectiveSub(req);
+    if (!auth0Sub) {
+      throw new MicroserviceError('No identity subject on the session', 401, 'CLA_IDENTITY_UNAVAILABLE', { service: SERVICE });
     }
 
-    const identity = await this.resolveIdentity(req);
-    const list = await this.fetchMyClas(req, identity);
-    const userIds = (list.userIds ?? []).map((id) => id.trim()).filter(Boolean);
+    // Deliberately not wrapped: a rejection here must reach the caller as a failure.
+    const identities = await this.auth0Service.getUserIdentities(req, auth0Sub);
 
-    if (userIds.length === 0) {
-      // Handing off without a real id lands the contributor on the Console's "invalid user ID"
-      // screen, which reads as a broken product rather than a failed lookup — fail here instead.
-      throw new MicroserviceError('No EasyCLA user record matches this session', 502, 'CLA_USER_UNRESOLVED', { service: SERVICE });
-    }
+    const accounts = identities
+      .filter((identity) => identity.provider === 'github')
+      .map((identity) => ({
+        githubId: normalizeGithubId(identity.user_id),
+        githubUsername: identity.profileData?.nickname?.trim() ?? '',
+      }))
+      // An identity whose number cannot be read is dropped rather than refused: it can
+      // never be selected, since the backend would not attest an unreadable account either.
+      .filter((account): account is GithubAccountOption => account.githubId !== null);
 
-    if (userIds.length > 1) {
-      logger.warning(req, 'cla_resolve_contributor_id', 'identity matches several EasyCLA user records; handing off the first', {
-        matched_count: userIds.length,
-      });
-    }
-
-    logger.success(req, 'cla_resolve_contributor_id', startTime);
-    return userIds[0] as string;
+    logger.success(req, 'cla_list_github_accounts', startTime, { account_count: accounts.length });
+    return { accounts };
   }
 
   /**
-   * Builds the two halves of the Console hand-off URL that only the server can produce: the
-   * session-resolved contributor id and the absolute return address.
+   * Submits the contributor's chosen GitHub account and returns the EasyCLA record
+   * identifier the hand-off consumes (#1252).
    *
-   * The client composes the final URL, because the Console base lives in the Angular environment
-   * (`urls.contributorConsole`) which the server layer does not import. Keeping these two here
-   * is what makes the identifier un-spoofable (FR-003) and the return address origin-correct.
+   * This layer is where the account is established as the contributor's, and the check that
+   * establishes it is here rather than in the browser. The CLA service records what it is
+   * sent without re-deriving ownership, so the submitted account is matched against the
+   * accounts the identity provider reports for this session before it is relayed. The picker
+   * makes the same match, but a caller can reach this endpoint without going through it.
+   *
+   * It still decides nothing about the outcome: it does not resolve a record and does not
+   * fall back when the upstream refuses, because what the contributor should do next differs
+   * per refusal and a fallback here could only mask one.
+   *
+   * No `bearerToken` override, unlike the read paths above: the default gateway token is
+   * the contributor's own token exchanged for the gateway audience, which is what makes the
+   * caller identifiable upstream. This route is blocked during impersonation instead.
    */
-  public async getSignHandoff(req: Request): Promise<ClaSignHandoff> {
-    // Derived first: if the origin is unusable there is no point minting a user record upstream.
+  public async bindSigningIdentity(req: Request, githubId: string): Promise<SigningIdentityResponse> {
+    const startTime = logger.startOperation(req, 'cla_bind_signing_identity');
+
+    // Derived before the write, not after. If the origin is unusable the hand-off cannot
+    // proceed anyway, and this endpoint records an identity attribute on a real record —
+    // so failing afterwards would leave that write behind with nothing to show for it.
     const redirectUrl = claReturnUrl(req);
-    const claUserId = await this.resolveContributorId(req);
 
-    return { claUserId, redirectUrl };
-  }
-
-  /**
-   * PROBE — `GET /v2/user-from-token`, the resolve-or-create the bridge below cannot do.
-   *
-   * Unlike its v4 namesake this route is *not* exempted from gateway auth, so it arrives with the
-   * gateway's injected headers, and it calls `get_or_create_user` — meaning it mints a record for a
-   * first-time signer instead of resolving to nothing.
-   *
-   * Whether it accepts *our* token is the open question. Its validator only requires a token
-   * signed by the configured Auth0 domain that carries a username claim; it does not check the
-   * audience, so a gateway-audience token is not disqualified on that ground. But the custom
-   * username claim is added by an Auth0 Action and is not guaranteed on every audience — if it is
-   * absent the validator answers "username claim not found".
-   *
-   * Returns null on any failure so the caller falls back rather than breaking the hand-off. The
-   * outcome is logged either way: this is here to answer the question, not to stay.
-   */
-  private async tryResolveOrCreateContributor(req: Request): Promise<string | null> {
-    try {
-      const user = await gatewayFetch<EasyClaUserFromTokenV2>(req, `${claServiceBaseUrl()}/v2/user-from-token`, {
-        operation: 'cla_probe_user_from_token_v2',
-        service: SERVICE,
-        errorMessage: 'Probe of /v2/user-from-token failed',
-        errorCode: 'UPSTREAM_ERROR',
-      });
-
-      const claUserId = user?.user_id?.trim();
-      if (!claUserId) {
-        logger.warning(req, 'cla_probe_user_from_token_v2', 'probe answered without a user_id; falling back to the userIds bridge');
-        return null;
-      }
-
-      logger.info(req, 'cla_probe_user_from_token_v2', 'probe succeeded — resolve-or-create is reachable with our token');
-      return claUserId;
-    } catch (error) {
-      logger.warning(req, 'cla_probe_user_from_token_v2', 'probe rejected; falling back to the userIds bridge', {
-        probe_status: error instanceof MicroserviceError ? error.statusCode : 'unknown',
-        probe_detail: error instanceof Error ? error.message : String(error),
-      });
-      return null;
+    // Matched on the account number, and the handle taken from the match rather than from the
+    // request: a handle is never matched on upstream, so accepting the submitted one would let
+    // a correct account be recorded under a handle the contributor does not own. A failed
+    // lookup throws out of here rather than yielding an empty list, so this cannot pass by the
+    // session's accounts being unreadable.
+    const { accounts } = await this.listGithubAccounts(req);
+    const chosen = accounts.find((account) => account.githubId === githubId);
+    if (!chosen) {
+      throw new MicroserviceError('The chosen GitHub account is not linked to this session', 403, 'CLA_ACCOUNT_NOT_LINKED', { service: SERVICE });
     }
+
+    let result: EasyClaSigningIdentity | null;
+    try {
+      result = await gatewayFetch<EasyClaSigningIdentity>(req, `${claServiceBaseUrl()}/v4/my-clas/signing-identity`, {
+        operation: 'cla_bind_signing_identity',
+        service: SERVICE,
+        errorMessage: 'Failed to record the signing GitHub identity',
+        errorCode: 'UPSTREAM_ERROR',
+        method: 'POST',
+        // The account is sent as a number: it is stored and queried as one upstream, and the
+        // endpoint's own model types it as an integer. The handle rides along because it
+        // cannot be derived upstream, and a record without one is unmatchable by the
+        // approval lists that are written against handles.
+        body: { githubId: Number(chosen.githubId), ...(chosen.githubUsername ? { githubUsername: chosen.githubUsername } : {}) },
+      });
+    } catch (error) {
+      // Refusals pass through as refusals, each keeping its own reason. Rethrown rather
+      // than handled: what the contributor should do next differs per reason, and only
+      // they can act on it.
+      throw withSigningIdentityRefusal(error);
+    }
+
+    const claUserId = result?.userId?.trim();
+    // `== null` rather than `=== undefined`: a JSON null would otherwise reach String() and be
+    // returned as the literal "null", which no account can equal.
+    if (!claUserId || result?.githubId == null) {
+      throw new MicroserviceError('Upstream did not return a recorded signing identity', 502, 'CLA_BINDING_INCOMPLETE', { service: SERVICE });
+    }
+
+    logger.success(req, 'cla_bind_signing_identity', startTime, { outcome: result.outcome ?? 'unknown' });
+    return {
+      claUserId,
+      githubId: String(result.githubId),
+      githubUsername: result.githubUsername,
+      // Returned from the binding rather than fetched by a second call, so the hand-off has
+      // no way to assemble a URL before the association exists. The record this hand-off
+      // belongs to is the one the binding just confirmed — never whichever record an identity
+      // search happens to return first, which is what this endpoint replaced.
+      redirectUrl,
+    };
   }
 
   /** Fetches the composed CLA list for the resolved identity from `GET /v4/my-clas`. */

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -76,12 +76,21 @@ export interface EasyClaMyClaPdf {
 }
 
 /**
- * Response for `GET /v2/user-from-token` — the legacy backend returns the raw DynamoDB user item,
- * hence snake_case keys rather than v4's camelCase model. Only the field the hand-off needs.
+ * Response for `POST /v4/my-clas/signing-identity` — the association the CLA service
+ * confirmed against the caller's own token and recorded (#1252).
  */
-export interface EasyClaUserFromTokenV2 {
-  /** The user's internal EasyCLA UUID — what the Console decision screen is keyed by. */
-  user_id?: string;
+export interface EasyClaSigningIdentity {
+  /** The EasyCLA record the confirmed account belongs to. Replaces the first-match guess. */
+  userId?: string;
+  /**
+   * The account actually recorded, as a number. Echoed so the caller can check that what
+   * was recorded is what was chosen — a confirmed-ownership answer does not establish that,
+   * because the contributor's other linked accounts would pass an ownership check too.
+   */
+  githubId?: number;
+  githubUsername?: string;
+  /** Which resolution path was taken. Observability only. */
+  outcome?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -106,13 +106,71 @@ export interface ClaGroupOption {
 }
 
 /**
- * Response for `GET /api/me/clas/sign-handoff` — the two halves of the Console URL that only
- * the server can produce. The client supplies the rest (Console base + CLA group) and composes
- * the final URL via `buildConsoleHandoffUrl`.
+ * One GitHub account the contributor has already linked, offered in the picker (#1252).
+ *
+ * Presentation only, and deliberately so: the CLA service re-derives the attested set from
+ * the caller's own token and refuses anything outside it, so a stale or over-broad list here
+ * can only produce a refusal downstream — never an incorrect association.
  */
-export interface ClaSignHandoff {
-  /** EasyCLA user record UUID, resolved from the session token — never from client input. */
+export interface GithubAccountOption {
+  /** Immutable GitHub account number. Handles get renamed and reclaimed; this does not. */
+  githubId: string;
+  /** Display handle. Never matched on. */
+  githubUsername: string;
+  avatarUrl?: string;
+}
+
+/** Response for `GET /api/me/clas/github-accounts`. */
+export interface GithubAccountOptions {
+  accounts: GithubAccountOption[];
+}
+
+/** Request body for `POST /api/me/clas/signing-identity`. */
+export interface SigningIdentityRequest {
+  /**
+   * The account the contributor picked. The server matches it against the accounts Auth0
+   * reports as linked to this session and refuses one that is not among them, which is what
+   * establishes the account as the contributor's — see `bindSigningIdentity`.
+   *
+   * The handle is deliberately not accepted alongside it. The server takes that from the
+   * matched account, so a caller cannot pair a number it owns with a handle it does not.
+   */
+  githubId: string;
+}
+
+/**
+ * Response for `POST /api/me/clas/signing-identity` — the association the service confirmed
+ * and recorded, plus the record identifier the hand-off consumes in place of resolving one
+ * for itself.
+ */
+export interface SigningIdentityResponse {
   claUserId: string;
-  /** Absolute URL back to the CLAs view. Absolute because the last hop is a server-side redirect. */
+  /** The account actually recorded, so the caller can check it against what was chosen. */
+  githubId: string;
+  githubUsername?: string;
+  /**
+   * Absolute URL back to the CLAs view. Absolute because the last hop is a server-side redirect.
+   *
+   * Returned from the binding rather than fetched separately so that the hand-off URL
+   * cannot be assembled before the association is confirmed — the parts to build it with
+   * simply do not exist until then. Ordering here is a correctness property, not a
+   * convenience: a URL built from an identifier obtained beforehand could carry a record
+   * the binding then refuses.
+   */
   redirectUrl: string;
 }
+
+/**
+ * Why the CLA service refused to record an association. Each maps to a different outcome for
+ * the contributor, and collapsing them loses information they need — a record that names
+ * nobody needs a human to reunite it with its owner, whereas a record already holding another
+ * account is the contributor's own to sort out.
+ */
+export type SigningIdentityRefusal =
+  | 'identity_unavailable'
+  | 'identity_mismatch'
+  | 'record_conflict'
+  | 'record_unclaimed'
+  | 'duplicate_github_id'
+  | 'lf_record_already_bound'
+  | 'recorded_mismatch';


### PR DESCRIPTION
Adds a GitHub account picker to the Sign a CLA flow and records the choice upstream before handing off to the Contributor Console. The account a CLA was recorded against used to be whichever record an identity search matched first — neither the contributor's choice nor stable between signings.

Closes [#1252](https://github.com/linuxfoundation/lfx-self-serve/issues/1252). Backend half: [easycla#5148](https://github.com/linuxfoundation/easycla/pull/5148).

**Stacked on `feat/GH-1256`** ([#1440](https://github.com/linuxfoundation/lfx-self-serve/pull/1440)) rather than `main`, so this diff shows only the picker. Draft until #1440 lands and the backend half is reviewed.

## Why the server-side check is the important part of this diff

The CLA service records the account it is sent **without re-deriving ownership**. So the list of accounts this app serves is not presentation — an account wrongly in that list would be recorded against the contributor.

The check that enforces this is in the **server layer**, not the browser. `bindSigningIdentity` re-resolves the session's linked accounts, matches the submitted number against them, and refuses with 403 `CLA_ACCOUNT_NOT_LINKED` otherwise. The picker performs the same match, but nothing obliges a caller to use the picker — `POST /api/me/clas/signing-identity` is reachable with `curl` and a normal session.

Three consequences worth keeping in review:

- **The handle is never accepted from the request.** It is read from the matched account, so a caller cannot pair an account number it owns with a handle it does not. `githubUsername` was therefore dropped from the request body entirely; Self Serve still sends it upstream, but derives it.
- **A failed identity lookup surfaces as a failure, not an empty list.** An empty list routes the contributor into account-linking, which would ask someone who has already linked an account to fix something that is not broken.
- **The re-resolve in `bindSigningIdentity` looks like duplication and is not.** It re-reads what `listGithubAccounts` returned to the browser moments earlier. Removing it to save a round trip would leave the account number unchecked on the only path that records it.

## Also here

- The account that comes back is compared against the one the contributor picked, and the hand-off stops on a mismatch. This is the only check anywhere that can catch signing as the wrong account: every other layer sees only the account it was handed, so a correct answer there is equally consistent with the wrong account having been sent.
- The picker is skipped for one linked account and routes to linking for none, so the extra step appears only for contributors who have a choice to make. "No picker" does not become "no binding" — dropping the write for the single-account case would leave them on the old order-dependent resolution.
- Sign is now guarded from when the picker opens rather than from when a group is chosen, which previously left a window to open two dialogs and bind twice.

## Two things a reviewer should know are missing

**#1252's Gerrit criterion is not met, and this PR cannot meet it.** The ticket asks that Gerrit signers skip the authorization step and hand off directly. Every selected CLA group currently enters the GitHub flow, because `ClaGroupOption` carries no platform discriminator — and nothing can populate one while the group list is still `cla-group-search.stub.ts`. The real four-source search ([#1250](https://github.com/linuxfoundation/lfx-self-serve/issues/1250)) is what will carry the platform. The gap is not reachable today, since no Gerrit-backed group can be selected from a stub, and becomes reachable the moment #1250 lands. Please do not close #1252 on this PR alone.

**CI runs no tests on this PR.** `quality-check.yml` is gated on `pull_request: branches: [main]`, so a PR stacked on a feature branch gets DCO, the licence-header check and the title lint only. The local gauntlet is the whole signal until this retargets to `main` after [#1440](https://github.com/linuxfoundation/lfx-self-serve/pull/1440) merges — worth knowing before reading the green checks as coverage.

## Test plan

- [ ] `npx turbo run lint` (0 errors) and `npx turbo run test` — 397 app, 1406 UI, 801 shared, all passing
- [ ] Two linked accounts: picker appears, choosing the second sends the second
- [ ] One linked account: no picker, still binds, hand-off proceeds
- [ ] Zero linked accounts: routes to `/profile/identities` rather than erroring
- [ ] `POST /api/me/clas/signing-identity` with an account number not linked to the session returns 403 and records nothing
- [ ] Impersonation: the write stays blocked, while viewing CLAs and linked accounts keeps working
