### PR TITLE
fix(committees): show past briefs link without waiting for current brief

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -210,18 +210,6 @@
             }
           </div>
 
-          @if (hasArchiveBriefs()) {
-            <div class="flex">
-              <button
-                type="button"
-                class="text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors"
-                (click)="onOpenArchive()"
-                data-testid="weekly-brief-card-past-briefs-button">
-                View past briefs
-              </button>
-            </div>
-          }
-
           <!-- Visible hints rather than tooltips on these disabled buttons: a
                disabled native <button> never receives focus/hover, so a
                tooltip-only explanation would be unreachable by keyboard and
@@ -272,6 +260,18 @@
         }
       </div>
     </lfx-card>
+  }
+
+  @if (hasArchiveBriefs()) {
+    <div class="flex">
+      <button
+        type="button"
+        class="text-xs text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+        (click)="onOpenArchive()"
+        data-testid="weekly-brief-card-past-briefs-button">
+        View past briefs
+      </button>
+    </div>
   }
 
   <p-confirmDialog />

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -139,10 +139,9 @@ export class WeeklyBriefCardComponent {
   public readonly ratingPending = signal(false);
 
   // Archive drawer visibility and availability signals.
-  // `hasArchiveBriefs` starts false and is set by a limit=1 preflight that fires once
-  // the current brief becomes available — avoids showing a "Past Briefs" button that
-  // opens to an empty drawer (LFXV2-3046 requirement: hide the affordance when < 2 briefs
-  // total exist, i.e. no archived past weeks).
+  // `hasArchiveBriefs` starts false and is set by a limit=1 preflight that fires as soon
+  // as the committee is known — avoids showing a "Past Briefs" button that opens to an
+  // empty drawer (LFXV2-3046: hide the affordance when no past briefs exist).
   public readonly archiveVisible = signal(false);
   public readonly hasArchiveBriefs = signal(false);
 
@@ -569,19 +568,13 @@ export class WeeklyBriefCardComponent {
       this.archiveVisible.set(false);
     });
 
-    // Archive preflight — fires once per committee when the current brief first becomes
-    // available. A limit=1 fetch confirms at least one past brief exists before the
-    // "Past Briefs" button is shown, per LFXV2-3046's "< 2 total → hide affordance" rule.
+    // Archive preflight — fires once per committee as soon as the uid is known,
+    // independently of the current brief. A limit=1 fetch confirms at least one past
+    // shareable brief exists before the "Past Briefs" button is shown.
     committeeUid$
       .pipe(
         switchMap((uid) =>
-          this.briefResponse$.pipe(
-            filter((r): r is WeeklyBriefCurrentResponse => !!r?.brief),
-            take(1),
-            switchMap(() =>
-              this.weeklyBriefService.listWeeklyBriefs(uid, { limit: 1 }).pipe(catchError(() => of(null as PaginatedResponse<WeeklyBrief> | null)))
-            )
-          )
+          this.weeklyBriefService.listWeeklyBriefs(uid, { limit: 1 }).pipe(catchError(() => of(null as PaginatedResponse<WeeklyBrief> | null)))
         ),
         takeUntilDestroyed(this.destroyRef)
       )

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -174,10 +174,6 @@ export class WeeklyBriefCardComponent {
   // every single generate/regenerate/load-into-generating call, not just once.
   private readonly committee$ = toObservable(this.committee);
 
-  // Observable mirror of briefResponse for use in reactive pipelines that need to react
-  // to the brief loading (e.g. the archive-available preflight).
-  private readonly briefResponse$ = toObservable(this.briefResponse);
-
   // Guards against starting a second concurrent poll — pollUntilTerminal is reachable
   // both from onGenerate and from the initial-load pipeline (a page load / navigation
   // landing on an already-`generating` brief).


### PR DESCRIPTION
## Summary

- Removes the dependency on the current week's brief loading before the archive preflight fires
- The \"View past briefs\" link now appears as soon as the committee is known, provided at least one past shareable brief exists in the index
- Previously the link would never appear when the current brief was missing, in an error state, generating, or otherwise non-renderable

## Motivation

LFXV2-3046 — committees with past briefs but a problematic current brief (error, generating, quiet week, etc.) had no way to access their archive history.

## What changed

| File | Change |
|---|---|
| `weekly-brief-card.component.ts` | Removed `briefResponse$.pipe(filter...take(1))` wrapper from the archive preflight; the `limit=1` check now fires directly off `committeeUid$` so it runs independently of the current brief's load state |

## Behaviour

- **Before:** preflight waited for `briefResponse` to emit a non-null `brief` before checking the archive — meaning the link was blocked whenever the current brief was absent or non-renderable
- **After:** preflight fires on committee navigation; link appears if ≥1 past brief in `generated`/`edited`/`approved` state exists, regardless of current brief state
- Reset on committee navigation, error handling, and drawer behaviour are all unchanged

## Known trade-offs

None introduced. Pre-existing `yarn build` failure on `main` (`chartjs-chart-sankey` missing dependency) is unrelated to this change.

## Test plan

- [ ] Navigate to a committee with past briefs but an errored/generating/empty current brief → \"View past briefs\" link now appears
- [ ] Navigate to a committee with no past briefs → link does not appear (unchanged)
- [ ] Navigate to a committee with past briefs and a normal current brief → link appears (unchanged)
- [ ] Navigate between committees → link resets and re-evaluates per committee (unchanged)

Resolves [LFXV2-3046](https://linuxfoundation.atlassian.net/browse/LFXV2-3046)

[LFXV2-3046]: https://linuxfoundation.atlassian.net/browse/LFXV2-3046?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Made with [Cursor](https://cursor.com)