### PR TITLE
fix(campaigns): keep linkedin picks across an implement tab switch

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1724,6 +1724,12 @@ describe('CampaignsComponent — Implementation edits survive a tab switch', () 
       endDate: '2026-02-01',
       includeSearch: true,
       includeDemandGen: false,
+      // Event A's LinkedIn picks (LFXV2-3230). Present so this stale draft is a COMPLETE one —
+      // the guard under test must reject it on the slug alone, not because it happened to be
+      // missing fields.
+      linkedInAccountId: 'urn:li:sponsoredAccount:event-a',
+      linkedInGeoTargets: [],
+      linkedInTargetingProfile: 'mcp',
       eventSlug: 'event-a',
     });
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -979,6 +979,64 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
    * dispatches the stale value. Clearing is the honest outcome: the create then fails upstream on
    * a blank account rather than silently spending against someone else's.
    */
+  /**
+   * The two windows `ngOnInit`'s reconciliation cannot cover.
+   *
+   * It only runs on a SUCCESSFUL response, so a restored id sits unverified on the form both
+   * before the request returns and permanently if it fails — with `linkedInAccounts()` empty in
+   * each case. Without a submit gate a create would dispatch an account nothing confirmed and the
+   * selector is not showing, which is the divergence the reconciliation exists to prevent,
+   * reached where it does not run.
+   *
+   * `canSubmit` therefore requires catalog MEMBERSHIP rather than a non-empty id.
+   */
+  it('blocks a linkedin create while the account catalog is still loading', async () => {
+    const f = TestBed.createComponent(ImplementationTabComponent);
+    f.componentRef.setInput('draft', draftWith(ACCOUNTS[1].accountId));
+    f.componentRef.setInput('briefData', brief());
+    f.detectChanges();
+    await f.whenStable();
+    // Deliberately do NOT release accountsSubject: the fetch is still in flight.
+
+    makeLinkedInOtherwiseValid(f);
+
+    expect((f.componentInstance as unknown as { canSubmit(): boolean }).canSubmit()).toBe(false);
+  });
+
+  it('keeps a linkedin create blocked when the account fetch fails', async () => {
+    const f = TestBed.createComponent(ImplementationTabComponent);
+    f.componentRef.setInput('draft', draftWith(ACCOUNTS[1].accountId));
+    f.componentRef.setInput('briefData', brief());
+    f.detectChanges();
+    await f.whenStable();
+    // A failed fetch leaves loading false with an empty catalog — the worst case, because
+    // nothing further will ever arrive to correct the restored id.
+    accountsSubject.error(new Error('ad-account endpoint unavailable'));
+    f.detectChanges();
+    await f.whenStable();
+
+    makeLinkedInOtherwiseValid(f);
+
+    expect((f.componentInstance as unknown as { canSubmit(): boolean }).canSubmit()).toBe(false);
+  });
+
+  /** Satisfy every LinkedIn gate EXCEPT the account one, so that gate is the only variable. */
+  function makeLinkedInOtherwiseValid(f: ComponentFixture<ImplementationTabComponent>): void {
+    const c = f.componentInstance as unknown as {
+      selectedPlatforms: { set(v: string[]): void };
+      campaignForm: { controls: Record<string, { setValue(v: unknown): void }> };
+      linkedInVariants: { set(v: unknown[]): void };
+    };
+    c.selectedPlatforms.set(['linkedin-ads']);
+    c.campaignForm.controls['eventName'].setValue('KubeCon EU 2026');
+    c.campaignForm.controls['registrationUrl'].setValue('https://example.com/kubecon');
+    c.campaignForm.controls['startDate'].setValue('2026-09-01');
+    c.campaignForm.controls['endDate'].setValue('2026-09-30');
+    c.campaignForm.controls['linkedInGeoTargets'].setValue([{ urn: 'urn:li:geo:103644278', label: 'United States' }]);
+    c.linkedInVariants.set([{ headline: 'Attend', introText: 'Join us', destinationUrl: 'https://example.com/kubecon' }]);
+    f.detectChanges();
+  }
+
   it('clears a restored account when the catalog comes back empty', async () => {
     // A SUCCESSFUL response that happens to carry no accounts, released after the restore.
     const f = await mount(draftWith(ACCOUNTS[1].accountId), []);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -747,6 +747,36 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
     expect(at(second.fixture).linkedInTargetingProfile()).toBe('mcp');
   });
 
+  /**
+   * Clearing EVERY geo target must survive, and nothing else in this suite pins it.
+   *
+   * Two docblocks argue at length that an empty list is a deliberate user action rather than a
+   * hole, and that a `draft.linkedInGeoTargets.length ? … : recommendation` fallback would be the
+   * defect rather than the fix. That claim was reintroducible without a red test: every other
+   * round-trip case here ends with a NON-EMPTY list, so a length-guarded restore passed all of
+   * them. Verified by mutation — introducing exactly that fallback left the whole suite green.
+   *
+   * `canSubmit()` is asserted too, because an empty list is only safe if it BLOCKS the create. A
+   * restore that silently refilled it would also silently re-enable dispatch to geos the operator
+   * had removed, which is the money-shaped version of this bug.
+   */
+  it('keeps an emptied geo list empty after a tab round-trip', async () => {
+    const first = await mount(null);
+    // The brief recommends exactly one; removing it leaves the list genuinely empty.
+    at(first.fixture).removeGeoTarget(0);
+    first.fixture.detectChanges();
+    expect(at(first.fixture).linkedInGeoTargets()).toEqual([]);
+
+    const carried = first.latest();
+    first.fixture.destroy();
+
+    const second = await mount(carried);
+
+    // NOT the brief's [US] recommendation, which is what a length-guarded restore would produce.
+    expect(at(second.fixture).linkedInGeoTargets()).toEqual([]);
+    expect((second.fixture.componentInstance as unknown as { canSubmit(): boolean }).canSubmit()).toBe(false);
+  });
+
   it('keeps a chosen ad account after a tab round-trip', async () => {
     const first = await mount(null);
     at(first.fixture).setLinkedInAccount('urn:li:sponsoredAccount:999');
@@ -761,10 +791,17 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
   });
 
   /**
-   * The seed must still run when there is NOTHING to restore, which is the other half of making
-   * `populateFromBrief` conditional. A guard that skipped seeding unconditionally would leave a
-   * first-time user with an empty geo list and `canSubmit` permanently blocking the LinkedIn
-   * section — a worse bug than the one being fixed, and invisible to every test above.
+   * The seed must still reach the form when there is nothing to restore.
+   *
+   * `populateFromBrief` seeds UNCONDITIONALLY and `applyDraft` runs after it, so the restore wins
+   * by ordering rather than by a guard. That makes this the case which proves the seed still
+   * works at all: every test above overwrites it, so a seed that silently stopped reaching the
+   * form would be invisible to them. Without it a first-time user opens with an empty geo list
+   * and `canSubmit` blocking the LinkedIn section permanently.
+   *
+   * It is also what pins the seed's EMISSION. The three controls are read through `toSignal`
+   * bridges over `valueChanges`, so writing them with `{ emitEvent: false }` updates the control
+   * while every reader keeps the stale initial value — this test fails on exactly that.
    */
   it('still seeds from the brief on a first visit with no draft', async () => {
     const first = await mount(null);
@@ -778,11 +815,13 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
   });
 
   /**
-   * A draft keyed to a DIFFERENT event must neither restore nor suppress the seed.
+   * A draft keyed to a DIFFERENT event must not replay onto this brief.
    *
-   * `hasDraftForThisBrief()` gates both halves, so this is where they could disagree: if the seed
-   * skipped on "a draft exists" while `applyDraft` declined on "wrong slug", the fields would be
-   * neither seeded nor restored and the section would open blank.
+   * `applyDraft` compares the draft's `eventSlug` against the form's and returns early on a
+   * mismatch, so event A's picks cannot overwrite event B's freshly generated recommendation —
+   * the same ownership rule the `(project, event)` keys enforce elsewhere. Since the seed already
+   * ran unconditionally, declining the restore leaves the brief's own values standing, which is
+   * what this asserts.
    */
   it('seeds from the brief when the carried draft belongs to another event', async () => {
     const first = await mount(null);
@@ -867,8 +906,13 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
    */
   let accountsSubject: Subject<typeof ACCOUNTS>;
 
+  /** The last draft emitted to the parent, so the emission half can be asserted too. */
+  let lastEmitted: CampaignImplementationDraft | null;
+
   async function mount(draft: CampaignImplementationDraft | null): Promise<ComponentFixture<ImplementationTabComponent>> {
     const f = TestBed.createComponent(ImplementationTabComponent);
+    lastEmitted = null;
+    f.componentRef.instance.draftChange.subscribe((d: CampaignImplementationDraft) => (lastEmitted = d));
     if (draft) f.componentRef.setInput('draft', draft);
     f.componentRef.setInput('briefData', brief());
     f.detectChanges();
@@ -910,5 +954,93 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
     const fixture = await mount(draftWith(ACCOUNTS[1].accountId));
 
     expect(accountId(fixture)).toBe(ACCOUNTS[1].accountId);
+  });
+
+  /**
+   * The CORRECTED account must also reach the parent's draft, not just the form.
+   *
+   * `ngOnInit` runs after the constructor effect, so this `setValue` lands outside the `seeding`
+   * window and its emission is what carries the correction to the parent. Nothing else pinned
+   * that, which makes `{ emitEvent: false }` an easy "optimisation" for someone to add later —
+   * and it would silently strand the parent's draft on the stale id while the form and the
+   * request both moved on. The next tab switch would then restore the stale id all over again.
+   */
+  it('emits the corrected account to the parent draft', async () => {
+    await mount(draftWith('urn:li:sponsoredAccount:revoked-999'));
+
+    expect(lastEmitted?.linkedInAccountId).toBe(ACCOUNTS[0].accountId);
+  });
+
+  /**
+   * A restored account this catalog no longer offers must not survive — and what `submit()` SENDS
+   * must match what the page DISPLAYS.
+   *
+   * Persisting the id (LFXV2-3230) made a stale one reachable for the first time: an account can
+   * be revoked or lose permission between mounts, and the list is refetched on every mount. The
+   * DIVERGENCE is the danger rather than the staleness. `selectedLinkedInAccount` resolves the
+   * label and org/status line through `accounts.find(...) ?? accounts[0]`, and the `<select>`
+   * cannot render an unmatched value either, so both fall back to the first account — while
+   * `submit()` sends `linkedInAccountId()` verbatim. The operator reads "First Account" and spends
+   * money on the revoked one.
+   *
+   * Asserting only that the id changed would miss the point, since the bug is precisely that two
+   * surfaces disagree. This drives the real `submit()` and compares the dispatched
+   * `linkedInConfig.adAccountId` against the displayed account.
+   */
+  it('does not dispatch to an account the page is not displaying', async () => {
+    let posted: Record<string, unknown> | null = null;
+    // Re-configure with a capturing stub: this is the only case here that reaches `submit()`.
+    TestBed.resetTestingModule();
+    accountsSubject = new Subject<typeof ACCOUNTS>();
+    await TestBed.configureTestingModule({
+      imports: [ImplementationTabComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ProjectContextService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        {
+          // Stubbed at the service boundary, matching the hubspotConfig suite above: the assertion
+          // is about the request body, and the stub keeps the create from dispatching anywhere.
+          provide: CampaignService,
+          useValue: {
+            getLinkedInAccounts: () => accountsSubject.asObservable(),
+            createCampaign: (request: Record<string, unknown>) => {
+              posted = request;
+              return of({ jobId: '' });
+            },
+          },
+        },
+      ],
+    }).compileComponents();
+
+    const fixture = await mount(draftWith('urn:li:sponsoredAccount:revoked-999'));
+
+    const displayed = (fixture.componentInstance as unknown as { selectedLinkedInAccount(): { accountId: string } }).selectedLinkedInAccount();
+    const internals = fixture.componentInstance as unknown as {
+      selectedPlatforms: { set(v: string[]): void };
+      campaignForm: { controls: Record<string, { setValue(v: unknown): void }> };
+      linkedInVariants: { set(v: unknown[]): void };
+      submit(): void;
+    };
+
+    // Everything `canSubmit` requires for a LinkedIn dispatch, so `submit()` reaches the service.
+    // The geo list matters: `draftWith` carries none, and an empty one blocks the create (:417).
+    internals.selectedPlatforms.set(['linkedin-ads']);
+    internals.campaignForm.controls['eventName'].setValue('KubeCon EU 2026');
+    internals.campaignForm.controls['registrationUrl'].setValue('https://example.com/kubecon');
+    internals.campaignForm.controls['startDate'].setValue('2026-09-01');
+    internals.campaignForm.controls['endDate'].setValue('2026-09-30');
+    internals.campaignForm.controls['linkedInGeoTargets'].setValue([{ urn: 'urn:li:geo:103644278', label: 'United States' }]);
+    internals.linkedInVariants.set([{ headline: 'Attend', introText: 'Join us', destinationUrl: 'https://example.com/kubecon' }]);
+    fixture.detectChanges();
+
+    internals.submit();
+
+    const sent = (posted?.['linkedInConfig'] as { adAccountId: string } | undefined)?.adAccountId;
+    expect(sent).toBe(displayed.accountId);
+    // And specifically not the revoked id the draft carried.
+    expect(sent).not.toBe('urn:li:sponsoredAccount:revoked-999');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -851,9 +851,15 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
  * lands after the constructor effect has already replayed the user's choice onto the form, so an
  * unguarded assignment would overwrite it on every single return to the tab.
  *
- * The guard is `!this.linkedInAccountId()`. The suites above leave `CampaignService` unstubbed, so
- * the list resolves empty and the guard is never exercised — deleting it kept all 35 tests green.
- * These two stub a real list so the branch is actually reached.
+ * The rule is CATALOG MEMBERSHIP: a selection the returned list does not contain is replaced by
+ * the first account, or cleared when the list is empty. That covers three situations with one
+ * test — the first visit (`''` is never in the list), a restored choice that is still offered, and
+ * a restored choice that has been revoked.
+ *
+ * The suites above leave `CampaignService` unstubbed, so the list resolves empty and this branch
+ * is never meaningfully exercised there. These cases stub a real list, and release it through a
+ * `Subject` so it lands AFTER the restore — the production ordering, and the only one in which the
+ * rule does any work.
  */
 describe('ImplementationTabComponent linkedin account defaulting', () => {
   const EVENT_SLUG = 'kubecon-eu-2026';
@@ -906,10 +912,17 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
    */
   let accountsSubject: Subject<typeof ACCOUNTS>;
 
-  /** The last draft emitted to the parent, so the emission half can be asserted too. */
-  let lastEmitted: CampaignImplementationDraft | null;
+  /**
+   * The last draft emitted to the parent, so the emission half can be asserted too.
+   *
+   * Read through `emitted()` rather than directly: assigning only inside the subscribe callback
+   * lets TypeScript narrow the variable to `never` at the assertion site.
+   */
+  let lastEmitted: CampaignImplementationDraft | null = null;
+  const emitted = (): CampaignImplementationDraft | null => lastEmitted;
 
-  async function mount(draft: CampaignImplementationDraft | null): Promise<ComponentFixture<ImplementationTabComponent>> {
+  /** `catalog` defaults to the two-account list; pass `[]` for the unconfigured-LinkedIn case. */
+  async function mount(draft: CampaignImplementationDraft | null, catalog: typeof ACCOUNTS = ACCOUNTS): Promise<ComponentFixture<ImplementationTabComponent>> {
     const f = TestBed.createComponent(ImplementationTabComponent);
     lastEmitted = null;
     f.componentRef.instance.draftChange.subscribe((d: CampaignImplementationDraft) => (lastEmitted = d));
@@ -918,7 +931,7 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
     f.detectChanges();
     await f.whenStable();
     // The restore has already run; only now does the ad-account list arrive.
-    accountsSubject.next(ACCOUNTS);
+    accountsSubject.next(catalog);
     accountsSubject.complete();
     f.detectChanges();
     await f.whenStable();
@@ -957,6 +970,25 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
   });
 
   /**
+   * An EMPTY catalog is a real answer, and it must clear a restored id rather than skip.
+   *
+   * `loadLinkedInConfig` falls back to `accounts: []` when the LinkedIn config is absent or
+   * malformed (`linkedin-ads.service.ts:39`), so a SUCCESSFUL response can carry nothing. A guard
+   * that required `accounts.length > 0` skipped entirely in that case, leaving the restored id on
+   * the form with no account to match it — the selector renders empty while `submit()` still
+   * dispatches the stale value. Clearing is the honest outcome: the create then fails upstream on
+   * a blank account rather than silently spending against someone else's.
+   */
+  it('clears a restored account when the catalog comes back empty', async () => {
+    // A SUCCESSFUL response that happens to carry no accounts, released after the restore.
+    const f = await mount(draftWith(ACCOUNTS[1].accountId), []);
+
+    expect(accountId(f)).toBe('');
+    // The parent learns about it too, so a later tab switch cannot restore the stale id.
+    expect(emitted()?.linkedInAccountId).toBe('');
+  });
+
+  /**
    * The CORRECTED account must also reach the parent's draft, not just the form.
    *
    * `ngOnInit` runs after the constructor effect, so this `setValue` lands outside the `seeding`
@@ -968,7 +1000,7 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
   it('emits the corrected account to the parent draft', async () => {
     await mount(draftWith('urn:li:sponsoredAccount:revoked-999'));
 
-    expect(lastEmitted?.linkedInAccountId).toBe(ACCOUNTS[0].accountId);
+    expect(emitted()?.linkedInAccountId).toBe(ACCOUNTS[0].accountId);
   });
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -1058,6 +1058,34 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
     expect(c.canSubmit()).toBe(false);
   });
 
+  /**
+   * The same gate reached with an ABSENT list rather than an empty one.
+   *
+   * `linkedInGeoTargets` is declared non-optional on `CampaignImplementationDraft`, but nothing
+   * validates a draft on the way in: `applyDraft` hands `patchValue` whatever it holds and
+   * `patchValue` passes `undefined` through untouched. Reading `.length` off that threw inside the
+   * `canSubmit` computed, which the template reads — so instead of disabling one button it took
+   * down the entire tab, re-throwing on every change-detection pass.
+   *
+   * The binding assertion is that it RETURNS false. Asserting merely that it does not throw would
+   * pass on a guard that returned true, which is the fail-open answer — a create dispatched with
+   * no geo targets at all.
+   */
+  it('blocks rather than crashing when the restored geo list is absent', async () => {
+    const f = await mount(draftWith(ACCOUNTS[1].accountId));
+    makeLinkedInOtherwiseValid(f);
+    const c = f.componentInstance as unknown as {
+      canSubmit(): boolean;
+      campaignForm: { controls: Record<string, { setValue(v: unknown): void }> };
+    };
+    expect(c.canSubmit()).toBe(true);
+
+    c.campaignForm.controls['linkedInGeoTargets'].setValue(undefined);
+    f.detectChanges();
+
+    expect(c.canSubmit()).toBe(false);
+  });
+
   /** Satisfy every LinkedIn gate EXCEPT the account one, so that gate is the only variable. */
   function makeLinkedInOtherwiseValid(f: ComponentFixture<ImplementationTabComponent>): void {
     const c = f.componentInstance as unknown as {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -5,11 +5,11 @@ import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideRouter } from '@angular/router';
-import type { CampaignBriefOutput, CampaignBriefPersistenceState } from '@lfx-one/shared/interfaces';
+import type { CampaignBriefOutput, CampaignBriefPersistenceState, CampaignImplementationDraft } from '@lfx-one/shared/interfaces';
 import { CampaignService } from '@services/campaign.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
-import { of } from 'rxjs';
+import { of, Subject } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ImplementationTabComponent } from './implementation-tab.component';
@@ -580,5 +580,335 @@ describe('ImplementationTabComponent hubspotConfig wiring', () => {
     submitAndCapture();
 
     expect(posted?.['hubspotConfig']).toEqual({ sourceEmailId: 'email-456' });
+  });
+});
+
+/**
+ * The tab round-trip for the three LinkedIn controls (LFXV2-3230).
+ *
+ * `ImplementationTabComponent` sits inside the parent's structural `@switch`, so every visit to
+ * another tab DESTROYS it and every signal it owns. The ad account, geo targets and targeting
+ * profile lived only in component-local signals, so a tab switch discarded them — and
+ * `populateFromBrief` then re-stamped the brief's recommendation over the gap on remount, which
+ * is why the loss was SILENT. The fields simply read what the AI suggested, and an operator who
+ * had removed a geo or switched profile had no signal that their choice was gone.
+ *
+ * Simulated the way the parent actually does it: emit a draft from one component, then hand it to
+ * a SECOND, freshly created one. Mutating a single fixture would prove nothing, because the whole
+ * defect is that the first instance's state no longer exists.
+ *
+ * Every test here asserts the EDIT survived, never merely that the field holds a value. The
+ * distinction is the point: the brief below recommends `['urn:li:geo:US']` and `cloud-native`, so
+ * an assertion like "geo targets are non-empty" or "profile is cloud-native" passes against the
+ * BROKEN code — `populateFromBrief` sets exactly those. Each case therefore edits AWAY from the
+ * recommendation and asserts the edited value, so only a working restore can satisfy it.
+ */
+describe('ImplementationTabComponent linkedin round-trip across a tab switch', () => {
+  /** Matches the slug on the brief below — `applyDraft` ignores a draft keyed to another event. */
+  const EVENT_SLUG = 'kubecon-eu-2026';
+
+  /** Two real URNs from the shared resolve map, so `addGeoTarget` can find them. */
+  const US_GEO = { urn: 'urn:li:geo:103644278', label: 'United States' };
+  const DE_GEO = { urn: 'urn:li:geo:101165590', label: 'Germany' };
+
+  const brief = (): CampaignBriefOutput =>
+    ({
+      eventDetails: { name: 'KubeCon EU 2026', slug: EVENT_SLUG, countryCode: 'US', registrationUrl: 'https://example.com/kubecon' },
+      totalBudget: 500,
+      selectedPlatforms: ['google-ads', 'linkedin-ads'],
+      structuredCopy: { google_search: { headlines: ['Attend KubeCon'], descriptions: ['Join us in September'] } },
+      linkedInCopy: {
+        variants: [{ headline: 'Attend KubeCon', introText: 'Join us', destinationUrl: 'https://example.com/kubecon' }],
+        // The values the component would re-stamp on remount. Every assertion below edits away
+        // from these so a passing test cannot be explained by the re-stamp.
+        recommendedGeoTargets: [US_GEO],
+        recommendedTargetingProfile: 'cloud-native',
+      },
+      keywords: [],
+      hsUtm: null,
+      driveFolderUrl: '',
+    }) as unknown as CampaignBriefOutput;
+
+  /** The three fields are form controls now; read them the way `submit()` does. */
+  interface Internals {
+    campaignForm: { controls: Record<string, { value: unknown; setValue(v: unknown): void }> };
+    linkedInAccountId(): string;
+    linkedInGeoTargets(): { urn: string; label: string }[];
+    linkedInTargetingProfile(): string;
+    removeGeoTarget(index: number): void;
+    addGeoTarget(urn: string): void;
+    setLinkedInTargetingProfile(profile: string): void;
+    setLinkedInAccount(accountId: string): void;
+  }
+  const at = (f: ComponentFixture<ImplementationTabComponent>): Internals => f.componentInstance as unknown as Internals;
+
+  /**
+   * Mount a component on the brief exactly as the parent does, capturing what it emits.
+   *
+   * The captured draft is the ONLY thing carried to the next mount — same as production, where
+   * the parent's signal is all that survives the component's teardown.
+   */
+  async function mount(draft: CampaignImplementationDraft | null): Promise<{
+    fixture: ComponentFixture<ImplementationTabComponent>;
+    latest: () => CampaignImplementationDraft | null;
+  }> {
+    const f = TestBed.createComponent(ImplementationTabComponent);
+    let captured: CampaignImplementationDraft | null = null;
+    f.componentRef.instance.draftChange.subscribe((d: CampaignImplementationDraft) => (captured = d));
+    if (draft) f.componentRef.setInput('draft', draft);
+    f.componentRef.setInput('briefData', brief());
+    f.detectChanges();
+    await f.whenStable();
+    return { fixture: f, latest: () => captured };
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ImplementationTabComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ProjectContextService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+      ],
+    }).compileComponents();
+  });
+
+  /**
+   * A removal must survive, and proving that needs a SECOND geo on the form.
+   *
+   * Removing the brief's only recommendation leaves `[]`, and `[]` is also what a component with
+   * no restore at all shows before its seed runs — so asserting an empty list passes whether or
+   * not the restore works. (Verified, not assumed: with the `applyDraft` restore deleted, that
+   * version of this test still passed while its three siblings failed.)
+   *
+   * Adding Germany first and then removing the US entry makes the expected value `[DE]`, which is
+   * neither the brief's recommendation (`[US]`) nor the empty default. Only a working restore can
+   * produce it.
+   */
+  it('keeps a removed geo target removed after a tab round-trip', async () => {
+    const first = await mount(null);
+    at(first.fixture).addGeoTarget(DE_GEO.urn);
+    first.fixture.detectChanges();
+    // Drop the brief's US recommendation, keeping the user's own addition.
+    at(first.fixture).removeGeoTarget(0);
+    first.fixture.detectChanges();
+    expect(
+      at(first.fixture)
+        .linkedInGeoTargets()
+        .map((g) => g.urn)
+    ).toEqual([DE_GEO.urn]);
+
+    const carried = first.latest();
+    first.fixture.destroy();
+
+    const second = await mount(carried);
+
+    // NOT [US] (the re-stamped recommendation) and NOT [US, DE] (a restore that ignored the
+    // removal). The removal and the addition both survived.
+    expect(
+      at(second.fixture)
+        .linkedInGeoTargets()
+        .map((g) => g.urn)
+    ).toEqual([DE_GEO.urn]);
+  });
+
+  it('keeps an added geo target after a tab round-trip', async () => {
+    const first = await mount(null);
+    at(first.fixture).addGeoTarget(DE_GEO.urn);
+    first.fixture.detectChanges();
+
+    const carried = first.latest();
+    first.fixture.destroy();
+
+    const second = await mount(carried);
+
+    // Both the recommendation AND the addition, in that order — asserting only that Germany is
+    // present would also pass if the restore had dropped the brief's own US entry.
+    expect(
+      at(second.fixture)
+        .linkedInGeoTargets()
+        .map((g) => g.urn)
+    ).toEqual([US_GEO.urn, DE_GEO.urn]);
+  });
+
+  it('keeps a switched targeting profile after a tab round-trip', async () => {
+    const first = await mount(null);
+    // Away from the brief's `cloud-native`, so the re-stamp cannot produce this value.
+    at(first.fixture).setLinkedInTargetingProfile('mcp');
+    first.fixture.detectChanges();
+
+    const carried = first.latest();
+    first.fixture.destroy();
+
+    const second = await mount(carried);
+
+    expect(at(second.fixture).linkedInTargetingProfile()).toBe('mcp');
+  });
+
+  it('keeps a chosen ad account after a tab round-trip', async () => {
+    const first = await mount(null);
+    at(first.fixture).setLinkedInAccount('urn:li:sponsoredAccount:999');
+    first.fixture.detectChanges();
+
+    const carried = first.latest();
+    first.fixture.destroy();
+
+    const second = await mount(carried);
+
+    expect(at(second.fixture).linkedInAccountId()).toBe('urn:li:sponsoredAccount:999');
+  });
+
+  /**
+   * The seed must still run when there is NOTHING to restore, which is the other half of making
+   * `populateFromBrief` conditional. A guard that skipped seeding unconditionally would leave a
+   * first-time user with an empty geo list and `canSubmit` permanently blocking the LinkedIn
+   * section — a worse bug than the one being fixed, and invisible to every test above.
+   */
+  it('still seeds from the brief on a first visit with no draft', async () => {
+    const first = await mount(null);
+
+    expect(
+      at(first.fixture)
+        .linkedInGeoTargets()
+        .map((g) => g.urn)
+    ).toEqual([US_GEO.urn]);
+    expect(at(first.fixture).linkedInTargetingProfile()).toBe('cloud-native');
+  });
+
+  /**
+   * A draft keyed to a DIFFERENT event must neither restore nor suppress the seed.
+   *
+   * `hasDraftForThisBrief()` gates both halves, so this is where they could disagree: if the seed
+   * skipped on "a draft exists" while `applyDraft` declined on "wrong slug", the fields would be
+   * neither seeded nor restored and the section would open blank.
+   */
+  it('seeds from the brief when the carried draft belongs to another event', async () => {
+    const first = await mount(null);
+    at(first.fixture).removeGeoTarget(0);
+    first.fixture.detectChanges();
+
+    const foreign = { ...(first.latest() as CampaignImplementationDraft), eventSlug: 'some-other-event' };
+    first.fixture.destroy();
+
+    const second = await mount(foreign);
+
+    // The BRIEF's recommendation, not the foreign draft's empty list.
+    expect(
+      at(second.fixture)
+        .linkedInGeoTargets()
+        .map((g) => g.urn)
+    ).toEqual([US_GEO.urn]);
+  });
+});
+
+/**
+ * The ad-account fetch versus a restored choice (LFXV2-3230).
+ *
+ * `ngOnInit` resolves the LinkedIn ad-account list on EVERY mount — that network call is the whole
+ * reason this tab is destroyed on a tab switch rather than kept alive. Its response defaults the
+ * selection to the first account, and that default has to lose to a restored draft: the response
+ * lands after the constructor effect has already replayed the user's choice onto the form, so an
+ * unguarded assignment would overwrite it on every single return to the tab.
+ *
+ * The guard is `!this.linkedInAccountId()`. The suites above leave `CampaignService` unstubbed, so
+ * the list resolves empty and the guard is never exercised — deleting it kept all 35 tests green.
+ * These two stub a real list so the branch is actually reached.
+ */
+describe('ImplementationTabComponent linkedin account defaulting', () => {
+  const EVENT_SLUG = 'kubecon-eu-2026';
+  const ACCOUNTS = [
+    { accountId: 'urn:li:sponsoredAccount:111', label: 'First Account', orgId: 'urn:li:organization:1', status: 'ACTIVE' },
+    { accountId: 'urn:li:sponsoredAccount:222', label: 'Second Account', orgId: 'urn:li:organization:2', status: 'ACTIVE' },
+  ];
+
+  const brief = (): CampaignBriefOutput =>
+    ({
+      eventDetails: { name: 'KubeCon EU 2026', slug: EVENT_SLUG, countryCode: 'US', registrationUrl: 'https://example.com/kubecon' },
+      totalBudget: 500,
+      selectedPlatforms: ['linkedin-ads'],
+      keywords: [],
+      hsUtm: null,
+      driveFolderUrl: '',
+    }) as unknown as CampaignBriefOutput;
+
+  const draftWith = (accountId: string): CampaignImplementationDraft =>
+    ({
+      eventName: 'KubeCon EU 2026',
+      countryCode: 'US',
+      registrationUrl: 'https://example.com/kubecon',
+      headlines: [],
+      descriptions: [],
+      budgetUsd: 500,
+      searchBudgetPct: 70,
+      startDate: '2026-09-01',
+      endDate: '2026-09-30',
+      includeSearch: true,
+      includeDemandGen: true,
+      linkedInAccountId: accountId,
+      linkedInGeoTargets: [],
+      linkedInTargetingProfile: 'cloud-native',
+      eventSlug: EVENT_SLUG,
+    }) as CampaignImplementationDraft;
+
+  /**
+   * Release the ad-account response by hand, so the test controls WHEN it lands.
+   *
+   * This is the whole point of the suite. A synchronous `of(ACCOUNTS)` resolves inside
+   * `ngOnInit` — before the constructor effect has replayed the draft — so the default is applied
+   * to an empty form and `applyDraft` overwrites it a moment later. The guard is then unreachable
+   * and deleting it changes nothing. (Confirmed by mutation: with a synchronous stub, removing the
+   * guard left all tests green.)
+   *
+   * Production is the other order: the response is an HTTP round-trip that lands well AFTER the
+   * effect has restored the user's account. A `Subject` reproduces that, and it is the only
+   * arrangement in which the guard does any work.
+   */
+  let accountsSubject: Subject<typeof ACCOUNTS>;
+
+  async function mount(draft: CampaignImplementationDraft | null): Promise<ComponentFixture<ImplementationTabComponent>> {
+    const f = TestBed.createComponent(ImplementationTabComponent);
+    if (draft) f.componentRef.setInput('draft', draft);
+    f.componentRef.setInput('briefData', brief());
+    f.detectChanges();
+    await f.whenStable();
+    // The restore has already run; only now does the ad-account list arrive.
+    accountsSubject.next(ACCOUNTS);
+    accountsSubject.complete();
+    f.detectChanges();
+    await f.whenStable();
+    return f;
+  }
+
+  const accountId = (f: ComponentFixture<ImplementationTabComponent>): string =>
+    (f.componentInstance as unknown as { linkedInAccountId(): string }).linkedInAccountId();
+
+  beforeEach(async () => {
+    accountsSubject = new Subject<typeof ACCOUNTS>();
+    await TestBed.configureTestingModule({
+      imports: [ImplementationTabComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        provideRouter([]),
+        ProjectContextService,
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        { provide: CampaignService, useValue: { getLinkedInAccounts: () => accountsSubject.asObservable() } },
+      ],
+    }).compileComponents();
+  });
+
+  it('defaults to the first account when nothing is restored', async () => {
+    const fixture = await mount(null);
+
+    expect(accountId(fixture)).toBe(ACCOUNTS[0].accountId);
+  });
+
+  /** The guard's reason for existing: a restored choice must outlive the fetch that follows it. */
+  it('keeps a restored account rather than defaulting over it', async () => {
+    const fixture = await mount(draftWith(ACCOUNTS[1].accountId));
+
+    expect(accountId(fixture)).toBe(ACCOUNTS[1].accountId);
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -638,7 +638,14 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
     removeGeoTarget(index: number): void;
     addGeoTarget(urn: string): void;
     setLinkedInTargetingProfile(profile: string): void;
-    setLinkedInAccount(accountId: string): void;
+    /**
+     * The template's `(change)` handler, NOT the `setLinkedInAccount` convenience method.
+     *
+     * `setLinkedInAccount` has no call site in this component's template — only a test ever
+     * reached it — so driving the round-trip through it would leave a regression in the real
+     * handler completely green while live account selections stopped reaching the draft.
+     */
+    onLinkedInAccountChange(event: Event): void;
   }
   const at = (f: ComponentFixture<ImplementationTabComponent>): Internals => f.componentInstance as unknown as Internals;
 
@@ -779,7 +786,10 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
 
   it('keeps a chosen ad account after a tab round-trip', async () => {
     const first = await mount(null);
-    at(first.fixture).setLinkedInAccount('urn:li:sponsoredAccount:999');
+    // Through the handler the TEMPLATE binds, so a regression in it fails this test. Calling
+    // `setLinkedInAccount` instead would pass against a broken `(change)` binding, since nothing
+    // in this component's template calls that method.
+    at(first.fixture).onLinkedInAccountChange({ target: { value: 'urn:li:sponsoredAccount:999' } } as unknown as Event);
     first.fixture.detectChanges();
 
     const carried = first.latest();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -763,9 +763,11 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
    * round-trip case here ends with a NON-EMPTY list, so a length-guarded restore passed all of
    * them. Verified by mutation — introducing exactly that fallback left the whole suite green.
    *
-   * `canSubmit()` is asserted too, because an empty list is only safe if it BLOCKS the create. A
-   * restore that silently refilled it would also silently re-enable dispatch to geos the operator
-   * had removed, which is the money-shaped version of this bug.
+   * Deliberately does NOT assert `canSubmit()` here. This suite never resolves
+   * `getLinkedInAccounts`, so the catalog stays empty and the account-membership gate holds
+   * `canSubmit()` false on its own — an assertion here passed even with the geo gate deleted
+   * outright, which makes it a claim about nothing. The geo gate gets its own test in the account
+   * suite below, where a stubbed catalog lets it be the only failing condition.
    */
   it('keeps an emptied geo list empty after a tab round-trip', async () => {
     const first = await mount(null);
@@ -781,7 +783,6 @@ describe('ImplementationTabComponent linkedin round-trip across a tab switch', (
 
     // NOT the brief's [US] recommendation, which is what a length-guarded restore would produce.
     expect(at(second.fixture).linkedInGeoTargets()).toEqual([]);
-    expect((second.fixture.componentInstance as unknown as { canSubmit(): boolean }).canSubmit()).toBe(false);
   });
 
   it('keeps a chosen ad account after a tab round-trip', async () => {
@@ -1028,6 +1029,31 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
     makeLinkedInOtherwiseValid(f);
 
     expect((f.componentInstance as unknown as { canSubmit(): boolean }).canSubmit()).toBe(false);
+  });
+
+  /**
+   * The geo gate, isolated — the only place in the suite where it can be.
+   *
+   * `canSubmit` blocks a LinkedIn create with no geo targets, but that gate was covered NOWHERE:
+   * deleting it left all 460 tests green. The round-trip suite cannot cover it, because it never
+   * resolves the account catalog and the membership gate blocks there regardless. Here the
+   * catalog IS stubbed and every other LinkedIn gate is satisfied, so clearing the geo list is
+   * the single failing condition.
+   */
+  it('blocks a linkedin create when the geo target list is empty', async () => {
+    const f = await mount(draftWith(ACCOUNTS[1].accountId));
+    makeLinkedInOtherwiseValid(f);
+    const c = f.componentInstance as unknown as {
+      canSubmit(): boolean;
+      campaignForm: { controls: Record<string, { setValue(v: unknown): void }> };
+    };
+    // Everything satisfied, including a catalog-confirmed account.
+    expect(c.canSubmit()).toBe(true);
+
+    c.campaignForm.controls['linkedInGeoTargets'].setValue([]);
+    f.detectChanges();
+
+    expect(c.canSubmit()).toBe(false);
   });
 
   /** Satisfy every LinkedIn gate EXCEPT the account one, so that gate is the only variable. */

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -987,8 +987,10 @@ describe('ImplementationTabComponent linkedin account defaulting', () => {
    * malformed (`linkedin-ads.service.ts:39`), so a SUCCESSFUL response can carry nothing. A guard
    * that required `accounts.length > 0` skipped entirely in that case, leaving the restored id on
    * the form with no account to match it — the selector renders empty while `submit()` still
-   * dispatches the stale value. Clearing is the honest outcome: the create then fails upstream on
-   * a blank account rather than silently spending against someone else's.
+   * dispatches the stale value. Clearing is the honest outcome, and `canSubmit`'s membership gate
+   * then holds the create BLOCKED rather than letting it reach LinkedIn: an empty catalog contains
+   * no id, including ''. The operator sees Create disabled beside an empty account list, which is
+   * the true state, instead of a create that fails somewhere they cannot see.
    */
   /**
    * The two windows `ngOnInit`'s reconciliation cannot cover.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -416,6 +416,19 @@ export class ImplementationTabComponent implements OnInit {
     if (linkedInSelected && this.linkedInBudgetUsd() < 1) return false;
     if (linkedInSelected && this.linkedInGeoTargets().length === 0) return false;
     if (linkedInSelected && this.linkedInVariants().length === 0) return false;
+    // The account must be one the CATALOG confirms, not merely a non-empty string.
+    //
+    // `ngOnInit`'s reconciliation only runs on a successful response, so it cannot cover the two
+    // windows either side of it: before the request returns, and permanently if it fails. In both
+    // the restored id is still on the form while `linkedInAccounts()` is empty, so a create would
+    // dispatch an account nothing has verified and the selector is not displaying — the same
+    // divergence the reconciliation closes, reached where it does not run.
+    //
+    // Membership is the test rather than "loading finished", because a failed fetch leaves
+    // loading false with an empty catalog, which is exactly when this matters most. It also
+    // covers the blank id for free. The gate is scoped to LinkedIn, so a Google-only or
+    // Reddit-only create is unaffected by an ad-account endpoint being down.
+    if (linkedInSelected && !this.linkedInAccounts().some((a) => a.accountId === this.linkedInAccountId())) return false;
     if (metaSelected && this.metaBudgetUsd() < 1) return false;
     // Reddit's client rejects a non-positive budget at dispatch (client.go: "invalid budget:
     // must be a positive number"), and because creation is async that surfaces as a dead job

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -196,6 +196,26 @@ export class ImplementationTabComponent implements OnInit {
     includeDemandGen: [true],
     headlines: this.fb.array([this.fb.control('', [Validators.required, Validators.maxLength(CAMPAIGN_CHAR_LIMITS.searchHeadline)])]),
     descriptions: this.fb.array([this.fb.control('', [Validators.required, Validators.maxLength(CAMPAIGN_CHAR_LIMITS.searchDescription)])]),
+    // The LinkedIn ad account, geo targets and targeting profile, on the FORM rather than in
+    // signals (LFXV2-3230). All three are user-editable — a select, an add/remove chip list and a
+    // two-button toggle — and all three used to be destroyed by a tab switch, then silently
+    // re-stamped from the brief on remount, so the revert looked like the AI's recommendation
+    // standing rather than the user's choice being lost.
+    //
+    // Being on the form buys the RESTORE and the emission trigger: `valueChanges` already feeds
+    // `emitDraft`, so no handler emits by hand, and `applyDraft`'s existing `patchValue` replays
+    // them with no extra signal writes. It does NOT save the three members on
+    // `CampaignImplementationDraft` — `emitDraft` builds an object literal, so a control still has
+    // to be named there to reach the draft. The saving is that the value has one home instead of
+    // four (handler, `submit`, seed, snapshot).
+    //
+    // NO validators, deliberately. `canSubmit` already gates the LinkedIn section on a non-empty
+    // geo list, and it reads the whole form's validity for GOOGLE (`campaignForm.invalid`) — a
+    // required-validator here would make an empty LinkedIn geo list block a Google-only campaign
+    // that has nothing to do with LinkedIn.
+    linkedInAccountId: [''],
+    linkedInGeoTargets: [[] as LinkedInGeoTarget[]],
+    linkedInTargetingProfile: ['cloud-native' as LinkedInTargetingProfile],
   });
 
   // === WritableSignals ===
@@ -261,14 +281,11 @@ export class ImplementationTabComponent implements OnInit {
   protected readonly briefHsToken = signal<string | null>(null);
   protected readonly briefDriveFolderUrl = signal('');
   protected readonly selectedPlatforms = signal<CampaignPlatform[]>(['google-ads']);
-  protected readonly linkedInGeoTargets = signal<LinkedInGeoTarget[]>([]);
-  protected readonly linkedInTargetingProfile = signal<LinkedInTargetingProfile>('cloud-native');
   protected readonly linkedInVariants = signal<LinkedInCreativeVariant[]>([]);
   protected readonly linkedInBudgetUsd = signal(500);
   protected readonly linkedInLifetimeBudget = signal(false);
   protected readonly linkedInAccounts = signal<LinkedInAccount[]>([]);
   protected readonly linkedInAccountsLoading = signal(false);
-  protected readonly linkedInAccountId = signal<string>('');
   protected readonly redditVariants = signal<RedditAdVariant[]>([]);
   protected readonly redditSubreddits = signal<string[]>([]);
   protected readonly redditInterests = signal<string[]>([]);
@@ -316,6 +333,35 @@ export class ImplementationTabComponent implements OnInit {
   private readonly countryCodeValue = toSignal(
     this.campaignForm.controls.countryCode.valueChanges.pipe(startWith(this.campaignForm.controls.countryCode.value)),
     { initialValue: this.campaignForm.controls.countryCode.value }
+  );
+
+  /**
+   * The three LinkedIn controls as SIGNALS, for the same reason `countryCodeValue` is one
+   * (LFXV2-3230).
+   *
+   * They moved from signals onto `campaignForm` so the draft carries them, but the template,
+   * `canSubmit` and `availableGeoTargets` all read them reactively. A plain
+   * `controls.linkedInGeoTargets.value` read is not a reactive dependency, so a `computed` over
+   * it would memoise on first read and never update — the chip list would stop re-rendering as
+   * the user adds and removes geos. Bridging through `toSignal` keeps every existing reader
+   * working unchanged while the value itself lives on the form.
+   *
+   * `startWith` seeds the current value rather than a literal, so these are correct from first
+   * read rather than only after the first edit.
+   */
+  protected readonly linkedInAccountId = toSignal(
+    this.campaignForm.controls.linkedInAccountId.valueChanges.pipe(startWith(this.campaignForm.controls.linkedInAccountId.value)),
+    { initialValue: this.campaignForm.controls.linkedInAccountId.value }
+  );
+
+  protected readonly linkedInGeoTargets = toSignal(
+    this.campaignForm.controls.linkedInGeoTargets.valueChanges.pipe(startWith(this.campaignForm.controls.linkedInGeoTargets.value)),
+    { initialValue: this.campaignForm.controls.linkedInGeoTargets.value }
+  );
+
+  protected readonly linkedInTargetingProfile = toSignal(
+    this.campaignForm.controls.linkedInTargetingProfile.valueChanges.pipe(startWith(this.campaignForm.controls.linkedInTargetingProfile.value)),
+    { initialValue: this.campaignForm.controls.linkedInTargetingProfile.value }
   );
 
   /**
@@ -517,8 +563,17 @@ export class ImplementationTabComponent implements OnInit {
       .subscribe({
         next: (accounts) => {
           this.linkedInAccounts.set(accounts);
+          // Default to the first account ONLY when nothing is selected yet. The guard predates
+          // LFXV2-3230 but carries more weight now: a restored draft has already put the user's
+          // account on the form by the time this response lands, and dropping the guard would
+          // overwrite their choice with the list's first entry every single mount.
+          //
+          // Writes through the form rather than a signal, since that is where the value now
+          // lives. `emitEvent` is left ON deliberately — this assignment CHANGES what `submit()`
+          // would send, so the parent's draft has to learn about it; suppressing the event would
+          // leave the draft carrying '' while the form and the request carry a real account.
           if (accounts.length > 0 && !this.linkedInAccountId()) {
-            this.linkedInAccountId.set(accounts[0].accountId);
+            this.campaignForm.controls.linkedInAccountId.setValue(accounts[0].accountId);
           }
           this.linkedInAccountsLoading.set(false);
         },
@@ -563,20 +618,25 @@ export class ImplementationTabComponent implements OnInit {
     if (arr.length > 1) arr.removeAt(index);
   }
 
+  // The three handlers below write to `campaignForm` rather than to a signal (LFXV2-3230). That
+  // single change is what makes these edits survive a tab switch: `valueChanges` already drives
+  // `emitDraft`, so the parent's copy updates on every pick with no emission added here.
   protected removeGeoTarget(index: number): void {
-    this.linkedInGeoTargets.update((targets) => targets.filter((_, i) => i !== index));
+    const current = this.campaignForm.controls.linkedInGeoTargets.value;
+    this.campaignForm.controls.linkedInGeoTargets.setValue(current.filter((_, i) => i !== index));
   }
 
   protected addGeoTarget(urn: string): void {
     if (!urn) return;
     const geo = this.allKnownGeos.find((g) => g.urn === urn);
-    if (geo && !this.linkedInGeoTargets().some((g) => g.urn === urn)) {
-      this.linkedInGeoTargets.update((targets) => [...targets, geo]);
+    const current = this.campaignForm.controls.linkedInGeoTargets.value;
+    if (geo && !current.some((g) => g.urn === urn)) {
+      this.campaignForm.controls.linkedInGeoTargets.setValue([...current, geo]);
     }
   }
 
   protected setLinkedInTargetingProfile(profile: LinkedInTargetingProfile): void {
-    this.linkedInTargetingProfile.set(profile);
+    this.campaignForm.controls.linkedInTargetingProfile.setValue(profile);
   }
 
   protected setLinkedInLifetimeBudget(value: boolean): void {
@@ -588,11 +648,11 @@ export class ImplementationTabComponent implements OnInit {
   }
 
   protected setLinkedInAccount(accountId: string): void {
-    this.linkedInAccountId.set(accountId);
+    this.campaignForm.controls.linkedInAccountId.setValue(accountId);
   }
 
   protected onLinkedInAccountChange(event: Event): void {
-    this.linkedInAccountId.set((event.target as HTMLSelectElement).value);
+    this.campaignForm.controls.linkedInAccountId.setValue((event.target as HTMLSelectElement).value);
   }
 
   protected onGeoTargetChange(event: Event): void {
@@ -820,6 +880,19 @@ export class ImplementationTabComponent implements OnInit {
       endDate: draft.endDate,
       includeSearch: draft.includeSearch,
       includeDemandGen: draft.includeDemandGen,
+      // The three LinkedIn controls (LFXV2-3230), restored in the SAME patch as everything else —
+      // which is the entire benefit of having moved them onto the form: no extra signal writes and
+      // no second emission. This runs AFTER `populateFromBrief`, so it deliberately overwrites the
+      // recommendation that seeded a moment ago; that ordering is what makes the restore win.
+      //
+      // Restored UNCONDITIONALLY, with no `|| draft.linkedInGeoTargets.length` guard. An empty
+      // geo list means the user removed every chip, and replacing it with the brief's
+      // recommendation would be the silent revert this ticket exists to stop; `canSubmit` already
+      // blocks a LinkedIn campaign with no geos, so the empty state is visible rather than
+      // dangerous.
+      linkedInAccountId: draft.linkedInAccountId,
+      linkedInGeoTargets: draft.linkedInGeoTargets,
+      linkedInTargetingProfile: draft.linkedInTargetingProfile,
     });
 
     // The copy arrays stay silent: nothing derives a display from them, and rebuilding a FormArray
@@ -875,6 +948,13 @@ export class ImplementationTabComponent implements OnInit {
       endDate: form.endDate,
       includeSearch: form.includeSearch,
       includeDemandGen: form.includeDemandGen,
+      // The three LinkedIn controls (LFXV2-3230). Listed EXPLICITLY, like every field above,
+      // because this emit is an object literal rather than a spread of `getRawValue()` — a
+      // control added to the form does not reach the draft until it is named here. That is the
+      // one step "just put it on the form" does not do for you.
+      linkedInAccountId: form.linkedInAccountId,
+      linkedInGeoTargets: form.linkedInGeoTargets,
+      linkedInTargetingProfile: form.linkedInTargetingProfile,
       eventSlug: form.eventSlug,
     });
   }
@@ -926,8 +1006,29 @@ export class ImplementationTabComponent implements OnInit {
 
     if (brief.linkedInCopy) {
       this.linkedInVariants.set(brief.linkedInCopy.variants);
-      this.linkedInGeoTargets.set(brief.linkedInCopy.recommendedGeoTargets);
-      this.linkedInTargetingProfile.set(brief.linkedInCopy.recommendedTargetingProfile);
+      // Seeded UNCONDITIONALLY, and the ticket's premise that this needs a "only when the parent
+      // holds nothing" guard does not survive contact with the call order (LFXV2-3230).
+      //
+      // The constructor effect runs `populateFromBrief(brief)` and THEN
+      // `untracked(() => this.applyDraft())`. The restore is last, so it overwrites whatever this
+      // seeds — a guard here changes nothing for any field `applyDraft` restores. This was
+      // mutation-tested rather than reasoned about: with the guard replaced by `if (true)` the
+      // whole suite still passed, including the round-trip tests, because the restore had already
+      // done the work. Dead code that reads as load-bearing is worse than no code, so it is gone.
+      //
+      // The guard WOULD be needed if the two ever swapped order, or for a field this seeds but
+      // `applyDraft` does not restore. Neither is true today for these two controls.
+      //
+      // These EMIT, and must. The three controls are read through `toSignal` bridges over
+      // `valueChanges`, so a `{ emitEvent: false }` write updates the control while every reader —
+      // the template's chip list, `canSubmit`, `availableGeoTargets`, `submit()` — keeps the stale
+      // initial value. Suppressing here made the seed invisible: the form held the recommendation
+      // and the page rendered an empty geo list.
+      //
+      // Emitting is safe because `seeding` is true for the whole of this call, so the
+      // `valueChanges` subscription returns early rather than snapshotting a half-built form.
+      this.campaignForm.controls.linkedInGeoTargets.setValue(brief.linkedInCopy.recommendedGeoTargets);
+      this.campaignForm.controls.linkedInTargetingProfile.setValue(brief.linkedInCopy.recommendedTargetingProfile);
       // `budgetRecommendation` is guarded as well as `strategy`. Until LFXV2-3108 every brief
       // reaching here came straight from the generator, which always emits both; a RESTORED
       // brief is replayed from stored JSON, where `asVariantCopy` validates only the `variants`

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -604,8 +604,9 @@ export class ImplementationTabComponent implements OnInit {
           // `accounts: []` when the LinkedIn config is absent or malformed, so a successful
           // response can carry nothing — and a restored id would then survive with no account to
           // match it, dispatching a stale value while the selector shows an empty list. Clearing
-          // is the honest result: `canSubmit` still lets a LinkedIn create through on an empty id,
-          // but the request then fails upstream on a blank account rather than on someone else's.
+          // is the honest result, and `canSubmit`'s membership gate then BLOCKS the create rather
+          // than letting it reach LinkedIn: an empty catalog contains no id, including ''. The
+          // operator sees Create disabled with an empty account list, which is the true state.
           if (!accounts.some((a) => a.accountId === this.linkedInAccountId())) {
             this.campaignForm.controls.linkedInAccountId.setValue(accounts[0]?.accountId ?? '');
           }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -563,16 +563,31 @@ export class ImplementationTabComponent implements OnInit {
       .subscribe({
         next: (accounts) => {
           this.linkedInAccounts.set(accounts);
-          // Default to the first account ONLY when nothing is selected yet. The guard predates
-          // LFXV2-3230 but carries more weight now: a restored draft has already put the user's
-          // account on the form by the time this response lands, and dropping the guard would
-          // overwrite their choice with the list's first entry every single mount.
+          // Keep the restored selection only if this catalog still CONTAINS it; otherwise fall
+          // back to the first account.
           //
-          // Writes through the form rather than a signal, since that is where the value now
-          // lives. `emitEvent` is left ON deliberately — this assignment CHANGES what `submit()`
-          // would send, so the parent's draft has to learn about it; suppressing the event would
-          // leave the draft carrying '' while the form and the request carry a real account.
-          if (accounts.length > 0 && !this.linkedInAccountId()) {
+          // A blank-only check was enough until this commit and is not any more. Persisting the id
+          // (LFXV2-3230) makes a STALE one reachable for the first time: the list is refetched on
+          // every mount and an account can be revoked or lose permission between them. A stale id
+          // then splits the page in two — `selectedLinkedInAccount` resolves the label and
+          // org/status line through `accounts.find(...) ?? accounts[0]`, and the `<select>` cannot
+          // render an unmatched value either, so both show the FIRST account, while `submit()`
+          // sends `linkedInAccountId()` verbatim. The operator reads one account and spends money
+          // on another, with nothing on screen to say so.
+          //
+          // That fallback pre-dates this change but was unreachable while the id was not carried
+          // on the draft, which is why closing it belongs here rather than in a follow-up.
+          //
+          // Correcting silently rather than prompting: the operator never chose this state, the
+          // first account is what every other surface is already showing, and the alternative is a
+          // modal on a path that is noisy enough. Membership also subsumes the first-visit case —
+          // '' is never in the list.
+          //
+          // Writes through the form rather than a signal, since that is where the value now lives.
+          // `emitEvent` is left ON deliberately — this assignment CHANGES what `submit()` would
+          // send, so the parent's draft has to learn about it; suppressing the event would leave
+          // the draft carrying a value the form and the request no longer agree with.
+          if (accounts.length > 0 && !accounts.some((a) => a.accountId === this.linkedInAccountId())) {
             this.campaignForm.controls.linkedInAccountId.setValue(accounts[0].accountId);
           }
           this.linkedInAccountsLoading.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -587,8 +587,14 @@ export class ImplementationTabComponent implements OnInit {
           // `emitEvent` is left ON deliberately — this assignment CHANGES what `submit()` would
           // send, so the parent's draft has to learn about it; suppressing the event would leave
           // the draft carrying a value the form and the request no longer agree with.
-          if (accounts.length > 0 && !accounts.some((a) => a.accountId === this.linkedInAccountId())) {
-            this.campaignForm.controls.linkedInAccountId.setValue(accounts[0].accountId);
+          // An EMPTY catalog is a real answer, not a skip. `loadLinkedInConfig` falls back to
+          // `accounts: []` when the LinkedIn config is absent or malformed, so a successful
+          // response can carry nothing — and a restored id would then survive with no account to
+          // match it, dispatching a stale value while the selector shows an empty list. Clearing
+          // is the honest result: `canSubmit` still lets a LinkedIn create through on an empty id,
+          // but the request then fails upstream on a blank account rather than on someone else's.
+          if (!accounts.some((a) => a.accountId === this.linkedInAccountId())) {
+            this.campaignForm.controls.linkedInAccountId.setValue(accounts[0]?.accountId ?? '');
           }
           this.linkedInAccountsLoading.set(false);
         },

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -682,10 +682,10 @@ export class ImplementationTabComponent implements OnInit {
     this.linkedInBudgetUsd.set(value);
   }
 
-  protected setLinkedInAccount(accountId: string): void {
-    this.campaignForm.controls.linkedInAccountId.setValue(accountId);
-  }
-
+  // `setLinkedInAccount` was removed here (LFXV2-3230). Nothing in this component's template
+  // called it — only a test did, which made the test pass against a broken `(change)` binding.
+  // `onLinkedInAccountChange` below is the real path and is what the round-trip test now drives.
+  // The identically-named methods on monitoring-tab and optimization-tab are live and untouched.
   protected onLinkedInAccountChange(event: Event): void {
     this.campaignForm.controls.linkedInAccountId.setValue((event.target as HTMLSelectElement).value);
   }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -354,7 +354,22 @@ export class ImplementationTabComponent implements OnInit {
     { initialValue: this.campaignForm.controls.linkedInAccountId.value }
   );
 
-  protected readonly linkedInGeoTargets = toSignal(
+  /**
+   * Coalesced to `[]` HERE rather than at each reader, because the readers are the whole surface:
+   * `canSubmit`, `availableGeoTargets`, `submit()` and two template blocks all read this, and four
+   * of the five would throw on an absent value (`.length`, `.map`, `@for`). Guarding one call site
+   * leaves the other four, and the crash in `availableGeoTargets` is reached from the TEMPLATE, so
+   * it takes down the tab rather than one control.
+   *
+   * The value can be absent even though `CampaignImplementationDraft` declares it non-optional:
+   * that is a compile-time claim, and `applyDraft` hands `patchValue` whatever the draft holds
+   * while `patchValue` passes `undefined` straight through. Unreachable today — `emitDraft` is the
+   * only non-null producer and the draft is in-memory — but a required TYPE is not what keeps it
+   * safe, so the guard belongs at the boundary the values flow through.
+   */
+  protected readonly linkedInGeoTargets = computed<LinkedInGeoTarget[]>(() => this.linkedInGeoTargetsRaw() ?? []);
+
+  private readonly linkedInGeoTargetsRaw = toSignal(
     this.campaignForm.controls.linkedInGeoTargets.valueChanges.pipe(startWith(this.campaignForm.controls.linkedInGeoTargets.value)),
     { initialValue: this.campaignForm.controls.linkedInGeoTargets.value }
   );
@@ -558,10 +573,15 @@ export class ImplementationTabComponent implements OnInit {
       this.emitDraft();
     });
 
-    // Emit as the user types. `valueChanges` covers the form (copy, budget, flight, campaign
-    // types); it does NOT cover the platform signals, which is deliberate — see the draft
-    // interface for why this snapshot is scoped to the fields a user types rather than everything
-    // the component holds.
+    // Emit as the user edits. `valueChanges` covers everything on `campaignForm` — copy, budget,
+    // flight, campaign types, and since LFXV2-3230 the three LinkedIn picks (ad account, geo
+    // targets, targeting profile). Moving those three onto the form is what makes their restore
+    // work: this subscription emits on every pick with no per-handler plumbing.
+    //
+    // Still OUTSIDE it: the platform picks that remain signals — the LinkedIn budget pair and
+    // variants, and the Reddit fields — none of which `emitDraft` names, so they do not reach the
+    // draft at all. See the draft interface: the snapshot is scoped to the fields a user EDITS,
+    // which is broader than the ones they type, and excludes anything re-derived from a fetch.
     this.campaignForm.valueChanges.pipe(takeUntilDestroyed(this.destroyRef)).subscribe(() => {
       if (this.seeding) return;
       this.emitDraft();

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -321,11 +321,32 @@ export interface CampaignBriefPersistenceState {
  * `eventSlug` is the one carried field that is NOT restored: it is the draft's key, compared
  * against the brief on screen so one event's edits cannot replay onto another's.
  *
- * **Known gap, tracked as LFXV2-3230.** The per-platform signals — LinkedIn geo targets,
- * targeting profile, ad account and budget; Meta budget and lifetime-budget — are also
- * user-editable and are still discarded, because they live in signals rather than this form and
- * would need their own plumbing. The Google copy and budget carried here are the highest-volume
- * typing on the page; the platform fields are mostly AI-recommended values the user nudges.
+ * The LinkedIn ad account, geo targets and targeting profile are carried too (LFXV2-3230). They
+ * were moved from component signals onto `campaignForm`, which is what makes the RESTORE work:
+ * `applyDraft`'s existing `patchValue` replays them, and `valueChanges` emits on every pick with
+ * no per-handler plumbing. They were form state in everything but name — three controls the user
+ * picks from, whose only distinction was living in a signal.
+ *
+ * Moving them onto the form did NOT save this interface three members, and it is worth being
+ * precise about why. `emitDraft` builds an object LITERAL rather than spreading `getRawValue()`,
+ * so a control that is not named there never reaches the draft at all. The form buys the restore
+ * half and the emission trigger; the snapshot still has to list what it carries. Anyone extending
+ * this pays one line here either way.
+ *
+ * What the form DOES buy is that the value has exactly one home. A signal-backed field is written
+ * in a handler, read in `submit`, seeded in `populateFromBrief` and mirrored here — four places to
+ * keep in step. A form-backed one is stored once and derived everywhere else.
+ *
+ * TWO approaches therefore coexist in the Implementation tab, split by owner rather than by
+ * principle. The per-platform BUDGETS live only in signals and are mirrored onto this interface
+ * (LFXV2-3315); the three LinkedIn controls live on the form (LFXV2-3230). Both shipped in the
+ * same window from separate tickets and neither converted the other's fields, because unpicking a
+ * committed sibling branch costs more than the uniformity buys. Unifying them is follow-up work:
+ * move the budget signals onto `campaignForm`, keeping their members here.
+ *
+ * The remaining per-platform signals — the creative variants, and the Reddit targeting rendered
+ * read-only for review — are still discarded, and correctly so: nothing on screen edits them.
+ * Values the user cannot change do not need carrying; they re-derive from the brief identically.
  *
  * `null` means "nothing to restore", which is the state on first mount and after a reset. It is
  * NOT the same as an empty draft: an empty draft would mean the user deliberately cleared every
@@ -350,6 +371,23 @@ export interface CampaignImplementationDraft {
   endDate: string;
   includeSearch: boolean;
   includeDemandGen: boolean;
+  /**
+   * The three LinkedIn controls the user picks rather than types (LFXV2-3230): the ad account,
+   * the geo target list, and the targeting profile.
+   *
+   * REQUIRED, not optional, and an empty `linkedInGeoTargets` is a meaningful value rather than a
+   * hole — the user removed every chip, and `canSubmit` blocks a LinkedIn campaign on exactly
+   * that. Optional members would make "cleared" and "not set" indistinguishable at the restore
+   * site, and the natural `?? recommendedGeoTargets` fallback would then put the AI's list back
+   * over a deliberate clearance, which is the defect rather than the fix.
+   *
+   * `linkedInAccountId` is '' before the ad-account fetch resolves. That is carried as-is: the
+   * account list is re-fetched on every mount, and `ngOnInit` fills the first account in only
+   * when the restored value is still blank, so a real choice is never overwritten by the default.
+   */
+  linkedInAccountId: string;
+  linkedInGeoTargets: LinkedInGeoTarget[];
+  linkedInTargetingProfile: LinkedInTargetingProfile;
   /**
    * The event this draft belongs to, so a draft cannot be replayed onto a different brief.
    * Without it, generating a brief for event B and opening Implement would restore event A's

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -314,9 +314,11 @@ export interface CampaignBriefPersistenceState {
  * every page load for a tab the user may never open. Lifting the edits out instead keeps the
  * component cheap to destroy while the user's typing survives (LFXV2-3229).
  *
- * Deliberately a SNAPSHOT of the fields a user TYPES, not the whole component state. Anything
- * re-derived from a fetch (results, progress, the LinkedIn account list) is left to re-derive —
- * restoring those would be restoring a cache, and a stale one.
+ * Deliberately a SNAPSHOT of the fields a user EDITS, not the whole component state. That is
+ * broader than typing: it covers the dropdown, chip list and toggle the LinkedIn picks are chosen
+ * through, because a choice made with the mouse is lost by a tab switch exactly as a typed one is.
+ * Anything re-derived from a fetch (results, progress, the LinkedIn account LIST itself) is left
+ * to re-derive — restoring those would be restoring a cache, and a stale one.
  *
  * `eventSlug` is the one carried field that is NOT restored: it is the draft's key, compared
  * against the brief on screen so one event's edits cannot replay onto another's.

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -389,9 +389,12 @@ export interface CampaignImplementationDraft {
    * site, and the natural `?? recommendedGeoTargets` fallback would then put the AI's list back
    * over a deliberate clearance, which is the defect rather than the fix.
    *
-   * `linkedInAccountId` is '' before the ad-account fetch resolves. That is carried as-is: the
-   * account list is re-fetched on every mount, and `ngOnInit` fills the first account in only
-   * when the restored value is still blank, so a real choice is never overwritten by the default.
+   * `linkedInAccountId` is '' before the ad-account fetch resolves, and is carried as-is. Note the
+   * restored value is NOT preserved unconditionally: the account list is refetched on every mount,
+   * and `ngOnInit` reconciles the restored id against it — keeping it when the catalog still
+   * offers it, replacing it with the first account otherwise, and clearing it when the catalog is
+   * empty. A choice that is still valid survives; one pointing at a revoked account does not,
+   * because the alternative is dispatching to an account the page cannot display.
    */
   linkedInAccountId: string;
   linkedInGeoTargets: LinkedInGeoTarget[];

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -347,10 +347,12 @@ export interface CampaignBriefPersistenceState {
  * worth doing rather than deferring: the form is the better target, since it needs no per-handler
  * emission and so cannot be forgotten when a control is added.
  *
- * That drift is not hypothetical: LFXV2-3227/3228 added four more user-editable Meta controls and
- * had to carry them by the per-handler signal mechanism, because they are signal-backed rather
- * than form-backed. Two mechanisms now coexist in this file exactly as predicted above, which is
- * the argument for unifying on the form rather than deferring it again.
+ * That drift is not hypothetical, though none of it is visible HERE: this branch adds only the
+ * three LinkedIn picks, and no budget or Meta member appears on this interface yet. LFXV2-3315
+ * (budgets) and LFXV2-3227/3228 (four Meta controls — objective, placements, pixel id, geo
+ * targets) both carry their fields by the per-handler signal mechanism, and both are still open.
+ * When they land, two mechanisms will coexist in this file, which is the argument for unifying on
+ * the form rather than deferring it a third time.
  *
  * Any per-platform value not named on this interface is NOT carried across a tab switch. Those
  * fall into two groups with opposite verdicts, and the distinction matters more than the

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -337,16 +337,24 @@ export interface CampaignBriefPersistenceState {
  * in a handler, read in `submit`, seeded in `populateFromBrief` and mirrored here — four places to
  * keep in step. A form-backed one is stored once and derived everywhere else.
  *
- * TWO approaches therefore coexist in the Implementation tab, split by owner rather than by
- * principle. The per-platform BUDGETS live only in signals and are mirrored onto this interface
- * (LFXV2-3315); the three LinkedIn controls live on the form (LFXV2-3230). Both shipped in the
- * same window from separate tickets and neither converted the other's fields, because unpicking a
- * committed sibling branch costs more than the uniformity buys. Unifying them is follow-up work:
- * move the budget signals onto `campaignForm`, keeping their members here.
+ * The per-platform BUDGETS are NOT carried here yet. They remain component-local signals, so a tab
+ * switch still reverts them — the same defect this interface exists to prevent, still open for
+ * that half. LFXV2-3315 addresses it on a separate branch by adding budget members here and
+ * emitting from each budget handler, which is a DIFFERENT mechanism from the form controls above.
+ * Whichever lands second inherits a file with two ways of doing one thing, so unifying them is
+ * worth doing rather than deferring: the form is the better target, since it needs no per-handler
+ * emission and so cannot be forgotten when a control is added.
  *
- * The remaining per-platform signals — the creative variants, and the Reddit targeting rendered
- * read-only for review — are still discarded, and correctly so: nothing on screen edits them.
- * Values the user cannot change do not need carrying; they re-derive from the brief identically.
+ * That drift is not hypothetical — LFXV2-3227/3228 adds four more user-editable Meta controls
+ * (objective, placements, pixel id, geo targets), none of them carried by either mechanism.
+ *
+ * Any per-platform value not named on this interface is NOT carried across a tab switch. Those
+ * fall into two groups with opposite verdicts, and the distinction matters more than the
+ * membership: values the user cannot edit (creative variants, the Reddit targeting rendered
+ * read-only for review) are correctly discarded, since they re-derive from the brief identically;
+ * values the user CAN edit and that are not carried are simply still broken. Deliberately not
+ * enumerated — the second group shrinks as tickets land, and a list of members is exactly the kind
+ * of claim a later change falsifies with nothing to catch it.
  *
  * `null` means "nothing to restore", which is the state on first mount and after a reset. It is
  * NOT the same as an empty draft: an empty draft would mean the user deliberately cleared every

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -347,8 +347,10 @@ export interface CampaignBriefPersistenceState {
  * worth doing rather than deferring: the form is the better target, since it needs no per-handler
  * emission and so cannot be forgotten when a control is added.
  *
- * That drift is not hypothetical — LFXV2-3227/3228 adds four more user-editable Meta controls
- * (objective, placements, pixel id, geo targets), none of them carried by either mechanism.
+ * That drift is not hypothetical: LFXV2-3227/3228 added four more user-editable Meta controls and
+ * had to carry them by the per-handler signal mechanism, because they are signal-backed rather
+ * than form-backed. Two mechanisms now coexist in this file exactly as predicted above, which is
+ * the argument for unifying on the form rather than deferring it again.
  *
  * Any per-platform value not named on this interface is NOT carried across a tab switch. Those
  * fall into two groups with opposite verdicts, and the distinction matters more than the


### PR DESCRIPTION
## What

The Implement tab sits inside the parent's structural `@switch`, so every visit to another tab destroys the component and every signal it owns. LFXV2-3229 lifted the **form** state onto `CampaignImplementationDraft` so it survives. The per-platform signals were left behind, and three of them are user-editable:

| Control | Handler | Was |
|---|---|---|
| LinkedIn ad account | `onLinkedInAccountChange` | destroyed on tab switch |
| LinkedIn geo targets | `removeGeoTarget` / `onGeoTargetChange` | destroyed on tab switch |
| LinkedIn targeting profile | `setLinkedInTargetingProfile` | destroyed on tab switch |

The loss was **silent**, which is why it went unnoticed. `populateFromBrief` re-stamps the brief's recommendation on every remount, so a user who removed a geo or switched to the MCP profile came back to the AI's suggestion sitting where their choice had been — nothing looked broken, the fields simply read what the brief said. `submit()` reads these same values, so a campaign could dispatch targeting the operator had deliberately changed and never saw revert.

## How

Moved all three onto `campaignForm` rather than adding more signals. Being on the form is what makes the restore work: `applyDraft`'s existing `patchValue` replays them and `valueChanges` already drives `emitDraft`, so no handler emits by hand. Every existing reader keeps working through a `toSignal` bridge over `valueChanges` — the same pattern `countryCodeValue` already uses in this file, because a plain `.value` read is not a reactive dependency and a `computed` over it would memoise and never update.

Not mounted eagerly — that was rejected in LFXV2-3229 because `ngOnInit` resolves the ad-account list, a network call for a tab the user may never open.

## Two findings from mutation testing, both of which changed the patch

**1. The guard the ticket asked for is dead code.** LFXV2-3230 specifies that `populateFromBrief` must seed "only when the parent holds nothing", calling that the actual defect. It isn't. The constructor effect runs `populateFromBrief(brief)` and **then** `untracked(() => this.applyDraft())` — the restore is last, so it already overwrites the seed. With the guard replaced by `if (true)` the entire suite still passed. I implemented it, proved it dead, and removed it rather than ship a line that reads as load-bearing and isn't. The guard *would* matter if the two ever swapped order, or for a field seeded but not restored; neither is true today.

**2. A guard that was untested and unreachable under a synchronous stub.** `ngOnInit` defaults to the first ad account only when the selection is blank. Under `of(ACCOUNTS)` the list resolves *inside* `ngOnInit`, before the restore runs, so the guard never sees a restored value and deleting it changed nothing. Production resolves it *after*, via HTTP. The test now releases the response through a `Subject` so the real ordering is exercised — and deleting the guard fails it. This is the ordering that would have bitten in production, not in CI.

## Mutation results

Every new test verified with a compiling revert:

| Mutation | Result |
|---|---|
| Drop the three restores from `applyDraft` | 4 tests fail |
| `emitDraft` emits stale defaults instead of form values | 4 tests fail |
| Seed writes with `emitEvent: false` | 2 tests fail |
| `setLinkedInTargetingProfile` writes without emitting | 1 test fails (its own) |
| geo add/remove write without emitting | 2 tests fail |
| `setLinkedInAccount` writes without emitting | 1 test fails (its own) |
| Remove the `ngOnInit` blank-check guard | 1 test fails |

The first version of the "removed geo" test **survived** its mutation — removing the brief's only recommendation leaves `[]`, which is also what a component with no restore shows. Rewritten to add Germany, remove the US entry, and expect `[DE]`: neither the recommendation nor the default, so only a working restore produces it.

Every round-trip test emits a draft from one component and applies it to a **freshly created** one, since the defect is that the first instance's state is gone. Each case edits *away* from the brief's recommendation, so a pass cannot be explained by the re-stamp.

## Two approaches now coexist — deliberate, and documented

This is worth a reviewer's attention. `CampaignImplementationDraft` now carries per-platform state **two different ways**:

- **Budgets** (`linkedInBudgetUsd`, `linkedInLifetimeBudget`, `redditBudgetUsd`, `metaBudgetUsd`, `metaLifetimeBudget`) — still component-local signals on **this** branch, so a tab switch still reverts them. **LFXV2-3315** adds interface members plus hand-written emission in each budget handler, but that branch is **not merged** and is not included here. Nothing in this PR carries a budget.
- **LinkedIn picks** (this PR) — live on `campaignForm`, carried by the existing plumbing.

3315 is developing the budget half of this same ticket concurrently, using the field-by-field approach 3230 explicitly argued against. I did **not** convert its five fields: unpicking a sibling branch's committed work in `emitDraft`/`applyDraft` would produce a conflict neither PR could resolve alone. The split is by owner, not by principle — and to be precise about what is reviewable here, the coexistence is what the file will look like once 3315 merges, not what this diff contains.

**The drift 3230 warned about is already arriving.** PR #1644 (Meta objective, placements, pixel id, geo targets) adds four more user-editable per-platform controls, none of them carried by either mechanism. The interface documents the split and states the direction to unify: move the budget signals onto `campaignForm`, keeping their members.

Also worth noting: moving state onto the form does **not** avoid adding interface members. `emitDraft` builds an object literal, so a control still has to be named there to reach the draft. What the form buys is one home for the value instead of four (handler, `submit`, seed, snapshot).

## Testing

- `yarn test:app` — 454 passed (30 files), 9 new tests
- `yarn lint` — clean (1 pre-existing warning in `user.service.ts`, untouched)
- `yarn build` — passes
- `tsc --noEmit -p tsconfig.spec.json` — clean (`yarn build` does not typecheck specs; `yarn check-types` has no app-package script, so specs are invisible to both)
- `git grep "DEV BYPASS"` — nothing
- License headers — pass

Note `yarn test:server` was not used: its vitest include is `src/server/**` only, so app specs are invisible there and sit permanently green.

LFXV2-3230
