### PR TITLE
fix(committees): keep failed member/invite operations staged on flush

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.html
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.html
@@ -66,6 +66,7 @@
                 <lfx-committee-members-manager
                   [committeeId]="committeeId()"
                   [memberUpdates]="memberUpdates()"
+                  [failedDeleteUids]="failedDeleteUids()"
                   [organizationRequirements]="organizationRequirements()"
                   [submitting]="submitting()"
                   [isEditMode]="isEditMode()"

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -8,7 +8,14 @@ import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { COMMITTEE_FORM_STEPS, COMMITTEE_INVITE_CONCURRENCY, COMMITTEE_LABEL, COMMITTEE_STEP_TITLES, COMMITTEE_TOTAL_STEPS } from '@lfx-one/shared/constants';
-import { Committee, MemberOperationResult, MemberOperationType, MemberPendingChanges, SucceededMemberOperations } from '@lfx-one/shared/interfaces';
+import {
+  Committee,
+  CommitteeMember,
+  MemberOperationResult,
+  MemberOperationType,
+  MemberPendingChanges,
+  SucceededMemberOperations,
+} from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -553,7 +560,14 @@ export class CommitteeManageComponent {
     // Add create operation if there are members to add
     if (memberUpdates.toAdd.length > 0) {
       for (const member of memberUpdates.toAdd) {
-        operations.push(this.createMemberOperation('add', member.email, () => this.committeeService.createCommitteeMember(committeeId, member)));
+        operations.push(
+          this.createMemberOperation(
+            'add',
+            member.email,
+            () => this.committeeService.createCommitteeMember(committeeId, member),
+            (createdMember) => createdMember
+          )
+        );
       }
     }
 
@@ -587,9 +601,14 @@ export class CommitteeManageComponent {
     return concat(memberOps$, inviteOps$).pipe(toArray());
   }
 
-  private createMemberOperation(type: MemberOperationType, identifier: string, operation: () => Observable<unknown>): Observable<MemberOperationResult> {
+  private createMemberOperation<T>(
+    type: MemberOperationType,
+    identifier: string,
+    operation: () => Observable<T>,
+    captureMember?: (result: T) => CommitteeMember
+  ): Observable<MemberOperationResult> {
     return operation().pipe(
-      switchMap(() => of({ type, identifier, success: true })),
+      switchMap((result) => of({ type, identifier, success: true, createdMember: captureMember?.(result) })),
       catchError(() => of({ type, identifier, success: false }))
     );
   }
@@ -597,14 +616,16 @@ export class CommitteeManageComponent {
   /** Groups the identifiers of successfully-flushed operations so the members-manager child can prune them (GH-1608). */
   private computeSucceededOperations(results: MemberOperationResult[]): SucceededMemberOperations {
     const succeeded = results.filter((result) => result.success);
-    const normalizedEmails = (type: MemberOperationType) =>
-      new Set(succeeded.filter((result) => result.type === type).map((result) => (result.identifier ?? '').trim().toLowerCase()));
 
     return {
-      addedEmails: normalizedEmails('add'),
+      addedMembers: new Map(
+        succeeded
+          .filter((result) => result.type === 'add' && result.createdMember)
+          .map((result) => [(result.identifier ?? '').trim().toLowerCase(), result.createdMember!])
+      ),
       updatedUids: new Set(succeeded.filter((result) => result.type === 'update').map((result) => result.identifier)),
       deletedUids: new Set(succeeded.filter((result) => result.type === 'delete').map((result) => result.identifier)),
-      invitedEmails: normalizedEmails('invite'),
+      invitedEmails: new Set(succeeded.filter((result) => result.type === 'invite').map((result) => (result.identifier ?? '').trim().toLowerCase())),
     };
   }
 

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -598,7 +598,7 @@ export class CommitteeManageComponent {
   private computeSucceededOperations(results: MemberOperationResult[]): SucceededMemberOperations {
     const succeeded = results.filter((result) => result.success);
     const normalizedEmails = (type: MemberOperationType) =>
-      new Set(succeeded.filter((result) => result.type === type).map((result) => result.identifier.trim().toLowerCase()));
+      new Set(succeeded.filter((result) => result.type === type).map((result) => (result.identifier ?? '').trim().toLowerCase()));
 
     return {
       addedEmails: normalizedEmails('add'),

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -21,7 +21,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { BehaviorSubject, catchError, concat, EMPTY, filter, finalize, from, map, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
+import { catchError, concat, EMPTY, filter, finalize, from, map, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
@@ -63,7 +63,12 @@ export class CommitteeManageComponent {
 
   // Member management state
   public memberUpdates = signal<MemberPendingChanges>({ toAdd: [], toUpdate: [], toDelete: [], toInvite: [] });
-  public memberUpdatesRefresh$ = new BehaviorSubject<void>(undefined);
+  /**
+   * uids of members whose delete failed on the most recent flush, owned here (rather than in the
+   * members-manager child) so the failure survives the child remounting when the PrimeNG step
+   * panel destroys/recreates it on navigation away from and back to step 4 (GH-1608 review).
+   */
+  public failedDeleteUids = signal<string[]>([]);
   // Reference to the mounted members-manager child so a partial flush failure can prune
   // successfully-applied items out of its local state without navigating away (GH-1608).
   private readonly membersManager = viewChild(CommitteeMembersManagerComponent);
@@ -256,6 +261,7 @@ export class CommitteeManageComponent {
         // Don't navigate away while any staged item failed — re-entering the wizard would lose
         // it. Prune the items that did succeed so a retry doesn't resubmit them (GH-1608).
         if (results.some((result) => !result.success)) {
+          this.failedDeleteUids.set(results.filter((result) => result.type === 'delete' && !result.success).map((result) => result.identifier));
           this.membersManager()?.pruneSucceeded(this.computeSucceededOperations(results));
           return;
         }
@@ -333,6 +339,9 @@ export class CommitteeManageComponent {
           // Don't navigate away while any staged item failed — re-entering the wizard would lose
           // it. Prune the items that did succeed so a retry doesn't resubmit them (GH-1608).
           if (memberResults.some((memberResult) => !memberResult.success)) {
+            this.failedDeleteUids.set(
+              memberResults.filter((memberResult) => memberResult.type === 'delete' && !memberResult.success).map((memberResult) => memberResult.identifier)
+            );
             this.membersManager()?.pruneSucceeded(this.computeSucceededOperations(memberResults));
             return;
           }
@@ -619,9 +628,9 @@ export class CommitteeManageComponent {
 
     return {
       addedMembers: new Map(
-        succeeded
-          .filter((result) => result.type === 'add' && result.createdMember)
-          .map((result) => [(result.identifier ?? '').trim().toLowerCase(), result.createdMember!])
+        succeeded.flatMap((result) =>
+          result.type === 'add' && result.createdMember ? [[(result.identifier ?? '').trim().toLowerCase(), result.createdMember] as const] : []
+        )
       ),
       updatedUids: new Set(succeeded.filter((result) => result.type === 'update').map((result) => result.identifier)),
       deletedUids: new Set(succeeded.filter((result) => result.type === 'delete').map((result) => result.identifier)),

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -2,13 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, inject, signal } from '@angular/core';
+import { Component, computed, inject, signal, viewChild } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { COMMITTEE_FORM_STEPS, COMMITTEE_INVITE_CONCURRENCY, COMMITTEE_LABEL, COMMITTEE_STEP_TITLES, COMMITTEE_TOTAL_STEPS } from '@lfx-one/shared/constants';
-import { Committee, MemberPendingChanges } from '@lfx-one/shared/interfaces';
+import { Committee, MemberOperationResult, MemberOperationType, MemberPendingChanges, SucceededMemberOperations } from '@lfx-one/shared/interfaces';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -57,6 +57,9 @@ export class CommitteeManageComponent {
   // Member management state
   public memberUpdates = signal<MemberPendingChanges>({ toAdd: [], toUpdate: [], toDelete: [], toInvite: [] });
   public memberUpdatesRefresh$ = new BehaviorSubject<void>(undefined);
+  // Reference to the mounted members-manager child so a partial flush failure can prune
+  // successfully-applied items out of its local state without navigating away (GH-1608).
+  private readonly membersManager = viewChild(CommitteeMembersManagerComponent);
 
   // Stepper state
   private internalStep = signal<number>(1);
@@ -242,6 +245,14 @@ export class CommitteeManageComponent {
       .pipe(finalize(() => this.submitting.set(false)))
       .subscribe((results) => {
         this.showMemberOperationToast(results);
+
+        // Don't navigate away while any staged item failed — re-entering the wizard would lose
+        // it. Prune the items that did succeed so a retry doesn't resubmit them (GH-1608).
+        if (results.some((result) => !result.success)) {
+          this.membersManager()?.pruneSucceeded(this.computeSucceededOperations(results));
+          return;
+        }
+
         this.router.navigate(['/groups']);
       });
   }
@@ -298,7 +309,7 @@ export class CommitteeManageComponent {
         finalize(() => this.submitting.set(false))
       )
       .subscribe({
-        next: (result: { committee: Committee; members: { type: string; success: number; failed: number }[] }) => {
+        next: (result: { committee: Committee; members: MemberOperationResult[] }) => {
           const memberResults = result.members;
 
           // Show success message
@@ -310,6 +321,13 @@ export class CommitteeManageComponent {
               summary: 'Success',
               detail: `${this.committeeLabel} updated successfully`,
             });
+          }
+
+          // Don't navigate away while any staged item failed — re-entering the wizard would lose
+          // it. Prune the items that did succeed so a retry doesn't resubmit them (GH-1608).
+          if (memberResults.some((memberResult) => !memberResult.success)) {
+            this.membersManager()?.pruneSucceeded(this.computeSucceededOperations(memberResults));
+            return;
           }
 
           // Navigate back to committees list
@@ -519,21 +537,23 @@ export class CommitteeManageComponent {
     // Add delete operation if there are members to delete
     if (memberUpdates.toDelete.length > 0) {
       for (const memberId of memberUpdates.toDelete) {
-        operations.push(this.createMemberOperation('delete', () => this.committeeService.deleteCommitteeMember(committeeId, memberId)));
+        operations.push(this.createMemberOperation('delete', memberId, () => this.committeeService.deleteCommitteeMember(committeeId, memberId)));
       }
     }
 
     // Add update operation if there are members to update
     if (memberUpdates.toUpdate.length > 0) {
       for (const update of memberUpdates.toUpdate) {
-        operations.push(this.createMemberOperation('update', () => this.committeeService.updateCommitteeMember(committeeId, update.uid, update.changes)));
+        operations.push(
+          this.createMemberOperation('update', update.uid, () => this.committeeService.updateCommitteeMember(committeeId, update.uid, update.changes))
+        );
       }
     }
 
     // Add create operation if there are members to add
     if (memberUpdates.toAdd.length > 0) {
       for (const member of memberUpdates.toAdd) {
-        operations.push(this.createMemberOperation('add', () => this.committeeService.createCommitteeMember(committeeId, member)));
+        operations.push(this.createMemberOperation('add', member.email, () => this.committeeService.createCommitteeMember(committeeId, member)));
       }
     }
 
@@ -546,7 +566,7 @@ export class CommitteeManageComponent {
    * (LFXV2-2606) — run with the same bounded concurrency as the immediate-send invite path
    * (COMMITTEE_INVITE_CONCURRENCY), after the member mutations finish.
    */
-  private flushMemberUpdates(): Observable<{ type: string; success: number; failed: number }[]> {
+  private flushMemberUpdates(): Observable<MemberOperationResult[]> {
     const committeeId = this.committeeId()!;
     const memberUpdates = this.memberUpdates();
 
@@ -558,7 +578,7 @@ export class CommitteeManageComponent {
       invites.length > 0
         ? from(invites).pipe(
             mergeMap(
-              (invite) => this.createMemberOperation('invite', () => this.committeeService.createCommitteeInvite(committeeId, invite)),
+              (invite) => this.createMemberOperation('invite', invite.invitee_email, () => this.committeeService.createCommitteeInvite(committeeId, invite)),
               COMMITTEE_INVITE_CONCURRENCY
             )
           )
@@ -567,16 +587,30 @@ export class CommitteeManageComponent {
     return concat(memberOps$, inviteOps$).pipe(toArray());
   }
 
-  private createMemberOperation(type: string, operation: () => Observable<unknown>) {
+  private createMemberOperation(type: MemberOperationType, identifier: string, operation: () => Observable<unknown>): Observable<MemberOperationResult> {
     return operation().pipe(
-      switchMap(() => of({ type, success: 1, failed: 0 })),
-      catchError(() => of({ type, success: 0, failed: 1 }))
+      switchMap(() => of({ type, identifier, success: true })),
+      catchError(() => of({ type, identifier, success: false }))
     );
   }
 
-  private showMemberOperationToast(results: { type: string; success: number; failed: number }[]): void {
-    const totalSuccess = results.reduce((sum, result) => sum + result.success, 0);
-    const totalFailed = results.reduce((sum, result) => sum + result.failed, 0);
+  /** Groups the identifiers of successfully-flushed operations so the members-manager child can prune them (GH-1608). */
+  private computeSucceededOperations(results: MemberOperationResult[]): SucceededMemberOperations {
+    const succeeded = results.filter((result) => result.success);
+    const normalizedEmails = (type: MemberOperationType) =>
+      new Set(succeeded.filter((result) => result.type === type).map((result) => result.identifier.trim().toLowerCase()));
+
+    return {
+      addedEmails: normalizedEmails('add'),
+      updatedUids: new Set(succeeded.filter((result) => result.type === 'update').map((result) => result.identifier)),
+      deletedUids: new Set(succeeded.filter((result) => result.type === 'delete').map((result) => result.identifier)),
+      invitedEmails: normalizedEmails('invite'),
+    };
+  }
+
+  private showMemberOperationToast(results: MemberOperationResult[]): void {
+    const totalSuccess = results.filter((result) => result.success).length;
+    const totalFailed = results.filter((result) => !result.success).length;
     const totalOperations = totalSuccess + totalFailed;
     const inviteOps = results.filter((result) => result.type === 'invite').length;
     const memberOps = results.length - inviteOps;

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
@@ -209,9 +209,9 @@
                   icon="fa-light fa-trash"
                   [text]="true"
                   styleClass="text-gray-400 hover:text-red-600"
-                  pTooltip="Remove"
+                  [pTooltip]="member.state === 'deleted' ? 'Retries automatically on next save' : 'Remove'"
                   tooltipPosition="top"
-                  [disabled]="mutationsDisabled()"
+                  [disabled]="mutationsDisabled() || member.state === 'deleted'"
                   (click)="handleMemberDelete(member.uid || member.tempId || '')">
                 </lfx-button>
               </div>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
@@ -189,9 +189,9 @@
                   icon="fa-light fa-pen"
                   [text]="true"
                   styleClass="text-gray-400 hover:text-blue-600"
-                  pTooltip="Edit"
+                  [pTooltip]="member.state === 'deleted' ? 'Retries automatically on next save' : 'Edit'"
                   tooltipPosition="top"
-                  [disabled]="mutationsDisabled()"
+                  [disabled]="mutationsDisabled() || member.state === 'deleted'"
                   data-testid="edit-member-button"
                   (click)="openEditMemberDialog(member)">
                 </lfx-button>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.html
@@ -161,6 +161,10 @@
               @if (member.state === 'modified') {
                 <span class="px-2 py-1 text-xs font-medium bg-amber-100 text-amber-800 rounded">Modified</span>
               }
+              <!-- Failed-delete indicator — still staged for retry on the next submit (GH-1608) -->
+              @if (member.state === 'deleted') {
+                <span class="px-2 py-1 text-xs font-medium bg-red-100 text-red-800 rounded">Failed to remove</span>
+              }
               <!-- Voting status badge -->
               @if (member.voting?.status) {
                 <span

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
@@ -115,8 +115,13 @@ export class CommitteeMembersManagerComponent implements OnInit {
   // In-flight guard so rapid clicks on "Invite by email" don't stack overlapping dialogs.
   private readonly loadingInvites = signal(false);
 
+  // uids of members whose delete failed on the last flush. Members in this state stay in state
+  // 'deleted' (so emitMemberUpdates() keeps re-queuing the delete on the next flush) but must
+  // remain visible — otherwise a failed delete silently vanishes from the roster (GH-1608).
+  private readonly failedDeleteUids = signal<Set<string>>(new Set());
+
   // Simple computed signals
-  public readonly visibleMembers = computed(() => this.membersWithState().filter((m) => m.state !== 'deleted'));
+  public readonly visibleMembers = computed(() => this.membersWithState().filter((m) => m.state !== 'deleted' || this.failedDeleteUids().has(m.uid)));
   public readonly memberCount = computed(() => this.visibleMembers().length);
   public readonly votingCount = computed(() => this.visibleMembers().filter((m) => this.isVotingMember(m)).length);
   /** Gates every action that stages/mutates member or invite state — load-in-progress, load-failed, or an active flush. */
@@ -324,19 +329,32 @@ export class CommitteeMembersManagerComponent implements OnInit {
    * editable (GH-1608).
    */
   public pruneSucceeded(succeeded: SucceededMemberOperations): void {
+    const failedDeleteUids = new Set<string>();
+
     this.membersWithState.update((members) =>
       members
         .filter((m) => {
-          if (m.state === 'new') {
-            return !succeeded.addedEmails.has((m.email ?? '').trim().toLowerCase());
-          }
           if (m.state === 'deleted') {
-            return !succeeded.deletedUids.has(m.uid);
+            if (succeeded.deletedUids.has(m.uid)) {
+              return false;
+            }
+            failedDeleteUids.add(m.uid);
           }
           return true;
         })
-        .map((m) => (m.state === 'modified' && succeeded.updatedUids.has(m.uid) ? this.createMemberWithState(m, 'existing') : m))
+        .map((m) => {
+          if (m.state === 'new') {
+            const createdMember = succeeded.addedMembers.get((m.email ?? '').trim().toLowerCase());
+            return createdMember ? this.createMemberWithState(createdMember, 'existing') : m;
+          }
+          if (m.state === 'modified' && succeeded.updatedUids.has(m.uid)) {
+            return this.createMemberWithState(m, 'existing');
+          }
+          return m;
+        })
     );
+
+    this.failedDeleteUids.set(failedDeleteUids);
 
     this.pendingInvites.update((current) => current.filter((invite) => !succeeded.invitedEmails.has((invite.invitee_email ?? '').trim().toLowerCase())));
 

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
@@ -22,6 +22,7 @@ import {
   CreateCommitteeInviteRequest,
   CreateCommitteeMemberRequest,
   MemberPendingChanges,
+  SucceededMemberOperations,
 } from '@lfx-one/shared/interfaces';
 import { generateTempId } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
@@ -314,6 +315,32 @@ export class CommitteeMembersManagerComponent implements OnInit {
     if (member?.email) {
       window.open(`mailto:${member.email}`, '_blank');
     }
+  }
+
+  /**
+   * Drops successfully-flushed items from local state after a partial flush failure, so a retry
+   * only resubmits what actually failed instead of re-creating/re-inviting/re-deleting items that
+   * already landed server-side. Failed items are left untouched — still staged, visible, and
+   * editable (GH-1608).
+   */
+  public pruneSucceeded(succeeded: SucceededMemberOperations): void {
+    this.membersWithState.update((members) =>
+      members
+        .filter((m) => {
+          if (m.state === 'new') {
+            return !succeeded.addedEmails.has((m.email ?? '').trim().toLowerCase());
+          }
+          if (m.state === 'deleted') {
+            return !succeeded.deletedUids.has(m.uid);
+          }
+          return true;
+        })
+        .map((m) => (m.state === 'modified' && succeeded.updatedUids.has(m.uid) ? this.createMemberWithState(m, 'existing') : m))
+    );
+
+    this.pendingInvites.update((current) => current.filter((invite) => !succeeded.invitedEmails.has((invite.invitee_email ?? '').trim().toLowerCase())));
+
+    this.emitMemberUpdates();
   }
 
   private openCollectInviteDialog(serverInvites: CommitteeInvite[]): void {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members-manager/committee-members-manager.component.ts
@@ -30,7 +30,7 @@ import { ConfirmationService, MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { DialogService, DynamicDialogModule, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { TooltipModule } from 'primeng/tooltip';
-import { BehaviorSubject, catchError, finalize, of, take, tap } from 'rxjs';
+import { catchError, finalize, of, take, tap } from 'rxjs';
 
 import { AddMemberDialogComponent } from '../add-member-dialog/add-member-dialog.component';
 import { MemberFormComponent } from '../member-form/member-form.component';
@@ -64,7 +64,13 @@ export class CommitteeMembersManagerComponent implements OnInit {
   // Input signals
   public committeeId = input.required<string | null>();
   public memberUpdates = input<MemberPendingChanges>({ toAdd: [], toUpdate: [], toDelete: [], toInvite: [] });
-  public refresh = input<BehaviorSubject<void>>();
+  /**
+   * uids of members whose delete failed on the most recent flush, owned by the parent
+   * (`committee-manage`) so the failure survives this component remounting when the PrimeNG step
+   * panel destroys/recreates it on navigation away from and back to step 4 — otherwise the
+   * "Failed to remove" row silently vanishes on return (GH-1608 review).
+   */
+  public failedDeleteUids = input<string[]>([]);
   /**
    * Live Step 3 draft values for the org-required flags. In edit mode these can differ from the
    * persisted `committee()` snapshot until the wizard is submitted — overridden onto it before
@@ -115,13 +121,15 @@ export class CommitteeMembersManagerComponent implements OnInit {
   // In-flight guard so rapid clicks on "Invite by email" don't stack overlapping dialogs.
   private readonly loadingInvites = signal(false);
 
-  // uids of members whose delete failed on the last flush. Members in this state stay in state
-  // 'deleted' (so emitMemberUpdates() keeps re-queuing the delete on the next flush) but must
-  // remain visible — otherwise a failed delete silently vanishes from the roster (GH-1608).
-  private readonly failedDeleteUids = signal<Set<string>>(new Set());
-
   // Simple computed signals
-  public readonly visibleMembers = computed(() => this.membersWithState().filter((m) => m.state !== 'deleted' || this.failedDeleteUids().has(m.uid)));
+  // Members in state 'deleted' stay in membersWithState (so emitMemberUpdates() keeps re-queuing
+  // the delete on the next flush) but must remain visible when their delete failed — otherwise a
+  // failed delete silently vanishes from the roster (GH-1608). Sourced from the failedDeleteUids
+  // input rather than local state so the failure survives this component remounting.
+  public readonly visibleMembers = computed(() => {
+    const failedDeletes = new Set(this.failedDeleteUids());
+    return this.membersWithState().filter((m) => m.state !== 'deleted' || failedDeletes.has(m.uid));
+  });
   public readonly memberCount = computed(() => this.visibleMembers().length);
   public readonly votingCount = computed(() => this.visibleMembers().filter((m) => this.isVotingMember(m)).length);
   /** Gates every action that stages/mutates member or invite state — load-in-progress, load-failed, or an active flush. */
@@ -170,13 +178,6 @@ export class CommitteeMembersManagerComponent implements OnInit {
 
     this.initializeMembers();
     this.loadCommittee();
-
-    this.refresh()
-      ?.pipe(takeUntilDestroyed(this.destroyRef))
-      .subscribe(() => {
-        this.initializeMembers();
-        this.loadCommittee();
-      });
   }
 
   public openInviteByEmailDialog(): void {
@@ -329,19 +330,9 @@ export class CommitteeMembersManagerComponent implements OnInit {
    * editable (GH-1608).
    */
   public pruneSucceeded(succeeded: SucceededMemberOperations): void {
-    const failedDeleteUids = new Set<string>();
-
     this.membersWithState.update((members) =>
       members
-        .filter((m) => {
-          if (m.state === 'deleted') {
-            if (succeeded.deletedUids.has(m.uid)) {
-              return false;
-            }
-            failedDeleteUids.add(m.uid);
-          }
-          return true;
-        })
+        .filter((m) => m.state !== 'deleted' || !succeeded.deletedUids.has(m.uid))
         .map((m) => {
           if (m.state === 'new') {
             const createdMember = succeeded.addedMembers.get((m.email ?? '').trim().toLowerCase());
@@ -353,8 +344,6 @@ export class CommitteeMembersManagerComponent implements OnInit {
           return m;
         })
     );
-
-    this.failedDeleteUids.set(failedDeleteUids);
 
     this.pendingInvites.update((current) => current.filter((invite) => !succeeded.invitedEmails.has((invite.invitee_email ?? '').trim().toLowerCase())));
 

--- a/packages/shared/src/interfaces/member.interface.ts
+++ b/packages/shared/src/interfaces/member.interface.ts
@@ -192,6 +192,34 @@ export interface MemberPendingChanges {
   toInvite: CreateCommitteeInviteRequest[];
 }
 
+/** Kind of staged operation flushed by the committee-manage wizard (GH-1608). */
+export type MemberOperationType = 'add' | 'update' | 'delete' | 'invite';
+
+/**
+ * Result of a single flushed member/invite operation.
+ * @description `identifier` traces the result back to the staged item that produced it — the
+ * member email for `add`, the member uid for `update`/`delete`, or the invitee email for
+ * `invite` — so a failure can be re-staged instead of silently discarded (GH-1608).
+ */
+export interface MemberOperationResult {
+  type: MemberOperationType;
+  identifier: string;
+  success: boolean;
+}
+
+/**
+ * Identifiers of successfully-flushed operations, grouped by type, normalized (trimmed +
+ * lowercased) where the identifier is an email. Used to prune already-applied changes out of the
+ * wizard's staged state after a partial flush failure, so retry only resubmits what actually
+ * failed (GH-1608).
+ */
+export interface SucceededMemberOperations {
+  addedEmails: Set<string>;
+  updatedUids: Set<string>;
+  deletedUids: Set<string>;
+  invitedEmails: Set<string>;
+}
+
 /**
  * Unified table row for the committee Members list.
  * Member rows carry a `CommitteeMember`; invite rows carry a `CommitteeInvite`.

--- a/packages/shared/src/interfaces/member.interface.ts
+++ b/packages/shared/src/interfaces/member.interface.ts
@@ -199,22 +199,27 @@ export type MemberOperationType = 'add' | 'update' | 'delete' | 'invite';
  * Result of a single flushed member/invite operation.
  * @description `identifier` traces the result back to the staged item that produced it — the
  * member email for `add`, the member uid for `update`/`delete`, or the invitee email for
- * `invite` — so a failure can be re-staged instead of silently discarded (GH-1608).
+ * `invite` — so a failure can be re-staged instead of silently discarded (GH-1608). `createdMember`
+ * carries the server-assigned record (with its real `uid`) for a successful `add`, so the staged
+ * row can be promoted to an `existing` member instead of merely dropped.
  */
 export interface MemberOperationResult {
   type: MemberOperationType;
   identifier: string;
   success: boolean;
+  createdMember?: CommitteeMember;
 }
 
 /**
  * Identifiers of successfully-flushed operations, grouped by type, normalized (trimmed +
  * lowercased) where the identifier is an email. Used to prune already-applied changes out of the
  * wizard's staged state after a partial flush failure, so retry only resubmits what actually
- * failed (GH-1608).
+ * failed (GH-1608). `addedMembers` carries the server-assigned record (with its real `uid`) for
+ * each successful add, keyed by normalized email, so the staged row can be promoted to `existing`
+ * instead of dropped.
  */
 export interface SucceededMemberOperations {
-  addedEmails: Set<string>;
+  addedMembers: Map<string, CommitteeMember>;
   updatedUids: Set<string>;
   deletedUids: Set<string>;
   invitedEmails: Set<string>;


### PR DESCRIPTION
## Summary

When the committee-manage wizard flushes staged member/invite operations (adds, updates, deletes, invites) and some fail, the failures were previously anonymized to aggregate success/fail counts and the wizard navigated away unconditionally — silently losing the failed items with no way to retry without re-entering data.

- Threads an identifier (member email/uid, invite email) through each flushed operation instead of anonymous counts, so a failure can be traced back to the exact staged item that produced it.
- Gates wizard navigation on `flushMemberUpdates()` returning zero failures — the wizard no longer navigates away while any operation failed.
- Adds `pruneSucceeded()` on the members-manager child component, which removes only the operations that landed server-side and leaves failed items staged, visible, and editable for retry.
- Guards `computeSucceededOperations()` against an undefined `identifier` (review fix from the first commit).

## Test plan

- [x] `yarn format:check` — clean
- [x] `yarn lint:check` — clean (one pre-existing unrelated warning in `user.service.ts`)
- [x] `yarn build` — succeeds
- [x] Reviewed by general/self-serve-convention/learnings reviewer trio, both per-commit and full-branch sweep — all clean

Fixes linuxfoundation/lfx-self-serve#1608