### PR TITLE
fix(docs): render 404 in place instead of redirecting to /docs/not-found

### DIFF
--- a/apps/lfx-one/e2e/docs/lifecycle.spec.ts
+++ b/apps/lfx-one/e2e/docs/lifecycle.spec.ts
@@ -41,9 +41,7 @@ test.describe('Docs portal — content lifecycle (US6)', () => {
 
     // On a miss the not-found view renders inline at the original URL (no
     // redirect); SSR emits a real 404 there via the render-context flag.
-    if (response) {
-      expect(response.status()).toBe(404);
-    }
+    expect(response?.status()).toBe(404);
     await expect(page).toHaveURL(/\/docs\/this-article-was-renamed$/);
     await expect(page.getByTestId('docs-not-found')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });

--- a/apps/lfx-one/e2e/docs/lifecycle.spec.ts
+++ b/apps/lfx-one/e2e/docs/lifecycle.spec.ts
@@ -36,17 +36,15 @@ test.use({ storageState: { cookies: [], origins: [] } });
 test.describe.configure({ timeout: TEST_TIMEOUT });
 
 test.describe('Docs portal — content lifecycle (US6)', () => {
-  test('renamed/deleted article URL serves the not-found page', async ({ page }) => {
+  test('renamed/deleted article URL serves the not-found page in place', async ({ page }) => {
     const response = await page.goto('/docs/this-article-was-renamed', { waitUntil: 'domcontentloaded' });
 
-    // SSR returns 404 for the dedicated /docs/not-found route via
-    // app.routes.server.ts. Browsers may follow internal navigations
-    // without a status code change, so we accept either the
-    // server-rendered 404 or a soft client redirect to the not-found
-    // page that still surfaces the recovery UI.
+    // On a miss the not-found view renders inline at the original URL (no
+    // redirect); SSR emits a real 404 there via the render-context flag.
     if (response) {
-      expect([200, 404]).toContain(response.status());
+      expect(response.status()).toBe(404);
     }
+    await expect(page).toHaveURL(/\/docs\/this-article-was-renamed$/);
     await expect(page.getByTestId('docs-not-found')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 

--- a/apps/lfx-one/e2e/docs/public-access.spec.ts
+++ b/apps/lfx-one/e2e/docs/public-access.spec.ts
@@ -98,11 +98,12 @@ test.describe('Docs portal — public access (US1)', () => {
     await expect(page.getByTestId('docs-article-title')).toBeVisible();
   });
 
-  test('a broken /docs/<missing> URL renders the 404 page with recovery links', async ({ page }) => {
+  test('a broken /docs/<missing> URL renders the 404 page in place with recovery links', async ({ page }) => {
     const response = await page.goto('/docs/this-slug-does-not-exist', { waitUntil: 'domcontentloaded' });
-    // The resolver redirects to /docs/not-found which is configured with
-    // status 404 in app.routes.server.ts.
+    // On a miss the not-found view renders inline; SSR emits a real 404 at the
+    // original URL (no redirect to /docs/not-found), mirroring /u/:username.
     expect(response?.status()).toBe(404);
+    await expect(page).toHaveURL(/\/docs\/this-slug-does-not-exist$/);
     await expect(page.getByTestId('docs-not-found')).toBeVisible();
     await expect(page.getByTestId('docs-not-found-back-link')).toHaveAttribute('href', '/docs');
   });

--- a/apps/lfx-one/src/app/app.routes.server.ts
+++ b/apps/lfx-one/src/app/app.routes.server.ts
@@ -6,8 +6,10 @@ import { RenderMode, ServerRoute } from '@angular/ssr';
 export const serverRoutes: ServerRoute[] = [
   // The docs portal not-found page must serve HTTP 404 so search engines
   // and Intercom ingest treat unresolved `/docs/<missing>` URLs correctly
-  // (FR-007, FR-014). The article resolver redirects miss-URLs to this
-  // path; Angular SSR matches this entry and emits the 404 status.
+  // (FR-007, FR-014). This entry keeps `/docs/not-found` reachable on a
+  // direct visit and emits the 404 status. Missing `/docs/<slug>` URLs no
+  // longer redirect here — they render the not-found view in place and get
+  // their 404 via the catch-all `**` route plus `renderContext.notFound`.
   {
     path: 'docs/not-found',
     renderMode: RenderMode.Server,

--- a/apps/lfx-one/src/app/modules/docs/docs.routes.ts
+++ b/apps/lfx-one/src/app/modules/docs/docs.routes.ts
@@ -10,17 +10,17 @@ import { docsArticleResolver } from './resolvers/docs-article.resolver';
  *
  * Routes (matched in order):
  *   - `''`           → `DocsLandingComponent`     — synthetic `/docs` landing (FR-002).
- *   - `'not-found'`  → `DocsNotFoundComponent`    — brand-styled 404 (FR-014, Edge Case 4);
- *                                                   the SSR layer pairs this with status 404 in
- *                                                   `app.routes.server.ts`.
- *   - `'**'`         → `DocsArticleComponent`     — any nested slug; the resolver redirects
- *                                                   miss-URLs to `/docs/not-found`.
+ *   - `'not-found'`  → `DocsNotFoundComponent`    — brand-styled 404, kept reachable for direct
+ *                                                   visits; SSR pairs it with status 404 (FR-014).
+ *   - `'**'`         → `DocsArticleComponent`     — any nested slug; on a miss the resolver returns
+ *                                                   `null` and the not-found view renders inline (404).
  *
  * Lazy-loaded via `loadComponent` so the article + landing chunks stay out
  * of the main browser bundle until a `/docs/**` URL is activated.
  *
- * Wildcard ordering matters: keep `not-found` BEFORE the `**` catch-all so
- * the static 404 page wins over the resolver-driven dynamic article match.
+ * Wildcard ordering matters: keep `not-found` BEFORE the `**` catch-all so a
+ * direct visit to `/docs/not-found` renders the dedicated page rather than
+ * falling into the resolver-driven dynamic article match.
  */
 export const DOCS_ROUTES: Routes = [
   {

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.html
@@ -85,5 +85,7 @@
     </div>
   </article>
 } @else {
-  <p class="text-gray-500" data-testid="docs-article-empty">Article not found.</p>
+  <!-- Miss: render the not-found page inline at the original URL (no redirect). SSR emits a
+       real HTTP 404 via the render-context flag set in docsArticleResolver. -->
+  <lfx-docs-not-found />
 }

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
@@ -235,6 +235,8 @@ export class DocsArticleComponent {
   }
 
   private initArticle() {
-    return toSignal<DocsArticle | undefined>(this.route.data.pipe(map((d): DocsArticle | undefined => d['article'])), { initialValue: undefined });
+    // `docsArticleResolver` yields `null` on a manifest miss (rendered as the
+    // inline not-found view); include it so the signal type matches the resolver.
+    return toSignal<DocsArticle | null | undefined>(this.route.data.pipe(map((d): DocsArticle | null => d['article'] ?? null)), { initialValue: undefined });
   }
 }

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-article/docs-article.component.ts
@@ -13,6 +13,7 @@ import { map } from 'rxjs/operators';
 
 import { DocsSearchComponent } from '../../components/docs-search/docs-search.component';
 import { DocsManifestService } from '../../services/docs-manifest.service';
+import { DocsNotFoundComponent } from '../docs-not-found/docs-not-found.component';
 
 /**
  * Renders one documentation article.
@@ -51,7 +52,7 @@ import { DocsManifestService } from '../../services/docs-manifest.service';
 @Component({
   selector: 'lfx-docs-article',
   standalone: true,
-  imports: [RouterLink, DatePipe, DocsSearchComponent],
+  imports: [RouterLink, DatePipe, DocsSearchComponent, DocsNotFoundComponent],
   templateUrl: './docs-article.component.html',
 })
 export class DocsArticleComponent {
@@ -64,7 +65,7 @@ export class DocsArticleComponent {
   private readonly host = inject(ElementRef<HTMLElement>);
   private readonly location = inject(Location);
 
-  /** Article resolved by `docsArticleResolver` — guaranteed non-null on a successful navigation. */
+  /** Article resolved by `docsArticleResolver`: the `DocsArticle` on a hit, or `null` on a miss (renders the inline not-found view). */
   protected readonly article = this.initArticle();
 
   /** Sibling articles in the same topic, denormalized for cheap renders. Consumed only by `topicArticles`. */

--- a/apps/lfx-one/src/app/modules/docs/pages/docs-not-found/docs-not-found.component.ts
+++ b/apps/lfx-one/src/app/modules/docs/pages/docs-not-found/docs-not-found.component.ts
@@ -10,20 +10,10 @@ import type { DocsTopic } from '@lfx-one/shared/interfaces';
 import { DocsManifestService } from '../../services/docs-manifest.service';
 
 /**
- * Brand-styled 404 surfaced when a `/docs/<missing>` URL doesn't resolve to
- * any article in the manifest (FR-014 / Edge Case 4).
+ * Brand-styled docs 404 (FR-014). Rendered inline by `DocsArticleComponent` on a
+ * miss (URL unchanged) and directly at `/docs/not-found`; both return HTTP 404.
  *
- * The HTTP-status side of the contract is enforced server-side via the
- * dedicated `/docs/not-found` entry in `apps/lfx-one/src/app/app.routes.server.ts`
- * (status: 404). The article resolver redirects miss-URLs to this route, so
- * SSR returns 404 to crawlers — preserving correct status semantics for
- * search-engine indexing while still showing a useful recovery page.
- *
- * Trade-off documented inline: the visible URL becomes `/docs/not-found`
- * (not the original missing slug). Angular SSR ≤20 has no first-class hook
- * to set HTTP status from a component without a route swap; replacing this
- * pattern with a custom token-based status setter is feasible later but
- * non-trivial. For MVP, status correctness wins over URL fidelity.
+ * Sets `robots: noindex` so neither surface is indexed while still offering recovery links.
  */
 @Component({
   selector: 'lfx-docs-not-found',

--- a/apps/lfx-one/src/app/modules/docs/resolvers/docs-article.resolver.ts
+++ b/apps/lfx-one/src/app/modules/docs/resolvers/docs-article.resolver.ts
@@ -1,9 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { inject } from '@angular/core';
-import { RedirectCommand, ResolveFn, Router, UrlSegment } from '@angular/router';
-import type { DocsArticle } from '@lfx-one/shared/interfaces';
+import { isPlatformServer } from '@angular/common';
+import { inject, PLATFORM_ID, REQUEST_CONTEXT } from '@angular/core';
+import { ResolveFn, UrlSegment } from '@angular/router';
+import type { DocsArticle, ServerRequestContext } from '@lfx-one/shared/interfaces';
 
 import { DocsManifestService } from '../services/docs-manifest.service';
 
@@ -17,19 +18,17 @@ import { DocsManifestService } from '../services/docs-manifest.service';
  * On hit: returns the article — `DocsArticleComponent` consumes it via
  * `route.snapshot.data['article']`.
  *
- * On miss: returns a `RedirectCommand` pointing at `/docs/not-found` so the
- * Angular 20 router triggers a navigation redirect (a bare `UrlTree` would
- * be stored as the resolved value and rendered as if it were an article).
- * The dedicated server route in `app.routes.server.ts` is configured with
- * `status: 404`, so SSR serves the proper HTTP status to crawlers.
+ * On miss: returns `null` so `DocsArticleComponent` renders not-found inline at
+ * the original URL; SSR sets `reqContext.notFound` to emit a real 404 (like `/u/`).
  *
  * URL normalization (FR / R: SC-008): trailing slash, mixed case, and
  * doubled slashes all resolve to the same canonical slug. The manifest is
  * generated lower-case so we lower-case the request side once here.
  */
-export const docsArticleResolver: ResolveFn<DocsArticle | RedirectCommand> = (route) => {
-  const router = inject(Router);
+export const docsArticleResolver: ResolveFn<DocsArticle | null> = (route) => {
   const manifest = inject(DocsManifestService);
+  const platformId = inject(PLATFORM_ID);
+  const reqContext = inject(REQUEST_CONTEXT, { optional: true }) as ServerRequestContext | null;
 
   const slug = normalizeSlug(route.url);
   const article = manifest.getArticle(slug);
@@ -37,12 +36,12 @@ export const docsArticleResolver: ResolveFn<DocsArticle | RedirectCommand> = (ro
     return article;
   }
 
-  // Miss → tell the router to redirect. Angular 20 only honors a redirect
-  // from a resolver when the returned value is a `RedirectCommand`; a bare
-  // `UrlTree` would be stored as `data['article']` and rendered as if it
-  // were the article (see `apps/lfx-one/node_modules/@angular/router`
-  // resolveNode → instanceof RedirectCommand check).
-  return new RedirectCommand(router.parseUrl('/docs/not-found'));
+  // Miss → render not-found in place (no route change). During SSR, signal the
+  // handler to emit a real HTTP 404 at the originally-requested path.
+  if (isPlatformServer(platformId) && reqContext) {
+    reqContext.notFound = true;
+  }
+  return null;
 };
 
 function normalizeSlug(segments: UrlSegment[]): string {


### PR DESCRIPTION
## Summary

- Align \`/docs/<missing>\` 404 handling with the \`/u/:username\` in-place pattern: a broken docs URL now renders the not-found view **inline at the original URL** and returns a real HTTP 404, instead of redirecting to \`/docs/not-found\`.
- \`docsArticleResolver\` no longer returns a \`RedirectCommand\` on a manifest miss — it returns \`null\` and, during SSR, sets \`reqContext.notFound\` so the Express handler rewrites the response to a 404 at the requested path (the same mechanism that powers \`/u/\` and the global not-found page).
- \`DocsArticleComponent\` renders \`<lfx-docs-not-found />\` in its \`@else\` branch on a miss, so the branded not-found page (with topic recovery links + \`robots: noindex\`) shows without a URL change.
- The dedicated \`/docs/not-found\` route stays reachable — direct visits still return the 404 page.
- Updated the docs e2e specs to assert the URL stays on the missing slug with a 404 status, matching the new in-place behavior.

## Why

Docs pages are public and behave like \`/u/\` profiles, but their 404 path diverged: a miss redirected to \`/docs/not-found\`, changing the visible URL and losing the original path. Rendering in place preserves the requested URL, returns an honest 404 for crawlers, and makes the two public surfaces consistent.

Closes linuxfoundation/lfx-self-serve#1636