### PR TITLE
docs(events): document visa letters, travel funding, and certificates

### DIFF
--- a/docs/user/events/attendance-certificates/index.md
+++ b/docs/user/events/attendance-certificates/index.md
@@ -20,11 +20,12 @@ After you attend a Linux Foundation event, you can download a Certificate of Att
 
 ## When the certificate is available
 
-The **Download Certificate** action appears only for events marked with the **Attended** status. A Certificate of Attendance may take up to two weeks after the event ends to become available for download.
+The **Download Certificate** action appears for events marked with the **Attended** status. A Certificate of Attendance may take up to two weeks after the event ends to become available.
 
-## If the certificate isn't available
+## If you can't download a certificate
 
-If you don't see the **Download Certificate** action for an event you attended, your attendance may not have been recorded yet, or the certificate may not yet be available. Wait until up to two weeks after the event ends, then check again. If it is still missing, contact the event organizer or reach out to LFX support through the Help Center.
+- **The action doesn't appear.** The **Download Certificate** action only shows once the event is marked **Attended**. If your attendance hasn't been recorded yet, the action won't appear — check back later, and if the event stays unmarked, contact the event organizer or reach out to LFX support through the Help Center.
+- **The download fails.** If the action appears but the download doesn't succeed, the certificate may not be ready yet. It can take up to two weeks after the event ends to become available — wait and try again. If it still fails after that, reach out to LFX support through the Help Center.
 
 ## Related
 

--- a/docs/user/events/attendance-certificates/index.md
+++ b/docs/user/events/attendance-certificates/index.md
@@ -1,0 +1,33 @@
+---
+title: Download an Attendance Certificate
+description: Download your Certificate of Attendance for a Linux Foundation event you attended in LFX Self Serve
+audience: [all]
+product_area: Events
+tags: [events, attendance, certificate, past-events]
+last_updated: 2026-08-19
+intercom_collection: Events
+---
+
+After you attend a Linux Foundation event, you can download a Certificate of Attendance from the **Past** tab on the My Events page. The certificate downloads as a PDF.
+
+## Steps
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Events** from the left navigation sidebar.
+3. Open the **Past** tab.
+4. Find the event in the list.
+5. Select **Download Certificate** to download the PDF.
+
+## When the certificate is available
+
+The **Download Certificate** action appears only for events marked with the **Attended** status. A Certificate of Attendance may take up to two weeks after the event ends to become available for download.
+
+## If the certificate isn't available
+
+If you don't see the **Download Certificate** action for an event you attended, your attendance may not have been recorded yet, or the certificate may not yet be available. Wait until up to two weeks after the event ends, then check again. If it is still missing, contact the event organizer or reach out to LFX support through the Help Center.
+
+## Related
+
+- [Events overview](../) — an overview of the Events section
+- [Browse Events](../browse-events/) — find upcoming and past events
+- [Request a Visa Support Letter](../visa-letters/) — travel documentation support for international attendees

--- a/docs/user/events/browse-events/index.md
+++ b/docs/user/events/browse-events/index.md
@@ -33,7 +33,7 @@ Registration is handled externally. The Events page displays events you are alre
 
 ## Filter events
 
-Filter by **All Foundations**, **All Roles**, **All Statuses** using the dropdown menus. Use the tabs to switch between **Upcoming**, **Past**, **Visa Letters**, and **Travel Funding**.
+Filter by **All Foundations**, **All Roles**, **All Statuses** using the dropdown menus. Use the tabs to switch between **Upcoming**, **Past**, [**Visa Letters**](../visa-letters/), and [**Travel Funding**](../travel-funding/).
 
 ## Register for an event
 
@@ -46,4 +46,7 @@ If no events appear, your current project context may not have any scheduled eve
 ## Related
 
 - [Events overview](../) — an overview of the Events section
+- [Request a Visa Support Letter](../visa-letters/) — travel documentation support for international attendees
+- [Apply for Travel Funding](../travel-funding/) — request funding to attend an event
+- [Download an Attendance Certificate](../attendance-certificates/) — get your certificate after an event
 - [Meetings](../../meetings/) — for internal project meetings, go to the Meetings section

--- a/docs/user/events/faq/index.md
+++ b/docs/user/events/faq/index.md
@@ -23,7 +23,7 @@ Event registration is handled externally (not within LFX Self Serve). My Events 
 
 ## Can I filter events by project or date?
 
-Filter using the **All Foundations**, **All Roles**, and **All Statuses** dropdowns. Tabs include **Upcoming**, **Past**, **Visa Letters**, and **Travel Funding**.
+Filter using the **All Foundations**, **All Roles**, and **All Statuses** dropdowns. Tabs include **Upcoming**, **Past**, [**Visa Letters**](../visa-letters/), and [**Travel Funding**](../travel-funding/).
 
 ## Can I see events I attended in the past?
 
@@ -32,6 +32,18 @@ Yes. Select the **Past** tab on the My Events page to view events you have previ
 ## How do I get notified about new events?
 
 Check the My Events page regularly for new events. Contact your project administrator for information about event announcements in your project.
+
+## How do I request a visa support letter?
+
+Open the [**Visa Letters**](../visa-letters/) tab on the My Events page and select **New Letter Application**. You can request a letter only for an event you are registered for. See [Request a Visa Support Letter](../visa-letters/).
+
+## How do I apply for travel funding?
+
+Open the [**Travel Funding**](../travel-funding/) tab on the My Events page and select **New Funding Application**. The Travel Fund helps community members attend events they otherwise could not; if your employer can cover the cost, please don't apply. See [Apply for Travel Funding](../travel-funding/).
+
+## How do I download my attendance certificate?
+
+Open the **Past** tab on the My Events page, find the event, and select **Download Certificate**. The action appears only for events marked **Attended**, and a certificate may take up to two weeks after the event ends to become available. See [Download an Attendance Certificate](../attendance-certificates/).
 
 ## Who do I contact about a specific event?
 

--- a/docs/user/events/index.md
+++ b/docs/user/events/index.md
@@ -21,6 +21,9 @@ The information below reflects **your individual** event registrations and atten
 - View event details including dates, location, and description
 - The Events page shows events you are already registered for. Registration is typically handled on the event's external registration page.
 - Filter using the **All Foundations**, **All Roles**, and **All Statuses** dropdowns. Switch between **Upcoming**, **Past**, **Visa Letters**, and **Travel Funding** tabs.
+- [Request a visa support letter](./visa-letters/) for an event you are registered for
+- [Apply for travel funding](./travel-funding/) to attend an event
+- [Download an attendance certificate](./attendance-certificates/) after you attend an event
 
 ### Who this applies to
 
@@ -50,5 +53,9 @@ Viewing your organization's events in Org Lens requires **admin access** to your
 
 ## Related sections
 
+- [Browse Events](./browse-events/) — how to find and view events
+- [Request a Visa Support Letter](./visa-letters/) — travel documentation support for international attendees
+- [Apply for Travel Funding](./travel-funding/) — request funding to attend an event
+- [Download an Attendance Certificate](./attendance-certificates/) — get your certificate after an event
 - [Meetings](../meetings/) — internal project meetings separate from public LFX events
 - [Dashboard](../dashboards/) — upcoming events may appear on your personal dashboard

--- a/docs/user/events/travel-funding/index.md
+++ b/docs/user/events/travel-funding/index.md
@@ -20,7 +20,7 @@ The Travel Fund helps open-source developers and community members attend Linux 
 4. Select **New Funding Application**.
 5. **Choose an Event** — select the event you want to attend, then continue.
 6. Review the **Terms and Conditions** and continue to accept them.
-7. Complete the **About Me** step with your applicant details. Some events (for example, CNCF and PyTorch events) ask for a few additional details on this step.
+7. Complete the **About Me** step with your applicant details.
 8. Complete the **Expenses** step with your estimated costs.
 9. Submit your application.
 

--- a/docs/user/events/travel-funding/index.md
+++ b/docs/user/events/travel-funding/index.md
@@ -1,0 +1,60 @@
+---
+title: Apply for Travel Funding
+description: Request travel funding to attend a Linux Foundation event you are registered for in LFX Self Serve
+audience: [all]
+product_area: Events
+tags: [events, travel-funding, travel-fund, attendance]
+last_updated: 2026-08-19
+intercom_collection: Events
+---
+
+The Travel Fund helps open-source developers and community members attend Linux Foundation events they would otherwise be unable to attend due to a lack of funding. Priority is given to applicants from underrepresented groups and those from lower-socioeconomic backgrounds. You apply for travel funding from the **Travel Funding** tab on the My Events page.
+
+> **Note:** If your employer is able to cover the cost of attending the event, please do not apply — the fund is intended for community members who have no other way to attend.
+
+## Steps
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Events** from the left navigation sidebar.
+3. Open the **Travel Funding** tab.
+4. Select **New Funding Application**.
+5. **Choose an Event** — select the event you want to attend, then continue.
+6. Review the **Terms and Conditions** and continue to accept them.
+7. Complete the **About Me** step with your applicant details. Some events (for example, CNCF and PyTorch events) ask for a few additional details on this step.
+8. Complete the **Expenses** step with your estimated costs.
+9. Submit your application.
+
+## What travel funding can cover
+
+- Coach-class airfare
+- Accommodation for the event dates, plus one night before the event
+- Ground transportation to and from the airport
+
+## What travel funding does not cover
+
+- Meals and food
+- Visa costs
+- Baggage fees
+- Ground transportation that is not to or from the airport
+
+## Approval
+
+Applications are reviewed by the Linux Foundation events team. A few things to keep in mind:
+
+- Funding decisions are final.
+- Applicants are generally not funded for multiple events in the same year, or for two years running.
+- Lower-cost requests are more likely to be approved, so keep your estimated expenses as reasonable as possible.
+
+## Application status
+
+After you submit, your request appears on the **Travel Funding** tab with its current **Status**. The status updates as the events team reviews your application and changes to **Approved** once it is approved. Each entry also shows the event, location, application date, and deadline.
+
+## Questions
+
+For questions about travel funding, contact the events team at [travelfund@linuxfoundation.org](mailto:travelfund@linuxfoundation.org).
+
+## Related
+
+- [Events overview](../) — an overview of the Events section
+- [Request a Visa Support Letter](../visa-letters/) — travel documentation support for international attendees
+- [Download an Attendance Certificate](../attendance-certificates/) — get your certificate after an event

--- a/docs/user/events/visa-letters/index.md
+++ b/docs/user/events/visa-letters/index.md
@@ -1,0 +1,53 @@
+---
+title: Request a Visa Support Letter
+description: Request a visa support letter to help international attendees obtain travel documents for a Linux Foundation event
+audience: [all]
+product_area: Events
+tags: [events, visa-letters, visa, travel, attendance]
+last_updated: 2026-08-19
+intercom_collection: Events
+---
+
+A visa support letter helps international attendees obtain the travel documentation they need to enter the event's host country. You request a visa support letter from the **Visa Letters** tab on the My Events page.
+
+> **Note:** You can request a visa support letter only for an event you are registered for. If you have not registered yet, register for the event first, then return to request your letter.
+
+## Steps
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Events** from the left navigation sidebar.
+3. Open the **Visa Letters** tab.
+4. Select **New Letter Application**.
+5. **Choose an Event** — select the event you are attending, then continue.
+6. Review the **Terms and Conditions** and continue to accept them.
+7. On the **Apply** step, complete the applicant information and submit your request.
+
+## What the application asks for
+
+Enter your details exactly as they appear on your passport so the letter is issued correctly:
+
+- First and last name
+- Email address
+- Passport number
+- Country of citizenship
+- Passport expiry date
+- Date of birth
+- Attendee type
+- Who is paying for your accommodation
+- The city of the embassy or consulate where you will apply
+- Your company or organization
+- The mailing address to use on the invitation letter
+
+## After you submit
+
+Your request appears on the **Visa Letters** tab with its current **Status**, along with the event, location, and application date. The Linux Foundation events team reviews your request and follows up with your visa support letter.
+
+## Questions
+
+For questions about visa support letters, contact the events team at [visaletters@linuxfoundation.org](mailto:visaletters@linuxfoundation.org).
+
+## Related
+
+- [Events overview](../) — an overview of the Events section
+- [Apply for Travel Funding](../travel-funding/) — request funding to attend an event
+- [Download an Attendance Certificate](../attendance-certificates/) — get your certificate after an event


### PR DESCRIPTION
## Summary

- Add three Events self-service how-to articles ahead of the legacy MyProfile (Individual Dashboard) cutover:
  - `events/travel-funding/` — apply for travel funding from the **Travel Funding** tab
  - `events/visa-letters/` — request a visa support letter from the **Visa Letters** tab (request-only flow)
  - `events/attendance-certificates/` — download a Certificate of Attendance from the **Past** tab (Attended only)
- Cross-link the new articles from the Events landing, Browse Events, and Events FAQ.
- Wording adapted from the legacy docs, converted to the self-serve format and kept strictly UI-level (no backend detail). Reconciled against the live app: visa letters documented as a request (no in-app download, no "apply for someone else"); certificate gated on Attended status.

Fixes LFXV2-3326
