### PR TITLE
docs(trainings): document rewards and coupons

### DIFF
--- a/docs/user/trainings/faq/index.md
+++ b/docs/user/trainings/faq/index.md
@@ -37,7 +37,7 @@ If it has been more than 2 days since you received your Pass notification and yo
 
 ## How do I earn and use training reward points?
 
-You earn reward points by completing training and passing certification exams. Your **Total Reward Points** and progress toward your next reward appear on the **Rewards** tab of the Training & Certifications page. See [Training Rewards and Coupons](../rewards/) for how to claim incentives and redeem coupons, or the [Rewards FAQ](https://training.linuxfoundation.org/tux-rewards/) for how points are earned and how long they last.
+You earn reward points on eligible Linux Foundation training and certification purchases. Your **Total Reward Points** and progress toward your next reward appear on the **Rewards** tab of the Training & Certifications page. See [Training Rewards and Coupons](../rewards/) for how to claim incentives and redeem coupons, or the [Rewards FAQ](https://training.linuxfoundation.org/tux-rewards/) for how points are earned and how long they last.
 
 ## How do I redeem a training coupon?
 

--- a/docs/user/trainings/faq/index.md
+++ b/docs/user/trainings/faq/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Trainings
 tags: [trainings, faq, certifications, enrollments]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-19
 intercom_collection: Trainings
 ---
 
@@ -34,6 +34,14 @@ Training enrollment expiry, if applicable, is shown in the LF Training Portal. C
 Yes. Completing certain Linux Foundation training programs qualifies you for LFX badges. After completing your training or certification, you will receive a separate email with instructions on how to claim your digital badge at our partner Acclaim’s website.
 
 If it has been more than 2 days since you received your Pass notification and you still have not received the email from Credly, please be sure to check your spam folder and then contact the LF Education support team in their support portal at <https://trainingsupport.linuxfoundation.org>
+
+## How do I earn and use training reward points?
+
+You earn reward points by completing training and passing certification exams. Your **Total Reward Points** and progress toward your next reward appear on the **Rewards** tab of the Training & Certifications page. See [Training Rewards and Coupons](../rewards/) for how to claim incentives and redeem coupons, or the [Rewards FAQ](https://training.linuxfoundation.org/tux-rewards/) for how points are earned and how long they last.
+
+## How do I redeem a training coupon?
+
+Open the **Rewards** tab on the Training & Certifications page. In the **My Coupons** column, use **Copy Code** to copy an available coupon, or **Redeem** to redeem one using your reward points, then paste the code at checkout on the Linux Foundation training platform. See [Training Rewards and Coupons](../rewards/) for details.
 
 ## Where can I find a list of available training courses?
 

--- a/docs/user/trainings/index.md
+++ b/docs/user/trainings/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Trainings
 tags: [trainings, courses, enrollments, certifications, learning]
 last_generated: 2026-05-22
-last_updated: 2026-06-22
+last_updated: 2026-08-19
 intercom_collection: Trainings
 ---
 
@@ -19,7 +19,7 @@ The information below reflects **your** training enrollments and certifications 
 
 - View your enrolled training courses
 - Check your enrollment and completion status
-- Access your earned certifications and rewards
+- Access your earned certifications and [rewards, incentives, and coupons](rewards/)
 
 Training enrollment is handled on the Linux Foundation training platform. LFX Self Serve displays your enrolled courses and certifications in read-only view. Use the **LF Training Portal** link on the Useful links tab to access your courses.
 
@@ -55,5 +55,6 @@ Viewing your company's training activity in Org Lens requires **admin access** t
 
 ## Related sections
 
+- [Training Rewards and Coupons](rewards/) — view reward points, claim incentives, and redeem coupons
 - [Badges](../badges/) — credentials earned from completed training programs
 - [Transactions](../account/transactions/) — training purchases appear in your transaction history

--- a/docs/user/trainings/rewards/index.md
+++ b/docs/user/trainings/rewards/index.md
@@ -20,7 +20,7 @@ The **Rewards** tab shows the reward points, incentives, and coupons you have ea
 
 ### Total reward points
 
-The top of the tab shows your **Total Reward Points** and a progress bar toward your next reward. You earn points by completing training modules and passing certification exams. If a program year applies, the tab also shows when it ends.
+The top of the tab shows your **Total Reward Points** and a progress bar toward your next reward. You earn points on eligible Linux Foundation training and certification purchases. If a program year applies, the tab also shows when it ends.
 
 > **Note:** Points are earned based on your training and certification purchases and take some time to appear after a purchase. For details on how points are earned and how long they last, see the [Rewards FAQ](https://training.linuxfoundation.org/tux-rewards/).
 

--- a/docs/user/trainings/rewards/index.md
+++ b/docs/user/trainings/rewards/index.md
@@ -4,6 +4,7 @@ description: View your reward points, claim incentives, and redeem coupons for L
 audience: [all]
 product_area: Trainings
 tags: [trainings, rewards, coupons, points, certifications]
+last_generated: 2026-08-19
 last_updated: 2026-08-19
 intercom_collection: Trainings
 ---

--- a/docs/user/trainings/rewards/index.md
+++ b/docs/user/trainings/rewards/index.md
@@ -1,0 +1,53 @@
+---
+title: Training Rewards and Coupons
+description: View your reward points, claim incentives, and redeem coupons for Linux Foundation training and certifications.
+audience: [all]
+product_area: Trainings
+tags: [trainings, rewards, coupons, points, certifications]
+last_updated: 2026-08-19
+intercom_collection: Trainings
+---
+
+The **Rewards** tab shows the reward points, incentives, and coupons you have earned toward Linux Foundation training and certifications. Rewards and coupons are for use within the Linux Foundation Education & Training platform — they cannot be exchanged for cash or non-training services.
+
+## Steps
+
+1. Sign in to [app.lfx.dev](https://app.lfx.dev).
+2. Select **Training & Certifications** from the left navigation sidebar.
+3. Select the **Rewards** tab.
+
+## What the Rewards tab shows
+
+### Total reward points
+
+The top of the tab shows your **Total Reward Points** and a progress bar toward your next reward. You earn points by completing training modules and passing certification exams. If a program year applies, the tab also shows when it ends.
+
+> **Note:** Points are earned based on your training and certification purchases and take some time to appear after a purchase. For details on how points are earned and how long they last, see the [Rewards FAQ](https://training.linuxfoundation.org/tux-rewards/).
+
+### Available Incentives
+
+The **Available Incentives** column lists offers you may be eligible for. Each card shows the incentive, its status, and any eligibility details. Depending on the incentive, you can:
+
+- **Copy Code** — copy the coupon code shown on the card, or
+- **Claim** — claim the incentive to generate a code.
+
+If there are no offers right now, the column shows an empty state — check back later for new incentives.
+
+### My Coupons
+
+The **My Coupons** column lists coupons available to you. Each card shows the coupon, its status, and a short description. Depending on the coupon, you can:
+
+- **Copy Code** — copy the coupon code to use at checkout, or
+- **Redeem** — redeem the coupon using your reward points. If you do not have enough points yet, the card shows how many more you need.
+
+If you do not have any redeemable coupons yet, the column shows an empty state with a link to browse the training catalog and earn more points.
+
+## Use a coupon code
+
+Copy the coupon code from the card, then paste it into the coupon field at checkout on the Linux Foundation training platform to apply the discount.
+
+## Related
+
+- [Training & Certifications overview](../) — an overview of the Training & Certifications section
+- [Badges](../../badges/) — credentials earned from completed training programs
+- [Transactions](../../account/transactions/) — training purchases appear in your transaction history


### PR DESCRIPTION
## Summary

- Add a new Trainings how-to, `trainings/rewards/`, documenting the **Rewards** tab (Training & Certifications → Rewards):
  - **Total Reward Points** and progress toward the next reward
  - **Available Incentives** — claim an incentive or copy its coupon code
  - **My Coupons** — redeem with points or copy the code, and how to use a code at checkout
  - **Scope & usage** — rewards/coupons are for the LF Education & Training platform only
- Cross-link the new article from the Trainings landing (What you can do + Related) and add two rewards Q&As to the Trainings FAQ.
- Content is kept strictly UI-level (no backend detail). Refreshed `last_updated` on the edited landing/FAQ pages.

Fixes LFXV2-3331
