### PR TITLE
fix(org-people): scrub real customer PII from test fixtures

### DIFF
--- a/.claude/rules/development-rules.md
+++ b/.claude/rules/development-rules.md
@@ -85,6 +85,7 @@ See the `/lfx` skill's `references/repo-map.md` for the upstream microservice re
 - **Run `yarn e2e` before major changes** to ensure all tests pass consistently
 - **Use `data-testid` naming convention** — `[section]-[component]-[element]` for hierarchical structure
 - **Test responsive behavior** — validate mobile, tablet, and desktop viewports appropriately
+- **Never use real customer or personal data in fixtures** — names, emails, and company domains in tests must be synthetic (e.g. `acme-motors.example`, `vendor-corp.example`). Copying a real payload from a bug report or support ticket into a test is the most common way this leaks — redact it first. `check-fixture-emails.sh` (wired into `.husky/pre-commit`) blocks staged `*.spec.ts`/`*.fixture.ts`/`*.ndjson` files containing a denylisted real customer/vendor domain; add a domain there when a new incident surfaces one (see GH-1674)
 - When running tests to validate UI tests, use `reporter=list`
 
 ## Documentation Maintenance

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -29,9 +29,26 @@ jobs:
 
       - name: Check fixture emails for real customer/vendor PII
         run: |
-          base_ref="${{ github.event.pull_request.base.ref || 'main' }}"
-          git fetch origin "${base_ref}" --depth=1
-          ./check-fixture-emails.sh "origin/${base_ref}"
+          # Pick the correct pre-change commit per event: for pull_request/merge_group this is the
+          # target base, NOT the current branch tip — on a push/merge_group run, "main" already
+          # points at the just-pushed commit, so diffing origin/main against HEAD would be empty
+          # and the guard would silently no-op on every direct or automated push.
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            base_sha="${{ github.event.pull_request.base.sha }}"
+          elif [ "${{ github.event_name }}" = "merge_group" ]; then
+            base_sha="${{ github.event.merge_group.base_sha }}"
+          elif [ -n "${{ github.event.before }}" ] && [ "${{ github.event.before }}" != "0000000000000000000000000000000000000000" ]; then
+            base_sha="${{ github.event.before }}"
+          else
+            base_sha=""
+          fi
+
+          if [ -z "${base_sha}" ]; then
+            echo "No pre-change commit available for this event (e.g. first push to a new branch) — skipping."
+            exit 0
+          fi
+
+          ./check-fixture-emails.sh "${base_sha}"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.github/workflows/quality-check.yml
+++ b/.github/workflows/quality-check.yml
@@ -24,6 +24,14 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check fixture emails for real customer/vendor PII
+        run: |
+          base_ref="${{ github.event.pull_request.base.ref || 'main' }}"
+          git fetch origin "${base_ref}" --depth=1
+          ./check-fixture-emails.sh "origin/${base_ref}"
 
       - name: Enable Corepack
         run: corepack enable

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -6,6 +6,13 @@ if [ $? -ne 0 ]; then
   exit 1
 fi
 
+# Check for real customer/vendor PII in staged test fixtures
+./check-fixture-emails.sh
+if [ $? -ne 0 ]; then
+  echo "❌ Fixture PII check failed. Replace real emails with synthetic test data."
+  exit 1
+fi
+
 # Run lint-staged for formatting and linting
 npx lint-staged
 yarn format:check

--- a/apps/lfx-one/e2e/org-people-avatars.spec.ts
+++ b/apps/lfx-one/e2e/org-people-avatars.spec.ts
@@ -16,21 +16,21 @@ const DATA_LOAD_TIMEOUT = 30_000;
 
 const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 const MOCK_UID = MOCK_ACCOUNT_ID;
-const MOCK_ACCOUNT_NAME = 'Toyota';
-const MOCK_ACCOUNT_SLUG = 'toyota';
+const MOCK_ACCOUNT_NAME = 'Acme Motors';
+const MOCK_ACCOUNT_SLUG = 'acme-motors';
 
-const CHIANING_EMAIL = 'johnny.wang@toyota.com';
+const MORGAN_EMAIL = 'morgan.diaz@acme-motors.example';
 
 // 1×1 transparent PNG — loads synchronously (no network) so the photo <img> path is deterministic.
 const PNG_1x1 = 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==';
 
-const CHIANING = {
-  email: CHIANING_EMAIL,
-  firstName: 'Chianing',
-  lastName: 'Wang',
-  fullName: 'Chianing Wang',
+const MORGAN = {
+  email: MORGAN_EMAIL,
+  firstName: 'Morgan',
+  lastName: 'Diaz',
+  fullName: 'Morgan Diaz',
   jobTitle: 'Infrastructure Architect',
-  initials: 'CW',
+  initials: 'MD',
   avatarUrl: PNG_1x1,
 };
 
@@ -49,7 +49,7 @@ function committeeMembersResponse() {
     appointedBy: 'Membership Entitlement',
     isOrgEditable: true,
     reason: null,
-    person: CHIANING,
+    person: MORGAN,
   });
   return {
     orgUid: MOCK_UID,
@@ -123,21 +123,21 @@ test.describe('Org People — avatar consistency', () => {
     );
     // The org-wide employee picker carries the same person (same avatar) — proving cross-surface consistency.
     await page.route(/\/api\/orgs\/[^/]+\/lens\/employees(?:\?.*)?$/, (route) =>
-      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ orgUid: MOCK_UID, employees: [CHIANING] }) })
+      route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({ orgUid: MOCK_UID, employees: [MORGAN] }) })
     );
 
     await gotoCommitteeTab(page);
 
     // Surface 1 — the People → Committee roster row renders the photo.
-    const row = page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`);
+    const row = page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`);
     await expect(row).toBeVisible();
     await expect(row.getByTestId('person-avatar-image')).toBeVisible();
 
     // Surface 2 — the reassign picker suggestion renders the same photo for the same person.
-    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
     await expect(page.getByTestId('org-people-committee-modal-reassign')).toBeVisible();
     await page.getByTestId('org-people-committee-modal-reassign-email-input').fill('wang');
-    const option = page.getByTestId(`org-people-committee-modal-reassign-employee-option-${CHIANING_EMAIL}`);
+    const option = page.getByTestId(`org-people-committee-modal-reassign-employee-option-${MORGAN_EMAIL}`);
     await expect(option).toBeVisible();
     await expect(option.getByTestId('person-avatar-image')).toBeVisible();
   });

--- a/apps/lfx-one/e2e/org-people-avatars.spec.ts
+++ b/apps/lfx-one/e2e/org-people-avatars.spec.ts
@@ -136,7 +136,7 @@ test.describe('Org People — avatar consistency', () => {
     // Surface 2 — the reassign picker suggestion renders the same photo for the same person.
     await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
     await expect(page.getByTestId('org-people-committee-modal-reassign')).toBeVisible();
-    await page.getByTestId('org-people-committee-modal-reassign-email-input').fill('wang');
+    await page.getByTestId('org-people-committee-modal-reassign-email-input').fill('morgan');
     const option = page.getByTestId(`org-people-committee-modal-reassign-employee-option-${MORGAN_EMAIL}`);
     await expect(option).toBeVisible();
     await expect(option.getByTestId('person-avatar-image')).toBeVisible();

--- a/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-reassign.spec.ts
@@ -11,17 +11,17 @@ const TOAST_TIMEOUT = 10_000;
 
 const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 const MOCK_UID = MOCK_ACCOUNT_ID;
-const MOCK_ACCOUNT_NAME = 'Toyota';
-const MOCK_ACCOUNT_SLUG = 'toyota';
+const MOCK_ACCOUNT_NAME = 'Acme Motors';
+const MOCK_ACCOUNT_SLUG = 'acme-motors';
 
-const MASAKI_EMAIL = 'masaki.isetani@toyota.com';
-const KENSUKE_EMAIL = 'kensuke.hanaoka@toyota.com';
-const REPLACEMENT_EMAIL = 'cara.dev@toyota.com';
+const ALEX_EMAIL = 'alex.chen@acme-motors.example';
+const JORDAN_EMAIL = 'jordan.reyes@acme-motors.example';
+const REPLACEMENT_EMAIL = 'cara.dev@acme-motors.example';
 
-const MASAKI = { email: MASAKI_EMAIL, firstName: 'Masaki', lastName: 'Isetani', fullName: 'Masaki Isetani', jobTitle: 'Senior Manager', initials: 'MI' };
-const KENSUKE = { email: KENSUKE_EMAIL, firstName: 'Kensuke', lastName: 'Hanaoka', fullName: 'Kensuke Hanaoka', jobTitle: 'Engineer', initials: 'KH' };
+const ALEX = { email: ALEX_EMAIL, firstName: 'Alex', lastName: 'Chen', fullName: 'Alex Chen', jobTitle: 'Senior Manager', initials: 'AC' };
+const JORDAN = { email: JORDAN_EMAIL, firstName: 'Jordan', lastName: 'Reyes', fullName: 'Jordan Reyes', jobTitle: 'Engineer', initials: 'JR' };
 
-function masakiSeat(uid: string, foundationName: string, foundationSlug: string, projectUid: string, votingStatus: string) {
+function alexSeat(uid: string, foundationName: string, foundationSlug: string, projectUid: string, votingStatus: string) {
   return {
     seatId: uid,
     memberUid: uid,
@@ -36,7 +36,7 @@ function masakiSeat(uid: string, foundationName: string, foundationSlug: string,
     appointedBy: 'Membership Entitlement',
     isOrgEditable: true,
     reason: null,
-    person: MASAKI,
+    person: ALEX,
   };
 }
 
@@ -44,12 +44,12 @@ function boardMembersResponse() {
   return {
     orgUid: MOCK_UID,
     assignments: [
-      masakiSeat('m-masaki-agl', 'Automotive Grade Linux', 'automotive-grade-linux', 'agl-root', 'Voting'),
-      masakiSeat('m-masaki-hl', 'Hyperledger Foundation', 'hyperledger-foundation', 'hl-root', 'Non-voting'),
+      alexSeat('m-alex-agl', 'Automotive Grade Linux', 'automotive-grade-linux', 'agl-root', 'Voting'),
+      alexSeat('m-alex-hl', 'Hyperledger Foundation', 'hyperledger-foundation', 'hl-root', 'Non-voting'),
       {
-        seatId: 'm-kensuke',
-        memberUid: 'm-kensuke',
-        committeeUid: 'c-kensuke',
+        seatId: 'm-jordan',
+        memberUid: 'm-jordan',
+        committeeUid: 'c-jordan',
         committeeName: 'Steering Committee',
         committeeCategory: 'Board',
         projectUid: 'agl-root',
@@ -60,7 +60,7 @@ function boardMembersResponse() {
         appointedBy: 'Board Election',
         isOrgEditable: false,
         reason: "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
-        person: KENSUKE,
+        person: JORDAN,
       },
     ],
     stats: { totalBoardMembers: 2, votingCount: 1, nonVotingCount: 2, foundationsCovered: 2 },
@@ -69,7 +69,7 @@ function boardMembersResponse() {
 
 const MOCK_EMPLOYEES = [
   { email: REPLACEMENT_EMAIL, firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', jobTitle: 'Senior Engineer', initials: 'CD' },
-  { email: 'evan.qa@toyota.com', firstName: 'Evan', lastName: 'QA', fullName: 'Evan QA', jobTitle: 'QA Lead', initials: 'EQ' },
+  { email: 'evan.qa@acme-motors.example', firstName: 'Evan', lastName: 'QA', fullName: 'Evan QA', jobTitle: 'QA Lead', initials: 'EQ' },
 ];
 
 function skipWhenAuthMissing(page: Page): void {
@@ -138,7 +138,7 @@ function reassignedSeatBody(seatId: string) {
   return {
     orgUid: MOCK_UID,
     seat: {
-      ...masakiSeat(seatId, 'Automotive Grade Linux', 'automotive-grade-linux', 'agl-root', 'Voting'),
+      ...alexSeat(seatId, 'Automotive Grade Linux', 'automotive-grade-linux', 'agl-root', 'Voting'),
       person: { email: REPLACEMENT_EMAIL, firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', jobTitle: null, initials: 'CD' },
     },
   };
@@ -167,7 +167,7 @@ test.describe('Org People → Board — Reassign Board Roles modal (US3)', () =>
     await stubEmployees(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-reassign-${ALEX_EMAIL}`).click();
 
     const modal = page.getByTestId('org-people-board-modal-reassign');
     await expect(modal).toBeVisible();
@@ -183,8 +183,8 @@ test.describe('Org People → Board — Reassign Board Roles modal (US3)', () =>
     await stubEmployees(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
-    await page.getByTestId('org-people-board-modal-reassign-role-checkbox-m-masaki-hl').click();
+    await page.getByTestId(`org-people-board-reassign-${ALEX_EMAIL}`).click();
+    await page.getByTestId('org-people-board-modal-reassign-role-checkbox-m-alex-hl').click();
     await expect(page.getByTestId('org-people-board-modal-reassign-primary-button')).toContainText('Save Changes (1 role)');
   });
 
@@ -194,7 +194,7 @@ test.describe('Org People → Board — Reassign Board Roles modal (US3)', () =>
     await stubEmployees(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-reassign-${ALEX_EMAIL}`).click();
     await expect(page.getByTestId('org-people-board-modal-reassign-primary-button')).toBeDisabled();
   });
 
@@ -211,7 +211,7 @@ test.describe('Org People → Board — Reassign Board Roles modal (US3)', () =>
     });
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-reassign-${ALEX_EMAIL}`).click();
     await page.getByTestId('org-people-board-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-board-modal-reassign-first-name-input').fill('Cara');
     await page.getByTestId('org-people-board-modal-reassign-last-name-input').fill('Dev');
@@ -227,7 +227,7 @@ test.describe('Org People → Board — Reassign Board Roles modal (US3)', () =>
     await stubEmployees(page);
     await stubReassignPatch(page, (route) => {
       const url = route.request().url();
-      if (url.includes('/m-masaki-hl/')) {
+      if (url.includes('/m-alex-hl/')) {
         return route.fulfill({
           status: 409,
           contentType: 'application/json',
@@ -239,7 +239,7 @@ test.describe('Org People → Board — Reassign Board Roles modal (US3)', () =>
     });
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-reassign-${ALEX_EMAIL}`).click();
     await page.getByTestId('org-people-board-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-board-modal-reassign-first-name-input').fill('Cara');
     await page.getByTestId('org-people-board-modal-reassign-last-name-input').fill('Dev');
@@ -258,7 +258,7 @@ test.describe('Org People → Board — Reassign Board Roles modal (US3)', () =>
     );
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-reassign-${ALEX_EMAIL}`).click();
     await page.getByTestId('org-people-board-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-board-modal-reassign-first-name-input').fill('Cara');
     await page.getByTestId('org-people-board-modal-reassign-last-name-input').fill('Dev');
@@ -277,14 +277,14 @@ test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
     await stubEmployees(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
-    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-alex-agl').click();
 
     const modal = page.getByTestId('org-people-board-modal-edit');
     await expect(modal).toBeVisible();
     await expect(page.getByTestId('org-people-board-modal-edit-title')).toHaveText('Edit Board Role');
     await expect(page.getByTestId('org-people-board-modal-edit-chips')).toContainText('Automotive Grade Linux');
-    await expect(page.getByTestId('org-people-board-modal-edit-current')).toContainText('Masaki Isetani');
+    await expect(page.getByTestId('org-people-board-modal-edit-current')).toContainText('Alex Chen');
   });
 
   test('Save fires exactly one PATCH and shows a success toast', async ({ page }) => {
@@ -294,12 +294,12 @@ test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
     let patchCount = 0;
     await stubReassignPatch(page, (route) => {
       patchCount += 1;
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody('m-masaki-agl')) });
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody('m-alex-agl')) });
     });
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
-    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-alex-agl').click();
     await page.getByTestId('org-people-board-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-board-modal-edit-first-name-input').fill('Cara');
     await page.getByTestId('org-people-board-modal-edit-last-name-input').fill('Dev');
@@ -318,8 +318,8 @@ test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
     );
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
-    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-alex-agl').click();
     await page.getByTestId('org-people-board-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-board-modal-edit-first-name-input').fill('Cara');
     await page.getByTestId('org-people-board-modal-edit-last-name-input').fill('Dev');
@@ -336,9 +336,9 @@ test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
     await stubEmployees(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`).click();
-    await expect(page.getByTestId('org-people-board-why-m-kensuke')).toBeVisible();
-    await expect(page.getByTestId('org-people-board-edit-m-kensuke')).toHaveCount(0);
+    await page.getByTestId(`org-people-board-row-${JORDAN_EMAIL}`).click();
+    await expect(page.getByTestId('org-people-board-why-m-jordan')).toBeVisible();
+    await expect(page.getByTestId('org-people-board-edit-m-jordan')).toHaveCount(0);
   });
 
   test('ArrowDown + Enter on the employee combobox selects the highlighted option (keyboard a11y)', async ({ page }) => {
@@ -347,11 +347,11 @@ test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
     await stubEmployees(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
-    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-alex-agl').click();
 
     const emailInput = page.getByTestId('org-people-board-modal-edit-email-input');
-    await emailInput.fill('toyota.com');
+    await emailInput.fill('acme-motors.example');
     await emailInput.press('ArrowDown');
 
     // The first option in the listbox is highlighted; aria-activedescendant on the input points to its id.
@@ -371,10 +371,10 @@ test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
     await stubEmployees(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-reassign-${MASAKI_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-reassign-${ALEX_EMAIL}`).click();
 
     const emailInput = page.getByTestId('org-people-board-modal-reassign-email-input');
-    await emailInput.fill('toyota.com');
+    await emailInput.fill('acme-motors.example');
     await emailInput.press('ArrowDown');
     await expect(emailInput).toHaveAttribute('aria-activedescendant', 'reassign-board-employee-option-0');
 
@@ -391,12 +391,12 @@ test.describe('Org People → Board — Edit Board Role modal (US4)', () => {
     let patchCount = 0;
     await stubReassignPatch(page, (route) => {
       patchCount += 1;
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody('m-masaki-agl')) });
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(reassignedSeatBody('m-alex-agl')) });
     });
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
-    await page.getByTestId('org-people-board-edit-m-masaki-agl').click();
+    await page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`).click();
+    await page.getByTestId('org-people-board-edit-m-alex-agl').click();
     await expect(page.getByTestId('org-people-board-modal-edit')).toBeVisible();
 
     await page.getByTestId('org-people-board-modal-edit-cancel').click();

--- a/apps/lfx-one/e2e/org-people-board-tab.spec.ts
+++ b/apps/lfx-one/e2e/org-people-board-tab.spec.ts
@@ -10,20 +10,20 @@ const DATA_LOAD_TIMEOUT = 30_000;
 
 const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 const MOCK_UID = MOCK_ACCOUNT_ID;
-const MOCK_ACCOUNT_NAME = 'Toyota';
-const MOCK_ACCOUNT_SLUG = 'toyota';
+const MOCK_ACCOUNT_NAME = 'Acme Motors';
+const MOCK_ACCOUNT_SLUG = 'acme-motors';
 
 // SC-001 dev-mode budget multiplier — `ng serve` adds 3–10× per interaction vs the production build.
 const PERF_DEV_MULTIPLIER = 5;
 
-const KENSUKE_EMAIL = 'kensuke.hanaoka@toyota.com';
-const KENTA_EMAIL = 'kenta.tada@toyota.com';
-const MASAKI_EMAIL = 'masaki.isetani@toyota.com';
-const YASUSHI_EMAIL = 'yasushi.ando@toyota.com';
+const JORDAN_EMAIL = 'jordan.reyes@acme-motors.example';
+const SAM_EMAIL = 'sam.rivera@acme-motors.example';
+const ALEX_EMAIL = 'alex.chen@acme-motors.example';
+const TAYLOR_EMAIL = 'taylor.kim@acme-motors.example';
 
-// Models the Toyota board screenshot: 4 members, 2 voting + 3 non-voting seats, 3 foundations.
-// Kensuke + Yasushi are foundation-controlled (read-only → "Why can't I edit?"); Kenta + Masaki hold
-// Membership-Entitlement seats (editable). Masaki spans 2 foundations with mixed voting status.
+// Models the Acme Motors board screenshot: 4 members, 2 voting + 3 non-voting seats, 3 foundations.
+// Jordan + Taylor are foundation-controlled (read-only → "Why can't I edit?"); Sam + Alex hold
+// Membership-Entitlement seats (editable). Alex spans 2 foundations with mixed voting status.
 function boardMembersResponse() {
   const seat = (
     uid: string,
@@ -50,32 +50,32 @@ function boardMembersResponse() {
     reason: isOrgEditable ? null : "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
     person,
   });
-  const kensuke = { email: KENSUKE_EMAIL, firstName: 'Kensuke', lastName: 'Hanaoka', fullName: 'Kensuke Hanaoka', jobTitle: 'Engineer', initials: 'KH' };
-  const kenta = { email: KENTA_EMAIL, firstName: 'Kenta', lastName: 'Tada', fullName: 'Kenta Tada', jobTitle: 'Principal Software Engineer', initials: 'KT' };
-  const masaki = {
-    email: MASAKI_EMAIL,
-    firstName: 'Masaki',
-    lastName: 'Isetani',
-    fullName: 'Masaki Isetani',
+  const jordan = { email: JORDAN_EMAIL, firstName: 'Jordan', lastName: 'Reyes', fullName: 'Jordan Reyes', jobTitle: 'Engineer', initials: 'JR' };
+  const sam = { email: SAM_EMAIL, firstName: 'Sam', lastName: 'Rivera', fullName: 'Sam Rivera', jobTitle: 'Principal Software Engineer', initials: 'SR' };
+  const alex = {
+    email: ALEX_EMAIL,
+    firstName: 'Alex',
+    lastName: 'Chen',
+    fullName: 'Alex Chen',
     jobTitle: 'Senior Manager, Open Source Strategy',
-    initials: 'MI',
+    initials: 'AC',
   };
-  const yasushi = {
-    email: YASUSHI_EMAIL,
-    firstName: 'Yasushi',
-    lastName: 'Ando',
-    fullName: 'Yasushi Ando',
+  const taylor = {
+    email: TAYLOR_EMAIL,
+    firstName: 'Taylor',
+    lastName: 'Kim',
+    fullName: 'Taylor Kim',
     jobTitle: 'Distinguished Engineer',
-    initials: 'YA',
+    initials: 'TK',
   };
   return {
     orgUid: MOCK_UID,
     assignments: [
-      seat('m-kensuke', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Non-voting', false, kensuke),
-      seat('m-kenta', 'Governing Board', 'ebpf-root', 'eBPF Foundation', 'ebpf-foundation', 'Voting', true, kenta),
-      seat('m-masaki-agl', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Voting', true, masaki),
-      seat('m-masaki-hl', 'Governing Board', 'hl-root', 'Hyperledger Foundation', 'hyperledger-foundation', 'Non-voting', true, masaki),
-      seat('m-yasushi', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Non-voting', false, yasushi),
+      seat('m-jordan', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Non-voting', false, jordan),
+      seat('m-sam', 'Governing Board', 'ebpf-root', 'eBPF Foundation', 'ebpf-foundation', 'Voting', true, sam),
+      seat('m-alex-agl', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Voting', true, alex),
+      seat('m-alex-hl', 'Governing Board', 'hl-root', 'Hyperledger Foundation', 'hyperledger-foundation', 'Non-voting', true, alex),
+      seat('m-taylor', 'Steering Committee', 'agl-root', 'Automotive Grade Linux', 'automotive-grade-linux', 'Non-voting', false, taylor),
     ],
     stats: { totalBoardMembers: 4, votingCount: 2, nonVotingCount: 3, foundationsCovered: 3 },
   };
@@ -159,8 +159,8 @@ test.describe('Org People → Board tab', () => {
     expect(elapsed).toBeLessThan(3000 * PERF_DEV_MULTIPLIER);
 
     // One row per person (4 members).
-    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${JORDAN_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`)).toBeVisible();
 
     // SC-004: total tile == distinct row count; voting + non-voting == total seat count.
     const total = await page.getByTestId('org-people-board-stat-total').innerText();
@@ -179,13 +179,13 @@ test.describe('Org People → Board tab', () => {
     await stubBoardMembers(page);
 
     await gotoBoardTab(page);
-    // Kensuke holds one board seat → a single "Non-voting" pill.
-    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toContainText('Non-voting');
-    // Masaki holds 2 foundations with mixed voting → "1 Voting" + "1 Non-voting" count pills + a Foundations badge.
-    const masaki = page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`);
-    await expect(masaki).toContainText('1 Voting');
-    await expect(masaki).toContainText('1 Non-voting');
-    await expect(masaki).toContainText('2 Foundations');
+    // Jordan holds one board seat → a single "Non-voting" pill.
+    await expect(page.getByTestId(`org-people-board-row-${JORDAN_EMAIL}`)).toContainText('Non-voting');
+    // Alex holds 2 foundations with mixed voting → "1 Voting" + "1 Non-voting" count pills + a Foundations badge.
+    const alex = page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`);
+    await expect(alex).toContainText('1 Voting');
+    await expect(alex).toContainText('1 Non-voting');
+    await expect(alex).toContainText('2 Foundations');
   });
 
   test('renders the empty state for an org with no board seats', async ({ page }) => {
@@ -217,11 +217,11 @@ test.describe('Org People → Board tab', () => {
     await stubBoardMembers(page);
 
     await gotoBoardTab(page);
-    // Kensuke is foundation-controlled → no enabled pencil, the "Why can't I edit?" affordance instead.
-    await expect(page.getByTestId(`org-people-board-why-${KENSUKE_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId(`org-people-board-reassign-${KENSUKE_EMAIL}`)).toHaveCount(0);
-    // Kenta holds an entitlement seat → the live Reassign pencil.
-    await expect(page.getByTestId(`org-people-board-reassign-${KENTA_EMAIL}`)).toBeVisible();
+    // Jordan is foundation-controlled → no enabled pencil, the "Why can't I edit?" affordance instead.
+    await expect(page.getByTestId(`org-people-board-why-${JORDAN_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-reassign-${JORDAN_EMAIL}`)).toHaveCount(0);
+    // Sam holds an entitlement seat → the live Reassign pencil.
+    await expect(page.getByTestId(`org-people-board-reassign-${SAM_EMAIL}`)).toBeVisible();
   });
 
   test('clicking "Why can\'t I edit?" opens the explanatory modal and "Got it" closes it', async ({ page }) => {
@@ -229,7 +229,7 @@ test.describe('Org People → Board tab', () => {
     await stubBoardMembers(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-why-${KENSUKE_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-why-${JORDAN_EMAIL}`).click();
 
     const modal = page.getByTestId('org-people-board-modal-why');
     await expect(modal).toBeVisible();
@@ -245,18 +245,18 @@ test.describe('Org People → Board tab', () => {
     await stubBoardMembers(page);
 
     await gotoBoardTab(page);
-    await expect(page.getByTestId(`org-people-board-why-${KENTA_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-why-${SAM_EMAIL}`)).toBeVisible();
     await expect(page.locator('[data-testid^="org-people-board-reassign-"]')).toHaveCount(0);
   });
 
-  test('expands Masaki and shows 2 board sub-rows (US2)', async ({ page }) => {
+  test('expands Alex and shows 2 board sub-rows (US2)', async ({ page }) => {
     await stubAccountContext(page);
     await stubBoardMembers(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`).click();
+    await page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`).click();
 
-    const expanded = page.getByTestId(`org-people-board-expanded-${MASAKI_EMAIL}`);
+    const expanded = page.getByTestId(`org-people-board-expanded-${ALEX_EMAIL}`);
     await expect(expanded).toBeVisible();
     await expect(expanded.locator('[data-testid^="org-people-board-subrow-"]')).toHaveCount(2);
   });
@@ -266,10 +266,10 @@ test.describe('Org People → Board tab', () => {
     await stubBoardMembers(page);
 
     await gotoBoardTab(page);
-    await page.getByTestId('org-people-board-search-input').locator('input').fill('Hanaoka');
+    await page.getByTestId('org-people-board-search-input').locator('input').fill('Reyes');
 
-    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId(`org-people-board-row-${KENTA_EMAIL}`)).toHaveCount(0);
+    await expect(page.getByTestId(`org-people-board-row-${JORDAN_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${SAM_EMAIL}`)).toHaveCount(0);
   });
 
   test('foundation filter narrows the rows (US2)', async ({ page }) => {
@@ -280,9 +280,9 @@ test.describe('Org People → Board tab', () => {
     await page.getByTestId('org-people-board-foundation-filter').click();
     await page.getByRole('option', { name: 'eBPF Foundation', exact: true }).click();
 
-    // Only people with an eBPF board seat (Kenta) remain.
-    await expect(page.getByTestId(`org-people-board-row-${KENTA_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}`)).toHaveCount(0);
+    // Only people with an eBPF board seat (Sam) remain.
+    await expect(page.getByTestId(`org-people-board-row-${SAM_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${JORDAN_EMAIL}`)).toHaveCount(0);
   });
 
   test('status filter "Voting" narrows to people with a voting board seat (US2)', async ({ page }) => {
@@ -293,10 +293,10 @@ test.describe('Org People → Board tab', () => {
     await page.getByTestId('org-people-board-status-filter').click();
     await page.getByRole('option', { name: 'Voting', exact: true }).click();
 
-    // Kenta (voting) + Masaki (one voting seat) remain; Kensuke + Yasushi (non-voting only) removed.
-    await expect(page.getByTestId(`org-people-board-row-${KENTA_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId(`org-people-board-row-${MASAKI_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId(`org-people-board-row-${YASUSHI_EMAIL}`)).toHaveCount(0);
+    // Sam (voting) + Alex (one voting seat) remain; Jordan + Taylor (non-voting only) removed.
+    await expect(page.getByTestId(`org-people-board-row-${SAM_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${ALEX_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId(`org-people-board-row-${TAYLOR_EMAIL}`)).toHaveCount(0);
   });
 
   test('sort by Foundations desc puts the most-foundations person first (US2)', async ({ page }) => {
@@ -307,8 +307,8 @@ test.describe('Org People → Board tab', () => {
     await page.getByRole('button', { name: /Foundations/i }).click();
 
     const firstRow = page.locator('[data-testid^="org-people-board-row-"]').first();
-    // Masaki holds 2 foundations — the max — so descending sort floats them to the top.
-    await expect(firstRow).toHaveAttribute('data-testid', `org-people-board-row-${MASAKI_EMAIL}`);
+    // Alex holds 2 foundations — the max — so descending sort floats them to the top.
+    await expect(firstRow).toHaveAttribute('data-testid', `org-people-board-row-${ALEX_EMAIL}`);
   });
 
   // Board rows have no personKey — drawer opens on Governance from table seats only.
@@ -322,11 +322,11 @@ test.describe('Org People → Board tab', () => {
     });
 
     await gotoBoardTab(page);
-    await page.getByTestId(`org-people-board-row-${KENSUKE_EMAIL}-name`).click();
+    await page.getByTestId(`org-people-board-row-${JORDAN_EMAIL}-name`).click();
 
     // Drawer opens with the row's header and lands on the Governance tab.
     await expect(page.getByTestId('person-detail-drawer-header')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
-    await expect(page.getByTestId('person-detail-drawer-header')).toContainText('Kensuke Hanaoka');
+    await expect(page.getByTestId('person-detail-drawer-header')).toContainText('Jordan Reyes');
     await expect(page.getByTestId('person-detail-drawer-tab-governance')).toHaveAttribute('aria-selected', 'true');
 
     // Governance renders the seat from the table (real data, not a demo pool): Board pill + foundation · committee.
@@ -339,7 +339,7 @@ test.describe('Org People → Board tab', () => {
     await expect(page.getByTestId('person-detail-drawer-detail-unavailable')).toBeVisible();
 
     // The name click stopped propagation, so the row did not also expand.
-    await expect(page.getByTestId(`org-people-board-expanded-${KENSUKE_EMAIL}`)).toHaveCount(0);
+    await expect(page.getByTestId(`org-people-board-expanded-${JORDAN_EMAIL}`)).toHaveCount(0);
     expect(personDetailCalls).toBe(0);
   });
 });

--- a/apps/lfx-one/e2e/org-people-committee-reassign.spec.ts
+++ b/apps/lfx-one/e2e/org-people-committee-reassign.spec.ts
@@ -11,11 +11,11 @@ const TOAST_TIMEOUT = 10_000;
 
 const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 const MOCK_UID = MOCK_ACCOUNT_ID;
-const MOCK_ACCOUNT_NAME = 'Toyota';
-const MOCK_ACCOUNT_SLUG = 'toyota';
+const MOCK_ACCOUNT_NAME = 'Acme Motors';
+const MOCK_ACCOUNT_SLUG = 'acme-motors';
 
-const CHIANING_EMAIL = 'johnny.wang@toyota.com';
-const REPLACEMENT_EMAIL = 'cara.dev@toyota.com';
+const MORGAN_EMAIL = 'morgan.diaz@acme-motors.example';
+const REPLACEMENT_EMAIL = 'cara.dev@acme-motors.example';
 
 function entitlementSeat(uid: string, committeeUid: string, committeeName: string) {
   return {
@@ -32,7 +32,7 @@ function entitlementSeat(uid: string, committeeUid: string, committeeName: strin
     appointedBy: 'Membership Entitlement',
     isOrgEditable: true,
     reason: null,
-    person: { email: CHIANING_EMAIL, firstName: 'Chianing', lastName: 'Wang', fullName: 'Chianing Wang', jobTitle: 'Infrastructure Architect', initials: 'CW' },
+    person: { email: MORGAN_EMAIL, firstName: 'Morgan', lastName: 'Diaz', fullName: 'Morgan Diaz', jobTitle: 'Infrastructure Architect', initials: 'MD' },
   };
 }
 
@@ -58,12 +58,12 @@ function committeeMembersResponse() {
         isOrgEditable: false,
         reason: "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
         person: {
-          email: CHIANING_EMAIL,
-          firstName: 'Chianing',
-          lastName: 'Wang',
-          fullName: 'Chianing Wang',
+          email: MORGAN_EMAIL,
+          firstName: 'Morgan',
+          lastName: 'Diaz',
+          fullName: 'Morgan Diaz',
           jobTitle: 'Infrastructure Architect',
-          initials: 'CW',
+          initials: 'MD',
         },
       },
     ],
@@ -73,7 +73,7 @@ function committeeMembersResponse() {
 
 const MOCK_EMPLOYEES = [
   { email: REPLACEMENT_EMAIL, firstName: 'Cara', lastName: 'Dev', fullName: 'Cara Dev', jobTitle: 'Senior Engineer', initials: 'CD' },
-  { email: 'evan.qa@toyota.com', firstName: 'Evan', lastName: 'QA', fullName: 'Evan QA', jobTitle: 'QA Lead', initials: 'EQ' },
+  { email: 'evan.qa@acme-motors.example', firstName: 'Evan', lastName: 'QA', fullName: 'Evan QA', jobTitle: 'QA Lead', initials: 'EQ' },
 ];
 
 function skipWhenAuthMissing(page: Page): void {
@@ -171,7 +171,7 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     await stubEmployees(page);
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
 
     const modal = page.getByTestId('org-people-committee-modal-reassign');
     await expect(modal).toBeVisible();
@@ -188,7 +188,7 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     await stubEmployees(page);
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-modal-reassign-role-checkbox-m-link').click();
     await expect(page.getByTestId('org-people-committee-modal-reassign-primary-button')).toContainText('Save Changes (2 roles)');
   });
@@ -199,7 +199,7 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     await stubEmployees(page);
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
     await expect(page.getByTestId('org-people-committee-modal-reassign-primary-button')).toBeDisabled();
   });
 
@@ -216,7 +216,7 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     });
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-committee-modal-reassign-first-name-input').fill('Cara');
     await page.getByTestId('org-people-committee-modal-reassign-last-name-input').fill('Dev');
@@ -244,7 +244,7 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     });
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-committee-modal-reassign-first-name-input').fill('Cara');
     await page.getByTestId('org-people-committee-modal-reassign-last-name-input').fill('Dev');
@@ -266,7 +266,7 @@ test.describe('Org People → Committee — Reassign Committee Roles modal (US3)
     );
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-modal-reassign-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-committee-modal-reassign-first-name-input').fill('Cara');
     await page.getByTestId('org-people-committee-modal-reassign-last-name-input').fill('Dev');
@@ -285,7 +285,7 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     await stubEmployees(page);
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-edit-m-inc').click();
 
     const modal = page.getByTestId('org-people-committee-modal-edit');
@@ -293,7 +293,7 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     await expect(page.getByTestId('org-people-committee-modal-edit-title')).toHaveText('Edit Committee Role');
     await expect(page.getByTestId('org-people-committee-modal-edit-chips')).toContainText('INC Software Working Area');
     await expect(page.getByTestId('org-people-committee-modal-edit-chips')).toContainText('Ultra Ethernet Consortium');
-    await expect(page.getByTestId('org-people-committee-modal-edit-current')).toContainText('Chianing Wang');
+    await expect(page.getByTestId('org-people-committee-modal-edit-current')).toContainText('Morgan Diaz');
   });
 
   test('Save fires exactly one PATCH and shows a success toast', async ({ page }) => {
@@ -311,7 +311,7 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     });
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-edit-m-inc').click();
     await page.getByTestId('org-people-committee-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-committee-modal-edit-first-name-input').fill('Cara');
@@ -331,7 +331,7 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     );
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-edit-m-inc').click();
     await page.getByTestId('org-people-committee-modal-edit-email-input').fill(REPLACEMENT_EMAIL);
     await page.getByTestId('org-people-committee-modal-edit-first-name-input').fill('Cara');
@@ -349,7 +349,7 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     await stubEmployees(page);
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`).click();
     await expect(page.getByTestId('org-people-committee-edit-m-tsc')).toBeDisabled();
   });
 
@@ -359,11 +359,11 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     await stubEmployees(page);
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-edit-m-inc').click();
 
     const emailInput = page.getByTestId('org-people-committee-modal-edit-email-input');
-    await emailInput.fill('toyota.com');
+    await emailInput.fill('acme-motors.example');
     await emailInput.press('ArrowDown');
 
     // The first option in the listbox is highlighted; aria-activedescendant on the input points to its id.
@@ -392,7 +392,7 @@ test.describe('Org People → Committee — Edit Committee Role modal (US4)', ()
     });
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`).click();
     await page.getByTestId('org-people-committee-edit-m-inc').click();
     await expect(page.getByTestId('org-people-committee-modal-edit')).toBeVisible();
 

--- a/apps/lfx-one/e2e/org-people-committee-tab.spec.ts
+++ b/apps/lfx-one/e2e/org-people-committee-tab.spec.ts
@@ -10,15 +10,15 @@ const DATA_LOAD_TIMEOUT = 30_000;
 
 const MOCK_ACCOUNT_ID = '0014100000Te2QjAAJ';
 const MOCK_UID = MOCK_ACCOUNT_ID;
-const MOCK_ACCOUNT_NAME = 'Toyota';
-const MOCK_ACCOUNT_SLUG = 'toyota';
+const MOCK_ACCOUNT_NAME = 'Acme Motors';
+const MOCK_ACCOUNT_SLUG = 'acme-motors';
 
 // SC-001 dev-mode budget multiplier — `ng serve` adds 3–10× per interaction vs the production build.
 const PERF_DEV_MULTIPLIER = 5;
 
-const CHIANING_EMAIL = 'johnny.wang@toyota.com';
+const MORGAN_EMAIL = 'morgan.diaz@acme-motors.example';
 
-// Three entitlement seats for Chianing Wang, all on Ultra Ethernet Consortium, plus a second person
+// Three entitlement seats for Morgan Diaz, all on Ultra Ethernet Consortium, plus a second person
 // on a different foundation so the stats tiles have concrete multi-foundation values.
 function committeeMembersResponse() {
   const uec = (uid: string, committeeUid: string, committeeName: string) => ({
@@ -35,7 +35,7 @@ function committeeMembersResponse() {
     appointedBy: 'Membership Entitlement',
     isOrgEditable: true,
     reason: null,
-    person: { email: CHIANING_EMAIL, firstName: 'Chianing', lastName: 'Wang', fullName: 'Chianing Wang', jobTitle: 'Infrastructure Architect', initials: 'CW' },
+    person: { email: MORGAN_EMAIL, firstName: 'Morgan', lastName: 'Diaz', fullName: 'Morgan Diaz', jobTitle: 'Infrastructure Architect', initials: 'MD' },
   });
   return {
     orgUid: MOCK_UID,
@@ -44,8 +44,8 @@ function committeeMembersResponse() {
       uec('m-perf', 'c-perf', 'Performance Working Group'),
       uec('m-link', 'c-link', 'Link Layer Working Group'),
       {
-        seatId: 'm-erick',
-        memberUid: 'm-erick',
+        seatId: 'm-casey',
+        memberUid: 'm-casey',
         committeeUid: 'c-tsc',
         committeeName: 'Technical Steering Committee',
         committeeCategory: 'Technical',
@@ -57,7 +57,14 @@ function committeeMembersResponse() {
         appointedBy: 'Community',
         isOrgEditable: false,
         reason: "This seat is held by foundation election or appointment, not by your organization's membership entitlement.",
-        person: { email: 'erick.mau@toyota.com', firstName: 'Erick', lastName: 'Mau', fullName: 'Erick Mau', jobTitle: 'Maintainer', initials: 'EM' },
+        person: {
+          email: 'casey.nguyen@acme-motors.example',
+          firstName: 'Casey',
+          lastName: 'Nguyen',
+          fullName: 'Casey Nguyen',
+          jobTitle: 'Maintainer',
+          initials: 'CN',
+        },
       },
     ],
     stats: { individualCount: 2, committeeCount: 4, foundationsCovered: 2 },
@@ -142,9 +149,9 @@ test.describe('Org People → Committee tab (spec 027 US1 + US2)', () => {
     console.log(`[SC-001] committee tab load → stats visible: ${elapsed} ms (prod budget 3000 ms; dev allowance ${3000 * PERF_DEV_MULTIPLIER} ms)`);
     expect(elapsed).toBeLessThan(3000 * PERF_DEV_MULTIPLIER);
 
-    // One row per person (Chianing Wang + Erick Mau).
-    await expect(page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId('org-people-committee-row-erick.mau@toyota.com')).toBeVisible();
+    // One row per person (Morgan Diaz + Casey Nguyen).
+    await expect(page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-row-casey.nguyen@acme-motors.example')).toBeVisible();
 
     // SC-004: stat tiles match the table-derived counts.
     const individuals = await page.getByTestId('org-people-committee-stat-individuals').innerText();
@@ -175,18 +182,18 @@ test.describe('Org People → Committee tab (spec 027 US1 + US2)', () => {
     await stubCommitteeMembers(page);
 
     await gotoCommitteeTab(page);
-    const pencil = page.getByTestId(`org-people-committee-reassign-${CHIANING_EMAIL}`);
+    const pencil = page.getByTestId(`org-people-committee-reassign-${MORGAN_EMAIL}`);
     await expect(pencil).toBeDisabled();
   });
 
-  test('expands Chianing Wang and shows 3 sub-rows on Ultra Ethernet Consortium (US2)', async ({ page }) => {
+  test('expands Morgan Diaz and shows 3 sub-rows on Ultra Ethernet Consortium (US2)', async ({ page }) => {
     await stubAccountContext(page);
     await stubCommitteeMembers(page);
 
     await gotoCommitteeTab(page);
-    await page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`).click();
+    await page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`).click();
 
-    const expanded = page.getByTestId(`org-people-committee-expanded-${CHIANING_EMAIL}`);
+    const expanded = page.getByTestId(`org-people-committee-expanded-${MORGAN_EMAIL}`);
     await expect(expanded).toBeVisible();
     await expect(expanded.locator('[data-testid^="org-people-committee-subrow-"]')).toHaveCount(3);
   });
@@ -198,8 +205,8 @@ test.describe('Org People → Committee tab (spec 027 US1 + US2)', () => {
     await gotoCommitteeTab(page);
     await page.getByTestId('org-people-committee-search-input').locator('input').fill('performance');
 
-    await expect(page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId('org-people-committee-row-erick.mau@toyota.com')).toHaveCount(0);
+    await expect(page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-row-casey.nguyen@acme-motors.example')).toHaveCount(0);
   });
 
   test('committee filter narrows the rows to that committee (US2)', async ({ page }) => {
@@ -211,7 +218,7 @@ test.describe('Org People → Committee tab (spec 027 US1 + US2)', () => {
     await page.getByTestId('org-people-committee-committee-filter').click();
     await page.getByRole('option', { name: 'Performance Working Group' }).click();
 
-    await expect(page.getByTestId(`org-people-committee-row-${CHIANING_EMAIL}`)).toBeVisible();
-    await expect(page.getByTestId('org-people-committee-row-erick.mau@toyota.com')).toHaveCount(0);
+    await expect(page.getByTestId(`org-people-committee-row-${MORGAN_EMAIL}`)).toBeVisible();
+    await expect(page.getByTestId('org-people-committee-row-casey.nguyen@acme-motors.example')).toHaveCount(0);
   });
 });

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -122,7 +122,7 @@ function seat(over: Record<string, unknown> = {}): never {
 
 function accessUser(over: Partial<OrgAccessUser> = {}): OrgAccessUser {
   return {
-    email: 'dqualls@linuxfoundation.org',
+    email: 'dqualls@lfx-partner.example',
     username: 'dqualls',
     name: 'Dano Qualls',
     initials: 'DQ',
@@ -182,8 +182,8 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
           lfid: '0032M00003ZzRIsQAN',
           lfUsername: 'dqualls',
           name: 'Dano Qualls',
-          email: 'dqualls@contractor.linuxfoundation.org',
-          emails: ['dqualls@contractor.linuxfoundation.org'],
+          email: 'dqualls@contractor.lfx-partner.example',
+          emails: ['dqualls@contractor.lfx-partner.example'],
           seatsCount: 3,
           boardSeatsCount: 0,
           committeeSeatsCount: 3,
@@ -197,7 +197,7 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
 
     expect(rows).toHaveLength(1);
     expect(rows[0].sources).toEqual(expect.arrayContaining(['snowflake', 'access']));
-    expect(rows[0].emails).toEqual(expect.arrayContaining(['dqualls@contractor.linuxfoundation.org', 'dqualls@linuxfoundation.org']));
+    expect(rows[0].emails).toEqual(expect.arrayContaining(['dqualls@contractor.lfx-partner.example', 'dqualls@lfx-partner.example']));
   });
 
   it('merges a committee seat into the stored row on username (the Devon case)', async () => {
@@ -243,8 +243,8 @@ describe('OrgPeopleDirectoryService.merge — access badge is server-attributed'
         storedRow({
           lfUsername: 'dqualls',
           name: 'Dano Qualls',
-          email: 'dqualls@contractor.linuxfoundation.org',
-          emails: ['dqualls@contractor.linuxfoundation.org'],
+          email: 'dqualls@contractor.lfx-partner.example',
+          emails: ['dqualls@contractor.lfx-partner.example'],
         }),
       ])
     );
@@ -280,25 +280,25 @@ describe('OrgPeopleDirectoryService.merge — access badge is server-attributed'
           personKey: 'p-dano',
           lfUsername: 'dqualls',
           name: 'Dano Qualls',
-          email: 'shared@linuxfoundation.org',
-          emails: ['shared@linuxfoundation.org'],
+          email: 'shared@lfx-partner.example',
+          emails: ['shared@lfx-partner.example'],
         }),
         storedRow({
-          personKey: 'p-jim',
-          lfUsername: 'jzemlin',
-          name: 'Jim Zemlin',
-          email: 'shared@linuxfoundation.org',
-          emails: ['shared@linuxfoundation.org'],
+          personKey: 'p-riley',
+          lfUsername: 'rfoster',
+          name: 'Riley Foster',
+          email: 'shared@lfx-partner.example',
+          emails: ['shared@lfx-partner.example'],
         }),
       ])
     );
-    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'shared@linuxfoundation.org', username: 'jzemlin', name: 'Jim Zemlin' })]);
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'shared@lfx-partner.example', username: 'rfoster', name: 'Riley Foster' })]);
 
     const { rows } = await run();
 
     const dano = rows.find((r) => r.lfUsername === 'dqualls');
-    const jim = rows.find((r) => r.lfUsername === 'jzemlin');
-    expect(jim?.accessBadge).toBe('admin');
+    const riley = rows.find((r) => r.lfUsername === 'rfoster');
+    expect(riley?.accessBadge).toBe('admin');
     expect(dano?.accessBadge).toBeUndefined();
   });
 });
@@ -312,14 +312,14 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
         storedRow({
           lfUsername: 'dqualls',
           name: 'Dano Qualls',
-          email: 'dqualls@contractor.linuxfoundation.org',
-          emails: ['dqualls@contractor.linuxfoundation.org'],
+          email: 'dqualls@contractor.lfx-partner.example',
+          emails: ['dqualls@contractor.lfx-partner.example'],
           seatsCount: 3,
           committeeSeatsCount: 3,
         }),
       ])
     );
-    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'dqualls@contractor.linuxfoundation.org', first_name: 'Dano', last_name: 'Qualls' })]);
+    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'dqualls@contractor.lfx-partner.example', first_name: 'Dano', last_name: 'Qualls' })]);
 
     const { rows } = await run();
 
@@ -367,10 +367,16 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
           personKey: 'p-a',
           lfUsername: 'dqualls',
           name: 'Dano Qualls',
-          email: 'shared@linuxfoundation.org',
-          emails: ['shared@linuxfoundation.org'],
+          email: 'shared@lfx-partner.example',
+          emails: ['shared@lfx-partner.example'],
         }),
-        storedRow({ personKey: 'p-b', lfUsername: 'jzemlin', name: 'Jim Zemlin', email: 'shared@linuxfoundation.org', emails: ['shared@linuxfoundation.org'] }),
+        storedRow({
+          personKey: 'p-b',
+          lfUsername: 'rfoster',
+          name: 'Riley Foster',
+          email: 'shared@lfx-partner.example',
+          emails: ['shared@lfx-partner.example'],
+        }),
       ])
     );
 
@@ -479,7 +485,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
 
 describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
   it('does not merge two different people who share an address', async () => {
-    // The Snowflake address→member index links dqualls@linuxfoundation.org to Jim Zemlin's member
+    // The Snowflake address→member index links dqualls@lfx-partner.example to Riley Foster's member
     // record. Two distinct usernames must never collapse, whatever their addresses say.
     getAllEmployees.mockResolvedValue(
       baseResponse([
@@ -487,15 +493,15 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
           personKey: 'p-dano',
           lfUsername: 'dqualls',
           name: 'Dano Qualls',
-          email: 'dqualls@linuxfoundation.org',
-          emails: ['dqualls@linuxfoundation.org'],
+          email: 'dqualls@lfx-partner.example',
+          emails: ['dqualls@lfx-partner.example'],
         }),
         storedRow({
-          personKey: 'p-jim',
-          lfUsername: 'jzemlin',
-          name: 'Jim Zemlin',
-          email: 'dqualls@linuxfoundation.org',
-          emails: ['dqualls@linuxfoundation.org'],
+          personKey: 'p-riley',
+          lfUsername: 'rfoster',
+          name: 'Riley Foster',
+          email: 'dqualls@lfx-partner.example',
+          emails: ['dqualls@lfx-partner.example'],
         }),
       ])
     );
@@ -503,7 +509,7 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
     const { rows } = await run();
 
     expect(rows).toHaveLength(2);
-    expect(rows.map((r) => r.lfUsername).sort()).toEqual(['dqualls', 'jzemlin']);
+    expect(rows.map((r) => r.lfUsername).sort()).toEqual(['dqualls', 'rfoster']);
   });
 
   it('does not merge an access principal into a person with a different username', async () => {
@@ -556,7 +562,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
 
   it('a pending invite is not merged into a person, even when the address matches', async () => {
     getAllEmployees.mockResolvedValue(
-      baseResponse([storedRow({ lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@linuxfoundation.org', emails: ['dqualls@linuxfoundation.org'] })])
+      baseResponse([storedRow({ lfUsername: 'dqualls', name: 'Dano Qualls', email: 'dqualls@lfx-partner.example', emails: ['dqualls@lfx-partner.example'] })])
     );
     getAccessPrincipals.mockResolvedValue([accessUser({ username: null, inviteStatus: 'pending', isPending: true })]);
 

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -76,14 +76,14 @@ function storedRow(over: Partial<OrgAllEmployeeRow> = {}): OrgAllEmployeeRow {
   return {
     personKey: 'lfnEMOUiFenugGty80',
     lfid: 'lfnEMOUiFenugGty80',
-    lfUsername: 'mcderk',
+    lfUsername: 'dclarke',
     cdpMemberId: null,
-    name: 'Kieran McDermott',
-    firstName: 'Kieran',
-    lastName: 'McDermott',
+    name: 'Devon Clarke',
+    firstName: 'Devon',
+    lastName: 'Clarke',
     title: 'VP Product',
-    email: 'kmcdermott@linuxfoundation.org',
-    emails: ['kmcdermott@linuxfoundation.org'],
+    email: 'dclarke@linuxfoundation.org',
+    emails: ['dclarke@linuxfoundation.org'],
     avatarUrl: null,
     sources: ['snowflake'],
     seatsCount: 22,
@@ -107,10 +107,10 @@ function seat(over: Record<string, unknown> = {}): never {
     committee_uid: 'c-1',
     committee_name: 'WG Identity & Trust',
     committee_category: 'Working Group',
-    first_name: 'Kieran',
-    last_name: 'McDermott',
-    email: 'kmcdermott@contractor.linuxfoundation.org',
-    username: 'mcderk',
+    first_name: 'Devon',
+    last_name: 'Clarke',
+    email: 'dclarke@contractor.linuxfoundation.org',
+    username: 'dclarke',
     role_name: 'LF Staff',
     voting_status: 'Observer',
     appointed_by: 'None',
@@ -149,15 +149,15 @@ beforeEach(() => {
 
 describe('resolveMergeKey', () => {
   it('prefers the verified identity over the address', () => {
-    expect(resolveMergeKey({ lfUsername: 'mcderk', email: 'anything@example.com' })).toBe('identity:mcderk');
+    expect(resolveMergeKey({ lfUsername: 'dclarke', email: 'anything@example.com' })).toBe('identity:dclarke');
   });
 
   it('lowercases and trims the username', () => {
-    expect(resolveMergeKey({ lfUsername: '  McDerK ' })).toBe('identity:mcderk');
+    expect(resolveMergeKey({ lfUsername: '  DClArKe ' })).toBe('identity:dclarke');
   });
 
   it('falls back to the lowercased address when no username is present', () => {
-    expect(resolveMergeKey({ lfUsername: null, email: 'Kmcdermott@LinuxFoundation.org' })).toBe('email:kmcdermott@linuxfoundation.org');
+    expect(resolveMergeKey({ lfUsername: null, email: 'Dclarke@LinuxFoundation.org' })).toBe('email:dclarke@linuxfoundation.org');
   });
 
   it('falls back when the username is blank rather than treating whitespace as an identity', () => {
@@ -200,23 +200,23 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
     expect(rows[0].emails).toEqual(expect.arrayContaining(['dqualls@contractor.linuxfoundation.org', 'dqualls@linuxfoundation.org']));
   });
 
-  it('merges a committee seat into the stored row on username (the Kieran case)', async () => {
+  it('merges a committee seat into the stored row on username (the Devon case)', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
     fetchAllOrgSeats.mockResolvedValue([seat()]);
 
     const { rows } = await run();
 
     expect(rows).toHaveLength(1);
-    expect(rows[0].emails).toEqual(expect.arrayContaining(['kmcdermott@linuxfoundation.org', 'kmcdermott@contractor.linuxfoundation.org']));
+    expect(rows[0].emails).toEqual(expect.arrayContaining(['dclarke@linuxfoundation.org', 'dclarke@contractor.linuxfoundation.org']));
   });
 
-  it('collapses a person arriving from three sources into one row (the Christopher Robinson case)', async () => {
+  it('collapses a person arriving from three sources into one row (the Jamie Ortiz case)', async () => {
     getAllEmployees.mockResolvedValue(
-      baseResponse([storedRow({ lfUsername: 'crob', name: 'Christopher Robinson', email: 'crob@intel.com', emails: ['crob@intel.com'] })])
+      baseResponse([storedRow({ lfUsername: 'jortiz', name: 'Jamie Ortiz', email: 'jortiz@vendor-corp.example', emails: ['jortiz@vendor-corp.example'] })])
     );
     fetchAllOrgSeats.mockResolvedValue([
-      seat({ email: 'christopher.robinson@intel.com', username: 'crob' }),
-      seat({ uid: 'seat-2', email: 'christopher.robinson@linuxfoundation.org', username: 'crob', committee_category: 'Board' }),
+      seat({ email: 'jamie.ortiz@vendor-corp.example', username: 'jortiz' }),
+      seat({ uid: 'seat-2', email: 'jamie.ortiz@linuxfoundation.org', username: 'jortiz', committee_category: 'Board' }),
     ]);
 
     const { rows } = await run();
@@ -330,7 +330,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
 
   it('keeps the stored counters authoritative when absorbing', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
-    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'kmcdermott@linuxfoundation.org' })]);
+    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'dclarke@linuxfoundation.org' })]);
 
     const { rows } = await run();
 
@@ -508,9 +508,9 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
 
   it('does not merge an access principal into a person with a different username', async () => {
     getAllEmployees.mockResolvedValue(
-      baseResponse([storedRow({ lfUsername: 'nickcoai', name: 'Nick Cooper', email: 'nickc@openai.com', emails: ['nickc@openai.com'] })])
+      baseResponse([storedRow({ lfUsername: 'spateloai', name: 'Sam Patel', email: 'spatel@partner-corp.example', emails: ['spatel@partner-corp.example'] })])
     );
-    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'kmcdermott@linuxfoundation.org', username: 'mcderk', name: 'Kieran McDermott' })]);
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@linuxfoundation.org', username: 'dclarke', name: 'Devon Clarke' })]);
 
     const { rows } = await run();
 
@@ -525,7 +525,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
 
     const { rows } = await run();
 
-    // Kieran: stored 22 + two live contractor seats ⇒ 22, not 24.
+    // Devon: stored 22 + two live contractor seats ⇒ 22, not 24.
     expect(rows[0].seatsCount).toBe(22);
     expect(rows[0].committeeSeatsCount).toBe(20);
     expect(rows[0].boardSeatsCount).toBe(2);
@@ -545,7 +545,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
 
   it('sources are de-duplicated and emails are lowercased and unique', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
-    fetchAllOrgSeats.mockResolvedValue([seat({ email: 'KMcDermott@LinuxFoundation.org' }), seat({ uid: 'seat-2', email: 'kmcdermott@linuxfoundation.org' })]);
+    fetchAllOrgSeats.mockResolvedValue([seat({ email: 'KClarke@LinuxFoundation.org' }), seat({ uid: 'seat-2', email: 'dclarke@linuxfoundation.org' })]);
 
     const { rows } = await run();
 
@@ -617,7 +617,7 @@ describe('OrgPeopleDirectoryService.merge — no regression for single-source pe
 describe('OrgPeopleDirectoryService.merge — stats count people, not rows (US2)', () => {
   it('counts a person who arrived from two sources exactly once', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
-    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'kmcdermott@contractor.linuxfoundation.org', username: 'mcderk', name: 'Kieran McDermott' })]);
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@contractor.linuxfoundation.org', username: 'dclarke', name: 'Devon Clarke' })]);
 
     const { rows, stats } = await run();
 

--- a/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-people-directory.service.spec.ts
@@ -82,8 +82,8 @@ function storedRow(over: Partial<OrgAllEmployeeRow> = {}): OrgAllEmployeeRow {
     firstName: 'Devon',
     lastName: 'Clarke',
     title: 'VP Product',
-    email: 'dclarke@linuxfoundation.org',
-    emails: ['dclarke@linuxfoundation.org'],
+    email: 'dclarke@lfx-partner.example',
+    emails: ['dclarke@lfx-partner.example'],
     avatarUrl: null,
     sources: ['snowflake'],
     seatsCount: 22,
@@ -109,7 +109,7 @@ function seat(over: Record<string, unknown> = {}): never {
     committee_category: 'Working Group',
     first_name: 'Devon',
     last_name: 'Clarke',
-    email: 'dclarke@contractor.linuxfoundation.org',
+    email: 'dclarke@contractor.lfx-partner.example',
     username: 'dclarke',
     role_name: 'LF Staff',
     voting_status: 'Observer',
@@ -157,7 +157,7 @@ describe('resolveMergeKey', () => {
   });
 
   it('falls back to the lowercased address when no username is present', () => {
-    expect(resolveMergeKey({ lfUsername: null, email: 'Dclarke@LinuxFoundation.org' })).toBe('email:dclarke@linuxfoundation.org');
+    expect(resolveMergeKey({ lfUsername: null, email: 'Dclarke@Lfx-Partner.Example' })).toBe('email:dclarke@lfx-partner.example');
   });
 
   it('falls back when the username is blank rather than treating whitespace as an identity', () => {
@@ -207,7 +207,7 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
     const { rows } = await run();
 
     expect(rows).toHaveLength(1);
-    expect(rows[0].emails).toEqual(expect.arrayContaining(['dclarke@linuxfoundation.org', 'dclarke@contractor.linuxfoundation.org']));
+    expect(rows[0].emails).toEqual(expect.arrayContaining(['dclarke@lfx-partner.example', 'dclarke@contractor.lfx-partner.example']));
   });
 
   it('collapses a person arriving from three sources into one row (the Jamie Ortiz case)', async () => {
@@ -216,7 +216,7 @@ describe('OrgPeopleDirectoryService.merge — identity matching (US1)', () => {
     );
     fetchAllOrgSeats.mockResolvedValue([
       seat({ email: 'jamie.ortiz@vendor-corp.example', username: 'jortiz' }),
-      seat({ uid: 'seat-2', email: 'jamie.ortiz@linuxfoundation.org', username: 'jortiz', committee_category: 'Board' }),
+      seat({ uid: 'seat-2', email: 'jamie.ortiz@lfx-partner.example', username: 'jortiz', committee_category: 'Board' }),
     ]);
 
     const { rows } = await run();
@@ -330,7 +330,7 @@ describe('OrgPeopleDirectoryService.merge — identity-less rows fold into the i
 
   it('keeps the stored counters authoritative when absorbing', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
-    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'dclarke@linuxfoundation.org' })]);
+    fetchAllOrgSeats.mockResolvedValue([seat({ username: null, email: 'dclarke@lfx-partner.example' })]);
 
     const { rows } = await run();
 
@@ -510,7 +510,7 @@ describe('OrgPeopleDirectoryService.merge — false-merge protection', () => {
     getAllEmployees.mockResolvedValue(
       baseResponse([storedRow({ lfUsername: 'spateloai', name: 'Sam Patel', email: 'spatel@partner-corp.example', emails: ['spatel@partner-corp.example'] })])
     );
-    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@linuxfoundation.org', username: 'dclarke', name: 'Devon Clarke' })]);
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@lfx-partner.example', username: 'dclarke', name: 'Devon Clarke' })]);
 
     const { rows } = await run();
 
@@ -545,7 +545,7 @@ describe('OrgPeopleDirectoryService.merge — invariants', () => {
 
   it('sources are de-duplicated and emails are lowercased and unique', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
-    fetchAllOrgSeats.mockResolvedValue([seat({ email: 'KClarke@LinuxFoundation.org' }), seat({ uid: 'seat-2', email: 'dclarke@linuxfoundation.org' })]);
+    fetchAllOrgSeats.mockResolvedValue([seat({ email: 'DClarke@Lfx-Partner.Example' }), seat({ uid: 'seat-2', email: 'dclarke@lfx-partner.example' })]);
 
     const { rows } = await run();
 
@@ -617,7 +617,7 @@ describe('OrgPeopleDirectoryService.merge — no regression for single-source pe
 describe('OrgPeopleDirectoryService.merge — stats count people, not rows (US2)', () => {
   it('counts a person who arrived from two sources exactly once', async () => {
     getAllEmployees.mockResolvedValue(baseResponse([storedRow()]));
-    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@contractor.linuxfoundation.org', username: 'dclarke', name: 'Devon Clarke' })]);
+    getAccessPrincipals.mockResolvedValue([accessUser({ email: 'dclarke@contractor.lfx-partner.example', username: 'dclarke', name: 'Devon Clarke' })]);
 
     const { rows, stats } = await run();
 

--- a/check-fixture-emails.sh
+++ b/check-fixture-emails.sh
@@ -29,8 +29,7 @@ denylist_pattern=$(printf '%s\n' "${denylisted_domains[@]}" | sed 's/\./\\./g' |
 violations=""
 
 for file in ${staged_files}; do
-  [ -f "${file}" ] || continue
-  matches=$(grep -EHn "@(${denylist_pattern})" "${file}")
+  matches=$(git show ":${file}" | grep -Ein "@(${denylist_pattern})" | sed "s|^|${file}:|")
   if [ -n "${matches}" ]; then
     violations="${violations}${matches}
 "

--- a/check-fixture-emails.sh
+++ b/check-fixture-emails.sh
@@ -3,15 +3,23 @@
 # Copyright The Linux Foundation and each contributor to LFX.
 # SPDX-License-Identifier: MIT
 
-# Flags emails from known real customer/vendor domains in staged test/fixture files.
+# Flags emails from known real customer/vendor domains introduced by a change to test/fixture files.
 # Test fixtures should use synthetic data (e.g. acme-motors.example, vendor-corp.example),
-# never real customer or personal emails. Scoped to staged files only — the repo already
-# has many pre-existing, harmless placeholder domains (acme.io, x.org, corp.com, ...) that
-# an allowlist-based whole-repo scan would flag as false positives.
+# never real customer or personal emails. Scoped to *added* lines only — the repo already has
+# pre-existing, harmless placeholder domains (acme.io, x.org, corp.com, ...) that a whole-file
+# scan would flag as false positives, and scanning the whole staged blob (rather than just what
+# changed) would also permanently block any future edit to a file that happens to contain an
+# old, already-fixed match elsewhere.
+#
+# Two modes:
+#   Local pre-commit (no args): diffs the git index (git diff --cached) for staged fixture files.
+#   CI (pass a base ref, e.g. "origin/main"): diffs that ref against HEAD — CI has no staged index.
 #
 # Add a domain here whenever a real-PII incident surfaces one (see GH-1674).
-# Exits 0 if no denylisted domain appears in staged changes.
+# Exits 0 if no denylisted domain appears in added lines.
 # Exits 1 and prints the offending file:line matches otherwise.
+
+base_ref="${1:-}"
 
 # Intentionally real domains — these ARE the blocklist, sourced from incidents (GH-1674). Do not "scrub" them.
 denylisted_domains=(
@@ -22,28 +30,44 @@ denylisted_domains=(
   contractor.linuxfoundation.org
 )
 
-staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(spec\.ts|fixture\.ts|ndjson)$')
+denylist_pattern=$(printf '%s\n' "${denylisted_domains[@]}" | sed 's/\./\\./g' | paste -sd '|' -)
 
-if [ -z "${staged_files}" ]; then
+# -M/-C detect renames/copies, but --diff-filter=ACMR still needs R explicit alongside them so a
+# rename-with-edits (which git may classify as R rather than M) isn't skipped from the file list.
+if [ -n "${base_ref}" ]; then
+  diff_args=(-M -C --diff-filter=ACMR "${base_ref}...HEAD")
+else
+  diff_args=(-M -C --diff-filter=ACMR --cached)
+fi
+
+changed_files=$(git diff "${diff_args[@]}" --name-only | grep -E '\.(spec\.ts|fixture\.ts|ndjson)$')
+
+if [ -z "${changed_files}" ]; then
   exit 0
 fi
 
-denylist_pattern=$(printf '%s\n' "${denylisted_domains[@]}" | sed 's/\./\\./g' | paste -sd '|' -)
 violations=""
 
 # Exact-domain match by design (covers @toyota.com, not @sub.toyota.com) — the denylist
 # is seeded from specific incidents, not meant as a comprehensive domain blocklist.
+# Only scans lines *added* by this change (unified diff "+" lines, header lines excluded) so
+# pre-existing matches elsewhere in an untouched file never block an unrelated edit.
 while IFS= read -r file; do
   [ -n "${file}" ] || continue
-  matches=$(git show ":${file}" | grep -Ein "@(${denylist_pattern})" | sed "s|^|${file}:|")
+  matches=$(
+    git diff "${diff_args[@]}" -U0 -- "${file}" |
+      grep -E '^[+]' | grep -v '^[+][+][+]' |
+      grep -Ein "@(${denylist_pattern})" |
+      sed "s|^|${file}: |"
+  )
   if [ -n "${matches}" ]; then
     violations="${violations}${matches}
 "
   fi
-done <<< "${staged_files}"
+done <<< "${changed_files}"
 
 if [ -n "${violations}" ]; then
-  echo "❌ Found email address(es) using a known real customer/vendor domain in staged test/fixture files:"
+  echo "❌ Found email address(es) using a known real customer/vendor domain in added lines of test/fixture files:"
   echo "${violations}"
   echo ""
   echo "Test fixtures must use synthetic data, not real customer or personal emails."

--- a/check-fixture-emails.sh
+++ b/check-fixture-emails.sh
@@ -13,10 +13,13 @@
 # Exits 0 if no denylisted domain appears in staged changes.
 # Exits 1 and prints the offending file:line matches otherwise.
 
+# Intentionally real domains — these ARE the blocklist, sourced from incidents (GH-1674). Do not "scrub" them.
 denylisted_domains=(
   toyota.com
   intel.com
   openai.com
+  linuxfoundation.org
+  contractor.linuxfoundation.org
 )
 
 staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(spec\.ts|fixture\.ts|ndjson)$')
@@ -28,13 +31,16 @@ fi
 denylist_pattern=$(printf '%s\n' "${denylisted_domains[@]}" | sed 's/\./\\./g' | paste -sd '|' -)
 violations=""
 
-for file in ${staged_files}; do
+# Exact-domain match by design (covers @toyota.com, not @sub.toyota.com) — the denylist
+# is seeded from specific incidents, not meant as a comprehensive domain blocklist.
+while IFS= read -r file; do
+  [ -n "${file}" ] || continue
   matches=$(git show ":${file}" | grep -Ein "@(${denylist_pattern})" | sed "s|^|${file}:|")
   if [ -n "${matches}" ]; then
     violations="${violations}${matches}
 "
   fi
-done
+done <<< "${staged_files}"
 
 if [ -n "${violations}" ]; then
   echo "❌ Found email address(es) using a known real customer/vendor domain in staged test/fixture files:"

--- a/check-fixture-emails.sh
+++ b/check-fixture-emails.sh
@@ -32,12 +32,16 @@ denylisted_domains=(
 
 denylist_pattern=$(printf '%s\n' "${denylisted_domains[@]}" | sed 's/\./\\./g' | paste -sd '|' -)
 
-# -M/-C detect renames/copies, but --diff-filter=ACMR still needs R explicit alongside them so a
-# rename-with-edits (which git may classify as R rather than M) isn't skipped from the file list.
+# -M detects renames (--diff-filter=ACMR still needs R explicit alongside it so a rename-with-edits,
+# which git may classify as R rather than M, isn't skipped from the file list). Deliberately NOT
+# passing -C (copy detection): a new fixture git considers a "copy" of an existing file is shown
+# with only its edited lines as a diff hunk — any denylisted email copied unchanged would never
+# appear as an added "+" line and would slip past the added-lines-only scan below. Without -C, a
+# new file is classified as a plain add and its full content shows up as added lines instead.
 if [ -n "${base_ref}" ]; then
-  diff_args=(-M -C --diff-filter=ACMR "${base_ref}...HEAD")
+  diff_args=(-M --diff-filter=ACMR "${base_ref}...HEAD")
 else
-  diff_args=(-M -C --diff-filter=ACMR --cached)
+  diff_args=(-M --diff-filter=ACMR --cached)
 fi
 
 changed_files=$(git diff "${diff_args[@]}" --name-only | grep -E '\.(spec\.ts|fixture\.ts|ndjson)$')

--- a/check-fixture-emails.sh
+++ b/check-fixture-emails.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Copyright The Linux Foundation and each contributor to LFX.
+# SPDX-License-Identifier: MIT
+
+# Flags emails from known real customer/vendor domains in staged test/fixture files.
+# Test fixtures should use synthetic data (e.g. acme-motors.example, vendor-corp.example),
+# never real customer or personal emails. Scoped to staged files only — the repo already
+# has many pre-existing, harmless placeholder domains (acme.io, x.org, corp.com, ...) that
+# an allowlist-based whole-repo scan would flag as false positives.
+#
+# Add a domain here whenever a real-PII incident surfaces one (see GH-1674).
+# Exits 0 if no denylisted domain appears in staged changes.
+# Exits 1 and prints the offending file:line matches otherwise.
+
+denylisted_domains=(
+  toyota.com
+  intel.com
+  openai.com
+)
+
+staged_files=$(git diff --cached --name-only --diff-filter=ACM | grep -E '\.(spec\.ts|fixture\.ts|ndjson)$')
+
+if [ -z "${staged_files}" ]; then
+  exit 0
+fi
+
+denylist_pattern=$(printf '%s\n' "${denylisted_domains[@]}" | sed 's/\./\\./g' | paste -sd '|' -)
+violations=""
+
+for file in ${staged_files}; do
+  [ -f "${file}" ] || continue
+  matches=$(grep -EHn "@(${denylist_pattern})" "${file}")
+  if [ -n "${matches}" ]; then
+    violations="${violations}${matches}
+"
+  fi
+done
+
+if [ -n "${violations}" ]; then
+  echo "❌ Found email address(es) using a known real customer/vendor domain in staged test/fixture files:"
+  echo "${violations}"
+  echo ""
+  echo "Test fixtures must use synthetic data, not real customer or personal emails."
+  echo "Use a reserved example domain instead (e.g. acme-motors.example, vendor-corp.example)."
+  exit 1
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Replaces real Toyota employee names/emails (and a few unrelated real individuals' names/emails) hardcoded in org-people e2e specs and one unit test spec with synthetic placeholders (e.g. `acme-motors.example`, `vendor-corp.example`), keeping variable/function names, seat IDs, and test descriptions internally consistent with the new synthetic identities.
- Adds `check-fixture-emails.sh`, a pre-commit safeguard (wired into `.husky/pre-commit`) that blocks staged `*.spec.ts`/`*.fixture.ts`/`*.ndjson` files containing an email from a small denylist of known real customer/vendor domains (seeded from this incident).
- Documents the fixture-data policy in `.claude/rules/development-rules.md`.

Closes #1674

## Test plan
- [x] `yarn check-types` passes
- [x] `yarn lint:check` passes (no new issues)
- [x] `yarn format:check` passes
- [x] `yarn build` passes (SSR bundle)
- [x] `yarn workspace lfx-one-ui exec vitest run src/server/services/org-people-directory.service.spec.ts` — all 36 tests pass
- [x] Repo-wide grep confirms no remaining real PII strings (names/emails/domains) from the reported incident
- [x] `check-fixture-emails.sh` verified against both a known-bad case (denylisted domain) and the redacted fixtures (clean)
- [ ] Playwright e2e suite for the 5 edited spec files not run in this environment (no live browser/auth setup) — recommend running `yarn e2e` for these files in CI/review