### PR TITLE
docs(user): refresh me-lens articles to match current UI

### DIFF
--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -4,7 +4,6 @@ description: View your signed Individual and Employee CLAs in LFX Self Serve, an
 audience: [all]
 product_area: Account
 tags: [account, cla, easycla, icla, ecla, identities]
-last_generated: 2026-08-04
 last_updated: 2026-08-11
 intercom_collection: Account
 ---

--- a/docs/user/account/transactions/index.md
+++ b/docs/user/account/transactions/index.md
@@ -4,7 +4,7 @@ description: View your billing and purchase history in LFX Self Serve.
 audience: [all]
 product_area: Account
 tags: [account, transactions, billing, purchases, history, receipts]
-last_updated: 2026-08-11
+last_updated: 2026-08-19
 intercom_collection: Account
 ---
 
@@ -39,7 +39,7 @@ All authenticated users can view their own transactions. Each user sees only the
 
 ### Empty state
 
-If you have no transactions, the page shows a message indicating no purchase history is available. Transactions are recorded only when you make a purchase through the LFX platform.
+If you have no transactions, the page shows the message "No transactions found. Recent purchases may take up to 48 hours to appear." Transactions are recorded only when you make a purchase through the LFX platform.
 
 ## Your company's activity
 

--- a/docs/user/badges/faq/index.md
+++ b/docs/user/badges/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about LFX badges.
 audience: [all]
 product_area: Badges
 tags: [badges, faq, credentials]
-last_generated: 2026-05-22
 last_updated: 2026-08-17
 intercom_collection: Badges
 ---

--- a/docs/user/badges/index.md
+++ b/docs/user/badges/index.md
@@ -4,7 +4,6 @@ description: View and manage the LFX credentialing badges you have earned across
 audience: [all]
 product_area: Badges
 tags: [badges, credentials, achievements, certifications]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Badges
 ---

--- a/docs/user/badges/view-your-badges/index.md
+++ b/docs/user/badges/view-your-badges/index.md
@@ -4,7 +4,6 @@ description: How to find and view your LFX credentialing badges.
 audience: [all]
 product_area: Badges
 tags: [badges, credentials, view]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Badges
 ---

--- a/docs/user/committees/create-committee/index.md
+++ b/docs/user/committees/create-committee/index.md
@@ -4,7 +4,6 @@ description: How to create a new committee for your project in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Committees
 tags: [committees, create, governance]
-last_generated: 2026-05-22
 last_updated: 2026-08-19
 intercom_collection: Committees
 ---

--- a/docs/user/committees/create-committee/index.md
+++ b/docs/user/committees/create-committee/index.md
@@ -5,7 +5,7 @@ audience: [maintainer, board-member, executive-director]
 product_area: Committees
 tags: [committees, create, governance]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-19
 intercom_collection: Committees
 ---
 
@@ -19,7 +19,7 @@ Make sure you have the correct project or foundation selected in the lens switch
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Select **Groups** from the left navigation sidebar.
-3. Select the option to create a new committee (route: `/groups/manage`).
+3. Select the option to create a new committee (route: `/groups/create`).
 4. Fill in the required fields:
    - **Committee name** — the display name for your committee
    - **Description** — a brief explanation of the committee's purpose and scope

--- a/docs/user/committees/create-committee/index.md
+++ b/docs/user/committees/create-committee/index.md
@@ -12,14 +12,14 @@ This article applies to users with **maintainer**, **board-member**, or **execut
 
 ## Before you begin
 
-Make sure you have the correct project or foundation selected in the lens switcher. The new committee will be associated with the currently active project context.
+Make sure you have the correct project or foundation selected in the lens switcher. The new committee will be associated with the currently active project or foundation context.
 
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
 2. Switch to your **Project** or **Foundation** lens using the lens switcher — creating a group isn't available in the **Me** lens.
 3. Select **Groups** from the left navigation sidebar.
-4. Select the option to create a new committee (route: `/groups/create`).
+4. Select the option to create a new committee (route: `/project/groups/create` or `/foundation/groups/create`).
 5. Fill in the required fields:
    - **Group name** — the display name for your committee
    - **Description** — a brief explanation of the committee's purpose and scope

--- a/docs/user/committees/create-committee/index.md
+++ b/docs/user/committees/create-committee/index.md
@@ -17,13 +17,14 @@ Make sure you have the correct project or foundation selected in the lens switch
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
-2. Select **Groups** from the left navigation sidebar.
-3. Select the option to create a new committee (route: `/groups/create`).
-4. Fill in the required fields:
-   - **Committee name** — the display name for your committee
+2. Switch to your **Project** or **Foundation** lens using the lens switcher — creating a group isn't available in the **Me** lens.
+3. Select **Groups** from the left navigation sidebar.
+4. Select the option to create a new committee (route: `/groups/create`).
+5. Fill in the required fields:
+   - **Group name** — the display name for your committee
    - **Description** — a brief explanation of the committee's purpose and scope
-5. Add initial members if needed.
-6. Save the committee.
+6. Add initial members if needed.
+7. Save the committee.
 
 ## After creation
 

--- a/docs/user/committees/faq/index.md
+++ b/docs/user/committees/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about committees in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Committees
 tags: [committees, faq, governance]
-last_generated: 2026-05-22
 last_updated: 2026-08-17
 intercom_collection: Committees
 ---

--- a/docs/user/committees/index.md
+++ b/docs/user/committees/index.md
@@ -4,7 +4,6 @@ description: View, create, and manage project committees (groups) in LFX Self Se
 audience: [maintainer, board-member, executive-director]
 product_area: Committees
 tags: [committees, groups, governance, membership, management]
-last_generated: 2026-05-22
 last_updated: 2026-05-23
 intercom_collection: Committees
 ---

--- a/docs/user/committees/manage-committees/index.md
+++ b/docs/user/committees/manage-committees/index.md
@@ -4,7 +4,6 @@ description: How to view and manage project committees in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Committees
 tags: [committees, manage, members, governance]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Committees
 ---

--- a/docs/user/crowdfunding/faq/index.md
+++ b/docs/user/crowdfunding/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about crowdfunding initiatives and donat
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, faq, initiatives, donations, recurring, refunds]
-last_generated: 2026-06-29
 last_updated: 2026-08-17
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/index.md
+++ b/docs/user/crowdfunding/index.md
@@ -4,7 +4,6 @@ description: Manage your crowdfunding initiatives and track your donations in LF
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, initiatives, donations, funding, sponsors]
-last_generated: 2026-06-16
 last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/manage-initiatives/index.md
+++ b/docs/user/crowdfunding/manage-initiatives/index.md
@@ -4,7 +4,6 @@ description: How to view initiative details, edit settings, and archive or activ
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, initiatives, manage, edit, archive, activate]
-last_generated: 2026-06-16
 last_updated: 2026-07-21
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/manage-payment-methods/index.md
+++ b/docs/user/crowdfunding/manage-payment-methods/index.md
@@ -4,7 +4,6 @@ description: How to add and remove saved payment methods for crowdfunding donati
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, payment methods, add, delete, credit card]
-last_generated: 2026-06-16
 last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/manage-recurring-donations/index.md
+++ b/docs/user/crowdfunding/manage-recurring-donations/index.md
@@ -4,7 +4,6 @@ description: How to view recurring donation details and cancel a recurring subsc
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, recurring donations, cancel, subscription, manage]
-last_generated: 2026-06-16
 last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/my-donations/index.md
+++ b/docs/user/crowdfunding/my-donations/index.md
@@ -4,7 +4,6 @@ description: View your donation history, manage payment methods, and manage recu
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, donations, recurring, payment methods, history]
-last_generated: 2026-06-16
 last_updated: 2026-06-16
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/my-initiatives/index.md
+++ b/docs/user/crowdfunding/my-initiatives/index.md
@@ -4,7 +4,6 @@ description: View and manage the crowdfunding initiatives you have created in LF
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, initiatives, manage, funding]
-last_generated: 2026-06-16
 last_updated: 2026-06-16
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/view-donations/index.md
+++ b/docs/user/crowdfunding/view-donations/index.md
@@ -4,7 +4,6 @@ description: How to view your donation history, stats, and recurring donations i
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, donations, view, history, recurring, one-time]
-last_generated: 2026-06-16
 last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/crowdfunding/view-initiatives/index.md
+++ b/docs/user/crowdfunding/view-initiatives/index.md
@@ -4,7 +4,6 @@ description: How to view and filter your crowdfunding initiatives by status in L
 audience: [all]
 product_area: Crowdfunding
 tags: [crowdfunding, initiatives, view, status, list]
-last_generated: 2026-06-16
 last_updated: 2026-06-29
 intercom_collection: Crowdfunding
 ---

--- a/docs/user/dashboards/faq/index.md
+++ b/docs/user/dashboards/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about navigating the LFX Self Serve dash
 audience: [all]
 product_area: Dashboards
 tags: [dashboard, faq, lens, persona]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Dashboards
 ---

--- a/docs/user/dashboards/index.md
+++ b/docs/user/dashboards/index.md
@@ -4,7 +4,6 @@ description: The LFX Self Serve dashboard provides a lens-based overview of your
 audience: [all]
 product_area: Dashboards
 tags: [dashboard, overview, lens, persona, me, foundation, project, org]
-last_generated: 2026-05-22
 last_updated: 2026-06-22
 intercom_collection: Dashboards
 ---

--- a/docs/user/dashboards/navigate-dashboards/index.md
+++ b/docs/user/dashboards/navigate-dashboards/index.md
@@ -4,7 +4,6 @@ description: How to switch lenses and use the LFX Self Serve dashboard effective
 audience: [all]
 product_area: Dashboards
 tags: [dashboard, lens, navigation, persona]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Dashboards
 ---

--- a/docs/user/documents/faq/index.md
+++ b/docs/user/documents/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about project documents in LFX Self Serv
 audience: [maintainer, board-member, executive-director]
 product_area: Documents
 tags: [documents, faq]
-last_generated: 2026-05-22
 last_updated: 2026-08-17
 intercom_collection: Documents
 ---

--- a/docs/user/documents/index.md
+++ b/docs/user/documents/index.md
@@ -4,7 +4,6 @@ description: Browse and manage project documents in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Documents
 tags: [documents, files, governance, project]
-last_generated: 2026-05-22
 last_updated: 2026-05-23
 intercom_collection: Documents
 ---

--- a/docs/user/documents/manage-documents/index.md
+++ b/docs/user/documents/manage-documents/index.md
@@ -4,7 +4,6 @@ description: How to browse and manage project documents in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Documents
 tags: [documents, manage, browse]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Documents
 ---

--- a/docs/user/events/browse-events/index.md
+++ b/docs/user/events/browse-events/index.md
@@ -4,7 +4,6 @@ description: How to find and view LFX events in LFX Self Serve.
 audience: [all]
 product_area: Events
 tags: [events, browse, attendance]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Events
 ---

--- a/docs/user/events/faq/index.md
+++ b/docs/user/events/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about LFX events.
 audience: [all]
 product_area: Events
 tags: [events, faq, attendance]
-last_generated: 2026-05-22
 last_updated: 2026-08-17
 intercom_collection: Events
 ---

--- a/docs/user/events/index.md
+++ b/docs/user/events/index.md
@@ -4,7 +4,6 @@ description: Browse LFX events and manage your attendance in LFX Self Serve.
 audience: [all]
 product_area: Events
 tags: [events, attendance, conferences, browse]
-last_generated: 2026-05-22
 last_updated: 2026-06-22
 intercom_collection: Events
 ---

--- a/docs/user/mailing-lists/create-mailing-list/index.md
+++ b/docs/user/mailing-lists/create-mailing-list/index.md
@@ -4,7 +4,6 @@ description: How to create a new mailing list for your project in LFX Self Serve
 audience: [maintainer, board-member, executive-director]
 product_area: Mailing Lists
 tags: [mailing-lists, create, setup]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Mailing Lists
 ---

--- a/docs/user/mailing-lists/faq/index.md
+++ b/docs/user/mailing-lists/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about mailing lists in LFX Self Serve.
 audience: [all]
 product_area: Mailing Lists
 tags: [mailing-lists, faq, subscribe]
-last_generated: 2026-05-22
 last_updated: 2026-08-17
 intercom_collection: Mailing Lists
 ---

--- a/docs/user/mailing-lists/index.md
+++ b/docs/user/mailing-lists/index.md
@@ -4,7 +4,6 @@ description: Subscribe, unsubscribe, and manage mailing lists for your Linux Fou
 audience: [all]
 product_area: Mailing Lists
 tags: [mailing-lists, email, subscribe, groups, communication]
-last_generated: 2026-05-22
 last_updated: 2026-05-23
 intercom_collection: Mailing Lists
 ---

--- a/docs/user/mailing-lists/manage-mailing-lists/index.md
+++ b/docs/user/mailing-lists/manage-mailing-lists/index.md
@@ -4,7 +4,6 @@ description: How to subscribe, unsubscribe, and manage mailing lists in LFX Self
 audience: [all]
 product_area: Mailing Lists
 tags: [mailing-lists, subscribe, manage]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Mailing Lists
 ---

--- a/docs/user/meetings/faq/index.md
+++ b/docs/user/meetings/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about meetings in LFX Self Serve.
 audience: [all]
 product_area: Meetings
 tags: [meetings, faq, schedule, join]
-last_generated: 2026-05-22
 last_updated: 2026-08-10
 intercom_collection: Meetings
 ---

--- a/docs/user/meetings/index.md
+++ b/docs/user/meetings/index.md
@@ -4,7 +4,6 @@ description: Schedule, manage, and join project meetings with calendar integrati
 audience: [all]
 product_area: Meetings
 tags: [meetings, schedule, calendar, join, zoom, virtual]
-last_generated: 2026-05-22
 last_updated: 2026-08-10
 intercom_collection: Meetings
 ---

--- a/docs/user/meetings/join-meeting/index.md
+++ b/docs/user/meetings/join-meeting/index.md
@@ -4,7 +4,6 @@ description: How to join a project meeting via the public LFX meeting link.
 audience: [all]
 product_area: Meetings
 tags: [meetings, join, public, attendee]
-last_generated: 2026-05-22
 last_updated: 2026-08-10
 intercom_collection: Meetings
 ---

--- a/docs/user/meetings/manage-meetings/index.md
+++ b/docs/user/meetings/manage-meetings/index.md
@@ -3,7 +3,6 @@ title: Manage Meetings
 description: How to edit, update, and cancel project meetings in LFX Self Serve.
 product_area: Meetings
 tags: [meetings, manage, edit, cancel]
-last_generated: 2026-05-22
 last_updated: 2026-08-19
 intercom_collection: Meetings
 ---

--- a/docs/user/meetings/manage-meetings/index.md
+++ b/docs/user/meetings/manage-meetings/index.md
@@ -4,7 +4,7 @@ description: How to edit, update, and cancel project meetings in LFX Self Serve.
 product_area: Meetings
 tags: [meetings, manage, edit, cancel]
 last_generated: 2026-05-22
-last_updated: 2026-08-10
+last_updated: 2026-08-19
 intercom_collection: Meetings
 ---
 
@@ -21,7 +21,7 @@ This article applies to users with **maintainer**, **board-member**, or **execut
 
 Select the edit (pencil) icon on a meeting you organize, or open the meeting's detail view and choose to edit it. Editing is only available for upcoming meetings. You can update the title, date, time, agenda, recurrence pattern, and platform/feature settings.
 
-For a meeting that's part of a recurring series, an edit currently applies only to that single occurrence — there's no option to apply it to the whole series or to future occurrences. This is separate from the delete/cancel scope below, which does let you act on the whole series.
+For a meeting that's part of a recurring series, you'll be asked what to edit: **Edit only this occurrence** (changes apply to just that meeting instance) or **Edit this and all future occurrences** (changes apply to this meeting and all later meetings in the series).
 
 ## Manage guests and registrants
 

--- a/docs/user/meetings/manage-meetings/index.md
+++ b/docs/user/meetings/manage-meetings/index.md
@@ -20,7 +20,7 @@ This article applies to users with **maintainer**, **board-member**, or **execut
 
 Select the edit (pencil) icon on a meeting you organize, or open the meeting's detail view and choose to edit it. Editing is only available for upcoming meetings. You can update the title, date, time, agenda, recurrence pattern, and platform/feature settings.
 
-For a meeting that's part of a recurring series, you'll be asked what to edit: **Edit only this occurrence** (changes apply to just that meeting instance) or **Edit this and all future occurrences** (changes apply to this meeting and all later meetings in the series).
+For a meeting that's part of a recurring series, an edit currently applies only to that single occurrence — there's no option to apply it to the whole series or to future occurrences. This is separate from the delete/cancel scope below, which does let you act on the whole series.
 
 ## Manage guests and registrants
 

--- a/docs/user/meetings/schedule-meeting/index.md
+++ b/docs/user/meetings/schedule-meeting/index.md
@@ -3,7 +3,6 @@ title: Schedule a Meeting
 description: How to create a new project meeting in LFX Self Serve.
 product_area: Meetings
 tags: [meetings, schedule, create, calendar]
-last_generated: 2026-05-22
 last_updated: 2026-08-10
 intercom_collection: Meetings
 ---

--- a/docs/user/profile/edit-profile/index.md
+++ b/docs/user/profile/edit-profile/index.md
@@ -4,7 +4,6 @@ description: How to update your personal information, photo, location, and conta
 audience: [all]
 product_area: Profile
 tags: [profile, edit, about-me, bio, photo, location]
-last_generated: 2026-05-22
 last_updated: 2026-08-12
 intercom_collection: Profile
 ---

--- a/docs/user/profile/faq/index.md
+++ b/docs/user/profile/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about your personal profile and public p
 audience: [all]
 product_area: Profile
 tags: [profile, faq, about-me, photo, public-profile, visibility]
-last_generated: 2026-05-22
 last_updated: 2026-08-17
 intercom_collection: Profile
 ---

--- a/docs/user/profile/index.md
+++ b/docs/user/profile/index.md
@@ -4,7 +4,6 @@ description: Manage your personal identity in LFX Self Serve — name, photo, Ab
 audience: [all]
 product_area: Profile
 tags: [profile, edit, about-me, photo, public-profile, visibility]
-last_generated: 2026-05-22
 last_updated: 2026-08-11
 intercom_collection: Profile
 ---

--- a/docs/user/surveys/create-survey/index.md
+++ b/docs/user/surveys/create-survey/index.md
@@ -4,7 +4,6 @@ description: How to create a new survey for your project in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Surveys
 tags: [surveys, create, nps, feedback]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Surveys
 ---

--- a/docs/user/surveys/faq/index.md
+++ b/docs/user/surveys/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about surveys in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Surveys
 tags: [surveys, faq, nps, feedback]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Surveys
 ---

--- a/docs/user/surveys/index.md
+++ b/docs/user/surveys/index.md
@@ -4,7 +4,6 @@ description: Create surveys, collect responses, and view NPS analytics in LFX Se
 audience: [maintainer, board-member, executive-director]
 product_area: Surveys
 tags: [surveys, nps, feedback, analytics, governance]
-last_generated: 2026-05-22
 last_updated: 2026-05-23
 intercom_collection: Surveys
 ---

--- a/docs/user/surveys/manage-surveys/index.md
+++ b/docs/user/surveys/manage-surveys/index.md
@@ -4,7 +4,6 @@ description: How to view, edit, and analyze surveys in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Surveys
 tags: [surveys, manage, responses, nps, analytics]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Surveys
 ---

--- a/docs/user/trainings/faq/index.md
+++ b/docs/user/trainings/faq/index.md
@@ -15,7 +15,7 @@ Use <https://training.linuxfoundation.org/about/contact-us/>
 
 ## How do I enroll in a training course?
 
-Enrollment is handled on the Linux Foundation training platform ([training.linuxfoundation.org](https://training.linuxfoundation.org)). LFX Self Serve shows your enrolled courses in read-only view. Go to the **Useful links** tab on the Training & Certifications page and select **LF Training Portal** to access the training catalog.
+Enrollment is handled on the Linux Foundation training platform ([training.linuxfoundation.org](https://training.linuxfoundation.org)). LFX Self Serve shows your enrolled courses in read-only view. In the **Useful links** section (right sidebar) on the Training & Certifications page, select **LF Training Portal** to access the training catalog.
 
 ## Why don't I see a training I enrolled in?
 
@@ -45,4 +45,4 @@ Open the **Rewards** tab on the Training & Certifications page. In the **My Coup
 
 ## Where can I find a list of available training courses?
 
-Visit the Linux Foundation training catalog at [https://training.linuxfoundation.org](https://training.linuxfoundation.org). You can also use the **LF Training Portal** link on the **Useful links** tab of the Training & Certifications page.
+Visit the Linux Foundation training catalog at [https://training.linuxfoundation.org](https://training.linuxfoundation.org). You can also use the **LF Training Portal** link in the **Useful links** section (right sidebar) of the Training & Certifications page.

--- a/docs/user/trainings/faq/index.md
+++ b/docs/user/trainings/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about training enrollments in LFX Self S
 audience: [all]
 product_area: Trainings
 tags: [trainings, faq, certifications, enrollments]
-last_generated: 2026-05-22
 last_updated: 2026-08-19
 intercom_collection: Trainings
 ---

--- a/docs/user/trainings/faq/index.md
+++ b/docs/user/trainings/faq/index.md
@@ -14,7 +14,7 @@ Use <https://training.linuxfoundation.org/about/contact-us/>
 
 ## How do I enroll in a training course?
 
-Enrollment is handled on the Linux Foundation training platform ([training.linuxfoundation.org](https://training.linuxfoundation.org)). LFX Self Serve shows your enrolled courses in read-only view. In the **Useful links** section (right sidebar) on the Training & Certifications page, select **LF Training Portal** to access the training catalog.
+Enrollment is handled on the Linux Foundation training platform ([training.linuxfoundation.org](https://training.linuxfoundation.org)). LFX Self Serve shows your enrolled courses in read-only view. In the **Useful links** section (right sidebar) on the Training & Certifications page, select **LF Education & Certification** to browse the training catalog and enroll.
 
 ## Why don't I see a training I enrolled in?
 
@@ -44,4 +44,4 @@ Open the **Rewards** tab on the Training & Certifications page. In the **My Coup
 
 ## Where can I find a list of available training courses?
 
-Visit the Linux Foundation training catalog at [https://training.linuxfoundation.org](https://training.linuxfoundation.org). You can also use the **LF Training Portal** link in the **Useful links** section (right sidebar) of the Training & Certifications page.
+Visit the Linux Foundation training catalog at [https://training.linuxfoundation.org](https://training.linuxfoundation.org). You can also use the **LF Education & Certification** link in the **Useful links** section (right sidebar) of the Training & Certifications page.

--- a/docs/user/trainings/index.md
+++ b/docs/user/trainings/index.md
@@ -28,7 +28,7 @@ All authenticated users can view their training enrollments.
 
 ### Navigation
 
-Go to **app.lfx.dev** and select **Training & Certifications** from the left navigation sidebar (route: `/me/training`). The page shows tabs for Certifications, Enrolled Trainings, and Rewards, plus a Useful links section in the right sidebar.
+Go to **app.lfx.dev** and select **Training & Certifications** from the left navigation sidebar (route: `/me/training`). The page shows tabs for Certifications, Enrolled Trainings, and Rewards, plus a **Useful links** section in the right sidebar.
 
 ### Relationship to badges
 

--- a/docs/user/trainings/index.md
+++ b/docs/user/trainings/index.md
@@ -21,7 +21,7 @@ The information below reflects **your** training enrollments and certifications 
 - Check your enrollment and completion status
 - Access your earned certifications and [rewards, incentives, and coupons](rewards/)
 
-Training enrollment is handled on the Linux Foundation training platform. LFX Self Serve displays your enrolled courses and certifications in read-only view. Use the **LF Training Portal** link on the Useful links tab to access your courses.
+Training enrollment is handled on the Linux Foundation training platform. LFX Self Serve displays your enrolled courses and certifications in read-only view. Use the **LF Training Portal** link in the Useful links section (right sidebar) to access your courses.
 
 ### Who this applies to
 
@@ -29,7 +29,7 @@ All authenticated users can view their training enrollments.
 
 ### Navigation
 
-Go to **app.lfx.dev** and select **Training & Certifications** from the left navigation sidebar (route: `/me/training`). The page shows tabs for Certifications, Enrolled Trainings, Rewards, and Useful links.
+Go to **app.lfx.dev** and select **Training & Certifications** from the left navigation sidebar (route: `/me/training`). The page shows tabs for Certifications, Enrolled Trainings, and Rewards, plus a Useful links section in the right sidebar.
 
 ### Relationship to badges
 

--- a/docs/user/trainings/index.md
+++ b/docs/user/trainings/index.md
@@ -4,7 +4,6 @@ description: View your Linux Foundation training enrollments and certifications 
 audience: [all]
 product_area: Trainings
 tags: [trainings, courses, enrollments, certifications, learning]
-last_generated: 2026-05-22
 last_updated: 2026-08-19
 intercom_collection: Trainings
 ---

--- a/docs/user/trainings/manage-trainings/index.md
+++ b/docs/user/trainings/manage-trainings/index.md
@@ -31,7 +31,7 @@ A **Useful links** section in the right sidebar provides links to the LF Trainin
 
 ## Resume or enroll in a training
 
-Enrollment in new training courses is handled on the Linux Foundation training platform, not within LFX Self Serve. To resume a course or enroll in a new one, go to the **Useful links** section in the right sidebar and select **LF Training Portal** to open [https://training.linuxfoundation.org](https://training.linuxfoundation.org).
+Enrollment in new training courses is handled on the Linux Foundation training platform, not within LFX Self Serve. In the **Useful links** section in the right sidebar, select **LF Training Portal** to resume a course you're already enrolled in ([trainingportal.linuxfoundation.org](https://trainingportal.linuxfoundation.org)), or **LF Education & Certification** to browse the catalog and enroll in a new course ([training.linuxfoundation.org](https://training.linuxfoundation.org)).
 
 ## Empty state
 

--- a/docs/user/trainings/manage-trainings/index.md
+++ b/docs/user/trainings/manage-trainings/index.md
@@ -5,7 +5,7 @@ audience: [all]
 product_area: Trainings
 tags: [trainings, enrollments, manage, status]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-19
 intercom_collection: Trainings
 ---
 
@@ -27,11 +27,12 @@ Tabs:
 - **Certifications** — certifications you have earned
 - **Enrolled Trainings** — courses you are currently enrolled in
 - **Rewards** — rewards associated with your learning activity
-- **Useful links** — links to the LF Training Portal, LF Education & Certification, and Certification Verification Tool
+
+A **Useful links** section in the right sidebar provides links to the LF Training Portal, LF Education & Certification, and Certification Verification Tool.
 
 ## Resume or enroll in a training
 
-Enrollment in new training courses is handled on the Linux Foundation training platform, not within LFX Self Serve. To resume a course or enroll in a new one, go to the **Useful links** tab and select **LF Training Portal** to open [https://training.linuxfoundation.org](https://training.linuxfoundation.org).
+Enrollment in new training courses is handled on the Linux Foundation training platform, not within LFX Self Serve. To resume a course or enroll in a new one, go to the **Useful links** section in the right sidebar and select **LF Training Portal** to open [https://training.linuxfoundation.org](https://training.linuxfoundation.org).
 
 ## Empty state
 

--- a/docs/user/trainings/manage-trainings/index.md
+++ b/docs/user/trainings/manage-trainings/index.md
@@ -4,7 +4,6 @@ description: How to view and manage your training enrollments in LFX Self Serve.
 audience: [all]
 product_area: Trainings
 tags: [trainings, enrollments, manage, status]
-last_generated: 2026-05-22
 last_updated: 2026-08-19
 intercom_collection: Trainings
 ---

--- a/docs/user/trainings/rewards/index.md
+++ b/docs/user/trainings/rewards/index.md
@@ -4,7 +4,6 @@ description: View your reward points, claim incentives, and redeem coupons for L
 audience: [all]
 product_area: Trainings
 tags: [trainings, rewards, coupons, points, certifications]
-last_generated: 2026-08-19
 last_updated: 2026-08-19
 intercom_collection: Trainings
 ---

--- a/docs/user/votes/create-vote/index.md
+++ b/docs/user/votes/create-vote/index.md
@@ -5,7 +5,7 @@ audience: [maintainer, board-member, executive-director]
 product_area: Votes
 tags: [votes, create, poll, governance, elections]
 last_generated: 2026-05-22
-last_updated: 2026-05-22
+last_updated: 2026-08-19
 intercom_collection: Votes
 ---
 
@@ -18,14 +18,14 @@ Confirm you have the correct project selected in the lens switcher. The new poll
 ## Steps
 
 1. Sign in to [app.lfx.dev](https://app.lfx.dev).
-2. Select **My Votes** from the left navigation.
+2. Switch to your **Project** or **Foundation** lens using the lens switcher, then select **Votes** from the left navigation.
 3. Select the option to create a new poll.
 4. Fill in the poll details, including title, description, voting options, end date, and voter eligibility settings.
 5. Save or publish the poll.
 
 ## After creation
 
-The poll appears in the **My Votes** dashboard with an **Active** status. Eligible voters can cast their votes until the poll closes.
+The poll appears in the **Votes** dashboard with an **Active** status. Eligible voters can cast their votes until the poll closes.
 
 ## Permissions
 

--- a/docs/user/votes/create-vote/index.md
+++ b/docs/user/votes/create-vote/index.md
@@ -8,11 +8,11 @@ last_updated: 2026-08-19
 intercom_collection: Votes
 ---
 
-This article applies to users with **maintainer**, **board-member**, or **executive-director** personas. Use this guide to create a new poll for your project's governance decisions.
+This article applies to users with **maintainer**, **board-member**, or **executive-director** personas. Use this guide to create a new poll for your project's or foundation's governance decisions.
 
 ## Before you begin
 
-Confirm you have the correct project selected in the lens switcher. The new poll will be associated with the currently active project context.
+Confirm you have the correct project or foundation selected in the lens switcher. The new poll will be associated with the currently active project or foundation context.
 
 ## Steps
 
@@ -24,7 +24,7 @@ Confirm you have the correct project selected in the lens switcher. The new poll
 
 ## After creation
 
-The poll appears in the **Votes** dashboard with an **Active** status. Eligible voters can cast their votes until the poll closes.
+If you publish the poll (**Open Vote**), it appears in the **Votes** dashboard with an **Active** status, and eligible voters can cast their votes until the poll closes. If you choose **Save as Draft** instead, the poll is saved with a **Draft** status and stays hidden from voters until you open it.
 
 ## Permissions
 

--- a/docs/user/votes/create-vote/index.md
+++ b/docs/user/votes/create-vote/index.md
@@ -4,7 +4,6 @@ description: How to create a new governance poll in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Votes
 tags: [votes, create, poll, governance, elections]
-last_generated: 2026-05-22
 last_updated: 2026-08-19
 intercom_collection: Votes
 ---

--- a/docs/user/votes/faq/index.md
+++ b/docs/user/votes/faq/index.md
@@ -4,7 +4,6 @@ description: Frequently asked questions about votes and polls in LFX Self Serve.
 audience: [all]
 product_area: Votes
 tags: [votes, faq, polls, governance, elections]
-last_generated: 2026-05-22
 last_updated: 2026-08-17
 intercom_collection: Votes
 ---

--- a/docs/user/votes/index.md
+++ b/docs/user/votes/index.md
@@ -5,7 +5,7 @@ audience: [maintainer, board-member, executive-director]
 product_area: Votes
 tags: [votes, polls, governance, decisions, elections]
 last_generated: 2026-05-22
-last_updated: 2026-05-23
+last_updated: 2026-08-19
 intercom_collection: Votes
 ---
 
@@ -23,7 +23,7 @@ The Votes section lets you create and manage polls for formal project governance
 
 ## Navigation
 
-Go to **app.lfx.dev** and select **Votes** from the left navigation sidebar. The votes dashboard (route: `/votes`) lists all polls for your active project context. Use the tabs to filter: **All**, **Active**, **Draft**, **Ended**.
+Switch to your **Project** or **Foundation** lens using the lens switcher, then select **Votes** from the left navigation sidebar. The votes dashboard (route: `/project/votes` or `/foundation/votes`) lists all polls for your active project context. Use the tabs to filter: **All**, **Active**, **Draft**, **Ended**.
 
 ## Key concepts
 

--- a/docs/user/votes/index.md
+++ b/docs/user/votes/index.md
@@ -4,7 +4,6 @@ description: Create polls, cast votes, and view results for project governance d
 audience: [maintainer, board-member, executive-director]
 product_area: Votes
 tags: [votes, polls, governance, decisions, elections]
-last_generated: 2026-05-22
 last_updated: 2026-08-19
 intercom_collection: Votes
 ---

--- a/docs/user/votes/index.md
+++ b/docs/user/votes/index.md
@@ -22,7 +22,9 @@ The Votes section lets you create and manage polls for formal project governance
 
 ## Navigation
 
-Switch to your **Project** or **Foundation** lens using the lens switcher, then select **Votes** from the left navigation sidebar. The votes dashboard (route: `/project/votes` or `/foundation/votes`) lists all polls for your active project context. Use the tabs to filter: **All**, **Active**, **Draft**, **Ended**.
+To view and cast votes, select **My Votes** from the left navigation sidebar in the **Me** lens (route: `/votes`) — this lists the polls you're eligible for across your projects and foundations.
+
+To manage polls for a specific context, switch to your **Project** or **Foundation** lens using the lens switcher, then select **Votes** from the left navigation sidebar. The votes dashboard (route: `/project/votes` or `/foundation/votes`) lists all polls for your active project or foundation context. Use the tabs to filter: **All**, **Active**, **Draft**, **Ended**.
 
 ## Key concepts
 

--- a/docs/user/votes/manage-votes/index.md
+++ b/docs/user/votes/manage-votes/index.md
@@ -4,7 +4,6 @@ description: How to view, update, and close polls in LFX Self Serve.
 audience: [maintainer, board-member, executive-director]
 product_area: Votes
 tags: [votes, manage, polls, results]
-last_generated: 2026-05-22
 last_updated: 2026-05-22
 intercom_collection: Votes
 ---


### PR DESCRIPTION
**Summary**

Freshness sweep of existing "Me"-lens documentation to match the current `app.lfx.dev` UI. Strictly UI-level wording/route corrections — no new articles.

- **Trainings** — "Useful links" is a right-sidebar section, not a tab; split resume-vs-enroll guidance to the correct links (LF Training Portal for enrolled courses, LF Education & Certification for the catalog) (`trainings/index.md`, `manage-trainings/index.md`, `faq/index.md`)
- **Committees** — corrected the create route to `/groups/create`, added the required lens-switch step, and aligned the "Group name" label with the rest of the article (`create-committee/index.md`)
- **Transactions** — matched the empty-state copy to the current UI (`transactions/index.md`)
- **Votes** — corrected navigation to the Me-lens "My Votes" (`/votes`) vs. the Project/Foundation-lens "Votes" (`/project/votes` · `/foundation/votes`), and clarified draft/active poll status (`votes/index.md`, `create-vote/index.md`)
- Refreshed `last_updated` on each edited article

**Frontmatter cleanup (LFXV2-3332)**

- Removed the unused `last_generated` frontmatter field from every doc that still carried it. Nothing in the build or app reads or writes it (the sitemap and manifest use `last_updated`), so it was dead metadata already tracked implicitly by git history. This is a frontmatter-only change across the remaining files in the diff.

Fixes LFXV2-3332