### PR TITLE
fix(meetings): discard abandoned owner drafts and email-match viewers

### DIFF
--- a/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
+++ b/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
@@ -16,6 +16,9 @@
  *   - The search pool only covers indexed meeting registrants, so the picker's "Enter details
  *     manually" affordance lets any name/email be set as owner; manual entry sends
  *     `owner: {name, email}` (no username) and an invalid email blocks the step.
+ *   - "Back to search" keeps a valid manual draft but discards an invalid one wholesale — a
+ *     surviving name-only trio would be sent as `owner` and replace the stored organizer upstream,
+ *     so the abandoned draft must leave all-empty controls and the save must omit the key.
  *   - The Clear affordance empties a picked/saved owner selection; the following save omits the
  *     `owner` key (create reverts to the creator default; edit keeps the stored owner).
  *
@@ -478,6 +481,12 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await emailInput.fill(MANUAL_OWNER.email);
     await expect(nextButton).toBeEnabled();
 
+    // A VALID draft survives "Back to search" — only an invalid one is discarded (covered in the
+    // next test). The remounted search box seeds from the kept ownerEmail, and the save below
+    // proves the kept draft is what actually ships.
+    await page.getByTestId('meeting-details-organizer-back-to-search').click();
+    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue(MANUAL_OWNER.email);
+
     // The organizer label reacts to the typed values just like a search pick.
     await expect(page.getByTestId('meeting-details-organizer-selected')).toContainText(`Current organizer: ${MANUAL_OWNER.name} (${MANUAL_OWNER.email})`);
 
@@ -486,5 +495,41 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
     // No username: a hand-typed identity is name+email only.
     expect((captured.put as Record<string, unknown>)['owner']).toEqual({ name: MANUAL_OWNER.name, email: MANUAL_OWNER.email });
+  });
+
+  test('back to search discards an invalid manual draft so the save omits owner', async ({ page }) => {
+    const captured = await stubMeetingEdit(page, buildEditMeeting({ user_id: 'u-owner-e2e', ...OWNER }));
+    await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
+
+    await gotoEditPage(page);
+    await openDetailsStep(page);
+    await expect(page.getByTestId('meeting-details-organizer-selected')).toContainText(`Current organizer: ${OWNER.name}`);
+
+    // The overlay footer is the only path into manual mode — type to open it.
+    await page.getByTestId('meeting-details-organizer-search').locator('input').fill('Radia');
+    await page.getByRole('button', { name: 'Enter details manually' }).click();
+    await expect(page.getByTestId('meeting-details-organizer-manual')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+
+    // Start a draft over the hydrated owner (the first manual edit drops the username), then
+    // abandon it while the email is invalid and gating the step.
+    const nextButton = page.getByTestId('meeting-manage-next-btn').locator('button');
+    await page.getByTestId('meeting-details-organizer-email-input').locator('input').fill('not-an-email');
+    await expect(nextButton).toBeDisabled();
+    await page.getByTestId('meeting-details-organizer-back-to-search').click();
+
+    // The WHOLE draft is discarded, not just the invalid email — a surviving hydrated name would
+    // be sent as a name-only `owner` and replace the stored organizer upstream. The step un-gates,
+    // the search box comes back empty, and no organizer label lingers.
+    await expect(page.getByTestId('meeting-details-organizer-search')).toBeVisible();
+    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue('');
+    await expect(page.getByTestId('meeting-details-organizer-selected')).toHaveCount(0);
+    await expect(nextButton).toBeEnabled();
+
+    await saveFromDetailsStep(page);
+
+    await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
+    // All-empty controls → key omitted → the stored owner (incl. username and avatar) survives,
+    // exactly like Clear.
+    expect(Object.keys(captured.put as Record<string, unknown>)).not.toContain('owner');
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -242,11 +242,13 @@ export class MeetingDetailsComponent implements OnInit {
   public backToOwnerSearch(): void {
     // An invalid manual email would keep gating the step invisibly after the switch — its error
     // message only renders in manual mode, and the remounted search box is a separate control that
-    // can't edit ownerEmail. Drop it; a typed name stays (name-only owners are valid upstream) and
-    // remains visible/clearable via the "Current organizer" row.
-    const ownerEmailCtrl = this.form().get('ownerEmail');
-    if (ownerEmailCtrl?.invalid) {
-      ownerEmailCtrl.setValue(null);
+    // can't edit ownerEmail. Discard the WHOLE abandoned draft, not just the email: the username is
+    // already gone (dropped on the first manual edit), so keeping the name would leave a valid
+    // name-only trio that a later save sends as `owner` — replacing the stored organizer's
+    // email/username/profile_picture upstream. All-empty controls omit the key instead, exactly
+    // like Clear, so the stored owner survives (as the helper text says). A valid draft is kept.
+    if (this.form().get('ownerEmail')?.invalid) {
+      this.clearOwnerSelection();
     }
     this.ownerManualEntry.set(false);
   }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-organizer/meeting-organizer.component.ts
@@ -47,11 +47,18 @@ export class MeetingOrganizerComponent {
       const meeting = this.meeting();
       const organizers = collectMeetingOrganizers(meeting, this.hosts());
 
-      return buildMeetingOrganizerChip(organizers, this.userService.viewerUsername(), {
-        meetingTitle: meeting.title,
-        meetingDate: this.formatMeetingDate(meeting),
-        detailUrl: this.buildDetailUrl(meeting),
-      });
+      return buildMeetingOrganizerChip(
+        organizers,
+        this.userService.viewerUsername(),
+        {
+          meetingTitle: meeting.title,
+          meetingDate: this.formatMeetingDate(meeting),
+          detailUrl: this.buildDetailUrl(meeting),
+        },
+        // Email is the only identity a manually-entered owner carries — without it the meeting's
+        // own organizer would never get the "you" variant on their card.
+        this.userService.viewerEmail()
+      );
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -378,9 +378,11 @@ export class MeetingsDashboardComponent {
     const projectFilter$ = toObservable(this.projectFilter);
     const pendingRsvpOnly$ = toObservable(this.pendingRsvpOnly);
     const organizerOnly$ = toObservable(this.organizerOnly);
-    // The viewer LFID backs the "Organized by me" predicate and can resolve after the meetings do,
-    // so it participates in the stream — otherwise the first filtered emission would use a null viewer.
+    // The viewer identity (LFID + primary email) backs the "Organized by me" predicate and can
+    // resolve after the meetings do, so it participates in the stream — otherwise the first
+    // filtered emission would use a null viewer.
     const viewerUsername$ = toObservable(this.userService.viewerUsername);
+    const viewerEmail$ = toObservable(this.userService.viewerEmail);
     const meLens$ = combineLatest([
       lens$,
       timeFilter$,
@@ -392,22 +394,26 @@ export class MeetingsDashboardComponent {
       pendingRsvpOnly$,
       organizerOnly$,
       viewerUsername$,
+      viewerEmail$,
     ]).pipe(
-      switchMap(([lens, timeFilter, searchQuery, meetingType, rawMeetings, foundation, project, pendingRsvpOnly, organizerOnly, viewerUsername]) => {
-        if (lens !== 'me' || timeFilter !== 'upcoming') {
-          return of<PageResult<Meeting>>({ data: [], page_token: undefined, reset: true });
+      switchMap(
+        ([lens, timeFilter, searchQuery, meetingType, rawMeetings, foundation, project, pendingRsvpOnly, organizerOnly, viewerUsername, viewerEmail]) => {
+          if (lens !== 'me' || timeFilter !== 'upcoming') {
+            return of<PageResult<Meeting>>({ data: [], page_token: undefined, reset: true });
+          }
+          const filtered = this.filterMeLensMeetings(rawMeetings, {
+            searchQuery,
+            meetingType,
+            foundation,
+            project,
+            pendingRsvpOnly,
+            organizerOnly,
+            viewerUsername,
+            viewerEmail,
+          });
+          return of<PageResult<Meeting>>({ data: filtered, page_token: undefined, reset: true });
         }
-        const filtered = this.filterMeLensMeetings(rawMeetings, {
-          searchQuery,
-          meetingType,
-          foundation,
-          project,
-          pendingRsvpOnly,
-          organizerOnly,
-          viewerUsername,
-        });
-        return of<PageResult<Meeting>>({ data: filtered, page_token: undefined, reset: true });
-      })
+      )
     );
 
     // Project/foundation lens: server-side filtering with pagination
@@ -483,6 +489,7 @@ export class MeetingsDashboardComponent {
     const pastProjectFilter$ = toObservable(this.projectFilter);
     const pastOrganizerOnly$ = toObservable(this.organizerOnly);
     const pastViewerUsername$ = toObservable(this.userService.viewerUsername);
+    const pastViewerEmail$ = toObservable(this.userService.viewerEmail);
     const meLens$ = combineLatest([
       lens$,
       timeFilter$,
@@ -493,8 +500,9 @@ export class MeetingsDashboardComponent {
       pastProjectFilter$,
       pastOrganizerOnly$,
       pastViewerUsername$,
+      pastViewerEmail$,
     ]).pipe(
-      switchMap(([lens, timeFilter, searchQuery, meetingType, rawPastMeetings, foundation, project, organizerOnly, viewerUsername]) => {
+      switchMap(([lens, timeFilter, searchQuery, meetingType, rawPastMeetings, foundation, project, organizerOnly, viewerUsername, viewerEmail]) => {
         if (lens !== 'me' || timeFilter !== 'past') {
           return of<PageResult<PastMeeting>>({ data: [], page_token: undefined, reset: true });
         }
@@ -507,6 +515,7 @@ export class MeetingsDashboardComponent {
           pendingRsvpOnly: false,
           organizerOnly,
           viewerUsername,
+          viewerEmail,
         });
         return of<PageResult<PastMeeting>>({ data: filtered, page_token: undefined, reset: true });
       })
@@ -668,7 +677,7 @@ export class MeetingsDashboardComponent {
   }
 
   private filterMeLensMeetings<T extends Meeting>(items: T[], filters: MeLensMeetingFilters): T[] {
-    const { searchQuery, meetingType, foundation, project, pendingRsvpOnly, organizerOnly, viewerUsername } = filters;
+    const { searchQuery, meetingType, foundation, project, pendingRsvpOnly, organizerOnly, viewerUsername, viewerEmail } = filters;
     let filtered = items;
 
     if (project) {
@@ -698,7 +707,8 @@ export class MeetingsDashboardComponent {
       // (MeetingRegistrantsDisplayComponent → resolvedHostsChange), so matching it here would mean
       // fetching registrants for every meeting in the list up front — real new API cost this
       // client-side filter (LFXV2-2824) doesn't take on.
-      filtered = filtered.filter((m) => isMeetingOrganizedByViewer(m, viewerUsername));
+      // No hosts (see above); the email matches owner records that carry no username (manual entry).
+      filtered = filtered.filter((m) => isMeetingOrganizedByViewer(m, viewerUsername, undefined, viewerEmail));
     }
 
     return this.filterBySearchAndType(filtered, searchQuery, meetingType);
@@ -999,6 +1009,7 @@ export class MeetingsDashboardComponent {
               pendingRsvpOnly: this.pendingRsvpOnly(),
               organizerOnly: this.organizerOnly(),
               viewerUsername: this.userService.viewerUsername(),
+              viewerEmail: this.userService.viewerEmail(),
             })
           : this.filterBySearchAndType([...this.rawFpUpcomingMeetings(), ...this.rawFpPastMeetings()], search, meetingType);
       return filtered.flatMap((m) => meetingToCalendarEvents(m) as EventInput[]);

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -66,6 +66,13 @@ export class UserService {
    * "Organized by me" meetings filter), so those surfaces can never resolve identity differently.
    */
   public readonly viewerUsername: Signal<string | null> = this.initViewerUsername();
+  /**
+   * The viewer's primary email from the OIDC claims — the fallback identity for organizer records
+   * that carry no username (a manually-entered meeting owner is saved as name+email only). Paired
+   * with {@link viewerUsername} everywhere viewer identity is compared, so the "Organized by you"
+   * chip and the "Organized by me" filter can't resolve identity differently.
+   */
+  public readonly viewerEmail: Signal<string | null> = computed(() => this.user()?.email || null);
   /** Cached Salesforce user ID from the API Gateway — null until first fetch */
   public readonly apiGatewayUserId = signal<string | null>(null);
 

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1433,4 +1433,6 @@ export interface MeLensMeetingFilters {
   organizerOnly: boolean;
   /** Viewer username/LFID used by the `organizerOnly` predicate; null disables matching. */
   viewerUsername: string | null;
+  /** Viewer primary email — matches `organizerOnly` against owner records that carry no username. */
+  viewerEmail: string | null;
 }

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -653,6 +653,26 @@ describe('collectMeetingOrganizers', () => {
 
     expect(collectMeetingOrganizers(meeting)).toEqual([{ name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' }]);
   });
+
+  it('dedupes the owner against a host whose username disagrees but email matches — stale LFIDs must not double-list a person', () => {
+    const meeting = { owner: { name: 'Grace Hopper', username: 'ghopper-old', email: 'grace@example.com' } } as Meeting;
+    const hosts = [
+      { first_name: 'Grace', last_name: 'Hopper', username: 'ghopper', email: 'grace@example.com', host: true },
+      { first_name: 'Alan', last_name: 'Turing', username: 'aturing', email: 'alan@example.com', host: true },
+    ];
+
+    // One Grace, still primary (index 0), carried by the richer host record.
+    expect(collectMeetingOrganizers(meeting, hosts).map((o) => o.username)).toEqual(['ghopper', 'aturing']);
+  });
+
+  it('keeps organizers with distinct usernames separate even when their display names collide', () => {
+    // Names are not identifiers: with no email pair to arbitrate, two records with different
+    // usernames stay two people, no matter what they are called.
+    const meeting = { owner: { name: 'Alex Kim', username: 'akim1', email: '' } } as Meeting;
+    const hosts = [{ first_name: 'Alex', last_name: 'Kim', username: 'akim2', email: '', host: true }];
+
+    expect(collectMeetingOrganizers(meeting, hosts)).toHaveLength(2);
+  });
 });
 
 describe('buildMeetingOrganizerMailto', () => {
@@ -721,6 +741,13 @@ describe('buildMeetingOrganizerChip', () => {
 
   it('marks the viewer as "you" and never links their name', () => {
     const chip = buildMeetingOrganizerChip([ada], 'auth0|alovelace', ctx);
+    expect(chip?.primary.isYou).toBe(true);
+    expect(chip?.primary.mailto).toBeNull();
+  });
+
+  it('marks a username-less owner as "you" via the viewer email — manual entries carry no username', () => {
+    const manualOwner = { name: 'Radia Perlman', username: '', email: 'radia@example.com' };
+    const chip = buildMeetingOrganizerChip([manualOwner], 'rperlman', ctx, 'radia@example.com');
     expect(chip?.primary.isYou).toBe(true);
     expect(chip?.primary.mailto).toBeNull();
   });
@@ -795,20 +822,39 @@ describe('isMeetingOrganizedByViewer', () => {
     expect(isMeetingOrganizedByViewer(webhookOwned, 'alovelace')).toBe(true);
   });
 
+  it('matches a username-less owner by the viewer email — manual entries are saved as name+email only', () => {
+    const manuallyOwned = meetingBy(ada, { owner: { name: 'Radia Perlman', username: '', email: 'radia@example.com' } });
+
+    expect(isMeetingOrganizedByViewer(manuallyOwned, 'rperlman', undefined, 'radia@example.com')).toBe(true);
+    // Case-insensitive on both sides.
+    expect(isMeetingOrganizedByViewer(manuallyOwned, 'rperlman', undefined, 'Radia@Example.com')).toBe(true);
+    // A different viewer email must not match, and without a viewer email the username-less owner
+    // has no identity to compare — the meeting drops out of the filter rather than over-matching.
+    expect(isMeetingOrganizedByViewer(manuallyOwned, 'ghopper', undefined, 'grace@example.com')).toBe(false);
+    expect(isMeetingOrganizedByViewer(manuallyOwned, 'rperlman')).toBe(false);
+  });
+
   it('agrees with the chip: the filter matches exactly when the chip renders an "Organized by you" entry', () => {
-    const cases: { meeting: Meeting; viewer: string | null }[] = [
+    const cases: { meeting: Meeting; viewer: string | null; viewerEmail?: string | null }[] = [
       { meeting: meetingBy(ada), viewer: 'alovelace' },
       { meeting: meetingBy(ada), viewer: 'auth0|alovelace' },
       { meeting: meetingBy(grace), viewer: 'alovelace' },
       { meeting: meetingBy(grace, { organizer: true }), viewer: 'alovelace' },
       { meeting: meetingBy({ name: 'Zoom Webhooks', username: 'zoom.webhooks', email: '' }), viewer: 'zoom.webhooks' },
       { meeting: meetingBy(ada), viewer: null },
+      // Manual (username-less) owner recognized by email on both surfaces, and by neither without it.
+      {
+        meeting: meetingBy(ada, { owner: { name: 'Radia Perlman', username: '', email: 'radia@example.com' } }),
+        viewer: 'rperlman',
+        viewerEmail: 'radia@example.com',
+      },
+      { meeting: meetingBy(ada, { owner: { name: 'Radia Perlman', username: '', email: 'radia@example.com' } }), viewer: 'rperlman', viewerEmail: null },
     ];
 
-    for (const { meeting, viewer } of cases) {
-      const chip = buildMeetingOrganizerChip(collectMeetingOrganizers(meeting), viewer);
+    for (const { meeting, viewer, viewerEmail } of cases) {
+      const chip = buildMeetingOrganizerChip(collectMeetingOrganizers(meeting), viewer, {}, viewerEmail);
       const chipSaysYou = !!chip && [chip.primary, ...chip.overflow].some((link) => link.isYou);
-      expect(isMeetingOrganizedByViewer(meeting, viewer)).toBe(chipSaysYou);
+      expect(isMeetingOrganizedByViewer(meeting, viewer, undefined, viewerEmail)).toBe(chipSaysYou);
     }
   });
 });

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -1136,17 +1136,27 @@ function hostToOrganizer(host: MeetingHostCandidate): MeetingUserInfo {
   };
 }
 
-/** Whether two organizers refer to the same person (by username, then email, then name). */
+/**
+ * Whether two organizers refer to the same person. A username match wins outright; otherwise a
+ * shared email reconciles records whose usernames disagree (an owner picked long ago can carry a
+ * stale LFID while the host record has the current one — without the email check that person
+ * would be listed twice). The name fallback only applies when neither identifier can arbitrate:
+ * names are not identifiers, so two records with distinct usernames and no email pair stay
+ * distinct people even when the display names collide.
+ */
 function sameOrganizer(a: MeetingUserInfo, b: MeetingUserInfo): boolean {
   const usernameA = normalizeUsername(a.username);
   const usernameB = normalizeUsername(b.username);
-  if (usernameA && usernameB) {
-    return usernameA === usernameB;
+  if (usernameA && usernameB && usernameA === usernameB) {
+    return true;
   }
   const emailA = a.email?.trim().toLowerCase();
   const emailB = b.email?.trim().toLowerCase();
   if (emailA && emailB) {
     return emailA === emailB;
+  }
+  if (usernameA && usernameB) {
+    return false;
   }
   const nameA = a.name?.trim().toLowerCase();
   const nameB = b.name?.trim().toLowerCase();
@@ -1251,12 +1261,21 @@ function normalizeUsername(username: string | null | undefined): string {
 /**
  * Whether a resolved organizer IS the current viewer — the single comparison behind both the
  * chip's "you" variant and the "Organized by me" list filter, so the two can never disagree.
- * An absent/empty viewer never matches (a logged-out or unresolved viewer must not match every
+ * A username match wins; otherwise the viewer's email arbitrates — a manually-entered owner is
+ * saved as name+email with no username, so without the email fallback that meeting's own
+ * organizer would never see "you" or match "Organized by me". Best-effort by design: a manual
+ * entry typed with one of the viewer's non-primary email aliases still won't match. An
+ * absent/empty viewer never matches (a logged-out or unresolved viewer must not match every
  * meeting).
  */
-function isViewerOrganizer(organizer: MeetingUserInfo, viewerUsername?: string | null): boolean {
+function isViewerOrganizer(organizer: MeetingUserInfo, viewerUsername?: string | null, viewerEmail?: string | null): boolean {
   const viewer = normalizeUsername(viewerUsername);
-  return !!viewer && normalizeUsername(organizer.username) === viewer;
+  if (viewer && normalizeUsername(organizer.username) === viewer) {
+    return true;
+  }
+  const email = viewerEmail?.trim().toLowerCase();
+  const organizerEmail = organizer.email?.trim().toLowerCase();
+  return !!email && !!organizerEmail && email === organizerEmail;
 }
 
 /**
@@ -1275,13 +1294,15 @@ function isViewerOrganizer(organizer: MeetingUserInfo, viewerUsername?: string |
  * @param meeting - Any object carrying optional `owner` / `created_by` (Meeting / PastMeeting).
  * @param viewerUsername - The current user's username/LFID (prefix-tolerant, case-insensitive).
  * @param hosts - Optional host candidates, when the surface has them (see collectMeetingOrganizers).
+ * @param viewerEmail - The viewer's primary email, matching organizer records that carry no username.
  */
 export function isMeetingOrganizedByViewer(
   meeting: Pick<Meeting, 'created_by' | 'owner'> | null | undefined,
   viewerUsername?: string | null,
-  hosts?: ReadonlyArray<MeetingHostCandidate>
+  hosts?: ReadonlyArray<MeetingHostCandidate>,
+  viewerEmail?: string | null
 ): boolean {
-  return collectMeetingOrganizers(meeting, hosts).some((organizer) => isViewerOrganizer(organizer, viewerUsername));
+  return collectMeetingOrganizers(meeting, hosts).some((organizer) => isViewerOrganizer(organizer, viewerUsername, viewerEmail));
 }
 
 /**
@@ -1292,18 +1313,20 @@ export function isMeetingOrganizedByViewer(
  * @param organizers - Resolved organizers (see {@link collectMeetingOrganizers}).
  * @param viewerUsername - The current user's username, for the "you" variant (never linked).
  * @param mailtoContext - Meeting title / formatted date / details URL for the mailto subject+body.
+ * @param viewerEmail - The viewer's primary email, matching organizer records that carry no username.
  */
 export function buildMeetingOrganizerChip(
   organizers: ReadonlyArray<MeetingUserInfo>,
   viewerUsername?: string | null,
-  mailtoContext: { meetingTitle?: string | null; meetingDate?: string | null; detailUrl?: string | null } = {}
+  mailtoContext: { meetingTitle?: string | null; meetingDate?: string | null; detailUrl?: string | null } = {},
+  viewerEmail?: string | null
 ): MeetingOrganizerChipModel | null {
   if (!organizers.length) {
     return null;
   }
 
   const toLink = (organizer: MeetingUserInfo, index: number): MeetingOrganizerLink => {
-    const isYou = isViewerOrganizer(organizer, viewerUsername);
+    const isYou = isViewerOrganizer(organizer, viewerUsername, viewerEmail);
     const name = getMeetingOrganizerDisplayName(organizer);
     return {
       // Suffix the identity with its position so two name-only organizers sharing a display name


### PR DESCRIPTION
## Summary

Follow-up to #1686 (the meeting owner picker / owner-first organizer display). The final Bugbot + CodeRabbit review round on that PR confirmed three findings, but the PR was merged before the fixes landed — this PR delivers them.

Refs #1673

### 1. "Back to search" could replace the stored organizer upstream (Bugbot [finding](https://github.com/linuxfoundation/lfx-self-serve/pull/1686#discussion_r3816330639))

`backToOwnerSearch()` discarded only the invalid **email** of an abandoned manual draft. The hydrated name survived as a valid name-only trio, so a later save sent `owner: {name}` — and upstream replaces the stored owner as a whole object, silently dropping the stored organizer's email/username/profile_picture. The whole invalid draft is now discarded (exactly Clear's semantics): all-empty controls omit the `owner` key, so the stored owner survives, as the field's helper text promises. A valid draft is still kept across the mode switch.

### 2. `sameOrganizer` couldn't reconcile stale LFIDs (CodeRabbit [finding](https://github.com/linuxfoundation/lfx-self-serve/pull/1686#discussion_r3816359068))

Username equality still wins outright, but a shared email now arbitrates when usernames disagree — an owner recorded under a stale LFID no longer double-lists next to the same person's current host record. Two distinct usernames with **no** email pair stay different people: names are not identifiers and only match when at most one identifier exists (pinned by a name-collision spec so a naive fall-through can't regress this).

### 3. Manually-entered owners never matched their viewer (Bugbot [finding](https://github.com/linuxfoundation/lfx-self-serve/pull/1686#discussion_r3816521612))

A manual owner is saved as name+email with no username, so the username-only viewer comparison could never mark that owner as "you" on the organizer chip nor match them under the "Organized by me" filter. Viewer identity now carries the primary email alongside the LFID through the single shared comparison (`isViewerOrganizer`), threaded via `UserService.viewerEmail` → `buildMeetingOrganizerChip` / `isMeetingOrganizedByViewer` / `MeLensMeetingFilters.viewerEmail`, so the chip and the filter can't resolve identity differently. Best-effort by design: a non-primary alias email won't match.

## Testing

- `packages/shared` vitest: 899 passing — `meeting.utils` now 158 specs (new stale-LFID dedupe, display-name-collision guard, email-fallback chip/filter cases, and the chip↔filter parity table extended with username-less owners)
- e2e (`meeting-owner-organizer.spec.ts`): new test — invalid manual draft + Back to search → draft discarded wholesale, step un-gates, save omits `owner`; the manual-entry test now also round-trips a **valid** draft through Back to search and proves it still ships
- `yarn check-types`, `yarn lint`, `yarn build` all green


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved organizer recognition using email when usernames are unavailable or inconsistent.
  - Meeting filters and organizer labels now more reliably identify manually entered owners.
  - Matching is case-insensitive and avoids incorrectly merging people with identical names.

- **Bug Fixes**
  - Valid manual owner details are preserved when returning to search.
  - Invalid or abandoned owner entries are cleared and excluded from meeting updates.
  - Improved consistency between calendar, upcoming, and past meeting filters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->