### PR TITLE
fix(meetings): make organizer picker reflect the committed owner

### DIFF
--- a/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
+++ b/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
@@ -9,15 +9,17 @@
  *     owner (meetings predating the field) falls back to the human created_by.
  *   - The "Organized by me" filter follows ownership: a meeting owned by the viewer matches even
  *     when someone else created it, and a meeting the viewer created but transferred away does not.
- *   - The edit wizard's Meeting Details step surfaces the saved owner ("Current organizer: ...");
- *     an untouched save omits the `owner` key entirely so upstream preserves the stored owner
- *     (including profile_picture, which the form never carries).
- *   - Picking a user in the organizer field sends `owner: {username, name, email}` on update.
- *   - The search pool only covers indexed meeting registrants, so the picker's "Enter details
- *     manually" affordance lets any name/email be set as owner; manual entry sends
+ *   - The edit wizard's Meeting Details step renders the saved owner directly in the organizer
+ *     search box (as "Name (email)"); an untouched save omits the `owner` key entirely so upstream
+ *     preserves the stored owner (including profile_picture, which the form never carries).
+ *   - Picking a user in the organizer field sends `owner: {username, name, email}` on update, and
+ *     the box re-renders to show the freshly picked name/email instead of the previous selection.
+ *   - The search pool is the same committee-member directory Invite Guests uses; the picker's
+ *     "Enter details manually" affordance still covers anyone outside it. Manual entry sends
  *     `owner: {name, email}` (no username) and an invalid email blocks the step.
- *   - The Clear affordance empties a picked/saved owner selection; the following save omits the
- *     `owner` key (create reverts to the creator default; edit keeps the stored owner).
+ *   - Clearing (in-field ⊗ or the "Revert" button) restores the saved owner rather than emptying
+ *     the field — upstream has no owner-removal path, so the following save still omits the
+ *     `owner` key (create flow with no saved owner instead empties every control).
  *
  * Prerequisites:
  *   - Dev server reachable at the Playwright baseURL (default http://localhost:4200)
@@ -50,7 +52,8 @@ const PROJECT_SLUG = 'owner-e2e-project';
 const PROJECT_NAME = 'Owner E2E Project';
 const MOCK_MEETING_UID = 'm0000000-0000-0000-0000-00000000e001';
 
-// UserSearchResult shape returned by GET /api/search/users (no avatar field).
+// UserSearchResult shape returned by GET /api/search/users for the committee_member pool the
+// organizer picker now searches (no avatar field).
 const PICKED_USER = {
   uid: 'user-e2e-owner-1',
   email: OWNER.email,
@@ -59,7 +62,8 @@ const PICKED_USER = {
   username: OWNER.username,
   job_title: null,
   organization: null,
-  type: 'meeting_registrant',
+  committee: null,
+  type: 'committee_member',
 };
 
 function fulfillJson(route: Route, body: unknown): Promise<void> {
@@ -391,13 +395,17 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await stubWizardContext(page);
   });
 
-  test('shows the saved owner on the details step and an untouched save omits the owner key', async ({ page }) => {
+  test('renders the saved owner directly in the box and an untouched save omits the owner key', async ({ page }) => {
     const captured = await stubMeetingEdit(page, buildEditMeeting({ user_id: 'u-owner-e2e', ...OWNER }));
 
     await gotoEditPage(page);
     await openDetailsStep(page);
 
-    await expect(page.getByTestId('meeting-details-organizer-selected')).toContainText(`Current organizer: ${OWNER.name}`);
+    // The box is the single source of display truth — hydration renders "Name (email)" directly,
+    // no separate confirmation line needed.
+    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+    // Untouched picker → no saved/current mismatch → the revert row stays hidden.
+    await expect(page.getByTestId('meeting-details-organizer-saved')).toHaveCount(0);
 
     await saveFromDetailsStep(page);
 
@@ -406,26 +414,33 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     expect(Object.keys(captured.put as Record<string, unknown>)).not.toContain('owner');
   });
 
-  test('clearing a saved owner empties the selection and the save omits the owner key', async ({ page }) => {
+  test('reverting a fresh pick restores the saved owner in the box and the save omits the owner key', async ({ page }) => {
     const captured = await stubMeetingEdit(page, buildEditMeeting({ user_id: 'u-owner-e2e', ...OWNER }));
+    await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
 
     await gotoEditPage(page);
     await openDetailsStep(page);
 
-    await expect(page.getByTestId('meeting-details-organizer-selected')).toContainText(`Current organizer: ${OWNER.name}`);
-    // The picker's own input seeds from ownerEmail on init (user-search's sync effect)…
-    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue(OWNER.email);
-    await page.getByTestId('meeting-details-organizer-clear').click();
-    await expect(page.getByTestId('meeting-details-organizer-selected')).toHaveCount(0);
-    // …and Clear must reset it too, not just the form controls, so the field doesn't keep
-    // displaying the cleared owner's email.
-    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue('');
+    const input = page.getByTestId('meeting-details-organizer-search').locator('input');
+    await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+
+    // Pick a different organizer — the box re-renders with the fresh pick, and the saved-owner row
+    // appears since the picker now disagrees with the saved baseline.
+    await input.fill('Grace');
+    await page.getByRole('option').filter({ hasText: OWNER.name }).click();
+    await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+    await expect(page.getByTestId('meeting-details-organizer-saved')).toContainText(`Saved organizer: ${OWNER.name} (${OWNER.email})`);
+
+    // Revert restores the saved owner and hides the row again.
+    await page.getByTestId('meeting-details-organizer-revert').click();
+    await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+    await expect(page.getByTestId('meeting-details-organizer-saved')).toHaveCount(0);
 
     await saveFromDetailsStep(page);
 
     await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
-    // Cleared controls → key omitted → upstream keeps the stored owner (the helper text documents
-    // that clearing does not unset a saved organizer).
+    // Reverted controls match the hydrated baseline → key omitted → upstream keeps the stored
+    // owner (there is no owner-removal path upstream, hence revert rather than empty).
     expect(Object.keys(captured.put as Record<string, unknown>)).not.toContain('owner');
   });
 
@@ -436,12 +451,14 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await gotoEditPage(page);
     await openDetailsStep(page);
 
-    // No saved owner → no hydration label until a user is picked.
-    await expect(page.getByTestId('meeting-details-organizer-selected')).toHaveCount(0);
+    // No saved owner → box starts empty.
+    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue('');
 
     await page.getByTestId('meeting-details-organizer-search').locator('input').fill('Grace');
     await page.getByRole('option').filter({ hasText: OWNER.name }).click();
-    await expect(page.getByTestId('meeting-details-organizer-selected')).toContainText(`Current organizer: ${OWNER.name}`);
+    await expect(page.getByTestId('meeting-details-organizer-search').locator('input')).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+    // No saved owner to compare against, so no revert row even though a pick was made.
+    await expect(page.getByTestId('meeting-details-organizer-saved')).toHaveCount(0);
 
     await saveFromDetailsStep(page);
 
@@ -449,11 +466,34 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     expect((captured.put as Record<string, unknown>)['owner']).toEqual({ username: OWNER.username, name: OWNER.name, email: OWNER.email });
   });
 
+  test('clearing with no saved owner empties the box and the save omits the owner key', async ({ page }) => {
+    const captured = await stubMeetingEdit(page, buildEditMeeting());
+    await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
+
+    await gotoEditPage(page);
+    await openDetailsStep(page);
+
+    const input = page.getByTestId('meeting-details-organizer-search').locator('input');
+    await input.fill('Grace');
+    await page.getByRole('option').filter({ hasText: OWNER.name }).click();
+    await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+
+    // In-field clear on a create-style (no saved-owner) edit empties the box outright — there's
+    // nothing to revert to.
+    await page.getByTestId('meeting-details-organizer-search').locator('.p-autocomplete-clear-icon').click();
+    await expect(input).toHaveValue('');
+
+    await saveFromDetailsStep(page);
+
+    await expect.poll(() => captured.put, { timeout: ELEMENT_TIMEOUT }).not.toBeNull();
+    expect(Object.keys(captured.put as Record<string, unknown>)).not.toContain('owner');
+  });
+
   test('manual entry sends owner {name, email} without a username on update', async ({ page }) => {
     const MANUAL_OWNER = { name: 'Radia Perlman', email: 'radia-e2e@example.com' };
     const captured = await stubMeetingEdit(page, buildEditMeeting());
-    // The wanted person is not among the indexed registrants — the results list shows someone
-    // else, and the overlay's "Enter details manually" footer is the way out (the Bugbot case).
+    // The wanted person is not among the committee members returned — the results list shows
+    // someone else, and the overlay's "Enter details manually" footer is the way out.
     await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
 
     await gotoEditPage(page);
@@ -477,9 +517,6 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
     await expect(nextButton).toBeDisabled();
     await emailInput.fill(MANUAL_OWNER.email);
     await expect(nextButton).toBeEnabled();
-
-    // The organizer label reacts to the typed values just like a search pick.
-    await expect(page.getByTestId('meeting-details-organizer-selected')).toContainText(`Current organizer: ${MANUAL_OWNER.name} (${MANUAL_OWNER.email})`);
 
     await saveFromDetailsStep(page);
 

--- a/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
+++ b/apps/lfx-one/e2e/meeting-owner-organizer.spec.ts
@@ -66,6 +66,21 @@ const PICKED_USER = {
   type: 'committee_member',
 };
 
+// Distinct from OWNER/PICKED_USER — the revert test hydrates OWNER as the saved baseline and
+// then picks this person, so the saved-owner row actually has something to disagree with
+// (picking PICKED_USER there would just re-select OWNER and the row would never appear).
+const DIFFERENT_PICKED_USER = {
+  uid: 'user-e2e-owner-2',
+  email: 'radia-e2e@example.com',
+  first_name: 'Radia',
+  last_name: 'Perlman',
+  username: 'rperlman-e2e',
+  job_title: null,
+  organization: null,
+  committee: null,
+  type: 'committee_member',
+};
+
 function fulfillJson(route: Route, body: unknown): Promise<void> {
   return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
 }
@@ -416,7 +431,7 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
 
   test('reverting a fresh pick restores the saved owner in the box and the save omits the owner key', async ({ page }) => {
     const captured = await stubMeetingEdit(page, buildEditMeeting({ user_id: 'u-owner-e2e', ...OWNER }));
-    await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [PICKED_USER] }));
+    await page.route('**/api/search/users*', (route) => fulfillJson(route, { results: [DIFFERENT_PICKED_USER] }));
 
     await gotoEditPage(page);
     await openDetailsStep(page);
@@ -426,9 +441,10 @@ test.describe('Meeting edit wizard — owner picker (GH-1673)', () => {
 
     // Pick a different organizer — the box re-renders with the fresh pick, and the saved-owner row
     // appears since the picker now disagrees with the saved baseline.
-    await input.fill('Grace');
-    await page.getByRole('option').filter({ hasText: OWNER.name }).click();
-    await expect(input).toHaveValue(`${OWNER.name} (${OWNER.email})`);
+    const pickedName = `${DIFFERENT_PICKED_USER.first_name} ${DIFFERENT_PICKED_USER.last_name}`;
+    await input.fill('Radia');
+    await page.getByRole('option').filter({ hasText: pickedName }).click();
+    await expect(input).toHaveValue(`${pickedName} (${DIFFERENT_PICKED_USER.email})`);
     await expect(page.getByTestId('meeting-details-organizer-saved')).toContainText(`Saved organizer: ${OWNER.name} (${OWNER.email})`);
 
     // Revert restores the saved owner and hides the row again.

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
@@ -284,7 +284,7 @@
             searchType="committee_member"
             emailControl="ownerEmail"
             usernameControl="ownerUsername"
-            [displayValue]="selectedOwnerLabel() || null"
+            [displayValue]="selectedOwnerLabel()"
             [showClear]="true"
             inputId="meeting-organizer"
             placeholder="Search for a user..."

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.html
@@ -281,9 +281,11 @@
         @if (!ownerManualEntry()) {
           <lfx-user-search
             [form]="form()"
-            searchType="meeting_registrant"
+            searchType="committee_member"
             emailControl="ownerEmail"
             usernameControl="ownerUsername"
+            [displayValue]="selectedOwnerLabel() || null"
+            [showClear]="true"
             inputId="meeting-organizer"
             placeholder="Search for a user..."
             styleClass="w-full"
@@ -329,15 +331,19 @@
             </div>
           </div>
         }
-        @if (selectedOwnerLabel()) {
+        @if (showSavedOwnerRevert()) {
           <div class="mt-1 flex items-center gap-2">
-            <p class="text-sm text-gray-600" data-testid="meeting-details-organizer-selected">Current organizer: {{ selectedOwnerLabel() }}</p>
-            <button type="button" class="text-sm text-primary hover:underline" (click)="clearOwnerSelection()" data-testid="meeting-details-organizer-clear">
-              Clear
+            <p class="text-sm text-gray-600" data-testid="meeting-details-organizer-saved">
+              Saved organizer: {{ savedOwnerLabel() }} — clearing reverts to this.
+            </p>
+            <button type="button" class="text-sm text-primary hover:underline" (click)="clearOwnerSelection()" data-testid="meeting-details-organizer-revert">
+              Revert
             </button>
           </div>
         }
-        <p class="mt-1 text-sm text-gray-500">Defaults to the meeting creator. Clearing this field won't remove a saved organizer.</p>
+        @if (!savedOwner()) {
+          <p class="mt-1 text-sm text-gray-500">Defaults to the meeting creator.</p>
+        }
       </div>
 
       <!-- Future Date/Time validation error -->

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -119,6 +119,23 @@ export class MeetingDetailsComponent implements OnInit {
     { initialValue: '' }
   );
 
+  // The committed organizer's username, tracked alongside selectedOwnerLabel so
+  // showSavedOwnerRevert can distinguish two different people who happen to share a display label
+  // (matches prepareOwnerData()'s own username+name+email comparison in meeting-manage.component.ts).
+  public readonly selectedOwnerUsername = toSignal(
+    toObservable(this.form).pipe(
+      switchMap((f) => {
+        const usernameCtrl = f.get('ownerUsername');
+        if (!usernameCtrl) return of(null);
+        return usernameCtrl.valueChanges.pipe(
+          startWith(usernameCtrl.value),
+          map((value) => (value as string | null) || null)
+        );
+      })
+    ),
+    { initialValue: null }
+  );
+
   // Same "Name (email)" formatting, applied to the saved-owner baseline rather than the live form
   // — used for the "Saved organizer: …" row so it reads identically to the picker's own display.
   public readonly savedOwnerLabel = computed(() => {
@@ -133,11 +150,16 @@ export class MeetingDetailsComponent implements OnInit {
   });
 
   // The saved-organizer row only makes sense once there's a saved owner to revert to, and only
-  // while the picker currently shows something else — once reverted, the picker's own label
-  // already matches and the row would be redundant.
+  // while the picker currently shows something else — once reverted, the picker's own label and
+  // username already match and the row would be redundant. Username is compared alongside the
+  // label (not just name+email) so two people who happen to share a display label still trip the
+  // saved-owner row, matching prepareOwnerData()'s own identity comparison.
   public readonly showSavedOwnerRevert = computed(() => {
     const savedLabel = this.savedOwnerLabel();
-    return Boolean(savedLabel) && savedLabel !== this.selectedOwnerLabel();
+    if (!savedLabel) return false;
+    const labelDiffers = savedLabel !== this.selectedOwnerLabel();
+    const usernameDiffers = (this.savedOwner()?.username || null) !== this.selectedOwnerUsername();
+    return labelDiffers || usernameDiffers;
   });
 
   // Duration options from shared constants

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { NgClass } from '@angular/common';
-import { Component, computed, DestroyRef, inject, input, OnInit, signal, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, inject, input, OnInit, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
@@ -16,7 +16,7 @@ import { TimePickerComponent } from '@components/time-picker/time-picker.compone
 import { UserSearchComponent } from '@components/user-search/user-search.component';
 import { GenerateAgendaRequest, MeetingTemplate } from '@lfx-one/shared';
 import { MEETING_DURATION_OPTIONS, RECURRING_MEETING_FEATURE, TIMEZONES, YOUTUBE_MAX_MEETING_TITLE_LENGTH } from '@lfx-one/shared/constants';
-import { UserSearchResult } from '@lfx-one/shared/interfaces';
+import { MeetingUserInfo, UserSearchResult } from '@lfx-one/shared/interfaces';
 import { getTimezoneUtcOffsetString, getWeekOfMonth } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -54,6 +54,9 @@ export class MeetingDetailsComponent implements OnInit {
 
   // Form group input from parent
   public readonly form = input.required<FormGroup>();
+  // The owner baseline hydrated from the loaded meeting (edit mode only) — drives the revert
+  // target for the organizer picker's clear affordance and the "Saved organizer" row.
+  public readonly savedOwner = input<MeetingUserInfo | null>(null);
 
   // Dependency injection
   private readonly destroyRef = inject(DestroyRef);
@@ -75,10 +78,6 @@ export class MeetingDetailsComponent implements OnInit {
   // Owner (organizer) picker signals
   public readonly ownerManualEntry = signal<boolean>(false);
 
-  // The single organizer picker instance — needed to reset its internal input text on Clear
-  // (the box seeds itself from ownerEmail on init, and nulling the bound controls doesn't empty it).
-  private readonly ownerSearch = viewChild(UserSearchComponent);
-
   public readonly youtubeTitleLimit = YOUTUBE_MAX_MEETING_TITLE_LENGTH;
   public readonly youtubeAmberThreshold = Math.floor(YOUTUBE_MAX_MEETING_TITLE_LENGTH * 0.9);
   public readonly titleLength = toSignal(
@@ -95,8 +94,9 @@ export class MeetingDetailsComponent implements OnInit {
     { initialValue: 0 }
   );
 
-  // Current organizer (owner) selection shown under the search box — lfx-user-search clears its
-  // own input after a pick, so this label is the only visible confirmation of the selection.
+  // The committed organizer, formatted as "Name (email)" — bound into lfx-user-search's
+  // [displayValue] so the input box always renders whatever is actually committed, whether that
+  // came from hydration or a fresh pick.
   public readonly selectedOwnerLabel = toSignal(
     toObservable(this.form).pipe(
       switchMap((f) => {
@@ -118,6 +118,27 @@ export class MeetingDetailsComponent implements OnInit {
     ),
     { initialValue: '' }
   );
+
+  // Same "Name (email)" formatting, applied to the saved-owner baseline rather than the live form
+  // — used for the "Saved organizer: …" row so it reads identically to the picker's own display.
+  public readonly savedOwnerLabel = computed(() => {
+    const saved = this.savedOwner();
+    if (!saved) return '';
+    const name = (saved.name || '').trim();
+    const email = (saved.email || '').trim();
+    if (name && email) {
+      return `${name} (${email})`;
+    }
+    return name || email;
+  });
+
+  // The saved-organizer row only makes sense once there's a saved owner to revert to, and only
+  // while the picker currently shows something else — once reverted, the picker's own label
+  // already matches and the row would be redundant.
+  public readonly showSavedOwnerRevert = computed(() => {
+    const savedLabel = this.savedOwnerLabel();
+    return Boolean(savedLabel) && savedLabel !== this.selectedOwnerLabel();
+  });
 
   // Duration options from shared constants
   public readonly durationOptions = MEETING_DURATION_OPTIONS;
@@ -231,10 +252,10 @@ export class MeetingDetailsComponent implements OnInit {
       ?.setValue(fullName || null);
   }
 
-  // The search pool is the indexed meeting-registrant directory, so a user who has never been
-  // registered to a meeting the caller can see is unfindable there — manual entry covers them.
-  // Any lingering username is dropped on the first manual edit (see the subscription in ngOnInit),
-  // not here, so switching modes without editing stays side-effect free.
+  // The search pool is the same committee-member directory Invite Guests uses; manual entry still
+  // covers anyone who isn't a committee member of a project the caller can see (e.g. an external
+  // organizer). Any lingering username is dropped on the first manual edit (see the subscription
+  // in ngOnInit), not here, so switching modes without editing stays side-effect free.
   public switchToOwnerManualEntry(): void {
     this.ownerManualEntry.set(true);
   }
@@ -243,7 +264,7 @@ export class MeetingDetailsComponent implements OnInit {
     // An invalid manual email would keep gating the step invisibly after the switch — its error
     // message only renders in manual mode, and the remounted search box is a separate control that
     // can't edit ownerEmail. Drop it; a typed name stays (name-only owners are valid upstream) and
-    // remains visible/clearable via the "Current organizer" row.
+    // remains visible/clearable via the picker's own displayValue.
     const ownerEmailCtrl = this.form().get('ownerEmail');
     if (ownerEmailCtrl?.invalid) {
       ownerEmailCtrl.setValue(null);
@@ -252,25 +273,16 @@ export class MeetingDetailsComponent implements OnInit {
   }
 
   // lfx-user-search binds ownerEmail/ownerUsername but not ownerName (composed in
-  // handleOwnerSelection), so its clear can't reach the name — sync it on the explicit clear event
-  // instead of inferring "cleared" from empty bound controls, which could misread an edit
-  // hydration that patches the name before an empty email emits.
+  // handleOwnerSelection); its own onClear only nulls the controls it binds, so this fills in the
+  // revert-or-clear semantics for all three owner controls together.
   public handleOwnerSearchCleared(): void {
-    this.form().get('ownerName')?.setValue(null);
+    this.revertOwnerToSaved();
   }
 
-  // Reverting a selection: lfx-user-search empties its own input right after a pick, so PrimeNG's
-  // in-field clear icon never shows for a committed selection — this button is the clear
-  // affordance instead. Emptying every owner control makes the save omit the `owner` key (create:
-  // upstream defaults to the creator; edit: the stored owner is preserved, as the helper text says).
+  // The "Revert" button next to the saved-organizer row — same revert-or-clear semantics as the
+  // in-field ⊗ (handleOwnerSearchCleared), plus it's the only clear affordance in manual-entry mode.
   public clearOwnerSelection(): void {
-    const form = this.form();
-    form.get('ownerUsername')?.setValue(null);
-    form.get('ownerName')?.setValue(null);
-    form.get('ownerEmail')?.setValue(null);
-    // The search box seeds its own input text from ownerEmail on init; nulling the controls
-    // doesn't empty it, so reset the picker itself too (absent in manual mode, where no box shows).
-    this.ownerSearch()?.onSearchClear();
+    this.revertOwnerToSaved();
   }
 
   // AI Helper public methods
@@ -527,6 +539,22 @@ export class MeetingDetailsComponent implements OnInit {
         // For custom, the recurrence pattern component will handle the values
         break;
     }
+  }
+
+  // Reverting a selection: on an edit with a saved organizer, "clearing" restores it rather than
+  // emptying the field — upstream has no owner-removal path, so once an owner is saved there's no
+  // true empty state to revert to. Without a saved owner (create flow, or an edit whose owner was
+  // never set) this empties every control instead, and the save still omits the `owner` key
+  // either way (create: upstream defaults to the creator; edit: the stored owner is preserved).
+  private revertOwnerToSaved(): void {
+    const form = this.form();
+    const saved = this.savedOwner();
+    form.get('ownerUsername')?.setValue(saved?.username || null);
+    form.get('ownerName')?.setValue(saved?.name || null);
+    form.get('ownerEmail')?.setValue(saved?.email || null);
+    // The Revert button is also the manual-entry mode's clear affordance (no autocomplete there,
+    // so no in-field ⊗) — reverting always returns to search mode.
+    this.ownerManualEntry.set(false);
   }
 
   private buildTimezoneOptions(date: Date): { label: string; value: string }[] {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-details/meeting-details.component.ts
@@ -549,12 +549,15 @@ export class MeetingDetailsComponent implements OnInit {
   private revertOwnerToSaved(): void {
     const form = this.form();
     const saved = this.savedOwner();
+    // The Revert button is also the manual-entry mode's clear affordance (no autocomplete there,
+    // so no in-field ⊗) — flip modes *before* patching the controls below. The manual-edit guard
+    // in ngOnInit only drops ownerUsername while ownerManualEntry() is true; patching name/email
+    // first would make it mistake this programmatic revert for a hand edit and wipe the
+    // just-restored username.
+    this.ownerManualEntry.set(false);
     form.get('ownerUsername')?.setValue(saved?.username || null);
     form.get('ownerName')?.setValue(saved?.name || null);
     form.get('ownerEmail')?.setValue(saved?.email || null);
-    // The Revert button is also the manual-entry mode's clear affordance (no autocomplete there,
-    // so no in-field ⊗) — reverting always returns to search mode.
-    this.ownerManualEntry.set(false);
   }
 
   private buildTimezoneOptions(date: Date): { label: string; value: string }[] {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.html
@@ -177,7 +177,7 @@
 
             <p-step-panel [value]="2" data-testid="meeting-manage-panel-1">
               <ng-template #content let-activateCallback="activateCallback">
-                <lfx-meeting-details [form]="form()"></lfx-meeting-details>
+                <lfx-meeting-details [form]="form()" [savedOwner]="hydratedOwner()"></lfx-meeting-details>
               </ng-template>
             </p-step-panel>
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
@@ -200,17 +200,32 @@ describe('MeetingManageComponent', () => {
 
     it('omits owner when the trimmed values still match the hydrated owner', async () => {
       const component = await createOwnerComponent();
-      component.hydratedOwner = { ...HYDRATED };
+      component.hydratedOwner.set({ ...HYDRATED });
       expect(component.prepareOwnerData({ ownerUsername: ' ghopper ', ownerName: 'Grace Hopper', ownerEmail: 'grace@example.com' })).toEqual({});
     });
 
     it('includes only the non-empty owner fields when the selection changed', async () => {
       const component = await createOwnerComponent();
-      component.hydratedOwner = { ...HYDRATED };
+      component.hydratedOwner.set({ ...HYDRATED });
       // Manual-entry shape: no username — the key must not appear as an empty string.
       expect(component.prepareOwnerData({ ownerUsername: '', ownerName: 'Radia Perlman', ownerEmail: 'radia@example.com' })).toEqual({
         owner: { name: 'Radia Perlman', email: 'radia@example.com' },
       });
+    });
+
+    it('omits owner after a revert-to-saved brings the picker back in line with the hydrated owner', async () => {
+      // Mirrors the organizer picker's revert affordance: the wizard patches the owner controls
+      // back to the saved baseline (meeting-details.component.ts's revertOwnerToSaved), and the
+      // next save must see no diff against hydratedOwner — same contract as an untouched picker.
+      const component = await createOwnerComponent();
+      component.hydratedOwner.set({ ...HYDRATED });
+      component.form().patchValue({ ownerUsername: 'someone-else', ownerName: 'Someone Else', ownerEmail: 'someone@example.com' });
+      expect(component.prepareOwnerData(component.form().getRawValue())).toEqual({
+        owner: { username: 'someone-else', name: 'Someone Else', email: 'someone@example.com' },
+      });
+
+      component.form().patchValue({ ownerUsername: HYDRATED.username, ownerName: HYDRATED.name, ownerEmail: HYDRATED.email });
+      expect(component.prepareOwnerData(component.form().getRawValue())).toEqual({});
     });
 
     it('re-baselines on syncHydratedOwnerFromForm so a repeat save omits the unchanged owner', async () => {
@@ -229,9 +244,9 @@ describe('MeetingManageComponent', () => {
 
     it('keeps the previous baseline when the form is empty — that save omitted the key, so the stored owner is unchanged', async () => {
       const component = await createOwnerComponent();
-      component.hydratedOwner = { ...HYDRATED };
+      component.hydratedOwner.set({ ...HYDRATED });
       component.syncHydratedOwnerFromForm();
-      expect(component.hydratedOwner).toEqual(HYDRATED);
+      expect(component.hydratedOwner()).toEqual(HYDRATED);
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -141,7 +141,9 @@ export class MeetingManageComponent {
   // Owner hydrated from the loaded meeting (edit mode). prepareOwnerData() compares against this
   // to omit the owner key when the picker is untouched — upstream replaces owner as a whole
   // object, so re-sending an unchanged owner would silently drop its stored profile_picture.
-  private hydratedOwner: MeetingUserInfo | null = null;
+  // Exposed publicly so the wizard can pass it down as the organizer picker's revert-on-clear
+  // baseline (savedOwner input on lfx-meeting-details).
+  public readonly hydratedOwner = signal<MeetingUserInfo | null>(null);
   public registrantUpdates = signal<RegistrantPendingChanges>({
     toAdd: [],
     toUpdate: [],
@@ -628,7 +630,7 @@ export class MeetingManageComponent {
       return {};
     }
 
-    const hydrated = this.hydratedOwner;
+    const hydrated = this.hydratedOwner();
     if (hydrated && hydrated.username === username && hydrated.name === name && hydrated.email === email) {
       return {};
     }
@@ -655,7 +657,7 @@ export class MeetingManageComponent {
     const email = (formValue.ownerEmail || '').trim();
 
     if (username || name || email) {
-      this.hydratedOwner = { username, name, email };
+      this.hydratedOwner.set({ username, name, email });
     }
   }
 
@@ -1112,7 +1114,7 @@ export class MeetingManageComponent {
     // Hydrate the owner picker from the stored owner; zero-valued and service-account owners
     // resolve to null, so the picker shows empty and prepareOwnerData() omits the key on save.
     const ownerInfo = resolveMeetingOwner(meeting);
-    this.hydratedOwner = ownerInfo;
+    this.hydratedOwner.set(ownerInfo);
 
     this.form().patchValue({
       title: meeting.title,

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.html
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.html
@@ -11,12 +11,14 @@
   [panelStyleClass]="panelStyleClass()"
   [dataTestId]="dataTestId()"
   [inputId]="inputId()"
+  [showClear]="showClear()"
   optionLabel="displayName"
   size="small"
   appendTo="body"
   (completeMethod)="onSearchComplete($event)"
   (onSelect)="onUserSelected($event)"
-  (onClear)="onSearchClear()">
+  (onClear)="onSearchClear()"
+  (onBlur)="onSearchBlur()">
   <ng-template #item let-user>
     <div class="w-full flex justify-between items-center gap-2">
       <div class="flex flex-col">

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
@@ -192,10 +192,14 @@ export class UserSearchComponent {
     this.onUserSelect.emit(selectedUser);
   }
 
-  // Only meaningful alongside displayValue: arbitrary typed text that was never selected (or
-  // stale text left after a blur without a pick) shouldn't linger — snap back to the committed
-  // label. Consumers without displayValue don't get an onBlur binding in the template, so this
-  // never fires for them.
+  /**
+   * Snaps the input box back to the committed `displayValue` on blur.
+   *
+   * Only meaningful alongside `displayValue`: arbitrary typed text that was never selected (or
+   * stale text left after a blur without a pick) shouldn't linger — snap back to the committed
+   * label. Consumers without `displayValue` don't get an `onBlur` binding in the template, so
+   * this never fires for them.
+   */
   public onSearchBlur(): void {
     const label = this.displayValue();
     if (label === null) {

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
@@ -33,6 +33,15 @@ export class UserSearchComponent {
   public organizationWebsiteControl = input<string>();
   public usernameControl = input<string>();
 
+  // Parent-composed committed label (e.g. "Name (email)"). When supplied, this becomes the single
+  // source of truth for the input box's text — hydration, selection, and clear all render through
+  // it instead of the box blanking itself after a pick. Consumers that don't supply it (e.g.
+  // registrant-form) keep today's behavior: seed-from-email on hydrate, blank-on-select.
+  public displayValue = input<string | null>(null);
+  // Forwarded to lfx-autocomplete's [showClear]. Only meaningful alongside displayValue — without
+  // a committed label to restore, an in-field clear icon would just blank the box permanently.
+  public showClear = input<boolean>(false);
+
   // UI customization inputs
   public placeholder = input<string>('Search users...');
   public styleClass = input<string>();
@@ -93,8 +102,23 @@ export class UserSearchComponent {
       initialValue: [],
     });
 
-    // Effect to sync the search input with the parent form's email control if provided
+    // Effect to keep the input box in sync with the parent-composed committed label. Writes both
+    // ways: a non-null label renders it (hydration or a fresh pick), and null clears the box —
+    // callers that want a revert-on-clear pass the saved label back through this same input rather
+    // than leaving the box empty.
     effect(() => {
+      const label = this.displayValue();
+      this.userSearchForm.get('userSearch')?.setValue(label ?? '', { emitEvent: false });
+    });
+
+    // Fallback for consumers that don't supply displayValue (e.g. registrant-form): seed the box
+    // from the parent form's email control on hydrate, but never clear it — this consumer's
+    // onUserSelected() still blanks the box itself after a pick.
+    effect(() => {
+      if (this.displayValue() !== null) {
+        return;
+      }
+
       const parentForm = this.form();
       const emailControlName = this.emailControl();
 
@@ -161,11 +185,31 @@ export class UserSearchComponent {
       parentForm.get(usernameControlName)?.setValue(selectedUser.username || null);
     }
 
-    // Clear the search field to show that selection is complete
-    this.userSearchForm.get('userSearch')?.setValue('', { emitEvent: false });
+    // Consumers driving displayValue re-render the box via that input once the parent's controls
+    // (patched above) flow back into its computed label — blanking here would just flash empty
+    // first. Consumers without displayValue still clear immediately, per today's behavior.
+    if (this.displayValue() === null) {
+      this.userSearchForm.get('userSearch')?.setValue('', { emitEvent: false });
+    }
 
     // Emit the selected user - parent component will handle showing individual fields
     this.onUserSelect.emit(selectedUser);
+  }
+
+  // Only meaningful alongside displayValue: arbitrary typed text that was never selected (or
+  // stale text left after a blur without a pick) shouldn't linger — snap back to the committed
+  // label. Consumers without displayValue don't get an onBlur binding in the template, so this
+  // never fires for them.
+  public onSearchBlur(): void {
+    const label = this.displayValue();
+    if (label === null) {
+      return;
+    }
+
+    const current = this.userSearchForm.get('userSearch')?.value ?? '';
+    if (current !== label) {
+      this.userSearchForm.get('userSearch')?.setValue(label, { emitEvent: false });
+    }
   }
 
   public onSearchClear(): void {

--- a/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
+++ b/apps/lfx-one/src/app/shared/components/user-search/user-search.component.ts
@@ -1,14 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, effect, inject, input, output, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { Component, DestroyRef, inject, input, output, Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { UserSearchResult } from '@lfx-one/shared/interfaces';
 import { rankUserSearchResults } from '@lfx-one/shared/utils';
 import { SearchService } from '@services/search.service';
 import { AutoCompleteCompleteEvent, AutoCompleteSelectEvent } from 'primeng/autocomplete';
-import { catchError, debounceTime, distinctUntilChanged, map, of, startWith, switchMap } from 'rxjs';
+import { catchError, combineLatest, debounceTime, distinctUntilChanged, map, of, startWith, switchMap } from 'rxjs';
 
 import { AutocompleteComponent } from '../autocomplete/autocomplete.component';
 
@@ -19,6 +19,7 @@ import { AutocompleteComponent } from '../autocomplete/autocomplete.component';
 })
 export class UserSearchComponent {
   private readonly searchService = inject(SearchService);
+  private readonly destroyRef = inject(DestroyRef);
 
   // Required inputs
   public form = input.required<FormGroup>();
@@ -102,34 +103,29 @@ export class UserSearchComponent {
       initialValue: [],
     });
 
-    // Effect to keep the input box in sync with the parent-composed committed label. Writes both
-    // ways: a non-null label renders it (hydration or a fresh pick), and null clears the box —
-    // callers that want a revert-on-clear pass the saved label back through this same input rather
-    // than leaving the box empty.
-    effect(() => {
-      const label = this.displayValue();
-      this.userSearchForm.get('userSearch')?.setValue(label ?? '', { emitEvent: false });
-    });
-
-    // Fallback for consumers that don't supply displayValue (e.g. registrant-form): seed the box
-    // from the parent form's email control on hydrate, but never clear it — this consumer's
-    // onUserSelected() still blanks the box itself after a pick.
-    effect(() => {
-      if (this.displayValue() !== null) {
-        return;
-      }
-
-      const parentForm = this.form();
-      const emailControlName = this.emailControl();
-
-      if (parentForm && emailControlName) {
-        const emailControlValue = parentForm.get(emailControlName)?.value;
-
-        if (emailControlValue && emailControlValue.trim()) {
-          this.userSearchForm.get('userSearch')?.setValue(emailControlValue, { emitEvent: false });
+    // Keep the input box in sync with the parent-composed committed label — a non-null label
+    // renders it (hydration, a fresh pick, or a revert-to-empty), and consumers that don't supply
+    // one (e.g. registrant-form) fall back to seeding the box from the parent form's email control
+    // on hydrate, but never clearing it (that consumer's onUserSelected() still blanks the box
+    // itself after a pick). toObservable()+subscribe rather than effect(): writing into a
+    // FormControl from an effect risks ExpressionChangedAfterItHasBeenCheckedError under zoneless
+    // change detection.
+    combineLatest([toObservable(this.displayValue), toObservable(this.form), toObservable(this.emailControl)])
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe(([label, parentForm, emailControlName]) => {
+        if (label !== null) {
+          this.userSearchForm.get('userSearch')?.setValue(label, { emitEvent: false });
+          return;
         }
-      }
-    });
+
+        if (parentForm && emailControlName) {
+          const emailControlValue = parentForm.get(emailControlName)?.value;
+
+          if (emailControlValue && emailControlValue.trim()) {
+            this.userSearchForm.get('userSearch')?.setValue(emailControlValue, { emitEvent: false });
+          }
+        }
+      });
   }
 
   public onSearchComplete(event: AutoCompleteCompleteEvent): void {


### PR DESCRIPTION
## Summary

Fixes three UX problems with the Meeting Organizer picker shipped in #1673 (71a8cdac4), all rooted in the input box and the selection state rendering the committed owner differently:

- Hydration seeds the box with the saved owner's email, but picking a new organizer blanks the box and moves confirmation to a separate "Current organizer: …" line — the field appears to lose your input.
- Clicking "Clear" wiped the field to blank even though the helper text says clearing won't remove a saved organizer — now it visually reverts to the saved organizer instead.
- No in-field clear affordance, requiring select-all + delete to edit pre-filled text — added an in-field `⊗`.

Also swapped the search pool from `meeting_registrant` to `committee_member` (same pool the Invite Guests step uses), since the registrant-only pool missed many searchable people.

## Changes

- `lfx-user-search`: opt-in `displayValue`/`showClear` inputs make the input box the single source of display truth (`Name (email)`) for hydration, fresh picks, and revert. Gated so `registrant-form.component.html` (the other consumer) keeps its existing clear-on-select behavior.
- `meeting-manage.component.ts`: `hydratedOwner` converted to a public signal so the wizard can pass the saved-owner baseline down.
- `meeting-details.component.ts`/`.html`: new `savedOwner` input; clearing (in-field `⊗` or the "Revert" button) now restores the saved organizer rather than emptying the field; switched `searchType` to `committee_member`.
- Rewrote `e2e/meeting-owner-organizer.spec.ts` for the new hydrate/pick/revert/clear/manual-entry flows and the `committee_member` pool.
- Added unit test coverage in `meeting-manage.component.spec.ts` for the revert-then-save omit-owner-key contract.

## Ticket

GH-1673

## Notes for reviewers

- **Branch naming deviation (documented per PR-readiness SHOULD_FIX):** branch is `fix/GH-1673-organizer-picker-ux` rather than the canonical `fix/GH-1673`, because that exact name is already in use by an separate, unrelated, currently-open PR (#1690) against the same tracking issue.
- Pre-PR reviewer trio (general, self-serve conventions, learnings) all returned clean on this commit — no Critical or Important findings requiring changes. Two Important-tier notes from the conventions reviewer point at pre-existing code in `user-search.component.ts` untouched by this diff.
- `yarn check-types`, `yarn lint:check`, `yarn build`, `yarn format` all pass. Unit tests for `meeting-manage.component.spec.ts` pass (9/9, including the new revert test).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Meeting organizers can be searched and selected from committee members.
  * Selected organizers remain visible as `Name (email)` with an option to clear.
  * Saved organizers are shown when editing meetings, with a **Revert** option to restore them.
  * New organizers can be cleared when no saved organizer exists.

* **Bug Fixes**
  * Organizer fields now consistently restore their saved values after editing or losing focus.
  * Meeting updates avoid sending unchanged organizer information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->