### PR TITLE
fix(events): use LF Open Source logo on China event certificates

### DIFF
--- a/apps/lfx-one/src/server/services/certificate.service.spec.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.spec.ts
@@ -1,0 +1,233 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors brand-kit.service.spec.ts: shared modules are mocked because the `@lfx-one/shared/*`
+// alias isn't wired into this app's vitest config. pdf.constants is aliased to its real source.
+const snowflakeMocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+const pdfMocks = vi.hoisted(() => ({
+  images: [] as { path: string; options: Record<string, unknown> | undefined }[],
+}));
+
+vi.mock('@lfx-one/shared/interfaces', () => ({}));
+vi.mock('./snowflake.service', () => ({
+  SnowflakeService: { getInstance: () => ({ execute: snowflakeMocks.execute }) },
+}));
+vi.mock('./logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+// PDFKit is stubbed so assertions read the draw calls instead of parsing a rendered binary.
+// `end()` synchronously fires the 'end' handler the service awaits.
+vi.mock('pdfkit', () => {
+  class FakePDFDocument {
+    private handlers: Record<string, ((arg?: unknown) => void)[]> = {};
+
+    public on(event: string, handler: (arg?: unknown) => void): this {
+      (this.handlers[event] ??= []).push(handler);
+      return this;
+    }
+
+    public image(path: string, ...rest: unknown[]): this {
+      const options = rest.find((arg) => typeof arg === 'object' && arg !== null) as Record<string, unknown> | undefined;
+      pdfMocks.images.push({ path, options });
+      return this;
+    }
+
+    public registerFont(): this {
+      return this;
+    }
+    public font(): this {
+      return this;
+    }
+    public fontSize(): this {
+      return this;
+    }
+    public fillColor(): this {
+      return this;
+    }
+    public lineGap(): this {
+      return this;
+    }
+    public text(): this {
+      return this;
+    }
+    public moveDown(): this {
+      return this;
+    }
+
+    public end(): void {
+      this.handlers['data']?.forEach((handler) => handler(Buffer.from('pdf')));
+      this.handlers['end']?.forEach((handler) => handler());
+    }
+  }
+
+  return { default: FakePDFDocument };
+});
+
+vi.mock('fs', () => {
+  const readFileSync = vi.fn(() => Buffer.from('font'));
+  const existsSync = vi.fn(() => true);
+  return { default: { readFileSync, existsSync }, readFileSync, existsSync };
+});
+
+import type { Request } from 'express';
+
+import { AuthorizationError, ResourceNotFoundError } from '../errors';
+import { CertificateService } from './certificate.service';
+
+const CNCF_PROJECT_ID = 'a0941000002wBz4AAE';
+const LF_OPEN_SOURCE_LOGO = 'lfopensource-logo.png';
+const TLF_LOGO = 'image2.png';
+const CNCF_LOGO = 'cncf-logo.png';
+
+const req = { path: '/api/events/certificate' } as unknown as Request;
+
+interface RowOverrides {
+  EVENT_COUNTRY?: string | null;
+  EVENT_SOURCE?: string | null;
+  PROJECT_ID?: string;
+  USER_ATTENDED?: number | boolean | null;
+}
+
+function mockRow(overrides: RowOverrides = {}): void {
+  snowflakeMocks.execute.mockResolvedValue({
+    rows: [
+      {
+        EVENT_NAME: 'Test Event',
+        EVENT_START_DATE: '2026-03-10T00:00:00.000Z',
+        EVENT_END_DATE: '2026-03-12T00:00:00.000Z',
+        EVENT_LOCATION: null,
+        EVENT_CITY: 'Shanghai',
+        EVENT_COUNTRY: 'China',
+        EVENT_SOURCE: 'backfill',
+        PROJECT_ID: 'a09410000000000AAA',
+        USER_ATTENDED: true,
+        ...overrides,
+      },
+    ],
+  });
+}
+
+/** The letterhead logo is the first image drawn; the signature is the second. */
+function drawnLogo(): { path: string; options: Record<string, unknown> | undefined } {
+  return pdfMocks.images[0];
+}
+
+function drawnSignature(): { path: string; options: Record<string, unknown> | undefined } {
+  return pdfMocks.images[1];
+}
+
+describe('CertificateService', () => {
+  let service: CertificateService;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    pdfMocks.images = [];
+    service = new CertificateService();
+  });
+
+  describe('LF Open Source logo override', () => {
+    it('applies the LF Open Source logo for a backfill event in China', async () => {
+      mockRow();
+
+      await service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      expect(drawnLogo().path).toContain(LF_OPEN_SOURCE_LOGO);
+    });
+
+    it('draws the override logo wider than the default so the wordmark stays legible', async () => {
+      mockRow();
+
+      await service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      // The wordmark is ~13.6:1; at the default 145pt width it renders about 10pt tall.
+      expect(drawnLogo().options?.['width']).toBe(240);
+    });
+
+    it('overrides a project template logo but keeps that project name and signature', async () => {
+      // Real data: event -6, KubeCon + CloudNativeCon China 2026, owned by CNCF.
+      mockRow({ PROJECT_ID: CNCF_PROJECT_ID });
+
+      await service.generateCertificate(req, { eventId: '-6', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      expect(drawnLogo().path).toContain(LF_OPEN_SOURCE_LOGO);
+      expect(drawnSignature().path).toContain('cncf-signature.png');
+    });
+
+    it.each([
+      ['uppercase country', { EVENT_COUNTRY: 'CHINA' }],
+      ['padded lowercase country', { EVENT_COUNTRY: ' china ' }],
+      ['capitalised source', { EVENT_SOURCE: 'Backfill' }],
+      ['padded source', { EVENT_SOURCE: ' BACKFILL ' }],
+    ])('applies the override despite %s', async (_label, overrides) => {
+      mockRow(overrides);
+
+      await service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      expect(drawnLogo().path).toContain(LF_OPEN_SOURCE_LOGO);
+    });
+  });
+
+  describe('events that must keep their existing logo', () => {
+    it.each([
+      // 84 China events come from Bevy and must not pick up the override.
+      ['a bevy-sourced China event', { EVENT_SOURCE: 'bevy' }],
+      ['a cvent-sourced China event', { EVENT_SOURCE: 'cvent' }],
+      // The one real non-China backfill event.
+      ['a backfill event in France', { EVENT_COUNTRY: 'France' }],
+      // Guards against a substring / LIKE '%china%' match.
+      ['a Hong Kong event', { EVENT_COUNTRY: 'Hong Kong (SAR China)' }],
+      ['a null source', { EVENT_SOURCE: null }],
+      ['a null country', { EVENT_COUNTRY: null }],
+    ])('keeps the default logo for %s', async (_label, overrides) => {
+      mockRow(overrides);
+
+      await service.generateCertificate(req, { eventId: 'evt-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      expect(drawnLogo().path).toContain(TLF_LOGO);
+      expect(drawnLogo().options?.['width']).toBe(145);
+    });
+
+    it('keeps the CNCF logo for a non-matching CNCF event', async () => {
+      mockRow({ PROJECT_ID: CNCF_PROJECT_ID, EVENT_SOURCE: 'cvent', EVENT_COUNTRY: 'United States' });
+
+      await service.generateCertificate(req, { eventId: 'evt-2', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      expect(drawnLogo().path).toContain(CNCF_LOGO);
+    });
+  });
+
+  describe('authorization and lookup', () => {
+    it('throws AuthorizationError when the user did not attend', async () => {
+      mockRow({ USER_ATTENDED: false });
+
+      await expect(service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' })).rejects.toThrow(
+        AuthorizationError
+      );
+    });
+
+    it('throws ResourceNotFoundError when no registration row matches', async () => {
+      snowflakeMocks.execute.mockResolvedValue({ rows: [] });
+
+      await expect(service.generateCertificate(req, { eventId: 'missing', userEmail: 'attendee@example.com', userName: 'Test Attendee' })).rejects.toThrow(
+        ResourceNotFoundError
+      );
+    });
+
+    it('selects EVENT_SOURCE and binds the event id and email in order', async () => {
+      mockRow();
+
+      await service.generateCertificate(req, { eventId: '-1', userEmail: 'attendee@example.com', userName: 'Test Attendee' });
+
+      const [sql, binds] = snowflakeMocks.execute.mock.calls[0];
+      expect(sql).toContain('EVENT_SOURCE');
+      expect((sql.match(/\?/g) ?? []).length).toBe(binds.length);
+      expect(binds).toEqual(['-1', 'attendee@example.com']);
+    });
+  });
+});

--- a/apps/lfx-one/src/server/services/certificate.service.ts
+++ b/apps/lfx-one/src/server/services/certificate.service.ts
@@ -13,7 +13,14 @@ import { AuthorizationError, ResourceNotFoundError } from '../errors';
 import { logger } from './logger.service';
 import { SnowflakeService } from './snowflake.service';
 import { PDFTemplateDetails, CertificateData, CertificateEventRow } from '@lfx-one/shared/interfaces';
-import { DEFAULT_TEMPLATE, PROJECT_TEMPLATES } from '@lfx-one/shared/constants/pdf.constants';
+import {
+  DEFAULT_LOGO_WIDTH,
+  DEFAULT_TEMPLATE,
+  LF_OPEN_SOURCE_LOGO,
+  LF_OPEN_SOURCE_LOGO_MATCH,
+  LF_OPEN_SOURCE_LOGO_WIDTH,
+  PROJECT_TEMPLATES,
+} from '@lfx-one/shared/constants/pdf.constants';
 
 // In production, import.meta.url points to the server bundle (dist/lfx-one/server/server.mjs)
 // and pdf-templates are copied there by the build script.
@@ -55,7 +62,20 @@ export class CertificateService {
       });
     }
 
-    const template = PROJECT_TEMPLATES[eventRow.PROJECT_ID] ?? DEFAULT_TEMPLATE;
+    const baseTemplate = PROJECT_TEMPLATES[eventRow.PROJECT_ID] ?? DEFAULT_TEMPLATE;
+
+    // Legal requires the LF Open Source mark for China backfill events, whichever project owns
+    // them. Logo only — name, address, body copy and signature stay with the base template.
+    const isLfOpenSourceOverride = this.requiresLfOpenSourceLogo(eventRow);
+    const template = isLfOpenSourceOverride ? { ...baseTemplate, logo: LF_OPEN_SOURCE_LOGO, logoWidth: LF_OPEN_SOURCE_LOGO_WIDTH } : baseTemplate;
+
+    if (isLfOpenSourceOverride) {
+      logger.debug(req, 'generate_certificate', 'Applying LF Open Source logo override', {
+        event_id: data.eventId,
+        event_source: eventRow.EVENT_SOURCE,
+        event_country: eventRow.EVENT_COUNTRY,
+      });
+    }
 
     logger.debug(req, 'generate_certificate', 'Building PDF', {
       event_id: data.eventId,
@@ -63,6 +83,17 @@ export class CertificateService {
     });
 
     return this.buildPdf(data.userName, eventRow, template);
+  }
+
+  /**
+   * Trimmed and lowercased so casing drift in imported CSV data doesn't skip the override, and
+   * whole-string so 'Hong Kong (SAR China)' doesn't match. Unmatched values keep the base logo.
+   */
+  private requiresLfOpenSourceLogo(event: CertificateEventRow): boolean {
+    const source = event.EVENT_SOURCE?.trim().toLowerCase();
+    const country = event.EVENT_COUNTRY?.trim().toLowerCase();
+
+    return source === LF_OPEN_SOURCE_LOGO_MATCH.EVENT_SOURCE.toLowerCase() && country === LF_OPEN_SOURCE_LOGO_MATCH.EVENT_COUNTRY.toLowerCase();
   }
 
   private async getEventRow(req: Request, eventId: string, userEmail: string): Promise<CertificateEventRow> {
@@ -74,6 +105,7 @@ export class CertificateService {
         EVENT_LOCATION,
         EVENT_CITY,
         EVENT_COUNTRY,
+        EVENT_SOURCE,
         PROJECT_ID,
         USER_ATTENDED
       FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
@@ -109,7 +141,7 @@ export class CertificateService {
       doc.font('Helvetica');
 
       // Project logo (top-left)
-      doc.image(join(TEMPLATE_DIR, 'images', template.logo), PAGE_START, 47, { width: 145 });
+      doc.image(join(TEMPLATE_DIR, 'images', template.logo), PAGE_START, 47, { width: template.logoWidth ?? DEFAULT_LOGO_WIDTH });
 
       // Address & link (top-right)
       doc

--- a/apps/lfx-one/vitest.config.ts
+++ b/apps/lfx-one/vitest.config.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { fileURLToPath } from 'node:url';
+
 import { defineConfig } from 'vitest/config';
 
 // Scoped to src/server. App-side specs under src/app run through the `test` target in
@@ -10,6 +12,13 @@ import { defineConfig } from 'vitest/config';
 // server spec picked up by the Angular builder pays for a browser it never uses, and an
 // app spec picked up here fails on the missing compiler.
 export default defineConfig({
+  resolve: {
+    alias: {
+      // A deep source import the package's `exports` map doesn't publish; it resolves through
+      // the tsconfig `@lfx-one/shared/*` path alias at build time. Mirrored here for specs.
+      '@lfx-one/shared/constants/pdf.constants': fileURLToPath(new URL('../../packages/shared/src/constants/pdf.constants.ts', import.meta.url)),
+    },
+  },
   test: {
     include: ['src/server/**/*.spec.ts'],
     environment: 'node',

--- a/packages/shared/src/constants/pdf.constants.ts
+++ b/packages/shared/src/constants/pdf.constants.ts
@@ -14,6 +14,30 @@ export const DEFAULT_TEMPLATE: PDFTemplateDetails = {
   signatureText: `Jim Zemlin\nExecutive Director`,
 };
 
+/**
+ * Logo mandated by legal for events held in China that were imported through the CSV
+ * backfill flow. Overrides the project/default letterhead logo — see GH-1695.
+ */
+export const LF_OPEN_SOURCE_LOGO = 'lfopensource-logo.png';
+
+/** Logo width used by the letterhead when a template doesn't specify its own. */
+export const DEFAULT_LOGO_WIDTH = 145;
+
+/**
+ * The 13.6:1 wordmark is illegible at DEFAULT_LOGO_WIDTH (~10pt tall); 240pt matches the
+ * Linux Foundation icon's visual weight and clears the address block at x=408.
+ */
+export const LF_OPEN_SOURCE_LOGO_WIDTH = 240;
+
+/**
+ * Event source + country pair that triggers the LF Open Source logo override. EVENT_SOURCE
+ * stands in for REGISTRATION_SOURCE, which the Platinum view does not expose — see GH-1695.
+ */
+export const LF_OPEN_SOURCE_LOGO_MATCH = {
+  EVENT_SOURCE: 'backfill',
+  EVENT_COUNTRY: 'China',
+} as const;
+
 export const PROJECT_TEMPLATES: Record<string, PDFTemplateDetails> = {
   a0941000002wBz4AAE: {
     link: 'https://www.cncf.io/',

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -293,6 +293,8 @@ export interface PDFTemplateDetails {
   desc: string;
   onBehalf: string;
   logo: string;
+  /** Rendered logo width in PDF points; falls back to DEFAULT_LOGO_WIDTH when omitted */
+  logoWidth?: number;
   signature: string;
   signatureText: string;
 }
@@ -304,6 +306,8 @@ export interface CertificateEventRow {
   EVENT_LOCATION: string | null;
   EVENT_CITY: string | null;
   EVENT_COUNTRY: string | null;
+  /** Origin system for the event (cvent, regfox, bevy, backfill); 'backfill' identifies CSV-imported events */
+  EVENT_SOURCE: string | null;
   PROJECT_ID: string;
   /** Attendance flag (1 = attended); certificates are only issued for attended events */
   USER_ATTENDED: number | null;


### PR DESCRIPTION
## Summary

- Legal requires the LF Open Source LLC mark on attendance certificates for events held in China. The letterhead logo previously came only from the event's `PROJECT_ID`, yielding The Linux Foundation logo by default or CNCF for CNCF-owned events.
- `certificate.service.ts` now matches on `EVENT_SOURCE` + `EVENT_COUNTRY` from `ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS` and swaps in the LF Open Source logo when both match.
- Matching is trimmed and lowercased so casing drift in imported data doesn't skip the override, and whole-string so `Hong Kong (SAR China)` does **not** match. Null or unmatched values fall through to current behavior.
- **Logo only** — entity name, letterhead address, body copy, "On behalf of…" line, and signature block stay with the project/default template. The override takes precedence over project templates, including CNCF.
- `PDFTemplateDetails` gains an optional `logoWidth`; the wordmark's 13.6:1 aspect ratio is illegible at the hard-coded 145pt, so it renders at 240pt (verified against rendered letterheads).
- Server-side only — no frontend, API contract, env var, or upstream data change. The `lfopensource-logo.png` asset was already in the repo.
- New `certificate.service.spec.ts` covers the override, CNCF precedence, casing/whitespace variants, the substring guard, null values, the `USER_ATTENDED` gate, and SQL bind alignment (17 tests).

Closes #1695
