### PR TITLE
refactor(meetings): generalize entity project-context primitives (GH-1641)

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -44,7 +44,7 @@ import {
   DEFAULT_MEETING_TYPE_CONFIG,
   getCurrentOrNextOccurrence,
   getLargestSessionShareUrl,
-  getMeetingEditCommands,
+  getEntityCommands,
   getPastMeetingResourceId,
   getPastMeetingTranscriptUrl,
   getUpcomingMeetingStartTime,
@@ -213,7 +213,9 @@ export class MeetingCardComponent implements OnInit {
   });
   // Canonical edit URL derives from the MEETING's project tier (is_foundation), not the viewer's
   // active lens; falls back to the flat path (lensRedirectGuard) when the tier is unenriched.
-  public readonly editCommands: Signal<string[]> = computed(() => getMeetingEditCommands(this.meeting()) ?? ['/meetings', this.meeting().id, 'edit']);
+  public readonly editCommands: Signal<string[]> = computed(
+    () => getEntityCommands('meetings', this.meeting().id, this.meeting().is_foundation, 'edit') ?? ['/meetings', this.meeting().id, 'edit']
+  );
 
   public readonly meetingDeleted = output<void>();
   public readonly project = this.projectService.project;
@@ -312,7 +314,18 @@ export class MeetingCardComponent implements OnInit {
 
   public copyMeetingLink(): void {
     const meeting = this.meeting();
-    const meetingUrl: URL = new URL(environment.urls.home + '/meetings/' + meeting.id);
+
+    let meetingUrl: URL;
+    try {
+      meetingUrl = new URL(environment.urls.home + '/meetings/' + meeting.id);
+    } catch {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Copy Failed',
+        detail: 'Unable to build the meeting link. Please try again.',
+      });
+      return;
+    }
 
     if (meeting.password) {
       meetingUrl.searchParams.set('password', meeting.password);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -49,7 +49,7 @@ import {
   formatTo12HourInTimezone,
   generateRecurrenceObject,
   getDefaultStartDateTime,
-  getMeetingEditCommands,
+  getEntityCommands,
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
   mapRecurrenceToFormValue,
@@ -94,7 +94,7 @@ import { MeetingResourcesSummaryComponent } from '../components/meeting-resource
 import { MeetingTypeSelectionComponent } from '../components/meeting-type-selection/meeting-type-selection.component';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
-import { hasMeetingWriteAccess, resolveMeetingWriteSlug } from '@shared/utils/write-access.util';
+import { hasMeetingWriteAccess, resolveEntityWriteSlug } from '@shared/utils/write-access.util';
 
 @Component({
   selector: 'lfx-meeting-manage',
@@ -748,10 +748,7 @@ export class MeetingManageComponent {
         }
         // Canonicalize on the created meeting's project tier — the create flow already resolved it
         // (projectQueryParamGuard effectiveKind → isFoundationContext), so no extra fetch is needed.
-        const editCommands = getMeetingEditCommands({
-          id: meetingId,
-          is_foundation: this.projectContextService.isFoundationContext(),
-        });
+        const editCommands = getEntityCommands('meetings', meetingId, this.projectContextService.isFoundationContext(), 'edit');
         this.router.navigate(editCommands ?? ['/meetings', meetingId, 'edit'], { queryParams: editQueryParams });
       } else {
         // Fallback to meetings list if no meeting ID
@@ -893,7 +890,7 @@ export class MeetingManageComponent {
             }
             // Mirror writerGuard's resolution order; the active-context fallback covers a meeting
             // carrying neither slug nor uid (the manage component owns that error path).
-            return resolveMeetingWriteSlug(meeting, this.projectContextService.activeContext()?.slug ?? null);
+            return resolveEntityWriteSlug(meeting, this.projectContextService.activeContext()?.slug ?? null);
           })
         )
       : toObservable(this.projectContextService.activeContext).pipe(map((ctx) => ctx?.slug ?? null));

--- a/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts
@@ -12,7 +12,7 @@ import { LensService } from '../services/lens.service';
  * when foundation or project lens is active. Lets the request through unchanged
  * for `me` and `org` lenses, where the flat routes are the canonical destination.
  * Carve-out: ENRICHED meeting EDIT links bypass this guard entirely — they canonicalize on the
- * meeting's own project tier (`is_foundation`) via `getMeetingEditCommands`, so me/org-lens
+ * meeting's own project tier (`is_foundation`) via `getEntityCommands`, so me/org-lens
  * users land on the tier-prefixed `/foundation|project/meetings/{id}/edit` URL. When
  * `is_foundation` is absent (unenriched payload), callers fall back to the flat
  * `/meetings/{id}/edit` path, which still runs this guard and redirects by active lens.

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -136,15 +136,31 @@ describe('writerGuard', () => {
     expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
   });
 
-  it('resolves from the active context without probing when the writeFeature has no registered entity probe', async () => {
-    getProject.mockReturnValue(of({ uid: 'stale-uid', slug: STALE_SLUG, writer: true }));
-
-    // entityScopedSlug alone must not trigger a probe — registry membership is the gate, so a
-    // feature that never registered a probe can't accidentally fire one after a route-flag flip.
+  it('fails closed when an entity-scoped route has no registered entity probe', async () => {
+    // entityScopedSlug with no usable probe is a route misconfiguration — fail closed (redirect,
+    // no downstream authorization probe) rather than fall back to the possibly stale context.
     const result = await runGuard(meetingRoute({ writeFeature: 'newsletters', entityScopedSlug: true }));
 
-    expect(result).toBe(true);
+    expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
+    expect(result).toEqual({ redirect: '/project/overview' });
     expect(getMeetingDetail).not.toHaveBeenCalled();
-    expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
+    expect(getProject).not.toHaveBeenCalled();
+    expect(getCommittee).not.toHaveBeenCalled();
+  });
+
+  it('fails closed when an entity-scoped route has no :id param', async () => {
+    const route = {
+      queryParamMap: convertToParamMap({}),
+      paramMap: convertToParamMap({}),
+      data: { writeFeature: 'meetings', entityScopedSlug: true },
+      parent: null,
+    } as unknown as ActivatedRouteSnapshot;
+
+    const result = await runGuard(route);
+
+    expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
+    expect(result).toEqual({ redirect: '/project/overview' });
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -135,4 +135,16 @@ describe('writerGuard', () => {
     expect(getMeetingDetail).not.toHaveBeenCalled();
     expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
   });
+
+  it('resolves from the active context without probing when the writeFeature has no registered entity probe', async () => {
+    getProject.mockReturnValue(of({ uid: 'stale-uid', slug: STALE_SLUG, writer: true }));
+
+    // entityScopedSlug alone must not trigger a probe — registry membership is the gate, so a
+    // feature that never registered a probe can't accidentally fire one after a route-flag flip.
+    const result = await runGuard(meetingRoute({ writeFeature: 'newsletters', entityScopedSlug: true }));
+
+    expect(result).toBe(true);
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
+  });
 });

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -86,16 +86,8 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
     if (!probe || !entityId || route.data?.['entityScopedSlug'] !== true) {
       return of(fromContext);
     }
-    // Resolve from the entity payload itself, preferring the BFF-enriched slug but falling back
-    // to the uid — the BFF `GET /api/projects/:slug` route sniffs UUIDs, so the downstream
-    // getProject access check resolves either identifier. Never fall back to the active context
-    // while the entity is readable: doing so would authorize against a stale, unrelated project.
-    // A failed project probe now denies against the entity's own project instead of
-    // silently switching to that stale context. Only a 404 falls back — the entity may simply not
-    // exist and the manage component owns that error path; every other failure resolves null and
-    // fails closed via the `if (!slug)` redirect, so no check runs against a stale project.
-    // Probe-friendly: getMeetingDetail is tap-free and short-TTL-cached, sharing the request with
-    // MeetingManageComponent's fetch on the same navigation.
+    // Resolve from the entity payload, never the active context — a readable entity with a stale
+    // context would authorize against the wrong project; only a 404 falls back, else fail closed.
     return probe(entityId).pipe(
       map((entity) => resolveEntityWriteSlug(entity, fromContext)),
       catchError((error) => of(error instanceof HttpErrorResponse && error.status === 404 ? fromContext : null))

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -66,16 +66,11 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const routeLens = route.parent?.data?.['lens'] ?? route.data?.['lens'];
   const overviewPath = routeLens === 'foundation' ? '/foundation/overview' : '/project/overview';
 
-  // On a meeting EDIT route, a missing or stale `?project=` means the active
-  // context can belong to a different project than the meeting being edited (bare
-  // `/meetings/:id/edit` links redirect by active lens and carry no project param). Authorizing
-  // against that stale context intermittently denied legitimate organizers — or worse, could
-  // authorize against the wrong project. Resolve the slug from the meeting itself first; fall
-  // back to the active context only on a 404 (it may simply not exist — the manage component
-  // handles that error path), and fail closed on any other read failure.
+  // A missing/stale `?project=` can authorize against a different project than the entity being
+  // edited — resolve the slug from the entity itself; only a 404 falls back, else fail closed.
   const writeFeature: string | undefined = route.data?.['writeFeature'];
-  // Entity probes keyed by writeFeature — a follow-up entity ticket adds one registry line, one
-  // inject(), and one route flag; the fail-closed semantics below exist in exactly one place.
+  // Entity probes keyed by writeFeature — a follow-up ticket adds one registry line + inject() +
+  // route flag; probes must be tap-free and short-TTL-cached so the guard shares the manage fetch.
   const entityProbes: Record<string, (id: string) => Observable<Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null>> = {
     meetings: (id) => meetingService.getMeetingDetail(id),
   };
@@ -104,11 +99,8 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
       const deny = () => deniedUrl;
       const supportsCommitteeWriter = writeFeature != null && COMMITTEE_WRITE_FEATURES.includes(writeFeature);
 
-      // Committee writers can create meetings, surveys, and votes associated with
-      // their committee. Only applicable when committee_uid is in the route query params.
-      // CommitteeService.getCommittee has a tap() that sets the committee signal as a
-      // side-effect — acceptable here: on deny navigation is blocked before any committee
-      // view renders; on allow the committee page overwrites it.
+      // Committee writers can create entities for their committee via ?committee_uid=.
+      // getCommittee's tap() side effect is safe here: deny blocks navigation; allow overwrites.
       const checkCommittee = (): Observable<true | ReturnType<typeof deny>> =>
         committeeService.getCommittee(committeeUid!).pipe(
           map((committee) => (committee?.writer === true ? (true as const) : deny())),
@@ -117,11 +109,8 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
 
       return projectService.getProject(slug, false, { meetingCoordinator: writeFeature === 'meetings' }).pipe(
         switchMap((project) => {
-          // project === null means the BFF returned 403/404/5xx — could be a real access
-          // denial (committee member without a direct project-level OpenFGA viewer relation)
-          // or a transient server error. Still attempt the committee check when applicable so
-          // a committee writer is not incorrectly denied solely because the project fetch
-          // failed. If no committee check is applicable, deny with feedback.
+          // project === null means the BFF fetch failed (403/404/5xx) — real denial or transient;
+          // still try the committee check so a committee writer isn't denied on a fetch failure.
           if (project === null) {
             return committeeUid && supportsCommitteeWriter ? checkCommittee() : of(deny());
           }

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 import { COMMITTEE_WRITE_FEATURES } from '@lfx-one/shared/constants';
+import { EntityWithProject } from '@lfx-one/shared/interfaces';
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';
@@ -11,7 +12,7 @@ import { MeetingService } from '../services/meeting.service';
 import { PersonaService } from '../services/persona.service';
 import { ProjectContextService } from '../services/project-context.service';
 import { ProjectService } from '../services/project.service';
-import { hasMeetingWriteAccess, resolveMeetingWriteSlug } from '../utils/write-access.util';
+import { hasMeetingWriteAccess, resolveEntityWriteSlug } from '../utils/write-access.util';
 
 /**
  * Protects create/edit/admin routes that require project write permission.
@@ -73,27 +74,30 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   // back to the active context only on a 404 (it may simply not exist — the manage component
   // handles that error path), and fail closed on any other read failure.
   const writeFeature: string | undefined = route.data?.['writeFeature'];
+  // Entity probes keyed by writeFeature — a follow-up entity ticket adds one registry line, one
+  // inject(), and one route flag; the fail-closed semantics below exist in exactly one place.
+  const entityProbes: Record<string, (id: string) => Observable<Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null>> = {
+    meetings: (id) => meetingService.getMeetingDetail(id),
+  };
   const resolveSlug = (): Observable<string | null> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
-    if (writeFeature !== 'meetings') {
+    const probe = writeFeature ? entityProbes[writeFeature] : undefined;
+    const entityId = route.paramMap.get('id');
+    if (!probe || !entityId || route.data?.['entityScopedSlug'] !== true) {
       return of(fromContext);
     }
-    const meetingId = route.paramMap.get('id');
-    if (!meetingId || route.data?.['entityScopedSlug'] !== true) {
-      return of(fromContext);
-    }
-    // Resolve from the meeting payload itself, preferring the BFF-enriched slug but falling back
+    // Resolve from the entity payload itself, preferring the BFF-enriched slug but falling back
     // to the uid — the BFF `GET /api/projects/:slug` route sniffs UUIDs, so the downstream
     // getProject access check resolves either identifier. Never fall back to the active context
-    // while the meeting is readable: doing so would authorize against a stale, unrelated project.
-    // A failed project probe now denies against the meeting's own project instead of
-    // silently switching to that stale context. Only a 404 falls back — the meeting may simply not
+    // while the entity is readable: doing so would authorize against a stale, unrelated project.
+    // A failed project probe now denies against the entity's own project instead of
+    // silently switching to that stale context. Only a 404 falls back — the entity may simply not
     // exist and the manage component owns that error path; every other failure resolves null and
     // fails closed via the `if (!slug)` redirect, so no check runs against a stale project.
     // Probe-friendly: getMeetingDetail is tap-free and short-TTL-cached, sharing the request with
     // MeetingManageComponent's fetch on the same navigation.
-    return meetingService.getMeetingDetail(meetingId).pipe(
-      map((meeting) => resolveMeetingWriteSlug(meeting, fromContext)),
+    return probe(entityId).pipe(
+      map((entity) => resolveEntityWriteSlug(entity, fromContext)),
       catchError((error) => of(error instanceof HttpErrorResponse && error.status === 404 ? fromContext : null))
     );
   };

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -31,7 +31,8 @@ import { hasMeetingWriteAccess, resolveEntityWriteSlug } from '../utils/write-ac
  * Slug resolution: on routes flagged `data.entityScopedSlug` (meeting edit), resolves
  * the slug from the meeting itself first — the active context can belong to a different project
  * when the edit link carried no `?project=`. A non-404 failure on that read resolves no slug at all,
- * so the guard redirects instead of authorizing against a stale context. Otherwise prefers the `?project=` query param
+ * so the guard redirects instead of authorizing against a stale context; a flagged route with no
+ * registered probe or `:id` param is misconfigured and likewise fails closed. Otherwise prefers the `?project=` query param
  * (authoritative for the navigation target, works before the lens has synced), then falls back
  * to the active context's slug. The flag lives in route data — not a routeConfig.path check — so
  * a route rename/restructure can't silently disable the entity-scoped resolution.
@@ -76,10 +77,15 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   };
   const resolveSlug = (): Observable<string | null> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;
+    if (route.data?.['entityScopedSlug'] !== true) {
+      return of(fromContext);
+    }
     const probe = writeFeature ? entityProbes[writeFeature] : undefined;
     const entityId = route.paramMap.get('id');
-    if (!probe || !entityId || route.data?.['entityScopedSlug'] !== true) {
-      return of(fromContext);
+    // A flagged route without a usable probe is misconfigured — fail closed rather than
+    // authorize against a possibly stale context.
+    if (!probe || !entityId) {
+      return of(null);
     }
     // Resolve from the entity payload, never the active context — a readable entity with a stale
     // context would authorize against the wrong project; only a 404 falls back, else fail closed.

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 import { COMMITTEE_WRITE_FEATURES } from '@lfx-one/shared/constants';
-import { EntityWithProject } from '@lfx-one/shared/interfaces';
+import type { EntityWithProject } from '@lfx-one/shared/interfaces';
 import { HttpErrorResponse } from '@angular/common/http';
 import { inject } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivateFn, Router } from '@angular/router';

--- a/apps/lfx-one/src/app/shared/utils/write-access.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/write-access.util.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Meeting, Project } from '@lfx-one/shared/interfaces';
+import { EntityWithProject, Project } from '@lfx-one/shared/interfaces';
 
 // Single definition of the meetings write predicate: when writerGuard and the two reactive
 // access signals each carried their own copy, drift denied or evicted meeting coordinators.
@@ -10,7 +10,7 @@ export function hasMeetingWriteAccess(project: Project | null): boolean {
 }
 
 // Prefers the BFF-enriched slug, falling back to the uid — `GET /api/projects/:slug` sniffs UUIDs,
-// so either resolves. `fallback` covers a meeting carrying neither.
-export function resolveMeetingWriteSlug(meeting: Pick<Meeting, 'project_slug' | 'project_uid'> | null, fallback: string | null): string | null {
-  return meeting?.project_slug ?? meeting?.project_uid ?? fallback;
+// so either resolves. `fallback` covers an entity carrying neither.
+export function resolveEntityWriteSlug(entity: Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null, fallback: string | null): string | null {
+  return entity?.project_slug ?? entity?.project_uid ?? fallback;
 }

--- a/apps/lfx-one/src/app/shared/utils/write-access.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/write-access.util.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { EntityWithProject, Project } from '@lfx-one/shared/interfaces';
+import type { EntityWithProject, Project } from '@lfx-one/shared/interfaces';
 
 // Single definition of the meetings write predicate: when writerGuard and the two reactive
 // access signals each carried their own copy, drift denied or evicted meeting coordinators.

--- a/apps/lfx-one/src/server/helpers/entity-project-enrichment.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/entity-project-enrichment.helper.spec.ts
@@ -10,10 +10,8 @@ const { computeIsFoundation, warning } = vi.hoisted(() => ({
   warning: vi.fn(),
 }));
 
-// This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
-// path alias isn't wired here, so runtime shared subpaths must be mocked (mirrors
-// meeting.helper.spec.ts). computeIsFoundation's real behavior is covered in the shared
-// package; here a stub is enough to assert the mapping passes it through.
+// `@lfx-one/shared/*` aliases aren't wired into this app's vitest config — mock runtime
+// subpaths (mirrors meeting.helper.spec.ts); a computeIsFoundation stub suffices here.
 vi.mock('@lfx-one/shared/utils', () => ({ computeIsFoundation }));
 vi.mock('../services/logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning, debug: vi.fn(), info: vi.fn() },

--- a/apps/lfx-one/src/server/helpers/entity-project-enrichment.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/entity-project-enrichment.helper.spec.ts
@@ -1,0 +1,87 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Project } from '@lfx-one/shared/interfaces';
+import type { Request } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { computeIsFoundation, warning } = vi.hoisted(() => ({
+  computeIsFoundation: vi.fn<(project: unknown) => boolean>(),
+  warning: vi.fn(),
+}));
+
+// This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
+// path alias isn't wired here, so runtime shared subpaths must be mocked (mirrors
+// meeting.helper.spec.ts). computeIsFoundation's real behavior is covered in the shared
+// package; here a stub is enough to assert the mapping passes it through.
+vi.mock('@lfx-one/shared/utils', () => ({ computeIsFoundation }));
+vi.mock('../services/logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning, debug: vi.fn(), info: vi.fn() },
+}));
+
+import { fetchEntityProject, toEntityProjectFields } from './entity-project-enrichment.helper';
+
+const req = {} as unknown as Request;
+const LOG_CONTEXT = { operation: 'get_meeting_by_id', meeting_id: 'meeting-1' };
+
+const projectServiceWith = (projects: Map<string, Project>) => ({ getProjectsByIds: vi.fn().mockResolvedValue(projects) });
+
+describe('fetchEntityProject', () => {
+  beforeEach(() => {
+    warning.mockClear();
+  });
+
+  it('returns null without calling the project service when the entity carries no project_uid', async () => {
+    const projectService = projectServiceWith(new Map());
+
+    const result = await fetchEntityProject(req, projectService as never, undefined, LOG_CONTEXT);
+
+    expect(result).toBeNull();
+    expect(projectService.getProjectsByIds).not.toHaveBeenCalled();
+  });
+
+  it('returns the project resolved by the ungated query-service lookup', async () => {
+    const project = { uid: 'p-1', slug: 'proj-one', name: 'Project One' } as Project;
+    const projectService = projectServiceWith(new Map([['p-1', project]]));
+
+    const result = await fetchEntityProject(req, projectService as never, 'p-1', LOG_CONTEXT);
+
+    expect(result).toBe(project);
+    expect(projectService.getProjectsByIds).toHaveBeenCalledWith(req, ['p-1']);
+  });
+
+  it('warns and continues with null when the lookup throws', async () => {
+    const error = new Error('query-service unavailable');
+    const projectService = { getProjectsByIds: vi.fn().mockRejectedValue(error) };
+
+    const result = await fetchEntityProject(req, projectService as never, 'p-1', LOG_CONTEXT);
+
+    expect(result).toBeNull();
+    expect(warning).toHaveBeenCalledWith(req, 'get_meeting_by_id', expect.stringContaining('continuing without project fields'), {
+      meeting_id: 'meeting-1',
+      project_uid: 'p-1',
+      err: error,
+    });
+  });
+});
+
+describe('toEntityProjectFields', () => {
+  it('maps slug, name, and the computed foundation flag', () => {
+    computeIsFoundation.mockReturnValue(true);
+    const project = { uid: 'p-1', slug: 'proj-one', name: 'Project One', parent_uid: 'parent-1' } as unknown as Project;
+
+    const fields = toEntityProjectFields(project);
+
+    expect(computeIsFoundation).toHaveBeenCalledWith(project);
+    expect(fields).toEqual({ project_slug: 'proj-one', project_name: 'Project One', is_foundation: true });
+  });
+
+  it('never exposes parent_project_uid, even when the project carries one', () => {
+    computeIsFoundation.mockReturnValue(false);
+    const project = { uid: 'p-1', slug: 'proj-one', name: 'Project One', parent_uid: 'parent-1' } as unknown as Project;
+
+    const fields = toEntityProjectFields(project);
+
+    expect(fields).not.toHaveProperty('parent_project_uid');
+  });
+});

--- a/apps/lfx-one/src/server/helpers/entity-project-enrichment.helper.ts
+++ b/apps/lfx-one/src/server/helpers/entity-project-enrichment.helper.ts
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { Project } from '@lfx-one/shared/interfaces';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
+import type { Request } from 'express';
+
+import { logger } from '../services/logger.service';
+import type { ProjectService } from '../services/project.service';
+
+/**
+ * Fetches an entity's project for detail enrichment. Returns null on failure so the entity
+ * still loads — the frontend falls back to resolving project context from `project_uid`.
+ *
+ * Uses the query-service metadata lookup (getProjectsByIds) rather than getProjectById: the
+ * /projects/:uid endpoint is relation-gated, and an entity writer may lack a project-level
+ * viewer relation (the committee-writer case writerGuard handles) — the direct fetch would
+ * 403 for exactly those users, and the client fallback hits the same gated endpoint, leaving
+ * the edit page in a stale context. The query-service path needs no project relation.
+ * Entity access was already checked by the caller, and the exposed fields
+ * (slug/name/is_foundation) are non-sensitive.
+ */
+export async function fetchEntityProject(
+  req: Request,
+  projectService: ProjectService,
+  projectUid: string | undefined,
+  logContext: { operation: string; [field: string]: unknown }
+): Promise<Project | null> {
+  if (!projectUid) {
+    return null;
+  }
+
+  const { operation, ...metadata } = logContext;
+  try {
+    const projects = await projectService.getProjectsByIds(req, [projectUid]);
+    return projects.get(projectUid) ?? null;
+  } catch (error) {
+    logger.warning(req, operation, 'Failed to fetch project for entity enrichment; continuing without project fields', {
+      ...metadata,
+      project_uid: projectUid,
+      err: error,
+    });
+    return null;
+  }
+}
+
+/**
+ * Maps a resolved project to the detail-enrichment fields the client context-sync consumes.
+ * `parent_project_uid` is deliberately excluded: nothing in the detail/edit flow consumes it,
+ * and it discloses hierarchy the caller may hold no relation to. List payloads still carry it
+ * via enrichWithProjectData for the dashboard filters.
+ */
+export function toEntityProjectFields(project: Project): { project_slug: string; project_name: string; is_foundation: boolean } {
+  return {
+    project_slug: project.slug,
+    project_name: project.name,
+    is_foundation: computeIsFoundation(project),
+  };
+}

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -30,7 +30,6 @@ import {
   PastOccurrenceSummary,
   PresignAttachmentRequest,
   PresignAttachmentResponse,
-  Project,
   QueryServiceCountResponse,
   QueryServiceResponse,
   UpdateMeetingAttachmentRequest,
@@ -40,7 +39,6 @@ import {
 } from '@lfx-one/shared/interfaces';
 import {
   buildRecurrenceNeverEndDate,
-  computeIsFoundation,
   getPastMeetingTranscriptUrl,
   mapITXResponseToMeetingRsvp,
   normalizeIndexedMeetingAiSummary,
@@ -50,6 +48,7 @@ import {
 import { Request } from 'express';
 
 import { AuthorizationError, ResourceNotFoundError, ServiceValidationError } from '../errors';
+import { fetchEntityProject, toEntityProjectFields } from '../helpers/entity-project-enrichment.helper';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getEffectiveUsername, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
@@ -227,16 +226,13 @@ export class MeetingService {
     // Project enrichment runs in parallel with the committee-name lookup (both depend only on
     // the meeting payload), so it adds no sequential latency.
     const [project, committeeNameMap] = await Promise.all([
-      includeProject ? this.fetchMeetingProject(req, meeting) : Promise.resolve(null),
+      includeProject
+        ? fetchEntityProject(req, this.projectService, meeting.project_uid, { operation: 'get_meeting_by_id', meeting_id: meeting.id })
+        : Promise.resolve(null),
       committees ? this.getCommitteeNameMap(req, [meeting]) : Promise.resolve(null),
     ]);
     if (project) {
-      meeting.project_slug = project.slug;
-      meeting.project_name = project.name;
-      meeting.is_foundation = computeIsFoundation(project);
-      // parent_project_uid is deliberately NOT mapped here: nothing in the detail/edit flow
-      // consumes it, and it discloses hierarchy the caller may hold no relation to. List
-      // payloads still carry it via enrichWithProjectData for the dashboard filters.
+      Object.assign(meeting, toEntityProjectFields(project));
     }
 
     if (committees && committeeNameMap) {
@@ -1796,36 +1792,6 @@ export class MeetingService {
 
   public async getMeetingProjectName<T extends Meeting>(req: Request, meetings: T[]): Promise<T[]> {
     return this.projectService.enrichWithProjectData(req, meetings) as Promise<T[]>;
-  }
-
-  /**
-   * Fetches the meeting's project for detail enrichment. Returns null on failure so the meeting
-   * still loads — the frontend falls back to resolving project context from `project_uid`.
-   *
-   * Uses the query-service metadata lookup (getProjectsByIds) rather than getProjectById: the
-   * /projects/:uid endpoint is relation-gated, and a meeting writer may lack a project-level
-   * viewer relation (the committee-writer case writerGuard handles) — the direct fetch would
-   * 403 for exactly those users, and the client fallback hits the same gated endpoint, leaving
-   * the edit page in a stale context. The query-service path needs no project relation.
-   * Meeting access was already checked by the caller, and the exposed fields
-   * (slug/name/is_foundation) are non-sensitive.
-   */
-  private async fetchMeetingProject(req: Request, meeting: Meeting): Promise<Project | null> {
-    if (!meeting.project_uid) {
-      return null;
-    }
-
-    try {
-      const projects = await this.projectService.getProjectsByIds(req, [meeting.project_uid]);
-      return projects.get(meeting.project_uid) ?? null;
-    } catch (error) {
-      logger.warning(req, 'get_meeting_by_id', 'Failed to fetch project for meeting enrichment; continuing without project fields', {
-        meeting_id: meeting.id,
-        project_uid: meeting.project_uid,
-        err: error,
-      });
-      return null;
-    }
   }
 
   /**

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -6827,7 +6827,7 @@ export class ProjectService {
         project_name: project?.name || (item as any).project_name || '',
         project_slug: project?.slug || (item as any).project_slug || '',
         // Leave is_foundation absent (not false) when the lookup fails — consumers like
-        // getMeetingEditCommands treat undefined as "tier unknown" and fall back safely,
+        // getEntityCommands treat undefined as "tier unknown" and fall back safely,
         // whereas a coerced false would mislabel a foundation-owned entity as project-owned.
         // Mirrors the meeting-detail enrichment's fail-soft contract.
         is_foundation: project ? computeIsFoundation(project) : ((item as any).is_foundation ?? undefined),

--- a/packages/shared/src/utils/entity-route.utils.spec.ts
+++ b/packages/shared/src/utils/entity-route.utils.spec.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { getEntityCommands } from './entity-route.utils';
+
+describe('getEntityCommands', () => {
+  it('prefixes foundation-owned entities with /foundation', () => {
+    expect(getEntityCommands('meetings', 'abc-123', true, 'edit')).toEqual(['/', 'foundation', 'meetings', 'abc-123', 'edit']);
+  });
+
+  it('prefixes regular-project entities with /project', () => {
+    expect(getEntityCommands('meetings', 'abc-123', false, 'edit')).toEqual(['/', 'project', 'meetings', 'abc-123', 'edit']);
+  });
+
+  it('builds the view path when no leaf is given', () => {
+    expect(getEntityCommands('groups', 'uid-1', false)).toEqual(['/', 'project', 'groups', 'uid-1']);
+  });
+
+  it('returns null when the tier is undefined so callers fall back to the flat path', () => {
+    expect(getEntityCommands('meetings', 'abc-123', undefined, 'edit')).toBeNull();
+  });
+
+  it('returns null when the tier is null so callers fall back to the flat path', () => {
+    expect(getEntityCommands('meetings', 'abc-123', null, 'edit')).toBeNull();
+  });
+});

--- a/packages/shared/src/utils/entity-route.utils.ts
+++ b/packages/shared/src/utils/entity-route.utils.ts
@@ -1,0 +1,14 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Canonical entity route builder keyed on the ENTITY's own project tier, not the viewer's transient lens.
+ * Null on unknown tier (undefined/null) preserves the flat-path `lensRedirectGuard` fallback contract.
+ */
+export function getEntityCommands(segment: string, id: string, isFoundation: boolean | null | undefined, leaf?: 'edit'): string[] | null {
+  if (isFoundation === undefined || isFoundation === null) {
+    return null;
+  }
+
+  return ['/', isFoundation ? 'foundation' : 'project', segment, id, ...(leaf ? [leaf] : [])];
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -5,6 +5,7 @@ export * from './avatar.utils';
 export * from './color.utils';
 export * from './date-time.utils';
 export * from './docs.utils';
+export * from './entity-route.utils';
 export * from './file.utils';
 export * from './form.utils';
 export * from './html-utils';

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -48,7 +48,6 @@ import {
   extractRegistrantEmails,
   filterUnlistedEmails,
   fromMeetingApiVotingStatuses,
-  getMeetingEditCommands,
   getMeetingOrganizerDisplayName,
   isCalendarDeadlinePast,
   isMeetingOccurrenceCancelled,
@@ -1119,20 +1118,6 @@ describe('buildMeetingOccurrenceRoute', () => {
       path: ['/meetings', '99152950841-1630560600000'],
       queryParams: undefined,
     });
-  });
-});
-
-describe('getMeetingEditCommands', () => {
-  it('prefixes foundation-owned meetings with /foundation', () => {
-    expect(getMeetingEditCommands({ id: 'abc-123', is_foundation: true })).toEqual(['/', 'foundation', 'meetings', 'abc-123', 'edit']);
-  });
-
-  it('prefixes regular-project meetings with /project', () => {
-    expect(getMeetingEditCommands({ id: 'abc-123', is_foundation: false })).toEqual(['/', 'project', 'meetings', 'abc-123', 'edit']);
-  });
-
-  it('returns null when is_foundation is absent so callers fall back to the flat path', () => {
-    expect(getMeetingEditCommands({ id: 'abc-123' })).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -712,21 +712,6 @@ export function buildMeetingOccurrenceRoute(
 }
 
 /**
- * Builds the canonical Angular router commands for a meeting's edit page, prefixing the path with
- * the MEETING's own project tier (`is_foundation`) rather than the viewer's transient active lens:
- * foundation-owned meetings edit under `/foundation/meetings/{id}/edit`, all other projects under
- * `/project/meetings/{id}/edit`. Returns null when `is_foundation` is absent (unenriched payload)
- * so callers can fall back to the flat `/meetings/{id}/edit` path handled by `lensRedirectGuard`.
- */
-export function getMeetingEditCommands(meeting: Pick<Meeting, 'id' | 'is_foundation'>): string[] | null {
-  if (meeting.is_foundation === undefined) {
-    return null;
-  }
-
-  return ['/', meeting.is_foundation ? 'foundation' : 'project', 'meetings', meeting.id, 'edit'];
-}
-
-/**
  * Sorts past meetings most-recent-first (descending by `scheduled_start_time`, falling back to
  * `start_time` when absent).
  *


### PR DESCRIPTION
## Summary

The meeting edit flow already canonicalizes routing and write-access checks on the meeting's own project (not the viewer's transient lens), but every piece of that plumbing was meeting-specific. This PR generalizes those pieces into entity-agnostic primitives — a shared tier-prefixed route builder, a generic write-slug resolver, a shared server-side project-enrichment helper, and a `writeFeature`-keyed entity probe registry in `writerGuard` — so upcoming entity features can adopt the same correct-by-construction behavior with a one-line registry entry instead of a copy-paste. Also included: `copyMeetingLink` now surfaces a "Copy Failed" toast when URL construction throws instead of failing silently.

Resolves GH-1641

## Behavior changes

| Before | After |
|---|---|
| If building the meeting share link failed (e.g. a misconfigured base URL), "Copy link" threw an unhandled error and the user saw no feedback at all. | A failed link build now shows a "Copy Failed" error toast asking the user to try again; successful copies behave exactly as before. |

Meeting routing, the write-access guard, and meeting-detail project enrichment behave exactly as they did before — this PR restructures that logic for reuse without changing its outcome.

## Technical changes

`packages/shared/src/utils/entity-route.utils.ts, packages/shared/src/utils/index.ts` — Shared route builder

- Adds `getEntityCommands(segment, id, isFoundation, leaf?)`: builds tier-prefixed router commands (`/foundation/<segment>/<id>/...` vs `/project/...`) keyed on the entity's own project tier
- Returns `null` when the tier is `undefined`/`null`, preserving the flat-path `lensRedirectGuard` fallback contract for unenriched payloads
- Exported from the shared utils barrel; new spec covers foundation/project prefixes, the no-leaf view path, and both null-tier cases

`packages/shared/src/utils/meeting.utils.ts` — Removed meeting-specific helper

- Deletes `getMeetingEditCommands` (superseded by `getEntityCommands`) along with its spec block

`apps/lfx-one/src/app/shared/utils/write-access.util.ts` — Write-slug resolver

- Generalizes `resolveMeetingWriteSlug` into `resolveEntityWriteSlug`, typed against `Pick<EntityWithProject, 'project_slug' | 'project_uid'>` instead of `Meeting`; resolution order (enriched slug → uid → fallback) is unchanged

`apps/lfx-one/src/app/shared/guards/writer.guard.ts` — Entity probe registry

- Replaces the hard-coded `writeFeature === 'meetings'` branch with an `entityProbes` registry keyed by `writeFeature` (only `meetings` registered today); features without a registered probe fail closed (redirect) rather than authorize against a possibly stale context, so flipping `entityScopedSlug` on an unregistered route can't accidentally fire a probe
- Registry contract documented inline: probes must be tap-free and short-TTL-cached so the guard shares the manage component's fetch
- Condenses over-cap comment blocks to the two-line comment-cap rule (no logic change)

`apps/lfx-one/src/server/helpers/entity-project-enrichment.helper.ts` — Server enrichment helper

- New `fetchEntityProject` extracted from `MeetingService.fetchMeetingProject`: resolves the project via the query-service metadata lookup (`getProjectsByIds`) rather than the relation-gated `/projects/:uid` endpoint, so entity writers without a project-level viewer relation don't 403; returns `null` on failure so the entity still loads
- New `toEntityProjectFields` mapper exposing only `project_slug` / `project_name` / `is_foundation` — `parent_project_uid` stays deliberately excluded from detail payloads
- Covered by a new spec for the helper

`apps/lfx-one/src/server/services/meeting.service.ts` — Meeting service

- Deletes the private `fetchMeetingProject` in favor of the shared helper and applies enrichment via `Object.assign(meeting, toEntityProjectFields(project))`; response shape and fail-soft behavior unchanged

`apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts, apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts` — Meeting components

- `editCommands` and the create-flow post-save navigation now call `getEntityCommands('meetings', ...)` with the same flat-path fallback
- Manage-page slug resolution mirrors the guard via `resolveEntityWriteSlug`
- `copyMeetingLink` wraps `new URL(...)` in try/catch and shows an error toast on failure

`apps/lfx-one/src/app/shared/guards/lens-redirect.guard.ts, apps/lfx-one/src/server/services/project.service.ts` — Comment touch-ups

- Updates stale `getMeetingEditCommands` references to `getEntityCommands`; the `is_foundation` fail-soft contract (absent, not coerced `false`, on lookup failure) is unchanged

`apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts` — Guard tests

- Adds coverage that a route with `entityScopedSlug: true` but no registered probe (`newsletters`) fails closed (redirects with no downstream authorization probe)

