### PR TITLE
fix(groups): open groups under their own project tier (GH-1566)

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -21,7 +21,7 @@ import {
   StatCardGridColumns,
   StatCardItem,
 } from '@lfx-one/shared/interfaces';
-import { buildEngagementStatCards, getGroupBehavioralClass, groupCommitteesByFoundation } from '@lfx-one/shared/utils';
+import { buildEngagementStatCards, getGroupBehavioralClass, getGroupCommands, groupCommitteesByFoundation } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { InvitationService } from '@services/invitation.service';
@@ -310,7 +310,11 @@ export class CommitteeDashboardComponent {
   }
 
   public onCommitteeClick(committee: Committee): void {
-    this.router.navigate(['/groups', committee.uid], {
+    // Canonical tier-prefixed view link (GH-1566): the group's own `is_foundation` picks
+    // /foundation vs /project instead of the viewer's transient active lens; `?project=` rides
+    // along when the row carries a slug. Unenriched rows keep the flat /groups/:uid fallback.
+    this.router.navigate(getGroupCommands(committee) ?? ['/groups', committee.uid], {
+      queryParams: committee.project_slug ? { project: committee.project_slug } : undefined,
       state: { backLabel: this.isMeLens() ? 'My Groups' : 'Groups' },
     });
   }

--- a/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts
@@ -312,7 +312,9 @@ export class CommitteeDashboardComponent {
   public onCommitteeClick(committee: Committee): void {
     // Canonical tier-prefixed view link (GH-1566): the group's own `is_foundation` picks
     // /foundation vs /project instead of the viewer's transient active lens; `?project=` rides
-    // along when the row carries a slug. Unenriched rows keep the flat /groups/:uid fallback.
+    // along when the row carries a slug. Non-Me rows are decorated with the active context's
+    // tier/slug (see initializeDecoratedCommittees); the flat /groups/:uid fallback remains for
+    // any row that still resolves no tier.
     this.router.navigate(getGroupCommands(committee) ?? ['/groups', committee.uid], {
       queryParams: committee.project_slug ? { project: committee.project_slug } : undefined,
       state: { backLabel: this.isMeLens() ? 'My Groups' : 'Groups' },
@@ -553,12 +555,26 @@ export class CommitteeDashboardComponent {
   }
 
   private initializeDecoratedCommittees(): Signal<Committee[]> {
-    return computed(() =>
-      this.committees().map((c) => {
+    return computed(() => {
+      // /api/committees returns query-service rows: they can carry an indexer-populated
+      // project_slug, but never is_foundation (only enrichWithProjectData supplies that).
+      // The list is scoped by `project_uid:<active context uid>` — an exact-match tag per the
+      // committee-service indexer contract — so every row is owned by the active context; fall
+      // back to its tier/slug so canonical tier-prefixed links (getGroupCommands) and `?project=`
+      // resolve instead of degrading to the flat /groups/:uid path (GH-1566).
+      const context = this.project();
+      const contextIsFoundation = this.isFoundationContext();
+      return this.committees().map((c) => {
         const behavioralClass = getGroupBehavioralClass(c.category);
-        return { ...c, behavioralClass, classDisplay: BEHAVIORAL_CLASS_CONFIG[behavioralClass] };
-      })
-    );
+        return {
+          ...c,
+          project_slug: c.project_slug ?? context?.slug,
+          is_foundation: c.is_foundation ?? contextIsFoundation,
+          behavioralClass,
+          classDisplay: BEHAVIORAL_CLASS_CONFIG[behavioralClass],
+        };
+      });
+    });
   }
 
   private initializeDecoratedMyCommittees(): Signal<MyCommittee[]> {

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.spec.ts
@@ -1,0 +1,206 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ApplicationRef, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { ActivatedRoute, convertToParamMap, NavigationEnd, Router } from '@angular/router';
+import { CommitteeService } from '@services/committee.service';
+import { LensService } from '@services/lens.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
+import { Committee, Project } from '@lfx-one/shared/interfaces';
+import { ConfirmationService, MessageService } from 'primeng/api';
+import { BehaviorSubject, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { CommitteeManageComponent } from './committee-manage.component';
+
+// Regression coverage for the committee edit context-correction flow (GH-1566): an edit payload
+// must select the COMMITTEE's project/tier (not the cookie-restored last-visited project), the
+// by-uid fallback must apply when enrichment withholds project_slug, the write-access leg must
+// stay provisionally true while pending so it cannot evict a guard-admitted user mid-edit, and
+// step navigation must merge query params so ?project= survives. Mirrors the meeting-manage
+// harness (constructor context-sync streams only — no detectChanges, no template rendering).
+describe('CommitteeManageComponent', () => {
+  const COMMITTEE_UID = 'committee-uid-1';
+  const PROJECT_UID = 'project-uid-1';
+  const PROJECT_SLUG = 'committee-project';
+  const STALE_SLUG = 'stale-project';
+
+  let getCommittee: ReturnType<typeof vi.fn>;
+  let getProject: ReturnType<typeof vi.fn>;
+  let setProject: ReturnType<typeof vi.fn>;
+  let setFoundation: ReturnType<typeof vi.fn>;
+  let setRouteLensKind: ReturnType<typeof vi.fn>;
+  let navigate: ReturnType<typeof vi.fn>;
+  let navigateByUrl: ReturnType<typeof vi.fn>;
+  let routerEvents$: BehaviorSubject<NavigationEnd>;
+  let queryParamMap$: BehaviorSubject<ReturnType<typeof convertToParamMap>>;
+  let activeContext: ReturnType<typeof signal<{ uid: string; slug: string; name: string } | null>>;
+
+  // Enriched detail payload: project_slug + is_foundation populated by the BFF — drives
+  // syncEntityProjectContext directly. Unenriched: project_uid only — triggers the by-uid
+  // fallback in initCommitteeContextFallback.
+  const enrichedCommittee = (isFoundation = false) =>
+    ({
+      uid: COMMITTEE_UID,
+      project_uid: PROJECT_UID,
+      project_slug: PROJECT_SLUG,
+      project_name: 'Test Project',
+      is_foundation: isFoundation,
+      name: 'TSC',
+      category: 'Technical Steering Committee',
+    }) as unknown as Committee;
+
+  const unenrichedCommittee = () =>
+    ({
+      uid: COMMITTEE_UID,
+      project_uid: PROJECT_UID,
+      name: 'TSC',
+      category: 'Technical Steering Committee',
+    }) as unknown as Committee;
+
+  // Minimal project payload: no foundation markers, so computeIsFoundation resolves false.
+  const resolvedProject = () => ({ uid: PROJECT_UID, name: 'Test Project', slug: PROJECT_SLUG, writer: true }) as unknown as Project;
+
+  const createComponent = async () => {
+    const fixture = TestBed.createComponent(CommitteeManageComponent);
+    // No fixture.detectChanges(): these tests exercise the constructor context-sync streams, not
+    // the template, and rendering would pull in the full PrimeNG stepper subtree for no signal.
+    await TestBed.inject(ApplicationRef).whenStable();
+    return fixture;
+  };
+
+  beforeEach(() => {
+    getCommittee = vi.fn();
+    getProject = vi.fn().mockReturnValue(of(resolvedProject()));
+    setProject = vi.fn();
+    setFoundation = vi.fn();
+    setRouteLensKind = vi.fn();
+    navigate = vi.fn();
+    navigateByUrl = vi.fn();
+    routerEvents$ = new BehaviorSubject<NavigationEnd>(new NavigationEnd(0, '/project/groups/x/edit', '/project/groups/x/edit'));
+    queryParamMap$ = new BehaviorSubject(convertToParamMap({}));
+    activeContext = signal({ uid: 'stale-uid', slug: STALE_SLUG, name: 'Stale Project' });
+
+    // Rendered step panels instantiate child components whose constructors fetch — stub the
+    // ones reachable in these tests (zoneless signal writes schedule a change-detection tick
+    // that whenStable() then waits on).
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: Router,
+          useValue: {
+            events: routerEvents$.asObservable(),
+            url: '/project/groups/x/edit',
+            parseUrl: vi.fn().mockReturnValue({ queryParams: {} }),
+            serializeUrl: vi.fn().mockReturnValue('/project/groups/x/edit'),
+            navigate,
+            navigateByUrl,
+            createUrlTree: vi.fn(),
+          },
+        },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            paramMap: of(convertToParamMap({ id: COMMITTEE_UID })),
+            queryParamMap: queryParamMap$.asObservable(),
+            snapshot: { queryParamMap: convertToParamMap({}), paramMap: convertToParamMap({ id: COMMITTEE_UID }) },
+          },
+        },
+        { provide: CommitteeService, useValue: { getCommittee, getCommitteesByProject: vi.fn().mockReturnValue(of([])) } },
+        { provide: ProjectService, useValue: { getProject, project: signal(null) } },
+        {
+          provide: ProjectContextService,
+          useValue: {
+            activeContext,
+            activeContextUid: () => 'stale-uid',
+            isFoundationContext: () => false,
+            canWrite: signal(true),
+            setProject,
+            setFoundation,
+            setRouteLensKind,
+          },
+        },
+        // evictOnWriteAccessLoss injects these directly — mocked so no transitive HttpClient chain.
+        { provide: PersonaService, useValue: { currentPersona: signal('maintainer') } },
+        { provide: LensService, useValue: { activeLens: signal('project') } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        // Real class, not a useValue fake — ConfirmDialog touches ConfirmationService's internal
+        // Subjects in its constructor (same pattern as committee-settings-tab.component.spec.ts).
+        ConfirmationService,
+        // PrimeNG stepper binds animation listeners when the template is compiled — required even
+        // without detectChanges(), since compilation alone wires the listener.
+        provideNoopAnimations(),
+      ],
+    });
+
+    // jsdom doesn't implement window.scrollTo (scrollToStepper) — stub to keep stderr clean.
+    window.scrollTo = vi.fn();
+  });
+
+  it('selects the committee’s own project and tier from an enriched edit payload', async () => {
+    getCommittee.mockReturnValue(of(enrichedCommittee(false)));
+    await createComponent();
+
+    expect(setRouteLensKind).toHaveBeenCalledWith('project');
+    expect(setProject).toHaveBeenCalledWith({ uid: PROJECT_UID, name: 'Test Project', slug: PROJECT_SLUG }, false);
+    expect(setFoundation).not.toHaveBeenCalled();
+  });
+
+  it('prefers the committee’s own tier over the /project/* route prefix for a foundation-owned group', async () => {
+    getCommittee.mockReturnValue(of(enrichedCommittee(true)));
+    await createComponent();
+
+    // preferEntityKind: a foundation-owned group edited under /project/groups/:id/edit must land
+    // in the foundation slot and re-point the route lens kind, not follow the URL prefix.
+    expect(setRouteLensKind).toHaveBeenCalledWith('foundation');
+    expect(setFoundation).toHaveBeenCalledWith({ uid: PROJECT_UID, name: 'Test Project', slug: PROJECT_SLUG }, false);
+    expect(setProject).not.toHaveBeenCalled();
+  });
+
+  it('falls back to a by-uid project lookup when the payload lacks project_slug', async () => {
+    getCommittee.mockReturnValue(of(unenrichedCommittee()));
+    await createComponent();
+
+    expect(getProject).toHaveBeenCalledWith(PROJECT_UID, false);
+    expect(setProject).toHaveBeenCalledWith({ uid: PROJECT_UID, name: 'Test Project', slug: PROJECT_SLUG }, false);
+    expect(setRouteLensKind).toHaveBeenCalledWith('project');
+  });
+
+  it('does not evict while the committee — and therefore the write-access leg — is still pending', async () => {
+    getCommittee.mockReturnValue(of(null));
+
+    await createComponent();
+
+    // The access leg never resolved (no committee → no project key), so it stayed provisionally
+    // true and no project lookup or eviction navigation fired.
+    expect(getProject).not.toHaveBeenCalled();
+    expect(navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('keys the write-access check off the committee’s own project, not the stale active context', async () => {
+    getCommittee.mockReturnValue(of(enrichedCommittee(false)));
+    await createComponent();
+
+    // writerGuard authorized against the committee's project; the access leg must evaluate that
+    // same target — never the cookie-restored stale context, whose false could win the race
+    // against the context correction and evict the admitted user mid-edit.
+    expect(getProject).toHaveBeenCalledWith(PROJECT_SLUG, false);
+    expect(getProject).not.toHaveBeenCalledWith(STALE_SLUG, expect.anything());
+    expect(navigateByUrl).not.toHaveBeenCalled();
+  });
+
+  it('merges query params on step navigation so ?project= survives', async () => {
+    getCommittee.mockReturnValue(of(enrichedCommittee(false)));
+    queryParamMap$.next(convertToParamMap({ step: '2', project: PROJECT_SLUG }));
+
+    const fixture = await createComponent();
+
+    fixture.componentInstance.previousStep();
+
+    expect(navigate).toHaveBeenCalledWith([], { queryParams: { step: 1 }, queryParamsHandling: 'merge' });
+  });
+});

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -2,26 +2,31 @@
 // SPDX-License-Identifier: MIT
 
 import { HttpErrorResponse } from '@angular/common/http';
-import { Component, computed, inject, signal, viewChild } from '@angular/core';
-import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { Component, computed, DestroyRef, inject, signal, Signal, viewChild } from '@angular/core';
+import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule, Validators } from '@angular/forms';
-import { ActivatedRoute, Router, RouterLink } from '@angular/router';
+import { ActivatedRoute, NavigationEnd, Router, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { COMMITTEE_FORM_STEPS, COMMITTEE_INVITE_CONCURRENCY, COMMITTEE_LABEL, COMMITTEE_STEP_TITLES, COMMITTEE_TOTAL_STEPS } from '@lfx-one/shared/constants';
 import {
   Committee,
   CommitteeMember,
+  EntityWithProject,
   MemberOperationResult,
   MemberOperationType,
   MemberPendingChanges,
+  ProjectContext,
   SucceededMemberOperations,
 } from '@lfx-one/shared/interfaces';
+import { computeIsFoundation } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
+import { ProjectService } from '@services/project.service';
 import { MessageService } from 'primeng/api';
 import { ConfirmDialogModule } from 'primeng/confirmdialog';
 import { StepperModule } from 'primeng/stepper';
-import { catchError, concat, EMPTY, filter, finalize, from, map, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
+import { catchError, concat, distinctUntilChanged, EMPTY, filter, finalize, from, map, merge, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
+import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
@@ -52,6 +57,8 @@ export class CommitteeManageComponent {
   private readonly committeeService = inject(CommitteeService);
   private readonly messageService = inject(MessageService);
   private readonly projectContextService = inject(ProjectContextService);
+  private readonly projectService = inject(ProjectService);
+  private readonly destroyRef = inject(DestroyRef);
   // Mode and state signals
   public mode = signal<'create' | 'edit'>('create');
   public committeeId = signal<string | null>(null);
@@ -60,6 +67,13 @@ export class CommitteeManageComponent {
   // Initialize committee data
   public committee = this.initializeCommittee();
   public project = computed(() => this.projectContextService.activeContext());
+  // Committee → EntityWithProject adapter so the active project context syncs from the loaded
+  // committee rather than the cookie-restored last-visited project (GH-1566).
+  private readonly committeeEntityContext: Signal<EntityWithProject | null> = this.initializeCommitteeEntityContext();
+  // Access predicate for evictOnWriteAccessLoss — keys the project-writer check off the
+  // COMMITTEE's own project (the target writerGuard authorized against), not the transient
+  // active context, so the context switch can't evict guard-admitted users mid-edit (GH-1566).
+  private readonly writeAccess: Signal<boolean> = this.initWriteAccess();
 
   // Member management state
   public memberUpdates = signal<MemberPendingChanges>({ toAdd: [], toUpdate: [], toDelete: [], toInvite: [] });
@@ -115,7 +129,17 @@ export class CommitteeManageComponent {
   public readonly committeeLabelPlural = COMMITTEE_LABEL.plural;
 
   public constructor() {
-    evictOnWriteAccessLoss();
+    evictOnWriteAccessLoss(this.writeAccess);
+
+    // Derive the project context from the loaded committee so a context-less edit link
+    // (/project/groups/:id/edit without ?project=) lands in the committee's project, not the
+    // cookie-restored last-visited project. The fallback covers BFF project-enrichment failure.
+    // preferEntityKind: a foundation-owned group can be edited under a /project/* URL, so the
+    // committee's own is_foundation (not the route prefix) picks the slot and re-points the route
+    // lens kind (mirror: meeting-manage post-GH-1432).
+    syncEntityProjectContext(this.committeeEntityContext, this.projectContextService, this.router, this.destroyRef, { preferEntityKind: true });
+    this.initCommitteeContextFallback();
+
     // Initialize step based on mode
     this.currentStep = toSignal(
       this.route.queryParamMap.pipe(
@@ -152,7 +176,7 @@ export class CommitteeManageComponent {
   public goToStep(step: number | undefined): void {
     if (step !== undefined && this.canNavigateToStep(step)) {
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step: step } });
+        this.router.navigate([], { queryParams: { step: step }, queryParamsHandling: 'merge' });
       } else {
         this.internalStep.set(step);
       }
@@ -169,7 +193,7 @@ export class CommitteeManageComponent {
       }
 
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step: next } });
+        this.router.navigate([], { queryParams: { step: next }, queryParamsHandling: 'merge' });
       } else {
         this.internalStep.set(next);
       }
@@ -181,7 +205,7 @@ export class CommitteeManageComponent {
     const previous = this.currentStep() - 1;
     if (previous >= 1) {
       if (this.isEditMode()) {
-        this.router.navigate([], { queryParams: { step: previous } });
+        this.router.navigate([], { queryParams: { step: previous }, queryParamsHandling: 'merge' });
       } else {
         this.internalStep.set(previous);
       }
@@ -379,6 +403,123 @@ export class CommitteeManageComponent {
     );
   }
 
+  /**
+   * Maps the loaded committee to the {@link EntityWithProject} shape consumed by
+   * syncEntityProjectContext — pre-enrichment payloads can lack the project fields entirely,
+   * so absent values map to null there (mirror: meeting-manage's initializeMeetingEntityContext;
+   * Committee already carries `uid`, so no id remap is needed).
+   */
+  private initializeCommitteeEntityContext(): Signal<EntityWithProject | null> {
+    return computed(() => {
+      const committee = this.committee();
+      if (!committee) {
+        return null;
+      }
+      return {
+        uid: committee.uid,
+        project_uid: committee.project_uid,
+        project_slug: committee.project_slug,
+        project_name: committee.project_name,
+        foundation_name: committee.foundation_name,
+        is_foundation: committee.is_foundation ?? null,
+      };
+    });
+  }
+
+  /**
+   * Fallback context sync for when the BFF project enrichment failed (the detail payload has
+   * `project_uid` but no `project_slug`): resolve the project by uid and set context from it.
+   * `getProject(uid, false)` — `current: false` so the fetch doesn't clobber ProjectService's
+   * shared `project` state — resolves to null on failure, so a failed fallback leaves the
+   * (stale) context untouched rather than erroring the page. (Mirror: meeting-manage's
+   * initMeetingContextFallback, minus its uncached-detail last resort — `fetchCommittee` is
+   * never cached, so a "fresh" refetch cannot return a different payload.)
+   *
+   * Runs whenever the payload lacks `project_slug`, even when the uid already matches the active
+   * context: the lookup is also what corrects the lens *kind* via `computeIsFoundation`. As in
+   * syncEntityProjectContext, NavigationEnd re-applies the correction: query-param step
+   * navigations re-assert the route's declared kind via syncLensFromRoute without re-running
+   * guards. The re-apply hits the shareReplay-cached getProject, so it costs no extra request.
+   */
+  private initCommitteeContextFallback(): void {
+    const unresolvedEntity$ = toObservable(this.committeeEntityContext).pipe(
+      distinctUntilChanged((a, b) => a?.uid === b?.uid && a?.project_uid === b?.project_uid)
+    );
+    const navigationReapply$ = this.router.events.pipe(
+      filter((event) => event instanceof NavigationEnd),
+      map(() => this.committeeEntityContext())
+    );
+    merge(unresolvedEntity$, navigationReapply$)
+      .pipe(
+        filter((entity): entity is EntityWithProject => !!entity?.project_uid && !entity.project_slug),
+        switchMap((entity) => this.projectService.getProject(entity.project_uid, false)),
+        takeUntilDestroyed(this.destroyRef)
+      )
+      .subscribe((project) => {
+        if (!project) {
+          // Relation-gated or failed lookup — nothing more to try; the context self-corrects on
+          // the next navigation once the detail payload carries its slug again.
+          return;
+        }
+        const context: ProjectContext = { uid: project.uid, name: project.name, slug: project.slug };
+        // Mirror syncEntityProjectContext: only write ?project= to the URL when already present.
+        const syncUrl = 'project' in this.router.parseUrl(this.router.url).queryParams;
+        applyEntityProjectContext(this.projectContextService, context, computeIsFoundation(project), syncUrl);
+      });
+  }
+
+  /**
+   * Access predicate for evictOnWriteAccessLoss — mirrors writerGuard's committees standard
+   * (project writer only: 'committees' is not in COMMITTEE_WRITE_FEATURES, so no committee-writer
+   * leg, and meetingCoordinator doesn't apply to this feature) so the context switch to the
+   * committee's project doesn't evict guard-admitted users.
+   *
+   * In edit mode the leg keys off the COMMITTEE's own project (slug, falling back to uid — the
+   * BFF getProject route sniffs UUIDs), the same target writerGuard authorized against. Keying
+   * off activeContext instead would evaluate the stale cookie-restored boot context, and its
+   * false could win the race against syncEntityProjectContext's correction (a cached boot project
+   * resolves faster than the committee fetch that triggers the switch). Create mode has no
+   * committee, so the guard-checked active context (?project=) is the key.
+   *
+   * The leg is pending (undefined) until its first resolution, and the predicate stays
+   * provisionally true while pending — writerGuard already authorized this navigation, so an
+   * unresolved leg is not an access-lost signal (mirror: meeting-manage's initWriteAccess).
+   */
+  private initWriteAccess(): Signal<boolean> {
+    const editCommitteeId = this.route.snapshot.paramMap.get('id');
+    const projectKey$: Observable<string | null | undefined> = editCommitteeId
+      ? toObservable(this.committee).pipe(
+          map((committee) => {
+            if (!committee) {
+              // Pending — in edit mode the authorization target comes from the committee itself.
+              return undefined;
+            }
+            // Mirror writerGuard's resolution order; the active-context fallback covers a committee
+            // carrying neither slug nor uid (the manage component owns that error path).
+            return committee.project_slug ?? committee.project_uid ?? this.projectContextService.activeContext()?.slug ?? null;
+          })
+        )
+      : toObservable(this.projectContextService.activeContext).pipe(map((ctx) => ctx?.slug ?? null));
+
+    const projectAccess = toSignal(
+      projectKey$.pipe(
+        filter((key): key is string | null => key !== undefined),
+        distinctUntilChanged(),
+        switchMap((key) => {
+          if (!key) {
+            return of(false);
+          }
+          return this.projectService.getProject(key, false).pipe(
+            map((project) => project?.writer === true),
+            catchError(() => of(false))
+          );
+        })
+      )
+      // No initialValue: undefined doubles as the leg's pending state (see the doc above).
+    );
+    return computed(() => projectAccess() !== false);
+  }
+
   private populateFormWithCommitteeData(committee: Committee): void {
     this.form.patchValue({
       name: committee.name,
@@ -464,7 +605,7 @@ export class CommitteeManageComponent {
 
     if (this.isEditMode()) {
       // In edit mode, navigate to step 4 for members
-      this.router.navigate([], { queryParams: { step: this.formSteps.ADD_MEMBERS } });
+      this.router.navigate([], { queryParams: { step: this.formSteps.ADD_MEMBERS }, queryParamsHandling: 'merge' });
     } else {
       this.router.navigate(['/groups']);
     }

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -536,6 +536,7 @@ export class CommitteeManageComponent {
       is_audit_enabled: committee.is_audit_enabled,
       public: committee.public,
       display_name: committee.display_name,
+      chat_channel: committee.chat_channel ?? null,
       sso_group_enabled: committee.sso_group_enabled,
       sso_group_name: committee.sso_group_name,
       website: committee.website,
@@ -558,6 +559,11 @@ export class CommitteeManageComponent {
       website: new FormControl('', [Validators.pattern(/^https?:\/\/.+\..+/)]),
 
       // Step 3: Settings
+      // chat_channel is bound by the settings step's Chat Channel card (shared with
+      // committee-settings-tab, whose form declares it) — without the control here the
+      // formControlName setup dereferences null and the field silently drops out of the
+      // create/update payload (GH-1566 review).
+      chat_channel: new FormControl(null),
       business_email_required: new FormControl(false),
       enable_voting: new FormControl(false),
       is_audit_enabled: new FormControl(false),

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -28,6 +28,7 @@ import { StepperModule } from 'primeng/stepper';
 import { catchError, concat, distinctUntilChanged, EMPTY, filter, finalize, from, map, merge, mergeMap, Observable, of, switchMap, take, toArray } from 'rxjs';
 import { applyEntityProjectContext, syncEntityProjectContext } from '@shared/utils/entity-project-context.util';
 import { getHttpErrorDetail } from '@shared/utils/http-error.utils';
+import { resolveEntityWriteSlug } from '@shared/utils/write-access.util';
 import { evictOnWriteAccessLoss } from '@shared/utils/evict-on-write-access-loss.util';
 
 import { CommitteeBasicInfoComponent } from '../components/committee-basic-info/committee-basic-info.component';
@@ -494,9 +495,11 @@ export class CommitteeManageComponent {
               // Pending — in edit mode the authorization target comes from the committee itself.
               return undefined;
             }
-            // Mirror writerGuard's resolution order; the active-context fallback covers a committee
-            // carrying neither slug nor uid (the manage component owns that error path).
-            return committee.project_slug ?? committee.project_uid ?? this.projectContextService.activeContext()?.slug ?? null;
+            // Mirror writerGuard's resolution order via the shared helper — when the guard and
+            // the reactive access signals each carried their own copy, drift evicted admitted
+            // users. The active-context fallback covers a committee carrying neither slug nor uid
+            // (the manage component owns that error path).
+            return resolveEntityWriteSlug(committee, this.projectContextService.activeContext()?.slug ?? null);
           })
         )
       : toObservable(this.projectContextService.activeContext).pipe(map((ctx) => ctx?.slug ?? null));

--- a/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts
@@ -433,8 +433,10 @@ export class CommitteeManageComponent {
    * `getProject(uid, false)` — `current: false` so the fetch doesn't clobber ProjectService's
    * shared `project` state — resolves to null on failure, so a failed fallback leaves the
    * (stale) context untouched rather than erroring the page. (Mirror: meeting-manage's
-   * initMeetingContextFallback, minus its uncached-detail last resort — `fetchCommittee` is
-   * never cached, so a "fresh" refetch cannot return a different payload.)
+   * initMeetingContextFallback, minus its fresh-detail last resort: `getCommitteeDetail` does
+   * support `skipCache`, but a refetch cannot recover a missing `project_slug` — the BFF's
+   * committee enrichment resolves the project through the same relation-gated `/projects/:uid`
+   * GET this fallback already tried, unlike meeting enrichment's ungated query-service lookup.)
    *
    * Runs whenever the payload lacks `project_slug`, even when the uid already matches the active
    * context: the lookup is also what corrects the lens *kind* via `computeIsFoundation`. As in

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -729,10 +729,12 @@ export class CommitteeViewComponent {
 
     let pollSucceeded = false;
 
+    // skipCache: every poll must read fresh — a cached pre-membership payload (10s detail TTL
+    // vs this 2.4s window) would replay through all six attempts and never surface my_role.
     timer(400, 400)
       .pipe(
         take(6),
-        exhaustMap(() => this.committeeService.getCommittee(committeeId).pipe(catchError(() => of(null)))),
+        exhaustMap(() => this.committeeService.getCommittee(committeeId, { skipCache: true }).pipe(catchError(() => of(null)))),
         filter((committee) => !!committee?.my_role),
         take(1),
         takeUntilDestroyed(this.destroyRef)

--- a/apps/lfx-one/src/app/modules/committees/committees.routes.ts
+++ b/apps/lfx-one/src/app/modules/committees/committees.routes.ts
@@ -27,6 +27,9 @@ export const COMMITTEE_ROUTES: Routes = [
     path: ':id/edit',
     loadComponent: () => import('./committee-manage/committee-manage.component').then((m) => m.CommitteeManageComponent),
     canActivate: [authGuard, writerGuard],
-    data: { writeFeature: 'committees' },
+    // entityScopedSlug: writerGuard resolves the authorization slug from the committee itself on
+    // this route. A route-data flag, not a path check, so a route rename/restructure
+    // can't silently revert the guard to stale-context authorization.
+    data: { writeFeature: 'committees', entityScopedSlug: true },
   },
 ];

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.html
@@ -33,18 +33,18 @@
   </ng-template>
 </p-toast>
 
-@if (invitations().length > 0) {
+@if (invitationRows().length > 0) {
   <section class="flex flex-col gap-4" data-testid="committee-invitations-section">
     <div class="flex items-center gap-3">
       <h2 class="flex items-center gap-2 shrink-0 text-base font-medium text-gray-900">
         <i class="fa-light fa-envelope-open-text text-lg" aria-hidden="true"></i>
-        <span>Invitations ({{ invitations().length }})</span>
+        <span>Invitations ({{ invitationRows().length }})</span>
       </h2>
       <div class="flex-1 border-t border-gray-200 self-center"></div>
     </div>
 
     <ul class="flex flex-col gap-3 list-none p-0 m-0" role="list" aria-label="Pending invitations" data-testid="committee-invitations-list">
-      @for (invitation of invitations(); track invitation.uid) {
+      @for (invitation of invitationRows(); track invitation.uid) {
         <li
           role="listitem"
           class="flex flex-col sm:flex-row sm:items-center gap-3 bg-white rounded-2xl border border-gray-200 shadow-sm px-4 py-3"
@@ -53,7 +53,8 @@
             <lfx-tag value="Invited" severity="info" icon="fa-light fa-envelope" styleClass="whitespace-nowrap shrink-0" />
             <div class="flex flex-col gap-0.5 min-w-0">
               <a
-                [routerLink]="['/groups', invitation.committee_uid]"
+                [routerLink]="invitation.viewCommands"
+                [queryParams]="invitation.viewQueryParams"
                 [state]="{ backLabel: 'My Groups' }"
                 class="text-sm font-medium text-blue-600 hover:text-blue-700 hover:underline truncate"
                 [attr.title]="invitation.committee_name"

--- a/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-invitations/committee-invitations.component.ts
@@ -5,10 +5,10 @@ import { computed, Component, DestroyRef, inject, output, Signal } from '@angula
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { ButtonComponent } from '@components/button/button.component';
 import { TagComponent } from '@components/tag/tag.component';
-import { PendingInvitation } from '@lfx-one/shared/interfaces';
+import { PendingInvitation, PendingInvitationRowVm } from '@lfx-one/shared/interfaces';
 import { RouterLink } from '@angular/router';
 import { InvitationSubtextPipe } from '@pipes/invitation-subtext.pipe';
-import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
+import { getEntityCommands, invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { InvitationAcceptFlowService } from '@services/invitation-accept-flow.service';
 import { InvitationService } from '@services/invitation.service';
 import { MessageService } from 'primeng/api';
@@ -53,6 +53,20 @@ export class CommitteeInvitationsComponent {
   /** Pending invitations not yet resolved (accepted/declined) this session. */
   public readonly invitations: Signal<PendingInvitation[]> = computed(() =>
     this.invitationService.pendingInvitations().filter((invitation) => !this.invitationService.resolvedInviteUids().has(invitation.uid))
+  );
+
+  /**
+   * Rows decorated with their canonical view link (GH-1566): the invited group's own
+   * `is_foundation` picks `/foundation` vs `/project`; rows without tier data keep the flat
+   * `/groups/:uid` fallback, and `?project=` rides along when a slug resolved. Pre-computed per
+   * row so the template stays binding-only (mirror: `MyGroupsCardGridComponent.initCards`).
+   */
+  protected readonly invitationRows: Signal<PendingInvitationRowVm[]> = computed(() =>
+    this.invitations().map((invitation) => ({
+      ...invitation,
+      viewCommands: getEntityCommands('groups', invitation.committee_uid, invitation.is_foundation) ?? ['/groups', invitation.committee_uid],
+      viewQueryParams: invitation.project_slug ? { project: invitation.project_slug } : null,
+    }))
   );
 
   /**

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -185,18 +185,15 @@
                       [pTooltip]="'Add Member — coming soon'"
                       tooltipPosition="top">
                     </lfx-button>
-                    <a [routerLink]="committee.editCommands" [queryParams]="committee.linkQueryParams">
-                      <lfx-button
-                        icon="fa-light fa-pencil"
-                        severity="secondary"
-                        size="small"
-                        [outlined]="false"
-                        [text]="true"
-                        styleClass="h-8 w-8 text-gray-500 hover:text-gray-700 hover:bg-gray-100"
-                        [attr.data-testid]="'committee-edit-' + committee.uid"
-                        [pTooltip]="'Edit ' + committeeLabel.singular"
-                        tooltipPosition="top">
-                      </lfx-button>
+                    <a
+                      [routerLink]="committee.editCommands"
+                      [queryParams]="committee.linkQueryParams"
+                      class="inline-flex h-8 w-8 cursor-pointer items-center justify-center rounded text-gray-500 hover:bg-gray-100 hover:text-gray-700"
+                      [attr.aria-label]="'Edit ' + committeeLabel.singular"
+                      [attr.data-testid]="'committee-edit-' + committee.uid"
+                      [pTooltip]="'Edit ' + committeeLabel.singular"
+                      tooltipPosition="top">
+                      <i class="fa-light fa-pencil" aria-hidden="true"></i>
                     </a>
                   </div>
                 </td>

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.html
@@ -32,7 +32,7 @@
         </lfx-empty-state>
       } @else {
         <lfx-table
-          [value]="committees()"
+          [value]="tableRows()"
           [paginator]="committees().length > 0"
           [rows]="10"
           [rowsPerPageOptions]="rppOptions()"
@@ -66,7 +66,7 @@
                   @if (isBoardMember()) {
                     <span class="text-sm font-medium">{{ committee.name || '-' }}</span>
                   } @else {
-                    <a [routerLink]="['/groups', committee.uid]" class="lfx-table-name-link text-sm">
+                    <a [routerLink]="committee.viewCommands" [queryParams]="committee.linkQueryParams" class="lfx-table-name-link text-sm">
                       {{ committee.name || '-' }}
                     </a>
                   }
@@ -185,7 +185,7 @@
                       [pTooltip]="'Add Member — coming soon'"
                       tooltipPosition="top">
                     </lfx-button>
-                    <a [routerLink]="['/groups', committee.uid, 'edit']">
+                    <a [routerLink]="committee.editCommands" [queryParams]="committee.linkQueryParams">
                       <lfx-button
                         icon="fa-light fa-pencil"
                         severity="secondary"

--- a/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-table/committee-table.component.ts
@@ -11,6 +11,8 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { TableComponent } from '@components/table/table.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { Committee, COMMITTEE_LABEL } from '@lfx-one/shared';
+import { CommitteeTableRowVm } from '@lfx-one/shared/interfaces';
+import { getGroupCommands } from '@lfx-one/shared/utils';
 import { PlatformIconPipe } from '@app/shared/pipes/platform-icon.pipe';
 import { PlatformLabelPipe } from '@app/shared/pipes/platform-label.pipe';
 import { PersonaService } from '@services/persona.service';
@@ -71,7 +73,24 @@ export class CommitteeTableComponent {
   protected readonly isBoardMember = computed(() => this.personaService.currentPersona() === 'board-member');
   protected readonly rppOptions = computed<number[] | undefined>(() => (this.committees().length > 10 ? [10, 25, 50] : undefined));
 
-  protected onRowSelect(event: { data: Committee }): void {
+  /**
+   * Rows decorated with their canonical view/edit link state (GH-1566): `getGroupCommands`
+   * prefixes the path with the row's OWN project tier (`is_foundation`) instead of the viewer's
+   * transient active lens, and `?project=` rides along when the row carries a `project_slug`.
+   * Rows without tier data keep the flat `/groups/:uid` fallback (the `??` inside the mapping),
+   * which `lensRedirectGuard` handles as before. Pre-computed once per input change rather than
+   * per change-detection cycle (angular-reactive-data §3.5).
+   */
+  protected readonly tableRows = computed<CommitteeTableRowVm[]>(() =>
+    this.committees().map((committee) => ({
+      ...committee,
+      viewCommands: getGroupCommands(committee) ?? ['/groups', committee.uid],
+      editCommands: getGroupCommands(committee, 'edit') ?? ['/groups', committee.uid, 'edit'],
+      linkQueryParams: committee.project_slug ? { project: committee.project_slug } : null,
+    }))
+  );
+
+  protected onRowSelect(event: { data: CommitteeTableRowVm }): void {
     this.rowClick.emit(event.data);
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/my-groups-card-grid/my-groups-card-grid.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/my-groups-card-grid/my-groups-card-grid.component.html
@@ -28,7 +28,8 @@
   <div class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4" data-testid="groups-card-grid">
     @for (item of visibleCards(); track item.committee.uid) {
       <a
-        [routerLink]="['/groups', item.committee.uid]"
+        [routerLink]="item.viewCommands"
+        [queryParams]="item.viewQueryParams"
         [state]="{ backLabel: 'My Groups' }"
         class="no-underline bg-white rounded-lg border border-gray-200 shadow-sm hover:shadow-md transition-shadow p-6 h-full flex flex-col gap-3 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500"
         [attr.aria-label]="item.ariaLabel"

--- a/apps/lfx-one/src/app/modules/committees/components/my-groups-card-grid/my-groups-card-grid.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/my-groups-card-grid/my-groups-card-grid.component.ts
@@ -8,7 +8,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { COMMITTEE_LABEL, GROUPS_CARD_GRID_PAGE_SIZE } from '@lfx-one/shared/constants';
 import { MyCommittee, MyGroupsCardVm } from '@lfx-one/shared/interfaces';
-import { formatRelativeTime, resolveGroupsCardRoleSeverity } from '@lfx-one/shared/utils';
+import { formatRelativeTime, getGroupCommands, resolveGroupsCardRoleSeverity } from '@lfx-one/shared/utils';
 import { TooltipModule } from 'primeng/tooltip';
 
 @Component({
@@ -70,6 +70,10 @@ export class MyGroupsCardGridComponent {
           committee,
           roleBadgeSeverity: resolveGroupsCardRoleSeverity(committee.my_role),
           lastActivityLabel,
+          // Canonical tier-prefixed view link (GH-1566): the group's own `is_foundation` picks
+          // /foundation vs /project; rows without tier data keep the flat /groups/:uid fallback.
+          viewCommands: getGroupCommands(committee) ?? ['/groups', committee.uid],
+          viewQueryParams: committee.project_slug ? { project: committee.project_slug } : null,
           ariaLabel: parts.join(', '),
         };
       })

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.html
@@ -132,11 +132,12 @@
                     } @else if (item.isInvitation) {
                       <div class="flex flex-col gap-0.5 sm:flex-1 sm:min-w-0 sm:px-4">
                         <!-- Title comes from the backend-built item.text (same copy as the drawer); the
-                           group name is split off as a link into the group (project-lens detail page). -->
+                           group name is split off as a link into the group's canonical tier-prefixed page (GH-1566). -->
                         <p class="text-sm text-gray-900 sm:truncate" [attr.title]="item.text" data-testid="dashboard-pending-actions-title">
                           {{ item.inviteTitlePrefix }}
                           <a
-                            [routerLink]="['/groups', item.committeeUid]"
+                            [routerLink]="item.inviteViewCommands"
+                            [queryParams]="item.inviteViewQueryParams"
                             [state]="{ backLabel: 'My Dashboard' }"
                             (click)="$event.stopPropagation()"
                             class="font-medium text-blue-600 hover:text-blue-700 hover:underline"

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -600,7 +600,9 @@ export class PendingActionsComponent {
         const inviteGroupName = item.inviteGroupName ?? item.badge;
         // Canonical tier-prefixed view link (GH-1566): the invited group's own `inviteIsFoundation`
         // picks /foundation vs /project; rows without tier data keep the flat /groups/:uid fallback.
-        const inviteViewCommands = item.committeeUid ? (getEntityCommands('groups', item.committeeUid, item.inviteIsFoundation) ?? ['/groups', item.committeeUid]) : null;
+        const inviteViewCommands = item.committeeUid
+          ? (getEntityCommands('groups', item.committeeUid, item.inviteIsFoundation) ?? ['/groups', item.committeeUid])
+          : null;
         const inviteViewQueryParams = item.inviteProjectSlug ? { project: item.inviteProjectSlug } : null;
         return {
           ...item,

--- a/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/pending-actions/pending-actions.component.ts
@@ -21,7 +21,7 @@ import { PollType } from '@lfx-one/shared/enums';
 import { MeetingService } from '@services/meeting.service';
 import { VoteService } from '@services/vote.service';
 import { HiddenActionsService } from '@shared/services/hidden-actions.service';
-import { invitationRequiresOrganization } from '@lfx-one/shared/utils';
+import { getEntityCommands, invitationRequiresOrganization } from '@lfx-one/shared/utils';
 import { InvitationAcceptFlowService } from '@shared/services/invitation-accept-flow.service';
 import { InvitationService } from '@shared/services/invitation.service';
 import { MessageService } from 'primeng/api';
@@ -594,10 +594,14 @@ export class PendingActionsComponent {
         const isVoteLoading = !!item.voteUid && loadingVoteUids.has(item.voteUid);
         const isVoteInlineExpanded = isVoteInline && expandedVoteKey === rowKey;
         const voteUsesDrawerVal = !!vote && this.voteUsesDrawer(vote);
-        // Require committeeUid too — the invitation branch builds a routerLink to /groups/:committeeUid
+        // Require committeeUid too — the invitation branch builds a routerLink to the group
         // and calls accept/decline with it, so a row missing it would render /groups/undefined.
         const isInvitation = item.type === 'Invitation' && !!item.inviteUid && !!item.committeeUid;
         const inviteGroupName = item.inviteGroupName ?? item.badge;
+        // Canonical tier-prefixed view link (GH-1566): the invited group's own `inviteIsFoundation`
+        // picks /foundation vs /project; rows without tier data keep the flat /groups/:uid fallback.
+        const inviteViewCommands = item.committeeUid ? (getEntityCommands('groups', item.committeeUid, item.inviteIsFoundation) ?? ['/groups', item.committeeUid]) : null;
+        const inviteViewQueryParams = item.inviteProjectSlug ? { project: item.inviteProjectSlug } : null;
         return {
           ...item,
           rowKey,
@@ -615,6 +619,8 @@ export class PendingActionsComponent {
           isInvitation,
           acceptAriaLabel: `Accept invite to ${inviteGroupName}`,
           declineAriaLabel: `Decline invite to ${inviteGroupName}`,
+          inviteViewCommands,
+          inviteViewQueryParams,
         };
       });
     });

--- a/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
+++ b/apps/lfx-one/src/app/shared/components/project-selector/project-selector.component.ts
@@ -7,9 +7,9 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, ReactiveFormsModule } from '@angular/forms';
 import { BOARD_SCOPED_PERSONA_PRIORITY, PROJECT_SCOPED_PERSONA_PRIORITY } from '@lfx-one/shared/constants';
 import { DisplayLensItem, LensItem, NavLens, PersonaType, ProjectContext, SelectorTab } from '@lfx-one/shared/interfaces';
-import { LensService } from '@services/lens.service';
 import { NavigationService } from '@services/navigation.service';
 import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
 import { AutoFocus } from 'primeng/autofocus';
 import { InputTextModule } from 'primeng/inputtext';
@@ -24,8 +24,8 @@ import { TooltipModule } from 'primeng/tooltip';
 })
 export class ProjectSelectorComponent {
   private readonly navigationService = inject(NavigationService);
-  private readonly lensService = inject(LensService);
   private readonly personaService = inject(PersonaService);
+  private readonly projectContextService = inject(ProjectContextService);
   private readonly platformId = inject(PLATFORM_ID);
 
   private readonly popoverRef = viewChild<Popover>('popover');
@@ -190,14 +190,20 @@ export class ProjectSelectorComponent {
             return detected.isFoundation ? 'Foundation' : 'Project';
           }
           // Curated mode: the item's own `isFoundation` is authoritative for writer-reachable entries
-          // that aren't persona-detected — resolve it before falling back to the active lens, which
-          // would otherwise mislabel a foundation as "Project" (or vice versa) from the wrong page.
+          // that aren't persona-detected — resolve it before falling back to the active context's
+          // kind, which would otherwise mislabel a foundation as "Project" (or vice versa) from the
+          // wrong page.
           const curated = this.items()?.find((item) => item.uid === selectedUid);
           if (curated) {
             return curated.isFoundation ? 'Foundation' : 'Project';
           }
         }
-        return this.lensService.activeLens() === 'foundation' ? 'Foundation' : 'Project';
+        // Last resort: the *displayed* context's kind — isFoundationContext is kept in lockstep
+        // with the activeContext this selector renders. activeLens would mislabel a wrong-tier
+        // deep link (e.g. /project/groups/:uid on a foundation-owned group): the entity context
+        // sync re-points routeLensKind at the entity's kind while activeLens still follows the URL
+        // prefix, so the badge would read "Project" next to the corrected foundation (GH-1566).
+        return this.projectContextService.isFoundationContext() ? 'Foundation' : 'Project';
       }
       return this.lens() === 'foundation' ? 'Foundation' : 'Project';
     });
@@ -215,7 +221,9 @@ export class ProjectSelectorComponent {
       const uid = this.selectedProject()?.uid;
       if (!uid) return null;
       const detected = this.personaService.detectedProjects().find((p) => p.projectUid === uid);
-      const isFoundation = detected?.isFoundation ?? this.lensService.activeLens() === 'foundation';
+      // Same corrected-context fallback as the lens type label — the role tier must agree with the
+      // displayed context on wrong-tier deep links, not the URL-derived lens (GH-1566).
+      const isFoundation = detected?.isFoundation ?? this.projectContextService.isFoundationContext();
       const priority = isFoundation ? BOARD_SCOPED_PERSONA_PRIORITY : PROJECT_SCOPED_PERSONA_PRIORITY;
       const personaProjects = this.personaService.personaProjects();
       for (const persona of priority) {

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.spec.ts
@@ -10,7 +10,7 @@ import { MeetingService } from '@shared/services/meeting.service';
 import { PersonaService } from '@shared/services/persona.service';
 import { ProjectContextService } from '@shared/services/project-context.service';
 import { ProjectService } from '@shared/services/project.service';
-import { Meeting } from '@lfx-one/shared/interfaces';
+import { Committee, Meeting } from '@lfx-one/shared/interfaces';
 import { firstValueFrom, of, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
@@ -20,16 +20,21 @@ import { writerGuard } from './writer.guard';
 // on the meeting read may fall back to the stale active context — every other failure must
 // resolve no slug at all so the guard redirects instead of authorizing against an unrelated
 // project. A future broadened catch would silently restore the cross-project authorization bug.
+// The committee edit route (GH-1566) shares the same entity-scoped resolution through
+// fetchCommittee, so its cases pin the identical contract for the committees branch.
 // Also covers the non-meetings early-returns (ED fast path, non-entity-scoped features) so the
 // file isn't a false sense of coverage for the guard's default flow.
 describe('writerGuard', () => {
   const MEETING_UID = 'meeting-uid-1';
   const MEETING_SLUG = 'meeting-project';
+  const COMMITTEE_UID = 'committee-uid-1';
+  const COMMITTEE_SLUG = 'committee-project';
   const STALE_SLUG = 'stale-project';
 
   let getMeetingDetail: ReturnType<typeof vi.fn>;
   let getProject: ReturnType<typeof vi.fn>;
   let getCommittee: ReturnType<typeof vi.fn>;
+  let fetchCommittee: ReturnType<typeof vi.fn>;
   let router: { parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
   let currentPersona: ReturnType<typeof signal<string>>;
 
@@ -40,6 +45,14 @@ describe('writerGuard', () => {
       queryParamMap: convertToParamMap({}),
       paramMap: convertToParamMap({ id: MEETING_UID }),
       data,
+      parent: null,
+    }) as unknown as ActivatedRouteSnapshot;
+
+  const committeeRoute = (): ActivatedRouteSnapshot =>
+    ({
+      queryParamMap: convertToParamMap({}),
+      paramMap: convertToParamMap({ id: COMMITTEE_UID }),
+      data: { writeFeature: 'committees', entityScopedSlug: true },
       parent: null,
     }) as unknown as ActivatedRouteSnapshot;
 
@@ -54,6 +67,7 @@ describe('writerGuard', () => {
     getMeetingDetail = vi.fn();
     getProject = vi.fn().mockReturnValue(of(null));
     getCommittee = vi.fn();
+    fetchCommittee = vi.fn();
     currentPersona = signal('maintainer');
     router = {
       parseUrl: vi.fn().mockImplementation((url: string) => ({ redirect: url }) as unknown as UrlTree),
@@ -65,7 +79,7 @@ describe('writerGuard', () => {
         { provide: PersonaService, useValue: { currentPersona } },
         { provide: ProjectContextService, useValue: { activeContext: () => ({ uid: 'stale-uid', slug: STALE_SLUG, name: 'Stale' }) } },
         { provide: ProjectService, useValue: { getProject } },
-        { provide: CommitteeService, useValue: { getCommittee } },
+        { provide: CommitteeService, useValue: { getCommittee, fetchCommittee } },
         { provide: MeetingService, useValue: { getMeetingDetail } },
         { provide: Router, useValue: router },
       ],
@@ -113,6 +127,49 @@ describe('writerGuard', () => {
 
     expect(result).toBe(true);
     expect(getProject).toHaveBeenCalledWith('p-uid', false, { meetingCoordinator: true });
+  });
+
+  it('authorizes committee edit against the committee’s own project when the read succeeds', async () => {
+    fetchCommittee.mockReturnValue(of({ uid: COMMITTEE_UID, project_uid: 'c-uid', project_slug: COMMITTEE_SLUG } as unknown as Committee));
+    getProject.mockReturnValue(of({ uid: 'c-uid', slug: COMMITTEE_SLUG, writer: true }));
+
+    const result = await runGuard(committeeRoute());
+
+    expect(result).toBe(true);
+    expect(fetchCommittee).toHaveBeenCalledWith(COMMITTEE_UID);
+    expect(getMeetingDetail).not.toHaveBeenCalled();
+    expect(getProject).toHaveBeenCalledWith(COMMITTEE_SLUG, false, { meetingCoordinator: false });
+  });
+
+  it('resolves the committee uid when the payload lacks an enriched slug, never the stale context', async () => {
+    fetchCommittee.mockReturnValue(of({ uid: COMMITTEE_UID, project_uid: 'c-uid', project_slug: null } as unknown as Committee));
+    getProject.mockReturnValue(of({ uid: 'c-uid', slug: COMMITTEE_SLUG, writer: true }));
+
+    const result = await runGuard(committeeRoute());
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith('c-uid', false, { meetingCoordinator: false });
+  });
+
+  it('falls back to the active context only on a 404 committee read', async () => {
+    fetchCommittee.mockReturnValue(throwError(() => httpError(404)));
+    getProject.mockReturnValue(of({ uid: 'stale-uid', slug: STALE_SLUG, writer: true }));
+
+    const result = await runGuard(committeeRoute());
+
+    expect(result).toBe(true);
+    expect(getProject).toHaveBeenCalledWith(STALE_SLUG, false, { meetingCoordinator: false });
+  });
+
+  it('fails closed on a 500 committee read without probing the stale project', async () => {
+    fetchCommittee.mockReturnValue(throwError(() => httpError(500)));
+
+    const result = await runGuard(committeeRoute());
+
+    expect(router.parseUrl).toHaveBeenCalledWith('/project/overview');
+    expect(result).toEqual({ redirect: '/project/overview' });
+    expect(getProject).not.toHaveBeenCalled();
+    expect(getCommittee).not.toHaveBeenCalled();
   });
 
   it('allows the executive-director persona synchronously with no HTTP calls', async () => {

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -28,8 +28,8 @@ import { hasMeetingWriteAccess, resolveEntityWriteSlug } from '../utils/write-ac
  *    `'surveys'`, or `'votes'`. The backend ruleset allows committee:uid#writer to
  *    create resources associated with their committee.
  *
- * Slug resolution: on routes flagged `data.entityScopedSlug` (meeting edit), resolves
- * the slug from the meeting itself first — the active context can belong to a different project
+ * Slug resolution: on routes flagged `data.entityScopedSlug` (meeting/group edit), resolves
+ * the slug from the entity itself first — the active context can belong to a different project
  * when the edit link carried no `?project=`. A non-404 failure on that read resolves no slug at all,
  * so the guard redirects instead of authorizing against a stale context; a flagged route with no
  * registered probe or `:id` param is misconfigured and likewise fails closed. Otherwise prefers the `?project=` query param
@@ -70,10 +70,13 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   // A missing/stale `?project=` can authorize against a different project than the entity being
   // edited — resolve the slug from the entity itself; only a 404 falls back, else fail closed.
   const writeFeature: string | undefined = route.data?.['writeFeature'];
-  // Entity probes keyed by writeFeature — a follow-up ticket adds one registry line + inject() +
-  // route flag; probes must be tap-free and short-TTL-cached so the guard shares the manage fetch.
+  // Entity probes keyed by writeFeature — a new entity adds one registry line + the route's
+  // entityScopedSlug flag. Probes must be tap-free: fetchCommittee, not getCommittee (which sets
+  // the shared committee signal), so a guard probe can't leak stale state into other pages. A
+  // short-TTL-cached probe (meetings) shares the manage component's fetch on the same navigation.
   const entityProbes: Record<string, (id: string) => Observable<Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null>> = {
     meetings: (id) => meetingService.getMeetingDetail(id),
+    committees: (id) => committeeService.fetchCommittee(id),
   };
   const resolveSlug = (): Observable<string | null> => {
     const fromContext = route.queryParamMap.get('project') ?? projectContextService.activeContext()?.slug ?? null;

--- a/apps/lfx-one/src/app/shared/guards/writer.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/writer.guard.ts
@@ -72,8 +72,9 @@ export const writerGuard: CanActivateFn = (route: ActivatedRouteSnapshot) => {
   const writeFeature: string | undefined = route.data?.['writeFeature'];
   // Entity probes keyed by writeFeature — a new entity adds one registry line + the route's
   // entityScopedSlug flag. Probes must be tap-free: fetchCommittee, not getCommittee (which sets
-  // the shared committee signal), so a guard probe can't leak stale state into other pages. A
-  // short-TTL-cached probe (meetings) shares the manage component's fetch on the same navigation.
+  // the shared committee signal), so a guard probe can't leak stale state into other pages. Both
+  // probes ride a short-TTL shared cache (getMeetingDetail / getCommitteeDetail via fetchCommittee),
+  // so the manage component's immediate refetch on the same navigation doesn't duplicate the request.
   const entityProbes: Record<string, (id: string) => Observable<Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null>> = {
     meetings: (id) => meetingService.getMeetingDetail(id),
     committees: (id) => committeeService.fetchCommittee(id),

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -29,7 +29,8 @@ import {
   PaginatedResponse,
   QueryServiceCountResponse,
 } from '@lfx-one/shared/interfaces';
-import { catchError, map, Observable, of, take, tap, throwError } from 'rxjs';
+import { COMMITTEE_DETAIL_CACHE_TTL_MS } from '@lfx-one/shared/constants';
+import { catchError, map, Observable, of, shareReplay, take, tap, throwError } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -38,6 +39,7 @@ export class CommitteeService {
   public committee: WritableSignal<Committee | null> = signal(null);
 
   private readonly http = inject(HttpClient);
+  private readonly committeeDetailCache = new Map<string, { observable: Observable<Committee>; cachedAt: number }>();
 
   public getCommittees(params?: HttpParams): Observable<Committee[]> {
     return this.http.get<Committee[]>('/api/committees', { params }).pipe(catchError(() => of([])));
@@ -110,16 +112,41 @@ export class CommitteeService {
   }
 
   public getCommittee(id: string): Observable<Committee> {
-    return this.http.get<Committee>(`/api/committees/${id}`).pipe(
-      catchError((error) => {
-        return throwError(() => error);
-      }),
-      tap((committee) => this.committee.set(committee ?? null))
+    return this.getCommitteeDetail(id).pipe(tap((committee) => this.committee.set(committee ?? null)));
+  }
+
+  /**
+   * Committee-detail fetch with a short-TTL shared cache: the writerGuard slug
+   * resolution and CommitteeManageComponent's initializeCommittee both need the same payload
+   * within one navigation — sharing the request avoids paying the detail endpoint's fan-out
+   * (settings, membership, access, inherited-permission, mailing-list, project-metadata
+   * enrichment) twice on every edit-page load. Probe-friendly: no `committee` signal
+   * side-effect. Entries evict on error and on write (updateCommittee/updateCommitteePermissions/
+   * deleteCommittee). Pass `skipCache` to force a fresh fetch when a caller needs enrichment that
+   * a cached payload may predate. `skipCache` replaces the cache entry with the new `request$`
+   * rather than invalidating — callers already subscribed to the prior `shareReplay(1)`
+   * observable continue to completion with the old payload, so racing `skipCache` callers can
+   * still observe a stale result. Mirrors MeetingService.getMeetingDetail.
+   */
+  public getCommitteeDetail(id: string, options?: { skipCache?: boolean }): Observable<Committee> {
+    const cached = this.committeeDetailCache.get(id);
+    if (!options?.skipCache && cached && Date.now() - cached.cachedAt < COMMITTEE_DETAIL_CACHE_TTL_MS) {
+      return cached.observable;
+    }
+    if (cached) {
+      this.committeeDetailCache.delete(id);
+    }
+    const request$ = this.http.get<Committee>(`/api/committees/${id}`).pipe(
+      tap({ error: () => this.committeeDetailCache.delete(id) }),
+      shareReplay(1)
     );
+    this.pruneExpiredCommitteeDetailCache();
+    this.committeeDetailCache.set(id, { observable: request$, cachedAt: Date.now() });
+    return request$;
   }
 
   public deleteCommittee(id: string): Observable<void> {
-    return this.http.delete<void>(`/api/committees/${id}`).pipe(take(1));
+    return this.http.delete<void>(`/api/committees/${id}`).pipe(take(1), tap(() => this.committeeDetailCache.delete(id)));
   }
 
   public createCommittee(committee: Partial<Committee>): Observable<Committee> {
@@ -130,17 +157,21 @@ export class CommitteeService {
   // one PUT still accepts it alongside base fields in a single merged payload; the BFF routes it
   // to the settings sub-resource internally (committee.service.ts's updateCommittee).
   public updateCommittee(id: string, committee: CommitteeUpdateData & Pick<CommitteeSettingsData, 'chat_webhook_url'>): Observable<Committee> {
-    return this.http.put<Committee>(`/api/committees/${id}`, committee).pipe(take(1));
+    return this.http.put<Committee>(`/api/committees/${id}`, committee).pipe(take(1), tap(() => this.committeeDetailCache.delete(id)));
   }
 
   /** Updates the writers and auditors permission lists for a committee. */
   public updateCommitteePermissions(committeeId: string, writers: CommitteeUser[], auditors: CommitteeUser[]): Observable<Committee> {
-    return this.http.put<Committee>(`/api/committees/${committeeId}`, { writers, auditors }).pipe(take(1));
+    return this.http.put<Committee>(`/api/committees/${committeeId}`, { writers, auditors }).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
   }
 
-  /** Fetches a committee by ID without updating shared service state. */
+  /**
+   * Fetches a committee by ID without updating shared service state. Shares the short-TTL
+   * detail cache via {@link getCommitteeDetail} so tap-free probes (writerGuard, committee
+   * sub-pages, meeting-manage's committee check) don't duplicate an in-flight detail fetch.
+   */
   public fetchCommittee(id: string): Observable<Committee> {
-    return this.http.get<Committee>(`/api/committees/${id}`).pipe(take(1));
+    return this.getCommitteeDetail(id);
   }
 
   // ── Sub-groups (children) ─────────────────────────────────────────────────
@@ -148,6 +179,15 @@ export class CommitteeService {
   /** Fetches child committees (sub-groups) of a parent committee */
   public getChildCommittees(parentUid: string): Observable<Committee[]> {
     return this.http.get<Committee[]>(`/api/committees/${parentUid}/children`).pipe(catchError(() => of([])));
+  }
+
+  private pruneExpiredCommitteeDetailCache(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.committeeDetailCache) {
+      if (now - entry.cachedAt >= COMMITTEE_DETAIL_CACHE_TTL_MS) {
+        this.committeeDetailCache.delete(key);
+      }
+    }
   }
 
   // Committee Members methods

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -145,17 +145,17 @@ export class CommitteeService {
     if (cached) {
       this.committeeDetailCache.delete(id);
     }
-    const request$ = this.http.get<Committee>(`/api/committees/${id}`).pipe(
-      tap({ error: () => this.committeeDetailCache.delete(id) }),
-      shareReplay(1)
-    );
+    const request$ = this.http.get<Committee>(`/api/committees/${id}`).pipe(tap({ error: () => this.committeeDetailCache.delete(id) }), shareReplay(1));
     this.pruneExpiredCommitteeDetailCache();
     this.committeeDetailCache.set(id, { observable: request$, cachedAt: Date.now() });
     return request$;
   }
 
   public deleteCommittee(id: string): Observable<void> {
-    return this.http.delete<void>(`/api/committees/${id}`).pipe(take(1), tap(() => this.committeeDetailCache.delete(id)));
+    return this.http.delete<void>(`/api/committees/${id}`).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(id))
+    );
   }
 
   public createCommittee(committee: Partial<Committee>): Observable<Committee> {
@@ -166,12 +166,18 @@ export class CommitteeService {
   // one PUT still accepts it alongside base fields in a single merged payload; the BFF routes it
   // to the settings sub-resource internally (committee.service.ts's updateCommittee).
   public updateCommittee(id: string, committee: CommitteeUpdateData & Pick<CommitteeSettingsData, 'chat_webhook_url'>): Observable<Committee> {
-    return this.http.put<Committee>(`/api/committees/${id}`, committee).pipe(take(1), tap(() => this.committeeDetailCache.delete(id)));
+    return this.http.put<Committee>(`/api/committees/${id}`, committee).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(id))
+    );
   }
 
   /** Updates the writers and auditors permission lists for a committee. */
   public updateCommitteePermissions(committeeId: string, writers: CommitteeUser[], auditors: CommitteeUser[]): Observable<Committee> {
-    return this.http.put<Committee>(`/api/committees/${committeeId}`, { writers, auditors }).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
+    return this.http.put<Committee>(`/api/committees/${committeeId}`, { writers, auditors }).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(committeeId))
+    );
   }
 
   /**
@@ -188,15 +194,6 @@ export class CommitteeService {
   /** Fetches child committees (sub-groups) of a parent committee */
   public getChildCommittees(parentUid: string): Observable<Committee[]> {
     return this.http.get<Committee[]>(`/api/committees/${parentUid}/children`).pipe(catchError(() => of([])));
-  }
-
-  private pruneExpiredCommitteeDetailCache(): void {
-    const now = Date.now();
-    for (const [key, entry] of this.committeeDetailCache) {
-      if (now - entry.cachedAt >= COMMITTEE_DETAIL_CACHE_TTL_MS) {
-        this.committeeDetailCache.delete(key);
-      }
-    }
   }
 
   // Committee Members methods
@@ -220,15 +217,24 @@ export class CommitteeService {
   ): Observable<CommitteeMember> {
     const params = options?.skipNotification ? new HttpParams().set('skip_notification', 'true') : undefined;
 
-    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/members`, memberData, { params }).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
+    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/members`, memberData, { params }).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(committeeId))
+    );
   }
 
   public updateCommitteeMember(committeeId: string, memberId: string, memberData: Partial<CreateCommitteeMemberRequest>): Observable<CommitteeMember> {
-    return this.http.put<CommitteeMember>(`/api/committees/${committeeId}/members/${memberId}`, memberData).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
+    return this.http.put<CommitteeMember>(`/api/committees/${committeeId}/members/${memberId}`, memberData).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(committeeId))
+    );
   }
 
   public deleteCommitteeMember(committeeId: string, memberId: string): Observable<void> {
-    return this.http.delete<void>(`/api/committees/${committeeId}/members/${memberId}`).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
+    return this.http.delete<void>(`/api/committees/${committeeId}/members/${memberId}`).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(committeeId))
+    );
   }
 
   // ── Committee Invites ───────────────────────────────────────────────────────
@@ -256,12 +262,18 @@ export class CommitteeService {
   /** Self-join an open group */
   public joinCommittee(committeeId: string, organization?: CommitteeOrganizationReference): Observable<CommitteeMember> {
     const body = organization ? { organization } : {};
-    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/join`, body).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
+    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/join`, body).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(committeeId))
+    );
   }
 
   /** Leave a group */
   public leaveCommittee(committeeId: string): Observable<void> {
-    return this.http.delete<void>(`/api/committees/${committeeId}/leave`).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
+    return this.http.delete<void>(`/api/committees/${committeeId}/leave`).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(committeeId))
+    );
   }
 
   /** Submit a join application for a group with join_mode 'application' */
@@ -277,9 +289,10 @@ export class CommitteeService {
 
   /** Approves a pending join application and adds the applicant as a member. */
   public approveApplication(committeeId: string, applicationId: string, body?: ApproveCommitteeJoinApplicationRequest): Observable<CommitteeMember> {
-    return this.http
-      .post<CommitteeMember>(`/api/committees/${committeeId}/applications/${applicationId}/approve`, { notify: true, ...body })
-      .pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
+    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/applications/${applicationId}/approve`, { notify: true, ...body }).pipe(
+      take(1),
+      tap(() => this.committeeDetailCache.delete(committeeId))
+    );
   }
 
   /** Rejects a pending join application. */
@@ -395,5 +408,14 @@ export class CommitteeService {
       params = params.set('project_uid', projectUid);
     }
     return this.http.get<string[]>('/api/committees/my-committee-uids', { params }).pipe(catchError(() => of([])));
+  }
+
+  private pruneExpiredCommitteeDetailCache(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.committeeDetailCache) {
+      if (now - entry.cachedAt >= COMMITTEE_DETAIL_CACHE_TTL_MS) {
+        this.committeeDetailCache.delete(key);
+      }
+    }
   }
 }

--- a/apps/lfx-one/src/app/shared/services/committee.service.ts
+++ b/apps/lfx-one/src/app/shared/services/committee.service.ts
@@ -30,7 +30,7 @@ import {
   QueryServiceCountResponse,
 } from '@lfx-one/shared/interfaces';
 import { COMMITTEE_DETAIL_CACHE_TTL_MS } from '@lfx-one/shared/constants';
-import { catchError, map, Observable, of, shareReplay, take, tap, throwError } from 'rxjs';
+import { catchError, map, Observable, of, shareReplay, take, tap } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -111,8 +111,14 @@ export class CommitteeService {
       .pipe(map((response) => response.count));
   }
 
-  public getCommittee(id: string): Observable<Committee> {
-    return this.getCommitteeDetail(id).pipe(tap((committee) => this.committee.set(committee ?? null)));
+  /**
+   * Fetches a committee and mirrors it into the shared `committee` signal. Shares the short-TTL
+   * detail cache via {@link getCommitteeDetail} — pass `skipCache: true` for reads that poll for a
+   * just-written change (e.g. post-join membership propagation), where replaying a cached
+   * pre-write payload would defeat the poll.
+   */
+  public getCommittee(id: string, options?: { skipCache?: boolean }): Observable<Committee> {
+    return this.getCommitteeDetail(id, options).pipe(tap((committee) => this.committee.set(committee ?? null)));
   }
 
   /**
@@ -122,8 +128,11 @@ export class CommitteeService {
    * (settings, membership, access, inherited-permission, mailing-list, project-metadata
    * enrichment) twice on every edit-page load. Probe-friendly: no `committee` signal
    * side-effect. Entries evict on error and on write (updateCommittee/updateCommitteePermissions/
-   * deleteCommittee). Pass `skipCache` to force a fresh fetch when a caller needs enrichment that
-   * a cached payload may predate. `skipCache` replaces the cache entry with the new `request$`
+   * deleteCommittee and the membership-changing writes: join/leave, member CRUD, application
+   * approve). Pass `skipCache` to force a fresh fetch when a caller needs enrichment that
+   * a cached payload may predate — including polls that wait for a just-written membership change
+   * to propagate (a cached pre-write payload would otherwise replay through the whole poll
+   * window). `skipCache` replaces the cache entry with the new `request$`
    * rather than invalidating — callers already subscribed to the prior `shareReplay(1)`
    * observable continue to completion with the old payload, so racing `skipCache` callers can
    * still observe a stale result. Mirrors MeetingService.getMeetingDetail.
@@ -211,15 +220,15 @@ export class CommitteeService {
   ): Observable<CommitteeMember> {
     const params = options?.skipNotification ? new HttpParams().set('skip_notification', 'true') : undefined;
 
-    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/members`, memberData, { params }).pipe(take(1));
+    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/members`, memberData, { params }).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
   }
 
   public updateCommitteeMember(committeeId: string, memberId: string, memberData: Partial<CreateCommitteeMemberRequest>): Observable<CommitteeMember> {
-    return this.http.put<CommitteeMember>(`/api/committees/${committeeId}/members/${memberId}`, memberData).pipe(take(1));
+    return this.http.put<CommitteeMember>(`/api/committees/${committeeId}/members/${memberId}`, memberData).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
   }
 
   public deleteCommitteeMember(committeeId: string, memberId: string): Observable<void> {
-    return this.http.delete<void>(`/api/committees/${committeeId}/members/${memberId}`).pipe(take(1));
+    return this.http.delete<void>(`/api/committees/${committeeId}/members/${memberId}`).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
   }
 
   // ── Committee Invites ───────────────────────────────────────────────────────
@@ -247,12 +256,12 @@ export class CommitteeService {
   /** Self-join an open group */
   public joinCommittee(committeeId: string, organization?: CommitteeOrganizationReference): Observable<CommitteeMember> {
     const body = organization ? { organization } : {};
-    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/join`, body).pipe(take(1));
+    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/join`, body).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
   }
 
   /** Leave a group */
   public leaveCommittee(committeeId: string): Observable<void> {
-    return this.http.delete<void>(`/api/committees/${committeeId}/leave`).pipe(take(1));
+    return this.http.delete<void>(`/api/committees/${committeeId}/leave`).pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
   }
 
   /** Submit a join application for a group with join_mode 'application' */
@@ -268,7 +277,9 @@ export class CommitteeService {
 
   /** Approves a pending join application and adds the applicant as a member. */
   public approveApplication(committeeId: string, applicationId: string, body?: ApproveCommitteeJoinApplicationRequest): Observable<CommitteeMember> {
-    return this.http.post<CommitteeMember>(`/api/committees/${committeeId}/applications/${applicationId}/approve`, { notify: true, ...body }).pipe(take(1));
+    return this.http
+      .post<CommitteeMember>(`/api/committees/${committeeId}/applications/${applicationId}/approve`, { notify: true, ...body })
+      .pipe(take(1), tap(() => this.committeeDetailCache.delete(committeeId)));
   }
 
   /** Rejects a pending join application. */

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -33,7 +33,7 @@ import {
   WorkExperienceCreateUpdateBody,
   WorkExperienceEntry,
 } from '@lfx-one/shared/interfaces';
-import { catchError, distinctUntilChanged, map, Observable, of, shareReplay, skip, startWith, Subject, switchMap, take, takeUntil } from 'rxjs';
+import { catchError, distinctUntilChanged, EMPTY, map, Observable, of, shareReplay, skip, startWith, Subject, switchMap, take, takeUntil } from 'rxjs';
 
 @Injectable({
   providedIn: 'root',
@@ -127,19 +127,19 @@ export class UserService {
         return;
       }
       this.getCurrentUserProfile()
-        .pipe(take(1))
-        .subscribe({
-          next: (profile) => {
-            // Only seed from this fetch if nothing has set the signal since it was kicked off —
-            // an in-session upload (onProfileSaved) that completes first must win, not get
-            // clobbered by this slower, now-stale fetch resolving afterward.
-            if (profile.profile?.picture && this.uploadedAvatarUrl() === null) {
-              this.uploadedAvatarUrl.set(profile.profile.picture);
-            }
-          },
-          // Best-effort: leave uploadedAvatarUrl null so effectiveAvatarUrl falls back to the
-          // Auth0 picture claim, which is already showing.
-          error: () => {},
+        .pipe(
+          take(1),
+          // Best-effort: on failure leave uploadedAvatarUrl null so effectiveAvatarUrl falls back
+          // to the Auth0 picture claim, which is already showing.
+          catchError(() => EMPTY)
+        )
+        .subscribe((profile) => {
+          // Only seed from this fetch if nothing has set the signal since it was kicked off —
+          // an in-session upload (onProfileSaved) that completes first must win, not get
+          // clobbered by this slower, now-stale fetch resolving afterward.
+          if (profile.profile?.picture && this.uploadedAvatarUrl() === null) {
+            this.uploadedAvatarUrl.set(profile.profile.picture);
+          }
         });
     });
   }

--- a/apps/lfx-one/src/app/shared/services/user.service.ts
+++ b/apps/lfx-one/src/app/shared/services/user.service.ts
@@ -131,7 +131,10 @@ export class UserService {
           take(1),
           // Best-effort: on failure leave uploadedAvatarUrl null so effectiveAvatarUrl falls back
           // to the Auth0 picture claim, which is already showing.
-          catchError(() => EMPTY)
+          catchError((error) => {
+            console.error('Failed to seed avatar from profile; falling back to the Auth0 picture claim:', error);
+            return EMPTY;
+          })
         )
         .subscribe((profile) => {
           // Only seed from this fetch if nothing has set the signal since it was kicked off —

--- a/apps/lfx-one/src/app/shared/utils/write-access.util.ts
+++ b/apps/lfx-one/src/app/shared/utils/write-access.util.ts
@@ -10,7 +10,10 @@ export function hasMeetingWriteAccess(project: Project | null): boolean {
 }
 
 // Prefers the BFF-enriched slug, falling back to the uid — `GET /api/projects/:slug` sniffs UUIDs,
-// so either resolves. `fallback` covers an entity carrying neither.
+// so either resolves. `fallback` covers an entity carrying neither. `||` (not `??`) is deliberate:
+// `enrichWithProjectData` writes `''` (not null) when the relation-gated project lookup fails, and a
+// nullish check would let that empty string short-circuit the uid/fallback fallthrough, wrongly
+// denying edit access when the uid (or the `?project=` context) would have resolved.
 export function resolveEntityWriteSlug(entity: Pick<EntityWithProject, 'project_slug' | 'project_uid'> | null, fallback: string | null): string | null {
-  return entity?.project_slug ?? entity?.project_uid ?? fallback;
+  return entity?.project_slug || entity?.project_uid || fallback;
 }

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -994,21 +994,28 @@ export class CommitteeService {
         committee_name: string;
         category?: string | null;
         project_name?: string | null;
+        project_slug?: string | null;
+        is_foundation?: boolean | null;
       }
     >();
 
     try {
       const committees = await this.getCommitteesByIds(req, committeeUids);
       const enriched = await this.projectService.enrichWithProjectData(req, Array.from(committees.values()));
-      const projectNameByCommittee = new Map(enriched.map((committee) => [committee.uid, committee.project_name]));
+      const enrichedByCommittee = new Map(enriched.map((committee) => [committee.uid, committee]));
 
       for (const uid of committeeUids) {
         const committee = committees.get(uid);
         if (committee) {
+          const enrichedCommittee = enrichedByCommittee.get(uid);
           committeeContext.set(uid, {
             committee_name: committee.name || uid,
             category: committee.category ?? null,
-            project_name: projectNameByCommittee.get(uid) || null,
+            project_name: enrichedCommittee?.project_name || null,
+            // Enrichment writes '' (not null) when the project lookup fails — normalize to null so
+            // consumers treat it as "no slug", never as an empty-string slug.
+            project_slug: enrichedCommittee?.project_slug || null,
+            is_foundation: enrichedCommittee?.is_foundation ?? null,
           });
         }
       }
@@ -1029,6 +1036,8 @@ export class CommitteeService {
         committee_uid: invite.committee_uid,
         committee_name: committeeName,
         project_name: context?.project_name ?? null,
+        project_slug: context?.project_slug ?? null,
+        is_foundation: context?.is_foundation ?? null,
         category: context?.category ?? null,
         role: invite.role ?? null,
         invitee_email: invite.invitee_email,

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { CommitteeMemberAppointedBy, CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { BehavioralClassDisplayConfig, CommitteeCategoryInfo, CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
+import type { BehavioralClassDisplayConfig, CommitteeCategoryInfo, CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
 import type { MeetingAllowedVotingStatus } from '../interfaces/meeting.interface';
 import { lfxColors } from './colors.constants';
 

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -668,6 +668,13 @@ export const OTHER_GROUPS_LABEL = 'Other Groups';
 export const GROUPS_CARD_GRID_PAGE_SIZE = 12;
 
 /**
+ * Short TTL for the committee-detail cache — just long enough for the writerGuard
+ * project probe and CommitteeManageComponent's immediate refetch to share one request, without
+ * serving stale data across edits (write paths evict explicitly). Mirrors MEETING_DETAIL_CACHE_TTL_MS.
+ */
+export const COMMITTEE_DETAIL_CACHE_TTL_MS = 10 * 1000;
+
+/**
  * Icon-tile tints for the Groups dashboard engagement stat cards (LFXV2-1711). A dedicated constant
  * rather than reusing `ORG_MEETINGS_KPI_ICON_CLASS`'s coincidentally-identical values: this package's
  * classes aren't scanned by `apps/lfx-one/tailwind.config.js`'s `content` glob, so they must be

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -526,6 +526,10 @@ export interface MyGroupsCardVm {
   committee: MyCommittee;
   roleBadgeSeverity: BadgeSeverity;
   lastActivityLabel: string;
+  /** Canonical tier-prefixed view-link commands (`getGroupCommands`), falling back to the flat `/groups/:uid` path when the row carries no `is_foundation`. Pre-computed per card so the template stays binding-only (GH-1566). */
+  viewCommands: string[];
+  /** `?project=` for the view link — present only when the committee carries a `project_slug`. */
+  viewQueryParams: { project: string } | null;
   /**
    * Full accessible name for the card `<a>`. `[attr.aria-label]` replaces the link's computed
    * accessible name outright, so every visible field (class label, project/foundation name, role,
@@ -533,6 +537,21 @@ export interface MyGroupsCardVm {
    * by assistive tech. See `MyGroupsCardGridComponent.initCards()`.
    */
   ariaLabel: string;
+}
+
+/**
+ * A committee-table row decorated with template-friendly link state (mirrors the
+ * `DecoratedPendingAction` precedent): the entity fields pass through untouched, and the
+ * canonical view/edit router commands + `?project=` params are pre-computed once per input
+ * change instead of per change-detection cycle (angular-reactive-data §3.5). `viewCommands` /
+ * `editCommands` already contain the flat `/groups/:uid` fallback when the row carries no
+ * `is_foundation`, so the template never branches (GH-1566).
+ */
+export interface CommitteeTableRowVm extends Committee {
+  viewCommands: string[];
+  editCommands: string[];
+  /** `?project=` for the view/edit links — present only when the committee carries a `project_slug`. */
+  linkQueryParams: { project: string } | null;
 }
 
 /**

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -1,12 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CommitteeMemberVisibility } from '../enums/committee.enum';
-import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { BadgeSeverity } from './components.interface';
-import { GroupsIOMailingList } from './mailing-list.interface';
-import { MeetingAttachment } from './meeting-attachment.interface';
-import { UserSearchResult } from './search.interface';
+import type { CommitteeMemberVisibility } from '../enums/committee.enum';
+import type { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
+import type { BadgeSeverity } from './components.interface';
+import type { GroupsIOMailingList } from './mailing-list.interface';
+import type { MeetingAttachment } from './meeting-attachment.interface';
+import type { UserSearchResult } from './search.interface';
 
 // ── v2.0 Taxonomy Types ─────────────────────────────────────────────────────
 

--- a/packages/shared/src/interfaces/committee.interface.ts
+++ b/packages/shared/src/interfaces/committee.interface.ts
@@ -134,6 +134,10 @@ export interface PendingInvitation {
   committee_name: string;
   /** Project display name — enriched (optional) */
   project_name?: string | null;
+  /** Owning project slug — enriched (optional); drives the `?project=` query param on the invitation's view link (GH-1566). */
+  project_slug?: string | null;
+  /** Whether the owning project is a foundation — enriched (optional); drives the `/foundation` vs `/project` tier prefix on the view link. Null/absent means tier unknown → callers keep the flat `/groups/:uid` fallback (GH-1566). */
+  is_foundation?: boolean | null;
   /** Committee category, for the My Groups class badge (optional) */
   category?: string | null;
   /** Suggested role on acceptance (from the invite) */
@@ -516,6 +520,18 @@ export interface CommitteeFoundationGroup {
   /** True for a bucket holding committees whose own project IS the foundation (`is_foundation === true`) — always sorted first. Usually one bucket, but a foundation-owned committee that resolves to a *different* label than another (e.g. a named foundation project plus a separate `FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL` fallback bucket) can produce more than one; the sort tolerates any count. */
   isFoundationLevel: boolean;
   committees: Committee[];
+}
+
+/**
+ * One pending-invitation row on the My Groups invitations list, decorated with pre-computed link
+ * state (mirrors `MyGroupsCardVm`): `viewCommands` carries the canonical tier-prefixed path
+ * (`getEntityCommands('groups', …)`) with the flat `/groups/:uid` fallback already folded in, so
+ * the template stays binding-only (GH-1566).
+ */
+export interface PendingInvitationRowVm extends PendingInvitation {
+  viewCommands: string[];
+  /** `?project=` for the view link — present only when the invitation carries a `project_slug`. */
+  viewQueryParams: { project: string } | null;
 }
 
 /**

--- a/packages/shared/src/interfaces/components.interface.ts
+++ b/packages/shared/src/interfaces/components.interface.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChartData, ChartOptions, ChartType } from 'chart.js';
+import type { ChartData, ChartOptions, ChartType } from 'chart.js';
 
 import type { CommitteeOrganizationReference } from './committee.interface';
 import type { Meeting } from './meeting.interface';
@@ -530,6 +530,10 @@ export interface PendingActionItem {
   committeeUid?: string;
   /** Committee/group display name (set on Invitation action types). Used for the "You've joined {Group}" toast and the accept/decline `aria-label`, so the copy doesn't have to be parsed back out of `text`. */
   inviteGroupName?: string;
+  /** Owning project slug for the invited group (set on Invitation action types) — drives the `?project=` query param on the view link (GH-1566). */
+  inviteProjectSlug?: string | null;
+  /** Whether the invited group's owning project is a foundation (set on Invitation action types) — drives the `/foundation` vs `/project` tier prefix on the view link; null/absent keeps the flat `/groups/:uid` fallback (GH-1566). */
+  inviteIsFoundation?: boolean | null;
   /** Invitation title text up to (and excluding) the group name (set on Invitation action types), e.g. "You've been invited to " — built alongside `text` so the UI can link just the group name without runtime string-splitting. */
   inviteTitlePrefix?: string;
   /** Suggested organization from the committee_invite (set on Invitation action types) */
@@ -575,6 +579,10 @@ export interface DecoratedPendingAction extends PendingActionItem {
   acceptAriaLabel: string;
   /** Precomputed `aria-label` for the Decline control ("Decline invite to {inviteGroupName}") — built in TS so the template never calls a method. */
   declineAriaLabel: string;
+  /** Precomputed canonical view link for the invited group (`getEntityCommands('groups', …)` with the flat `/groups/:uid` fallback folded in); null when the row carries no `committeeUid` (GH-1566). */
+  inviteViewCommands: string[] | null;
+  /** Precomputed `?project=` query params for the invitation view link; null when no project slug resolved. */
+  inviteViewQueryParams: { project: string } | null;
 }
 
 /** Pending action row for the right-side drawer — adds inline-RSVP flags and per-row meeting-fetch state. */

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -13,7 +13,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { Committee, CommitteeMember, GroupsEngagementStats } from '../interfaces';
+import type { Committee, CommitteeMember, GroupsEngagementStats } from '../interfaces';
 import { FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL } from '../constants/committees.constants';
 import { CommitteeMemberRole } from '../enums/committee-member.enum';
 import {
@@ -21,6 +21,7 @@ import {
   buildEngagementStatCards,
   canManageCommitteeMembers,
   countVotingReps,
+  getGroupCommands,
   groupCommitteesByFoundation,
   resolveCommitteeMemberPermission,
   resolveGroupsCardRoleSeverity,
@@ -131,6 +132,26 @@ describe('buildCommitteeCreateQueryParams', () => {
 
   it('omits the project key when the committee has no project slug', () => {
     expect(buildCommitteeCreateQueryParams(committee({ uid: 'cmte-9' }))).toEqual({ committee_uid: 'cmte-9' });
+  });
+});
+
+describe('getGroupCommands', () => {
+  it('prefixes foundation-owned groups with /foundation', () => {
+    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: true }))).toEqual(['/', 'foundation', 'groups', 'cmte-9']);
+  });
+
+  it('prefixes non-foundation groups with /project', () => {
+    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: false }))).toEqual(['/', 'project', 'groups', 'cmte-9']);
+  });
+
+  it('appends the edit leaf when requested, sharing the same tier logic', () => {
+    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: true }), 'edit')).toEqual(['/', 'foundation', 'groups', 'cmte-9', 'edit']);
+    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: false }), 'edit')).toEqual(['/', 'project', 'groups', 'cmte-9', 'edit']);
+  });
+
+  it('returns null when is_foundation is absent so callers fall back to the flat /groups/:uid path', () => {
+    expect(getGroupCommands(committee({ uid: 'cmte-9' }))).toBeNull();
+    expect(getGroupCommands(committee({ uid: 'cmte-9' }), 'edit')).toBeNull();
   });
 });
 

--- a/packages/shared/src/utils/committee.utils.spec.ts
+++ b/packages/shared/src/utils/committee.utils.spec.ts
@@ -21,7 +21,6 @@ import {
   buildEngagementStatCards,
   canManageCommitteeMembers,
   countVotingReps,
-  getGroupCommands,
   groupCommitteesByFoundation,
   resolveCommitteeMemberPermission,
   resolveGroupsCardRoleSeverity,
@@ -135,25 +134,9 @@ describe('buildCommitteeCreateQueryParams', () => {
   });
 });
 
-describe('getGroupCommands', () => {
-  it('prefixes foundation-owned groups with /foundation', () => {
-    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: true }))).toEqual(['/', 'foundation', 'groups', 'cmte-9']);
-  });
-
-  it('prefixes non-foundation groups with /project', () => {
-    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: false }))).toEqual(['/', 'project', 'groups', 'cmte-9']);
-  });
-
-  it('appends the edit leaf when requested, sharing the same tier logic', () => {
-    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: true }), 'edit')).toEqual(['/', 'foundation', 'groups', 'cmte-9', 'edit']);
-    expect(getGroupCommands(committee({ uid: 'cmte-9', is_foundation: false }), 'edit')).toEqual(['/', 'project', 'groups', 'cmte-9', 'edit']);
-  });
-
-  it('returns null when is_foundation is absent so callers fall back to the flat /groups/:uid path', () => {
-    expect(getGroupCommands(committee({ uid: 'cmte-9' }))).toBeNull();
-    expect(getGroupCommands(committee({ uid: 'cmte-9' }), 'edit')).toBeNull();
-  });
-});
+// getGroupCommands has no dedicated spec block here: it delegates to getEntityCommands
+// (entity-route.utils.spec.ts already covers the 'groups' segment and both null-tier cases), so
+// duplicate route-building tests would test the delegation, not behavior.
 
 describe('canManageCommitteeMembers', () => {
   it('is true when the effective writer flag is set (covers inherited foundation Manage)', () => {

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -14,6 +14,7 @@ import {
   OTHER_GROUPS_LABEL,
 } from '../constants/committees.constants';
 import { formatRelativeTime } from './date-time.utils';
+import { getEntityCommands } from './entity-route.utils';
 import { slugify } from './string.utils';
 
 /**
@@ -76,15 +77,14 @@ export function getGroupBehavioralClass(category: string | undefined): GroupBeha
  * active lens: foundation-owned groups live under `/foundation/groups/{uid}`, all other
  * projects under `/project/groups/{uid}`. Returns null when `is_foundation` is absent
  * (unenriched payload) so callers can fall back to the flat `/groups/{uid}` path handled by
- * `lensRedirectGuard`. Pass `leaf: 'edit'` for the edit route — one helper serves both so the
- * view/edit tier logic can't drift apart (mirror: `getMeetingEditCommands`).
+ * `lensRedirectGuard`. Pass `leaf: 'edit'` for the edit route.
+ *
+ * Thin committee-shaped wrapper over {@link getEntityCommands} — the tier/edit/fallback contract
+ * lives there alone so the two can never drift (this copy once diverged on null-tier handling);
+ * its spec covers the `groups` segment, so no duplicate route-building tests live here.
  */
 export function getGroupCommands(committee: Pick<Committee, 'uid' | 'is_foundation'>, leaf?: 'edit'): string[] | null {
-  if (committee.is_foundation === undefined) {
-    return null;
-  }
-
-  return ['/', committee.is_foundation ? 'foundation' : 'project', 'groups', committee.uid, ...(leaf ? [leaf] : [])];
+  return getEntityCommands('groups', committee.uid, committee.is_foundation, leaf);
 }
 
 /**

--- a/packages/shared/src/utils/committee.utils.ts
+++ b/packages/shared/src/utils/committee.utils.ts
@@ -2,11 +2,11 @@
 // SPDX-License-Identifier: MIT
 
 import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { Committee, CommitteeFoundationGroup, CommitteeMemberPermissionInfo, GroupBehavioralClass } from '../interfaces/committee.interface';
-import { GroupsEngagementStats } from '../interfaces/groups-engagement-stats.interface';
-import { CommitteeMember } from '../interfaces/member.interface';
-import { BadgeSeverity } from '../interfaces/components.interface';
-import { StatCardItem } from '../interfaces/stat-card.interface';
+import type { Committee, CommitteeFoundationGroup, CommitteeMemberPermissionInfo, GroupBehavioralClass } from '../interfaces/committee.interface';
+import type { GroupsEngagementStats } from '../interfaces/groups-engagement-stats.interface';
+import type { CommitteeMember } from '../interfaces/member.interface';
+import type { BadgeSeverity } from '../interfaces/components.interface';
+import type { StatCardItem } from '../interfaces/stat-card.interface';
 import {
   CATEGORY_BEHAVIORAL_CLASS,
   FOUNDATION_LEVEL_GROUP_FALLBACK_LABEL,
@@ -68,6 +68,23 @@ export function getGroupBehavioralClass(category: string | undefined): GroupBeha
   }
 
   return 'other';
+}
+
+/**
+ * Builds the canonical Angular router commands for a group's view or edit page, prefixing the
+ * path with the GROUP's own project tier (`is_foundation`) rather than the viewer's transient
+ * active lens: foundation-owned groups live under `/foundation/groups/{uid}`, all other
+ * projects under `/project/groups/{uid}`. Returns null when `is_foundation` is absent
+ * (unenriched payload) so callers can fall back to the flat `/groups/{uid}` path handled by
+ * `lensRedirectGuard`. Pass `leaf: 'edit'` for the edit route — one helper serves both so the
+ * view/edit tier logic can't drift apart (mirror: `getMeetingEditCommands`).
+ */
+export function getGroupCommands(committee: Pick<Committee, 'uid' | 'is_foundation'>, leaf?: 'edit'): string[] | null {
+  if (committee.is_foundation === undefined) {
+    return null;
+  }
+
+  return ['/', committee.is_foundation ? 'foundation' : 'project', 'groups', committee.uid, ...(leaf ? [leaf] : [])];
 }
 
 /**

--- a/packages/shared/src/utils/invitation.utils.spec.ts
+++ b/packages/shared/src/utils/invitation.utils.spec.ts
@@ -106,6 +106,18 @@ describe('buildInvitationActions', () => {
     const [action] = buildInvitationActions([invitation()]);
     expect(action.inviteRequiresOrganization).toBe(true);
   });
+
+  it('carries the owning project slug and tier through for the canonical view link (GH-1566)', () => {
+    const [action] = buildInvitationActions([invitation({ project_slug: 'pytorch', is_foundation: false })]);
+    expect(action.inviteProjectSlug).toBe('pytorch');
+    expect(action.inviteIsFoundation).toBe(false);
+  });
+
+  it('normalizes absent project slug/tier to null so the view link falls back to the flat path', () => {
+    const [action] = buildInvitationActions([invitation()]);
+    expect(action.inviteProjectSlug).toBeNull();
+    expect(action.inviteIsFoundation).toBeNull();
+  });
 });
 
 describe('committeeRequiresOrganization', () => {

--- a/packages/shared/src/utils/invitation.utils.ts
+++ b/packages/shared/src/utils/invitation.utils.ts
@@ -147,6 +147,8 @@ export function buildInvitationActions(invitations: PendingInvitation[]): Pendin
       inviteUid: invitation.uid,
       committeeUid: invitation.committee_uid,
       inviteGroupName: invitation.committee_name,
+      inviteProjectSlug: invitation.project_slug ?? null,
+      inviteIsFoundation: invitation.is_foundation ?? null,
       inviteOrganization: invitation.organization ?? null,
       inviteRequiresOrganization,
       ...(expiry ? { date: expiry } : {}),


### PR DESCRIPTION
## Summary

Group (committee) links and the group edit flow previously leaned on the viewer's transient active lens: every group link pointed at the flat `/groups/:uid` path and rendered under whichever project/foundation context happened to be active, and the edit route authorized against whatever context was restored from the last visit. This PR makes group navigation canonical — a group always opens under its own project tier (`/foundation/groups/:uid` for foundation-owned groups, `/project/groups/:uid` otherwise, with `?project=` riding along) — and makes the edit page derive both its authorization target and its active project context from the committee itself.

This is a stacked PR on top of `feat/gh-1641-shared-ctx-primitives`: it consumes the shared entity-context primitives introduced there (`syncEntityProjectContext`, `applyEntityProjectContext`, the `evictOnWriteAccessLoss` predicate parameter) and mirrors the meeting-manage pattern post-GH-1432.

Resolves #1566

## Behavior changes

### Group links open under the group's own tier

| Before | After |
|---|---|
| Clicking a group from the dashboard table, the My Groups cards, or a row click always navigated to the flat `/groups/:uid` path, which renders under whichever lens (project or foundation) the viewer currently has active — so a foundation-owned group could render inside a project lens, or land in the wrong project entirely. | Group links prefix the path with the group's own tier — foundation-owned groups open at `/foundation/groups/:uid`, other project groups at `/project/groups/:uid` — and carry `?project=` when the group knows its project slug, so the group always opens in its owning project's context. Rows without tier data keep the old flat-path behavior. |

### Edit authorization and context come from the group itself

| Before | After |
|---|---|
| Opening a group edit link that carried no `?project=` authorized against whatever project context was already active (often the cookie-restored last-visited project), so someone with write access to the group's project could be wrongly bounced — and when the context did switch mid-edit, the write-access watcher could kick out a user the guard had just admitted. | The edit route's guard reads the committee itself to decide which project to authorize against (failing closed if that read errors, rather than checking against a stale project), the edit page syncs the active context to the committee's project — with a fallback project lookup when the payload lacks its slug — and the mid-edit eviction check evaluates the committee's own project, the same target the guard authorized against. |

### Stepper navigation keeps the project in the URL

| Before | After |
|---|---|
| Moving between steps in the group edit stepper replaced the query string, silently dropping `?project=` and the context it pins. | Step navigations merge query params, so `?project=` survives moving between steps. |

## Technical changes

`packages/shared/src/utils/committee.utils.ts` — Shared group-link helper

- Adds `getGroupCommands(committee, leaf?)`: builds canonical router commands prefixed by the group's own `is_foundation` tier, with an optional `'edit'` leaf so view and edit tier logic can't drift apart (mirror: `getMeetingEditCommands`); returns `null` when `is_foundation` is absent so callers fall back to the flat `/groups/:uid` path handled by `lensRedirectGuard`
- Switches interface imports to `import type`

`packages/shared/src/interfaces/committee.interface.ts` — View-model types

- Adds `CommitteeTableRowVm extends Committee` with pre-computed `viewCommands` / `editCommands` / `linkQueryParams` (mirrors the `DecoratedPendingAction` precedent — computed once per input change, not per change-detection cycle)
- Extends `MyGroupsCardVm` with `viewCommands` / `viewQueryParams` so card templates stay binding-only

`apps/lfx-one/src/app/shared/guards/writer.guard.ts`, `apps/lfx-one/src/app/shared/utils/write-access.util.ts` — Writer guard

- Extends `data.entityScopedSlug` handling beyond meetings to `writeFeature: 'committees'`: on the group edit route the guard resolves the authorization slug from the committee itself via the tap-free `fetchCommittee` probe plus the new `resolveCommitteeWriteSlug` (`project_slug ?? project_uid ?? fallback`, mirroring `resolveMeetingWriteSlug`)
- Fails closed (resolves `null` → redirect) on non-404 probe errors; only a 404 falls back to the context slug so the manage component keeps owning the not-found path

`apps/lfx-one/src/app/modules/committees/committees.routes.ts` — Routes

- Flags the `:id/edit` route with `entityScopedSlug: true` as route data (not a path check) so a route rename can't silently revert the guard to stale-context authorization

`apps/lfx-one/src/app/modules/committees/committee-manage/committee-manage.component.ts` — Group edit page

- Syncs the active project context from the loaded committee via `syncEntityProjectContext` with `preferEntityKind: true`, so the committee's own `is_foundation` (not the route prefix) picks the context slot and re-points the route lens kind
- Adds `initCommitteeContextFallback`: when the payload carries `project_uid` but no `project_slug` (BFF enrichment failure), resolves the project via `getProject(uid, false)` and applies it — re-applying on `NavigationEnd` through the shareReplay-cached lookup at no extra request cost
- Adds `initWriteAccess`: keys `evictOnWriteAccessLoss` off the committee's own project (slug, falling back to uid) in edit mode — the same target `writerGuard` authorized against — so the context switch can't evict guard-admitted users mid-edit; the leg stays provisionally true while pending
- Adds `queryParamsHandling: 'merge'` to all stepper navigations so `?project=` survives step changes

`apps/lfx-one/src/app/modules/committees/committee-dashboard/committee-dashboard.component.ts`, `.../components/committee-table/committee-table.component.ts`, `.../components/my-groups-card-grid/my-groups-card-grid.component.ts` (+ templates) — Link call sites

- Dashboard row clicks, committee-table name/edit links, and My Groups card anchors all navigate via `getGroupCommands(...) ?? ['/groups', uid]` with `?project=` when the row carries a slug
- Committee table feeds the `lfx-table` decorated `tableRows()` (canonical link state pre-computed per input change); templates bind the pre-computed values with no per-row branching

`apps/lfx-one/src/app/shared/services/user.service.ts` — Drive-by cleanup

- Converts the avatar-seeding fetch's subscribe error-handler to `catchError(() => EMPTY)`; behavior unchanged (still falls back to the Auth0 picture claim)

`packages/shared/src/utils/committee.utils.spec.ts` — Tests

- Covers `getGroupCommands`: foundation vs project tier prefix, the shared edit leaf, and the `null` fallback when `is_foundation` is absent
