### PR TITLE
feat(meetings): add per-meeting cancel-on-committee-removal override (PCC-181)

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
@@ -80,6 +80,22 @@
           <strong>{{ filteredCommitteeMembers().length }}</strong> unique member(s) will be added to the invitation list.
         }
       </p>
+
+      @if (form().get('visibility')?.value === meetingVisibility.PUBLIC) {
+        <div class="flex flex-col gap-1">
+          <label for="cancel-on-committee-removal" class="block text-neutral-950 mb-2">Registration on {{ committeeLabel.singular.toLowerCase() }} removal</label>
+          <lfx-select
+            [form]="form()"
+            control="cancel_on_committee_removal"
+            [options]="cancelOnCommitteeRemovalOptions"
+            styleClass="w-full"
+            id="cancel-on-committee-removal"
+            data-testid="cancel-on-committee-removal-select"></lfx-select>
+          <p class="mt-1 text-sm text-gray-500">
+            Whether removing someone from a linked {{ committeeLabel.singular.toLowerCase() }} also cancels their registration on this meeting
+          </p>
+        </div>
+      }
     }
   }
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
@@ -81,11 +81,9 @@
         }
       </p>
 
-      @if (form().get('visibility')?.value === meetingVisibility.PUBLIC) {
+      @if (isPublicVisibility()) {
         <div class="flex flex-col gap-1">
-          <label for="cancel-on-committee-removal" class="block text-neutral-950 mb-2"
-            >Registration on {{ committeeLabel.singular.toLowerCase() }} removal</label
-          >
+          <label for="cancel-on-committee-removal" class="block text-neutral-950 mb-2">Registration on {{ committeeLabelSingularLower }} removal</label>
           <lfx-select
             [form]="form()"
             control="cancel_on_committee_removal"
@@ -94,7 +92,7 @@
             inputId="cancel-on-committee-removal"
             data-testid="cancel-on-committee-removal-select"></lfx-select>
           <p class="mt-1 text-sm text-gray-500">
-            Whether removing someone from a linked {{ committeeLabel.singular.toLowerCase() }} also cancels their registration on this meeting
+            Whether removing someone from a linked {{ committeeLabelSingularLower }} also cancels their registration on this meeting
           </p>
         </div>
       }

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.html
@@ -83,13 +83,15 @@
 
       @if (form().get('visibility')?.value === meetingVisibility.PUBLIC) {
         <div class="flex flex-col gap-1">
-          <label for="cancel-on-committee-removal" class="block text-neutral-950 mb-2">Registration on {{ committeeLabel.singular.toLowerCase() }} removal</label>
+          <label for="cancel-on-committee-removal" class="block text-neutral-950 mb-2"
+            >Registration on {{ committeeLabel.singular.toLowerCase() }} removal</label
+          >
           <lfx-select
             [form]="form()"
             control="cancel_on_committee_removal"
             [options]="cancelOnCommitteeRemovalOptions"
             styleClass="w-full"
-            id="cancel-on-committee-removal"
+            inputId="cancel-on-committee-removal"
             data-testid="cancel-on-committee-removal-select"></lfx-select>
           <p class="mt-1 text-sm text-gray-500">
             Whether removing someone from a linked {{ committeeLabel.singular.toLowerCase() }} also cancels their registration on this meeting

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
@@ -13,7 +13,7 @@ import { sanitizeMeetingCommittees, sanitizeMeetingCommitteeUids } from '@lfx-on
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, filter, forkJoin, map, of, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, filter, forkJoin, map, of, startWith, switchMap, tap } from 'rxjs';
 
 interface CommitteeMemberDisplay extends CommitteeMember {
   committeeName: string;
@@ -56,6 +56,7 @@ export class MeetingCommitteeManagerComponent {
   // Voting status options for dropdown
   public readonly votingStatusOptions = MEETING_VOTING_STATUSES;
   public readonly committeeLabel = COMMITTEE_LABEL;
+  public readonly committeeLabelSingularLower = COMMITTEE_LABEL.singular.toLowerCase();
   public readonly cancelOnCommitteeRemovalOptions = CANCEL_ON_COMMITTEE_REMOVAL_OPTIONS;
   public readonly meetingVisibility = MeetingVisibility;
 
@@ -65,6 +66,7 @@ export class MeetingCommitteeManagerComponent {
     const committees = this.committeeOptions();
     return committees.some((c) => selectedIds.includes(c.uid) && c.enable_voting);
   });
+  public isPublicVisibility: Signal<boolean> = this.initIsPublicVisibility();
 
   public constructor() {
     this.committeeForm = new FormGroup({
@@ -169,6 +171,23 @@ export class MeetingCommitteeManagerComponent {
         )
       ),
       { initialValue: [] }
+    );
+  }
+
+  /**
+   * Tracks the parent form's visibility control reactively, so the template can bind a
+   * signal instead of calling form().get('visibility')?.value on every check cycle.
+   */
+  private initIsPublicVisibility(): Signal<boolean> {
+    return toSignal(
+      toObservable(this.form).pipe(
+        switchMap((form) => {
+          const control = form.get('visibility');
+          return control ? control.valueChanges.pipe(startWith(control.value)) : of(null);
+        }),
+        map((value) => value === this.meetingVisibility.PUBLIC)
+      ),
+      { initialValue: this.form().get('visibility')?.value === this.meetingVisibility.PUBLIC }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
@@ -5,9 +5,10 @@ import { Component, computed, DestroyRef, inject, input, InputSignal, output, Ou
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
+import { SelectComponent } from '@components/select/select.component';
 import { Committee, CommitteeMember, MeetingCommittee } from '@lfx-one/shared';
-import { CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
-import { COMMITTEE_LABEL, MEETING_VOTING_STATUSES } from '@lfx-one/shared/constants';
+import { CommitteeMemberVotingStatus, MeetingVisibility } from '@lfx-one/shared/enums';
+import { CANCEL_ON_COMMITTEE_REMOVAL_OPTIONS, COMMITTEE_LABEL, MEETING_VOTING_STATUSES } from '@lfx-one/shared/constants';
 import { sanitizeMeetingCommittees, sanitizeMeetingCommitteeUids } from '@lfx-one/shared/utils';
 import { CommitteeService } from '@services/committee.service';
 import { ProjectContextService } from '@services/project-context.service';
@@ -21,7 +22,7 @@ interface CommitteeMemberDisplay extends CommitteeMember {
 
 @Component({
   selector: 'lfx-meeting-committee-manager',
-  imports: [ReactiveFormsModule, MultiSelectComponent, TooltipModule],
+  imports: [ReactiveFormsModule, MultiSelectComponent, SelectComponent, TooltipModule],
   templateUrl: './meeting-committee-manager.component.html',
 })
 export class MeetingCommitteeManagerComponent {
@@ -55,6 +56,8 @@ export class MeetingCommitteeManagerComponent {
   // Voting status options for dropdown
   public readonly votingStatusOptions = MEETING_VOTING_STATUSES;
   public readonly committeeLabel = COMMITTEE_LABEL;
+  public readonly cancelOnCommitteeRemovalOptions = CANCEL_ON_COMMITTEE_REMOVAL_OPTIONS;
+  public readonly meetingVisibility = MeetingVisibility;
 
   // Computed signals
   public hasVotingEnabledCommittee = computed(() => {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-committee-manager/meeting-committee-manager.component.ts
@@ -187,7 +187,7 @@ export class MeetingCommitteeManagerComponent {
         }),
         map((value) => value === this.meetingVisibility.PUBLIC)
       ),
-      { initialValue: this.form().get('visibility')?.value === this.meetingVisibility.PUBLIC }
+      { initialValue: false }
     );
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.spec.ts
@@ -10,6 +10,7 @@ import { CommitteeService } from '@services/committee.service';
 import { MeetingService } from '@services/meeting.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
+import { CancelOnCommitteeRemoval, MeetingVisibility } from '@lfx-one/shared/enums';
 import { Meeting } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { BehaviorSubject, of, throwError } from 'rxjs';
@@ -247,6 +248,47 @@ describe('MeetingManageComponent', () => {
       component.hydratedOwner.set({ ...HYDRATED });
       component.syncHydratedOwnerFromForm();
       expect(component.hydratedOwner()).toEqual(HYDRATED);
+    });
+  });
+
+  // Pins the stale-value fix: hiding the override control (private meeting, or no linked
+  // committees) must not let a previously-chosen cancel/keep value leak into the save payload.
+  describe('cancel_on_committee_removal payload gating', () => {
+    const createPayloadComponent = async () => {
+      getMeetingDetail.mockReturnValue(of(unenrichedMeeting()));
+      getProject.mockReturnValue(of(null));
+      const fixture = await createComponent();
+      return fixture.componentInstance as any;
+    };
+
+    it('preserves an explicit cancel/keep override on a public meeting with a linked committee', async () => {
+      const component = await createPayloadComponent();
+      component.form().patchValue({
+        visibility: MeetingVisibility.PUBLIC,
+        committees: [{ uid: 'committee-1' }],
+        cancel_on_committee_removal: CancelOnCommitteeRemoval.CANCEL,
+      });
+      expect(component.prepareMeetingData().cancel_on_committee_removal).toBe(CancelOnCommitteeRemoval.CANCEL);
+    });
+
+    it('forces inherit when the meeting is private, even if a stale override value remains in the form', async () => {
+      const component = await createPayloadComponent();
+      component.form().patchValue({
+        visibility: MeetingVisibility.PRIVATE,
+        committees: [{ uid: 'committee-1' }],
+        cancel_on_committee_removal: CancelOnCommitteeRemoval.CANCEL,
+      });
+      expect(component.prepareMeetingData().cancel_on_committee_removal).toBe(CancelOnCommitteeRemoval.INHERIT);
+    });
+
+    it('forces inherit when no committee is linked, even if a stale override value remains in the form', async () => {
+      const component = await createPayloadComponent();
+      component.form().patchValue({
+        visibility: MeetingVisibility.PUBLIC,
+        committees: [],
+        cancel_on_committee_removal: CancelOnCommitteeRemoval.KEEP,
+      });
+      expect(component.prepareMeetingData().cancel_on_committee_removal).toBe(CancelOnCommitteeRemoval.INHERIT);
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-manage/meeting-manage.component.ts
@@ -25,7 +25,7 @@ import {
   TOTAL_STEPS,
   YOUTUBE_MAX_MEETING_TITLE_LENGTH,
 } from '@lfx-one/shared/constants';
-import { MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
+import { CancelOnCommitteeRemoval, MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
 import { EntityWithProject, ProjectContext } from '@lfx-one/shared/interfaces';
 import {
   BatchRegistrantOperationResponse,
@@ -597,6 +597,10 @@ export class MeetingManageComponent {
       ai_summary_enabled: formValue.zoom_ai_enabled || false,
       require_ai_summary_approval: formValue.zoom_ai_enabled ? formValue.require_ai_summary_approval || false : false,
       artifact_visibility: formValue.recording_enabled || formValue.zoom_ai_enabled ? formValue.artifact_visibility || DEFAULT_ARTIFACT_VISIBILITY : null,
+      cancel_on_committee_removal:
+        formValue.visibility === MeetingVisibility.PUBLIC && formValue.committees?.length
+          ? formValue.cancel_on_committee_removal || CancelOnCommitteeRemoval.INHERIT
+          : CancelOnCommitteeRemoval.INHERIT,
       auto_email_reminder_enabled: formValue.auto_email_reminder_enabled || false,
       // Total whole minutes before start, clamped to the upstream 120-1440 range. Omitted when disabled:
       // ITX resets the stored time to 0 whenever enabled is explicitly false, so no time value is needed.
@@ -1138,6 +1142,7 @@ export class MeetingManageComponent {
       zoom_ai_enabled: meeting.ai_summary_enabled || false,
       require_ai_summary_approval: meeting.require_ai_summary_approval ?? false,
       artifact_visibility: meeting.artifact_visibility ?? DEFAULT_ARTIFACT_VISIBILITY,
+      cancel_on_committee_removal: meeting.cancel_on_committee_removal ?? CancelOnCommitteeRemoval.INHERIT,
       auto_email_reminder_enabled: meeting.auto_email_reminder_enabled ?? false,
       reminderHours: reminderHours,
       reminderMinutes: reminderTotalMinutes % 60,
@@ -1327,6 +1332,7 @@ export class MeetingManageComponent {
         zoom_ai_enabled: new FormControl(false),
         require_ai_summary_approval: new FormControl(false),
         artifact_visibility: new FormControl(DEFAULT_ARTIFACT_VISIBILITY),
+        cancel_on_committee_removal: new FormControl(CancelOnCommitteeRemoval.INHERIT),
         auto_email_reminder_enabled: new FormControl(false),
         reminderHours: new FormControl({ value: DEFAULT_EMAIL_REMINDER_HOURS, disabled: true }, [
           Validators.required,

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ArtifactVisibility, MeetingVisibility } from '../enums';
+import { ArtifactVisibility, CancelOnCommitteeRemoval, MeetingVisibility } from '../enums';
 import type { AttachmentCategory, CardSelectorOption, MeetingTypeConfig } from '../interfaces';
 import { lfxColors } from './colors.constants';
 
@@ -111,6 +111,17 @@ export const ARTIFACT_VISIBILITY_OPTIONS = [
   { label: 'Meeting Hosts Only', value: ArtifactVisibility.MEETING_HOSTS },
   { label: 'Meeting Guests', value: ArtifactVisibility.MEETING_PARTICIPANTS },
   { label: 'Public', value: ArtifactVisibility.PUBLIC },
+];
+
+/**
+ * Cancel-on-committee-removal per-meeting override options
+ * @description Lets a meeting override the project default for whether committee removal cancels
+ * registration on this (public) meeting
+ */
+export const CANCEL_ON_COMMITTEE_REMOVAL_OPTIONS = [
+  { label: 'Use project default', value: CancelOnCommitteeRemoval.INHERIT },
+  { label: 'Cancel registration', value: CancelOnCommitteeRemoval.CANCEL },
+  { label: 'Keep registration', value: CancelOnCommitteeRemoval.KEEP },
 ];
 
 /**

--- a/packages/shared/src/enums/meeting.enum.ts
+++ b/packages/shared/src/enums/meeting.enum.ts
@@ -60,6 +60,20 @@ export enum ArtifactVisibility {
 }
 
 /**
+ * Per-meeting override for cancelling registration on committee removal
+ * @description Governs the public-meeting branch only: whether removing someone from a linked
+ * committee also cancels their registration on this specific meeting, overriding the project default
+ */
+export enum CancelOnCommitteeRemoval {
+  /** Use the project-level default */
+  INHERIT = 'inherit',
+  /** Always cancel registration on committee removal for this meeting */
+  CANCEL = 'cancel',
+  /** Never cancel registration on committee removal for this meeting */
+  KEEP = 'keep',
+}
+
+/**
  * Query service meeting resource types
  * @description Types used when fetching meetings from the query service
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { PAST_MEETING_SORT } from '../constants/meeting.constants';
-import type { ArtifactVisibility, MeetingType, MeetingVisibility, RecurrenceType } from '../enums';
+import type { ArtifactVisibility, CancelOnCommitteeRemoval, MeetingType, MeetingVisibility, RecurrenceType } from '../enums';
 import type { TagSeverity } from './components.interface';
 
 // ============================================================================
@@ -293,6 +293,8 @@ export interface Meeting {
   show_meeting_attendees?: boolean | null;
   /** Who can access meeting artifacts (recordings, transcripts, AI summaries) */
   artifact_visibility: ArtifactVisibility | null;
+  /** Per-meeting override for cancelling registration on committee removal; "inherit" defers to the project default */
+  cancel_on_committee_removal: CancelOnCommitteeRemoval | null;
   /** Minutes before meeting registrants can join */
   early_join_time_minutes?: number;
   /** Array of organizer usernames */
@@ -441,6 +443,7 @@ export interface CreateMeetingRequest {
   youtube_upload_enabled?: boolean; // YouTube upload integration
   show_meeting_attendees?: boolean; // Show meeting attendees on meeting details page
   artifact_visibility?: ArtifactVisibility; // Who can access meeting artifacts
+  cancel_on_committee_removal?: CancelOnCommitteeRemoval; // Per-meeting override for cancel-on-committee-removal; "inherit" defers to the project default
   early_join_time_minutes?: number; // Minutes before meeting registrants can join
   organizers?: string[]; // Array of organizer email addresses
   owner?: MeetingOwnerInput; // Meeting owner; omit to default to the creator
@@ -471,6 +474,7 @@ export interface UpdateMeetingRequest {
   youtube_upload_enabled?: boolean | null; // YouTube upload integration
   show_meeting_attendees?: boolean | null; // Show meeting attendees on meeting details page
   artifact_visibility?: ArtifactVisibility | null; // Who can access meeting artifacts
+  cancel_on_committee_removal?: CancelOnCommitteeRemoval | null; // Per-meeting override for cancel-on-committee-removal; "inherit" defers to the project default
   early_join_time_minutes?: number; // Minutes before meeting registrants can join
   organizers?: string[]; // Array of organizer email addresses
   owner?: MeetingOwnerInput; // Meeting owner; omit to preserve the stored owner (cannot be unset)


### PR DESCRIPTION
## Summary

Ports PCC's "cancel registration on committee removal" per-meeting setting into Self Serve, and fixes a stale-value bug found while wiring it up.

When someone is removed from a committee, auto-cancel their registration on any public meeting that committee is linked to. This adds a per-meeting dropdown: "Use project default" / "Cancel registration" / "Keep registration", so meeting owners can override that behavior for a specific meeting. It only shows up on public meetings with at least one linked committee, matching how the backend already gates this.

## Fix

- Added `CancelOnCommitteeRemoval` enum (`inherit`/`cancel`/`keep`) in `packages/shared/src/enums/meeting.enum.ts`
- Added `CANCEL_ON_COMMITTEE_REMOVAL_OPTIONS` dropdown options in `packages/shared/src/constants/meeting.constants.ts`
- Added `cancel_on_committee_removal` to `Meeting`, `CreateMeetingRequest`, `UpdateMeetingRequest` in `packages/shared/src/interfaces/meeting.interface.ts`
- Added the "Registration on committee removal" select to `meeting-committee-manager.component.html`/`.ts`, shown only when the meeting is public and has at least one linked committee
- Wired the field through `meeting-manage.component.ts` (form control, load-for-edit, save payload)

## Ticket

PCC-181
## Testing

- Ran `yarn lint:check` clean, no errors (1 pre-existing unrelated warning in `user.service.ts`).
- Ran `yarn build` (full production build, all packages) compiles clean, no TypeScript errors.
- Confirmed the running dev server picked up the changes via hot reload and still 200 with no compile crash.