### PR TITLE
feat(meetings): add the platform & features composer section

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -49,7 +49,7 @@
             <lfx-composer-date-schedule [form]="formService.form()" />
           }
           @case ('platform-features') {
-            <lfx-meeting-platform-features [form]="formService.form()" (goToTitleSection)="onGoToTitleSection()" />
+            <lfx-composer-platform-features [form]="formService.form()" (goToTitleSection)="onGoToTitleSection()" />
           }
           @case ('guests') {
             @if (formService.meetingId(); as meetingUid) {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -13,13 +13,13 @@ import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
 import { filter, pairwise } from 'rxjs';
 
-import { MeetingPlatformFeaturesComponent } from '../components/meeting-platform-features/meeting-platform-features.component';
 import { MeetingRegistrantsManagerComponent } from '../components/meeting-registrants-manager/meeting-registrants-manager.component';
 import { MeetingResourcesSummaryComponent } from '../components/meeting-resources-summary/meeting-resources-summary.component';
 import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerService } from './meeting-composer.service';
 import { ComposerDateScheduleComponent } from './sections/composer-date-schedule.component';
 import { ComposerDetailsAccessComponent } from './sections/composer-details-access.component';
+import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-features.component';
 
 /**
  * Globally mounted host for the meeting composer drawer (LFXV2-3234).
@@ -36,7 +36,7 @@ import { ComposerDetailsAccessComponent } from './sections/composer-details-acce
     TextareaComponent,
     ComposerDetailsAccessComponent,
     ComposerDateScheduleComponent,
-    MeetingPlatformFeaturesComponent,
+    ComposerPlatformFeaturesComponent,
     MeetingRegistrantsManagerComponent,
     MeetingResourcesSummaryComponent,
   ],

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.html
@@ -1,0 +1,168 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="flex flex-col gap-6" data-testid="composer-platform-features">
+  <div class="flex flex-col gap-1">
+    <h2>Platform &amp; features</h2>
+    <p class="text-sm text-gray-500">Select your video platform and enable transparency features like recording and transcripts.</p>
+  </div>
+
+  <!-- Platform -->
+  <div class="flex flex-col gap-2">
+    <span class="text-sm font-medium text-gray-900"> Platform <span class="text-red-500">*</span> </span>
+    <div data-testid="composer-platform-chips">
+      <lfx-select-button
+        [form]="form()"
+        control="platform"
+        [options]="platformChipOptions"
+        optionDisabled="disabled"
+        [unselectable]="false"
+        [required]="true" />
+    </div>
+    @if (form().get('platform')?.errors?.['required'] && form().get('platform')?.touched) {
+      <p class="text-sm text-red-600" data-testid="composer-platform-required-error">Please select a meeting platform</p>
+    }
+  </div>
+
+  <!-- Features -->
+  <div class="flex flex-col gap-3">
+    <div class="flex flex-col gap-1">
+      <span class="text-sm font-medium text-gray-900">Meeting features</span>
+      <p class="text-xs text-gray-500">
+        Open source thrives on transparency and accessibility. Recording meetings, generating transcripts, and enabling features helps include community members
+        who can't attend live and creates valuable documentation.
+      </p>
+    </div>
+
+    <lfx-feature-toggle [feature]="recordingFeature" [form]="form()" />
+
+    <lfx-feature-toggle [feature]="aiSummaryFeature" [form]="form()">
+      @if (form().get('zoom_ai_enabled')?.value) {
+        <div class="mt-4 border-t border-gray-200 pt-4">
+          <lfx-checkbox
+            [form]="form()"
+            control="require_ai_summary_approval"
+            label="Requires host approval before sharing with guests"
+            labelClass="text-sm text-gray-700"
+            data-testid="composer-ai-approval-checkbox" />
+        </div>
+      }
+    </lfx-feature-toggle>
+
+    <lfx-feature-toggle [feature]="transcriptFeature" [form]="form()" />
+
+    <lfx-feature-toggle [feature]="youtubeFeature" [form]="form()" />
+
+    @if (!form().get('recording_enabled')?.value) {
+      <p class="text-xs text-gray-500" data-testid="composer-recording-dependency-hint">Transcripts and YouTube upload need recording enabled.</p>
+    }
+
+    @if (form().get('youtube_upload_enabled')?.value && form().get('title')?.errors?.['maxlength']) {
+      <div class="flex gap-3 rounded-lg border border-amber-300 bg-amber-50 p-4" data-testid="composer-youtube-title-warning">
+        <i class="fa-light fa-triangle-exclamation mt-0.5 flex-shrink-0 text-amber-500" aria-hidden="true"></i>
+        <div class="flex flex-col gap-1">
+          <p class="text-sm font-semibold text-amber-800">Meeting title too long for YouTube</p>
+          <p class="text-sm text-amber-700">
+            The meeting date is appended to the video title on upload, so the title must be {{ youtubeTitleLimit }} characters or fewer. The current title has
+            {{ titleLength() }} characters.
+          </p>
+          <button
+            type="button"
+            class="self-start text-sm font-medium text-amber-800 underline hover:text-amber-900"
+            (click)="goToTitleSection.emit()"
+            data-testid="composer-youtube-title-fix-button">
+            Go back to Details &amp; Access to shorten the title
+          </button>
+        </div>
+      </div>
+    }
+  </div>
+
+  <!-- Artifact access -->
+  @if (form().get('recording_enabled')?.value || form().get('zoom_ai_enabled')?.value) {
+    <div class="flex flex-col gap-2">
+      <!-- p-select's inputId lands on a span[role=combobox], so this associates via aria-labelledby, not `for` -->
+      <label id="composer-artifact-visibility-label" class="text-sm font-medium text-gray-900">
+        @if (form().get('recording_enabled')?.value && form().get('zoom_ai_enabled')?.value) {
+          Who can access recordings &amp; summaries
+        } @else if (form().get('recording_enabled')?.value) {
+          Who can access recordings
+        } @else {
+          Who can access summaries
+        }
+      </label>
+      <lfx-select
+        [form]="form()"
+        control="artifact_visibility"
+        [options]="artifactVisibilityOptions"
+        appendTo="body"
+        inputId="composer-artifact-visibility"
+        ariaLabelledBy="composer-artifact-visibility-label"
+        placeholder="Select artifact visibility"
+        styleClass="w-full"
+        dataTest="composer-artifact-visibility-select" />
+    </div>
+  }
+
+  <!-- Email reminder -->
+  <lfx-feature-toggle [feature]="emailReminderFeature" [form]="form()">
+    @if (form().get('auto_email_reminder_enabled')?.value) {
+      <div class="mt-4 flex flex-col gap-2 border-t border-gray-200 pt-4">
+        <div class="flex flex-wrap items-center gap-x-2 gap-y-1" role="group" aria-label="Send reminder before the meeting starts">
+          <div class="flex items-center gap-2">
+            <lfx-input-number
+              class="w-20 flex-none"
+              [form]="form()"
+              control="reminderHours"
+              size="small"
+              id="composer-reminder-hours"
+              data-testid="composer-reminder-hours" />
+            <label for="composer-reminder-hours" class="text-sm text-gray-900">hours</label>
+          </div>
+          <div class="flex items-center gap-2">
+            <lfx-input-number
+              class="w-20 flex-none"
+              [form]="form()"
+              control="reminderMinutes"
+              size="small"
+              id="composer-reminder-minutes"
+              data-testid="composer-reminder-minutes" />
+            <label for="composer-reminder-minutes" class="text-sm text-gray-900">minutes</label>
+          </div>
+          <span class="text-sm text-gray-900">before the meeting starts</span>
+          <i
+            class="fa-light fa-info-circle cursor-help text-gray-400"
+            tabindex="0"
+            role="img"
+            [attr.aria-label]="emailReminderTooltip"
+            [pTooltip]="emailReminderTooltip"
+            tooltipEvent="both"
+            tooltipPosition="right"
+            tooltipStyleClass="text-xs max-w-xs"
+            data-testid="composer-reminder-tooltip"></i>
+        </div>
+        @if (form().get('reminderHours')?.errors?.['required'] && form().get('reminderHours')?.touched) {
+          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-required-error">Reminder hours is required</p>
+        }
+        @if (form().get('reminderHours')?.errors?.['pattern'] && form().get('reminderHours')?.touched) {
+          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-pattern-error">Reminder hours must be a whole number</p>
+        }
+        @if (form().get('reminderHours')?.errors?.['min'] && form().get('reminderHours')?.touched) {
+          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-min-error">Reminder must be at least 2 hours before the meeting starts</p>
+        }
+        @if (form().get('reminderHours')?.errors?.['max'] && form().get('reminderHours')?.touched) {
+          <p class="text-sm text-red-600" data-testid="composer-reminder-hours-max-error">Reminder cannot be more than 24 hours before the meeting starts</p>
+        }
+        @if (
+          (form().get('reminderMinutes')?.errors?.['required'] ||
+            form().get('reminderMinutes')?.errors?.['pattern'] ||
+            form().get('reminderMinutes')?.errors?.['min'] ||
+            form().get('reminderMinutes')?.errors?.['max']) &&
+          form().get('reminderMinutes')?.touched
+        ) {
+          <p class="text-sm text-red-600" data-testid="composer-reminder-minutes-error">Minutes must be a whole number between 0 and 59</p>
+        }
+      </div>
+    }
+  </lfx-feature-toggle>
+</div>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-platform-features.component.ts
@@ -1,0 +1,142 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, DestroyRef, inject, input, OnInit, output, Signal } from '@angular/core';
+import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
+import { FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { CheckboxComponent } from '@components/checkbox/checkbox.component';
+import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggle.component';
+import { InputNumberComponent } from '@components/input-number/input-number.component';
+import { SelectButtonComponent } from '@components/select-button/select-button.component';
+import { SelectComponent } from '@components/select/select.component';
+import {
+  ARTIFACT_VISIBILITY_OPTIONS,
+  DEFAULT_EMAIL_REMINDER_HOURS,
+  DEFAULT_EMAIL_REMINDER_MINUTES,
+  EMAIL_REMINDER_FEATURE,
+  EMAIL_REMINDER_TOOLTIP,
+  MAX_EMAIL_REMINDER_HOURS,
+  MEETING_FEATURES,
+  MEETING_PLATFORMS,
+  YOUTUBE_MAX_MEETING_TITLE_LENGTH,
+} from '@lfx-one/shared/constants';
+import { TooltipModule } from 'primeng/tooltip';
+
+import { MeetingComposerFormService } from '../meeting-composer-form.service';
+
+/**
+ * Platform & Features section of the meeting composer (LFXV2-3237).
+ * @description Owns `platform`, the four feature toggles, `require_ai_summary_approval`,
+ * `artifact_visibility`, and the email reminder timing. The recording dependency wiring and the
+ * YouTube title-length validator behaviour are unchanged from the wizard.
+ */
+@Component({
+  selector: 'lfx-composer-platform-features',
+  imports: [ReactiveFormsModule, CheckboxComponent, FeatureToggleComponent, InputNumberComponent, SelectButtonComponent, SelectComponent, TooltipModule],
+  templateUrl: './composer-platform-features.component.html',
+})
+export class ComposerPlatformFeaturesComponent implements OnInit {
+  private readonly destroyRef = inject(DestroyRef);
+  private readonly formService = inject(MeetingComposerFormService);
+
+  public readonly form = input.required<FormGroup>();
+  public readonly goToTitleSection = output<void>();
+
+  protected readonly youtubeTitleLimit = YOUTUBE_MAX_MEETING_TITLE_LENGTH;
+  protected readonly artifactVisibilityOptions = ARTIFACT_VISIBILITY_OPTIONS;
+  protected readonly emailReminderFeature = EMAIL_REMINDER_FEATURE;
+  protected readonly emailReminderTooltip = EMAIL_REMINDER_TOOLTIP;
+
+  protected readonly recordingFeature = MEETING_FEATURES.find((feature) => feature.key === 'recording_enabled')!;
+  protected readonly aiSummaryFeature = MEETING_FEATURES.find((feature) => feature.key === 'zoom_ai_enabled')!;
+  protected readonly transcriptFeature = MEETING_FEATURES.find((feature) => feature.key === 'transcript_enabled')!;
+  protected readonly youtubeFeature = MEETING_FEATURES.find((feature) => feature.key === 'youtube_upload_enabled')!;
+
+  // Unavailable platforms stay listed but disabled, so the roadmap is visible without being pickable.
+  protected readonly platformChipOptions = MEETING_PLATFORMS.map((platform) => ({
+    label: platform.available ? platform.label : `${platform.label} (Coming Soon)`,
+    value: platform.value,
+    disabled: !platform.available,
+  }));
+
+  protected readonly titleLength: Signal<number> = this.initTitleLength();
+
+  public ngOnInit(): void {
+    // Transcripts and YouTube upload both consume the recording, so they follow it on and off.
+    this.form()
+      .get('recording_enabled')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((recordingEnabled: boolean) => {
+        ['transcript_enabled', 'youtube_upload_enabled'].forEach((controlName) => {
+          const control = this.form().get(controlName);
+
+          if (!control) {
+            return;
+          }
+
+          if (recordingEnabled) {
+            control.enable();
+          } else {
+            control.setValue(false);
+            control.disable();
+          }
+
+          control.updateValueAndValidity();
+        });
+      });
+
+    this.form()
+      .get('auto_email_reminder_enabled')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((reminderEnabled: boolean) => this.syncReminderTimingControls(reminderEnabled));
+
+    this.form()
+      .get('reminderHours')
+      ?.valueChanges.pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((hours) => this.syncReminderMinutesControl(Number(hours)));
+  }
+
+  private initTitleLength(): Signal<number> {
+    return computed(() => {
+      // `revision` bumps on every value change; a plain control read would not be reactive.
+      this.formService.revision();
+      return (this.form().get('title')?.value as string | null)?.length ?? 0;
+    });
+  }
+
+  private syncReminderTimingControls(reminderEnabled: boolean): void {
+    const hoursControl = this.form().get('reminderHours');
+    const minutesControl = this.form().get('reminderMinutes');
+
+    if (!hoursControl || !minutesControl) {
+      return;
+    }
+
+    if (!reminderEnabled) {
+      hoursControl.setValue(DEFAULT_EMAIL_REMINDER_HOURS, { emitEvent: false });
+      hoursControl.disable({ emitEvent: false });
+      minutesControl.setValue(DEFAULT_EMAIL_REMINDER_MINUTES, { emitEvent: false });
+      minutesControl.disable({ emitEvent: false });
+      return;
+    }
+
+    hoursControl.enable({ emitEvent: false });
+    this.syncReminderMinutesControl(Number(hoursControl.value));
+  }
+
+  private syncReminderMinutesControl(hours: number): void {
+    const minutesControl = this.form().get('reminderMinutes');
+
+    if (!minutesControl || !this.form().get('auto_email_reminder_enabled')?.value) {
+      return;
+    }
+
+    // Minutes stay locked at 0 while hours sits at the 24-hour maximum.
+    if (hours === MAX_EMAIL_REMINDER_HOURS) {
+      minutesControl.setValue(DEFAULT_EMAIL_REMINDER_MINUTES, { emitEvent: false });
+      minutesControl.disable({ emitEvent: false });
+    } else {
+      minutesControl.enable({ emitEvent: false });
+    }
+  }
+}

--- a/apps/lfx-one/src/app/shared/components/select-button/select-button.component.html
+++ b/apps/lfx-one/src/app/shared/components/select-button/select-button.component.html
@@ -7,6 +7,7 @@
     [options]="options()"
     [optionLabel]="optionLabel()"
     [optionValue]="optionValue()"
+    [optionDisabled]="optionDisabled()"
     (onChange)="handleChange($event)"
     [size]="size()"
     [class]="class()"

--- a/apps/lfx-one/src/app/shared/components/select-button/select-button.component.ts
+++ b/apps/lfx-one/src/app/shared/components/select-button/select-button.component.ts
@@ -18,6 +18,7 @@ export class SelectButtonComponent {
   public readonly options = input<any[]>([]);
   public readonly optionLabel = input<string>('label');
   public readonly optionValue = input<string>('value');
+  public readonly optionDisabled = input<string | undefined>(undefined);
 
   public readonly size = input<'small' | 'large'>('small');
   public readonly unselectable = input<boolean>(true);


### PR DESCRIPTION
## What

Re-skins **Platform & Features** into the new composer section layout.

## How

- Platform chips (Zoom active, Teams / In-Person disabled "Coming Soon").
- Feature toggle cards for Recording, AI Meeting Summary, Generate Transcripts and YouTube
  auto-upload, preserving the wizard's dependency wiring: transcript / YouTube / show-attendees stay
  disabled unless recording is on, and the YouTube toggle still adds and removes the title
  `maxLength(YOUTUBE_MAX_MEETING_TITLE_LENGTH)` validator.
- "Requires host approval before sharing with guests" nests under AI summary when it is on.
- The artifact-visibility select appears only when recording or AI summary is enabled.

## Notes for review

`MEETING_PLATFORMS` values do not match the upstream contract and `platform` is not sent in the
create/update bodies — pre-existing, carried forward unchanged here.

Refs #1456
