### PR TITLE
feat(meetings): add the quick create meeting dialog

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -16,6 +16,7 @@ import {
   MAX_EMAIL_REMINDER_HOURS,
   MAX_EMAIL_REMINDER_TIME,
   MEETING_AGENDA_MAX_LENGTH,
+  MEETING_DURATION_CHIP_OPTIONS,
   MIN_CUSTOM_DURATION,
   MIN_EARLY_JOIN_TIME,
   MIN_EMAIL_REMINDER_HOURS,
@@ -25,6 +26,7 @@ import { MeetingType, MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   BatchRegistrantOperationResponse,
   Committee,
+  CommitteeMember,
   CreateMeetingRequest,
   ImportantLinkFormValue,
   Meeting,
@@ -45,6 +47,7 @@ import {
   combineDateTime,
   formatTo12HourInTimezone,
   generateRecurrenceObject,
+  generateTempId,
   getDefaultStartDateTime,
   getUserTimezone,
   isRecurrenceNeverEndSentinel,
@@ -198,6 +201,11 @@ export class MeetingComposerFormService {
     if (context.mode === 'edit' && context.meetingUid) {
       this.loadMeeting(context.meetingUid);
       this.loadGuests(context.meetingUid);
+    }
+
+    // Set after the subscriptions are wired so the type's visibility/restriction defaults still apply.
+    if (context.mode === 'create' && context.meetingType) {
+      this.form().get('meeting_type')?.setValue(context.meetingType);
     }
   }
 
@@ -396,6 +404,142 @@ export class MeetingComposerFormService {
   /** Recurrence the current form state would submit — for read-only summaries such as the preview. */
   public recurrencePayload(): MeetingRecurrence | null {
     return this.buildRecurrencePayload(this.form().getRawValue());
+  }
+
+  /**
+   * Writes a duration in minutes across the chip control and its custom companion.
+   * @description Duration lives in two controls, so every writer outside Date & Schedule — the agenda
+   * template estimate, the AI estimate, the quick create prefill — has to set both or leave the pair
+   * inconsistent. Values off the chip scale land in `customDuration` and mark it touched, so its
+   * range error is visible rather than silently deadening submit.
+   */
+  public setDuration(minutes: number): void {
+    const isChipValue = MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === minutes);
+    const form = this.form();
+
+    form.get('duration')?.setValue(isChipValue ? minutes : 'custom');
+    form.get('customDuration')?.setValue(isChipValue ? null : minutes);
+
+    if (!isChipValue) {
+      form.get('customDuration')?.markAsTouched();
+    }
+  }
+
+  /**
+   * Reconciles the guest list against the members of the currently selected groups.
+   * @description Members already invited keep their saved state so they aren't deleted and re-created,
+   * members that dropped out of every selected group are queued for deletion, and the rest are added.
+   * Lives here rather than in the Guests section because the quick create dialog selects groups too.
+   */
+  public syncCommitteeMembers(members: CommitteeMember[]): void {
+    const memberByEmail = new Map<string, CommitteeMember>();
+    members.forEach((member) => {
+      if (member.email) {
+        memberByEmail.set(member.email.toLowerCase(), member);
+      }
+    });
+
+    const suppressed = this.suppressedGuestEmails();
+
+    this.updateGuests((current) => {
+      const reconciled = current.reduce<MeetingRegistrantWithState[]>((kept, guest) => {
+        if (guest.type !== 'committee') {
+          kept.push(guest);
+          return kept;
+        }
+
+        const email = guest.email?.toLowerCase() ?? '';
+        if (memberByEmail.has(email)) {
+          memberByEmail.delete(email);
+          // Reconciliation has to be idempotent: a guest queued for deletion because they left every
+          // selected group is restored when they turn up in one again. A guest the organizer removed by
+          // hand is suppressed, so their deletion survives re-emission.
+          const restore = guest.state === 'deleted' && !suppressed.has(email);
+          kept.push(restore ? { ...guest, state: 'existing' } : guest);
+          return kept;
+        }
+
+        if (guest.state !== 'new') {
+          kept.push({ ...guest, state: 'deleted' });
+        }
+
+        return kept;
+      }, []);
+
+      const invited = new Set(reconciled.filter((guest) => guest.state !== 'deleted').map((guest) => guest.email?.toLowerCase() ?? ''));
+
+      // Whatever is left in the map is a member nobody has invited or explicitly removed yet.
+      const additions = Array.from(memberByEmail.values())
+        .filter((member) => {
+          const email = member.email?.toLowerCase() ?? '';
+          return !invited.has(email) && !suppressed.has(email);
+        })
+        .map((member) => this.toGroupGuest(member));
+
+      return [...reconciled, ...additions];
+    });
+  }
+
+  /** Fields shared by every locally-added guest; `created_at` / `updated_at` are stamped upstream. */
+  public newGuestDefaults(): MeetingRegistrantWithState {
+    return {
+      uid: '',
+      meeting_id: this.meetingId() ?? '',
+      occurrence_id: null,
+      email: '',
+      first_name: '',
+      last_name: '',
+      job_title: null,
+      org_name: null,
+      host: false,
+      org_is_member: false,
+      org_is_project_member: false,
+      avatar_url: null,
+      username: null,
+      linkedin_profile: null,
+      created_at: '',
+      updated_at: '',
+      type: 'direct',
+      invite_accepted: null,
+      attended: null,
+      state: 'new',
+      tempId: generateTempId(),
+    };
+  }
+
+  /**
+   * Minutes the form currently resolves to, whichever of the two duration controls holds it.
+   * @description `customDuration` starts out as an empty string and holds whatever the numeric input
+   * produces, so it is coerced rather than cast.
+   */
+  public effectiveDuration(): number | null {
+    const duration = this.form().get('duration')?.value as number | 'custom' | null;
+
+    if (duration !== 'custom') {
+      return duration ?? null;
+    }
+
+    const customDuration = Number(this.form().get('customDuration')?.value);
+
+    return Number.isFinite(customDuration) && customDuration > 0 ? customDuration : null;
+  }
+
+  private toGroupGuest(member: CommitteeMember): MeetingRegistrantWithState {
+    return {
+      ...this.newGuestDefaults(),
+      email: member.email,
+      first_name: member.first_name,
+      last_name: member.last_name,
+      job_title: member.job_title || null,
+      org_name: member.organization?.name || null,
+      username: member.username || null,
+      linkedin_profile: member.linkedin_profile || null,
+      type: 'committee',
+      committee_uid: member.committee_uid,
+      committee_name: member.committee_name,
+      committee_role: member.role?.name || null,
+      committee_voting_status: member.voting?.status || null,
+    };
   }
 
   // Private initializer functions

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -1,9 +1,13 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+@if (composer.isQuickCreate()) {
+  <lfx-quick-create-dialog (create)="onSubmit()" />
+}
+
 <!-- Meeting composer drawer (LFXV2-3234) -->
 <p-drawer
-  [visible]="composer.isOpen()"
+  [visible]="composer.isOpen() && !composer.isQuickCreate()"
   (visibleChange)="onVisibleChange($event)"
   position="right"
   [modal]="true"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -15,6 +15,7 @@ import { MeetingComposerFormService } from './meeting-composer-form.service';
 import { MeetingComposerPreviewComponent } from './meeting-composer-preview.component';
 import { MeetingComposerRailComponent } from './meeting-composer-rail.component';
 import { MeetingComposerService } from './meeting-composer.service';
+import { QuickCreateDialogComponent } from './quick-create-dialog.component';
 import { ComposerAgendaResourcesComponent } from './sections/composer-agenda-resources.component';
 import { ComposerDateScheduleComponent } from './sections/composer-date-schedule.component';
 import { ComposerDetailsAccessComponent } from './sections/composer-details-access.component';
@@ -39,6 +40,7 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
     ComposerPlatformFeaturesComponent,
     ComposerGuestsComponent,
     ComposerAgendaResourcesComponent,
+    QuickCreateDialogComponent,
   ],
   templateUrl: './meeting-composer-host.component.html',
   providers: [MeetingComposerFormService],

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer.service.ts
@@ -32,6 +32,7 @@ export class MeetingComposerService {
 
   public readonly isOpen = computed(() => this._context() !== null);
   public readonly isEditMode = computed(() => this._context()?.mode === 'edit');
+  public readonly isQuickCreate = computed(() => this._context()?.variant === 'quick');
 
   public open(context: MeetingComposerContext): void {
     const section = context.section ?? FIRST_SECTION;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.html
@@ -1,0 +1,68 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<!-- Quick create dialog (LFXV2-3241) -->
+<p-dialog
+  [visible]="composer.isOpen()"
+  (visibleChange)="onVisibleChange($event)"
+  [modal]="true"
+  [draggable]="false"
+  [dismissableMask]="true"
+  header="Create meeting"
+  styleClass="w-[min(1024px,94vw)]">
+  <div class="grid grid-cols-1 gap-6 lg:grid-cols-2" data-testid="quick-create-body">
+    <div class="flex min-w-0 flex-col gap-6">
+      <lfx-composer-details-access [form]="formService.form()" [showHeading]="false" />
+
+      @if (prefilledType()) {
+        <p class="text-xs text-gray-500" data-testid="quick-create-prefill-hint">Pre-filled for this meeting type — edit freely.</p>
+      }
+
+      <div class="flex flex-col gap-2">
+        <label for="quick-create-agenda" class="text-sm font-medium text-gray-900">Agenda</label>
+        <lfx-textarea
+          [form]="formService.form()"
+          control="description"
+          id="quick-create-agenda"
+          placeholder="Enter meeting agenda and key discussion points"
+          styleClass="w-full"
+          [rows]="6"
+          [maxlength]="agendaMaxLength"
+          data-testid="quick-create-agenda-textarea" />
+        <div class="flex items-center justify-between gap-2">
+          @if (prefilledType()) {
+            <p class="text-xs text-gray-500" data-testid="quick-create-agenda-hint">Suggested agenda template — adjust as needed.</p>
+          }
+          <p class="ml-auto text-xs" [ngClass]="agendaCounterClass()">{{ agendaLength() }}/{{ agendaMaxLength }}</p>
+        </div>
+      </div>
+
+      <lfx-meeting-committee-manager
+        [selectedCommittees]="formService.form().get('committees')?.value || []"
+        [form]="formService.form()"
+        [committeeContext]="formService.committeeContext()"
+        (committeeMembersChange)="onCommitteeMembersChange($event)" />
+    </div>
+
+    <div class="flex min-w-0 flex-col gap-6">
+      <lfx-composer-date-schedule [form]="formService.form()" [showHeading]="false" [showEarlyJoin]="false" />
+    </div>
+  </div>
+
+  <ng-template #footer>
+    <div class="flex w-full items-center justify-between gap-2" data-testid="quick-create-footer">
+      <p class="text-xs text-gray-500">You can configure advanced settings later.</p>
+
+      <div class="flex items-center gap-2">
+        <lfx-button label="Cancel" severity="secondary" [text]="true" size="small" data-testid="quick-create-cancel" (onClick)="composer.close()" />
+        <lfx-button
+          label="Create meeting"
+          size="small"
+          [loading]="formService.submitting()"
+          [disabled]="!canSubmit()"
+          data-testid="quick-create-submit"
+          (onClick)="onCreate()" />
+      </div>
+    </div>
+  </ng-template>
+</p-dialog>

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/quick-create-dialog.component.ts
@@ -1,0 +1,136 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { NgClass } from '@angular/common';
+import { Component, computed, inject, output, signal, type Signal } from '@angular/core';
+import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { ButtonComponent } from '@components/button/button.component';
+import { TextareaComponent } from '@components/textarea/textarea.component';
+import { DEFAULT_DURATION, MEETING_AGENDA_MAX_LENGTH, MEETING_AGENDA_WARNING_LENGTH, MEETING_TEMPLATES } from '@lfx-one/shared/constants';
+import { MeetingType } from '@lfx-one/shared/enums';
+import type { CommitteeMember, MeetingTemplate } from '@lfx-one/shared/interfaces';
+import { DialogModule } from 'primeng/dialog';
+import { startWith, switchMap } from 'rxjs';
+
+import { MeetingCommitteeManagerComponent } from '../components/meeting-committee-manager/meeting-committee-manager.component';
+import { MeetingComposerFormService } from './meeting-composer-form.service';
+import { MeetingComposerService } from './meeting-composer.service';
+import { ComposerDateScheduleComponent } from './sections/composer-date-schedule.component';
+import { ComposerDetailsAccessComponent } from './sections/composer-details-access.component';
+
+/**
+ * Quick create dialog (LFXV2-3241).
+ * @description The condensed create surface: the same form and the same submit path as the drawer, laid
+ * out as two columns with no rail and no per-section gating. It composes the drawer's Details & Access
+ * and Date & Schedule sections rather than reimplementing their controls, so validators, hint copy and
+ * type-driven defaults can't drift between the two surfaces. Platform, features and resources keep
+ * their form defaults and are edited later in the drawer.
+ */
+@Component({
+  selector: 'lfx-quick-create-dialog',
+  imports: [
+    NgClass,
+    DialogModule,
+    ButtonComponent,
+    TextareaComponent,
+    ComposerDetailsAccessComponent,
+    ComposerDateScheduleComponent,
+    MeetingCommitteeManagerComponent,
+  ],
+  templateUrl: './quick-create-dialog.component.html',
+})
+export class QuickCreateDialogComponent {
+  protected readonly composer = inject(MeetingComposerService);
+  protected readonly formService = inject(MeetingComposerFormService);
+
+  /** Submit stays with the host, so both surfaces save through one path. */
+  public readonly create = output<void>();
+
+  protected readonly agendaMaxLength = MEETING_AGENDA_MAX_LENGTH;
+
+  /** Meeting type whose template was applied, so the prefill hints only claim what was actually filled. */
+  protected readonly prefilledType = signal<MeetingType | null>(null);
+
+  protected readonly agendaLength: Signal<number> = computed(() => {
+    this.formService.revision();
+    return (this.formService.form().get('description')?.value as string | null)?.length ?? 0;
+  });
+  protected readonly agendaCounterClass: Signal<string> = computed(() => {
+    const length = this.agendaLength();
+
+    if (length >= MEETING_AGENDA_MAX_LENGTH) {
+      return 'text-red-600';
+    }
+
+    return length >= MEETING_AGENDA_WARNING_LENGTH ? 'text-amber-600' : 'text-gray-500';
+  });
+  protected readonly canSubmit: Signal<boolean> = computed(() => {
+    // FormGroup validity is not reactive; `revision` is what makes this recompute.
+    this.formService.revision();
+    return this.formService.form().valid;
+  });
+
+  public constructor() {
+    // The form instance is replaced on every open, and the type can be seeded by the entry point before
+    // this dialog mounts, so the current value is replayed rather than waiting for the next change.
+    toObservable(this.formService.form)
+      .pipe(
+        switchMap((form) => {
+          const control = form.get('meeting_type');
+          return control ? control.valueChanges.pipe(startWith(control.value as MeetingType | null)) : [];
+        }),
+        takeUntilDestroyed()
+      )
+      .subscribe((meetingType: MeetingType | null) => this.applyTypeTemplate(meetingType));
+  }
+
+  protected onVisibleChange(visible: boolean): void {
+    if (!visible) {
+      this.composer.close();
+    }
+  }
+
+  protected onCommitteeMembersChange(members: CommitteeMember[]): void {
+    this.formService.syncCommitteeMembers(members);
+  }
+
+  protected onCreate(): void {
+    this.create.emit();
+  }
+
+  /**
+   * Seeds title, agenda and duration from the meeting type's first template.
+   * @description Only untouched fields are written — switching type after typing a title must not discard
+   * it — so duration is seeded only while it still holds the form default.
+   */
+  private applyTypeTemplate(meetingType: MeetingType | null): void {
+    const template = meetingType ? this.firstTemplate(meetingType) : null;
+
+    if (!template) {
+      this.prefilledType.set(null);
+      return;
+    }
+
+    const form = this.formService.form();
+    const title = form.get('title');
+    const description = form.get('description');
+
+    if (!(title?.value as string | null)?.trim()) {
+      title?.setValue(template.title);
+    }
+
+    if (!(description?.value as string | null)?.trim()) {
+      description?.setValue(template.content);
+    }
+
+    if (this.formService.effectiveDuration() === DEFAULT_DURATION) {
+      this.formService.setDuration(template.estimatedDuration);
+    }
+
+    this.prefilledType.set(meetingType);
+  }
+
+  private firstTemplate(meetingType: MeetingType): MeetingTemplate | null {
+    return MEETING_TEMPLATES.find((group) => group.meetingType === meetingType)?.templates[0] ?? null;
+  }
+}

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -15,7 +15,6 @@ import {
   MAX_FILE_SIZE_MB,
   MEETING_AGENDA_MAX_LENGTH,
   MEETING_AGENDA_WARNING_LENGTH,
-  MEETING_DURATION_CHIP_OPTIONS,
   MIN_CUSTOM_DURATION,
 } from '@lfx-one/shared/constants';
 import { MeetingType } from '@lfx-one/shared/enums';
@@ -257,8 +256,7 @@ export class ComposerAgendaResourcesComponent {
    * the allowed range is dropped with a warning (writing it would trip the form service's min/max
    * validators and deaden submit from a section the organizer can't see); an estimate that already
    * matches the current duration is a silent no-op; any other estimate is written and announced, since
-   * the duration they picked has just been overwritten. Estimates outside the chip values go to
-   * `customDuration` rather than being clamped.
+   * the duration they picked has just been overwritten.
    */
   private applyEstimatedDuration(estimate: number): void {
     const estimatedDuration = Math.round(estimate);
@@ -272,43 +270,17 @@ export class ComposerAgendaResourcesComponent {
       return;
     }
 
-    if (this.effectiveDuration() === estimatedDuration) {
+    if (this.formService.effectiveDuration() === estimatedDuration) {
       return;
     }
 
-    const isChipValue = MEETING_DURATION_CHIP_OPTIONS.some((option) => option.value === estimatedDuration);
-    const customDuration = this.form().get('customDuration');
-    const durationControl = this.form().get('duration');
-
-    durationControl?.setValue(isChipValue ? estimatedDuration : 'custom');
-    customDuration?.setValue(isChipValue ? null : estimatedDuration);
-
-    if (!isChipValue) {
-      customDuration?.markAsTouched();
-    }
+    this.formService.setDuration(estimatedDuration);
 
     this.messageService.add({
       severity: 'info',
       summary: 'Duration updated',
       detail: `Meeting duration set to ${estimatedDuration} minutes. Change it in Date & Schedule if that's not right.`,
     });
-  }
-
-  /**
-   * Minutes the form currently resolves to, whichever of the two duration controls holds it.
-   * @description `customDuration` starts out as an empty string and holds whatever the numeric input
-   * produces, so it is coerced rather than cast.
-   */
-  private effectiveDuration(): number | null {
-    const duration = this.form().get('duration')?.value as number | 'custom' | null;
-
-    if (duration !== 'custom') {
-      return duration ?? null;
-    }
-
-    const customDuration = Number(this.form().get('customDuration')?.value);
-
-    return Number.isFinite(customDuration) && customDuration > 0 ? customDuration : null;
   }
 
   private validateFile(file: File, queued: PendingAttachment[]): string | null {

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.html
@@ -2,10 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6" data-testid="composer-date-schedule">
-  <div class="flex flex-col gap-1">
-    <h2>Date &amp; Schedule</h2>
-    <p class="text-sm text-gray-500">When it happens and how often it repeats.</p>
-  </div>
+  @if (showHeading()) {
+    <div class="flex flex-col gap-1">
+      <h2>Date &amp; Schedule</h2>
+      <p class="text-sm text-gray-500">When it happens and how often it repeats.</p>
+    </div>
+  }
 
   <!-- Start date + start time -->
   <div class="grid grid-cols-1 gap-4 sm:grid-cols-2">
@@ -103,29 +105,31 @@
   </div>
 
   <!-- Early join -->
-  <div class="flex flex-col gap-2">
-    <span id="composer-early-join-label" class="flex items-center gap-2 text-sm font-medium text-gray-900">
-      Early join
-      <i
-        class="fa-light fa-info-circle cursor-help text-gray-400"
-        tabindex="0"
-        role="img"
-        [attr.aria-label]="earlyJoinTooltip"
-        [pTooltip]="earlyJoinTooltip"
-        tooltipEvent="both"
-        tooltipPosition="right"
-        tooltipStyleClass="text-xs max-w-xs"></i>
-    </span>
-    <div role="group" aria-labelledby="composer-early-join-label" data-testid="composer-early-join-chips">
-      <lfx-select-button [form]="form()" control="early_join_time_minutes" [options]="earlyJoinOptions" [unselectable]="false" />
+  @if (showEarlyJoin()) {
+    <div class="flex flex-col gap-2">
+      <span id="composer-early-join-label" class="flex items-center gap-2 text-sm font-medium text-gray-900">
+        Early join
+        <i
+          class="fa-light fa-info-circle cursor-help text-gray-400"
+          tabindex="0"
+          role="img"
+          [attr.aria-label]="earlyJoinTooltip"
+          [pTooltip]="earlyJoinTooltip"
+          tooltipEvent="both"
+          tooltipPosition="right"
+          tooltipStyleClass="text-xs max-w-xs"></i>
+      </span>
+      <div role="group" aria-labelledby="composer-early-join-label" data-testid="composer-early-join-chips">
+        <lfx-select-button [form]="form()" control="early_join_time_minutes" [options]="earlyJoinOptions" [unselectable]="false" />
+      </div>
+      @if (form().get('early_join_time_minutes')?.errors?.['min'] && form().get('early_join_time_minutes')?.touched) {
+        <p class="text-sm text-red-600" data-testid="composer-early-join-min-error">Early join time must be at least {{ minEarlyJoinTime }} minutes</p>
+      }
+      @if (form().get('early_join_time_minutes')?.errors?.['max'] && form().get('early_join_time_minutes')?.touched) {
+        <p class="text-sm text-red-600" data-testid="composer-early-join-max-error">Early join time cannot exceed {{ maxEarlyJoinTime }} minutes</p>
+      }
     </div>
-    @if (form().get('early_join_time_minutes')?.errors?.['min'] && form().get('early_join_time_minutes')?.touched) {
-      <p class="text-sm text-red-600" data-testid="composer-early-join-min-error">Early join time must be at least {{ minEarlyJoinTime }} minutes</p>
-    }
-    @if (form().get('early_join_time_minutes')?.errors?.['max'] && form().get('early_join_time_minutes')?.touched) {
-      <p class="text-sm text-red-600" data-testid="composer-early-join-max-error">Early join time cannot exceed {{ maxEarlyJoinTime }} minutes</p>
-    }
-  </div>
+  }
 
   <hr class="border-gray-200" />
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-date-schedule.component.ts
@@ -54,6 +54,10 @@ export class ComposerDateScheduleComponent implements OnInit {
   private readonly destroyRef = inject(DestroyRef);
 
   public readonly form = input.required<FormGroup>();
+  /** Quick create labels its own columns and has no room for the section heading. */
+  public readonly showHeading = input(true);
+  /** Early join is an advanced setting the quick create dialog leaves at its default. */
+  public readonly showEarlyJoin = input(true);
 
   protected readonly durationOptions = MEETING_DURATION_CHIP_OPTIONS;
   protected readonly earlyJoinOptions = EARLY_JOIN_CHIP_OPTIONS;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.html
@@ -2,10 +2,12 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="flex flex-col gap-6" data-testid="composer-details-access">
-  <div class="flex flex-col gap-1">
-    <h2>Details &amp; Access</h2>
-    <p class="text-sm text-gray-500">Name the meeting and set who it's for.</p>
-  </div>
+  @if (showHeading()) {
+    <div class="flex flex-col gap-1">
+      <h2>Details &amp; Access</h2>
+      <p class="text-sm text-gray-500">Name the meeting and set who it's for.</p>
+    </div>
+  }
 
   <!-- Meeting title -->
   <div class="flex flex-col gap-2">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-details-access.component.ts
@@ -40,6 +40,8 @@ export class ComposerDetailsAccessComponent {
   private readonly formService = inject(MeetingComposerFormService);
 
   public readonly form = input.required<FormGroup>();
+  /** Quick create labels its own columns and has no room for the section heading. */
+  public readonly showHeading = input(true);
 
   protected readonly visibilityOptions = MEETING_VISIBILITY_OPTIONS;
   protected readonly joinRestrictionOptions = MEETING_JOIN_RESTRICTION_OPTIONS;

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-guests.component.ts
@@ -8,7 +8,7 @@ import { FeatureToggleComponent } from '@components/feature-toggle/feature-toggl
 import { UserSearchComponent } from '@components/user-search/user-search.component';
 import { COMMITTEE_LABEL, SHOW_MEETING_ATTENDEES_FEATURE } from '@lfx-one/shared/constants';
 import type { CommitteeMember, ManualGuestDialogResult, MeetingRegistrantWithState } from '@lfx-one/shared/interfaces';
-import { avatarInitials, generateTempId } from '@lfx-one/shared/utils';
+import { avatarInitials } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -108,58 +108,8 @@ export class ComposerGuestsComponent {
     );
   }
 
-  /**
-   * Reconciles the guest list against the members of the currently selected groups.
-   * @description Members already invited keep their saved state so they aren't deleted and re-created,
-   * members that dropped out of every selected group are queued for deletion, and the rest are added.
-   */
   protected onCommitteeMembersChange(members: CommitteeMember[]): void {
-    const memberByEmail = new Map<string, CommitteeMember>();
-    members.forEach((member) => {
-      if (member.email) {
-        memberByEmail.set(member.email.toLowerCase(), member);
-      }
-    });
-
-    const suppressed = this.formService.suppressedGuestEmails();
-
-    this.formService.updateGuests((current) => {
-      const reconciled = current.reduce<MeetingRegistrantWithState[]>((kept, guest) => {
-        if (guest.type !== 'committee') {
-          kept.push(guest);
-          return kept;
-        }
-
-        const email = guest.email?.toLowerCase() ?? '';
-        if (memberByEmail.has(email)) {
-          memberByEmail.delete(email);
-          // Reconciliation has to be idempotent: a guest queued for deletion because they left every
-          // selected group is restored when they turn up in one again. A guest the organizer removed by
-          // hand is suppressed, so their deletion survives re-emission.
-          const restore = guest.state === 'deleted' && !suppressed.has(email);
-          kept.push(restore ? { ...guest, state: 'existing' } : guest);
-          return kept;
-        }
-
-        if (guest.state !== 'new') {
-          kept.push({ ...guest, state: 'deleted' });
-        }
-
-        return kept;
-      }, []);
-
-      const invited = new Set(reconciled.filter((guest) => guest.state !== 'deleted').map((guest) => guest.email?.toLowerCase() ?? ''));
-
-      // Whatever is left in the map is a member nobody has invited or explicitly removed yet.
-      const additions = Array.from(memberByEmail.values())
-        .filter((member) => {
-          const email = member.email?.toLowerCase() ?? '';
-          return !invited.has(email) && !suppressed.has(email);
-        })
-        .map((member) => this.toGroupGuest(member));
-
-      return [...reconciled, ...additions];
-    });
+    this.formService.syncCommitteeMembers(members);
   }
 
   private openManualDialog(prefill: Record<string, unknown> | null): void {
@@ -188,7 +138,7 @@ export class ComposerGuestsComponent {
     }
 
     const guest: MeetingRegistrantWithState = {
-      ...this.baseGuest(),
+      ...this.formService.newGuestDefaults(),
       email,
       first_name: (formValue['first_name'] as string | null) ?? '',
       last_name: (formValue['last_name'] as string | null) ?? '',
@@ -199,50 +149,5 @@ export class ComposerGuestsComponent {
     };
 
     this.formService.updateGuests((current) => [guest, ...current]);
-  }
-
-  private toGroupGuest(member: CommitteeMember): MeetingRegistrantWithState {
-    return {
-      ...this.baseGuest(),
-      email: member.email,
-      first_name: member.first_name,
-      last_name: member.last_name,
-      job_title: member.job_title || null,
-      org_name: member.organization?.name || null,
-      username: member.username || null,
-      linkedin_profile: member.linkedin_profile || null,
-      type: 'committee',
-      committee_uid: member.committee_uid,
-      committee_name: member.committee_name,
-      committee_role: member.role?.name || null,
-      committee_voting_status: member.voting?.status || null,
-    };
-  }
-
-  /** Fields shared by every locally-added guest; `created_at` / `updated_at` are stamped upstream. */
-  private baseGuest(): MeetingRegistrantWithState {
-    return {
-      uid: '',
-      meeting_id: this.formService.meetingId() ?? '',
-      occurrence_id: null,
-      email: '',
-      first_name: '',
-      last_name: '',
-      job_title: null,
-      org_name: null,
-      host: false,
-      org_is_member: false,
-      org_is_project_member: false,
-      avatar_url: null,
-      username: null,
-      linkedin_profile: null,
-      created_at: '',
-      updated_at: '',
-      type: 'direct',
-      invite_accepted: null,
-      attended: null,
-      state: 'new',
-      tempId: generateTempId(),
-    };
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -13,14 +13,26 @@
         <div class="flex justify-between items-center w-full gap-4">
           <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>
           @if (activeLens() !== 'me' && canWriteMeetings()) {
-            <lfx-button
-              icon="fa-light fa-calendar"
-              severity="info"
-              [attr.data-testid]="'meeting-create-button'"
-              label="Create Meeting"
-              size="small"
-              (onClick)="onCreateMeeting()">
-            </lfx-button>
+            <div class="flex items-center gap-1">
+              <lfx-button
+                icon="fa-light fa-calendar"
+                severity="info"
+                [attr.data-testid]="'meeting-create-button'"
+                label="Create Meeting"
+                size="small"
+                (onClick)="onCreateMeeting()">
+              </lfx-button>
+              <lfx-button
+                icon="fa-light fa-chevron-down"
+                severity="info"
+                [outlined]="true"
+                size="small"
+                ariaLabel="More create options"
+                [attr.data-testid]="'meeting-create-options-button'"
+                (onClick)="createMenu.toggle($event)">
+              </lfx-button>
+              <lfx-menu #createMenu [model]="createMenuItems" [popup]="true" appendTo="body"></lfx-menu>
+            </div>
           }
         </div>
         <p class="mt-1 text-sm text-gray-500">Coordinate decisions, align stakeholders, and maintain transparent governance in your project</p>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -12,9 +12,11 @@ import { FullCalendarComponent } from '@app/shared/components/fullcalendar/fullc
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { MenuComponent } from '@components/menu/menu.component';
 import { environment } from '@environments/environment';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS } from '@lfx-one/shared/constants';
+import { MEETING_RECORDING_COUNT_FETCH_CONCURRENCY, MEETING_TYPE_CONFIGS, MEETING_TYPE_OPTIONS } from '@lfx-one/shared/constants';
+import { MeetingType } from '@lfx-one/shared/enums';
 import { Lens, MeLensMeetingFilters, Meeting, MeetingCalendarClickProps, PageResult, PastMeeting, ProjectContext, ViewMode } from '@lfx-one/shared/interfaces';
 import {
   getCurrentOrNextOccurrence,
@@ -34,6 +36,7 @@ import { ProjectContextService } from '@services/project-context.service';
 import { ProjectService } from '@services/project.service';
 import { UserService } from '@services/user.service';
 import { OnRenderDirective } from '@shared/directives/on-render.directive';
+import { MenuItem } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
 import { SkeletonModule } from 'primeng/skeleton';
 import {
@@ -72,6 +75,7 @@ import { MeetingsTopBarComponent } from './components/meetings-top-bar/meetings-
     EmptyStateComponent,
     FullCalendarComponent,
     SkeletonModule,
+    MenuComponent,
   ],
   providers: [DialogService],
   templateUrl: './meetings-dashboard.component.html',
@@ -89,6 +93,27 @@ export class MeetingsDashboardComponent {
   private readonly platformId = inject(PLATFORM_ID);
   private readonly dialogService = inject(DialogService);
   private readonly composer = inject(MeetingComposerService);
+
+  /**
+   * Create Meeting dropdown: a quick start per meeting type, then the full drawer.
+   * @description A type row opens the quick dialog pre-selected, so its template prefill runs immediately.
+   */
+  public readonly createMenuItems: MenuItem[] = [
+    {
+      label: 'Quick start',
+      items: MEETING_TYPE_OPTIONS.map((option) => ({
+        label: option.label,
+        icon: option.info.icon,
+        command: () => this.onQuickCreateMeeting(option.value),
+      })),
+    },
+    { separator: true },
+    {
+      label: 'Advanced',
+      icon: 'fa-light fa-sliders',
+      command: () => this.onAdvancedCreateMeeting(),
+    },
+  ];
 
   public readonly activeLens: Signal<Lens> = this.lensService.activeLens;
   protected readonly personaLoaded = this.personaService.personaLoaded;
@@ -256,7 +281,16 @@ export class MeetingsDashboardComponent {
     );
   }
 
+  /** Main button: the quick create dialog. The dropdown covers per-type quick starts and the drawer. */
   public onCreateMeeting(): void {
+    this.composer.open({ mode: 'create', variant: 'quick' });
+  }
+
+  public onQuickCreateMeeting(meetingType: MeetingType): void {
+    this.composer.open({ mode: 'create', variant: 'quick', meetingType });
+  }
+
+  public onAdvancedCreateMeeting(): void {
     this.composer.open({ mode: 'create' });
   }
 

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1444,9 +1444,16 @@ export interface MeetingComposerContext {
    * @description Takes precedence over the ambient project context, which resolves asynchronously.
    */
   projectUid?: string;
-  /** Section to land on; defaults to the first section. */
+  /** Section to land on; defaults to the first section. Ignored by the quick create dialog. */
   section?: MeetingComposerSectionId;
+  /** Surface to open — the full drawer (default) or the quick create dialog. */
+  variant?: MeetingComposerVariant;
+  /** Meeting type the quick create dialog opens pre-selected with, so its template prefill runs immediately. */
+  meetingType?: MeetingType;
 }
+
+/** Composer surface: the full sectioned drawer, or the condensed quick create dialog. */
+export type MeetingComposerVariant = 'drawer' | 'quick';
 
 /** Dialog data for the composer's manual guest entry dialog. */
 export interface ManualGuestDialogData {


### PR DESCRIPTION
## What

Adds the **Quick create** dialog — a two-column `p-dialog` with meeting-type smart defaults for the
common case, reachable from the Create meeting picker on the meetings dashboard.

## How

- Selecting a type chip prefills title / duration / visibility / restricted / group / agenda from
  `MEETING_TEMPLATES`, with hints anchored to the fields they explain.
- Reuses the drawer's section components in a `compact` variant and the **same**
  `MeetingComposerFormService` submit path, so quick and advanced create write identical payloads.

## Notes for review

- `/meetings/create` and the create-artifact picker's "Create Meeting" now open the quick dialog
  rather than the full drawer. That was not in the epic's planned scope — added on request.
- Duration prefill is skipped when a template's estimate isn't one of the duration chips.

Refs #1460
