### PR TITLE
feat(meetings): replace post-create navigation with a toast

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.html
@@ -5,6 +5,37 @@
   <lfx-quick-create-dialog (create)="onSubmit()" />
 }
 
+<!-- Post-create toast (LFXV2-3242): creating no longer navigates, so this is the way back to the meeting -->
+<p-toast [key]="toastKey" position="top-right">
+  <ng-template let-message pTemplate="message">
+    <div class="flex w-full items-start gap-3" data-testid="meeting-composer-toast">
+      <i class="fa-light fa-circle-check mt-0.5 shrink-0 text-xl text-emerald-500" aria-hidden="true"></i>
+      <div class="flex min-w-0 flex-1 flex-col gap-1">
+        <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
+        <span class="break-words text-xs text-gray-600">{{ message.detail }}</span>
+        <div class="mt-1 flex items-center gap-3">
+          <button
+            type="button"
+            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            data-testid="meeting-composer-toast-edit"
+            (click)="onEditCreatedMeeting(message.data)">
+            <i class="fa-light fa-pen text-[10px]" aria-hidden="true"></i>
+            <span>Edit meeting</span>
+          </button>
+          <a
+            [routerLink]="message.data.meetingUrl"
+            class="inline-flex items-center gap-1 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            data-testid="meeting-composer-toast-details"
+            (click)="onDismissToast()">
+            <i class="fa-light fa-arrow-up-right-from-square text-[10px]" aria-hidden="true"></i>
+            <span>Meeting details</span>
+          </a>
+        </div>
+      </div>
+    </div>
+  </ng-template>
+</p-toast>
+
 <!-- Meeting composer drawer (LFXV2-3234) -->
 <p-drawer
   [visible]="composer.isOpen() && !composer.isQuickCreate()"

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-host.component.ts
@@ -3,12 +3,14 @@
 
 import { Component, computed, inject, type Signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
-import { MEETING_COMPOSER_SECTIONS } from '@lfx-one/shared/constants';
-import type { MeetingComposerSection } from '@lfx-one/shared/interfaces';
+import { MEETING_COMPOSER_SECTIONS, MEETING_COMPOSER_TOAST_KEY, MEETING_COMPOSER_TOAST_LIFE } from '@lfx-one/shared/constants';
+import type { Meeting, MeetingComposerSection, MeetingComposerToastData } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
 import { DrawerModule } from 'primeng/drawer';
+import { ToastModule } from 'primeng/toast';
 import { filter, pairwise } from 'rxjs';
 
 import { MeetingComposerFormService } from './meeting-composer-form.service';
@@ -41,6 +43,8 @@ import { ComposerPlatformFeaturesComponent } from './sections/composer-platform-
     ComposerGuestsComponent,
     ComposerAgendaResourcesComponent,
     QuickCreateDialogComponent,
+    ToastModule,
+    RouterLink,
   ],
   templateUrl: './meeting-composer-host.component.html',
   providers: [MeetingComposerFormService],
@@ -53,6 +57,7 @@ export class MeetingComposerHostComponent {
   protected readonly formService = inject(MeetingComposerFormService);
 
   protected readonly sections: readonly MeetingComposerSection[] = MEETING_COMPOSER_SECTIONS;
+  protected readonly toastKey = MEETING_COMPOSER_TOAST_KEY;
 
   protected readonly activeIndex: Signal<number> = computed(() => this.sections.findIndex((section) => section.id === this.composer.activeSection()));
   protected readonly isLastSection: Signal<boolean> = computed(() => this.activeIndex() === this.sections.length - 1);
@@ -121,14 +126,52 @@ export class MeetingComposerHostComponent {
 
     // `submit()` completes without emitting when the save outlived its open, so reaching here always
     // means the current open is the one that was saved.
-    this.formService.submit().subscribe(() => {
-      this.messageService.add({
-        severity: 'success',
-        summary: 'Success',
-        detail: wasEditMode ? 'Meeting updated successfully' : 'Meeting created successfully',
-      });
+    this.formService.submit().subscribe((meeting) => {
+      if (wasEditMode) {
+        this.messageService.add({ severity: 'success', summary: 'Meeting updated', detail: 'Your changes have been saved.' });
+      } else {
+        this.announceCreatedMeeting(meeting);
+      }
 
       this.composer.close();
+    });
+  }
+
+  /** Reopens the composer on the meeting the toast was raised for. */
+  protected onEditCreatedMeeting(data: MeetingComposerToastData): void {
+    this.messageService.clear(this.toastKey);
+    this.composer.open({ mode: 'edit', meetingUid: data.meetingUid });
+  }
+
+  protected onDismissToast(): void {
+    this.messageService.clear(this.toastKey);
+  }
+
+  /**
+   * Raises the post-create toast (LFXV2-3242).
+   * @description Creating no longer navigates to the saved meeting, so this toast is the only route back
+   * to it. A create that returned no meeting has nothing to link to, and falls back to a plain
+   * confirmation rather than a toast whose actions would dead-end.
+   */
+  private announceCreatedMeeting(meeting: Meeting | null): void {
+    if (!meeting?.id) {
+      this.messageService.add({ severity: 'success', summary: 'Meeting created', detail: 'Open it from the list to review the details.' });
+      return;
+    }
+
+    const data: MeetingComposerToastData = {
+      meetingUid: meeting.id,
+      meetingTitle: meeting.title ?? 'Untitled meeting',
+      meetingUrl: `/meetings/${meeting.id}`,
+    };
+
+    this.messageService.add({
+      key: this.toastKey,
+      severity: 'success',
+      summary: 'Meeting created',
+      detail: data.meetingTitle,
+      life: MEETING_COMPOSER_TOAST_LIFE,
+      data,
     });
   }
 }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -335,6 +335,16 @@ export const MEETING_COMPOSER_PREVIEW_FEATURES: MeetingComposerPreviewFeature[] 
 ).map(({ control, label }) => ({ control, label, icon: MEETING_FEATURE_BY_KEY[control].icon }));
 
 /**
+ * Toast key for the composer's post-save confirmation.
+ * @description Its own key so the action-bearing create toast renders through the composer's template
+ * rather than the app-wide `p-toast`.
+ */
+export const MEETING_COMPOSER_TOAST_KEY = 'meeting-composer-toast';
+
+/** How long the post-create toast stays up, in ms — longer than a plain toast because it carries actions. */
+export const MEETING_COMPOSER_TOAST_LIFE = 10000;
+
+/**
  * Default meeting duration in minutes
  * @description Standard meeting length when no custom duration is specified
  */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1455,6 +1455,18 @@ export interface MeetingComposerContext {
 /** Composer surface: the full sectioned drawer, or the condensed quick create dialog. */
 export type MeetingComposerVariant = 'drawer' | 'quick';
 
+/**
+ * What the post-create toast needs to render its actions.
+ * @description Carried on the PrimeNG message's `data`, since creating no longer navigates anywhere —
+ * the toast is the only route back to the meeting that was just created.
+ */
+export interface MeetingComposerToastData {
+  meetingUid: string;
+  meetingTitle: string;
+  /** Router link to the meeting's details page. */
+  meetingUrl: string;
+}
+
 /** Dialog data for the composer's manual guest entry dialog. */
 export interface ManualGuestDialogData {
   /** Values carried over from the search field, when the directory result was incomplete. */


### PR DESCRIPTION
## What

Replaces the post-create auto-navigation with a toast carrying actions.

## How

Creating a meeting now closes the composer and shows a keyed toast `Meeting created: {title}` with
"Edit meeting" (reopens the composer in edit mode) and "Meeting details". Edit mode shows a plain
"Meeting updated".

## Behavior change — needs QA notes

Create **no longer navigates** to the meeting's Guests tab. Anyone relying on landing there after
creating will need to use the toast action or the meetings list.

Refs #1461
