### PR TITLE
fix(meetings): persist and enrich registrant group attribution

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -779,7 +779,9 @@ export class MeetingComposerFormService {
     this.guestsLoadFailed.set(false);
 
     this.meetingService
-      .getMeetingRegistrants(meetingUid, false)
+      // include_committee: the Guests rows render a "via [Group]" chip, which needs the committee
+      // metadata the plain projection omits.
+      .getMeetingRegistrants(meetingUid, false, undefined, true)
       .pipe(
         take(1),
         catchError((error: unknown) => {

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -359,10 +359,24 @@ export class MeetingService {
     );
   }
 
-  public getMeetingRegistrants(meetingUid: string, includeRsvp: boolean = false, occurrenceId?: string): Observable<MeetingRegistrant[]> {
+  /**
+   * `includeCommittee` opts into committee enrichment (`committee_name`, `committee_role`,
+   * `committee_category`, `committee_voting_status`, `committee_appointed_by`). It costs a
+   * per-committee fan-out upstream, so it stays opt-in for the callers that actually render group
+   * attribution — the composer's Guests list.
+   */
+  public getMeetingRegistrants(
+    meetingUid: string,
+    includeRsvp: boolean = false,
+    occurrenceId?: string,
+    includeCommittee: boolean = false
+  ): Observable<MeetingRegistrant[]> {
     let params = new HttpParams().set('include_rsvp', includeRsvp.toString());
     if (occurrenceId) {
       params = params.set('occurrence_id', occurrenceId);
+    }
+    if (includeCommittee) {
+      params = params.set('include_committee', 'true');
     }
     return this.http.get<MeetingRegistrant[]>(`/api/meetings/${meetingUid}/registrants`, { params });
   }
@@ -509,7 +523,12 @@ export class MeetingService {
   }
 
   /**
-   * Strips metadata from MeetingRegistrantWithState to create CreateMeetingRegistrantRequest
+   * Strips metadata from MeetingRegistrantWithState to create CreateMeetingRegistrantRequest.
+   *
+   * `committee_uid` is forwarded (as the v2 UID the picker works in) so a guest added from a group
+   * is persisted as `type: 'committee'` upstream instead of collapsing to `direct`. The BFF resolves
+   * it to the v1 SFID upstream expects; the other `committee_*` fields are response-only enrichment
+   * and are deliberately dropped.
    */
   public stripMetadata(meetingUid: string, registrant: MeetingRegistrantWithState): CreateMeetingRegistrantRequest {
     return {
@@ -520,6 +539,7 @@ export class MeetingService {
       host: registrant.host || false,
       job_title: registrant.job_title || null,
       org_name: registrant.org_name || null,
+      committee_uid: registrant.committee_uid || null,
     };
   }
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -1,0 +1,168 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { NextFunction, Request, Response } from 'express';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const MEETING_ID = 'meeting-1111';
+const V2_COMMITTEE_UID = 'cmte-v2-aaaa';
+const V1_COMMITTEE_SFID = 'a09v1SFIDaaaa';
+
+const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock } = vi.hoisted(() => ({
+  meetingSvc: {
+    getMeetingById: vi.fn(),
+    getMeetingRegistrants: vi.fn(),
+    addMeetingRegistrant: vi.fn(),
+  },
+  aiSvc: { generateMeetingAgenda: vi.fn() },
+  committeeSvc: { getCommitteeById: vi.fn(), getCommitteeMembers: vi.fn() },
+  resolveCommitteeV2UidsToV1IdsMock: vi.fn(),
+}));
+
+// The `@lfx-one/shared/*` path alias isn't wired into vitest, and the controller only uses those
+// imports as types — stub the barrels so their runtime module graphs never load.
+vi.mock('@lfx-one/shared/interfaces', () => ({}));
+vi.mock('@lfx-one/shared/enums', () => ({}));
+vi.mock('@lfx-one/shared/constants', () => ({}));
+vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null) }));
+
+vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
+vi.mock('../helpers/meeting.helper', () => ({
+  addInvitedStatusToMeeting: vi.fn(),
+  applyHostKeyVisibility: vi.fn(),
+  enrichMeetingsWithCreatedBy: vi.fn(),
+  stripHostKey: vi.fn(),
+}));
+vi.mock('../helpers/committee-v1-mapping.helper', () => ({
+  resolveCommitteeV2UidsToV1Ids: resolveCommitteeV2UidsToV1IdsMock,
+}));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(() => 'user@example.com') }));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
+
+vi.mock('../services/meeting.service', () => ({ MeetingService: vi.fn(() => meetingSvc) }));
+vi.mock('../services/ai.service', () => ({ AiService: vi.fn(() => aiSvc) }));
+vi.mock('../services/committee.service', () => ({ CommitteeService: vi.fn(() => committeeSvc) }));
+vi.mock('../services/nats.service', () => ({ NatsService: vi.fn(() => ({})) }));
+vi.mock('../services/user.service', () => ({ UserService: vi.fn(() => ({})) }));
+vi.mock('../services/access-check.service', () => ({ AccessCheckService: vi.fn(() => ({})) }));
+vi.mock('../services/logger.service', () => ({
+  logger: {
+    startOperation: vi.fn(() => 0),
+    success: vi.fn(),
+    error: vi.fn(),
+    warning: vi.fn(),
+    info: vi.fn(),
+    debug: vi.fn(),
+    sanitize: vi.fn((value: unknown) => value),
+  },
+}));
+
+class FakeValidationError extends Error {
+  public constructor(public readonly fields: unknown) {
+    super('validation');
+  }
+}
+vi.mock('../errors', () => ({
+  ServiceValidationError: {
+    forField: (field: string) => new FakeValidationError({ [field]: 'required' }),
+    fromFieldErrors: (fields: unknown) => new FakeValidationError(fields),
+  },
+}));
+
+const { MeetingController } = await import('./meeting.controller');
+
+function buildRes(): Response {
+  const res = { status: vi.fn(() => res), json: vi.fn(() => res), send: vi.fn(() => res) } as unknown as Response;
+  return res;
+}
+
+function buildReq(overrides: Partial<Request> = {}): Request {
+  return { params: { uid: MEETING_ID }, query: {}, body: {}, path: '/api/meetings', ...overrides } as unknown as Request;
+}
+
+describe('MeetingController', () => {
+  let controller: InstanceType<typeof MeetingController>;
+  let next: NextFunction;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new MeetingController();
+    next = vi.fn();
+  });
+
+  describe('addMeetingRegistrants', () => {
+    beforeEach(() => {
+      meetingSvc.addMeetingRegistrant.mockImplementation((_req: Request, registrant: Record<string, unknown>) => Promise.resolve(registrant));
+    });
+
+    // GH-1463: upstream stores a v1 SFID and derives type: 'committee' from it. Forwarding the v2
+    // UID the picker works in would persist a bogus committee reference.
+    it('rewrites a group guest committee_uid from the v2 UID to the v1 SFID', async () => {
+      resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map([[V2_COMMITTEE_UID, V1_COMMITTEE_SFID]]));
+      const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: V2_COMMITTEE_UID }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ committee_uid: V1_COMMITTEE_SFID }));
+    });
+
+    it('strips an unresolvable committee_uid rather than forwarding a v2 UID upstream', async () => {
+      resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map());
+      const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: V2_COMMITTEE_UID }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ committee_uid: null }));
+    });
+
+    it('skips the mapping lookup entirely for directly-added guests', async () => {
+      const req = buildReq({ body: [{ email: 'a@example.com' }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      expect(resolveCommitteeV2UidsToV1IdsMock).not.toHaveBeenCalled();
+      expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ email: 'a@example.com' }));
+    });
+  });
+
+  describe('getMeetingRegistrants', () => {
+    const registrant = { uid: 'reg-1', email: 'a@example.com', committee_uid: V1_COMMITTEE_SFID };
+
+    beforeEach(() => {
+      meetingSvc.getMeetingRegistrants.mockResolvedValue([{ ...registrant }]);
+      meetingSvc.getMeetingById.mockResolvedValue({ uid: MEETING_ID, committees: [{ uid: V2_COMMITTEE_UID }] });
+      resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map([[V2_COMMITTEE_UID, V1_COMMITTEE_SFID]]));
+      committeeSvc.getCommitteeById.mockResolvedValue({ uid: V2_COMMITTEE_UID, name: 'TAC', category: 'Technical' });
+      committeeSvc.getCommitteeMembers.mockResolvedValue([{ email: 'a@example.com', role: { name: 'Chair' }, voting: { status: 'Voting Rep' } }]);
+    });
+
+    // GH-1463: the composer's Guests rows render a "via [Group]" chip, which needs this metadata at
+    // open time — the plain projection omits it.
+    it('enriches committee metadata when include_committee=true', async () => {
+      const res = buildRes();
+
+      await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ committee_name: 'TAC', committee_role: 'Chair', committee_category: 'Technical' })]);
+    });
+
+    it('leaves registrants unenriched by default, without fetching the meeting', async () => {
+      const res = buildRes();
+
+      await controller.getMeetingRegistrants(buildReq(), res, next);
+
+      expect(meetingSvc.getMeetingById).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith([registrant]);
+    });
+
+    it('degrades to unenriched rows when the meeting fetch fails', async () => {
+      meetingSvc.getMeetingById.mockRejectedValue(new Error('upstream down'));
+      const res = buildRes();
+
+      await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith([registrant]);
+    });
+  });
+});

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -367,16 +367,24 @@ export class MeetingController {
 
   /**
    * GET /meetings/:uid/registrants
+   *
+   * `include_committee=true` opts into the same committee enrichment `getMyMeetingRegistrants`
+   * applies, so callers that render group attribution (the meeting composer's Guests list) get
+   * `committee_name` / `committee_role` / `committee_category` / `committee_voting_status` /
+   * `committee_appointed_by` populated. It stays opt-in because it costs a per-committee
+   * details + members fan-out that the plain registrant listing has no use for.
    */
   public async getMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
-    const { include_rsvp, occurrence_id } = req.query;
+    const { include_rsvp, occurrence_id, include_committee } = req.query;
     const includeRsvp = include_rsvp === 'true';
+    const includeCommittee = include_committee === 'true';
     const occurrenceId = typeof occurrence_id === 'string' && occurrence_id.length > 0 ? occurrence_id : undefined;
 
     const startTime = logger.startOperation(req, 'get_meeting_registrants', {
       meeting_id: uid,
       include_rsvp: includeRsvp,
+      include_committee: includeCommittee,
       occurrence_id: occurrenceId,
     });
 
@@ -394,14 +402,30 @@ export class MeetingController {
       // Get the meeting registrants
       const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId);
 
+      // Enrichment needs the meeting's committees as the source of truth for the v1↔v2 mapping.
+      // A failed meeting fetch degrades to unenriched rows rather than failing the whole listing.
+      let payload = registrants;
+      if (includeCommittee && registrants.length > 0) {
+        try {
+          const meeting = await this.meetingService.getMeetingById(req, uid);
+          payload = await this.enrichCommitteeRegistrants(req, meeting, registrants);
+        } catch (error) {
+          logger.warning(req, 'get_meeting_registrants', 'Committee enrichment failed, returning unenriched registrants', {
+            meeting_id: uid,
+            error: error instanceof Error ? error.message : 'Unknown error',
+          });
+        }
+      }
+
       logger.success(req, 'get_meeting_registrants', startTime, {
         meeting_id: uid,
-        registrant_count: registrants.length,
+        registrant_count: payload.length,
         include_rsvp: includeRsvp,
+        include_committee: includeCommittee,
       });
 
       // Send the registrants data to the client
-      res.json(registrants);
+      res.json(payload);
     } catch (error) {
       // Send the error to the next middleware
       next(error);
@@ -617,9 +641,13 @@ export class MeetingController {
         return;
       }
 
+      // Group-added guests arrive carrying the v2 committee UID the picker works in; upstream
+      // stores a v1 SFID and derives `type: 'committee'` from it.
+      const resolvedRegistrants = await this.resolveRegistrantCommitteeUids(req, registrantData);
+
       // Process registrants with fail-fast for 403 errors
       // This will stop the processing if a 403 error is encountered
-      const { results, shouldReturn } = await this.processRegistrantOperations(req, next, 'add_meeting_registrants', uid, registrantData, (registrant) =>
+      const { results, shouldReturn } = await this.processRegistrantOperations(req, next, 'add_meeting_registrants', uid, resolvedRegistrants, (registrant) =>
         this.meetingService.addMeetingRegistrant(req, registrant)
       );
 
@@ -1760,5 +1788,38 @@ export class MeetingController {
   private async resolveV2ToV1CommitteeMappings(req: Request, v2CommitteeUids: string[]): Promise<Map<string, string>> {
     const v2ToV1Map = await resolveCommitteeV2UidsToV1Ids(req, this.natsService, v2CommitteeUids);
     return new Map([...v2ToV1Map].map(([v2Uid, v1Sfid]) => [v1Sfid, v2Uid]));
+  }
+
+  /**
+   * Rewrites each registrant's `committee_uid` from the v2 UID the client works in to the v1 SFID
+   * upstream stores. Upstream derives `type: 'committee'` from that field, so dropping it (as the
+   * BFF used to) silently persists a group-added guest as `direct` and loses attribution.
+   *
+   * An unresolvable UID is stripped rather than forwarded — a v2 UID upstream would be stored as a
+   * bogus committee reference, which is worse than the guest landing as `direct`.
+   */
+  private async resolveRegistrantCommitteeUids(req: Request, registrants: CreateMeetingRegistrantRequest[]): Promise<CreateMeetingRegistrantRequest[]> {
+    const v2Uids = [...new Set(registrants.map((registrant) => registrant.committee_uid).filter((value): value is string => !!value))];
+
+    if (v2Uids.length === 0) {
+      return registrants;
+    }
+
+    const v2ToV1Map = await resolveCommitteeV2UidsToV1Ids(req, this.natsService, v2Uids);
+
+    if (v2ToV1Map.size < v2Uids.length) {
+      logger.warning(req, 'resolve_registrant_committee_uids', 'Some committee UIDs could not be resolved to v1 SFIDs', {
+        requested: v2Uids.length,
+        resolved: v2ToV1Map.size,
+      });
+    }
+
+    return registrants.map((registrant) => {
+      if (!registrant.committee_uid) {
+        return registrant;
+      }
+
+      return { ...registrant, committee_uid: v2ToV1Map.get(registrant.committee_uid) ?? null };
+    });
   }
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -564,6 +564,12 @@ export interface CreateMeetingRegistrantRequest {
   avatar_url?: string | null;
   /** User's LFID */
   username?: string | null;
+  /**
+   * Committee this registrant was added from, as a **v2** committee UID.
+   * Upstream stores a v1 committee SFID and derives `type: 'committee'` from it, so the BFF
+   * resolves v2 → v1 before proxying. Omit for a directly-added guest.
+   */
+  committee_uid?: string | null;
 }
 
 /**


### PR DESCRIPTION
## What

BE-1, part 1 — persists and enriches **registrant group attribution** so a guest added via a group
keeps that attribution through create, read and RSVP counting.

## How

`committee_uid` is now sent on the registrant create path and the read path enriches registrants with
their committee so the "via [Group]" chip and the group / direct guest counts are correct across every
creation path.

## Notes for review

The registrant **update** path still drops `committee_uid`, and a submitted `committee_uid` is not
ownership-checked. Both are called out rather than fixed here.

Refs #1463
