### PR TITLE
fix(meetings): make the agenda ai helper usable outside details

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -306,10 +306,14 @@ export class MeetingRegistrantsDisplayComponent {
               // available (non-recurring meetings). See LFXV2-2864.
               const meeting = this.meeting() as Meeting;
               const occurrenceId = resolveRsvpOccurrenceId(meeting);
-              // Use access-controlled endpoint for meeting join page, regular endpoint for organizer views
+              // Use access-controlled endpoint for meeting join page, regular endpoint for organizer views.
+              // The organizer branch asks for committee enrichment because the group filter compares
+              // `registrant.committee_uid` against `meeting.committees[].uid` (v2) — unenriched, the field
+              // still holds the upstream v1 SFID and no option would ever match. The `/my` endpoint
+              // enriches unconditionally, so it needs no flag.
               const registrantsObservable = useMyEndpoint
                 ? this.meetingService.getMyMeetingRegistrants(meeting.id, true, occurrenceId)
-                : this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId);
+                : this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId, true);
 
               return registrantsObservable.pipe(
                 catchError(() => of([])),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -249,6 +249,14 @@ describe('MeetingComposerFormService — load retry', () => {
     expect(getMeeting).toHaveBeenCalledTimes(2);
   });
 
+  // GH-1463: the "via [Group]" chip needs `committee_*` metadata, which the registrant listing only
+  // returns behind `include_committee`. Dropping that flag would silently restore the missing chip.
+  it('asks for committee enrichment when loading the guest list', () => {
+    service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
+
+    expect(getMeetingRegistrants).toHaveBeenCalledWith('meeting-1', false, undefined, true);
+  });
+
   it('leaves a guest list that loaded fine alone on retry', () => {
     service.initialize({ mode: 'edit', meetingUid: 'meeting-1' });
     expect(getMeetingRegistrants).toHaveBeenCalledTimes(1);

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.spec.ts
@@ -308,6 +308,19 @@ describe('MeetingComposerFormService — load retry', () => {
     expect(getMeeting).not.toHaveBeenCalled();
   });
 
+  // GH-1464: `aiPrompt` is a scratch field the save payload never carries, but it lives in the group
+  // `validateForSubmit()` reads. A validator on it would block the meeting from saving over a value
+  // the meeting doesn't even have, with no error UI anywhere to explain the dead button.
+  it('does not let an over-long AI goal block the meeting save', () => {
+    service.initialize({ mode: 'create', projectUid: 'project-1' });
+    service.form().patchValue({ title: 'Composer meeting', meeting_type: 'Technical' });
+    expect(service.validateForSubmit()).toBe(true);
+
+    service.form().get('aiPrompt')?.setValue('x'.repeat(5000));
+
+    expect(service.validateForSubmit()).toBe(true);
+  });
+
   it('does not re-fetch in create mode, where meetingId comes from the save', () => {
     service.initialize({ mode: 'create', projectUid: 'project-1' });
     service.meetingId.set('meeting-1');

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -16,6 +16,7 @@ import {
   MAX_EMAIL_REMINDER_HOURS,
   MAX_EMAIL_REMINDER_TIME,
   MEETING_AGENDA_MAX_LENGTH,
+  MEETING_AGENDA_PROMPT_MAX_LENGTH,
   MEETING_DURATION_CHIP_OPTIONS,
   MIN_CUSTOM_DURATION,
   MIN_EARLY_JOIN_TIME,
@@ -615,7 +616,9 @@ export class MeetingComposerFormService {
 
         title: new FormControl('', [Validators.required]),
         description: new FormControl('', [Validators.maxLength(MEETING_AGENDA_MAX_LENGTH)]),
-        aiPrompt: new FormControl(''),
+        // Bounded because the goal is interpolated verbatim into the AI prompt; the server drops
+        // anything past the same cap rather than truncating it mid-sentence.
+        aiPrompt: new FormControl('', [Validators.maxLength(MEETING_AGENDA_PROMPT_MAX_LENGTH)]),
         startDate: new FormControl(defaultDateTime.date, [Validators.required]),
         startTime: new FormControl(defaultDateTime.time, [Validators.required]),
         duration: new FormControl(DEFAULT_DURATION, [Validators.required]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -16,7 +16,6 @@ import {
   MAX_EMAIL_REMINDER_HOURS,
   MAX_EMAIL_REMINDER_TIME,
   MEETING_AGENDA_MAX_LENGTH,
-  MEETING_AGENDA_PROMPT_MAX_LENGTH,
   MEETING_DURATION_CHIP_OPTIONS,
   MIN_CUSTOM_DURATION,
   MIN_EARLY_JOIN_TIME,
@@ -616,9 +615,11 @@ export class MeetingComposerFormService {
 
         title: new FormControl('', [Validators.required]),
         description: new FormControl('', [Validators.maxLength(MEETING_AGENDA_MAX_LENGTH)]),
-        // Bounded because the goal is interpolated verbatim into the AI prompt; the server drops
-        // anything past the same cap rather than truncating it mid-sentence.
-        aiPrompt: new FormControl('', [Validators.maxLength(MEETING_AGENDA_PROMPT_MAX_LENGTH)]),
+        // Deliberately unvalidated. `aiPrompt` is a scratch field that never reaches the save payload,
+        // but it lives in the group `validateForSubmit()` reads, so any validator here would block the
+        // meeting from saving over a value the meeting doesn't even carry. The cap is enforced where it
+        // can't do that damage: `maxlength` on the textarea (untypeable) and a server-side drop.
+        aiPrompt: new FormControl(''),
         startDate: new FormControl(defaultDateTime.date, [Validators.required]),
         startTime: new FormControl(defaultDateTime.time, [Validators.required]),
         duration: new FormControl(DEFAULT_DURATION, [Validators.required]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/meeting-composer-form.service.ts
@@ -615,10 +615,13 @@ export class MeetingComposerFormService {
 
         title: new FormControl('', [Validators.required]),
         description: new FormControl('', [Validators.maxLength(MEETING_AGENDA_MAX_LENGTH)]),
-        // Deliberately unvalidated. `aiPrompt` is a scratch field that never reaches the save payload,
-        // but it lives in the group `validateForSubmit()` reads, so any validator here would block the
-        // meeting from saving over a value the meeting doesn't even carry. The cap is enforced where it
-        // can't do that damage: `maxlength` on the textarea (untypeable) and a server-side drop.
+        // Deliberately carries no validator, and must stay that way. `aiPrompt` is a scratch field
+        // that never reaches the save payload, but it lives in the group `validateForSubmit()` reads,
+        // so a validator here would block the meeting from saving over a value the meeting doesn't
+        // even carry — with the Save button still enabled and no error UI to explain it. The cap is
+        // enforced where it can't do that damage: a native `maxlength` attribute on the textarea
+        // (see `TextareaComponent.maxlength`, bound as `[attr.maxlength]` precisely so it does not
+        // become a validator), and a server-side truncation in `MeetingController.readPromptField`.
         aiPrompt: new FormControl(''),
         startDate: new FormControl(defaultDateTime.date, [Validators.required]),
         startTime: new FormControl(defaultDateTime.time, [Validators.required]),

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
@@ -54,7 +54,9 @@
           [rows]="3"
           [maxlength]="promptMaxLength"
           data-testid="composer-agenda-ai-prompt" />
-        <p class="self-end text-xs text-gray-500" data-testid="composer-agenda-ai-prompt-counter">{{ aiPromptLength() }}/{{ promptMaxLength }}</p>
+        <p class="self-end text-xs" [ngClass]="aiPromptCounterClass()" data-testid="composer-agenda-ai-prompt-counter">
+          {{ aiPromptLength() }}/{{ promptMaxLength }}
+        </p>
 
         <div class="flex justify-end gap-2">
           <lfx-button

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
@@ -54,6 +54,7 @@
           [rows]="3"
           [maxlength]="promptMaxLength"
           data-testid="composer-agenda-ai-prompt" />
+        <p class="self-end text-xs text-gray-500" data-testid="composer-agenda-ai-prompt-counter">{{ aiPromptLength() }}/{{ promptMaxLength }}</p>
 
         <div class="flex justify-end gap-2">
           <lfx-button

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.html
@@ -52,6 +52,7 @@
           placeholder="e.g. Review Q3 roadmap progress and agree on the release date"
           styleClass="w-full"
           [rows]="3"
+          [maxlength]="promptMaxLength"
           data-testid="composer-agenda-ai-prompt" />
 
         <div class="flex justify-end gap-2">

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.spec.ts
@@ -1,0 +1,117 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MEETING_AGENDA_PROMPT_MAX_LENGTH, MEETING_AGENDA_PROMPT_WARNING_LENGTH } from '@lfx-one/shared/constants';
+import { CommitteeService } from '@services/committee.service';
+import { MeetingService } from '@services/meeting.service';
+import { PersonaService } from '@services/persona.service';
+import { ProjectContextService } from '@services/project-context.service';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { MeetingComposerFormService } from '../meeting-composer-form.service';
+import { ComposerAgendaResourcesComponent } from './composer-agenda-resources.component';
+
+/**
+ * Covers the AI helper's request guard, which is deliberately presence-only: the server truncates an
+ * over-budget descriptor rather than rejecting it, so nothing that passes here can fail there for
+ * length. A length check added on this side would re-open the dead end the truncation removed — an
+ * over-budget title with no goal would be refused locally with no way for the organizer to fix it.
+ *
+ * Also pins `aiPrompt` staying validator-free. It is a scratch field that never reaches the save
+ * payload, but it lives in the FormGroup `validateForSubmit()` reads over, so a validator here would
+ * disable Save with no error UI to explain why.
+ */
+describe('ComposerAgendaResourcesComponent — AI helper guard', () => {
+  let fixture: ComponentFixture<ComposerAgendaResourcesComponent>;
+  let component: ComposerAgendaResourcesComponent;
+  let formService: MeetingComposerFormService;
+  let generateAgenda: ReturnType<typeof vi.fn>;
+  let messageAdd: ReturnType<typeof vi.fn>;
+
+  const generate = (): void => component['onGenerateAgenda']();
+
+  beforeEach(async () => {
+    generateAgenda = vi.fn(() => of({ agenda: 'Roll call', estimatedDuration: 30 }));
+    messageAdd = vi.fn();
+
+    TestBed.configureTestingModule({
+      providers: [
+        MeetingComposerFormService,
+        { provide: MessageService, useValue: { add: messageAdd } },
+        { provide: CommitteeService, useValue: {} },
+        { provide: MeetingService, useValue: { generateAgenda } },
+        { provide: ProjectContextService, useValue: { activeContext: () => null, activeContextUid: () => null } },
+        { provide: PersonaService, useValue: { currentPersona: () => null } },
+        { provide: DialogService, useValue: { open: vi.fn() } },
+      ],
+    });
+    TestBed.overrideComponent(ComposerAgendaResourcesComponent, { set: { template: '', imports: [] } });
+
+    formService = TestBed.inject(MeetingComposerFormService);
+    formService.initialize({ mode: 'create', projectUid: 'project-1' });
+
+    fixture = TestBed.createComponent(ComposerAgendaResourcesComponent);
+    fixture.componentRef.setInput('form', formService.form());
+    component = fixture.componentInstance;
+    await fixture.whenStable();
+  });
+
+  it('refuses to call the endpoint with neither a title nor a goal', () => {
+    generate();
+
+    expect(generateAgenda).not.toHaveBeenCalled();
+    expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'warn' }));
+  });
+
+  it('sends an over-budget title rather than refusing it, since the server truncates', () => {
+    const title = 'y'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH + 50);
+    formService.form().get('title')?.setValue(title);
+
+    generate();
+
+    expect(generateAgenda).toHaveBeenCalledWith(expect.objectContaining({ title }));
+  });
+
+  it('sends an over-budget goal rather than refusing it', () => {
+    const context = 'x'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH + 50);
+    formService.form().get('aiPrompt')?.setValue(context);
+
+    generate();
+
+    expect(generateAgenda).toHaveBeenCalledWith(expect.objectContaining({ context }));
+  });
+
+  it('keeps the form valid with an over-budget aiPrompt, so Save stays live', () => {
+    formService.form().get('title')?.setValue('TAC Monthly');
+    formService
+      .form()
+      .get('aiPrompt')
+      ?.setValue('x'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH * 5));
+
+    expect(formService.form().get('aiPrompt')?.errors).toBeNull();
+    expect(formService.form().get('aiPrompt')?.valid).toBe(true);
+  });
+
+  it('counts the prompt characters for the cap indicator', () => {
+    formService.form().get('aiPrompt')?.setValue('Plan the Q3 release');
+
+    expect(component['aiPromptLength']()).toBe('Plan the Q3 release'.length);
+  });
+
+  it('escalates the prompt counter colour toward the cap', () => {
+    const prompt = formService.form().get('aiPrompt');
+
+    prompt?.setValue('x'.repeat(10));
+    expect(component['aiPromptCounterClass']()).toBe('text-gray-500');
+
+    prompt?.setValue('x'.repeat(MEETING_AGENDA_PROMPT_WARNING_LENGTH));
+    expect(component['aiPromptCounterClass']()).toBe('text-amber-600');
+
+    prompt?.setValue('x'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH));
+    expect(component['aiPromptCounterClass']()).toBe('text-red-600');
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -15,6 +15,7 @@ import {
   MAX_FILE_SIZE_MB,
   MEETING_AGENDA_MAX_LENGTH,
   MEETING_AGENDA_PROMPT_MAX_LENGTH,
+  MEETING_AGENDA_PROMPT_WARNING_LENGTH,
   MEETING_AGENDA_WARNING_LENGTH,
   MIN_CUSTOM_DURATION,
 } from '@lfx-one/shared/constants';
@@ -81,15 +82,14 @@ export class ComposerAgendaResourcesComponent {
     this.formService.revision();
     return (this.form().get('aiPrompt')?.value as string | null)?.length ?? 0;
   });
-  protected readonly agendaCounterClass: Signal<string> = computed(() => {
-    const length = this.agendaLength();
-
-    if (length >= MEETING_AGENDA_MAX_LENGTH) {
-      return 'text-red-600';
-    }
-
-    return length >= MEETING_AGENDA_WARNING_LENGTH ? 'text-amber-600' : 'text-gray-500';
-  });
+  protected readonly agendaCounterClass: Signal<string> = computed(() =>
+    this.counterClass(this.agendaLength(), MEETING_AGENDA_WARNING_LENGTH, MEETING_AGENDA_MAX_LENGTH)
+  );
+  // Same escalation as the agenda's counter two fields up. Without it the prompt counter reads a flat
+  // gray at the exact moment it matters — when the field has saturated and is dropping keystrokes.
+  protected readonly aiPromptCounterClass: Signal<string> = computed(() =>
+    this.counterClass(this.aiPromptLength(), MEETING_AGENDA_PROMPT_WARNING_LENGTH, MEETING_AGENDA_PROMPT_MAX_LENGTH)
+  );
   protected readonly pendingAttachments: Signal<PendingAttachment[]> = computed(() => {
     this.formService.revision();
     return (this.form().get('attachments')?.value as PendingAttachment[] | null) ?? [];
@@ -325,5 +325,14 @@ export class ComposerAgendaResourcesComponent {
     }
 
     return null;
+  }
+
+  /** Shared escalation for both character counters in this section: gray, amber near the cap, red at it. */
+  private counterClass(length: number, warnAt: number, max: number): string {
+    if (length >= max) {
+      return 'text-red-600';
+    }
+
+    return length >= warnAt ? 'text-amber-600' : 'text-gray-500';
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -14,6 +14,7 @@ import {
   MAX_FILE_SIZE_BYTES,
   MAX_FILE_SIZE_MB,
   MEETING_AGENDA_MAX_LENGTH,
+  MEETING_AGENDA_PROMPT_MAX_LENGTH,
   MEETING_AGENDA_WARNING_LENGTH,
   MIN_CUSTOM_DURATION,
 } from '@lfx-one/shared/constants';
@@ -53,6 +54,9 @@ export class ComposerAgendaResourcesComponent {
   public readonly form = input.required<FormGroup>();
 
   protected readonly agendaMaxLength = MEETING_AGENDA_MAX_LENGTH;
+  /** Hard cap on the AI goal. Enforced on the input rather than as a validator — see the control's
+   * declaration in `MeetingComposerFormService`: a validator here would block the meeting save. */
+  protected readonly promptMaxLength = MEETING_AGENDA_PROMPT_MAX_LENGTH;
   protected readonly maxFileSizeBytes = MAX_FILE_SIZE_BYTES;
   protected readonly acceptString = generateAcceptString();
   protected readonly acceptedTypesDisplay = getAcceptedFileTypesDisplay();
@@ -133,10 +137,11 @@ export class ComposerAgendaResourcesComponent {
     const meetingType = this.meetingType();
     const project = this.projectContextService.activeContext();
 
-    // A title or a goal — whichever the organizer has — is enough. The section rail can jump here
-    // before Details & Access is filled in, so the type and project may legitimately be missing;
-    // the backend drops absent descriptors from the prompt rather than rejecting the request. This
-    // guard deliberately mirrors the server's `!title && !context` contract.
+    // A title or a goal — whichever the organizer has — is enough. Edit mode drops the rail's
+    // section locking entirely, so the organizer can be standing here having just cleared the title;
+    // the project also resolves asynchronously and may not be there yet. The backend drops absent
+    // descriptors from the prompt rather than rejecting the request. This guard deliberately mirrors
+    // the server's `!title && !context` contract.
     if (!context && !title) {
       this.messageService.add({
         severity: 'warn',

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -54,8 +54,10 @@ export class ComposerAgendaResourcesComponent {
   public readonly form = input.required<FormGroup>();
 
   protected readonly agendaMaxLength = MEETING_AGENDA_MAX_LENGTH;
-  /** Hard cap on the AI goal. Enforced on the input rather than as a validator — see the control's
-   * declaration in `MeetingComposerFormService`: a validator here would block the meeting save. */
+  /** Hard cap on the AI goal. Enforced as a native `maxlength` attribute on the textarea and again by
+   * the server, which truncates an over-budget descriptor rather than dropping it — never as a
+   * validator: see the control's declaration in `MeetingComposerFormService` for why a validator on
+   * this scratch field would silently block the meeting save. */
   protected readonly promptMaxLength = MEETING_AGENDA_PROMPT_MAX_LENGTH;
   protected readonly maxFileSizeBytes = MAX_FILE_SIZE_BYTES;
   protected readonly acceptString = generateAcceptString();
@@ -72,6 +74,12 @@ export class ComposerAgendaResourcesComponent {
   protected readonly agendaLength: Signal<number> = computed(() => {
     this.formService.revision();
     return (this.form().get('description')?.value as string | null)?.length ?? 0;
+  });
+  // The prompt cap is a native attribute with no validator behind it, so without a counter the field
+  // just stops accepting characters with nothing to explain why.
+  protected readonly aiPromptLength: Signal<number> = computed(() => {
+    this.formService.revision();
+    return (this.form().get('aiPrompt')?.value as string | null)?.length ?? 0;
   });
   protected readonly agendaCounterClass: Signal<string> = computed(() => {
     const length = this.agendaLength();
@@ -139,9 +147,10 @@ export class ComposerAgendaResourcesComponent {
 
     // A title or a goal — whichever the organizer has — is enough. Edit mode drops the rail's
     // section locking entirely, so the organizer can be standing here having just cleared the title;
-    // the project also resolves asynchronously and may not be there yet. The backend drops absent
-    // descriptors from the prompt rather than rejecting the request. This guard deliberately mirrors
-    // the server's `!title && !context` contract.
+    // the project also resolves asynchronously and may not be there yet. The backend omits absent
+    // descriptors from the prompt and truncates over-budget ones rather than rejecting the request, so
+    // this presence-only guard mirrors the server's `!title && !context` contract exactly — nothing
+    // that passes here can fail there for length.
     if (!context && !title) {
       this.messageService.add({
         severity: 'warn',

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -128,19 +128,20 @@ export class ComposerAgendaResourcesComponent {
 
   protected onGenerateAgenda(): void {
     const form = this.form();
-    const context = form.get('aiPrompt')?.value as string | null;
-    const title = form.get('title')?.value as string | null;
+    const context = (form.get('aiPrompt')?.value as string | null)?.trim() || null;
+    const title = (form.get('title')?.value as string | null)?.trim() || null;
     const meetingType = this.meetingType();
     const project = this.projectContextService.activeContext();
 
-    // Only a goal is strictly required — the helper is reachable from any section (and from Quick
-    // create), so the title, type, and project may legitimately not be filled in yet. The backend
-    // drops the missing descriptors from the prompt rather than rejecting the request.
-    if (!context) {
+    // A title or a goal — whichever the organizer has — is enough. The section rail can jump here
+    // before Details & Access is filled in, so the type and project may legitimately be missing;
+    // the backend drops absent descriptors from the prompt rather than rejecting the request. This
+    // guard deliberately mirrors the server's `!title && !context` contract.
+    if (!context && !title) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Missing information',
-        detail: 'Describe what the meeting is for before generating an agenda.',
+        detail: 'Add a meeting title, or describe what the meeting is for, before generating an agenda.',
       });
       return;
     }
@@ -149,7 +150,7 @@ export class ComposerAgendaResourcesComponent {
       ...(meetingType ? { meetingType } : {}),
       ...(title ? { title } : {}),
       ...(project ? { projectName: project.name } : {}),
-      context,
+      ...(context ? { context } : {}),
       maxCharacters: MEETING_AGENDA_MAX_LENGTH,
     };
 

--- a/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-composer/sections/composer-agenda-resources.component.ts
@@ -133,16 +133,25 @@ export class ComposerAgendaResourcesComponent {
     const meetingType = this.meetingType();
     const project = this.projectContextService.activeContext();
 
-    if (!project || !title || !meetingType || !context) {
+    // Only a goal is strictly required — the helper is reachable from any section (and from Quick
+    // create), so the title, type, and project may legitimately not be filled in yet. The backend
+    // drops the missing descriptors from the prompt rather than rejecting the request.
+    if (!context) {
       this.messageService.add({
         severity: 'warn',
         summary: 'Missing information',
-        detail: 'Add the meeting title and type, and describe the goal, before generating an agenda.',
+        detail: 'Describe what the meeting is for before generating an agenda.',
       });
       return;
     }
 
-    const request: GenerateAgendaRequest = { meetingType, title, projectName: project.name, context, maxCharacters: MEETING_AGENDA_MAX_LENGTH };
+    const request: GenerateAgendaRequest = {
+      ...(meetingType ? { meetingType } : {}),
+      ...(title ? { title } : {}),
+      ...(project ? { projectName: project.name } : {}),
+      context,
+      maxCharacters: MEETING_AGENDA_MAX_LENGTH,
+    };
 
     this.isGeneratingAgenda.set(true);
     this.meetingService

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
@@ -12,6 +12,6 @@
     [readonly]="readonly()"
     [class]="styleClass()"
     [autoResize]="autoResize()"
-    [maxlength]="maxlength() || null"
+    [attr.maxlength]="maxlength() || null"
     [attr.data-test]="dataTest()"></textarea>
 </ng-container>

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.spec.ts
@@ -15,7 +15,11 @@ import { TextareaComponent } from './textarea.component';
  * silently attaches a validator to the *caller's* control — a caller that only wanted the browser to
  * stop accepting characters ends up with an invalid `FormGroup` and, in the composer's case, a Save
  * button that does nothing with no error UI to explain it. `[attr.maxlength]` sets the attribute
- * without the directive. These specs fail if the property binding ever comes back.
+ * without the directive.
+ *
+ * The regression guard is specifically `leaves the control valid at a value over the cap`. Angular
+ * reflects a property-bound `maxlength` to the attribute as well, so the attribute assertions below
+ * pass either way — they pin the rendered contract, not the absence of the validator.
  */
 describe('TextareaComponent — maxlength', () => {
   const CAP = 1000;

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.spec.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.spec.ts
@@ -1,0 +1,62 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { FormControl, FormGroup } from '@angular/forms';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { TextareaComponent } from './textarea.component';
+
+/**
+ * Guards the `maxlength` binding, which is a footgun this wrapper has already stepped on once.
+ *
+ * Angular's `MaxLengthValidator` has selector `[maxlength][formControlName]` and ships inside the
+ * `ReactiveFormsModule` this component imports, so binding `[maxlength]` on the inner `<textarea>`
+ * silently attaches a validator to the *caller's* control — a caller that only wanted the browser to
+ * stop accepting characters ends up with an invalid `FormGroup` and, in the composer's case, a Save
+ * button that does nothing with no error UI to explain it. `[attr.maxlength]` sets the attribute
+ * without the directive. These specs fail if the property binding ever comes back.
+ */
+describe('TextareaComponent — maxlength', () => {
+  const CAP = 1000;
+
+  let fixture: ComponentFixture<TextareaComponent>;
+  let form: FormGroup;
+
+  const textarea = (): HTMLTextAreaElement => {
+    const el = fixture.nativeElement.querySelector('textarea');
+    if (!el) throw new Error('no textarea rendered');
+    return el as HTMLTextAreaElement;
+  };
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [TextareaComponent] }).compileComponents();
+
+    form = new FormGroup({ notes: new FormControl('') });
+
+    fixture = TestBed.createComponent(TextareaComponent);
+    fixture.componentRef.setInput('form', form);
+    fixture.componentRef.setInput('control', 'notes');
+    fixture.componentRef.setInput('maxlength', CAP);
+    await fixture.whenStable();
+  });
+
+  it('renders the cap as a native attribute', () => {
+    expect(textarea().getAttribute('maxlength')).toBe(String(CAP));
+  });
+
+  it('leaves the control valid at a value over the cap', async () => {
+    form.get('notes')?.setValue('a'.repeat(CAP + 1));
+    await fixture.whenStable();
+
+    expect(form.get('notes')?.errors).toBeNull();
+    expect(form.valid).toBe(true);
+  });
+
+  it('omits the attribute entirely when no cap is set', async () => {
+    fixture.componentRef.setInput('maxlength', undefined);
+    await fixture.whenStable();
+
+    expect(textarea().hasAttribute('maxlength')).toBe(false);
+  });
+});

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -22,6 +22,14 @@ export class TextareaComponent {
   public readonly = input<boolean>(false);
   public styleClass = input<string>();
   public autoResize = input<boolean>(false);
+  /**
+   * Native character cap on the `<textarea>`. Bound as `[attr.maxlength]`, not `[maxlength]`:
+   * Angular's `MaxLengthValidator` has selector `[maxlength][formControlName]` and ships in the
+   * `ReactiveFormsModule` this component imports, so a property binding here would silently attach
+   * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
+   * caller that only wanted the browser to stop typing at the cap. Callers that want the value
+   * gated declare `Validators.maxLength` on the control themselves.
+   */
   public maxlength = input<number>();
   public dataTest = input<string>();
 }

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -28,7 +28,9 @@ export class TextareaComponent {
    * `ReactiveFormsModule` this component imports, so a property binding here would silently attach
    * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
    * caller that only wanted the browser to stop typing at the cap. Callers that want the value
-   * gated declare `Validators.maxLength` on the control themselves.
+   * gated declare `Validators.maxLength` on the control themselves — as the composer's agenda and
+   * the settings description do. The rest rely on the native cap alone, which holds for typing and
+   * pasting but not for a value written programmatically with `setValue`.
    */
   public maxlength = input<number>();
   public dataTest = input<string>();

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -531,9 +531,12 @@ export class MeetingService {
    * it to the v1 SFID upstream expects; the other `committee_*` fields are response-only enrichment
    * and are deliberately dropped.
    *
-   * A direct guest omits the key rather than sending `null` — upstream declares the field a
-   * non-nullable optional `string`. The BFF drops a stray `null` anyway, but relying on that would
-   * mean shipping an off-contract body and trusting the proxy to launder it.
+   * Every optional string is omitted when empty rather than sent as `null`: upstream declares
+   * `committee_uid`, `job_title` and `org` alike as non-nullable optional `string`s
+   * (`CreateItxRegistrantRequestBody`). The BFF drops a stray `null` anyway, but relying on that
+   * would mean shipping an off-contract body and trusting the proxy to launder it. The create body
+   * has nothing to clear, so omission loses no meaning — unlike {@link getChangedFields}, where
+   * `null` is how an update erases a stored value.
    */
   public stripMetadata(meetingUid: string, registrant: MeetingRegistrantWithState): CreateMeetingRegistrantRequest {
     return {
@@ -542,8 +545,8 @@ export class MeetingService {
       first_name: registrant.first_name,
       last_name: registrant.last_name,
       host: registrant.host || false,
-      job_title: registrant.job_title || null,
-      org_name: registrant.org_name || null,
+      ...(registrant.job_title ? { job_title: registrant.job_title } : {}),
+      ...(registrant.org_name ? { org_name: registrant.org_name } : {}),
       ...(registrant.committee_uid ? { committee_uid: registrant.committee_uid } : {}),
     };
   }

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -361,9 +361,10 @@ export class MeetingService {
 
   /**
    * `includeCommittee` opts into committee enrichment (`committee_name`, `committee_role`,
-   * `committee_category`, `committee_voting_status`, `committee_appointed_by`). It costs a
-   * per-committee fan-out upstream, so it stays opt-in for the callers that actually render group
-   * attribution — the composer's Guests list.
+   * `committee_category`, `committee_voting_status`, `committee_appointed_by`), and normalizes
+   * `committee_uid` from the upstream v1 SFID to the v2 UID. It costs the BFF a per-committee fan-out
+   * to the committee service, so it stays opt-in for the callers that actually need group attribution:
+   * the composer's Guests list, and the registrants display's group filter.
    */
   public getMeetingRegistrants(
     meetingUid: string,
@@ -529,6 +530,10 @@ export class MeetingService {
    * is persisted as `type: 'committee'` upstream instead of collapsing to `direct`. The BFF resolves
    * it to the v1 SFID upstream expects; the other `committee_*` fields are response-only enrichment
    * and are deliberately dropped.
+   *
+   * A direct guest omits the key rather than sending `null` — upstream declares the field a
+   * non-nullable optional `string`. The BFF drops a stray `null` anyway, but relying on that would
+   * mean shipping an off-contract body and trusting the proxy to launder it.
    */
   public stripMetadata(meetingUid: string, registrant: MeetingRegistrantWithState): CreateMeetingRegistrantRequest {
     return {
@@ -539,7 +544,7 @@ export class MeetingService {
       host: registrant.host || false,
       job_title: registrant.job_title || null,
       org_name: registrant.org_name || null,
-      committee_uid: registrant.committee_uid || null,
+      ...(registrant.committee_uid ? { committee_uid: registrant.committee_uid } : {}),
     };
   }
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -90,6 +90,47 @@ describe('MeetingController', () => {
     next = vi.fn();
   });
 
+  describe('generateAgenda', () => {
+    beforeEach(() => {
+      aiSvc.generateMeetingAgenda.mockResolvedValue({ agenda: 'Roll call', estimatedDuration: 30 });
+    });
+
+    // GH-1464: the composer surfaces the helper from any section and from Quick create, so it can
+    // be invoked before a title / type / project exist. Those must not be hard requirements.
+    it('generates from a free-text goal alone, with no title, type, or project', async () => {
+      const req = buildReq({ body: { context: 'Plan the Q3 release' } });
+
+      await controller.generateAgenda(req, buildRes(), next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(
+        req,
+        expect.objectContaining({ context: 'Plan the Q3 release', title: undefined, meetingType: undefined, projectName: undefined })
+      );
+    });
+
+    it('generates from a title alone, with no goal', async () => {
+      await controller.generateAgenda(buildReq({ body: { title: 'TAC Monthly' } }), buildRes(), next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ title: 'TAC Monthly' }));
+    });
+
+    it('rejects only when neither a title nor a goal is provided', async () => {
+      await controller.generateAgenda(buildReq({ body: { projectName: 'ASWF' } }), buildRes(), next);
+
+      expect(aiSvc.generateMeetingAgenda).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+    });
+
+    // The controller used to drop maxCharacters, so the client's agenda cap never reached the model.
+    it('forwards the caller-supplied maxCharacters cap', async () => {
+      await controller.generateAgenda(buildReq({ body: { title: 'TAC Monthly', maxCharacters: 1200 } }), buildRes(), next);
+
+      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ maxCharacters: 1200 }));
+    });
+  });
+
   describe('addMeetingRegistrants', () => {
     beforeEach(() => {
       meetingSvc.addMeetingRegistrant.mockImplementation((_req: Request, registrant: Record<string, unknown>) => Promise.resolve(registrant));

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -144,17 +144,30 @@ describe('MeetingController', () => {
       expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ title: 'TAC Monthly', context: 'Plan Q3' }));
     });
 
-    // An over-long goal is dropped, not truncated — half a sentence is a worse prompt than none.
-    it('drops a goal that exceeds the prompt budget', async () => {
-      const req = buildReq({ body: { title: 'TAC Monthly', context: 'x'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH + 1) } });
+    // An over-budget descriptor is truncated, not dropped. Dropping made the endpoint's contract
+    // impossible for the client to satisfy: the client guard tests for the *presence* of a title or
+    // goal, so an over-budget title with no goal passed the client and then failed `!title && !context`
+    // here as an unfixable "could not generate an agenda".
+    it('truncates a goal that exceeds the prompt budget instead of dropping it', async () => {
+      const req = buildReq({ body: { title: 'TAC Monthly', context: 'x'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH + 50) } });
 
       await controller.generateAgenda(req, buildRes(), next);
 
-      // Asserted on the actual argument rather than `objectContaining({ context: undefined })`,
-      // which would also pass if the key were present with a real value stripped elsewhere.
+      // Asserted on the actual argument rather than `objectContaining`, which would also pass if the
+      // key were present with a value stripped elsewhere.
       const [, request] = aiSvc.generateMeetingAgenda.mock.calls[0];
-      expect(request.context).toBeUndefined();
+      expect(request.context).toBe('x'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH));
       expect(request.title).toBe('TAC Monthly');
+    });
+
+    it('truncates an over-budget title and still generates when it is the only descriptor', async () => {
+      const req = buildReq({ body: { title: 'y'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH + 50) } });
+
+      await controller.generateAgenda(req, buildRes(), next);
+
+      expect(next).not.toHaveBeenCalled();
+      const [, request] = aiSvc.generateMeetingAgenda.mock.calls[0];
+      expect(request.title).toBe('y'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH));
     });
 
     // The controller used to drop maxCharacters, so the client's agenda cap never reached the model.
@@ -173,7 +186,7 @@ describe('MeetingController', () => {
       ['a negative value', -1, MEETING_AGENDA_MAX_LENGTH],
       ['a zero cap', 0, MEETING_AGENDA_MAX_LENGTH],
       ['a fractional value', 900.7, 900],
-    ])('clamps %s to a usable agenda cap', async (_label, supplied, expected) => {
+    ])('resolves %s to a usable agenda cap', async (_label, supplied, expected) => {
       await controller.generateAgenda(buildReq({ body: { title: 'TAC Monthly', maxCharacters: supplied } }), buildRes(), next);
 
       expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ maxCharacters: expected }));

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -31,7 +31,13 @@ vi.mock('@lfx-one/shared/enums', () => ({}));
 // Literals rather than the consts above: `vi.mock` factories are hoisted, so they can't close over
 // module-level bindings. Kept in sync with `MEETING_AGENDA_*` in the shared constants barrel.
 vi.mock('@lfx-one/shared/constants', () => ({ MEETING_AGENDA_MAX_LENGTH: 2000, MEETING_AGENDA_PROMPT_MAX_LENGTH: 1000 }));
-vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null) }));
+// `truncateToUtf16Units` is the real implementation: the truncation assertions below are about what
+// the controller sends upstream, so stubbing it would test the stub. `string.utils` has no imports of
+// its own, so pulling it in directly doesn't drag the aliased barrel's graph along.
+vi.mock('@lfx-one/shared/utils', async () => ({
+  resolveMeetingOrganizer: vi.fn(() => null),
+  truncateToUtf16Units: (await import('../../../../../packages/shared/src/utils/string.utils')).truncateToUtf16Units,
+}));
 
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
 vi.mock('../helpers/meeting.helper', () => ({

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -102,8 +102,9 @@ describe('MeetingController', () => {
       aiSvc.generateMeetingAgenda.mockResolvedValue({ agenda: 'Roll call', estimatedDuration: 30 });
     });
 
-    // GH-1464: the composer's section rail can jump to Agenda & Resources before Details & Access
-    // is filled in, so a title / type / project may not exist yet. Those must not be requirements.
+    // GH-1464: in edit mode the rail imposes no section locking, so the organizer can reach Agenda &
+    // Resources with the title cleared; the project context also resolves asynchronously. A title /
+    // type / project must therefore not be requirements.
     it('generates from a free-text goal alone, with no title, type, or project', async () => {
       const req = buildReq({ body: { context: 'Plan the Q3 release' } });
 
@@ -149,7 +150,11 @@ describe('MeetingController', () => {
 
       await controller.generateAgenda(req, buildRes(), next);
 
-      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ context: undefined }));
+      // Asserted on the actual argument rather than `objectContaining({ context: undefined })`,
+      // which would also pass if the key were present with a real value stripped elsewhere.
+      const [, request] = aiSvc.generateMeetingAgenda.mock.calls[0];
+      expect(request.context).toBeUndefined();
+      expect(request.title).toBe('TAC Monthly');
     });
 
     // The controller used to drop maxCharacters, so the client's agenda cap never reached the model.
@@ -165,7 +170,9 @@ describe('MeetingController', () => {
       ['a non-numeric value', 'abc', MEETING_AGENDA_MAX_LENGTH],
       ['an absent value', undefined, MEETING_AGENDA_MAX_LENGTH],
       ['a value above the agenda cap', MEETING_AGENDA_MAX_LENGTH + 500, MEETING_AGENDA_MAX_LENGTH],
-      ['a negative value', -1, 1],
+      ['a negative value', -1, MEETING_AGENDA_MAX_LENGTH],
+      ['a zero cap', 0, MEETING_AGENDA_MAX_LENGTH],
+      ['a fractional value', 900.7, 900],
     ])('clamps %s to a usable agenda cap', async (_label, supplied, expected) => {
       await controller.generateAgenda(buildReq({ body: { title: 'TAC Monthly', maxCharacters: supplied } }), buildRes(), next);
 
@@ -189,13 +196,25 @@ describe('MeetingController', () => {
       expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ committee_uid: V1_COMMITTEE_SFID }));
     });
 
+    // The key is deleted, not nulled: upstream declares `committee_uid` a non-nullable optional
+    // `string`, so omission is on-contract and an explicit `null` is not.
     it('strips an unresolvable committee_uid rather than forwarding a v2 UID upstream', async () => {
       resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map());
       const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: V2_COMMITTEE_UID }] });
 
       await controller.addMeetingRegistrants(req, buildRes(), next);
 
-      expect(meetingSvc.addMeetingRegistrant).toHaveBeenCalledWith(req, expect.objectContaining({ committee_uid: null }));
+      const [, forwarded] = meetingSvc.addMeetingRegistrant.mock.calls[0];
+      expect(forwarded).not.toHaveProperty('committee_uid');
+    });
+
+    it('drops a client-sent null committee_uid instead of proxying it upstream', async () => {
+      const req = buildReq({ body: [{ email: 'a@example.com', committee_uid: null }] });
+
+      await controller.addMeetingRegistrants(req, buildRes(), next);
+
+      const [, forwarded] = meetingSvc.addMeetingRegistrant.mock.calls[0];
+      expect(forwarded).not.toHaveProperty('committee_uid');
     });
 
     it('skips the mapping lookup entirely for directly-added guests', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -4,6 +4,11 @@
 import type { NextFunction, Request, Response } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Mirrors of the real `@lfx-one/shared/constants` values — the barrel is stubbed below, so these
+// are what the controller under test actually reads.
+const MEETING_AGENDA_MAX_LENGTH = 2000;
+const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
+
 const MEETING_ID = 'meeting-1111';
 const V2_COMMITTEE_UID = 'cmte-v2-aaaa';
 const V1_COMMITTEE_SFID = 'a09v1SFIDaaaa';
@@ -23,7 +28,9 @@ const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock } = v
 // imports as types — stub the barrels so their runtime module graphs never load.
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
 vi.mock('@lfx-one/shared/enums', () => ({}));
-vi.mock('@lfx-one/shared/constants', () => ({}));
+// Literals rather than the consts above: `vi.mock` factories are hoisted, so they can't close over
+// module-level bindings. Kept in sync with `MEETING_AGENDA_*` in the shared constants barrel.
+vi.mock('@lfx-one/shared/constants', () => ({ MEETING_AGENDA_MAX_LENGTH: 2000, MEETING_AGENDA_PROMPT_MAX_LENGTH: 1000 }));
 vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null) }));
 
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
@@ -95,8 +102,8 @@ describe('MeetingController', () => {
       aiSvc.generateMeetingAgenda.mockResolvedValue({ agenda: 'Roll call', estimatedDuration: 30 });
     });
 
-    // GH-1464: the composer surfaces the helper from any section and from Quick create, so it can
-    // be invoked before a title / type / project exist. Those must not be hard requirements.
+    // GH-1464: the composer's section rail can jump to Agenda & Resources before Details & Access
+    // is filled in, so a title / type / project may not exist yet. Those must not be requirements.
     it('generates from a free-text goal alone, with no title, type, or project', async () => {
       const req = buildReq({ body: { context: 'Plan the Q3 release' } });
 
@@ -123,11 +130,46 @@ describe('MeetingController', () => {
       expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
     });
 
+    it('rejects a whitespace-only title and goal rather than prompting on blanks', async () => {
+      await controller.generateAgenda(buildReq({ body: { title: '   ', context: '\n\t' } }), buildRes(), next);
+
+      expect(aiSvc.generateMeetingAgenda).not.toHaveBeenCalled();
+      expect(next).toHaveBeenCalledWith(expect.any(FakeValidationError));
+    });
+
+    it('trims the descriptors it forwards, since both land verbatim in the prompt', async () => {
+      await controller.generateAgenda(buildReq({ body: { title: '  TAC Monthly  ', context: ' Plan Q3 ' } }), buildRes(), next);
+
+      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ title: 'TAC Monthly', context: 'Plan Q3' }));
+    });
+
+    // An over-long goal is dropped, not truncated — half a sentence is a worse prompt than none.
+    it('drops a goal that exceeds the prompt budget', async () => {
+      const req = buildReq({ body: { title: 'TAC Monthly', context: 'x'.repeat(MEETING_AGENDA_PROMPT_MAX_LENGTH + 1) } });
+
+      await controller.generateAgenda(req, buildRes(), next);
+
+      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ context: undefined }));
+    });
+
     // The controller used to drop maxCharacters, so the client's agenda cap never reached the model.
     it('forwards the caller-supplied maxCharacters cap', async () => {
       await controller.generateAgenda(buildReq({ body: { title: 'TAC Monthly', maxCharacters: 1200 } }), buildRes(), next);
 
       expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ maxCharacters: 1200 }));
+    });
+
+    // maxCharacters reaches the model twice — as the response schema's maxLength and inside the
+    // prompt — so an unvalidated body value would surface as an opaque upstream failure.
+    it.each([
+      ['a non-numeric value', 'abc', MEETING_AGENDA_MAX_LENGTH],
+      ['an absent value', undefined, MEETING_AGENDA_MAX_LENGTH],
+      ['a value above the agenda cap', MEETING_AGENDA_MAX_LENGTH + 500, MEETING_AGENDA_MAX_LENGTH],
+      ['a negative value', -1, 1],
+    ])('clamps %s to a usable agenda cap', async (_label, supplied, expected) => {
+      await controller.generateAgenda(buildReq({ body: { title: 'TAC Monthly', maxCharacters: supplied } }), buildRes(), next);
+
+      expect(aiSvc.generateMeetingAgenda).toHaveBeenCalledWith(expect.anything(), expect.objectContaining({ maxCharacters: expected }));
     });
   });
 
@@ -185,6 +227,16 @@ describe('MeetingController', () => {
       await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
 
       expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ committee_name: 'TAC', committee_role: 'Chair', committee_category: 'Technical' })]);
+    });
+
+    // Upstream stores the v1 SFID, but every client-side comparison (and the create path) works in
+    // v2 UIDs — handing back the SFID would make one field mean two things by direction.
+    it('normalizes the enriched committee_uid from the v1 SFID back to the v2 UID', async () => {
+      const res = buildRes();
+
+      await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ committee_uid: V2_COMMITTEE_UID })]);
     });
 
     it('leaves registrants unenriched by default, without fetching the meeting', async () => {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -19,6 +19,7 @@ import {
   UpdateMeetingRegistrantRequest,
   UpdateMeetingRequest,
 } from '@lfx-one/shared/interfaces';
+import { truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
@@ -577,8 +578,20 @@ export class MeetingController {
           registrant_count: registrants.length,
         });
 
-        // Enrich committee registrant data with committee details and member info
-        const enrichedRegistrants = await this.enrichCommitteeRegistrants(req, meeting, registrants);
+        // Enrich committee registrant data with committee details and member info. Degrades to
+        // unenriched rows rather than failing the listing, matching `getMeetingRegistrants` — group
+        // attribution is decoration, and `resolveV2ToV1CommitteeMappings` goes over NATS, so a
+        // transient committee-service problem shouldn't cost the organizer the guest list. The
+        // interface docstring on `MeetingRegistrant.committee_uid` promises this on both paths.
+        let enrichedRegistrants = registrants;
+        try {
+          enrichedRegistrants = await this.enrichCommitteeRegistrants(req, meeting, registrants);
+        } catch (error) {
+          logger.warning(req, 'get_my_meeting_registrants', 'Committee enrichment failed, returning unenriched registrants', {
+            meeting_id: uid,
+            err: error,
+          });
+        }
 
         logger.success(req, 'get_my_meeting_registrants', startTime, {
           meeting_id: uid,
@@ -1516,12 +1529,18 @@ export class MeetingController {
       // written against a shortened descriptor — so log it. Derived by comparing what arrived against
       // what `readPromptField` kept rather than re-testing the budget here, so the threshold lives in
       // exactly one place. Lengths only: the values themselves are user content.
+      // One flatMap rather than filter-then-map so the narrowing survives into the payload — the
+      // separated form needs a cast and an optional chain for facts the filter already established.
       const truncated = [
         { field: 'title', raw: rawTitle, kept: title },
         { field: 'context', raw: rawContext, kept: context },
-      ]
-        .filter(({ raw, kept }) => typeof raw === 'string' && kept !== undefined && raw.trim().length > kept.length)
-        .map(({ field, raw, kept }) => ({ field, from: (raw as string).trim().length, to: kept?.length }));
+      ].flatMap(({ field, raw, kept }) => {
+        if (typeof raw !== 'string' || kept === undefined) {
+          return [];
+        }
+        const from = raw.trim().length;
+        return from > kept.length ? [{ field, from, to: kept.length }] : [];
+      });
 
       if (truncated.length > 0) {
         logger.warning(req, 'generate_agenda', 'Truncated an over-budget prompt descriptor', {
@@ -1897,7 +1916,7 @@ export class MeetingController {
       return undefined;
     }
 
-    return trimmed.length > MEETING_AGENDA_PROMPT_MAX_LENGTH ? trimmed.slice(0, MEETING_AGENDA_PROMPT_MAX_LENGTH) : trimmed;
+    return truncateToUtf16Units(trimmed, MEETING_AGENDA_PROMPT_MAX_LENGTH);
   }
 
   /**

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { MEETING_AGENDA_MAX_LENGTH, MEETING_AGENDA_PROMPT_MAX_LENGTH } from '@lfx-one/shared/constants';
 import {
   AttachmentCategory,
   BatchRegistrantOperationResponse,
@@ -412,7 +413,7 @@ export class MeetingController {
         } catch (error) {
           logger.warning(req, 'get_meeting_registrants', 'Committee enrichment failed, returning unenriched registrants', {
             meeting_id: uid,
-            error: error instanceof Error ? error.message : 'Unknown error',
+            err: error,
           });
         }
       }
@@ -1493,16 +1494,20 @@ export class MeetingController {
     });
 
     try {
-      const { meetingType, title, projectName, context, maxCharacters } = req.body;
+      const { meetingType, projectName, maxCharacters } = req.body;
+      // The composer's section rail lets the organizer reach Agenda & Resources before Details &
+      // Access is filled in, so a title / type / project are not guaranteed to exist yet. Only
+      // require enough signal to write a useful agenda — a title or a free-text goal — and let the
+      // prompt builder omit the rest. Both are trimmed first: whitespace is not signal, and both
+      // land verbatim in the model prompt.
+      const title = MeetingController.readPromptField(req.body['title']);
+      const context = MeetingController.readPromptField(req.body['context']);
 
-      // The composer reaches this helper from any section and from Quick create, so title / type /
-      // project are not guaranteed to be filled in yet. Only require enough signal to write a
-      // useful agenda — a title or a free-text context — and let the prompt builder omit the rest.
       if (!title && !context) {
         const validationError = ServiceValidationError.fromFieldErrors(
           {
-            title: 'Provide a meeting title or describe what the meeting is for',
-            context: 'Provide a meeting title or describe what the meeting is for',
+            title: `Provide a meeting title (max ${MEETING_AGENDA_PROMPT_MAX_LENGTH} characters) or describe what the meeting is for`,
+            context: `Describe what the meeting is for (max ${MEETING_AGENDA_PROMPT_MAX_LENGTH} characters) or provide a meeting title`,
           },
           'Agenda generation validation failed',
           {
@@ -1520,7 +1525,7 @@ export class MeetingController {
         title,
         projectName,
         context,
-        maxCharacters,
+        maxCharacters: MeetingController.clampAgendaMaxCharacters(maxCharacters),
       });
 
       // Usage telemetry: the helper is far more discoverable in the composer than it was in the
@@ -1765,6 +1770,11 @@ export class MeetingController {
 
       return {
         ...registrant,
+        // Hand the client back the v2 UID it works in. Upstream stores the v1 SFID, but the composer
+        // compares this field against `meeting.committees[].uid` (v2) and sends it back on create,
+        // where `resolveRegistrantCommitteeUids` expects v2 — leaving the SFID here would mean the
+        // same field carries two identifier spaces depending on which direction it was travelling.
+        committee_uid: v2Uid,
         // Committee details
         committee_name: committee?.name || null,
         committee_category: committee?.category || null,
@@ -1830,5 +1840,36 @@ export class MeetingController {
 
       return { ...registrant, committee_uid: v2ToV1Map.get(registrant.committee_uid) ?? null };
     });
+  }
+
+  /**
+   * Normalizes a free-text field that will be interpolated into an AI prompt.
+   * Anything that isn't a non-empty string once trimmed, or that exceeds the prompt budget, is
+   * dropped rather than truncated — a half-sentence goal produces a worse agenda than no goal.
+   */
+  private static readPromptField(value: unknown): string | undefined {
+    if (typeof value !== 'string') {
+      return undefined;
+    }
+
+    const trimmed = value.trim();
+
+    return trimmed.length > 0 && trimmed.length <= MEETING_AGENDA_PROMPT_MAX_LENGTH ? trimmed : undefined;
+  }
+
+  /**
+   * Clamps the caller-supplied agenda cap into the range the agenda field actually accepts.
+   * The value reaches the model twice — as `maxLength` in the response schema and interpolated into
+   * the prompt — so an unvalidated `-1` / `"abc"` / `{}` off the request body would either produce an
+   * opaque upstream 500 or let a caller ask for an agenda the `description` control can't hold.
+   */
+  private static clampAgendaMaxCharacters(value: unknown): number {
+    const parsed = typeof value === 'number' ? value : Number.NaN;
+
+    if (!Number.isFinite(parsed)) {
+      return MEETING_AGENDA_MAX_LENGTH;
+    }
+
+    return Math.min(Math.max(Math.floor(parsed), 1), MEETING_AGENDA_MAX_LENGTH);
   }
 }

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -370,10 +370,12 @@ export class MeetingController {
    * GET /meetings/:uid/registrants
    *
    * `include_committee=true` opts into the same committee enrichment `getMyMeetingRegistrants`
-   * applies, so callers that render group attribution (the meeting composer's Guests list) get
-   * `committee_name` / `committee_role` / `committee_category` / `committee_voting_status` /
-   * `committee_appointed_by` populated. It stays opt-in because it costs a per-committee
-   * details + members fan-out that the plain registrant listing has no use for.
+   * applies, so callers that render group attribution (the meeting composer's Guests list, and the
+   * registrants display's group filter) get `committee_name` / `committee_role` /
+   * `committee_category` / `committee_voting_status` / `committee_appointed_by` populated, and get
+   * `committee_uid` normalized from the upstream v1 SFID to the v2 UID. It stays opt-in because it
+   * costs a per-committee details + members fan-out — to the committee service, not upstream — that
+   * the plain registrant listing has no use for.
    */
   public async getMeetingRegistrants(req: Request, res: Response, next: NextFunction): Promise<void> {
     const { uid } = req.params;
@@ -518,79 +520,85 @@ export class MeetingController {
       const m2mToken = await generateM2MToken(req);
       req.bearerToken = m2mToken;
 
-      // Use tags_all to filter by both meeting_id and email
-      logger.debug(req, 'get_my_meeting_registrants', 'Checking if user is a registrant', {
-        meeting_id: uid,
-        user_email: userEmail,
-      });
-      const userRegistrantCheck = await this.meetingService.getMeetingRegistrantsByEmail(req, uid, userEmail);
-
-      logger.debug(req, 'get_my_meeting_registrants', 'User registrant check complete', {
-        meeting_id: uid,
-        user_email: userEmail,
-        registrant_count: userRegistrantCheck.length,
-      });
-
-      // Step 6: If user is not a registrant, check if they are an organizer
-      if (userRegistrantCheck.length === 0) {
-        if (!meeting.organizer) {
-          logger.success(req, 'get_my_meeting_registrants', startTime, {
-            meeting_id: uid,
-            user_email: userEmail,
-            is_registrant: false,
-            is_organizer: false,
-            registrant_count: 0,
-          });
-          res.json([]);
-          return;
-        }
-
-        logger.debug(req, 'get_my_meeting_registrants', 'User is not a registrant but is an organizer, granting access', {
+      // Everything that runs under the M2M token lives in this try/finally so the restore below can't
+      // be skipped. It used to sit inline on the happy path, which meant an enrichment throw — or the
+      // early `res.json([])` for a non-registrant non-organizer — left the M2M token on `req` for
+      // whatever ran next in the request's lifetime.
+      try {
+        // Use tags_all to filter by both meeting_id and email
+        logger.debug(req, 'get_my_meeting_registrants', 'Checking if user is a registrant', {
           meeting_id: uid,
           user_email: userEmail,
         });
+        const userRegistrantCheck = await this.meetingService.getMeetingRegistrantsByEmail(req, uid, userEmail);
+
+        logger.debug(req, 'get_my_meeting_registrants', 'User registrant check complete', {
+          meeting_id: uid,
+          user_email: userEmail,
+          registrant_count: userRegistrantCheck.length,
+        });
+
+        // Step 6: If user is not a registrant, check if they are an organizer
+        if (userRegistrantCheck.length === 0) {
+          if (!meeting.organizer) {
+            logger.success(req, 'get_my_meeting_registrants', startTime, {
+              meeting_id: uid,
+              user_email: userEmail,
+              is_registrant: false,
+              is_organizer: false,
+              registrant_count: 0,
+            });
+            res.json([]);
+            return;
+          }
+
+          logger.debug(req, 'get_my_meeting_registrants', 'User is not a registrant but is an organizer, granting access', {
+            meeting_id: uid,
+            user_email: userEmail,
+          });
+        }
+
+        // Step 7: User is a registrant or organizer, fetch all registrants using M2M token
+        logger.debug(req, 'get_my_meeting_registrants', 'Fetching registrants with M2M token', {
+          meeting_id: uid,
+          user_email: userEmail,
+          include_rsvp: includeRsvp,
+        });
+
+        logger.debug(req, 'get_my_meeting_registrants', 'M2M token generated, fetching all registrants', {
+          meeting_id: uid,
+          has_m2m_token: !!m2mToken,
+        });
+
+        const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId);
+
+        logger.debug(req, 'get_my_meeting_registrants', 'Fetched all registrants, enriching committee data', {
+          meeting_id: uid,
+          registrant_count: registrants.length,
+        });
+
+        // Enrich committee registrant data with committee details and member info
+        const enrichedRegistrants = await this.enrichCommitteeRegistrants(req, meeting, registrants);
+
+        logger.success(req, 'get_my_meeting_registrants', startTime, {
+          meeting_id: uid,
+          user_email: userEmail,
+          is_registrant: userRegistrantCheck.length > 0,
+          is_organizer: meeting.organizer,
+          registrant_count: enrichedRegistrants.length,
+          include_rsvp: includeRsvp,
+        });
+
+        // Send the registrants data to the client
+        res.json(enrichedRegistrants);
+      } finally {
+        // Restore original token (delete if it was undefined to avoid leaving M2M token)
+        if (originalToken !== undefined) {
+          req.bearerToken = originalToken;
+        } else {
+          delete req.bearerToken;
+        }
       }
-
-      // Step 7: User is a registrant or organizer, fetch all registrants using M2M token
-      logger.debug(req, 'get_my_meeting_registrants', 'Fetching registrants with M2M token', {
-        meeting_id: uid,
-        user_email: userEmail,
-        include_rsvp: includeRsvp,
-      });
-
-      logger.debug(req, 'get_my_meeting_registrants', 'M2M token generated, fetching all registrants', {
-        meeting_id: uid,
-        has_m2m_token: !!m2mToken,
-      });
-
-      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId);
-
-      logger.debug(req, 'get_my_meeting_registrants', 'Fetched all registrants, enriching committee data', {
-        meeting_id: uid,
-        registrant_count: registrants.length,
-      });
-
-      // Enrich committee registrant data with committee details and member info
-      const enrichedRegistrants = await this.enrichCommitteeRegistrants(req, meeting, registrants);
-
-      // Restore original token (delete if it was undefined to avoid leaving M2M token)
-      if (originalToken !== undefined) {
-        req.bearerToken = originalToken;
-      } else {
-        delete req.bearerToken;
-      }
-
-      logger.success(req, 'get_my_meeting_registrants', startTime, {
-        meeting_id: uid,
-        user_email: userEmail,
-        is_registrant: userRegistrantCheck.length > 0,
-        is_organizer: meeting.organizer,
-        registrant_count: enrichedRegistrants.length,
-        include_rsvp: includeRsvp,
-      });
-
-      // Send the registrants data to the client
-      res.json(enrichedRegistrants);
     } catch (error) {
       // Send the error to the next middleware
       next(error);
@@ -1500,21 +1508,24 @@ export class MeetingController {
       // client's project context resolves asynchronously. Only require enough signal to write a
       // useful agenda — a title or a free-text goal — and let the prompt builder omit the rest.
       // Both are trimmed first: whitespace is not signal, and both land verbatim in the model
-      // prompt, which is also why both are capped.
+      // prompt, which is also why both are capped at the prompt budget.
       const title = MeetingController.readPromptField(rawTitle);
       const context = MeetingController.readPromptField(rawContext);
 
-      // A dropped over-budget descriptor is otherwise invisible: the request still succeeds on the
-      // remaining one, so the organizer sees a generated agenda that ignored what they typed. Log the
-      // discard (lengths only — the values themselves are user content) so it's at least diagnosable.
-      const overBudget = [['title', rawTitle] as const, ['context', rawContext] as const].filter(
-        ([, raw]) => typeof raw === 'string' && raw.trim().length > MEETING_AGENDA_PROMPT_MAX_LENGTH
-      );
+      // Truncation is invisible to the organizer — the request still succeeds and returns an agenda
+      // written against a shortened descriptor — so log it. Derived by comparing what arrived against
+      // what `readPromptField` kept rather than re-testing the budget here, so the threshold lives in
+      // exactly one place. Lengths only: the values themselves are user content.
+      const truncated = [
+        { field: 'title', raw: rawTitle, kept: title },
+        { field: 'context', raw: rawContext, kept: context },
+      ]
+        .filter(({ raw, kept }) => typeof raw === 'string' && kept !== undefined && raw.trim().length > kept.length)
+        .map(({ field, raw, kept }) => ({ field, from: (raw as string).trim().length, to: kept?.length }));
 
-      if (overBudget.length > 0) {
-        logger.warning(req, 'generate_agenda', 'Dropped an over-budget prompt descriptor', {
-          dropped_fields: overBudget.map(([field]) => field),
-          lengths: overBudget.map(([, raw]) => (raw as string).trim().length),
+      if (truncated.length > 0) {
+        logger.warning(req, 'generate_agenda', 'Truncated an over-budget prompt descriptor', {
+          truncated,
           limit: MEETING_AGENDA_PROMPT_MAX_LENGTH,
         });
       }
@@ -1522,8 +1533,8 @@ export class MeetingController {
       if (!title && !context) {
         const validationError = ServiceValidationError.fromFieldErrors(
           {
-            title: `Provide a meeting title (max ${MEETING_AGENDA_PROMPT_MAX_LENGTH} characters) or describe what the meeting is for`,
-            context: `Describe what the meeting is for (max ${MEETING_AGENDA_PROMPT_MAX_LENGTH} characters) or provide a meeting title`,
+            title: 'Provide a meeting title or describe what the meeting is for',
+            context: 'Describe what the meeting is for or provide a meeting title',
           },
           'Agenda generation validation failed',
           {
@@ -1541,7 +1552,7 @@ export class MeetingController {
         title,
         projectName,
         context,
-        maxCharacters: MeetingController.clampAgendaMaxCharacters(maxCharacters),
+        maxCharacters: MeetingController.resolveAgendaMaxCharacters(maxCharacters),
       });
 
       // Usage telemetry: the helper is far more discoverable in the composer than it was in the
@@ -1857,16 +1868,23 @@ export class MeetingController {
         return { ...registrant, committee_uid: v1Sfid };
       }
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructure-to-strip: the key is deleted, not read
       const { committee_uid: _dropped, ...withoutCommittee } = registrant;
       return withoutCommittee;
     });
   }
 
   /**
-   * Normalizes a free-text field that will be interpolated into an AI prompt.
-   * Anything that isn't a non-empty string once trimmed, or that exceeds the prompt budget, is
-   * dropped rather than truncated — a half-sentence goal produces a worse agenda than no goal.
+   * Normalizes a free-text field that will be interpolated into an AI prompt: anything that isn't a
+   * non-empty string once trimmed is dropped, and anything over the prompt budget is truncated to it.
+   *
+   * Truncated, not dropped. Dropping was the earlier behaviour on the theory that half a sentence is
+   * a worse prompt than none, but it made the endpoint's contract impossible for a caller to satisfy
+   * honestly: the client's own guard tests for the *presence* of a title or goal, so an over-budget
+   * title with no goal passed the client and then failed `!title && !context` here, surfacing as a
+   * generic "could not generate an agenda" that no amount of retrying could fix. Truncating keeps the
+   * leading budget's worth of signal, so a descriptor the organizer typed is never silently discarded
+   * in full and the client guard mirrors this one exactly.
    */
   private static readPromptField(value: unknown): string | undefined {
     if (typeof value !== 'string') {
@@ -1875,18 +1893,24 @@ export class MeetingController {
 
     const trimmed = value.trim();
 
-    return trimmed.length > 0 && trimmed.length <= MEETING_AGENDA_PROMPT_MAX_LENGTH ? trimmed : undefined;
+    if (trimmed.length === 0) {
+      return undefined;
+    }
+
+    return trimmed.length > MEETING_AGENDA_PROMPT_MAX_LENGTH ? trimmed.slice(0, MEETING_AGENDA_PROMPT_MAX_LENGTH) : trimmed;
   }
 
   /**
-   * Clamps the caller-supplied agenda cap into the range the agenda field actually accepts.
+   * Resolves the caller-supplied agenda cap to a value the agenda field can actually hold.
    * The value reaches the model twice — as `maxLength` in the response schema and interpolated into
    * the prompt — so an unvalidated `-1` / `"abc"` / `{}` off the request body would either produce an
    * opaque upstream 500 or let a caller ask for an agenda the `description` control can't hold.
    * Out-of-range values fall back to the default rather than being pinned to the nearest bound: a cap
    * of 1 is honoured nonsense that guarantees a useless completion, and the caller still pays for it.
+   * A caller that asked for an out-of-range cap gets no signal that it was substituted — acceptable
+   * because the only caller in the app sends `MEETING_AGENDA_MAX_LENGTH` itself.
    */
-  private static clampAgendaMaxCharacters(value: unknown): number {
+  private static resolveAgendaMaxCharacters(value: unknown): number {
     const parsed = typeof value === 'number' ? value : Number.NaN;
 
     const floored = Math.floor(parsed);

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -1493,15 +1493,16 @@ export class MeetingController {
     });
 
     try {
-      const { meetingType, title, projectName, context } = req.body;
+      const { meetingType, title, projectName, context, maxCharacters } = req.body;
 
-      // Validate required fields
-      if (!meetingType || !title || !projectName) {
+      // The composer reaches this helper from any section and from Quick create, so title / type /
+      // project are not guaranteed to be filled in yet. Only require enough signal to write a
+      // useful agenda — a title or a free-text context — and let the prompt builder omit the rest.
+      if (!title && !context) {
         const validationError = ServiceValidationError.fromFieldErrors(
           {
-            meetingType: !meetingType ? 'Meeting type is required' : [],
-            title: !title ? 'Title is required' : [],
-            projectName: !projectName ? 'Project name is required' : [],
+            title: 'Provide a meeting title or describe what the meeting is for',
+            context: 'Provide a meeting title or describe what the meeting is for',
           },
           'Agenda generation validation failed',
           {
@@ -1519,10 +1520,18 @@ export class MeetingController {
         title,
         projectName,
         context,
+        maxCharacters,
       });
 
+      // Usage telemetry: the helper is far more discoverable in the composer than it was in the
+      // wizard, so track how it's actually being invoked (and how much it costs) per request.
       logger.success(req, 'generate_agenda', startTime, {
         estimated_duration: response.estimatedDuration,
+        meeting_type: meetingType || null,
+        has_title: !!title,
+        has_project_name: !!projectName,
+        has_context: !!context,
+        agenda_length: response.agenda.length,
       });
 
       res.json(response);

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -1494,14 +1494,30 @@ export class MeetingController {
     });
 
     try {
-      const { meetingType, projectName, maxCharacters } = req.body;
-      // The composer's section rail lets the organizer reach Agenda & Resources before Details &
-      // Access is filled in, so a title / type / project are not guaranteed to exist yet. Only
-      // require enough signal to write a useful agenda — a title or a free-text goal — and let the
-      // prompt builder omit the rest. Both are trimmed first: whitespace is not signal, and both
-      // land verbatim in the model prompt.
-      const title = MeetingController.readPromptField(req.body['title']);
-      const context = MeetingController.readPromptField(req.body['context']);
+      const { meetingType, projectName, maxCharacters, title: rawTitle, context: rawContext } = req.body;
+      // A title / type / project are not guaranteed to exist: edit mode drops the rail's section
+      // locking, so the organizer can request an agenda having just cleared the title, and the
+      // client's project context resolves asynchronously. Only require enough signal to write a
+      // useful agenda — a title or a free-text goal — and let the prompt builder omit the rest.
+      // Both are trimmed first: whitespace is not signal, and both land verbatim in the model
+      // prompt, which is also why both are capped.
+      const title = MeetingController.readPromptField(rawTitle);
+      const context = MeetingController.readPromptField(rawContext);
+
+      // A dropped over-budget descriptor is otherwise invisible: the request still succeeds on the
+      // remaining one, so the organizer sees a generated agenda that ignored what they typed. Log the
+      // discard (lengths only — the values themselves are user content) so it's at least diagnosable.
+      const overBudget = [['title', rawTitle] as const, ['context', rawContext] as const].filter(
+        ([, raw]) => typeof raw === 'string' && raw.trim().length > MEETING_AGENDA_PROMPT_MAX_LENGTH
+      );
+
+      if (overBudget.length > 0) {
+        logger.warning(req, 'generate_agenda', 'Dropped an over-budget prompt descriptor', {
+          dropped_fields: overBudget.map(([field]) => field),
+          lengths: overBudget.map(([, raw]) => (raw as string).trim().length),
+          limit: MEETING_AGENDA_PROMPT_MAX_LENGTH,
+        });
+      }
 
       if (!title && !context) {
         const validationError = ServiceValidationError.fromFieldErrors(
@@ -1815,16 +1831,17 @@ export class MeetingController {
    * BFF used to) silently persists a group-added guest as `direct` and loses attribution.
    *
    * An unresolvable UID is stripped rather than forwarded — a v2 UID upstream would be stored as a
-   * bogus committee reference, which is worse than the guest landing as `direct`.
+   * bogus committee reference, which is worse than the guest landing as `direct`. Stripped means the
+   * key is deleted, not nulled: upstream's `CreateItxRegistrantRequestBody` declares `committee_uid`
+   * as a non-nullable optional `string`, so an explicit `null` is off-contract even though omission
+   * is fine. A `null` arriving from the client is dropped for the same reason.
    */
   private async resolveRegistrantCommitteeUids(req: Request, registrants: CreateMeetingRegistrantRequest[]): Promise<CreateMeetingRegistrantRequest[]> {
     const v2Uids = [...new Set(registrants.map((registrant) => registrant.committee_uid).filter((value): value is string => !!value))];
 
-    if (v2Uids.length === 0) {
-      return registrants;
-    }
-
-    const v2ToV1Map = await resolveCommitteeV2UidsToV1Ids(req, this.natsService, v2Uids);
+    // Still fall through to the map when there's nothing to resolve — a client that sent an explicit
+    // `committee_uid: null` needs the key dropped, and only the map below does that.
+    const v2ToV1Map = v2Uids.length > 0 ? await resolveCommitteeV2UidsToV1Ids(req, this.natsService, v2Uids) : new Map<string, string>();
 
     if (v2ToV1Map.size < v2Uids.length) {
       logger.warning(req, 'resolve_registrant_committee_uids', 'Some committee UIDs could not be resolved to v1 SFIDs', {
@@ -1834,11 +1851,15 @@ export class MeetingController {
     }
 
     return registrants.map((registrant) => {
-      if (!registrant.committee_uid) {
-        return registrant;
+      const v1Sfid = registrant.committee_uid ? v2ToV1Map.get(registrant.committee_uid) : undefined;
+
+      if (v1Sfid) {
+        return { ...registrant, committee_uid: v1Sfid };
       }
 
-      return { ...registrant, committee_uid: v2ToV1Map.get(registrant.committee_uid) ?? null };
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { committee_uid: _dropped, ...withoutCommittee } = registrant;
+      return withoutCommittee;
     });
   }
 
@@ -1862,14 +1883,18 @@ export class MeetingController {
    * The value reaches the model twice — as `maxLength` in the response schema and interpolated into
    * the prompt — so an unvalidated `-1` / `"abc"` / `{}` off the request body would either produce an
    * opaque upstream 500 or let a caller ask for an agenda the `description` control can't hold.
+   * Out-of-range values fall back to the default rather than being pinned to the nearest bound: a cap
+   * of 1 is honoured nonsense that guarantees a useless completion, and the caller still pays for it.
    */
   private static clampAgendaMaxCharacters(value: unknown): number {
     const parsed = typeof value === 'number' ? value : Number.NaN;
 
-    if (!Number.isFinite(parsed)) {
+    const floored = Math.floor(parsed);
+
+    if (!Number.isFinite(parsed) || floored < 1 || floored > MEETING_AGENDA_MAX_LENGTH) {
       return MEETING_AGENDA_MAX_LENGTH;
     }
 
-    return Math.min(Math.max(Math.floor(parsed), 1), MEETING_AGENDA_MAX_LENGTH);
+    return floored;
   }
 }

--- a/apps/lfx-one/src/server/middleware/rate-limit.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/rate-limit.middleware.ts
@@ -32,10 +32,18 @@ export const publicApiRateLimiter = rateLimit({
 /**
  * Rate limiter for AI generation endpoints.
  *
- * Applied per-route to endpoints that call out to the LiteLLM proxy. Those calls are far more
- * expensive than a normal proxy read, and the global `apiRateLimiter` (500/min) is nowhere near
- * tight enough to bound them. Keyed on the authenticated user where available so one user on a
- * shared egress IP can't exhaust the budget for everyone behind it.
+ * Applied per-route to `POST /api/meetings/generate-agenda`. That call fans out to the LiteLLM
+ * proxy and is far more expensive than a normal proxy read, while the global `apiRateLimiter`
+ * (500/min) is nowhere near tight enough to bound it. Keyed on the authenticated user where
+ * available so one user on a shared egress IP can't exhaust the budget for everyone behind it;
+ * anonymous callers fall back to a /56-masked IP key.
+ *
+ * Not yet applied to the other LiteLLM callers (newsletter generation, weekly-brief action-item
+ * extraction) — those are reached from different modules and are only bounded by the global limiter.
+ *
+ * The counter lives in the default in-process MemoryStore, so the effective ceiling is
+ * `limit × replicas`. That's exact today (`ecosystem.config.js` runs a single instance) but would
+ * need a shared store to hold under horizontal scaling.
  */
 export const aiRateLimiter = rateLimit({
   windowMs: 60 * 1000, // 1 minute window

--- a/apps/lfx-one/src/server/middleware/rate-limit.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/rate-limit.middleware.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import rateLimit from 'express-rate-limit';
+import rateLimit, { ipKeyGenerator } from 'express-rate-limit';
 
 /**
  * App-wide rate limiter for API routes.
@@ -27,6 +27,22 @@ export const publicApiRateLimiter = rateLimit({
   max: 100, // limit each IP to 100 requests per window
   standardHeaders: true,
   legacyHeaders: false,
+});
+
+/**
+ * Rate limiter for AI generation endpoints.
+ *
+ * Applied per-route to endpoints that call out to the LiteLLM proxy. Those calls are far more
+ * expensive than a normal proxy read, and the global `apiRateLimiter` (500/min) is nowhere near
+ * tight enough to bound them. Keyed on the authenticated user where available so one user on a
+ * shared egress IP can't exhaust the budget for everyone behind it.
+ */
+export const aiRateLimiter = rateLimit({
+  windowMs: 60 * 1000, // 1 minute window
+  max: 10, // limit each user (or IP, when anonymous) to 10 AI generations per window
+  standardHeaders: true,
+  legacyHeaders: false,
+  keyGenerator: (req) => req.oidc?.user?.['sub'] || ipKeyGenerator(req.ip ?? ''),
 });
 
 /**

--- a/apps/lfx-one/src/server/routes/meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/meetings.route.ts
@@ -74,9 +74,9 @@ router.put('/:uid/attachments/:attachmentId', (req, res, next) => meetingControl
 
 router.delete('/:uid/attachments/:attachmentId', (req, res, next) => meetingController.deleteMeetingAttachment(req, res, next));
 
-// AI agenda generation endpoint. The composer surfaces this helper from every section and from
-// Quick create, so it's reachable far more often than the old wizard's single Details step —
-// rate-limited per user on top of the global /api limiter.
+// AI agenda generation endpoint. Reachable from the composer's Agenda & Resources section, which
+// the section rail can jump to at any point — including before a title or type exists. Every call
+// costs a LiteLLM completion, so it's rate-limited per user on top of the global /api limiter.
 router.post('/generate-agenda', aiRateLimiter, (req, res, next) => meetingController.generateAgenda(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/routes/meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/meetings.route.ts
@@ -4,6 +4,7 @@
 import express, { Router } from 'express';
 
 import { MeetingController } from '../controllers/meeting.controller';
+import { aiRateLimiter } from '../middleware/rate-limit.middleware';
 
 const router = Router();
 
@@ -73,7 +74,9 @@ router.put('/:uid/attachments/:attachmentId', (req, res, next) => meetingControl
 
 router.delete('/:uid/attachments/:attachmentId', (req, res, next) => meetingController.deleteMeetingAttachment(req, res, next));
 
-// AI agenda generation endpoint
-router.post('/generate-agenda', (req, res, next) => meetingController.generateAgenda(req, res, next));
+// AI agenda generation endpoint. The composer surfaces this helper from every section and from
+// Quick create, so it's reachable far more often than the old wizard's single Details step —
+// rate-limited per user on top of the global /api limiter.
+router.post('/generate-agenda', aiRateLimiter, (req, res, next) => meetingController.generateAgenda(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/routes/meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/meetings.route.ts
@@ -74,9 +74,11 @@ router.put('/:uid/attachments/:attachmentId', (req, res, next) => meetingControl
 
 router.delete('/:uid/attachments/:attachmentId', (req, res, next) => meetingController.deleteMeetingAttachment(req, res, next));
 
-// AI agenda generation endpoint. Reachable only from the composer's Agenda & Resources section, and
-// in edit mode that section is reachable with no title or type set. Every call costs a LiteLLM
-// completion, so it's rate-limited per user on top of the global /api limiter.
+// AI agenda generation endpoint. The composer's Agenda & Resources section is the only caller in the
+// app, but this is an ordinary authenticated route any client holding a session can post to — and
+// every call costs a LiteLLM completion, so it carries a per-user AI limiter on top of the global
+// /api one. The body's descriptors are all optional because in edit mode the section is reachable
+// with no title or type set.
 router.post('/generate-agenda', aiRateLimiter, (req, res, next) => meetingController.generateAgenda(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/routes/meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/meetings.route.ts
@@ -74,9 +74,9 @@ router.put('/:uid/attachments/:attachmentId', (req, res, next) => meetingControl
 
 router.delete('/:uid/attachments/:attachmentId', (req, res, next) => meetingController.deleteMeetingAttachment(req, res, next));
 
-// AI agenda generation endpoint. Reachable from the composer's Agenda & Resources section, which
-// the section rail can jump to at any point — including before a title or type exists. Every call
-// costs a LiteLLM completion, so it's rate-limited per user on top of the global /api limiter.
+// AI agenda generation endpoint. Reachable only from the composer's Agenda & Resources section, and
+// in edit mode that section is reachable with no title or type set. Every call costs a LiteLLM
+// completion, so it's rate-limited per user on top of the global /api limiter.
 router.post('/generate-agenda', aiRateLimiter, (req, res, next) => meetingController.generateAgenda(req, res, next));
 
 export default router;

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -25,6 +25,9 @@ vi.mock('@lfx-one/shared/constants', async () => {
     AI_NEWSLETTER_SYSTEM_PROMPT: 'newsletter prompt',
     AI_REQUEST_CONFIG: actual.AI_REQUEST_CONFIG,
     DURATION_ESTIMATION: { BASE_DURATION: 15, TIME_PER_ITEM: 10, MINIMUM_DURATION: 30, MAXIMUM_DURATION: 240 },
+    // Mirrors `MEETING_AGENDA_MAX_LENGTH` in the shared constants barrel; a literal because the
+    // meeting constants module can't be pulled in here without loading its own dependency graph.
+    MEETING_AGENDA_MAX_LENGTH: 2000,
     NEWSLETTER_AI_MAX_TOKENS: 12_000,
     WEEKLY_BRIEF_ACTION_ITEM_OWNER_ROLE_MAX_LENGTH: 100,
     WEEKLY_BRIEF_ACTION_ITEM_TEXT_MAX_LENGTH: 300,

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -10,14 +10,16 @@ vi.mock('./logger.service', () => ({
 // The `@lfx-one/shared/*` alias isn't wired into this app's vitest config — a real, unmocked
 // import re-triggers the Angular JIT-compilation failure (matches weekly-brief.service.spec.ts's
 // convention). Most values below are inert mock strings/numbers this file's assertions don't
-// depend on being "real" — except AI_REQUEST_CONFIG, which the timeout-split tests below assert
-// against directly. That one is pulled from the real file via a direct relative import inside this
-// async factory (bypassing the '@lfx-one/shared/constants' alias, which resolves to the barrel —
-// all constants files, including ones with the Angular-tainted transitive imports this mock exists
-// to avoid; the direct file only pulls in its own plain './weekly-brief.constants' import), so the
-// mock structurally cannot drift from the value AiService actually uses in production.
+// depend on being "real" — except AI_REQUEST_CONFIG and MEETING_AGENDA_MAX_LENGTH, which the
+// timeout-split and agenda-clamping tests below assert against directly. Those two are pulled from
+// their real files via direct relative imports inside this async factory (bypassing the
+// '@lfx-one/shared/constants' alias, which resolves to the barrel — all constants files, including
+// ones with the Angular-tainted transitive imports this mock exists to avoid; the two direct files
+// only pull in their own plain sibling imports), so the mock structurally cannot drift from the
+// values AiService actually uses in production.
 vi.mock('@lfx-one/shared/constants', async () => {
   const actual = await import('../../../../../packages/shared/src/constants/ai.constants');
+  const meeting = await import('../../../../../packages/shared/src/constants/meeting.constants');
   return {
     AI_AGENDA_SYSTEM_PROMPT: 'agenda prompt',
     AI_BRIEF_ACTION_ITEMS_SYSTEM_PROMPT: 'brief action items prompt',
@@ -25,9 +27,9 @@ vi.mock('@lfx-one/shared/constants', async () => {
     AI_NEWSLETTER_SYSTEM_PROMPT: 'newsletter prompt',
     AI_REQUEST_CONFIG: actual.AI_REQUEST_CONFIG,
     DURATION_ESTIMATION: { BASE_DURATION: 15, TIME_PER_ITEM: 10, MINIMUM_DURATION: 30, MAXIMUM_DURATION: 240 },
-    // Mirrors `MEETING_AGENDA_MAX_LENGTH` in the shared constants barrel; a literal because the
-    // meeting constants module can't be pulled in here without loading its own dependency graph.
-    MEETING_AGENDA_MAX_LENGTH: 2000,
+    // Pulled from the real file for the same reason as AI_REQUEST_CONFIG: the cap is asserted against
+    // directly below, so a hand-copied literal could drift from the value AiService actually clamps to.
+    MEETING_AGENDA_MAX_LENGTH: meeting.MEETING_AGENDA_MAX_LENGTH,
     NEWSLETTER_AI_MAX_TOKENS: 12_000,
     WEEKLY_BRIEF_ACTION_ITEM_OWNER_ROLE_MAX_LENGTH: 100,
     WEEKLY_BRIEF_ACTION_ITEM_TEXT_MAX_LENGTH: 300,
@@ -285,6 +287,58 @@ describe('AiService.generateMeetingAgenda', () => {
 
       expect(prompt).toContain('must not exceed 1200 characters');
       expect(body.response_format.json_schema.schema.properties.agenda.maxLength).toBe(1200);
+    });
+  });
+
+  // The schema's `maxLength` and the prompt's cap are both hints the model can ignore. The composer
+  // writes the returned agenda into a control carrying `Validators.maxLength(MEETING_AGENDA_MAX_LENGTH)`
+  // programmatically — past the textarea's native cap — so an over-cap agenda would leave the whole
+  // form invalid and Save silently inert. Hence the clamp on the way out.
+  describe('agenda length clamping', () => {
+    it('clamps an over-cap agenda from the JSON path', async () => {
+      fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ agenda: 'x'.repeat(1500), duration: 30 })));
+
+      const result = await service.generateMeetingAgenda(req, { title: 'TAC Monthly', maxCharacters: 1200 });
+
+      expect(result.agenda).toHaveLength(1200);
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'generate_meeting_agenda',
+        expect.stringContaining('truncating'),
+        expect.objectContaining({ source: 'json' })
+      );
+    });
+
+    it('clamps an over-cap agenda from the plain-text fallback path', async () => {
+      fetchMock.mockResolvedValue(mockChatResponse('y'.repeat(1500)));
+
+      const result = await service.generateMeetingAgenda(req, { title: 'TAC Monthly', maxCharacters: 1200 });
+
+      expect(result.agenda).toHaveLength(1200);
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'generate_meeting_agenda',
+        expect.stringContaining('truncating'),
+        expect.objectContaining({ source: 'text_fallback' })
+      );
+    });
+
+    it('leaves an agenda within the cap untouched and logs nothing', async () => {
+      fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ agenda: 'Roll call', duration: 30 })));
+
+      const result = await service.generateMeetingAgenda(req, { title: 'TAC Monthly', maxCharacters: 1200 });
+
+      expect(result.agenda).toBe('Roll call');
+      expect(logger.warning).not.toHaveBeenCalled();
+    });
+
+    it('falls back to MEETING_AGENDA_MAX_LENGTH when the caller supplies no cap', async () => {
+      const { MEETING_AGENDA_MAX_LENGTH } = await import('@lfx-one/shared/constants');
+      fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ agenda: 'z'.repeat(MEETING_AGENDA_MAX_LENGTH + 500), duration: 30 })));
+
+      const result = await service.generateMeetingAgenda(req, { title: 'TAC Monthly' });
+
+      expect(result.agenda).toHaveLength(MEETING_AGENDA_MAX_LENGTH);
     });
   });
 });

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -239,6 +239,51 @@ describe('AiService.generateMeetingAgenda', () => {
 
     expect(timeoutSpy).toHaveBeenCalledWith(AI_REQUEST_CONFIG.TIMEOUT_MS);
   });
+
+  // GH-1464: the helper is reachable before Details & Access is filled in, so `buildPrompt` has to
+  // omit each absent descriptor rather than emit an "undefined" clause the model would read as text.
+  describe('prompt shape with partial descriptors', () => {
+    async function promptFor(request: Parameters<AiService['generateMeetingAgenda']>[1]): Promise<string> {
+      fetchMock.mockResolvedValue(mockChatResponse(JSON.stringify({ agenda: 'agenda text', duration: 30 })));
+
+      await service.generateMeetingAgenda(req, request);
+
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+      return body.messages.find((message: { role: string }) => message.role === 'user').content;
+    }
+
+    it('omits the title and project clauses when only a goal is supplied', async () => {
+      const prompt = await promptFor({ context: 'Plan the Q3 release' });
+
+      expect(prompt).toContain('Additional context: Plan the Q3 release');
+      expect(prompt).not.toContain('titled');
+      // The project clause reads `for the <name> project` — the type fallback also says "project".
+      expect(prompt).not.toContain('for the ');
+      expect(prompt).not.toContain('undefined');
+    });
+
+    it('omits the context clause when only a title is supplied', async () => {
+      const prompt = await promptFor({ title: 'TAC Monthly' });
+
+      expect(prompt).toContain('titled "TAC Monthly"');
+      expect(prompt).not.toContain('Additional context');
+      expect(prompt).not.toContain('undefined');
+    });
+
+    it('describes a project team meeting when no meeting type is chosen', async () => {
+      const prompt = await promptFor({ title: 'TAC Monthly' });
+
+      expect(prompt).toContain('for a project team meeting');
+    });
+
+    it('states the character cap in both the prompt and the response schema', async () => {
+      const prompt = await promptFor({ title: 'TAC Monthly', maxCharacters: 1200 });
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+      expect(prompt).toContain('must not exceed 1200 characters');
+      expect(body.response_format.json_schema.schema.properties.agenda.maxLength).toBe(1200);
+    });
+  });
 });
 
 describe('AiService.generateNewsletter', () => {

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -40,6 +40,11 @@ vi.mock('@lfx-one/shared/enums', () => ({
   MeetingType: { BOARD: 'board', MAINTAINERS: 'maintainers', MARKETING: 'marketing', TECHNICAL: 'technical', LEGAL: 'legal', OTHER: 'other', NONE: 'none' },
 }));
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
+// Real implementation, not a stub: the clamping tests below assert on the agenda string the service
+// returns, so a stubbed truncator would test the stub. `string.utils` imports nothing of its own.
+vi.mock('@lfx-one/shared/utils', async () => ({
+  truncateToUtf16Units: (await import('../../../../../packages/shared/src/utils/string.utils')).truncateToUtf16Units,
+}));
 
 import { AI_REQUEST_CONFIG } from '@lfx-one/shared/constants';
 import type { Request } from 'express';

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -366,9 +366,10 @@ export class AiService {
   }
 
   /**
-   * Every descriptor beyond the meeting type is optional — the composer can invoke the helper from
-   * any section (and from Quick create) before a title or project is set, so each clause is only
-   * appended when there's something to say.
+   * Every descriptor is optional, including the meeting type — the composer's section rail lets the
+   * organizer reach Agenda & Resources before Details & Access is filled in, so a title, type, or
+   * project may legitimately not exist yet. Each clause is only appended when there's something to
+   * say; the controller guarantees at least a title or a goal.
    */
   private buildPrompt(request: GenerateAgendaRequest): string {
     let prompt = `Generate a meeting agenda for a ${this.getMeetingTypeDescription(request.meetingType)} meeting`;

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -8,6 +8,7 @@ import {
   AI_NEWSLETTER_SYSTEM_PROMPT,
   AI_REQUEST_CONFIG,
   DURATION_ESTIMATION,
+  MEETING_AGENDA_MAX_LENGTH,
   NEWSLETTER_AI_MAX_TOKENS,
   WEEKLY_BRIEF_ACTION_ITEM_OWNER_ROLE_MAX_LENGTH,
   WEEKLY_BRIEF_ACTION_ITEM_TEXT_MAX_LENGTH,
@@ -86,8 +87,8 @@ export class AiService {
                   type: 'string',
                   description:
                     'Well-structured meeting agenda with time allocations and clear objectives. ' +
-                    `Must not exceed ${request.maxCharacters || 2000} characters.`,
-                  maxLength: request.maxCharacters || 2000,
+                    `Must not exceed ${request.maxCharacters || MEETING_AGENDA_MAX_LENGTH} characters.`,
+                  maxLength: request.maxCharacters || MEETING_AGENDA_MAX_LENGTH,
                 },
                 duration: {
                   type: 'number',
@@ -366,10 +367,10 @@ export class AiService {
   }
 
   /**
-   * Every descriptor is optional, including the meeting type — the composer's section rail lets the
-   * organizer reach Agenda & Resources before Details & Access is filled in, so a title, type, or
-   * project may legitimately not exist yet. Each clause is only appended when there's something to
-   * say; the controller guarantees at least a title or a goal.
+   * Every descriptor is optional, including the meeting type — in edit mode the composer's rail
+   * imposes no section locking, so the organizer can ask for an agenda with the title cleared, and the
+   * client's project context resolves asynchronously. Each clause is only appended when there's
+   * something to say; the controller guarantees at least a title or a goal.
    */
   private buildPrompt(request: GenerateAgendaRequest): string {
     let prompt = `Generate a meeting agenda for a ${this.getMeetingTypeDescription(request.meetingType)} meeting`;

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -365,9 +365,23 @@ export class AiService {
     }
   }
 
+  /**
+   * Every descriptor beyond the meeting type is optional — the composer can invoke the helper from
+   * any section (and from Quick create) before a title or project is set, so each clause is only
+   * appended when there's something to say.
+   */
   private buildPrompt(request: GenerateAgendaRequest): string {
     let prompt = `Generate a meeting agenda for a ${this.getMeetingTypeDescription(request.meetingType)} meeting`;
-    prompt += ` titled "${request.title}" for the ${request.projectName} project.`;
+
+    if (request.title) {
+      prompt += ` titled "${request.title}"`;
+    }
+
+    if (request.projectName) {
+      prompt += ` for the ${request.projectName} project`;
+    }
+
+    prompt += '.';
 
     if (request.context) {
       prompt += ` Additional context: ${request.context}`;
@@ -382,7 +396,8 @@ export class AiService {
     return prompt;
   }
 
-  private getMeetingTypeDescription(meetingType: MeetingType): string {
+  /** `default` also covers an unset type — the helper is reachable before one is chosen. */
+  private getMeetingTypeDescription(meetingType?: MeetingType): string {
     switch (meetingType) {
       case MeetingType.BOARD:
         return 'board governance';

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -60,6 +60,9 @@ export class AiService {
     });
 
     try {
+      // Resolved once: the same cap is asked of the model (in the schema and the prompt) and enforced
+      // on the way back out, so the three can't disagree.
+      const agendaMaxCharacters = request.maxCharacters || MEETING_AGENDA_MAX_LENGTH;
       const prompt = this.buildPrompt(request);
       const chatRequest: OpenAIChatRequest = {
         model: this.model,
@@ -86,9 +89,8 @@ export class AiService {
                 agenda: {
                   type: 'string',
                   description:
-                    'Well-structured meeting agenda with time allocations and clear objectives. ' +
-                    `Must not exceed ${request.maxCharacters || MEETING_AGENDA_MAX_LENGTH} characters.`,
-                  maxLength: request.maxCharacters || MEETING_AGENDA_MAX_LENGTH,
+                    'Well-structured meeting agenda with time allocations and clear objectives. ' + `Must not exceed ${agendaMaxCharacters} characters.`,
+                  maxLength: agendaMaxCharacters,
                 },
                 duration: {
                   type: 'number',
@@ -104,7 +106,7 @@ export class AiService {
       };
 
       const response = await this.makeAiRequest(chatRequest);
-      const result = this.extractAgendaAndDuration(req, response);
+      const result = this.extractAgendaAndDuration(req, response, agendaMaxCharacters);
 
       logger.success(req, 'generate_meeting_agenda', startTime, {
         estimatedDuration: result.estimatedDuration,
@@ -452,7 +454,18 @@ export class AiService {
     return response.json();
   }
 
-  private extractAgendaAndDuration(req: Request, response: OpenAIChatResponse): GenerateAgendaResponse {
+  /**
+   * @param maxCharacters Hard cap applied to the returned agenda.
+   *
+   * The cap is enforced here rather than trusted from the response schema's `maxLength` hint, which
+   * the model is free to overshoot (`MAX_TOKENS` leaves ample room to), and which the text-extraction
+   * fallback below bypasses entirely by returning the whole completion. That matters beyond tidiness:
+   * the composer writes this string straight into its `description` control, which carries
+   * `Validators.maxLength(MEETING_AGENDA_MAX_LENGTH)`. An over-length agenda would therefore make the
+   * composer's whole form invalid and silently disable Save — the same class of dead button GH-1464
+   * fixed for the AI goal, reached through the AI helper itself.
+   */
+  private extractAgendaAndDuration(req: Request, response: OpenAIChatResponse, maxCharacters: number): GenerateAgendaResponse {
     if (!response.choices || response.choices.length === 0) {
       throw new Error('No agenda generated');
     }
@@ -479,7 +492,7 @@ export class AiService {
       const cappedDuration = Math.max(DURATION_ESTIMATION.MINIMUM_DURATION, Math.min(parsed.duration, DURATION_ESTIMATION.MAXIMUM_DURATION));
 
       return {
-        agenda: parsed.agenda.trim(),
+        agenda: AiService.capAgendaLength(req, parsed.agenda.trim(), maxCharacters, 'json'),
         estimatedDuration: cappedDuration,
       };
     } catch (parseError) {
@@ -497,9 +510,28 @@ export class AiService {
       const cappedFallbackDuration = Math.max(DURATION_ESTIMATION.MINIMUM_DURATION, Math.min(fallbackDuration, DURATION_ESTIMATION.MAXIMUM_DURATION));
 
       return {
-        agenda: content.trim(),
+        agenda: AiService.capAgendaLength(req, content.trim(), maxCharacters, 'text_fallback'),
         estimatedDuration: cappedFallbackDuration,
       };
     }
+  }
+
+  /**
+   * Trims an agenda to the requested cap, logging when it had to. Truncated rather than rejected: a
+   * shortened agenda is still a usable draft the organizer can edit, whereas a thrown error costs
+   * them the whole generation.
+   */
+  private static capAgendaLength(req: Request, agenda: string, maxCharacters: number, source: 'json' | 'text_fallback'): string {
+    if (agenda.length <= maxCharacters) {
+      return agenda;
+    }
+
+    logger.warning(req, 'generate_meeting_agenda', 'Agenda exceeded the requested cap, truncating', {
+      agenda_length: agenda.length,
+      max_characters: maxCharacters,
+      source,
+    });
+
+    return agenda.slice(0, maxCharacters);
   }
 }

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -25,6 +25,7 @@ import {
   OpenAIChatRequest,
   OpenAIChatResponse,
 } from '@lfx-one/shared/interfaces';
+import { truncateToUtf16Units } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { logger } from './logger.service';
@@ -61,8 +62,11 @@ export class AiService {
 
     try {
       // Resolved once: the same cap is asked of the model (in the schema and the prompt) and enforced
-      // on the way back out, so the three can't disagree.
-      const agendaMaxCharacters = request.maxCharacters || MEETING_AGENDA_MAX_LENGTH;
+      // on the way back out, so the three can't disagree. Floored at 1 because `maxCharacters` is a
+      // plain optional number on the request — the app's only caller pre-validates it, but nothing in
+      // this service's contract says so, and a negative would make the clamp's `slice` chop the tail
+      // off the agenda instead of capping it.
+      const agendaMaxCharacters = Math.max(1, request.maxCharacters || MEETING_AGENDA_MAX_LENGTH);
       const prompt = this.buildPrompt(request);
       const chatRequest: OpenAIChatRequest = {
         model: this.model,
@@ -532,6 +536,6 @@ export class AiService {
       source,
     });
 
-    return agenda.slice(0, maxCharacters);
+    return truncateToUtf16Units(agenda, maxCharacters);
   }
 }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -671,8 +671,9 @@ export const MEETING_AGENDA_MAX_LENGTH = 2000;
 export const MEETING_AGENDA_WARNING_LENGTH = 1800;
 
 /**
- * Character limit for the free-text goal fed to the AI agenda helper.
- * The value is interpolated straight into the model prompt, so it needs a ceiling of its own —
+ * Character limit for each free-text descriptor fed to the AI agenda helper — the goal and the
+ * meeting title alike.
+ * Both are interpolated straight into the model prompt, so they need a ceiling of their own —
  * `express.json`'s body limit is far too coarse to bound a prompt.
  */
 export const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -678,6 +678,9 @@ export const MEETING_AGENDA_WARNING_LENGTH = 1800;
  */
 export const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
 
+/** Prompt length at which the character counter turns amber — same 90% of cap as the agenda's */
+export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
+
 /** Lower bound for the custom meeting duration, in minutes */
 export const MIN_CUSTOM_DURATION = 5;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -670,6 +670,13 @@ export const MEETING_AGENDA_MAX_LENGTH = 2000;
 /** Agenda length at which the character counter turns amber */
 export const MEETING_AGENDA_WARNING_LENGTH = 1800;
 
+/**
+ * Character limit for the free-text goal fed to the AI agenda helper.
+ * The value is interpolated straight into the model prompt, so it needs a ceiling of its own —
+ * `express.json`'s body limit is far too coarse to bound a prompt.
+ */
+export const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
+
 /** Lower bound for the custom meeting duration, in minutes */
 export const MIN_CUSTOM_DURATION = 5;
 

--- a/packages/shared/src/interfaces/ai.interface.ts
+++ b/packages/shared/src/interfaces/ai.interface.ts
@@ -7,13 +7,17 @@ import { MeetingType } from '../enums';
  * Request interface for AI agenda generation
  */
 export interface GenerateAgendaRequest {
-  /** Type of meeting for agenda generation */
-  meetingType: MeetingType;
-  /** Meeting title */
-  title: string;
-  /** Name of the project for contextualized agenda */
-  projectName: string;
-  /** Additional context or specific requirements */
+  /**
+   * Type of meeting for agenda generation.
+   * Optional: the composer can reach the helper before a type is chosen, in which case the prompt
+   * falls back to a generic project meeting.
+   */
+  meetingType?: MeetingType;
+  /** Meeting title. Optional — omitted from the prompt when the user hasn't set one yet. */
+  title?: string;
+  /** Name of the project for contextualized agenda. Optional, same reason as `title`. */
+  projectName?: string;
+  /** Additional context or specific requirements. Required when `title` is absent. */
   context?: string;
   /** Maximum characters allowed for the generated agenda */
   maxCharacters?: number;

--- a/packages/shared/src/interfaces/ai.interface.ts
+++ b/packages/shared/src/interfaces/ai.interface.ts
@@ -10,7 +10,7 @@ export interface GenerateAgendaRequest {
   /**
    * Type of meeting for agenda generation.
    * Optional: the composer can reach the helper before a type is chosen, in which case the prompt
-   * falls back to a generic project meeting.
+   * describes a project team meeting.
    */
   meetingType?: MeetingType;
   /** Meeting title. Optional — omitted from the prompt when the user hasn't set one yet. */
@@ -19,7 +19,7 @@ export interface GenerateAgendaRequest {
   projectName?: string;
   /** Additional context or specific requirements. Required when `title` is absent. */
   context?: string;
-  /** Maximum characters allowed for the generated agenda */
+  /** Maximum characters allowed for the generated agenda. Clamped server-side to `1..MEETING_AGENDA_MAX_LENGTH`. */
   maxCharacters?: number;
 }
 

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -523,8 +523,12 @@ export interface MeetingRegistrant {
    * Committee this registrant was added from (present when `type` is `committee`).
    * Upstream returns the v1 committee SFID; the BFF normalizes it back to the **v2** UID on enriched
    * reads (`include_committee=true`, and every `/my` registrant response) so the field means the same
-   * thing in both directions. Two carve-outs: an unenriched read returns the raw SFID, and an SFID with
-   * no v2 counterpart is passed through unchanged even on an enriched response.
+   * thing in both directions. Treat the normalization as best-effort rather than guaranteed — an
+   * enriched response still returns the raw SFID when the meeting has no committees, when the whole
+   * v1↔v2 mapping comes back empty, when this particular SFID has no v2 counterpart, or when
+   * enrichment throws (the BFF logs a warning and serves the unenriched rows with a 200 rather than
+   * failing the listing). Code that matches this field against a v2 committee UID should degrade
+   * gracefully on a miss rather than assume one can't happen.
    */
   committee_uid?: string | null;
   /** Committee name (resolved from committee_uid) - response only */
@@ -573,10 +577,12 @@ export interface CreateMeetingRegistrantRequest {
   /**
    * Committee this registrant was added from, as a **v2** committee UID.
    * Upstream stores a v1 committee SFID and derives `type: 'committee'` from it, so the BFF
-   * resolves v2 → v1 before proxying. Omit for a directly-added guest — upstream declares the field a
-   * non-nullable optional `string`, so the BFF drops the key rather than forwarding a `null`.
+   * resolves v2 → v1 before proxying. Omit for a directly-added guest: upstream declares the field a
+   * non-nullable optional `string`, so `null` is off-contract and the BFF drops the key rather than
+   * forwarding it. Typed without `| null` so that's enforceable at compile time for internal callers —
+   * the BFF's runtime drop stays as a guard for bodies it doesn't build itself.
    */
-  committee_uid?: string | null;
+  committee_uid?: string;
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -519,7 +519,11 @@ export interface MeetingRegistrant {
   // Fields NOT in API - likely response-only
   /** Registrant's type */
   type: 'direct' | 'committee';
-  /** Registrant Committee UID (if type is committee) */
+  /**
+   * Committee this registrant was added from (present when `type` is `committee`).
+   * Upstream returns the v1 committee SFID; the BFF normalizes it back to the **v2** UID during
+   * `include_committee` enrichment so the field means the same thing in both directions.
+   */
   committee_uid?: string | null;
   /** Committee name (resolved from committee_uid) - response only */
   committee_name?: string | null;
@@ -567,7 +571,7 @@ export interface CreateMeetingRegistrantRequest {
   /**
    * Committee this registrant was added from, as a **v2** committee UID.
    * Upstream stores a v1 committee SFID and derives `type: 'committee'` from it, so the BFF
-   * resolves v2 → v1 before proxying. Omit for a directly-added guest.
+   * resolves v2 → v1 before proxying. Send `null` (or omit) for a directly-added guest.
    */
   committee_uid?: string | null;
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -521,8 +521,10 @@ export interface MeetingRegistrant {
   type: 'direct' | 'committee';
   /**
    * Committee this registrant was added from (present when `type` is `committee`).
-   * Upstream returns the v1 committee SFID; the BFF normalizes it back to the **v2** UID during
-   * `include_committee` enrichment so the field means the same thing in both directions.
+   * Upstream returns the v1 committee SFID; the BFF normalizes it back to the **v2** UID on enriched
+   * reads (`include_committee=true`, and every `/my` registrant response) so the field means the same
+   * thing in both directions. Two carve-outs: an unenriched read returns the raw SFID, and an SFID with
+   * no v2 counterpart is passed through unchanged even on an enriched response.
    */
   committee_uid?: string | null;
   /** Committee name (resolved from committee_uid) - response only */
@@ -571,7 +573,8 @@ export interface CreateMeetingRegistrantRequest {
   /**
    * Committee this registrant was added from, as a **v2** committee UID.
    * Upstream stores a v1 committee SFID and derives `type: 'committee'` from it, so the BFF
-   * resolves v2 → v1 before proxying. Send `null` (or omit) for a directly-added guest.
+   * resolves v2 → v1 before proxying. Omit for a directly-added guest — upstream declares the field a
+   * non-nullable optional `string`, so the BFF drops the key rather than forwarding a `null`.
    */
   committee_uid?: string | null;
 }

--- a/packages/shared/src/utils/string.utils.spec.ts
+++ b/packages/shared/src/utils/string.utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { capCodePointEdit, codePointLength, slugify, splitIntoParagraphs } from './string.utils';
+import { capCodePointEdit, codePointLength, slugify, splitIntoParagraphs, truncateToUtf16Units } from './string.utils';
 
 describe('codePointLength', () => {
   it('counts ASCII the same as String.length', () => {
@@ -123,5 +123,36 @@ describe('splitIntoParagraphs', () => {
   it('returns an empty array for empty or whitespace-only input', () => {
     expect(splitIntoParagraphs('')).toEqual([]);
     expect(splitIntoParagraphs('  \n\n  ')).toEqual([]);
+  });
+});
+
+describe('truncateToUtf16Units', () => {
+  it('returns the value untouched when it is within the cap', () => {
+    expect(truncateToUtf16Units('agenda', 10)).toBe('agenda');
+    expect(truncateToUtf16Units('agenda', 6)).toBe('agenda');
+  });
+
+  it('clips to exactly the cap in UTF-16 units', () => {
+    expect(truncateToUtf16Units('abcdef', 3)).toBe('abc');
+    expect(truncateToUtf16Units('x'.repeat(2001), 2000)).toHaveLength(2000);
+  });
+
+  it('drops a boundary code unit rather than splitting a surrogate pair', () => {
+    // '🎉' is a surrogate pair, so a cap of 3 would otherwise land between its two units.
+    const value = `ab🎉cd`;
+    const truncated = truncateToUtf16Units(value, 3);
+
+    expect(truncated).toBe('ab');
+    // The real guard: no lone surrogate survived the cut.
+    expect([...truncated]).toHaveLength(2);
+  });
+
+  it('keeps a surrogate pair whole when the cut falls after it', () => {
+    expect(truncateToUtf16Units('ab🎉cd', 4)).toBe('ab🎉');
+  });
+
+  it('returns an empty string for a non-positive cap', () => {
+    expect(truncateToUtf16Units('agenda', 0)).toBe('');
+    expect(truncateToUtf16Units('agenda', -5)).toBe('');
   });
 });

--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -148,6 +148,32 @@ export function capCodePointEdit(previous: string, next: string, max: number): s
   return [...head, ...inserted, ...tail].join('');
 }
 
+/**
+ * Truncate to at most `max` UTF-16 code units without leaving a lone surrogate behind.
+ * @param value - The string to truncate
+ * @param max - The maximum number of UTF-16 code units
+ * @returns `value` unchanged when within the cap, otherwise clipped to `max` units (or `max - 1` when
+ * the cut would land inside a surrogate pair)
+ *
+ * Deliberately measured in UTF-16 units rather than code points, unlike {@link codePointLength} and
+ * {@link capCodePointEdit}: these caps guard values that are handed to `Validators.maxLength` or a
+ * native `maxlength` attribute, both of which count UTF-16 units. Truncating by code point would let a
+ * string full of emoji pass a code-point cap and still fail the validator on the other side — which,
+ * for the meeting composer's agenda, means an invalid form and a Save button that does nothing.
+ */
+export function truncateToUtf16Units(value: string, max: number): string {
+  if (value.length <= max || max <= 0) {
+    return value.length <= max ? value : '';
+  }
+
+  // A high surrogate at the last kept position means the cut splits a pair; drop it rather than emit
+  // an unpaired code unit.
+  const lastKept = value.charCodeAt(max - 1);
+  const splitsPair = lastKept >= 0xd800 && lastKept <= 0xdbff;
+
+  return value.slice(0, splitsPair ? max - 1 : max);
+}
+
 /** Best-effort split of a display name into [firstName, lastName]; `null` parts when nothing usable (e.g. an email used as the name). */
 export function splitDisplayName(name: string | null): [string | null, string | null] {
   const trimmed = (name ?? '').trim();


### PR DESCRIPTION
## What

BE-2 — makes the meeting agenda **AI helper** usable from the composer's Agenda & Resources section
(outside the original Details step) and verifies its availability and rate limits.

## How

- `GenerateAgendaRequest`'s `meetingType` / `title` / `projectName` became optional so the helper can
  run before those fields are filled; prompt descriptors are truncated on UTF-16 pair boundaries
  rather than dropped.
- The AI goal no longer blocks save, and off-contract nulls are omitted from the request.
- `aiRateLimiter` covers the agenda route.

## Notes for review — please read

- **Shared-component behavior change:** `lfx-textarea`'s `[maxlength]` became `[attr.maxlength]`, so
  it no longer attaches a maxlength *validator*. This touches **20+ consumers** of the component
  outside meetings.
- Two **preflight-protected** files are modified — `ai.service.ts` (floor-to-fallback change) and
  `rate-limit.middleware.ts`. These need a code-owner look.
- `resolveAgendaMaxCharacters` still substitutes silently, and the two prompt sanitizers live on the
  controller rather than in a shared helper.

Refs #1464
