### PR TITLE
fix(meetings): send registrant fields upstream by their real names

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -73,8 +73,9 @@ export class PublicRegistrationModalComponent {
           first_name: formValue.first_name,
           last_name: formValue.last_name,
           // Omitted when blank rather than sent as `null` — see the note on
-          // `CreateMeetingRegistrantRequest`. This is the path with no user session, so the BFF's
-          // null-drop is the only thing between this form and upstream; don't lean on it.
+          // `CreateMeetingRegistrantRequest`. There is no null-laundering anywhere on this path: the
+          // BFF's one such drop is `committee_uid`-specific and this endpoint doesn't send one, so a
+          // `null` here would reach upstream verbatim, onto a field it declares non-nullable.
           ...(formValue.job_title ? { job_title: formValue.job_title } : {}),
           ...(formValue.org_name ? { org_name: formValue.org_name } : {}),
         })

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -73,9 +73,10 @@ export class PublicRegistrationModalComponent {
           first_name: formValue.first_name,
           last_name: formValue.last_name,
           // Omitted when blank rather than sent as `null` — see the note on
-          // `CreateMeetingRegistrantRequest`. There is no null-laundering anywhere on this path: the
-          // BFF's one such drop is `committee_uid`-specific and this endpoint doesn't send one, so a
-          // `null` here would reach upstream verbatim, onto a field it declares non-nullable.
+          // `CreateMeetingRegistrantRequest`. Upstream declares both fields non-nullable. The BFF now
+          // drops a blank or nullish one on this path too (`toSelfRegistration`, then
+          // `toUpstreamRegistrantBody`), so this is defense in depth rather than the only guard — keep
+          // it, because neither of those exists to serve this form and both could be re-scoped.
           ...(formValue.job_title ? { job_title: formValue.job_title } : {}),
           ...(formValue.org_name ? { org_name: formValue.org_name } : {}),
         })

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -9,6 +9,7 @@ import { OrganizationSearchComponent } from '@components/organization-search/org
 import { MeetingRegistrant, User } from '@lfx-one/shared/interfaces';
 import { markFormControlsAsTouched } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
+import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
@@ -90,9 +91,13 @@ export class PublicRegistrationModalComponent {
             });
             this.ref.close({ registered: true, registrant });
           },
-          error: (error: any) => {
+          error: (error: unknown) => {
             this.submitting.set(false);
-            const errorMessage = error?.error?.message || 'Failed to register for this meeting';
+            // `error?.error?.message` never matched: the server's error body is `{ error, code }` with
+            // no `message` key (`BaseApiError.toResponse`), so every failure showed the fallback and a
+            // registrant was never told which field was wrong. `extractErrorMessage` reads `message`
+            // then `error`, so a validation message reaches the toast.
+            const errorMessage = extractErrorMessage(error, 'Failed to register for this meeting');
             this.messageService.add({
               severity: 'error',
               summary: 'Registration Failed',

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -95,8 +95,8 @@ export class PublicRegistrationModalComponent {
             this.submitting.set(false);
             // `error?.error?.message` never matched: the server's error body is `{ error, code }` with
             // no `message` key (`BaseApiError.toResponse`), so every failure showed the fallback and a
-            // registrant was never told which field was wrong. `extractErrorMessage` reads `message`
-            // then `error`, so a validation message reaches the toast.
+            // registrant was never told which field was wrong. `extractErrorMessage` reads the body's
+            // `error` key too, so a validation message reaches the toast.
             const errorMessage = extractErrorMessage(error, 'Failed to register for this meeting');
             this.messageService.add({
               severity: 'error',

--- a/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/public-registration-modal/public-registration-modal.component.ts
@@ -72,8 +72,11 @@ export class PublicRegistrationModalComponent {
           email: formValue.email,
           first_name: formValue.first_name,
           last_name: formValue.last_name,
-          job_title: formValue.job_title || null,
-          org_name: formValue.org_name || null,
+          // Omitted when blank rather than sent as `null` — see the note on
+          // `CreateMeetingRegistrantRequest`. This is the path with no user session, so the BFF's
+          // null-drop is the only thing between this form and upstream; don't lean on it.
+          ...(formValue.job_title ? { job_title: formValue.job_title } : {}),
+          ...(formValue.org_name ? { org_name: formValue.org_name } : {}),
         })
         .subscribe({
           next: (registrant: MeetingRegistrant) => {

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -29,7 +29,7 @@ export class TextareaComponent {
    * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
    * caller that only wanted the browser to stop typing at the cap. Callers that want the value
    * gated declare `Validators.maxLength` on the control themselves — the composer's agenda, the
-   * settings description and the org-profile description all do. The rest rely on the native cap
+   * crowdfunding initiative settings description and the org-profile description all do. The rest rely on the native cap
    * alone, which holds for typing and pasting but not for a value written programmatically with
    * `setValue`.
    */

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -28,9 +28,10 @@ export class TextareaComponent {
    * `ReactiveFormsModule` this component imports, so a property binding here would silently attach
    * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
    * caller that only wanted the browser to stop typing at the cap. Callers that want the value
-   * gated declare `Validators.maxLength` on the control themselves — as the composer's agenda and
-   * the settings description do. The rest rely on the native cap alone, which holds for typing and
-   * pasting but not for a value written programmatically with `setValue`.
+   * gated declare `Validators.maxLength` on the control themselves — the composer's agenda, the
+   * settings description and the org-profile description all do. The rest rely on the native cap
+   * alone, which holds for typing and pasting but not for a value written programmatically with
+   * `setValue`.
    */
   public maxlength = input<number>();
   public dataTest = input<string>();

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -29,9 +29,9 @@ export class TextareaComponent {
    * a validator to the caller's control and make the whole `FormGroup` invalid — invisible to a
    * caller that only wanted the browser to stop typing at the cap. Callers that want the value
    * gated declare `Validators.maxLength` on the control themselves — the composer's agenda, the
-   * crowdfunding initiative settings description and the org-profile description all do. The rest rely on the native cap
-   * alone, which holds for typing and pasting but not for a value written programmatically with
-   * `setValue`.
+   * crowdfunding initiative settings description and the newsletter drawer's raw content and system
+   * prompt among them. The rest rely on the native cap alone, which holds for typing and pasting but
+   * not for a value written programmatically with `setValue`.
    */
   public maxlength = input<number>();
   public dataTest = input<string>();

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -533,10 +533,10 @@ export class MeetingService {
    *
    * Every optional string is omitted when empty rather than sent as `null`: upstream declares
    * `committee_uid`, `job_title` and `org` alike as non-nullable optional `string`s
-   * (`CreateItxRegistrantRequestBody`). The BFF drops a stray `null` anyway, but relying on that
-   * would mean shipping an off-contract body and trusting the proxy to launder it. The create body
-   * has nothing to clear, so omission loses no meaning — unlike {@link getChangedFields}, where
-   * `null` is how an update erases a stored value.
+   * (`CreateItxRegistrantRequestBody`). Nothing downstream launders a stray `null` — the BFF's only
+   * such drop is `committee_uid`-specific, on the v2 → v1 resolution path — so a `null` here reaches
+   * upstream verbatim. The create body has nothing to clear, so omission loses no meaning — unlike
+   * {@link getChangedFields}, where `null` is how an update erases a stored value.
    */
   public stripMetadata(meetingUid: string, registrant: MeetingRegistrantWithState): CreateMeetingRegistrantRequest {
     return {

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.spec.ts
@@ -5,11 +5,55 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { firstValueFrom, Observable, throwError } from 'rxjs';
 import { describe, expect, it } from 'vitest';
 
-import { isTransientHttpError, retryTransientHttpError } from './http-error.utils';
+import { extractErrorMessage, isTransientHttpError, retryTransientHttpError } from './http-error.utils';
 
 function httpError(status: number): HttpErrorResponse {
   return new HttpErrorResponse({ status, statusText: 'x', url: '/api/thing' });
 }
+
+describe('extractErrorMessage', () => {
+  // `error` and not `message` is the key that matters: `BaseApiError.toResponse()` emits
+  // `{ error, code }`, so a reader that only knows `message` shows the fallback on every server
+  // validation failure — which is what it did before this was the util in use.
+  it('reads the `error` key this server actually sends', () => {
+    const error = new HttpErrorResponse({ status: 400, error: { error: 'Email address is required.', code: 'VALIDATION_ERROR' } });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Email address is required.');
+  });
+
+  it('still reads a `message` key, for upstream bodies that use it', () => {
+    const error = new HttpErrorResponse({ status: 400, error: { message: 'Upstream said no' } });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Upstream said no');
+  });
+
+  // Angular populates `HttpErrorResponse.message` for every failure with a string built for a
+  // console — "Http failure response for /api/thing: 0 Unknown Error". Preferring it would put a URL
+  // and a status code in front of a user on exactly the failures with no body to read.
+  it('prefers the caller fallback over Angular internal message text', () => {
+    const detail = extractErrorMessage(httpError(0), 'Could not reach the server. Please try again.');
+
+    expect(detail).toBe('Could not reach the server. Please try again.');
+    expect(detail).not.toContain('Http failure');
+  });
+
+  it('falls back when the body is an object with no usable string', () => {
+    const error = new HttpErrorResponse({ status: 500, error: { code: 'BOOM' } });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('fallback');
+  });
+
+  it('uses a plain-string body as the message', () => {
+    const error = new HttpErrorResponse({ status: 502, error: 'Bad gateway' });
+
+    expect(extractErrorMessage(error, 'fallback')).toBe('Bad gateway');
+  });
+
+  it('reads a thrown Error message, and falls back for anything else', () => {
+    expect(extractErrorMessage(new Error('boom'), 'fallback')).toBe('boom');
+    expect(extractErrorMessage(null, 'fallback')).toBe('fallback');
+  });
+});
 
 describe('isTransientHttpError', () => {
   // Each status is named rather than looped so a failure says WHICH class of

--- a/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
+++ b/apps/lfx-one/src/app/shared/utils/http-error.utils.ts
@@ -34,6 +34,16 @@ export function getHttpErrorDetail(err: HttpErrorResponse, fallback: string): st
  * a thrown Error, or any other value. Used by components that catch errors
  * from `firstValueFrom(...)` or RxJS `catchError` and need to surface a
  * single string to the UI.
+ *
+ * `body.error` is read as well as `body.message` because that is the key this server's error
+ * envelope actually uses — `BaseApiError.toResponse()` emits `{ error, code }` and no `message`.
+ *
+ * When the body yields nothing, the caller's `fallback` wins over `HttpErrorResponse.message`.
+ * Angular fills that property in for every failure with a string built for a developer reading a
+ * console — "Http failure response for /public/api/...: 0 Unknown Error" — so preferring it would
+ * put a URL and a status code in front of a user on exactly the failures where the body is empty:
+ * a network drop, or a 500 with no envelope. Every call site passes a written-for-a-human fallback;
+ * that is the one to show.
  */
 export function extractErrorMessage(error: unknown, fallback: string): string {
   if (error instanceof HttpErrorResponse) {
@@ -43,7 +53,7 @@ export function extractErrorMessage(error: unknown, fallback: string): string {
       const candidate = [body.message, body.error].find((value): value is string => typeof value === 'string' && value.trim().length > 0);
       if (candidate) return candidate;
     }
-    return error.message || fallback;
+    return fallback;
   }
 
   if (error instanceof Error && error.message) return error.message;

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -17,6 +17,7 @@ const { meetingSvc, aiSvc, committeeSvc, resolveCommitteeV2UidsToV1IdsMock } = v
   meetingSvc: {
     getMeetingById: vi.fn(),
     getMeetingRegistrants: vi.fn(),
+    getMeetingRegistrantsByEmail: vi.fn(),
     addMeetingRegistrant: vi.fn(),
   },
   aiSvc: { generateMeetingAgenda: vi.fn() },
@@ -291,6 +292,40 @@ describe('MeetingController', () => {
       const res = buildRes();
 
       await controller.getMeetingRegistrants(buildReq({ query: { include_committee: 'true' } }), res, next);
+
+      expect(next).not.toHaveBeenCalled();
+      expect(res.json).toHaveBeenCalledWith([registrant]);
+    });
+  });
+
+  describe('getMyMeetingRegistrants', () => {
+    const registrant = { uid: 'reg-1', email: 'a@example.com', committee_uid: V1_COMMITTEE_SFID };
+
+    beforeEach(() => {
+      meetingSvc.getMeetingById.mockResolvedValue({ uid: MEETING_ID, organizer: true, committees: [{ uid: V2_COMMITTEE_UID }] });
+      meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([{ uid: 'reg-self', email: 'user@example.com' }]);
+      meetingSvc.getMeetingRegistrants.mockResolvedValue([{ ...registrant }]);
+      resolveCommitteeV2UidsToV1IdsMock.mockResolvedValue(new Map([[V2_COMMITTEE_UID, V1_COMMITTEE_SFID]]));
+      committeeSvc.getCommitteeById.mockResolvedValue({ uid: V2_COMMITTEE_UID, name: 'TAC', category: 'Technical' });
+      committeeSvc.getCommitteeMembers.mockResolvedValue([{ email: 'a@example.com', role: { name: 'Chair' }, voting: { status: 'Voting Rep' } }]);
+    });
+
+    it('enriches committee metadata for a registrant of the meeting', async () => {
+      const res = buildRes();
+
+      await controller.getMyMeetingRegistrants(buildReq(), res, next);
+
+      expect(res.json).toHaveBeenCalledWith([expect.objectContaining({ committee_name: 'TAC', committee_uid: V2_COMMITTEE_UID })]);
+    });
+
+    // Group attribution is decoration; the guest list is not. The v2 → v1 mapping goes over NATS, so a
+    // transient committee-service problem must not turn this listing into a 500 — and this is the
+    // degradation `MeetingRegistrant.committee_uid`'s docstring promises on both read paths.
+    it('degrades to unenriched rows when the committee mapping lookup fails', async () => {
+      resolveCommitteeV2UidsToV1IdsMock.mockRejectedValue(new Error('nats timeout'));
+      const res = buildRes();
+
+      await controller.getMyMeetingRegistrants(buildReq(), res, next);
 
       expect(next).not.toHaveBeenCalled();
       expect(res.json).toHaveBeenCalledWith([registrant]);

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -912,7 +912,8 @@ export class ProjectController {
     }
 
     try {
-      // Public route has no session — obtain M2M token so meeting service calls succeed.
+      // `/public/api` is optional-auth, so a session may or may not exist. Fall back to an M2M token
+      // when there's no user bearer token, so meeting service calls succeed either way.
       if (!req.bearerToken) {
         req.bearerToken = await generateM2MToken(req);
       }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -6,6 +6,8 @@ import { MeetingVisibility } from '@lfx-one/shared/enums';
 import type { Meeting } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+import type { ServiceValidationError } from '../errors/service-validation.error';
+
 const MEETING_ID = 'meeting-1111';
 const PROJECT_UID = 'project-2222';
 
@@ -544,7 +546,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(forwardedBody()).toMatchObject({ email: 'a@example.com', first_name: 'A', org_name: 'Acme' });
   });
 
-  it.each(['first_name', 'last_name', 'job_title', 'org_name'])('caps %s so nothing unbounded reaches upstream', async (field) => {
+  it.each(['first_name', 'last_name', 'job_title', 'org_name', 'occurrence_id'])('caps %s so nothing unbounded reaches upstream', async (field) => {
     const { req, res, next } = buildRegisterReqRes({ ...validBody, [field]: 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH * 2) });
 
     await controller.registerForPublicMeeting(req, res, next);
@@ -553,16 +555,24 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(forwardedBody()[field]).toHaveLength(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
   });
 
-  // Truncating the record's identity key would turn a too-long address into a different, valid-looking
-  // one and send an invite there — so it's rejected instead of capped.
-  it('rejects an over-length email rather than truncating it', async () => {
-    const local = 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
-    const { req, res, next } = buildRegisterReqRes({ ...validBody, email: `${local}@example.com` });
+  // The two identity keys are rejected rather than capped: truncating one would turn an unusable value
+  // into a different, valid-looking one — an invite to the wrong address, or a lookup against the wrong
+  // meeting. The error has to name the field, or a caller that did send an email is told it was
+  // missing.
+  it.each([
+    ['email', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
+    ['meeting_id', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+  ])('rejects an over-length %s by name rather than truncating it', async (field, overrides) => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, ...overrides });
 
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
+
+    const error = next.mock.calls[0][0] as ServiceValidationError;
+
+    expect(error.validationErrors).toEqual([expect.objectContaining({ field, message: expect.stringContaining(`${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH}`) })]);
   });
 
   // Which occurrences the registration covers is part of what a registrant states about their own

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { PUBLIC_REGISTRATION_FIELD_MAX_LENGTH } from '@lfx-one/shared/constants';
 import { MeetingVisibility } from '@lfx-one/shared/enums';
 import type { Meeting } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -88,11 +89,19 @@ vi.mock('../services/logger.service', () => ({
     info: vi.fn(),
   },
 }));
-vi.mock('../utils/auth-helper', () => ({
-  getEffectiveEmail: getEffectiveEmailMock,
-  getEffectiveUsername: getEffectiveUsernameMock,
-  getUsernameFromAuth: vi.fn(),
-}));
+// `stripAuthPrefix` is kept real rather than stubbed: the controller's prefix stripping only matters
+// because it has to agree with what the read paths do, and a stand-in here would assert agreement with
+// the stand-in instead.
+vi.mock('../utils/auth-helper', async () => {
+  const actual = await vi.importActual<typeof import('../utils/auth-helper')>('../utils/auth-helper');
+
+  return {
+    getEffectiveEmail: getEffectiveEmailMock,
+    getEffectiveUsername: getEffectiveUsernameMock,
+    getUsernameFromAuth: vi.fn(),
+    stripAuthPrefix: actual.stripAuthPrefix,
+  };
+});
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
 vi.mock('../utils/security.util', () => ({ validatePassword: validatePasswordMock }));
 
@@ -432,8 +441,9 @@ describe('PublicMeetingController.getMeetingOccurrences', () => {
 });
 
 /**
- * This endpoint takes no session and writes upstream under an M2M token, so the request body is the
- * only thing describing who the registrant is — and an anonymous caller controls all of it.
+ * This endpoint is optional-auth and always writes upstream under an M2M token, so apart from the
+ * username it reads off a session when one exists, the request body is the only thing describing who
+ * the registrant is — and the caller controls all of it.
  */
 describe('PublicMeetingController.registerForPublicMeeting', () => {
   let controller: PublicMeetingController;
@@ -534,19 +544,44 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(forwardedBody()).toMatchObject({ email: 'a@example.com', first_name: 'A', org_name: 'Acme' });
   });
 
-  it('caps each free-text field so nothing unbounded reaches upstream', async () => {
-    const { req, res, next } = buildRegisterReqRes({ ...validBody, org_name: 'x'.repeat(400) });
+  it.each(['first_name', 'last_name', 'job_title', 'org_name'])('caps %s so nothing unbounded reaches upstream', async (field) => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, [field]: 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH * 2) });
 
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    expect(forwardedBody().org_name).toHaveLength(255);
+    expect(forwardedBody()[field]).toHaveLength(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
+  });
+
+  // Truncating the record's identity key would turn a too-long address into a different, valid-looking
+  // one and send an invite there — so it's rejected instead of capped.
+  it('rejects an over-length email rather than truncating it', async () => {
+    const local = 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, email: `${local}@example.com` });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  // Which occurrences the registration covers is part of what a registrant states about their own
+  // attendance. No in-app caller sends it yet, so only this test keeps it from falling out again.
+  it('still forwards a single-occurrence scope', async () => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, occurrence_id: '1666848600' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forwardedBody().occurrence_id).toBe('1666848600');
   });
 
   // Derived from the session, never from the body: a signed-in registrant keeps their LFID on a
-  // record written with application credentials, and a forged `username` still can't get in.
-  it('takes username from the session and ignores the one in the body', async () => {
-    getEffectiveUsernameMock.mockReturnValue('realuser');
+  // record written with application credentials, and a forged `username` still can't get in. The
+  // provider prefix is stripped because a registrant record stores the plain LFID — every read path
+  // strips before matching, so a prefixed row would be invisible to the join-URL lookup.
+  it('takes username from the session, strips its provider prefix, and ignores the body', async () => {
+    getEffectiveUsernameMock.mockReturnValue('auth0|realuser');
     const { req, res, next } = buildRegisterReqRes({ ...validBody, username: 'someone-else' });
 
     await controller.registerForPublicMeeting(req, res, next);

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -35,6 +35,7 @@ const {
     resolveCreatedByForMeetings: vi.fn().mockResolvedValue(new Map()),
     getMeetingHostKey: vi.fn(),
     getPastOccurrencesForMeeting: vi.fn(),
+    addMeetingRegistrantWithM2M: vi.fn(),
   },
   projectSvc: { getProjectById: vi.fn() },
   addInvitedStatusToMeetingMock: vi.fn(),
@@ -422,5 +423,75 @@ describe('PublicMeetingController.getMeetingOccurrences', () => {
 
     expect(generateM2MTokenMock).toHaveBeenCalledTimes(1);
     expect(req.bearerToken).toBe('m2m-token');
+  });
+});
+
+/**
+ * This endpoint takes no session and writes upstream under an M2M token, so the request body is the
+ * only thing describing who the registrant is — and an anonymous caller controls all of it.
+ */
+describe('PublicMeetingController.registerForPublicMeeting', () => {
+  let controller: PublicMeetingController;
+
+  const validBody = { meeting_id: MEETING_ID, email: 'a@example.com', first_name: 'A', last_name: 'B' };
+
+  function buildRegisterReqRes(body: Record<string, unknown>) {
+    const req = { body, params: {}, query: {}, headers: {}, path: '/public/api/meetings/register', log: {} } as any;
+    const res = { json: vi.fn(), status: vi.fn().mockReturnThis() } as any;
+    return { req, res, next: vi.fn() };
+  }
+
+  const forwardedBody = () => meetingSvc.addMeetingRegistrantWithM2M.mock.calls[0][1];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new PublicMeetingController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    meetingSvc.addMeetingRegistrantWithM2M.mockResolvedValue({ uid: 'reg-1' });
+  });
+
+  it('forwards the fields a registrant may state about themselves', async () => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, job_title: 'Dev', org_name: 'Acme' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forwardedBody()).toMatchObject({ ...validBody, job_title: 'Dev', org_name: 'Acme' });
+    expect(res.status).toHaveBeenCalledWith(201);
+  });
+
+  // `host` grants "access to host key for the meeting" upstream, and `committee_uid` claims committee
+  // membership. Neither is an anonymous caller's to assert, and the M2M token means upstream has no
+  // way to tell that the claim came from the public form.
+  it('does not let an anonymous caller grant itself host access or claim a committee', async () => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, host: true, committee_uid: 'committee-1' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forwardedBody().host).toBe(false);
+    expect(forwardedBody()).not.toHaveProperty('committee_uid');
+  });
+
+  it('drops any other field the caller invents', async () => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, username: 'someone-else', uid: 'reg-hijack', type: 'committee' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    for (const key of ['username', 'uid', 'type']) {
+      expect(forwardedBody()).not.toHaveProperty(key);
+    }
+  });
+
+  it('still rejects a non-public meeting before writing anything', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE }));
+    const { req, res, next } = buildRegisterReqRes(validBody);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -50,7 +50,12 @@ vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public',
 vi.mock('@lfx-one/shared/utils', () => ({ resolveMeetingOrganizer: vi.fn(() => null) }));
 // meeting.helper imports HOST_KEY_* from shared/constants; stub the barrel so the full constants
 // module graph (which re-imports shared/enums for ArtifactVisibility etc.) doesn't load.
-vi.mock('@lfx-one/shared/constants', () => ({ HOST_KEY_EARLY_MINUTES: 70, HOST_KEY_LATE_MINUTES: 40, MEETING_PASSWORD_HEADER: 'x-meeting-password' }));
+vi.mock('@lfx-one/shared/constants', () => ({
+  HOST_KEY_EARLY_MINUTES: 70,
+  HOST_KEY_LATE_MINUTES: 40,
+  MEETING_PASSWORD_HEADER: 'x-meeting-password',
+  PUBLIC_REGISTRATION_FIELD_MAX_LENGTH: 255,
+}));
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
 
 vi.mock('../services/meeting.service', () => ({
@@ -449,6 +454,9 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     generateM2MTokenMock.mockResolvedValue('m2m-token');
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.addMeetingRegistrantWithM2M.mockResolvedValue({ uid: 'reg-1' });
+    // Anonymous by default — this route is optional-auth, and `clearAllMocks` leaves return values
+    // from earlier suites in place, so pin it rather than inherit one.
+    getEffectiveUsernameMock.mockReturnValue(null);
   });
 
   it('forwards the fields a registrant may state about themselves', async () => {
@@ -475,14 +483,86 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
   });
 
   it('drops any other field the caller invents', async () => {
-    const { req, res, next } = buildRegisterReqRes({ ...validBody, username: 'someone-else', uid: 'reg-hijack', type: 'committee' });
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, uid: 'reg-hijack', type: 'committee' });
 
     await controller.registerForPublicMeeting(req, res, next);
 
     expect(next).not.toHaveBeenCalled();
-    for (const key of ['username', 'uid', 'type']) {
+    for (const key of ['uid', 'type']) {
       expect(forwardedBody()).not.toHaveProperty(key);
     }
+  });
+
+  it('omits username entirely for an anonymous caller', async () => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, username: 'someone-else' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forwardedBody()).not.toHaveProperty('username');
+  });
+
+  // The route mounts the handler with no express-validator, so a non-string is what actually gets to
+  // choose whether it clears the `if (!registrantData.email …)` gate. Narrowing to a string is the
+  // only thing that stops an object or array being forwarded upstream under the M2M token.
+  it.each([[{ nested: 'x' }], [['a@example.com']], [42], [null]])('rejects a non-string email (%j) instead of forwarding it', async (email) => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, email });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not throw on a missing body', async () => {
+    const { req, res, next } = buildRegisterReqRes(undefined as any);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  // Query-service tag matching is case-sensitive and every read path lowercases, so a mixed-case
+  // registration would be indexed under a tag no later invited-status lookup matches.
+  it('lowercases and trims the fields it forwards', async () => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, email: '  A@Example.COM ', first_name: ' A ', org_name: ' Acme ' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forwardedBody()).toMatchObject({ email: 'a@example.com', first_name: 'A', org_name: 'Acme' });
+  });
+
+  it('caps each free-text field so nothing unbounded reaches upstream', async () => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, org_name: 'x'.repeat(400) });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forwardedBody().org_name).toHaveLength(255);
+  });
+
+  // Derived from the session, never from the body: a signed-in registrant keeps their LFID on a
+  // record written with application credentials, and a forged `username` still can't get in.
+  it('takes username from the session and ignores the one in the body', async () => {
+    getEffectiveUsernameMock.mockReturnValue('realuser');
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, username: 'someone-else' });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(forwardedBody().username).toBe('realuser');
+  });
+
+  it('responds with the registrant the service returned', async () => {
+    meetingSvc.addMeetingRegistrantWithM2M.mockResolvedValue({ uid: 'reg-1', org_name: 'Acme' });
+    const { req, res, next } = buildRegisterReqRes(validBody);
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(res.status).toHaveBeenCalledWith(201);
+    expect(res.json).toHaveBeenCalledWith({ uid: 'reg-1', org_name: 'Acme' });
   });
 
   it('still rejects a non-public meeting before writing anything', async () => {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -546,7 +546,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(forwardedBody()).toMatchObject({ email: 'a@example.com', first_name: 'A', org_name: 'Acme' });
   });
 
-  it.each(['first_name', 'last_name', 'job_title', 'org_name', 'occurrence_id'])('caps %s so nothing unbounded reaches upstream', async (field) => {
+  it.each(['first_name', 'last_name', 'job_title', 'org_name'])('caps %s so nothing unbounded reaches upstream', async (field) => {
     const { req, res, next } = buildRegisterReqRes({ ...validBody, [field]: 'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH * 2) });
 
     await controller.registerForPublicMeeting(req, res, next);
@@ -555,13 +555,17 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     expect(forwardedBody()[field]).toHaveLength(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
   });
 
-  // The two identity keys are rejected rather than capped: truncating one would turn an unusable value
-  // into a different, valid-looking one — an invite to the wrong address, or a lookup against the wrong
-  // meeting. The error has to name the field, or a caller that did send an email is told it was
-  // missing.
+  // The three identifiers are rejected rather than capped: truncating one would turn an unusable value
+  // into a different, valid-looking one — a lookup against the wrong meeting, an invite to the wrong
+  // address, or a registration scoped to the wrong occurrence.
+  //
+  // Both the field array and the top-level message are asserted. The array alone isn't enough: the
+  // modal renders `error.message` and discards `errors[]`, so a generic message there would leave the
+  // registrant with nothing to act on — which is exactly what the old "Email is required" path did.
   it.each([
     ['email', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
     ['meeting_id', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+    ['occurrence_id', { occurrence_id: '1'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
   ])('rejects an over-length %s by name rather than truncating it', async (field, overrides) => {
     const { req, res, next } = buildRegisterReqRes({ ...validBody, ...overrides });
 
@@ -573,6 +577,7 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
     const error = next.mock.calls[0][0] as ServiceValidationError;
 
     expect(error.validationErrors).toEqual([expect.objectContaining({ field, message: expect.stringContaining(`${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH}`) })]);
+    expect(error.message).toBe(`${field} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`);
   });
 
   // Which occurrences the registration covers is part of what a registrant states about their own

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -58,6 +58,13 @@ vi.mock('@lfx-one/shared/constants', () => ({
   HOST_KEY_LATE_MINUTES: 40,
   MEETING_PASSWORD_HEADER: 'x-meeting-password',
   PUBLIC_REGISTRATION_FIELD_MAX_LENGTH: 255,
+  PUBLIC_REGISTRATION_FIELD_LABELS: {
+    meeting_id: 'Meeting ID',
+    occurrence_id: 'Occurrence ID',
+    email: 'Email address',
+    first_name: 'First name',
+    last_name: 'Last name',
+  },
 }));
 vi.mock('../helpers/validation.helper', () => ({ validateUidParameter: vi.fn(() => true) }));
 
@@ -560,13 +567,14 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
   // address, or a registration scoped to the wrong occurrence.
   //
   // Both the field array and the top-level message are asserted. The array alone isn't enough: the
-  // modal renders `error.message` and discards `errors[]`, so a generic message there would leave the
-  // registrant with nothing to act on — which is exactly what the old "Email is required" path did.
+  // modal shows the top-level message — serialized as the body's `error` key — and discards
+  // `errors[]`, so a generic message there would leave the registrant with nothing to act on, which is
+  // exactly what the old "Registration data validation failed" path did.
   it.each([
-    ['email', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
-    ['meeting_id', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
-    ['occurrence_id', { occurrence_id: '1'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
-  ])('rejects an over-length %s by name rather than truncating it', async (field, overrides) => {
+    ['email', 'Email address', { email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com` }],
+    ['meeting_id', 'Meeting ID', { meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+    ['occurrence_id', 'Occurrence ID', { occurrence_id: '1'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1) }],
+  ])('rejects an over-length %s by name rather than truncating it', async (field, label, overrides) => {
     const { req, res, next } = buildRegisterReqRes({ ...validBody, ...overrides });
 
     await controller.registerForPublicMeeting(req, res, next);
@@ -576,8 +584,45 @@ describe('PublicMeetingController.registerForPublicMeeting', () => {
 
     const error = next.mock.calls[0][0] as ServiceValidationError;
 
+    // `errors[]` keeps the wire key; the message a person reads gets the label.
     expect(error.validationErrors).toEqual([expect.objectContaining({ field, message: expect.stringContaining(`${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH}`) })]);
-    expect(error.message).toBe(`${field} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`);
+    expect(error.message).toBe(`${label} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`);
+  });
+
+  // Two at once, because the join is what a single-field case can't catch: an `and`-joined message has
+  // to still read as one sentence, and both fields have to survive into `errors[]`.
+  it('names every over-length identifier in one message', async () => {
+    const { req, res, next } = buildRegisterReqRes({
+      ...validBody,
+      meeting_id: 'm'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH + 1),
+      email: `${'x'.repeat(PUBLIC_REGISTRATION_FIELD_MAX_LENGTH)}@example.com`,
+    });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    const error = next.mock.calls[0][0] as ServiceValidationError;
+
+    expect(error.validationErrors.map((entry) => entry.field)).toEqual(['meeting_id', 'email']);
+    expect(error.message).toBe(`Meeting ID and Email address must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`);
+  });
+
+  // The required-field path had the same defect the length path was fixed for: its top-level message
+  // was a generic "Registration data validation failed", so the registrant saw nothing actionable.
+  it.each([
+    ['email', { email: '' }, 'Email address is required.'],
+    ['first_name', { first_name: '  ' }, 'First name is required.'],
+    ['meeting_id', { meeting_id: '' }, 'Meeting ID is required.'],
+  ])('names a missing %s in the message the registrant sees', async (field, overrides, expected) => {
+    const { req, res, next } = buildRegisterReqRes({ ...validBody, ...overrides });
+
+    await controller.registerForPublicMeeting(req, res, next);
+
+    expect(meetingSvc.addMeetingRegistrantWithM2M).not.toHaveBeenCalled();
+
+    const error = next.mock.calls[0][0] as ServiceValidationError;
+
+    expect(error.validationErrors.map((entry) => entry.field)).toEqual([field]);
+    expect(error.message).toBe(expected);
   });
 
   // Which occurrences the registration covers is part of what a registrant states about their own

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -506,24 +506,35 @@ export class PublicMeetingController {
     const registrantData = this.toSelfRegistration(req, req.body);
     const meetingId = registrantData.meeting_id;
 
-    // Reject an over-length identity key rather than truncating it. `toSelfRegistration` caps the
-    // free-text fields, but truncating a meeting UID or an email address would turn an unusable value
-    // into a different, valid-looking one — a lookup against the wrong meeting, or an invite sent to an
-    // address nobody asked for. Rejected by name so the caller isn't told a field it did send was
-    // missing.
+    // Reject an over-length identifier rather than truncating it. `toSelfRegistration` caps the
+    // free-text fields, but truncating one of these three would turn an unusable value into a
+    // different, valid-looking one: a lookup against the wrong meeting, an invite sent to an address
+    // nobody asked for, or a registration scoped to the wrong occurrence. Rejected by name so the
+    // caller isn't told a field it did send was missing.
     //
-    // Ahead of `startOperation`, because these two are the only fields that reach it untruncated and it
+    // Ahead of `startOperation`, because these are the only fields that reach it untruncated and it
     // logs `meeting_id` verbatim — checking after would put an unbounded value in the logs, which is
     // exactly what the cap exists to prevent. `apiErrorHandler` logs the rejection centrally.
-    const overLength = Object.entries({ meeting_id: meetingId, email: registrantData.email }).filter(
-      ([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH
-    );
+    //
+    // Length is measured on the stored form rather than the submitted one — `email` is already
+    // lowercased here, and lowercasing can lengthen a value for a handful of Unicode code points. The
+    // stored form is what has to fit, so that's what's checked.
+    const overLength = Object.entries({
+      meeting_id: meetingId,
+      email: registrantData.email,
+      occurrence_id: registrantData.occurrence_id ?? '',
+    }).filter(([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
 
     if (overLength.length > 0) {
+      const fields = overLength.map(([field]) => field);
+
       return next(
         ServiceValidationError.fromFieldErrors(
-          Object.fromEntries(overLength.map(([field]) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
-          'Registration data validation failed',
+          Object.fromEntries(fields.map((field) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
+          // The cause goes in the top-level message, not only in `errors[]`: the one consumer of this
+          // endpoint renders `error.message` and discards the field array, so a generic "validation
+          // failed" here would leave the registrant with no idea which field to shorten.
+          `${fields.join(', ')} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`,
           {
             operation: 'register_for_public_meeting',
             service: 'public_meeting_controller',
@@ -645,9 +656,10 @@ export class PublicMeetingController {
    * for in the first place. `email` is lowercased for the same reason, since query-service matching is
    * case-sensitive and every read path lowercases.
    *
-   * `email` and `meeting_id` are trimmed but not truncated, unlike the free-text fields — truncating
-   * an identity key would turn an unusable value into a different, valid-looking one. The caller
-   * rejects an over-length one by name instead, so the response says what was actually wrong.
+   * The three identifiers — `meeting_id`, `email` and `occurrence_id` — are trimmed but not truncated,
+   * unlike the free-text fields, because truncating one would turn an unusable value into a different,
+   * valid-looking one. The caller rejects an over-length one by name instead, so the response says
+   * what was actually wrong.
    *
    * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
    * register a third party's address for a public meeting and trigger an invite to it — and when the
@@ -658,14 +670,14 @@ export class PublicMeetingController {
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
     const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
-    // Identity keys are narrowed and trimmed but never truncated — see the length branch in
+    // Identifiers are narrowed and trimmed but never truncated — see the length branch in
     // `registerForPublicMeeting`, which rejects them by name instead.
     const identity = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim() : '');
     const sessionUsername = getEffectiveUsername(req);
     const username = sessionUsername ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
     const orgName = text('org_name');
-    const occurrenceId = text('occurrence_id');
+    const occurrenceId = identity('occurrence_id');
 
     return {
       meeting_id: identity('meeting_id'),

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -20,7 +20,7 @@ import { validateUidParameter } from '../helpers/validation.helper';
 import { AccessCheckService } from '../services/access-check.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
-import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveUsername, stripAuthPrefix } from '../utils/auth-helper';
 import { ProjectService } from '../services/project.service';
 import { generateM2MToken } from '../utils/m2m-token.util';
 import { validatePassword } from '../utils/security.util';
@@ -593,14 +593,14 @@ export class PublicMeetingController {
   }
 
   /**
-   * Narrows an anonymous request body to the fields a person may set about themselves.
+   * Narrows a self-registration request body to the fields a person may state about themselves.
    *
-   * This endpoint takes no session and forwards upstream under an M2M token, so whatever survives
-   * this function is written with application-level credentials and no user to attribute it to. The
-   * body used to be assigned wholesale, which let an anonymous caller set `host: true` — upstream
-   * documents that as "access to host key for the meeting" — or claim membership of a committee by
-   * passing `committee_uid`. Neither is the caller's to decide, so both are dropped here rather than
-   * left to upstream's discretion.
+   * `/public/api` is `auth: 'optional'`, so this runs both with and without a session — but it always
+   * forwards upstream under an M2M token, so whatever survives this function is written with
+   * application-level credentials. The body used to be assigned wholesale, which let a caller set
+   * `host: true` — upstream documents that as "access to host key for the meeting" — or claim
+   * membership of a committee by passing `committee_uid`. Neither is the caller's to decide, so both
+   * are dropped here rather than left to upstream's discretion.
    *
    * An allowlist rather than a denylist: a field added to `CreateMeetingRegistrantRequest` later
    * should have to be opted in to the public path deliberately, not inherit it.
@@ -612,29 +612,43 @@ export class PublicMeetingController {
    *
    * `username` is taken from the session when there is one and never from the body — a signed-in
    * registrant keeps their LFID attribution on a record written with application credentials, and a
-   * forged one still can't get in. `email` is lowercased because query-service tag matching is
-   * case-sensitive and every read path lowercases; a mixed-case registration would otherwise be
-   * indexed under a tag no later lookup matches.
+   * forged one still can't get in. It's stripped of any provider prefix because a registrant record
+   * stores the plain LFID: every read path strips before matching (`getMeetingRegistrantsByUsername`),
+   * so an `auth0|`-prefixed row would be invisible to the join-URL lookup that the username is stamped
+   * for in the first place. `email` is lowercased for the same reason, since query-service matching is
+   * case-sensitive and every read path lowercases.
    *
-   * One thing this doesn't close: `email` is the one field here that can't be self-asserted on a
-   * session-less route, so anyone can register a third party's address for a public meeting and
-   * trigger an invite to it. `publicApiRateLimiter` caps the volume, not the primitive.
+   * An over-length `email` is dropped rather than truncated, unlike the free-text fields — truncating
+   * the record's identity key would turn a too-long address into a different, valid-looking one and
+   * send an invite there.
+   *
+   * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
+   * register a third party's address for a public meeting and trigger an invite to it — and when the
+   * caller is signed in, the resulting row also carries their LFID against an address they don't own,
+   * which `getMeetingRegistrantsForUser`'s email-OR-username query matches for both parties.
+   * `publicApiRateLimiter` caps the volume, not the primitive.
    */
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
     const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
-    const username = getEffectiveUsername(req);
+    const rawEmail = typeof raw['email'] === 'string' ? raw['email'].trim() : '';
+    const sessionUsername = getEffectiveUsername(req);
+    const username = sessionUsername ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
     const orgName = text('org_name');
+    const occurrenceId = text('occurrence_id');
 
     return {
       meeting_id: text('meeting_id'),
-      email: text('email').toLowerCase(),
+      email: rawEmail.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH ? '' : rawEmail.toLowerCase(),
       first_name: text('first_name'),
       last_name: text('last_name'),
       host: false,
       ...(jobTitle ? { job_title: jobTitle } : {}),
       ...(orgName ? { org_name: orgName } : {}),
+      // Which occurrences the registration covers is part of what a registrant states about their own
+      // attendance, so it stays allowlisted even though no in-app caller sends it yet.
+      ...(occurrenceId ? { occurrence_id: occurrenceId } : {}),
       ...(username ? { username } : {}),
     };
   }

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -506,6 +506,33 @@ export class PublicMeetingController {
     const registrantData = this.toSelfRegistration(req, req.body);
     const meetingId = registrantData.meeting_id;
 
+    // Reject an over-length identity key rather than truncating it. `toSelfRegistration` caps the
+    // free-text fields, but truncating a meeting UID or an email address would turn an unusable value
+    // into a different, valid-looking one — a lookup against the wrong meeting, or an invite sent to an
+    // address nobody asked for. Rejected by name so the caller isn't told a field it did send was
+    // missing.
+    //
+    // Ahead of `startOperation`, because these two are the only fields that reach it untruncated and it
+    // logs `meeting_id` verbatim — checking after would put an unbounded value in the logs, which is
+    // exactly what the cap exists to prevent. `apiErrorHandler` logs the rejection centrally.
+    const overLength = Object.entries({ meeting_id: meetingId, email: registrantData.email }).filter(
+      ([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH
+    );
+
+    if (overLength.length > 0) {
+      return next(
+        ServiceValidationError.fromFieldErrors(
+          Object.fromEntries(overLength.map(([field]) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
+          'Registration data validation failed',
+          {
+            operation: 'register_for_public_meeting',
+            service: 'public_meeting_controller',
+            path: req.path,
+          }
+        )
+      );
+    }
+
     const startTime = logger.startOperation(req, 'register_for_public_meeting', {
       meeting_id: meetingId,
     });
@@ -618,9 +645,9 @@ export class PublicMeetingController {
    * for in the first place. `email` is lowercased for the same reason, since query-service matching is
    * case-sensitive and every read path lowercases.
    *
-   * An over-length `email` is dropped rather than truncated, unlike the free-text fields — truncating
-   * the record's identity key would turn a too-long address into a different, valid-looking one and
-   * send an invite there.
+   * `email` and `meeting_id` are trimmed but not truncated, unlike the free-text fields — truncating
+   * an identity key would turn an unusable value into a different, valid-looking one. The caller
+   * rejects an over-length one by name instead, so the response says what was actually wrong.
    *
    * What this doesn't close: `email` is the one field here that can't be self-asserted, so anyone can
    * register a third party's address for a public meeting and trigger an invite to it — and when the
@@ -631,7 +658,9 @@ export class PublicMeetingController {
   private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
     const raw = (body ?? {}) as Record<string, unknown>;
     const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
-    const rawEmail = typeof raw['email'] === 'string' ? raw['email'].trim() : '';
+    // Identity keys are narrowed and trimmed but never truncated — see the length branch in
+    // `registerForPublicMeeting`, which rejects them by name instead.
+    const identity = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim() : '');
     const sessionUsername = getEffectiveUsername(req);
     const username = sessionUsername ? stripAuthPrefix(sessionUsername) : '';
     const jobTitle = text('job_title');
@@ -639,8 +668,8 @@ export class PublicMeetingController {
     const occurrenceId = text('occurrence_id');
 
     return {
-      meeting_id: text('meeting_id'),
-      email: rawEmail.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH ? '' : rawEmail.toLowerCase(),
+      meeting_id: identity('meeting_id'),
+      email: identity('email').toLowerCase(),
       first_name: text('first_name'),
       last_name: text('last_name'),
       host: false,

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Meeting } from '@lfx-one/shared';
-import { MEETING_PASSWORD_HEADER, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH } from '@lfx-one/shared/constants';
+import { MEETING_PASSWORD_HEADER, PUBLIC_REGISTRATION_FIELD_LABELS, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH } from '@lfx-one/shared/constants';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import { CreateMeetingRegistrantRequest, MeetingOccurrenceSummary, MeetingRegistrant, PublicMeetingOccurrencesResponse } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
@@ -519,22 +519,26 @@ export class PublicMeetingController {
     // Length is measured on the stored form rather than the submitted one — `email` is already
     // lowercased here, and lowercasing can lengthen a value for a handful of Unicode code points. The
     // stored form is what has to fit, so that's what's checked.
-    const overLength = Object.entries({
+    const identifiers = {
       meeting_id: meetingId,
       email: registrantData.email,
       occurrence_id: registrantData.occurrence_id ?? '',
-    }).filter(([, value]) => value.length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH);
+    };
+    const overLength = (Object.keys(identifiers) as (keyof typeof identifiers)[]).filter(
+      (field) => identifiers[field].length > PUBLIC_REGISTRATION_FIELD_MAX_LENGTH
+    );
 
     if (overLength.length > 0) {
-      const fields = overLength.map(([field]) => field);
-
       return next(
         ServiceValidationError.fromFieldErrors(
-          Object.fromEntries(fields.map((field) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
+          Object.fromEntries(overLength.map((field) => [field, `Must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`])),
           // The cause goes in the top-level message, not only in `errors[]`: the one consumer of this
-          // endpoint renders `error.message` and discards the field array, so a generic "validation
-          // failed" here would leave the registrant with no idea which field to shorten.
-          `${fields.join(', ')} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer`,
+          // endpoint shows the top-level message — serialized as the body's `error` key, since
+          // `BaseApiError.toResponse` emits no `message` — and discards the field array. A generic
+          // "validation failed" here would leave the registrant with no idea which field to shorten.
+          //
+          // Labels rather than wire keys, because this string is read by someone looking at a form.
+          `${overLength.map((field) => PUBLIC_REGISTRATION_FIELD_LABELS[field]).join(' and ')} must be ${PUBLIC_REGISTRATION_FIELD_MAX_LENGTH} characters or fewer.`,
           {
             operation: 'register_for_public_meeting',
             service: 'public_meeting_controller',
@@ -549,26 +553,17 @@ export class PublicMeetingController {
     });
 
     try {
-      // Validate the meeting ID is provided
-      if (!meetingId) {
-        const validationError = ServiceValidationError.forField('meeting_id', 'Meeting ID is required', {
-          operation: 'register_for_public_meeting',
-          service: 'public_meeting_controller',
-          path: req.path,
-        });
+      // Validate the required fields, `meeting_id` among them. Named individually in the top-level
+      // message for the same reason as the length rejection above: that message is the only part of
+      // this error the registration modal shows, so a generic "validation failed" here is what turns
+      // a fixable empty field into an unexplained failure.
+      const missing = (['meeting_id', 'email', 'first_name', 'last_name'] as const).filter((field) => !registrantData[field]);
 
-        return next(validationError);
-      }
-
-      // Validate required fields
-      if (!registrantData.email || !registrantData.first_name || !registrantData.last_name) {
+      if (missing.length > 0) {
+        const labels = missing.map((field) => PUBLIC_REGISTRATION_FIELD_LABELS[field]);
         const validationError = ServiceValidationError.fromFieldErrors(
-          {
-            email: !registrantData.email ? 'Email is required' : [],
-            first_name: !registrantData.first_name ? 'First name is required' : [],
-            last_name: !registrantData.last_name ? 'Last name is required' : [],
-          },
-          'Registration data validation failed',
+          Object.fromEntries(missing.map((field, index) => [field, `${labels[index]} is required`])),
+          `${labels.join(' and ')} ${missing.length > 1 ? 'are' : 'is'} required.`,
           {
             operation: 'register_for_public_meeting',
             service: 'public_meeting_controller',

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { Meeting } from '@lfx-one/shared';
-import { MEETING_PASSWORD_HEADER } from '@lfx-one/shared/constants';
+import { MEETING_PASSWORD_HEADER, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH } from '@lfx-one/shared/constants';
 import { MeetingVisibility, QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import { CreateMeetingRegistrantRequest, MeetingOccurrenceSummary, MeetingRegistrant, PublicMeetingOccurrencesResponse } from '@lfx-one/shared/interfaces';
 import { NextFunction, Request, Response } from 'express';
@@ -503,7 +503,7 @@ export class PublicMeetingController {
    * Registers a user to a public, non-restricted meeting
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const registrantData = this.toSelfRegistration(req.body);
+    const registrantData = this.toSelfRegistration(req, req.body);
     const meetingId = registrantData.meeting_id;
 
     const startTime = logger.startOperation(req, 'register_for_public_meeting', {
@@ -604,17 +604,38 @@ export class PublicMeetingController {
    *
    * An allowlist rather than a denylist: a field added to `CreateMeetingRegistrantRequest` later
    * should have to be opted in to the public path deliberately, not inherit it.
+   *
+   * Values are narrowed, not just keys. The route mounts the handler bare — no express-validator — so
+   * the parameter is `unknown` rather than the request interface, which would be an assertion about a
+   * shape nothing produced. Anything that isn't a string is dropped, which is what stops an object or
+   * array from clearing the caller's `if (!registrantData.email …)` gate and reaching upstream.
+   *
+   * `username` is taken from the session when there is one and never from the body — a signed-in
+   * registrant keeps their LFID attribution on a record written with application credentials, and a
+   * forged one still can't get in. `email` is lowercased because query-service tag matching is
+   * case-sensitive and every read path lowercases; a mixed-case registration would otherwise be
+   * indexed under a tag no later lookup matches.
+   *
+   * One thing this doesn't close: `email` is the one field here that can't be self-asserted on a
+   * session-less route, so anyone can register a third party's address for a public meeting and
+   * trigger an invite to it. `publicApiRateLimiter` caps the volume, not the primitive.
    */
-  private toSelfRegistration(body: CreateMeetingRegistrantRequest): CreateMeetingRegistrantRequest {
+  private toSelfRegistration(req: Request, body: unknown): CreateMeetingRegistrantRequest {
+    const raw = (body ?? {}) as Record<string, unknown>;
+    const text = (key: string): string => (typeof raw[key] === 'string' ? (raw[key] as string).trim().slice(0, PUBLIC_REGISTRATION_FIELD_MAX_LENGTH) : '');
+    const username = getEffectiveUsername(req);
+    const jobTitle = text('job_title');
+    const orgName = text('org_name');
+
     return {
-      meeting_id: body?.meeting_id,
-      email: body?.email,
-      first_name: body?.first_name,
-      last_name: body?.last_name,
+      meeting_id: text('meeting_id'),
+      email: text('email').toLowerCase(),
+      first_name: text('first_name'),
+      last_name: text('last_name'),
       host: false,
-      ...(body?.job_title ? { job_title: body.job_title } : {}),
-      ...(body?.org_name ? { org_name: body.org_name } : {}),
-      ...(body?.occurrence_id ? { occurrence_id: body.occurrence_id } : {}),
+      ...(jobTitle ? { job_title: jobTitle } : {}),
+      ...(orgName ? { org_name: orgName } : {}),
+      ...(username ? { username } : {}),
     };
   }
 

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -503,7 +503,7 @@ export class PublicMeetingController {
    * Registers a user to a public, non-restricted meeting
    */
   public async registerForPublicMeeting(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const registrantData: CreateMeetingRegistrantRequest = req.body;
+    const registrantData = this.toSelfRegistration(req.body);
     const meetingId = registrantData.meeting_id;
 
     const startTime = logger.startOperation(req, 'register_for_public_meeting', {
@@ -590,6 +590,32 @@ export class PublicMeetingController {
       // Error handler will log
       next(error);
     }
+  }
+
+  /**
+   * Narrows an anonymous request body to the fields a person may set about themselves.
+   *
+   * This endpoint takes no session and forwards upstream under an M2M token, so whatever survives
+   * this function is written with application-level credentials and no user to attribute it to. The
+   * body used to be assigned wholesale, which let an anonymous caller set `host: true` — upstream
+   * documents that as "access to host key for the meeting" — or claim membership of a committee by
+   * passing `committee_uid`. Neither is the caller's to decide, so both are dropped here rather than
+   * left to upstream's discretion.
+   *
+   * An allowlist rather than a denylist: a field added to `CreateMeetingRegistrantRequest` later
+   * should have to be opted in to the public path deliberately, not inherit it.
+   */
+  private toSelfRegistration(body: CreateMeetingRegistrantRequest): CreateMeetingRegistrantRequest {
+    return {
+      meeting_id: body?.meeting_id,
+      email: body?.email,
+      first_name: body?.first_name,
+      last_name: body?.last_name,
+      host: false,
+      ...(body?.job_title ? { job_title: body.job_title } : {}),
+      ...(body?.org_name ? { org_name: body.org_name } : {}),
+      ...(body?.occurrence_id ? { occurrence_id: body.occurrence_id } : {}),
+    };
   }
 
   /**

--- a/apps/lfx-one/src/server/routes/public-meetings.route.ts
+++ b/apps/lfx-one/src/server/routes/public-meetings.route.ts
@@ -8,7 +8,8 @@ import { PublicMeetingController } from '../controllers/public-meeting.controlle
 const router = Router();
 const publicMeetingController = new PublicMeetingController();
 
-// POST /public/api/meetings/register - register for a public, non-restricted meeting (public access, no authentication required)
+// POST /public/api/meetings/register - register for a public, non-restricted meeting (optional auth:
+// no session required, but the handler reads the registrant's username off one when it exists)
 router.post('/register', (req, res, next) => publicMeetingController.registerForPublicMeeting(req, res, next));
 
 // GET /public/api/meetings/past/:id - get a past meeting with tiered access (public access, no authentication required)

--- a/apps/lfx-one/src/server/services/ai.service.spec.ts
+++ b/apps/lfx-one/src/server/services/ai.service.spec.ts
@@ -293,6 +293,23 @@ describe('AiService.generateMeetingAgenda', () => {
       expect(prompt).toContain('must not exceed 1200 characters');
       expect(body.response_format.json_schema.schema.properties.agenda.maxLength).toBe(1200);
     });
+
+    // The prompt used to read the raw request while the schema and the outbound clamp read the resolved
+    // cap, so the three could disagree — the model was told "-5 characters" while the schema advertised
+    // something else. Both non-positive and absent caps resolve to the default, matching the policy
+    // `resolveAgendaMaxCharacters` states at the HTTP boundary.
+    it.each([
+      ['no cap', undefined],
+      ['a zero cap', 0],
+      ['a negative cap', -5],
+    ])('resolves %s to the default in both the prompt and the schema', async (_label, maxCharacters) => {
+      const { MEETING_AGENDA_MAX_LENGTH } = await import('@lfx-one/shared/constants');
+      const prompt = await promptFor({ title: 'TAC Monthly', maxCharacters });
+      const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+
+      expect(prompt).toContain(`must not exceed ${MEETING_AGENDA_MAX_LENGTH} characters`);
+      expect(body.response_format.json_schema.schema.properties.agenda.maxLength).toBe(MEETING_AGENDA_MAX_LENGTH);
+    });
   });
 
   // The schema's `maxLength` and the prompt's cap are both hints the model can ignore. The composer

--- a/apps/lfx-one/src/server/services/ai.service.ts
+++ b/apps/lfx-one/src/server/services/ai.service.ts
@@ -61,13 +61,14 @@ export class AiService {
     });
 
     try {
-      // Resolved once: the same cap is asked of the model (in the schema and the prompt) and enforced
-      // on the way back out, so the three can't disagree. Floored at 1 because `maxCharacters` is a
-      // plain optional number on the request — the app's only caller pre-validates it, but nothing in
-      // this service's contract says so, and a negative would make the clamp's `slice` chop the tail
-      // off the agenda instead of capping it.
-      const agendaMaxCharacters = Math.max(1, request.maxCharacters || MEETING_AGENDA_MAX_LENGTH);
-      const prompt = this.buildPrompt(request);
+      // Resolved once and then used everywhere: the same cap is asked of the model (in the schema and
+      // in the prompt) and enforced on the way back out, so the three can't disagree. A non-positive
+      // `maxCharacters` falls back to the default rather than being floored at 1, matching the policy
+      // `resolveAgendaMaxCharacters` already states at the HTTP boundary — a cap of 1 is honoured
+      // nonsense that guarantees a useless completion. `maxCharacters` is a plain optional number on
+      // the request, so this service defends itself rather than trusting its callers to pre-validate.
+      const agendaMaxCharacters = request.maxCharacters && request.maxCharacters > 0 ? request.maxCharacters : MEETING_AGENDA_MAX_LENGTH;
+      const prompt = this.buildPrompt({ ...request, maxCharacters: agendaMaxCharacters });
       const chatRequest: OpenAIChatRequest = {
         model: this.model,
         messages: [

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -326,9 +326,26 @@ describe('MeetingService registrant write payloads', () => {
     expect(bodyOf()).toEqual({ email: 'a@example.com', first_name: 'A', last_name: 'B', host: true });
   });
 
-  // The update body uses `null` to erase a stored value, so the rename has to preserve it rather than
-  // treat it like an omission.
-  it('renames on update and preserves an explicit null', async () => {
+  it('renames on update too, since the PUT reuses the same body schema', async () => {
+    await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: 'Acme',
+      avatar_url: 'https://example.com/a.png',
+      occurrence_id: '1666848600',
+    });
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants/reg-1');
+    expect(bodyOf()).toMatchObject({ org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+  });
+
+  // `getChangedFields` nulls all three whenever they're blank — always, for the two with no form
+  // control. All three targets are declared non-nullable, and before the rename Goa dropped the
+  // undeclared key outright; omitting keeps that outcome instead of planting a null on a declared
+  // field on every ordinary registrant edit.
+  it('omits an explicit null rather than renaming it onto a non-nullable field', async () => {
     await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
       meeting_id: 'meeting-1',
       email: 'a@example.com',
@@ -339,7 +356,43 @@ describe('MeetingService registrant write payloads', () => {
       occurrence_id: null,
     });
 
-    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants/reg-1');
-    expect(bodyOf()).toMatchObject({ org: null, profile_picture: null, occurrence: null });
+    for (const key of ['org', 'profile_picture', 'occurrence', 'org_name', 'avatar_url', 'occurrence_id']) {
+      expect(bodyOf()).not.toHaveProperty(key);
+    }
+  });
+
+  // The public self-registration path writes the same upstream endpoint with an M2M token, and it's
+  // the one path where a registrant types their own organization — so it has to rename too.
+  it('renames on the public M2M create path', async () => {
+    await service.addMeetingRegistrantWithM2M(
+      req,
+      { meeting_id: 'meeting-1', email: 'a@example.com', first_name: 'A', last_name: 'B', org_name: 'Acme' },
+      'm2m-token'
+    );
+
+    expect(bodyOf()).toMatchObject({ org: 'Acme' });
+    expect(bodyOf()).not.toHaveProperty('org_name');
+    expect(bodyOf()).not.toHaveProperty('meeting_id');
+  });
+
+  // ITX answers a write with `ITXZoomMeetingRegistrant`, which uses the upstream spelling. Without
+  // the inverse rename the returned object satisfies `MeetingRegistrant` only nominally, and the
+  // modal renders a just-saved registrant with no organization.
+  it.each([
+    ['create', (s: MeetingService) => s.addMeetingRegistrant(req, { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' })],
+    ['update', (s: MeetingService) => s.updateMeetingRegistrant(req, 'm', 'r', { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' })],
+    [
+      'public M2M create',
+      (s: MeetingService) => s.addMeetingRegistrantWithM2M(req, { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' }, 'm2m-token'),
+    ],
+  ])('maps the %s response back to the app spelling', async (_label, call) => {
+    proxyRequest.mockResolvedValue({ uid: 'reg-1', org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+
+    const result = await call(service);
+
+    expect(result).toMatchObject({ uid: 'reg-1', org_name: 'Acme', avatar_url: 'https://example.com/a.png', occurrence_id: '1666848600' });
+    expect(result).not.toHaveProperty('org');
+    expect(result).not.toHaveProperty('profile_picture');
+    expect(result).not.toHaveProperty('occurrence');
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -386,13 +386,25 @@ describe('MeetingService registrant write payloads', () => {
       (s: MeetingService) => s.addMeetingRegistrantWithM2M(req, { meeting_id: 'm', email: 'a@example.com', first_name: 'A', last_name: 'B' }, 'm2m-token'),
     ],
   ])('maps the %s response back to the app spelling', async (_label, call) => {
-    proxyRequest.mockResolvedValue({ uid: 'reg-1', org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+    proxyRequest.mockResolvedValue({
+      uid: 'reg-1',
+      org: 'Acme',
+      profile_picture: 'https://example.com/a.png',
+      occurrence: '1666848600',
+      modified_at: '2026-08-17T00:00:00Z',
+    });
 
     const result = await call(service);
 
-    expect(result).toMatchObject({ uid: 'reg-1', org_name: 'Acme', avatar_url: 'https://example.com/a.png', occurrence_id: '1666848600' });
-    expect(result).not.toHaveProperty('org');
-    expect(result).not.toHaveProperty('profile_picture');
-    expect(result).not.toHaveProperty('occurrence');
+    expect(result).toMatchObject({
+      uid: 'reg-1',
+      org_name: 'Acme',
+      avatar_url: 'https://example.com/a.png',
+      occurrence_id: '1666848600',
+      updated_at: '2026-08-17T00:00:00Z',
+    });
+    for (const upstreamKey of ['org', 'profile_picture', 'occurrence', 'modified_at']) {
+      expect(result).not.toHaveProperty(upstreamKey);
+    }
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -278,3 +278,68 @@ describe('MeetingService.getPastOccurrencesForMeeting', () => {
     expect(result).toEqual([]);
   });
 });
+
+/**
+ * The ITX registrant contract (`CreateItxRegistrantRequestBody`, reused verbatim for the PUT) declares
+ * `org`, `profile_picture` and `occurrence`; the app's read model — sourced from the v1 query-service
+ * index — spells them `org_name`, `avatar_url` and `occurrence_id`. Goa ignores undeclared body keys,
+ * so without the rename these three were dropped upstream behind a 200.
+ */
+describe('MeetingService registrant write payloads', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    proxyRequest.mockResolvedValue({});
+    service = new MeetingService();
+  });
+
+  const bodyOf = (): Record<string, unknown> => proxyRequest.mock.calls[0][5] as Record<string, unknown>;
+
+  it('renames org_name, avatar_url and occurrence_id on create', async () => {
+    await service.addMeetingRegistrant(req, {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: 'Acme',
+      avatar_url: 'https://example.com/a.png',
+      occurrence_id: '1666848600',
+    });
+
+    expect(bodyOf()).toMatchObject({ org: 'Acme', profile_picture: 'https://example.com/a.png', occurrence: '1666848600' });
+    expect(bodyOf()).not.toHaveProperty('org_name');
+    expect(bodyOf()).not.toHaveProperty('avatar_url');
+    expect(bodyOf()).not.toHaveProperty('occurrence_id');
+  });
+
+  it('drops meeting_id from the create body, since it is the path parameter', async () => {
+    await service.addMeetingRegistrant(req, { meeting_id: 'meeting-1', email: 'a@example.com', first_name: 'A', last_name: 'B' });
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants');
+    expect(bodyOf()).not.toHaveProperty('meeting_id');
+  });
+
+  it('omits the renamed keys entirely when the caller omitted them', async () => {
+    await service.addMeetingRegistrant(req, { meeting_id: 'meeting-1', email: 'a@example.com', first_name: 'A', last_name: 'B', host: true });
+
+    expect(bodyOf()).toEqual({ email: 'a@example.com', first_name: 'A', last_name: 'B', host: true });
+  });
+
+  // The update body uses `null` to erase a stored value, so the rename has to preserve it rather than
+  // treat it like an omission.
+  it('renames on update and preserves an explicit null', async () => {
+    await service.updateMeetingRegistrant(req, 'meeting-1', 'reg-1', {
+      meeting_id: 'meeting-1',
+      email: 'a@example.com',
+      first_name: 'A',
+      last_name: 'B',
+      org_name: null,
+      avatar_url: null,
+      occurrence_id: null,
+    });
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/itx/meetings/meeting-1/registrants/reg-1');
+    expect(bodyOf()).toMatchObject({ org: null, profile_picture: null, occurrence: null });
+  });
+});

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1781,12 +1781,18 @@ export class MeetingService {
    * `meeting_id` is dropped for the same reason it isn't declared: it's the path parameter, and the
    * caller has already used it to build the URL.
    *
-   * A `null` is omitted rather than renamed. `UpdateMeetingRegistrantRequest` uses `null` to erase a
-   * stored value, but all three targets are declared as non-nullable `type: string`, and
-   * `getChangedFields` sends `null` for every one of them whenever the value is blank — which is
-   * always, for the two that have no form control. Renaming those nulls would newly plant an
-   * off-contract value on a declared field on ordinary registrant edits, where before this rename Goa
-   * discarded the whole key as undeclared. Omitting keeps that outcome exactly.
+   * A `null` on one of the three renamed fields is omitted rather than renamed.
+   * `UpdateMeetingRegistrantRequest` uses `null` to erase a stored value, but all three targets are
+   * declared as non-nullable `type: string`, and `getChangedFields` sends `null` for every one of them
+   * whenever the value is blank — which is always, for the two that have no form control. Renaming
+   * those nulls would newly plant an off-contract value on a declared field on ordinary registrant
+   * edits, where before this rename Goa discarded the whole key as undeclared. Omitting keeps that
+   * outcome exactly.
+   *
+   * That omission is scoped to the renamed fields only. `getChangedFields` also nulls `job_title`,
+   * `username` and `linkedin_profile`; those keep whatever they had before, because their upstream
+   * handling is untouched by this rename (`job_title` and `username` are declared — non-nullable, so a
+   * `null` is off-contract there too, and unfixed — and `linkedin_profile` isn't declared at all).
    *
    * Cost: clearing an organization on an edit leaves the stored value in place. It did before this
    * rename too, so nothing regresses — but it stays unfixed until upstream states how these fields are
@@ -1797,9 +1803,10 @@ export class MeetingService {
     const { org_name, avatar_url, occurrence_id } = body;
     const upstream: Record<string, unknown> = { ...body };
 
-    // Typed so a rename on either request interface fails the build here rather than silently
-    // re-introducing the drop this method exists to prevent.
-    const appOnlyKeys: (keyof CreateMeetingRegistrantRequest | keyof UpdateMeetingRegistrantRequest)[] = [
+    // Intersection, not union: a union only rejects a key once it's gone from *both* interfaces, so a
+    // rename on one of them would still compile while the `delete` quietly stopped matching. All four
+    // keys exist on both, so the intersection compiles as-is and does fail the build on either rename.
+    const appOnlyKeys: (keyof CreateMeetingRegistrantRequest & keyof UpdateMeetingRegistrantRequest)[] = [
       'meeting_id',
       'org_name',
       'avatar_url',
@@ -1821,24 +1828,33 @@ export class MeetingService {
   /**
    * Inverse of {@link toUpstreamRegistrantBody}, for the body ITX returns from a registrant write.
    *
-   * The POST and PUT both respond with `ITXZoomMeetingRegistrant`, which spells the three fields the
-   * same way the request body does — `org`, `profile_picture`, `occurrence`. Both write methods used
-   * to declare the response as `MeetingRegistrant` and hand it straight back, so the object the
-   * registrant modal renders after a successful save had `org_name` and `avatar_url` undefined no
-   * matter what was stored. Renaming on the way out is what makes that declared type true.
+   * The POST and PUT both respond with `ITXZoomMeetingRegistrant`, which spells the three request
+   * fields the same way the request body does — `org`, `profile_picture`, `occurrence` — and spells the
+   * modification timestamp `modified_at` rather than `updated_at`. Both write methods used to declare
+   * the response as `MeetingRegistrant` and hand it straight back, so the object the registrant modal
+   * renders after a successful save had `org_name` and `avatar_url` undefined no matter what was
+   * stored. Renaming on the way out is what makes those four fields true.
    *
-   * Only these three are remapped: every other field the app reads off a write response already
-   * shares its upstream name. The read paths need no equivalent, because they come from the v1
-   * query-service index, which already uses the app's spelling.
+   * The declared type is still wider than the response: `ITXZoomMeetingRegistrant` carries no
+   * `meeting_id`, `org_is_member`, `org_is_project_member`, `invite_accepted` or `linkedin_profile`,
+   * all of which `MeetingRegistrant` declares as required. They're absent under any spelling, so
+   * there's nothing to rename — the `as` cast is what covers the gap, and a consumer that needs them
+   * has to read the registrant back rather than trust a write response. The read paths need no mapper
+   * at all, because they come from the v1 query-service index, which already uses the app's spelling.
+   *
+   * Absent stays absent rather than becoming `null` — the app's spelling is only introduced for a
+   * value upstream actually returned, so a missing field reads as "the write response didn't say"
+   * instead of "upstream stored nothing".
    */
   private fromUpstreamRegistrant(upstream: Record<string, unknown>): MeetingRegistrant {
-    const { org, profile_picture, occurrence, ...rest } = upstream;
+    const { org, profile_picture, occurrence, modified_at, ...rest } = upstream;
 
     return {
       ...rest,
       ...(org === undefined ? {} : { org_name: org }),
       ...(profile_picture === undefined ? {} : { avatar_url: profile_picture }),
       ...(occurrence === undefined ? {} : { occurrence_id: occurrence }),
+      ...(modified_at === undefined ? {} : { updated_at: modified_at }),
     } as MeetingRegistrant;
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -734,7 +734,7 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ registrantData });
     logger.debug(req, 'add_meeting_registrant', 'Creating meeting registrant', sanitizedPayload);
 
-    const newRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
+    const newRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${registrantData.meeting_id}/registrants`,
@@ -743,7 +743,7 @@ export class MeetingService {
       this.toUpstreamRegistrantBody(registrantData)
     );
 
-    return newRegistrant;
+    return this.fromUpstreamRegistrant(newRegistrant);
   }
 
   /**
@@ -758,7 +758,7 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ updateData });
     logger.debug(req, 'update_meeting_registrant', 'Updating meeting registrant payload', sanitizedPayload);
 
-    const updatedRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
+    const updatedRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${meetingUid}/registrants/${registrantUid}`,
@@ -767,7 +767,7 @@ export class MeetingService {
       this.toUpstreamRegistrantBody(updateData)
     );
 
-    return updatedRegistrant;
+    return this.fromUpstreamRegistrant(updatedRegistrant);
   }
 
   /**
@@ -1654,15 +1654,16 @@ export class MeetingService {
     const sanitizedPayload = logger.sanitize({ registrantData });
     logger.debug(req, 'add_meeting_registrant_with_m2m', 'Creating meeting registrant with M2M token', sanitizedPayload);
 
-    const newRegistrant = await this.microserviceProxy.proxyRequest<MeetingRegistrant>(
+    const upstreamRegistrant = await this.microserviceProxy.proxyRequest<Record<string, unknown>>(
       req,
       'LFX_V2_SERVICE',
       `/itx/meetings/${registrantData.meeting_id}/registrants`,
       'POST',
       undefined,
-      registrantData,
+      this.toUpstreamRegistrantBody(registrantData),
       { Authorization: `Bearer ${m2mToken}`, ['X-Sync']: 'true' }
     );
+    const newRegistrant = this.fromUpstreamRegistrant(upstreamRegistrant);
 
     logger.success(req, 'add_meeting_registrant_with_m2m', startTime, {
       meeting_id: registrantData.meeting_id,
@@ -1780,21 +1781,64 @@ export class MeetingService {
    * `meeting_id` is dropped for the same reason it isn't declared: it's the path parameter, and the
    * caller has already used it to build the URL.
    *
-   * Values pass through untouched, including the `null`s the update body uses to erase a stored value.
+   * A `null` is omitted rather than renamed. `UpdateMeetingRegistrantRequest` uses `null` to erase a
+   * stored value, but all three targets are declared as non-nullable `type: string`, and
+   * `getChangedFields` sends `null` for every one of them whenever the value is blank — which is
+   * always, for the two that have no form control. Renaming those nulls would newly plant an
+   * off-contract value on a declared field on ordinary registrant edits, where before this rename Goa
+   * discarded the whole key as undeclared. Omitting keeps that outcome exactly.
+   *
+   * Cost: clearing an organization on an edit leaves the stored value in place. It did before this
+   * rename too, so nothing regresses — but it stays unfixed until upstream states how these fields are
+   * erased. Don't guess between `null` and `''` here; `occurrence` already gives blank its own meaning
+   * ("blank = all occurrences"), so a wrong guess silently rescopes an invite.
    */
   private toUpstreamRegistrantBody(body: CreateMeetingRegistrantRequest | UpdateMeetingRegistrantRequest): Record<string, unknown> {
-    const { org_name, avatar_url, occurrence_id } = body as UpdateMeetingRegistrantRequest;
+    const { org_name, avatar_url, occurrence_id } = body;
     const upstream: Record<string, unknown> = { ...body };
 
-    for (const appOnlyKey of ['meeting_id', 'org_name', 'avatar_url', 'occurrence_id']) {
+    // Typed so a rename on either request interface fails the build here rather than silently
+    // re-introducing the drop this method exists to prevent.
+    const appOnlyKeys: (keyof CreateMeetingRegistrantRequest | keyof UpdateMeetingRegistrantRequest)[] = [
+      'meeting_id',
+      'org_name',
+      'avatar_url',
+      'occurrence_id',
+    ];
+
+    for (const appOnlyKey of appOnlyKeys) {
       delete upstream[appOnlyKey];
     }
 
     return {
       ...upstream,
-      ...(org_name === undefined ? {} : { org: org_name }),
-      ...(avatar_url === undefined ? {} : { profile_picture: avatar_url }),
-      ...(occurrence_id === undefined ? {} : { occurrence: occurrence_id }),
+      ...(org_name == null ? {} : { org: org_name }),
+      ...(avatar_url == null ? {} : { profile_picture: avatar_url }),
+      ...(occurrence_id == null ? {} : { occurrence: occurrence_id }),
     };
+  }
+
+  /**
+   * Inverse of {@link toUpstreamRegistrantBody}, for the body ITX returns from a registrant write.
+   *
+   * The POST and PUT both respond with `ITXZoomMeetingRegistrant`, which spells the three fields the
+   * same way the request body does — `org`, `profile_picture`, `occurrence`. Both write methods used
+   * to declare the response as `MeetingRegistrant` and hand it straight back, so the object the
+   * registrant modal renders after a successful save had `org_name` and `avatar_url` undefined no
+   * matter what was stored. Renaming on the way out is what makes that declared type true.
+   *
+   * Only these three are remapped: every other field the app reads off a write response already
+   * shares its upstream name. The read paths need no equivalent, because they come from the v1
+   * query-service index, which already uses the app's spelling.
+   */
+  private fromUpstreamRegistrant(upstream: Record<string, unknown>): MeetingRegistrant {
+    const { org, profile_picture, occurrence, ...rest } = upstream;
+
+    return {
+      ...rest,
+      ...(org === undefined ? {} : { org_name: org }),
+      ...(profile_picture === undefined ? {} : { avatar_url: profile_picture }),
+      ...(occurrence === undefined ? {} : { occurrence_id: occurrence }),
+    } as MeetingRegistrant;
   }
 }

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -740,7 +740,7 @@ export class MeetingService {
       `/itx/meetings/${registrantData.meeting_id}/registrants`,
       'POST',
       undefined,
-      registrantData
+      this.toUpstreamRegistrantBody(registrantData)
     );
 
     return newRegistrant;
@@ -764,7 +764,7 @@ export class MeetingService {
       `/itx/meetings/${meetingUid}/registrants/${registrantUid}`,
       'PUT',
       undefined,
-      updateData
+      this.toUpstreamRegistrantBody(updateData)
     );
 
     return updatedRegistrant;
@@ -1766,5 +1766,35 @@ export class MeetingService {
       recurrence_type: recurrence.type,
     });
     return { ...recurrence, end_date_time: neverEndDate };
+  }
+
+  /**
+   * Renames the three registrant fields whose app-side names differ from the upstream ITX contract.
+   *
+   * `CreateItxRegistrantRequestBody` (reused verbatim for the PUT) declares `org`, `profile_picture`
+   * and `occurrence`; the app's read model — which comes from the v1 query-service index, not from
+   * ITX — spells them `org_name`, `avatar_url` and `occurrence_id`. Goa silently ignores body keys it
+   * doesn't declare, so without this rename the organization an organizer types, the avatar, and a
+   * single-occurrence invite were all dropped on the way upstream, behind a 201.
+   *
+   * `meeting_id` is dropped for the same reason it isn't declared: it's the path parameter, and the
+   * caller has already used it to build the URL.
+   *
+   * Values pass through untouched, including the `null`s the update body uses to erase a stored value.
+   */
+  private toUpstreamRegistrantBody(body: CreateMeetingRegistrantRequest | UpdateMeetingRegistrantRequest): Record<string, unknown> {
+    const { org_name, avatar_url, occurrence_id } = body as UpdateMeetingRegistrantRequest;
+    const upstream: Record<string, unknown> = { ...body };
+
+    for (const appOnlyKey of ['meeting_id', 'org_name', 'avatar_url', 'occurrence_id']) {
+      delete upstream[appOnlyKey];
+    }
+
+    return {
+      ...upstream,
+      ...(org_name === undefined ? {} : { org: org_name }),
+      ...(avatar_url === undefined ? {} : { profile_picture: avatar_url }),
+      ...(occurrence_id === undefined ? {} : { occurrence: occurrence_id }),
+    };
   }
 }

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -692,10 +692,10 @@ export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
  * bounds and small enough that nothing unbounded reaches upstream or the logs.
  *
  * Two rules, both keyed off this one number. The free-text fields — first/last name, job title,
- * organization, occurrence ID — are truncated at the cap. The identity keys, `email` and `meeting_id`,
+ * organization — are truncated at the cap. The identifiers, `meeting_id`, `email` and `occurrence_id`,
  * are rejected with a validation error instead, since truncating one would turn an unusable value into
- * a different, valid-looking one: an invite sent to the wrong address, or a lookup against the wrong
- * meeting.
+ * a different, valid-looking one: a lookup against the wrong meeting, an invite sent to the wrong
+ * address, or a registration scoped to the wrong occurrence.
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -681,6 +681,18 @@ export const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
 /** Prompt length at which the character counter turns amber — same 90% of cap as the agenda's */
 export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
 
+/**
+ * Character ceiling for each free-text field an anonymous caller may set on itself when registering
+ * for a public meeting (`POST /public/api/meetings/register`).
+ *
+ * That route has no express-validator and no session, and forwards upstream under an M2M token, so
+ * without a ceiling here the only bound on a name or organization is `express.json`'s body limit —
+ * megabytes, applied to the whole body rather than per field. 255 is generous for every field it
+ * covers (email, first/last name, job title, organization) and small enough that nothing unbounded
+ * reaches upstream or the logs.
+ */
+export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
+
 /** Lower bound for the custom meeting duration, in minutes */
 export const MIN_CUSTOM_DURATION = 5;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -689,11 +689,13 @@ export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
  * and it always forwards upstream under an M2M token. Without a ceiling here the only bound on a name
  * or organization is `express.json`'s body limit —
  * megabytes, applied to the whole body rather than per field. 255 is generous for every field it
- * covers — the meeting UID, email, first/last name, job title, organization and occurrence ID — and
- * small enough that nothing unbounded reaches upstream or the logs.
+ * bounds and small enough that nothing unbounded reaches upstream or the logs.
  *
- * Free-text fields are truncated at the cap; `email` is dropped instead, since truncating the record's
- * identity key would produce a different, valid-looking address to invite.
+ * Two rules, both keyed off this one number. The free-text fields — first/last name, job title,
+ * organization, occurrence ID — are truncated at the cap. The identity keys, `email` and `meeting_id`,
+ * are rejected with a validation error instead, since truncating one would turn an unusable value into
+ * a different, valid-looking one: an invite sent to the wrong address, or a lookup against the wrong
+ * meeting.
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -699,6 +699,26 @@ export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 
+/**
+ * Human labels for the public-registration fields the route rejects by name.
+ *
+ * The rejection's top-level message is the one string the registration modal shows, so it is read by
+ * someone filling in a form, not by someone reading a request body — `email` there says "Email
+ * address", not the wire key. `errors[]` stays keyed by the wire name for anything reading the
+ * fields programmatically.
+ *
+ * `meeting_id` and `occurrence_id` are in the map even though no form field corresponds to them:
+ * they can only be wrong if a caller built the request itself, and that caller is still better served
+ * by a name it can recognize than by silence.
+ */
+export const PUBLIC_REGISTRATION_FIELD_LABELS = {
+  meeting_id: 'Meeting ID',
+  occurrence_id: 'Occurrence ID',
+  email: 'Email address',
+  first_name: 'First name',
+  last_name: 'Last name',
+} as const;
+
 /** Lower bound for the custom meeting duration, in minutes */
 export const MIN_CUSTOM_DURATION = 5;
 

--- a/packages/shared/src/constants/meeting.constants.ts
+++ b/packages/shared/src/constants/meeting.constants.ts
@@ -682,14 +682,18 @@ export const MEETING_AGENDA_PROMPT_MAX_LENGTH = 1000;
 export const MEETING_AGENDA_PROMPT_WARNING_LENGTH = 900;
 
 /**
- * Character ceiling for each free-text field an anonymous caller may set on itself when registering
- * for a public meeting (`POST /public/api/meetings/register`).
+ * Character ceiling for each free-text field a caller may set on itself when registering for a public
+ * meeting (`POST /public/api/meetings/register`).
  *
- * That route has no express-validator and no session, and forwards upstream under an M2M token, so
- * without a ceiling here the only bound on a name or organization is `express.json`'s body limit —
+ * That route has no express-validator and is optional-auth — so it runs with or without a session —
+ * and it always forwards upstream under an M2M token. Without a ceiling here the only bound on a name
+ * or organization is `express.json`'s body limit —
  * megabytes, applied to the whole body rather than per field. 255 is generous for every field it
- * covers (email, first/last name, job title, organization) and small enough that nothing unbounded
- * reaches upstream or the logs.
+ * covers — the meeting UID, email, first/last name, job title, organization and occurrence ID — and
+ * small enough that nothing unbounded reaches upstream or the logs.
+ *
+ * Free-text fields are truncated at the cap; `email` is dropped instead, since truncating the record's
+ * identity key would produce a different, valid-looking address to invite.
  */
 export const PUBLIC_REGISTRATION_FIELD_MAX_LENGTH = 255;
 

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -554,6 +554,19 @@ export interface MeetingRegistrant {
  * @description Data required to add a new registrant to a meeting
  */
 export interface CreateMeetingRegistrantRequest {
+  /*
+   * Every optional field is typed without `| null`: upstream declares them all as non-nullable
+   * optional `string`s in `CreateItxRegistrantRequestBody`, and nothing between here and there
+   * launders a `null` — the BFF's one such drop is `committee_uid`-specific — so a `null` would reach
+   * upstream verbatim. Keeping it out of the type is what makes omission enforceable at compile time
+   * rather than a convention each caller has to remember. A create has nothing to clear, so omission
+   * loses no meaning — unlike `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a
+   * stored value.
+   *
+   * Note that three of these names differ from the wire: the BFF renames `org_name` → `org`,
+   * `avatar_url` → `profile_picture` and `occurrence_id` → `occurrence` before proxying, so this
+   * interface follows the app's read model (the v1 query-service index) rather than the ITX body.
+   */
   /** UUID of the meeting */
   meeting_id: string;
   /** User's email address */
@@ -565,22 +578,20 @@ export interface CreateMeetingRegistrantRequest {
   /** Whether user should have host access */
   host?: boolean;
   /** User's job title */
-  job_title?: string | null;
+  job_title?: string;
   /** User's organization */
-  org_name?: string | null;
+  org_name?: string;
   /** Specific occurrence ID to invite to (blank = all occurrences) */
-  occurrence_id?: string | null;
+  occurrence_id?: string;
   /** User's avatar URL */
-  avatar_url?: string | null;
+  avatar_url?: string;
   /** User's LFID */
-  username?: string | null;
+  username?: string;
   /**
    * Committee this registrant was added from, as a **v2** committee UID.
    * Upstream stores a v1 committee SFID and derives `type: 'committee'` from it, so the BFF
-   * resolves v2 → v1 before proxying. Omit for a directly-added guest: upstream declares the field a
-   * non-nullable optional `string`, so `null` is off-contract and the BFF drops the key rather than
-   * forwarding it. Typed without `| null` so that's enforceable at compile time for internal callers —
-   * the BFF's runtime drop stays as a guard for bodies it doesn't build itself.
+   * resolves v2 → v1 before proxying. Omit for a directly-added guest, as for every other optional
+   * field on this body.
    */
   committee_uid?: string;
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -601,6 +601,20 @@ export interface CreateMeetingRegistrantRequest {
  * @description Data required for PUT request to update an existing registrant
  */
 export interface UpdateMeetingRegistrantRequest {
+  /*
+   * The PUT reuses `CreateItxRegistrantRequestBody`, so the BFF renames `org_name`, `avatar_url` and
+   * `occurrence_id` on the way out (see `MeetingService.toUpstreamRegistrantBody`).
+   *
+   * Two known gaps, both pre-dating that rename:
+   *
+   * - `null` does not erase. Every target is declared non-nullable, and `MeetingService.getChangedFields`
+   *   nulls each of these whenever it's blank, so the BFF omits a `null` rather than sending one.
+   *   Clearing a stored organization therefore doesn't take effect. Fixing it needs upstream to say how
+   *   these fields are erased — don't guess between `null` and `''`; `occurrence` already gives blank
+   *   its own meaning ("blank = all occurrences").
+   * - `linkedin_profile` is not declared upstream at all, under this or any other name, so Goa discards
+   *   it. The registrant form still validates it and still reports success. Tracked separately.
+   */
   /** UUID of the meeting (required) */
   meeting_id: string;
   /** User's email address (required) */

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -561,11 +561,11 @@ export interface CreateMeetingRegistrantRequest {
    * create has nothing to clear, so omission loses no meaning — unlike
    * `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a stored value.
    *
-   * The BFF does drop a nullish `org_name`, `avatar_url` or `occurrence_id` on the way out
-   * (`MeetingService.toUpstreamRegistrantBody`), and drops a blank one again on the public
-   * self-registration path (`PublicMeetingController.toSelfRegistration`) — but both exist to serve
-   * the rename and the public trust boundary, not to launder this type, and neither covers
-   * `job_title`, `username` or `committee_uid`. Treat the type as the guard.
+   * `MeetingService.toUpstreamRegistrantBody` does drop a nullish `org_name`, `avatar_url` or
+   * `occurrence_id` on the way out — but it exists to serve the rename, not to launder this type, and
+   * it doesn't cover `job_title`, `username` or `committee_uid`. (The public self-registration path
+   * narrows harder still, but only because it's a trust boundary; nothing else shares that treatment.)
+   * Treat the type as the guard.
    *
    * Note that three of these names differ from the wire: the BFF renames `org_name` → `org`,
    * `avatar_url` → `profile_picture` and `occurrence_id` → `occurrence` before proxying, so this

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -556,12 +556,16 @@ export interface MeetingRegistrant {
 export interface CreateMeetingRegistrantRequest {
   /*
    * Every optional field is typed without `| null`: upstream declares them all as non-nullable
-   * optional `string`s in `CreateItxRegistrantRequestBody`, and nothing between here and there
-   * launders a `null` — the BFF's one such drop is `committee_uid`-specific — so a `null` would reach
-   * upstream verbatim. Keeping it out of the type is what makes omission enforceable at compile time
-   * rather than a convention each caller has to remember. A create has nothing to clear, so omission
-   * loses no meaning — unlike `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a
-   * stored value.
+   * optional `string`s in `CreateItxRegistrantRequestBody`. Keeping `null` out of the type is what
+   * makes omission enforceable at compile time rather than a convention each caller has to remember. A
+   * create has nothing to clear, so omission loses no meaning — unlike
+   * `UpdateMeetingRegistrantRequest`, where `null` is how an update erases a stored value.
+   *
+   * The BFF does drop a nullish `org_name`, `avatar_url` or `occurrence_id` on the way out
+   * (`MeetingService.toUpstreamRegistrantBody`), and drops a blank one again on the public
+   * self-registration path (`PublicMeetingController.toSelfRegistration`) — but both exist to serve
+   * the rename and the public trust boundary, not to launder this type, and neither covers
+   * `job_title`, `username` or `committee_uid`. Treat the type as the guard.
    *
    * Note that three of these names differ from the wire: the BFF renames `org_name` → `org`,
    * `avatar_url` → `profile_picture` and `occurrence_id` → `occurrence` before proxying, so this

--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -152,18 +152,28 @@ export function capCodePointEdit(previous: string, next: string, max: number): s
  * Truncate to at most `max` UTF-16 code units without leaving a lone surrogate behind.
  * @param value - The string to truncate
  * @param max - The maximum number of UTF-16 code units
- * @returns `value` unchanged when within the cap, otherwise clipped to `max` units (or `max - 1` when
- * the cut would land inside a surrogate pair)
+ * @returns `value` unchanged when within the cap, `''` when `max` is not a positive number, otherwise
+ * clipped to `max` units (or `max - 1` when the cut would land inside a surrogate pair)
  *
  * Deliberately measured in UTF-16 units rather than code points, unlike {@link codePointLength} and
- * {@link capCodePointEdit}: these caps guard values that are handed to `Validators.maxLength` or a
- * native `maxlength` attribute, both of which count UTF-16 units. Truncating by code point would let a
- * string full of emoji pass a code-point cap and still fail the validator on the other side — which,
- * for the meeting composer's agenda, means an invalid form and a Save button that does nothing.
+ * {@link capCodePointEdit}. That matters where the truncated value is handed to `Validators.maxLength`
+ * or a native `maxlength` attribute, both of which count UTF-16 units: truncating by code point would
+ * let a string full of emoji pass a code-point cap and still fail the validator on the other side —
+ * which, for the meeting composer's agenda, means an invalid form and a Save button that does nothing.
+ * Callers whose value never reaches a form control (the AI prompt descriptors) get only the
+ * lone-surrogate guarantee above, which is reason enough on its own.
+ *
+ * Surrogate pairs are the only unit kept whole — a cut can still split a ZWJ sequence or orphan a
+ * combining mark. Honouring grapheme clusters would break parity with the UTF-16 counts these caps
+ * exist to satisfy.
  */
 export function truncateToUtf16Units(value: string, max: number): string {
-  if (value.length <= max || max <= 0) {
-    return value.length <= max ? value : '';
+  if (!(max > 0)) {
+    return '';
+  }
+
+  if (value.length <= max) {
+    return value;
   }
 
   // A high surrogate at the last kept position means the cut splits a pair; drop it rather than emit


### PR DESCRIPTION
## What

BE-1, part 2 — sends registrant fields upstream by their real names on every ITX path, and narrows
the public registration body at the trust boundary.

## How

- The BFF now renames `org_name` → `org`, `avatar_url` → `profile_picture`, `occurrence_id` →
  `occurrence` and drops `meeting_id` on all three registrant write paths; write responses are mapped
  back from the ITX spelling (including `modified_at` → `updated_at`). A `null` on those three is
  omitted rather than sent.
- The public registration body is allowlisted: `host` forced to `false`, values trimmed, free text
  capped at 255, `email` lowercased, over-length identifiers rejected by name, and `username` taken
  from the session.
- The registration modal now surfaces server validation messages it previously swallowed.

## Explicit trade-off — please read

On the public registration route **anyone can register a third party's email address** and trigger an
invite to it, and a signed-in caller's LFID is stamped on that row. `getMeetingRegistrantsForUser`
then matches that row for both parties, and the RSVP path takes `registrants[0]`. This is
rate-limited by `publicApiRateLimiter`, not prevented. Also: `occurrence_id` has no format guard, and
the 255-char cap and required-field set are local policy rather than a mirror of the upstream
contract.

Refs #1463
