### PR TITLE
fix(dashboards): tokenize org-groups copy via COMMITTEE_LABEL

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -37,7 +37,7 @@
   } @else if (!hasCompany()) {
     <lfx-empty-state
       icon="fa-light fa-building"
-      title="Select an organization to view {{ committeeLabel.singular.toLowerCase() }} participation."
+      title="Select an organization to view {{ committeeLabelSingularLower }} participation."
       data-testid="org-groups-no-company-state" />
   } @else if (fetchError()) {
     <lfx-empty-state

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -252,7 +252,7 @@
 
   <ng-template #groupListSkeleton>
     @for (i of [1, 2, 3, 4, 5]; track i) {
-      <div class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4">
+      <div class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-groups-list-skeleton-row">
         <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
         <div class="flex flex-col gap-1 flex-1">
           <p-skeleton width="40%" height="1rem" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -125,7 +125,7 @@
         @if (isFiltering()) {
           <button
             type="button"
-            class="text-xs font-medium text-gray-500 underline hover:text-slate-900"
+            class="text-xs font-medium text-gray-500 underline hover:text-gray-900"
             data-testid="org-groups-clear-filters"
             (click)="clearFilters()">
             Clear filters

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -3,10 +3,14 @@
 
 <main class="container mx-auto flex flex-col gap-6 px-4 sm:px-6 lg:px-8" data-testid="org-groups-page">
   <header class="flex flex-col gap-2" data-testid="org-groups-header">
-    <h1 class="font-display font-light text-2xl" data-testid="org-groups-title">{{ committeeLabel.plural }}</h1>
-    <p class="text-sm text-gray-500" data-testid="org-groups-subtitle">
-      {{ committeeLabel.plural }} your organization's employees participate in across Linux Foundation projects.
-    </p>
+    <h1 class="font-display font-light text-2xl" data-testid="org-groups-title">
+      @if (companyName()) {
+        {{ committeeLabel.plural }} &mdash; {{ companyName() }}
+      } @else {
+        {{ committeeLabel.plural }}
+      }
+    </h1>
+    <p class="text-sm text-gray-500" data-testid="org-groups-subtitle">Where your employees hold seats across Linux Foundation projects.</p>
   </header>
 
   @if (hasNoOrgAccess()) {
@@ -22,14 +26,13 @@
       </p>
     </section>
   } @else if (!loaded()) {
-    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" data-testid="org-groups-skeleton">
-      @for (i of [1, 2, 3, 4]; track i) {
-        <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4">
-          <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
-          <p-skeleton width="3rem" height="1.75rem" />
-          <p-skeleton width="80%" height="0.75rem" />
-        </div>
-      }
+    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="Group participation summary" data-testid="org-groups-skeleton">
+      <ng-container [ngTemplateOutlet]="statCardsSkeleton" />
+    </section>
+    <section aria-label="Group list" data-testid="org-groups-list-loading">
+      <div class="flex flex-col gap-3" data-testid="org-groups-list-skeleton">
+        <ng-container [ngTemplateOutlet]="groupListSkeleton" />
+      </div>
     </section>
   } @else if (!hasCompany()) {
     <lfx-empty-state icon="fa-light fa-building" title="Select an organization to view group participation." data-testid="org-groups-no-company-state" />
@@ -37,19 +40,49 @@
     <lfx-empty-state
       icon="fa-light fa-circle-exclamation"
       title="Unable to load group participation"
-      description="Something went wrong while fetching group data. Please try refreshing the page."
+      subtitle="Something went wrong while fetching group data. Please try refreshing the page."
       data-testid="org-groups-error-state" />
   } @else {
+    @if (showRoster()) {
+      <!-- Filter bar -->
+      <div class="flex flex-col gap-3 md:flex-row md:items-center md:gap-4" data-testid="org-groups-filter-bar">
+        <div class="flex-1">
+          <lfx-input-text
+            [form]="filterForm"
+            control="search"
+            placeholder="Search {{ committeeLabelPluralLower }}..."
+            icon="fa-light fa-magnifying-glass"
+            styleClass="w-full"
+            size="small"
+            dataTest="org-groups-search-input" />
+        </div>
+        <div class="w-full md:w-56">
+          <lfx-select
+            [form]="filterForm"
+            control="foundation"
+            size="small"
+            [options]="foundationOptions()"
+            styleClass="w-full"
+            ariaLabel="Filter by foundation"
+            dataTest="org-groups-foundation-filter" />
+        </div>
+        <div class="w-full md:w-56">
+          <lfx-select
+            [form]="filterForm"
+            control="type"
+            size="small"
+            [options]="typeOptions()"
+            styleClass="w-full"
+            ariaLabel="Filter by type"
+            dataTest="org-groups-type-filter" />
+        </div>
+      </div>
+    }
+
     <!-- Stat strip -->
     <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="Group participation summary" data-testid="org-groups-stat-strip">
       @if (groupsLoading()) {
-        @for (i of [1, 2, 3, 4]; track i) {
-          <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4">
-            <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
-            <p-skeleton width="3rem" height="1.75rem" />
-            <p-skeleton width="80%" height="0.75rem" />
-          </div>
-        }
+        <ng-container [ngTemplateOutlet]="statCardsSkeleton" />
       } @else {
         <!-- Total groups card -->
         <div class="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-groups-stat-total">
@@ -86,30 +119,45 @@
       }
     </section>
 
+    @if (showRoster()) {
+      <div class="flex items-center justify-between text-sm text-gray-500" data-testid="org-groups-result-line">
+        <span data-testid="org-groups-result-count">Showing {{ filteredGroups().length }} of {{ groups().length }} {{ committeeLabelPluralLower }}</span>
+        @if (isFiltering()) {
+          <button
+            type="button"
+            class="text-xs font-medium text-gray-500 underline hover:text-slate-900"
+            data-testid="org-groups-clear-filters"
+            (click)="clearFilters()">
+            Clear filters
+          </button>
+        }
+      </div>
+    }
+
     <!-- Group list -->
     <section aria-label="Group list" data-testid="org-groups-list">
       @if (groupsLoading()) {
         <div class="flex flex-col gap-3" data-testid="org-groups-list-skeleton">
-          @for (i of [1, 2, 3, 4, 5]; track i) {
-            <div class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4">
-              <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
-              <div class="flex flex-col gap-1 flex-1">
-                <p-skeleton width="40%" height="1rem" />
-                <p-skeleton width="25%" height="0.75rem" />
-              </div>
-              <p-skeleton width="3rem" height="1.25rem" />
-            </div>
-          }
+          <ng-container [ngTemplateOutlet]="groupListSkeleton" />
         </div>
       } @else if (groups().length === 0) {
         <lfx-empty-state
           icon="fa-light fa-users-rectangle"
-          title="No group participation found."
-          description="Your organization's employees are not listed as members of any working groups or committees."
+          title="No {{ committeeLabelSingularLower }} participation found."
+          subtitle="Your organization's employees are not listed as members of any {{ committeeLabelPluralLower }}."
           data-testid="org-groups-empty-state" />
+      } @else if (filteredGroups().length === 0) {
+        <lfx-empty-state
+          icon="fa-light fa-filter-slash"
+          title="No {{ committeeLabelPluralLower }} match the current filters"
+          subtitle="Try adjusting your search or filter selections."
+          ctaLabel="Clear filters"
+          ctaIcon="fa-light fa-filter-slash"
+          (ctaClick)="clearFilters()"
+          data-testid="org-groups-filtered-empty-state" />
       } @else {
         <div class="flex flex-col gap-2" role="list" data-testid="org-groups-list-items">
-          @for (group of groupsWithClass(); track group.uid) {
+          @for (group of filteredGroups(); track group.uid) {
             @let config = behavioralClassConfig[group.cls];
             <div
               role="listitem"
@@ -191,4 +239,27 @@
       }
     </section>
   }
+
+  <ng-template #statCardsSkeleton>
+    @for (i of [1, 2, 3, 4]; track i) {
+      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4">
+        <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
+        <p-skeleton width="3rem" height="1.75rem" />
+        <p-skeleton width="80%" height="0.75rem" />
+      </div>
+    }
+  </ng-template>
+
+  <ng-template #groupListSkeleton>
+    @for (i of [1, 2, 3, 4, 5]; track i) {
+      <div class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4">
+        <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
+        <div class="flex flex-col gap-1 flex-1">
+          <p-skeleton width="40%" height="1rem" />
+          <p-skeleton width="25%" height="0.75rem" />
+        </div>
+        <p-skeleton width="3rem" height="1.25rem" />
+      </div>
+    }
+  </ng-template>
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -242,7 +242,7 @@
 
   <ng-template #statCardsSkeleton>
     @for (i of [1, 2, 3, 4]; track i) {
-      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4">
+      <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-groups-stat-skeleton-card">
         <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
         <p-skeleton width="3rem" height="1.75rem" />
         <p-skeleton width="80%" height="0.75rem" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -26,21 +26,24 @@
       </p>
     </section>
   } @else if (!loaded()) {
-    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="Group participation summary" data-testid="org-groups-skeleton">
+    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="{{ committeeLabel.singular }} participation summary" data-testid="org-groups-skeleton">
       <ng-container [ngTemplateOutlet]="statCardsSkeleton" />
     </section>
-    <section aria-label="Group list" data-testid="org-groups-list-loading">
+    <section aria-label="{{ committeeLabel.singular }} list" data-testid="org-groups-list-loading">
       <div class="flex flex-col gap-3" data-testid="org-groups-list-skeleton">
         <ng-container [ngTemplateOutlet]="groupListSkeleton" />
       </div>
     </section>
   } @else if (!hasCompany()) {
-    <lfx-empty-state icon="fa-light fa-building" title="Select an organization to view group participation." data-testid="org-groups-no-company-state" />
+    <lfx-empty-state
+      icon="fa-light fa-building"
+      title="Select an organization to view {{ committeeLabel.singular.toLowerCase() }} participation."
+      data-testid="org-groups-no-company-state" />
   } @else if (fetchError()) {
     <lfx-empty-state
       icon="fa-light fa-circle-exclamation"
-      title="Unable to load group participation"
-      subtitle="Something went wrong while fetching group data. Please try refreshing the page."
+      title="Unable to load {{ committeeLabelSingularLower }} participation"
+      subtitle="Something went wrong while fetching {{ committeeLabelSingularLower }} data. Please try refreshing the page."
       data-testid="org-groups-error-state" />
   } @else {
     @if (showRoster()) {
@@ -80,7 +83,7 @@
     }
 
     <!-- Stat strip -->
-    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="Group participation summary" data-testid="org-groups-stat-strip">
+    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="{{ committeeLabel.singular }} participation summary" data-testid="org-groups-stat-strip">
       @if (groupsLoading()) {
         <ng-container [ngTemplateOutlet]="statCardsSkeleton" />
       } @else {
@@ -135,7 +138,7 @@
     }
 
     <!-- Group list -->
-    <section aria-label="Group list" data-testid="org-groups-list">
+    <section aria-label="{{ committeeLabel.singular }} list" data-testid="org-groups-list">
       @if (groupsLoading()) {
         <div class="flex flex-col gap-3" data-testid="org-groups-list-skeleton">
           <ng-container [ngTemplateOutlet]="groupListSkeleton" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -97,7 +97,7 @@ function listSkeletonRows(fixture: ComponentFixture<OrgGroupsComponent>): NodeLi
 }
 
 function statSkeletonCards(fixture: ComponentFixture<OrgGroupsComponent>): NodeListOf<Element> {
-  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-skeleton"] > div, [data-testid="org-groups-stat-strip"] > div');
+  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-stat-skeleton-card"]');
 }
 
 /** The row-link testid ('org-groups-row-link-<uid>') is deliberately not a prefix-extension of the

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -420,7 +420,10 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
     await TestBed.configureTestingModule({
       imports: [OrgGroupsComponent],
       providers: [
-        { provide: AccountContextService, useValue: { selectedAccount: signal({ accountId: 'a1', accountName: 'Acme Corp', uid: 'org-1' }), hasOrgSelectorAccess: signal(true) } },
+        {
+          provide: AccountContextService,
+          useValue: { selectedAccount: signal({ accountId: 'a1', accountName: 'Acme Corp', uid: 'org-1' }), hasOrgSelectorAccess: signal(true) },
+        },
         { provide: OrgNavigationService, useValue: { loaded: signal(true) } },
         { provide: OrgRoleGrantsService, useValue: { loaded: signal(true) } },
         { provide: PersonaService, useValue: { personaLoaded: signal(true) } },

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -93,7 +93,7 @@ function groupsResponse(groups: OrgLensGroupSummary[]): OrgLensGroupsResponse {
 }
 
 function listSkeletonRows(fixture: ComponentFixture<OrgGroupsComponent>): NodeListOf<Element> {
-  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-skeleton"] > div');
+  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-skeleton-row"]');
 }
 
 function statSkeletonCards(fixture: ComponentFixture<OrgGroupsComponent>): NodeListOf<Element> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -100,6 +100,10 @@ function statSkeletonCards(fixture: ComponentFixture<OrgGroupsComponent>): NodeL
   return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-stat-skeleton-card"]');
 }
 
+function has(fixture: ComponentFixture<OrgGroupsComponent>, testid: string): boolean {
+  return !!fixture.nativeElement.querySelector(`[data-testid="${testid}"]`);
+}
+
 /** The row-link testid ('org-groups-row-link-<uid>') is deliberately not a prefix-extension of the
  *  row container's ('org-groups-item-<uid>') — the latter also prefixes the per-row -name/-project/-seats
  *  sub-testids, so it can't be used for a `^=` row count without over-matching. */
@@ -140,13 +144,31 @@ describe('OrgGroupsComponent', () => {
   it('renders the same skeleton shape for the initial page load and the group-fetch loading state', async () => {
     // !loaded() branch — org navigation hasn't resolved yet.
     const { fixture: initialLoad } = await render({ orgNavigationLoaded: false });
+    expect(has(initialLoad, 'org-groups-skeleton')).toBe(true);
+    expect(has(initialLoad, 'org-groups-stat-strip')).toBe(false);
+    expect(has(initialLoad, 'org-groups-list-loading')).toBe(true);
+    expect(has(initialLoad, 'org-groups-list')).toBe(false);
     expect(statSkeletonCards(initialLoad).length).toBe(4);
     expect(listSkeletonRows(initialLoad).length).toBe(5);
 
     // groupsLoading() branch — page loaded, but the group fetch never resolves.
     const { fixture: groupsFetching } = await render({ getGroups: () => new Subject<OrgLensGroupsResponse>() });
+    expect(has(groupsFetching, 'org-groups-stat-strip')).toBe(true);
+    expect(has(groupsFetching, 'org-groups-skeleton')).toBe(false);
+    expect(has(groupsFetching, 'org-groups-list')).toBe(true);
+    expect(has(groupsFetching, 'org-groups-list-loading')).toBe(false);
+    expect(has(groupsFetching, 'org-groups-stat-total')).toBe(false);
     expect(statSkeletonCards(groupsFetching).length).toBe(4);
     expect(listSkeletonRows(groupsFetching).length).toBe(5);
+  });
+
+  it('renders the populated stat strip and group list once data arrives', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-stat-total"]')?.textContent).toContain('4');
+    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-stat-seats"]')?.textContent).toContain('19');
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-items"] > div').length).toBe(4);
+    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-skeleton"]')).toBeNull();
   });
 
   it('includes the selected account name in the H1, separated by a dash', async () => {
@@ -415,11 +437,10 @@ describe('OrgGroupsComponent', () => {
 describe('OrgGroupsComponent — project label and row/foundation routing', () => {
   let fixture: ComponentFixture<OrgGroupsComponent>;
 
-  async function render(response: OrgLensGroupsResponse): Promise<void> {
-    // Delegates to the shared setup below rather than duplicating the TestBed providers —
-    // two near-identical configurations meant a provider change here could silently drift
-    // from the other describe block's.
-    fixture = await renderGroupsPage({ accountName: 'Acme Corp', getGroups: () => of(response) });
+  // Named renderRow (not render) — a same-named local function would shadow the module-level
+  // render() and recurse into itself instead of delegating to it.
+  async function renderRow(response: OrgLensGroupsResponse): Promise<void> {
+    ({ fixture } = await render({ accountName: 'Acme Corp', getGroups: () => of(response) }));
   }
 
   function group(over: Partial<OrgLensGroupSummary> = {}): OrgLensGroupSummary {
@@ -448,7 +469,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   }
 
   it('prefers project_name over project_slug in the project line and aria-label', async () => {
-    await render({
+    await renderRow({
       groups: [group({ project_name: 'Cloud Native Computing Foundation', project_slug: 'cncf' })],
       total_groups: 1,
       total_seats: 3,
@@ -459,7 +480,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   });
 
   it('falls back to project_slug when project_name is absent', async () => {
-    await render({
+    await renderRow({
       groups: [group({ project_slug: 'cncf' })],
       total_groups: 1,
       total_seats: 3,
@@ -470,7 +491,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   });
 
   it('omits the project line and label segment when neither is set', async () => {
-    await render({
+    await renderRow({
       groups: [group()],
       total_groups: 1,
       total_seats: 3,
@@ -481,7 +502,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   });
 
   it('uses the singular "seat" in the aria-label for a single-seat group', async () => {
-    await render({
+    await renderRow({
       groups: [group({ org_seat_count: 1 })],
       total_groups: 1,
       total_seats: 1,
@@ -491,7 +512,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   });
 
   it('renders the foundation name as a link to /org/memberships/<slug> when project_slug is present', async () => {
-    await render({
+    await renderRow({
       groups: [group({ project_name: 'Ultra Ethernet Consortium Fund', project_slug: 'uepf' })],
       total_groups: 1,
       total_seats: 3,
@@ -507,7 +528,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   });
 
   it('renders the foundation name as plain text (no link) when project_slug is absent', async () => {
-    await render({
+    await renderRow({
       // project_name can be set from the committee index even when project_slug is missing —
       // the link must still be gated on project_slug alone, per the destination route's contract.
       groups: [group({ project_name: 'Ultra Ethernet Consortium Fund', project_slug: undefined })],
@@ -521,7 +542,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   });
 
   it('clicking the foundation link navigates to the membership route, not the group route', async () => {
-    await render({
+    await renderRow({
       groups: [group({ project_name: 'Ultra Ethernet Consortium Fund', project_slug: 'uepf' })],
       total_groups: 1,
       total_seats: 3,
@@ -541,7 +562,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   // the absolute-inset-0 / pointer-events overlay actually covers the row and routes clicks
   // correctly at runtime. That overlay-mechanics risk needs an e2e/Playwright check to close.
   it('links the row itself to the group detail route', async () => {
-    await render({
+    await renderRow({
       groups: [group({ uid: 'g1', project_slug: 'cncf' })],
       total_groups: 1,
       total_seats: 3,
@@ -549,120 +570,5 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
 
     const rowLink = fixture.nativeElement.querySelector('[data-testid="org-groups-row-link-g1"]');
     expect(rowLink?.getAttribute('href')).toBe('/groups/g1');
-  });
-});
-
-async function renderGroupsPage(options: RenderOptions = {}): Promise<ComponentFixture<OrgGroupsComponent>> {
-  const { accountName = 'Acme Motors, Inc.', orgNavigationLoaded = true, getGroups = () => of(emptyGroupsResponse()) } = options;
-
-  TestBed.resetTestingModule();
-  await TestBed.configureTestingModule({
-    imports: [OrgGroupsComponent],
-    providers: [
-      {
-        provide: AccountContextService,
-        useValue: {
-          selectedAccount: signal({ accountId: 'acc-1', accountName, accountSlug: 'acme', membershipTier: '', uid: 'org-uid-1' }),
-          hasOrgSelectorAccess: signal(true),
-        },
-      },
-      { provide: OrgNavigationService, useValue: { loaded: signal(orgNavigationLoaded) } },
-      { provide: OrgRoleGrantsService, useValue: { loaded: signal(true) } },
-      { provide: PersonaService, useValue: { personaLoaded: signal(true) } },
-      { provide: OrgLensGroupsService, useValue: { getGroups } },
-      provideRouter([]),
-    ],
-  }).compileComponents();
-
-  const fixture = TestBed.createComponent(OrgGroupsComponent);
-  await fixture.whenStable();
-  fixture.detectChanges();
-  return fixture;
-}
-
-function populatedGroupsResponse(): OrgLensGroupsResponse {
-  const groups: OrgLensGroupSummary[] = [
-    { uid: 'group-1', name: 'Platform Working Group', category: 'Working Group', project_slug: 'acme-platform', org_seat_count: 3 },
-    { uid: 'group-2', name: 'Security SIG', category: 'Special Interest Group', project_slug: 'acme-platform', org_seat_count: 1 },
-  ];
-  return { groups, total_groups: groups.length, total_seats: 4 };
-}
-
-function has(fixture: ComponentFixture<OrgGroupsComponent>, testid: string): boolean {
-  return !!fixture.nativeElement.querySelector(`[data-testid="${testid}"]`);
-}
-
-function listSkeletonRowsIn(fixture: ComponentFixture<OrgGroupsComponent>): NodeListOf<Element> {
-  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-skeleton"] > div');
-}
-
-function statSkeletonCardsIn(fixture: ComponentFixture<OrgGroupsComponent>, wrapperTestid: string): NodeListOf<Element> {
-  return fixture.nativeElement.querySelectorAll(`[data-testid="${wrapperTestid}"] > div`);
-}
-
-describe('OrgGroupsComponent — loading state and copy', () => {
-  it('renders the same skeleton shape for the initial page load and the group-fetch loading state', async () => {
-    // !loaded() branch — org navigation hasn't resolved yet.
-    const initialLoad = await renderGroupsPage({ orgNavigationLoaded: false });
-    expect(has(initialLoad, 'org-groups-skeleton')).toBe(true);
-    expect(has(initialLoad, 'org-groups-stat-strip')).toBe(false);
-    expect(has(initialLoad, 'org-groups-list-loading')).toBe(true);
-    expect(has(initialLoad, 'org-groups-list')).toBe(false);
-    expect(statSkeletonCardsIn(initialLoad, 'org-groups-skeleton').length).toBe(4);
-    expect(listSkeletonRowsIn(initialLoad).length).toBe(5);
-
-    // groupsLoading() branch — page loaded, but the group fetch never resolves.
-    const groupsFetching = await renderGroupsPage({ getGroups: () => new Subject<OrgLensGroupsResponse>() });
-    expect(has(groupsFetching, 'org-groups-stat-strip')).toBe(true);
-    expect(has(groupsFetching, 'org-groups-skeleton')).toBe(false);
-    expect(has(groupsFetching, 'org-groups-list')).toBe(true);
-    expect(has(groupsFetching, 'org-groups-list-loading')).toBe(false);
-    expect(has(groupsFetching, 'org-groups-stat-total')).toBe(false);
-    expect(statSkeletonCardsIn(groupsFetching, 'org-groups-stat-strip').length).toBe(4);
-    expect(listSkeletonRowsIn(groupsFetching).length).toBe(5);
-  });
-
-  it('renders the populated stat strip and group list once data arrives', async () => {
-    const fixture = await renderGroupsPage({ getGroups: () => of(populatedGroupsResponse()) });
-
-    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-stat-total"]')?.textContent).toContain('2');
-    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-stat-seats"]')?.textContent).toContain('4');
-    expect(fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-items"] > div').length).toBe(2);
-    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-skeleton"]')).toBeNull();
-  });
-
-  it('includes the selected account name in the H1, separated by a dash', async () => {
-    const fixture = await renderGroupsPage({ accountName: 'Acme Motors, Inc.' });
-
-    const title = fixture.nativeElement.querySelector('[data-testid="org-groups-title"]');
-
-    expect(title?.textContent?.trim()).toBe('Groups — Acme Motors, Inc.');
-  });
-
-  it('omits the dash from the H1 when no account name is selected', async () => {
-    const fixture = await renderGroupsPage({ accountName: '' });
-
-    const title = fixture.nativeElement.querySelector('[data-testid="org-groups-title"]');
-
-    expect(title?.textContent?.trim()).toBe('Groups');
-  });
-
-  it('renders the group-participation empty state copy', async () => {
-    const fixture = await renderGroupsPage({ getGroups: () => of(emptyGroupsResponse()) });
-
-    const emptyState = fixture.nativeElement.querySelector('[data-testid="org-groups-empty-state"]');
-
-    expect(emptyState?.textContent).toContain(`No ${COMMITTEE_LABEL.singular.toLowerCase()} participation found.`);
-    expect(emptyState?.textContent).toContain(`any ${COMMITTEE_LABEL.plural.toLowerCase()}.`);
-  });
-
-  it('renders the fetch-error subtitle on the empty state', async () => {
-    const fixture = await renderGroupsPage({ getGroups: () => throwError(() => new Error('boom')) });
-
-    const errorState = fixture.nativeElement.querySelector('[data-testid="org-groups-error-state"]');
-
-    expect(errorState?.textContent).toContain(
-      `Something went wrong while fetching ${COMMITTEE_LABEL.singular.toLowerCase()} data. Please try refreshing the page.`
-    );
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -1,32 +1,416 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { provideRouter, Router } from '@angular/router';
+import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
+import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
+import type { Account, OrgDropdownOption, OrgLensGroupSummary, OrgLensGroupsResponse } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensGroupsService } from '@services/org-lens-groups.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
-import { of } from 'rxjs';
+import { of, Subject, throwError } from 'rxjs';
 import { describe, expect, it, vi } from 'vitest';
-
-import type { Account, OrgLensGroupsResponse, OrgLensGroupSummary } from '@lfx-one/shared/interfaces';
+import { signal, type WritableSignal } from '@angular/core';
 
 import { OrgGroupsComponent } from './org-groups.component';
 
-const ACCOUNT: Account = { accountId: 'a1', accountName: 'Acme Corp', uid: 'org-1' };
-
-function group(over: Partial<OrgLensGroupSummary> = {}): OrgLensGroupSummary {
-  return {
-    uid: 'g1',
-    name: 'WG Identity & Trust',
-    category: 'Working Group',
-    org_seat_count: 3,
-    ...over,
-  };
+interface RenderOptions {
+  accountName?: string;
+  orgNavigationLoaded?: boolean;
+  getGroups?: () => ReturnType<OrgLensGroupsService['getGroups']>;
+  queryParams?: Record<string, string>;
 }
+
+interface Rendered {
+  fixture: ComponentFixture<OrgGroupsComponent>;
+  navigate: ReturnType<typeof vi.fn>;
+  selectedAccount: WritableSignal<Account>;
+}
+
+async function render(options: RenderOptions = {}): Promise<Rendered> {
+  const { accountName = 'Acme Motors, Inc.', orgNavigationLoaded = true, getGroups = () => of(emptyGroupsResponse()), queryParams = {} } = options;
+
+  const selectedAccount = signal<Account>({ accountId: 'acc-1', accountName, accountSlug: 'acme', membershipTier: '', uid: 'org-uid-1' });
+
+  TestBed.resetTestingModule();
+  await TestBed.configureTestingModule({
+    imports: [OrgGroupsComponent],
+    providers: [
+      {
+        provide: AccountContextService,
+        useValue: { selectedAccount, hasOrgSelectorAccess: signal(true) },
+      },
+      { provide: OrgNavigationService, useValue: { loaded: signal(orgNavigationLoaded) } },
+      { provide: OrgRoleGrantsService, useValue: { loaded: signal(true) } },
+      { provide: PersonaService, useValue: { personaLoaded: signal(true) } },
+      { provide: OrgLensGroupsService, useValue: { getGroups } },
+      // Real Router (via provideRouter) so the rendered group rows' [routerLink] (createUrlTree, etc.)
+      // keeps working; only `navigate` — the method the URL-sync subscription actually calls — is spied on.
+      provideRouter([]),
+      {
+        provide: ActivatedRoute,
+        useValue: {
+          snapshot: { queryParamMap: convertToParamMap(queryParams), queryParams },
+        },
+      },
+    ],
+  }).compileComponents();
+
+  const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true) as unknown as ReturnType<typeof vi.fn>;
+
+  const fixture = TestBed.createComponent(OrgGroupsComponent);
+  await fixture.whenStable();
+  fixture.detectChanges();
+  return { fixture, navigate, selectedAccount };
+}
+
+function emptyGroupsResponse(): OrgLensGroupsResponse {
+  return { groups: [], total_groups: 0, total_seats: 0 };
+}
+
+/** Server-sorted (seat count desc, then name asc) — the component never re-sorts, so fixtures already reflect that order. */
+function buildGroups(): OrgLensGroupSummary[] {
+  return [
+    { uid: 'g1', name: 'Committee Steering TAG', category: 'TSC', project_uid: 'p-cncf', project_slug: 'cncf', project_name: 'CNCF', org_seat_count: 10 },
+    { uid: 'g2', name: 'Zephyr Working Group', category: 'Working Group', project_uid: 'p-zephyr', project_slug: 'zephyr-project', org_seat_count: 5 },
+    {
+      uid: 'g3',
+      name: 'Ambassador Program',
+      category: 'Ambassador',
+      project_uid: 'p-ossf',
+      project_slug: 'openssf',
+      project_name: 'OpenSSF',
+      org_seat_count: 3,
+    },
+    { uid: 'g4', name: 'Committee Newsletter', category: 'Newsletter', project_uid: 'p-cncf', project_slug: 'cncf', project_name: 'CNCF', org_seat_count: 1 },
+  ];
+}
+
+function groupsResponse(groups: OrgLensGroupSummary[]): OrgLensGroupsResponse {
+  return { groups, total_groups: groups.length, total_seats: groups.reduce((sum, g) => sum + g.org_seat_count, 0) };
+}
+
+function listSkeletonRows(fixture: ComponentFixture<OrgGroupsComponent>): NodeListOf<Element> {
+  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-skeleton"] > div');
+}
+
+function statSkeletonCards(fixture: ComponentFixture<OrgGroupsComponent>): NodeListOf<Element> {
+  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-skeleton"] > div, [data-testid="org-groups-stat-strip"] > div');
+}
+
+/** The row-link testid ('org-groups-row-link-<uid>') is deliberately not a prefix-extension of the
+ *  row container's ('org-groups-item-<uid>') — the latter also prefixes the per-row -name/-project/-seats
+ *  sub-testids, so it can't be used for a `^=` row count without over-matching. */
+function renderedItemUids(fixture: ComponentFixture<OrgGroupsComponent>): string[] {
+  return Array.from(fixture.nativeElement.querySelectorAll('[data-testid^="org-groups-row-link-"]')).map((el) =>
+    (el as HTMLElement).getAttribute('data-testid')!.replace('org-groups-row-link-', '')
+  );
+}
+
+/** filterForm/typeOptions are `protected` — reach in via a narrow cast, mirroring the repo's existing spec convention (see brand-kit-form.component.spec.ts). */
+function filterForm(fixture: ComponentFixture<OrgGroupsComponent>): {
+  get(key: string): { setValue(v: string): void } | null;
+  reset(v: Record<string, string>): void;
+} {
+  return (
+    fixture.componentInstance as unknown as {
+      filterForm: { get(key: string): { setValue(v: string): void } | null; reset(v: Record<string, string>): void };
+    }
+  ).filterForm;
+}
+
+function typeOptions(fixture: ComponentFixture<OrgGroupsComponent>): OrgDropdownOption[] {
+  return (fixture.componentInstance as unknown as { typeOptions: () => OrgDropdownOption[] }).typeOptions();
+}
+
+function foundationOptions(fixture: ComponentFixture<OrgGroupsComponent>): OrgDropdownOption[] {
+  return (fixture.componentInstance as unknown as { foundationOptions: () => OrgDropdownOption[] }).foundationOptions();
+}
+
+/** Lets the real `debounceTime(150)` on the filter form settle, then flushes change detection. */
+async function flushFilterChange(fixture: ComponentFixture<OrgGroupsComponent>): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 200));
+  fixture.detectChanges();
+  await fixture.whenStable();
+}
+
+describe('OrgGroupsComponent', () => {
+  it('renders the same skeleton shape for the initial page load and the group-fetch loading state', async () => {
+    // !loaded() branch — org navigation hasn't resolved yet.
+    const { fixture: initialLoad } = await render({ orgNavigationLoaded: false });
+    expect(statSkeletonCards(initialLoad).length).toBe(4);
+    expect(listSkeletonRows(initialLoad).length).toBe(5);
+
+    // groupsLoading() branch — page loaded, but the group fetch never resolves.
+    const { fixture: groupsFetching } = await render({ getGroups: () => new Subject<OrgLensGroupsResponse>() });
+    expect(statSkeletonCards(groupsFetching).length).toBe(4);
+    expect(listSkeletonRows(groupsFetching).length).toBe(5);
+  });
+
+  it('includes the selected account name in the H1, separated by a dash', async () => {
+    const { fixture } = await render({ accountName: 'Acme Motors, Inc.' });
+
+    const title = fixture.nativeElement.querySelector('[data-testid="org-groups-title"]');
+
+    expect(title?.textContent?.trim()).toBe('Groups — Acme Motors, Inc.');
+  });
+
+  it('omits the dash from the H1 when no account name is selected', async () => {
+    const { fixture } = await render({ accountName: '' });
+
+    const title = fixture.nativeElement.querySelector('[data-testid="org-groups-title"]');
+
+    expect(title?.textContent?.trim()).toBe('Groups');
+  });
+
+  it('derives the roster-empty copy from COMMITTEE_LABEL rather than a hardcoded literal', async () => {
+    const { fixture } = await render({ getGroups: () => of(emptyGroupsResponse()) });
+
+    const emptyState = fixture.nativeElement.querySelector('[data-testid="org-groups-empty-state"]');
+
+    expect(emptyState?.textContent).toContain(`No ${COMMITTEE_LABEL.singular.toLowerCase()} participation found.`);
+    expect(emptyState?.textContent).toContain(`any ${COMMITTEE_LABEL.plural.toLowerCase()}.`);
+  });
+
+  it('renders the fetchError subtitle now that the empty-state input mismatch is fixed', async () => {
+    const { fixture } = await render({ getGroups: () => throwError(() => new Error('boom')) });
+
+    const errorState = fixture.nativeElement.querySelector('[data-testid="org-groups-error-state"]');
+
+    expect(errorState?.textContent).toContain('Something went wrong while fetching group data. Please try refreshing the page.');
+  });
+
+  it('search matches on group name and on foundation name', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    filterForm(fixture).get('search')?.setValue('zephyr');
+    await flushFilterChange(fixture);
+
+    // 'zephyr' only appears in g2's NAME, not any foundation label.
+    expect(renderedItemUids(fixture)).toEqual(['g2']);
+
+    filterForm(fixture).get('search')?.setValue('cncf');
+    await flushFilterChange(fixture);
+
+    // 'cncf' appears only in g1/g4's FOUNDATION name ("CNCF"), not in either group's name.
+    expect(renderedItemUids(fixture)).toEqual(['g1', 'g4']);
+  });
+
+  it('composes search, foundation, and type filters with AND', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    // 'committee' matches g1 + g4 by name; foundation slug 'cncf' also matches g1 + g4;
+    // type 'special-interest-group' narrows to g4 alone (g1 is oversight-committee).
+    filterForm(fixture).get('search')?.setValue('committee');
+    filterForm(fixture).get('foundation')?.setValue('cncf');
+    filterForm(fixture).get('type')?.setValue('special-interest-group');
+    await flushFilterChange(fixture);
+
+    expect(renderedItemUids(fixture)).toEqual(['g4']);
+  });
+
+  it('excludes zero-count classes from type options and shows correct counts for present ones', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    const options = typeOptions(fixture);
+    const labels = options.map((o) => o.label);
+
+    // No governing-board or "other" groups in the fixture — must not appear.
+    expect(labels.some((l) => l.startsWith('Boards'))).toBe(false);
+    expect(labels.some((l) => l.startsWith('Other'))).toBe(false);
+
+    expect(labels).toContain('All types');
+    expect(labels).toContain('Oversight (1)');
+    expect(labels).toContain('Working Groups (1)');
+    expect(labels).toContain('Ambassadors (1)');
+    expect(labels).toContain('SIGs (1)');
+  });
+
+  it('keys foundation options on project_slug (a stable identity) with the resolved name as the label', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    const options = foundationOptions(fixture);
+
+    expect(options).toContainEqual({ label: 'All foundations', value: '' });
+    expect(options).toContainEqual({ label: 'CNCF', value: 'cncf' });
+    expect(options).toContainEqual({ label: 'OpenSSF', value: 'openssf' });
+    // g2 has no project_name — falls back to the slug for both label and value.
+    expect(options).toContainEqual({ label: 'zephyr-project', value: 'zephyr-project' });
+    // g1 and g4 share the 'cncf' slug — must appear once, not twice.
+    expect(options.filter((o) => o.value === 'cncf')).toHaveLength(1);
+  });
+
+  it('lets a resolved name win the shared label even when the unenriched sibling sorts first', async () => {
+    // Server sort is seat-count desc, so the UNENRICHED group of this foundation sorts ahead of the
+    // enriched one — exactly the ordering that would leak the raw slug if label selection depended on
+    // iteration order instead of "does this group have a project_name".
+    const groups: OrgLensGroupSummary[] = [
+      { uid: 'h1', name: 'Big Unenriched Group', category: 'TSC', project_uid: 'p-x', project_slug: 'x-project', org_seat_count: 10 },
+      {
+        uid: 'h2',
+        name: 'Small Enriched Group',
+        category: 'Ambassador',
+        project_uid: 'p-x',
+        project_slug: 'x-project',
+        project_name: 'X Project',
+        org_seat_count: 1,
+      },
+    ];
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(groups)) });
+
+    expect(foundationOptions(fixture)).toContainEqual({ label: 'X Project', value: 'x-project' });
+
+    // Search by the resolved name must also match the unenriched sibling, not just the enriched group.
+    filterForm(fixture).get('search')?.setValue('X Project');
+    await flushFilterChange(fixture);
+    expect(renderedItemUids(fixture)).toEqual(['h1', 'h2']);
+  });
+
+  it('also matches search on the raw slug, as a convenience for a search term that is the technical slug', async () => {
+    const groups: OrgLensGroupSummary[] = [
+      { uid: 'h1', name: 'Group One', category: 'TSC', project_uid: 'p-x', project_slug: 'x-project', project_name: 'X Project', org_seat_count: 1 },
+    ];
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(groups)) });
+
+    // 'x-project' appears only in the slug — not in the name or the resolved label ("X Project").
+    filterForm(fixture).get('search')?.setValue('x-project');
+    await flushFilterChange(fixture);
+
+    expect(renderedItemUids(fixture)).toEqual(['h1']);
+  });
+
+  it('renders filtered-empty copy distinct from roster-empty copy when a filter matches nothing', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    filterForm(fixture).get('search')?.setValue('no-such-group-xyz');
+    await flushFilterChange(fixture);
+
+    const filteredEmpty = fixture.nativeElement.querySelector('[data-testid="org-groups-filtered-empty-state"]');
+    const rosterEmpty = fixture.nativeElement.querySelector('[data-testid="org-groups-empty-state"]');
+
+    expect(filteredEmpty).toBeTruthy();
+    expect(rosterEmpty).toBeFalsy();
+    expect(filteredEmpty?.textContent).toContain(`No ${COMMITTEE_LABEL.plural.toLowerCase()} match the current filters`);
+    expect(filteredEmpty?.textContent).not.toContain('participation found');
+  });
+
+  it('hides the filter bar while the roster is empty or still loading', async () => {
+    const { fixture: emptyRoster } = await render({ getGroups: () => of(emptyGroupsResponse()) });
+    expect(emptyRoster.nativeElement.querySelector('[data-testid="org-groups-filter-bar"]')).toBeFalsy();
+
+    const { fixture: stillLoading } = await render({ getGroups: () => new Subject<OrgLensGroupsResponse>() });
+    expect(stillLoading.nativeElement.querySelector('[data-testid="org-groups-filter-bar"]')).toBeFalsy();
+
+    const { fixture: loaded } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+    expect(loaded.nativeElement.querySelector('[data-testid="org-groups-filter-bar"]')).toBeTruthy();
+  });
+
+  it('keeps a URL-seeded filter on first render (does not clear it as if the org just switched)', async () => {
+    const { fixture } = await render({
+      getGroups: () => of(groupsResponse(buildGroups())),
+      queryParams: { q: 'zephyr' },
+    });
+    // Flush the same real-time debounce window an org-switch reset would go through — without this,
+    // the assertion would pass whether or not the skip(1) guard actually protects the seeded value.
+    await flushFilterChange(fixture);
+
+    expect(renderedItemUids(fixture)).toEqual(['g2']);
+  });
+
+  it('clears the filter form when the selected org actually switches', async () => {
+    const { fixture, selectedAccount } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    filterForm(fixture).get('search')?.setValue('zephyr');
+    await flushFilterChange(fixture);
+    expect(renderedItemUids(fixture)).toEqual(['g2']);
+
+    // clearFilters() resets the form synchronously, but filteredGroups reads the debounced filterValues
+    // signal, so this needs the same real-time flush as a direct user edit.
+    selectedAccount.set({ accountId: 'acc-2', accountName: 'Vendor Corp', accountSlug: 'vendor-corp', membershipTier: '', uid: 'org-uid-2' });
+    await flushFilterChange(fixture);
+
+    expect(renderedItemUids(fixture)).toEqual(['g1', 'g2', 'g3', 'g4']);
+  });
+
+  it('clearing filters restores the full list in the original (seat-desc, name-asc) order', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    filterForm(fixture).get('search')?.setValue('zephyr');
+    await flushFilterChange(fixture);
+    expect(renderedItemUids(fixture)).toEqual(['g2']);
+
+    const clearButton = fixture.nativeElement.querySelector('[data-testid="org-groups-clear-filters"]') as HTMLButtonElement;
+    expect(clearButton).toBeTruthy();
+    clearButton.click();
+    await flushFilterChange(fixture);
+
+    expect(renderedItemUids(fixture)).toEqual(['g1', 'g2', 'g3', 'g4']);
+  });
+
+  it('decodes ?q=, ?foundation=, and ?type= from the URL into the filtered result on initial render', async () => {
+    const { fixture } = await render({
+      getGroups: () => of(groupsResponse(buildGroups())),
+      queryParams: { q: 'committee', foundation: 'cncf', type: 'special-interest-group' },
+    });
+    // Flush past the debounce window so this also proves the decoded filter *survives* first render,
+    // not just that the (pre-debounce) initial value happens to already reflect it.
+    await flushFilterChange(fixture);
+
+    expect(renderedItemUids(fixture)).toEqual(['g4']);
+  });
+
+  it('writes the query param on filter change and removes it when reset to default', async () => {
+    const { fixture, navigate } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    filterForm(fixture).get('type')?.setValue('working-group');
+    await flushFilterChange(fixture);
+
+    expect(navigate).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({
+        queryParams: { q: null, foundation: null, type: 'working-group' },
+        queryParamsHandling: 'merge',
+        replaceUrl: true,
+      })
+    );
+
+    navigate.mockClear();
+    filterForm(fixture).get('type')?.setValue('');
+    await flushFilterChange(fixture);
+
+    expect(navigate).toHaveBeenCalledWith(
+      [],
+      expect.objectContaining({
+        queryParams: { q: null, foundation: null, type: null },
+      })
+    );
+  });
+
+  it('falls back to the default when ?type= is a malformed/unknown value, without throwing', async () => {
+    // render() itself would reject/throw if construction failed on the bogus param — awaiting it directly
+    // is the assertion that decoding a malformed value never throws.
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())), queryParams: { type: 'bogus-value' } });
+
+    // No type filter applied — full roster renders.
+    expect(renderedItemUids(fixture)).toEqual(['g1', 'g2', 'g3', 'g4']);
+  });
+
+  it('preserves an unrelated ?project= param (never overwrites the app-wide reserved key) when a filter changes', async () => {
+    const { fixture, navigate } = await render({
+      getGroups: () => of(groupsResponse(buildGroups())),
+      queryParams: { project: 'some-other-project' },
+    });
+
+    filterForm(fixture).get('foundation')?.setValue('openssf');
+    await flushFilterChange(fixture);
+
+    expect(navigate).toHaveBeenCalled();
+    const [, navOptions] = navigate.mock.calls[navigate.mock.calls.length - 1] as [unknown, { queryParams: Record<string, unknown> }];
+    expect(navOptions.queryParams).not.toHaveProperty('project');
+  });
+});
 
 describe('OrgGroupsComponent — project label and row/foundation routing', () => {
   let fixture: ComponentFixture<OrgGroupsComponent>;
@@ -36,7 +420,7 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
     await TestBed.configureTestingModule({
       imports: [OrgGroupsComponent],
       providers: [
-        { provide: AccountContextService, useValue: { selectedAccount: signal(ACCOUNT), hasOrgSelectorAccess: signal(true) } },
+        { provide: AccountContextService, useValue: { selectedAccount: signal({ accountId: 'a1', accountName: 'Acme Corp', uid: 'org-1' }), hasOrgSelectorAccess: signal(true) } },
         { provide: OrgNavigationService, useValue: { loaded: signal(true) } },
         { provide: OrgRoleGrantsService, useValue: { loaded: signal(true) } },
         { provide: PersonaService, useValue: { personaLoaded: signal(true) } },
@@ -47,6 +431,16 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
 
     fixture = TestBed.createComponent(OrgGroupsComponent);
     await fixture.whenStable();
+  }
+
+  function group(over: Partial<OrgLensGroupSummary> = {}): OrgLensGroupSummary {
+    return {
+      uid: 'g1',
+      name: 'WG Identity & Trust',
+      category: 'Working Group',
+      org_seat_count: 3,
+      ...over,
+    };
   }
 
   function projectLineElement(): HTMLElement | null {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -416,24 +416,10 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
   let fixture: ComponentFixture<OrgGroupsComponent>;
 
   async function render(response: OrgLensGroupsResponse): Promise<void> {
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      imports: [OrgGroupsComponent],
-      providers: [
-        {
-          provide: AccountContextService,
-          useValue: { selectedAccount: signal({ accountId: 'a1', accountName: 'Acme Corp', uid: 'org-1' }), hasOrgSelectorAccess: signal(true) },
-        },
-        { provide: OrgNavigationService, useValue: { loaded: signal(true) } },
-        { provide: OrgRoleGrantsService, useValue: { loaded: signal(true) } },
-        { provide: PersonaService, useValue: { personaLoaded: signal(true) } },
-        { provide: OrgLensGroupsService, useValue: { getGroups: () => of(response) } },
-        provideRouter([]),
-      ],
-    }).compileComponents();
-
-    fixture = TestBed.createComponent(OrgGroupsComponent);
-    await fixture.whenStable();
+    // Delegates to the shared setup below rather than duplicating the TestBed providers —
+    // two near-identical configurations meant a provider change here could silently drift
+    // from the other describe block's.
+    fixture = await renderGroupsPage({ accountName: 'Acme Corp', getGroups: () => of(response) });
   }
 
   function group(over: Partial<OrgLensGroupSummary> = {}): OrgLensGroupSummary {
@@ -563,5 +549,120 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
 
     const rowLink = fixture.nativeElement.querySelector('[data-testid="org-groups-row-link-g1"]');
     expect(rowLink?.getAttribute('href')).toBe('/groups/g1');
+  });
+});
+
+async function renderGroupsPage(options: RenderOptions = {}): Promise<ComponentFixture<OrgGroupsComponent>> {
+  const { accountName = 'Acme Motors, Inc.', orgNavigationLoaded = true, getGroups = () => of(emptyGroupsResponse()) } = options;
+
+  TestBed.resetTestingModule();
+  await TestBed.configureTestingModule({
+    imports: [OrgGroupsComponent],
+    providers: [
+      {
+        provide: AccountContextService,
+        useValue: {
+          selectedAccount: signal({ accountId: 'acc-1', accountName, accountSlug: 'acme', membershipTier: '', uid: 'org-uid-1' }),
+          hasOrgSelectorAccess: signal(true),
+        },
+      },
+      { provide: OrgNavigationService, useValue: { loaded: signal(orgNavigationLoaded) } },
+      { provide: OrgRoleGrantsService, useValue: { loaded: signal(true) } },
+      { provide: PersonaService, useValue: { personaLoaded: signal(true) } },
+      { provide: OrgLensGroupsService, useValue: { getGroups } },
+      provideRouter([]),
+    ],
+  }).compileComponents();
+
+  const fixture = TestBed.createComponent(OrgGroupsComponent);
+  await fixture.whenStable();
+  fixture.detectChanges();
+  return fixture;
+}
+
+function populatedGroupsResponse(): OrgLensGroupsResponse {
+  const groups: OrgLensGroupSummary[] = [
+    { uid: 'group-1', name: 'Platform Working Group', category: 'Working Group', project_slug: 'acme-platform', org_seat_count: 3 },
+    { uid: 'group-2', name: 'Security SIG', category: 'Special Interest Group', project_slug: 'acme-platform', org_seat_count: 1 },
+  ];
+  return { groups, total_groups: groups.length, total_seats: 4 };
+}
+
+function has(fixture: ComponentFixture<OrgGroupsComponent>, testid: string): boolean {
+  return !!fixture.nativeElement.querySelector(`[data-testid="${testid}"]`);
+}
+
+function listSkeletonRowsIn(fixture: ComponentFixture<OrgGroupsComponent>): NodeListOf<Element> {
+  return fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-skeleton"] > div');
+}
+
+function statSkeletonCardsIn(fixture: ComponentFixture<OrgGroupsComponent>, wrapperTestid: string): NodeListOf<Element> {
+  return fixture.nativeElement.querySelectorAll(`[data-testid="${wrapperTestid}"] > div`);
+}
+
+describe('OrgGroupsComponent — loading state and copy', () => {
+  it('renders the same skeleton shape for the initial page load and the group-fetch loading state', async () => {
+    // !loaded() branch — org navigation hasn't resolved yet.
+    const initialLoad = await renderGroupsPage({ orgNavigationLoaded: false });
+    expect(has(initialLoad, 'org-groups-skeleton')).toBe(true);
+    expect(has(initialLoad, 'org-groups-stat-strip')).toBe(false);
+    expect(has(initialLoad, 'org-groups-list-loading')).toBe(true);
+    expect(has(initialLoad, 'org-groups-list')).toBe(false);
+    expect(statSkeletonCardsIn(initialLoad, 'org-groups-skeleton').length).toBe(4);
+    expect(listSkeletonRowsIn(initialLoad).length).toBe(5);
+
+    // groupsLoading() branch — page loaded, but the group fetch never resolves.
+    const groupsFetching = await renderGroupsPage({ getGroups: () => new Subject<OrgLensGroupsResponse>() });
+    expect(has(groupsFetching, 'org-groups-stat-strip')).toBe(true);
+    expect(has(groupsFetching, 'org-groups-skeleton')).toBe(false);
+    expect(has(groupsFetching, 'org-groups-list')).toBe(true);
+    expect(has(groupsFetching, 'org-groups-list-loading')).toBe(false);
+    expect(has(groupsFetching, 'org-groups-stat-total')).toBe(false);
+    expect(statSkeletonCardsIn(groupsFetching, 'org-groups-stat-strip').length).toBe(4);
+    expect(listSkeletonRowsIn(groupsFetching).length).toBe(5);
+  });
+
+  it('renders the populated stat strip and group list once data arrives', async () => {
+    const fixture = await renderGroupsPage({ getGroups: () => of(populatedGroupsResponse()) });
+
+    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-stat-total"]')?.textContent).toContain('2');
+    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-stat-seats"]')?.textContent).toContain('4');
+    expect(fixture.nativeElement.querySelectorAll('[data-testid="org-groups-list-items"] > div').length).toBe(2);
+    expect(fixture.nativeElement.querySelector('[data-testid="org-groups-skeleton"]')).toBeNull();
+  });
+
+  it('includes the selected account name in the H1, separated by a dash', async () => {
+    const fixture = await renderGroupsPage({ accountName: 'Acme Motors, Inc.' });
+
+    const title = fixture.nativeElement.querySelector('[data-testid="org-groups-title"]');
+
+    expect(title?.textContent?.trim()).toBe('Groups — Acme Motors, Inc.');
+  });
+
+  it('omits the dash from the H1 when no account name is selected', async () => {
+    const fixture = await renderGroupsPage({ accountName: '' });
+
+    const title = fixture.nativeElement.querySelector('[data-testid="org-groups-title"]');
+
+    expect(title?.textContent?.trim()).toBe('Groups');
+  });
+
+  it('renders the group-participation empty state copy', async () => {
+    const fixture = await renderGroupsPage({ getGroups: () => of(emptyGroupsResponse()) });
+
+    const emptyState = fixture.nativeElement.querySelector('[data-testid="org-groups-empty-state"]');
+
+    expect(emptyState?.textContent).toContain(`No ${COMMITTEE_LABEL.singular.toLowerCase()} participation found.`);
+    expect(emptyState?.textContent).toContain(`any ${COMMITTEE_LABEL.plural.toLowerCase()}.`);
+  });
+
+  it('renders the fetch-error subtitle on the empty state', async () => {
+    const fixture = await renderGroupsPage({ getGroups: () => throwError(() => new Error('boom')) });
+
+    const errorState = fixture.nativeElement.querySelector('[data-testid="org-groups-error-state"]');
+
+    expect(errorState?.textContent).toContain(
+      `Something went wrong while fetching ${COMMITTEE_LABEL.singular.toLowerCase()} data. Please try refreshing the page.`
+    );
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -1,16 +1,27 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { RouterLink } from '@angular/router';
+import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL } from '@lfx-one/shared/constants';
-import type { GroupBehavioralClass, OrgLensGroupSummary, OrgLensGroupsResponse, OrgLensGroupVm } from '@lfx-one/shared/interfaces';
+import type {
+  BehavioralClassDisplayConfig,
+  GroupBehavioralClass,
+  OrgDropdownOption,
+  OrgLensGroupSummary,
+  OrgLensGroupsResponse,
+  OrgLensGroupVm,
+} from '@lfx-one/shared/interfaces';
 import { getGroupBehavioralClass } from '@lfx-one/shared/utils';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, distinctUntilChanged, filter, of, switchMap, tap } from 'rxjs';
+import { catchError, debounceTime, distinctUntilChanged, filter, map, of, skip, switchMap, tap } from 'rxjs';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { InputTextComponent } from '@components/input-text/input-text.component';
+import { SelectComponent } from '@components/select/select.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensGroupsService } from '@services/org-lens-groups.service';
@@ -20,7 +31,7 @@ import { PersonaService } from '@services/persona.service';
 
 @Component({
   selector: 'lfx-org-groups',
-  imports: [EmptyStateComponent, RouterLink, SkeletonModule, TagComponent],
+  imports: [EmptyStateComponent, InputTextComponent, NgTemplateOutlet, ReactiveFormsModule, RouterLink, SelectComponent, SkeletonModule, TagComponent],
   templateUrl: './org-groups.component.html',
 })
 export class OrgGroupsComponent {
@@ -29,9 +40,23 @@ export class OrgGroupsComponent {
   private readonly orgRoleGrantsService = inject(OrgRoleGrantsService);
   private readonly personaService = inject(PersonaService);
   private readonly groupsService = inject(OrgLensGroupsService);
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
 
   protected readonly committeeLabel = COMMITTEE_LABEL;
   protected readonly behavioralClassConfig = BEHAVIORAL_CLASS_CONFIG;
+  // Hoisted so the template never calls .toLowerCase() on every change-detection pass (frontend-checklist §4).
+  protected readonly committeeLabelPluralLower = COMMITTEE_LABEL.plural.toLowerCase();
+  protected readonly committeeLabelSingularLower = COMMITTEE_LABEL.singular.toLowerCase();
+
+  // ── Filter bar (client-side over the already-loaded roster; GH-1778) ───────
+  protected readonly filterForm = new FormGroup({
+    search: new FormControl<string>(this.route.snapshot.queryParamMap.get('q') ?? '', { nonNullable: true }),
+    foundation: new FormControl<string>(this.route.snapshot.queryParamMap.get('foundation') ?? '', { nonNullable: true }),
+    type: new FormControl<GroupBehavioralClass | ''>(this.initTypeFromUrl(), { nonNullable: true }),
+  });
+
+  protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
 
   // ── Auth / access guards (mirrors org-meetings pattern) ───────────────────
   protected readonly hasNoOrgAccess: Signal<boolean> = computed(
@@ -49,9 +74,22 @@ export class OrgGroupsComponent {
   // ── Data ──────────────────────────────────────────────────────────────────
   protected readonly fetchError = signal(false);
   private readonly groupsLoadingState = signal(false);
+
+  private readonly filterValues = this.initFilterValues();
+
   // Loading: initial (undefined) OR explicit flag set during org-switch (null stays after an error,
   // so groupsData() === undefined alone would miss the reload-after-error skeleton).
   protected readonly groupsLoading = computed(() => this.hasCompany() && (this.groupsData() === undefined || this.groupsLoadingState()));
+
+  // Single source of truth for "there's a roster to show controls over" — shared by the filter bar and
+  // the result line so the two conditions can't drift apart.
+  protected readonly showRoster: Signal<boolean> = computed(() => !this.groupsLoading() && this.groups().length > 0);
+
+  // Shared with the constructor's org-switch filter reset below — mirrors committee-members' orgUid$.
+  private readonly orgUid$ = toObservable(computed(() => this.accountContext.selectedAccount().uid)).pipe(
+    filter((id): id is string => !!id),
+    distinctUntilChanged()
+  );
 
   private readonly groupsData: Signal<OrgLensGroupsResponse | null | undefined> = this.initGroupsData();
 
@@ -62,11 +100,35 @@ export class OrgGroupsComponent {
 
   protected readonly behavioralClassCounts: Signal<Record<GroupBehavioralClass, number>> = this.initBehavioralClassCounts();
 
+  protected readonly isFiltering: Signal<boolean> = this.initIsFiltering();
+  private readonly foundationLabelsBySlug: Signal<Map<string, string>> = this.initFoundationLabelsBySlug();
+  protected readonly foundationOptions: Signal<OrgDropdownOption[]> = this.initFoundationOptions();
+  protected readonly typeOptions: Signal<OrgDropdownOption[]> = this.initTypeOptions();
+  protected readonly filteredGroups: Signal<OrgLensGroupVm[]> = this.initFilteredGroups();
+
+  public constructor() {
+    // State → URL, mirrors org-projects' filterForm.valueChanges → router.navigate pattern. `merge`
+    // preserves unrelated params (e.g. ?project=, utm_*); null at default lets merge strip an owned key.
+    // valueChanges never emits the form's initial (already URL-seeded) value, so this never navigates on mount.
+    this.filterForm.valueChanges.pipe(debounceTime(150), takeUntilDestroyed()).subscribe(() => {
+      const v = this.filterForm.getRawValue();
+      const target = { q: v.search.trim() || null, foundation: v.foundation || null, type: v.type || null };
+      void this.router.navigate([], { relativeTo: this.route, queryParams: target, queryParamsHandling: 'merge', replaceUrl: true });
+    });
+
+    // A filter value from the previous org (e.g. its foundation slug) would almost never match the
+    // next org's roster. `skip(1)` so the URL-seeded initial filter survives first load — only an
+    // actual org switch clears it, mirroring committee-members' resetAllState() on orgUid$.
+    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => this.clearFilters());
+  }
+
+  protected clearFilters(): void {
+    this.filterForm.reset({ search: '', foundation: '', type: '' });
+  }
+
   private initGroupsData(): Signal<OrgLensGroupsResponse | null | undefined> {
     return toSignal(
-      toObservable(computed(() => this.accountContext.selectedAccount().uid)).pipe(
-        filter((id): id is string => !!id),
-        distinctUntilChanged(),
+      this.orgUid$.pipe(
         tap(() => {
           this.groupsLoadingState.set(true);
           this.fetchError.set(false);
@@ -74,7 +136,8 @@ export class OrgGroupsComponent {
         switchMap((id) =>
           this.groupsService.getGroups(id).pipe(
             tap(() => this.groupsLoadingState.set(false)),
-            catchError(() => {
+            catchError((error: unknown) => {
+              console.error('Failed to load org groups:', error);
               this.fetchError.set(true);
               this.groupsLoadingState.set(false);
               return of(null);
@@ -115,5 +178,88 @@ export class OrgGroupsComponent {
       }
       return counts;
     });
+  }
+
+  private initIsFiltering(): Signal<boolean> {
+    return computed(() => {
+      const v = this.filterValues();
+      return v.search.trim().length > 0 || !!v.foundation || !!v.type;
+    });
+  }
+
+  // Resolved name always wins over a slug fallback, regardless of which group of a shared foundation
+  // is seen first — enrichment is still resolved per-committee server-side, so an unenriched group can
+  // sort ahead of an enriched sibling. Shared by the Foundation select (labels) and search (so an
+  // unenriched group still matches its foundation's resolved name, not just its own slug). Mirrors
+  // org-projects' bySlug map. `projectLabel` (project_name || project_slug) comes from groupsWithClass().
+  private initFoundationLabelsBySlug(): Signal<Map<string, string>> {
+    return computed(() => {
+      const bySlug = new Map<string, string>();
+      for (const g of this.groupsWithClass()) {
+        if (!g.project_slug) continue;
+        if (g.project_name || !bySlug.has(g.project_slug)) bySlug.set(g.project_slug, g.projectLabel);
+      }
+      return bySlug;
+    });
+  }
+
+  private initFoundationOptions(): Signal<OrgDropdownOption[]> {
+    return computed(() => {
+      const options = [...this.foundationLabelsBySlug().entries()].sort((a, b) => a[1].localeCompare(b[1])).map(([slug, label]) => ({ label, value: slug }));
+      return [{ label: 'All foundations', value: '' }, ...options];
+    });
+  }
+
+  private initTypeOptions(): Signal<OrgDropdownOption[]> {
+    return computed(() => {
+      const counts = this.behavioralClassCounts();
+      const entries = Object.entries(this.behavioralClassConfig) as [GroupBehavioralClass, BehavioralClassDisplayConfig][];
+      const present = entries.filter(([key]) => counts[key] > 0);
+      return [{ label: 'All types', value: '' }, ...present.map(([key, cfg]) => ({ label: `${cfg.label} (${counts[key]})`, value: key }))];
+    });
+  }
+
+  private initFilteredGroups(): Signal<OrgLensGroupVm[]> {
+    return computed(() => {
+      const v = this.filterValues();
+      const q = v.search.trim().toLowerCase();
+      const foundation = v.foundation;
+      const type = v.type;
+
+      const labelsBySlug = this.foundationLabelsBySlug();
+      return this.groupsWithClass().filter((g) => {
+        if (foundation && g.project_slug !== foundation) return false;
+        if (type && g.cls !== type) return false;
+        // Match on the resolved-per-foundation label (so an unenriched group still matches a search for
+        // its foundation's resolved name, see initFoundationLabelsBySlug) and on the raw slug too, as a
+        // convenience for a search term that happens to be the technical slug rather than the display name.
+        const label = (g.project_slug && labelsBySlug.get(g.project_slug)) || g.projectLabel;
+        const slug = g.project_slug ?? '';
+        if (q && !g.name.toLowerCase().includes(q) && !label.toLowerCase().includes(q) && !slug.toLowerCase().includes(q)) return false;
+        return true;
+      });
+    });
+  }
+
+  // Mirrors committee-members' inline debounce pattern — no shared debounce helper exists in the repo.
+  // `valueChanges` is typed `Partial<...>` by Angular's typed forms even though every control here is
+  // non-nullable, so re-read via getRawValue() to keep a fully-typed value (no `search: string | undefined`).
+  private initFilterValues(): Signal<{ search: string; foundation: string; type: GroupBehavioralClass | '' }> {
+    return toSignal(
+      this.filterForm.valueChanges.pipe(
+        debounceTime(150),
+        map(() => this.filterForm.getRawValue())
+      ),
+      { initialValue: this.filterForm.getRawValue() }
+    );
+  }
+
+  // Only `type` needs enum validation — it's the one param with a real finite domain (the 6
+  // GroupBehavioralClass keys). search/foundation are free strings: a bogus value just matches
+  // nothing, never throws.
+  private initTypeFromUrl(): GroupBehavioralClass | '' {
+    const raw = this.route.snapshot.queryParamMap.get('type');
+    const validKeys = new Set(Object.keys(this.behavioralClassConfig));
+    return raw && validKeys.has(raw) ? (raw as GroupBehavioralClass) : '';
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -206,7 +206,9 @@ export class OrgGroupsComponent {
 
   private initFoundationOptions(): Signal<OrgDropdownOption[]> {
     return computed(() => {
-      const options = [...this.foundationLabelsBySlug().entries()].sort((a, b) => a[1].localeCompare(b[1])).map(([slug, label]) => ({ label, value: slug }));
+      const options = [...this.foundationLabelsBySlug().entries()]
+        .sort((a, b) => a[1].localeCompare(b[1], 'en-US'))
+        .map(([slug, label]) => ({ label, value: slug }));
       return [{ label: 'All foundations', value: '' }, ...options];
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -5,7 +5,7 @@ import { NgTemplateOutlet } from '@angular/common';
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { ActivatedRoute, Router, RouterLink } from '@angular/router';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
-import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { FormControl, FormGroup } from '@angular/forms';
 import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import type {
   BehavioralClassDisplayConfig,
@@ -31,7 +31,7 @@ import { PersonaService } from '@services/persona.service';
 
 @Component({
   selector: 'lfx-org-groups',
-  imports: [EmptyStateComponent, InputTextComponent, NgTemplateOutlet, ReactiveFormsModule, RouterLink, SelectComponent, SkeletonModule, TagComponent],
+  imports: [EmptyStateComponent, InputTextComponent, NgTemplateOutlet, RouterLink, SelectComponent, SkeletonModule, TagComponent],
   templateUrl: './org-groups.component.html',
 })
 export class OrgGroupsComponent {
@@ -94,7 +94,8 @@ export class OrgGroupsComponent {
   private readonly groupsData: Signal<OrgLensGroupsResponse | null | undefined> = this.initGroupsData();
 
   protected readonly groups: Signal<OrgLensGroupSummary[]> = computed(() => this.groupsData()?.groups ?? []);
-  protected readonly groupsWithClass: Signal<OrgLensGroupVm[]> = this.initGroupsWithClass();
+  // Not read from the template — filteredGroups() is what the @for actually iterates.
+  private readonly groupsWithClass: Signal<OrgLensGroupVm[]> = this.initGroupsWithClass();
   protected readonly totalGroups: Signal<number> = computed(() => this.groupsData()?.total_groups ?? 0);
   protected readonly totalSeats: Signal<number> = computed(() => this.groupsData()?.total_seats ?? 0);
 


### PR DESCRIPTION
## Summary

Tokenizes the remaining hardcoded "group" strings on `/org/groups` through `COMMITTEE_LABEL`, so this page's copy follows the same label source as the rest of Org Lens:

- The skeleton and list section `aria-label`s, and the no-company empty state, now interpolate `committeeLabel.singular` instead of a literal "Group".
- The `fetchError` state's title and subtitle use the hoisted `committeeLabelSingularLower`.
- While doing this, found that `<lfx-empty-state>` has no `description` input (only `subtitle`), so the explanatory copy on the roster-empty state **and** the sibling `fetchError` state was silently never rendering — fixed both occurrences.

Adds this branch's `describe('OrgGroupsComponent — loading state and copy')` block, covering loading-shape parity between the two skeleton branches, the populated stat strip/list, H1 account-name interpolation, and the label-derived empty-state copy.

### Stacked on #1787

This is the second PR in a four-deep stack for epic #1776:

```
main
 └─ #1787  feat/GH-1778             filter bar
     └─ #1788  ← this PR            copy tokenization
         └─ #1790  fix/GH-1779      stat strip
             └─ #1789  fix/GH-1782  contrast + mobile chip
```

Its base is `feat/GH-1778`, not `main`, so the diff below is scoped to this branch's own change — 2 files, +129/−25.

Two things this PR originally carried now live in its base and no longer appear in the diff: the shared `ng-template` skeleton refactor (via `NgTemplateOutlet`) and the `companyName` computed behind the `Groups — {org name}` H1. Both are in #1787. Their tests stay here, since this is where they were written.

Merge bottom-up: #1787, then this, then #1790, then #1789.

### Known trade-off

The empty-state and fetch-error copy changes have no e2e coverage (no e2e spec exists for `/org/groups` yet) — the unit spec asserts both states' exact copy, but the KB pattern this would otherwise satisfy specifically wants e2e-layer coverage. Documenting rather than adding new e2e infrastructure, since that's out of scope for this ticket.

### Follow-up nit

The lowercase label is reached two different ways in the same template — `committeeLabel.singular.toLowerCase()` on the no-company state, `committeeLabelSingularLower` on the fetchError state. Harmless, but worth unifying on the hoisted property in a later pass.

## Test plan

- [x] `yarn lint` / `yarn format:check` / `yarn check-types` / `yarn build` all pass
- [x] `org-groups.component.spec.ts` — 34/34 pass across three describe blocks: this branch's 6, plus the 20 filter-bar and 8 row/routing tests inherited from the base
- [x] Full server vitest suite — 1589/1589 pass
- [x] Verified manually: loading shape is stable end-to-end, H1 shows `Groups — {org name}`, empty-state and fetch-error copy now render

Closes linuxfoundation/lfx-self-serve#1783
