### PR TITLE
fix(org-groups): fix contrast and mobile visibility on group row

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -189,51 +189,70 @@
                 [attr.data-testid]="'org-groups-row-link-' + group.uid"
                 [attr.aria-label]="group.ariaLabel"></a>
 
-              <!-- text-gray-900 + peer-hover:text-blue-600 here, with no color class on the name
+              <!-- text-gray-900 + peer-hover:text-blue-700 here, with no color class on the name
                    `<p>` itself, so the name inherits this wrapper's color — every other child
                    (seat count, icons, tag) sets its own explicit color and is unaffected. -->
-              <div class="pointer-events-none flex w-full items-center gap-4 text-gray-900 transition-colors peer-hover:text-blue-600">
+              <div
+                class="pointer-events-none flex w-full items-start gap-4 text-gray-900 transition-colors peer-hover:text-blue-700 sm:items-center"
+                [attr.data-testid]="'org-groups-item-row-content-' + group.uid">
                 <!-- Icon -->
                 <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full" [class]="config.bgColor">
                   <i [class]="config.icon + ' ' + config.color + ' text-base'" aria-hidden="true"></i>
                 </div>
 
-                <!-- Name + meta -->
-                <div class="flex flex-col gap-0.5 flex-1 min-w-0">
-                  <p class="truncate text-sm font-medium" [attr.data-testid]="'org-groups-item-name-' + group.uid">
-                    {{ group.name }}
-                  </p>
-                  <!-- /org/memberships/:slug, not /org/projects/:slug — the org-projects page is
-                       Snowflake/CDP-scoped to sub-project activity rows and doesn't resolve
-                       foundation-level slugs (verified live: /org/projects/uepf 404s,
-                       /org/memberships/uepf works). Known residual gap, two causes: (1) the
-                       memberships route only resolves an *active* Snowflake membership row for
-                       the org (server's org-lens-memberships.service.ts getMembershipDetail) — a
-                       foundation the org has a committee seat in but no active membership for
-                       (expired tier, or a seat that predates/exists independent of formal
-                       membership) dead-ends on the memberships not-found state; (2)
-                       group.project_slug here is the project-service slug from the
-                       committee-service seat record,
-                       while the memberships route matches against Snowflake's foundationSlug —
-                       verified equal for the sampled cases (uepf, cncf) but not guaranteed equal
-                       in general, so a slug mismatch is a second, unverified way to dead-end.
-                       Narrower than before this fix (the common case now works), not fully
-                       closed. -->
-                  @if (group.project_slug) {
-                    <a
-                      [routerLink]="['/org/memberships', group.project_slug]"
-                      class="pointer-events-auto relative z-10 block w-fit truncate text-xs text-gray-400 transition-colors hover:text-blue-600 hover:underline"
-                      [attr.data-testid]="'org-groups-item-project-' + group.uid"
-                      [attr.aria-label]="group.projectAriaLabel">
-                      {{ group.projectLabel }}
-                    </a>
-                  } @else if (group.projectLabel) {
-                    <p class="truncate text-xs text-gray-400" [attr.data-testid]="'org-groups-item-project-' + group.uid">{{ group.projectLabel }}</p>
-                  }
-                </div>
+                <!-- Name + meta + behavioral class chip: stacked below `sm`; `sm:contents` folds this
+                     wrapper away so the name/meta block and chip become direct flex items of the row
+                     again, reproducing the pre-existing desktop layout. `sm:contents` gives the wrapper
+                     no box of its own at `sm+`, so its own `flex-1`/`min-w-0` stop applying there — the
+                     inner block below carries its own `flex-1 min-w-0` so it, not the wrapper, is the
+                     item that grows to push the chip/seat-count/chevron to the row's right edge. Kept
+                     unconditional (not `sm:`-scoped): at mobile this block is a column child with no
+                     extra vertical space to grow into (the row is `items-start`, sized to content), so
+                     the class is inert there and only takes effect once `sm:contents` makes it a real
+                     horizontal flex item. -->
+                <div class="flex flex-1 min-w-0 flex-col gap-2 sm:contents" [attr.data-testid]="'org-groups-item-meta-wrapper-' + group.uid">
+                  <div class="flex flex-1 min-w-0 flex-col gap-0.5" [attr.data-testid]="'org-groups-item-meta-block-' + group.uid">
+                    <p class="truncate text-sm font-medium" [attr.data-testid]="'org-groups-item-name-' + group.uid">
+                      {{ group.name }}
+                    </p>
+                    <!-- /org/memberships/:slug, not /org/projects/:slug — the org-projects page is
+                         Snowflake/CDP-scoped to sub-project activity rows and doesn't resolve
+                         foundation-level slugs (verified live: /org/projects/uepf 404s,
+                         /org/memberships/uepf works). Known residual gap, two causes: (1) the
+                         memberships route only resolves an *active* Snowflake membership row for
+                         the org (server's org-lens-memberships.service.ts getMembershipDetail) — a
+                         foundation the org has a committee seat in but no active membership for
+                         (expired tier, or a seat that predates/exists independent of formal
+                         membership) dead-ends on the memberships not-found state; (2)
+                         group.project_slug here is the project-service slug from the
+                         committee-service seat record,
+                         while the memberships route matches against Snowflake's foundationSlug —
+                         verified equal for the sampled cases (uepf, cncf) but not guaranteed equal
+                         in general, so a slug mismatch is a second, unverified way to dead-end.
+                         Narrower than before this fix (the common case now works), not fully
+                         closed. -->
+                    @if (group.project_slug) {
+                      <a
+                        [routerLink]="['/org/memberships', group.project_slug]"
+                        class="pointer-events-auto relative z-10 block w-fit truncate text-xs text-gray-500 transition-colors hover:text-blue-700 hover:underline"
+                        [attr.data-testid]="'org-groups-item-project-' + group.uid"
+                        [attr.aria-label]="group.projectAriaLabel">
+                        {{ group.projectLabel }}
+                      </a>
+                    } @else if (group.projectLabel) {
+                      <p class="truncate text-xs text-gray-500" [attr.data-testid]="'org-groups-item-project-' + group.uid">{{ group.projectLabel }}</p>
+                    }
+                  </div>
 
-                <!-- Behavioral class chip -->
-                <lfx-tag [value]="config.label" [severity]="'secondary'" class="shrink-0 hidden sm:flex" />
+                  <!-- `flex`, not the default: as a flex item here the host would blockify to
+                       `block` regardless, but block gives it an inline-formatting-context strut
+                       sized by the inherited body font — `flex` avoids that extra height. -->
+                  <lfx-tag
+                    [value]="config.label"
+                    [severity]="'secondary'"
+                    class="flex w-fit shrink-0"
+                    [attr.data-testid]="'org-groups-item-class-chip-' + group.uid" />
+                </div>
 
                 <!-- Seat count -->
                 <div class="flex items-center gap-1 shrink-0 text-sm text-gray-600" [attr.data-testid]="'org-groups-item-seats-' + group.uid">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -571,6 +571,135 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
     const rowLink = fixture.nativeElement.querySelector('[data-testid="org-groups-row-link-g1"]');
     expect(rowLink?.getAttribute('href')).toBe('/groups/g1');
   });
+
+  describe('contrast (GH-1782)', () => {
+    it('foundation link uses passing gray-500/blue-700 contrast, not gray-400/blue-600 (GH-1782)', async () => {
+      await renderRow({
+        groups: [group({ project_name: 'Ultra Ethernet Consortium Fund', project_slug: 'uepf' })],
+        total_groups: 1,
+        total_seats: 3,
+      });
+
+      const link = projectLineElement();
+      expect(link).not.toBeNull();
+      expect(link?.className).toContain('text-gray-500');
+      expect(link?.className).not.toContain('text-gray-400');
+      expect(link?.className).toContain('hover:text-blue-700');
+      expect(link?.className).not.toContain('hover:text-blue-600');
+    });
+
+    it('foundation plain-text fallback uses passing gray-500 contrast, not gray-400 (GH-1782)', async () => {
+      await renderRow({
+        groups: [group({ project_name: 'Ultra Ethernet Consortium Fund', project_slug: undefined })],
+        total_groups: 1,
+        total_seats: 3,
+      });
+
+      const fallback = projectLineElement();
+      expect(fallback).not.toBeNull();
+      expect(fallback?.className).toContain('text-gray-500');
+      expect(fallback?.className).not.toContain('text-gray-400');
+    });
+
+    it('group name hovers to passing blue-700, not blue-600 (GH-1782)', async () => {
+      await renderRow({ groups: [group()], total_groups: 1, total_seats: 3 });
+
+      // The name `<p>` sets no color of its own (see the template comment above this row) — it
+      // inherits from this wrapper, so the hover color only takes effect if the name actually lives
+      // inside it. Assert containment, not just that each element independently exists.
+      const rowContent = fixture.nativeElement.querySelector('[data-testid^="org-groups-item-row-content-"]');
+      const name = fixture.nativeElement.querySelector('[data-testid^="org-groups-item-name-"]');
+      expect(rowContent).not.toBeNull();
+      expect(rowContent?.contains(name)).toBe(true);
+      expect(rowContent?.className).toContain('peer-hover:text-blue-700');
+      expect(rowContent?.className).not.toContain('peer-hover:text-blue-600');
+
+      // `peer-hover:` compiles to `.peer:hover ~ &` — it only fires if the stretched row link is a
+      // *preceding* sibling of this wrapper (same parent, earlier in document order), not merely
+      // present somewhere in the row.
+      const rowLink = fixture.nativeElement.querySelector('[data-testid^="org-groups-row-link-"]');
+      expect(rowLink).not.toBeNull();
+      expect((rowLink?.className ?? '').split(/\s+/)).toContain('peer');
+      expect(rowLink?.parentElement).toBe(rowContent?.parentElement);
+      expect((rowLink?.compareDocumentPosition(rowContent) ?? 0) & Node.DOCUMENT_POSITION_FOLLOWING).toBeTruthy();
+    });
+  });
+
+  describe('responsive row layout (GH-1782)', () => {
+    it('behavioral class chip has no hidden class at any breakpoint (GH-1782)', async () => {
+      await renderRow({
+        groups: [group()],
+        total_groups: 1,
+        total_seats: 3,
+      });
+
+      const chip = fixture.nativeElement.querySelector('[data-testid^="org-groups-item-class-chip-"]');
+      expect(chip).not.toBeNull();
+      const chipClasses = (chip?.getAttribute('class') ?? '').split(/\s+/);
+      expect(chipClasses.some((c: string) => c === 'hidden' || c.endsWith(':hidden'))).toBe(false);
+    });
+
+    it('behavioral class chip keeps its explicit flex display and shrink-0, so a "drop redundant class" pass cannot silently regress it (GH-1782)', async () => {
+      // Without `flex`, the host still renders (it blockifies to `block` as a flex item either
+      // way) — no other assertion here would fail, only the strut-height regression `flex` fixes
+      // would silently come back. Without `shrink-0`, the chip would default to flex-shrink: 1 as
+      // a direct sibling of the flex-1 name column once `sm:contents` folds the wrapper away at
+      // `sm+`, letting it get squeezed instead of keeping its natural width.
+      await renderRow({ groups: [group()], total_groups: 1, total_seats: 3 });
+
+      const chip = fixture.nativeElement.querySelector('[data-testid^="org-groups-item-class-chip-"]');
+      expect(chip).not.toBeNull();
+      const chipClasses = (chip?.getAttribute('class') ?? '').split(/\s+/);
+      expect(chipClasses).toContain('flex');
+      expect(chipClasses).toContain('shrink-0');
+    });
+
+    it('name/meta block keeps a growing flex class, so it fills the row and pins the chip/seat/chevron right at every breakpoint (GH-1782)', async () => {
+      // Regression coverage: an earlier revision of this fix moved `flex-1` onto the `sm:contents`
+      // wrapper instead of this block. Since `display: contents` gives that wrapper no box of its
+      // own at `sm+`, its flex classes stopped applying there, and the name column collapsed to
+      // content width — bunching the chip/seat-count/chevron to the left instead of the row's right
+      // edge. Every a11y assertion in this file still passed throughout, so this test locks the
+      // layout-critical class directly onto the element that must carry it, and checks it's actually
+      // the wrapper's child — not just that both elements independently exist somewhere in the DOM.
+      await renderRow({ groups: [group()], total_groups: 1, total_seats: 3 });
+
+      const nameBlock = fixture.nativeElement.querySelector('[data-testid^="org-groups-item-meta-block-"]');
+      const wrapper = fixture.nativeElement.querySelector('[data-testid^="org-groups-item-meta-wrapper-"]');
+      const nameBlockClasses = (nameBlock?.className ?? '').split(/\s+/);
+
+      expect(nameBlock).not.toBeNull();
+      expect(wrapper).not.toBeNull();
+      expect(wrapper?.contains(nameBlock)).toBe(true);
+      expect(wrapper?.className).toContain('sm:contents');
+      expect(nameBlockClasses).toContain('flex-1');
+      expect(nameBlockClasses).toContain('min-w-0');
+    });
+  });
+
+  describe('row testid contract', () => {
+    it('gives each row its own uid-scoped testids, not a duplicate shared across rows (GH-1782)', async () => {
+      await renderRow({
+        groups: [group({ uid: 'g1' }), group({ uid: 'g2', name: 'SIG Storage' })],
+        total_groups: 2,
+        total_seats: 6,
+      });
+
+      for (const prefix of ['org-groups-item-row-content-', 'org-groups-item-meta-wrapper-', 'org-groups-item-meta-block-', 'org-groups-item-class-chip-']) {
+        const matches = fixture.nativeElement.querySelectorAll(`[data-testid^="${prefix}"]`);
+        expect(matches.length).toBe(2);
+        expect(matches[0].getAttribute('data-testid')).toBe(`${prefix}g1`);
+        expect(matches[1].getAttribute('data-testid')).toBe(`${prefix}g2`);
+      }
+
+      // These wrapper/block testids must NOT fall under the `org-groups-item-name-` prefix: an
+      // existing e2e spec (org-groups-row-link-robust.spec.ts) collects exactly that prefix and
+      // asserts it resolves 1:1 to the name <p> elements — a collision here would silently break it.
+      const nameMatches = fixture.nativeElement.querySelectorAll('[data-testid^="org-groups-item-name-"]');
+      expect(nameMatches.length).toBe(2);
+      expect(Array.from(nameMatches).every((el) => (el as HTMLElement).tagName === 'P')).toBe(true);
+    });
+  });
 });
 
 /**


### PR DESCRIPTION
## Summary

- Foundation-line text and its hover state failed WCAG AA contrast (`gray-400` 2.63:1, `blue-600` 4.04:1 against white) — swapped to `gray-500` (4.76:1) and `blue-700` (6.49:1), including the group name's own hover color which had the identical `blue-600` failure.
- The behavioral-class chip (Working Group / SIG / etc.) was hidden below `sm` via `hidden sm:flex`, leaving only the row icon's color as a signal on mobile — a color-only signal, and the icon is `aria-hidden`. The chip is now visible at every breakpoint, stacked under the group name on narrow viewports via a `sm:contents` wrapper trick that folds back into the original desktop row layout at `sm+`.

### Stacked on #1790

Top of a four-deep stack for epic #1776:

```
main
 └─ #1787  feat/GH-1778         filter bar
     └─ #1788  fix/GH-1783-…    copy tokenization
         └─ #1790  fix/GH-1779  stat strip
             └─ #1789  ← this PR  contrast + mobile chip
```

Base is `fix/GH-1779`, not `main`. Merge bottom-up: #1787, #1788, #1790, then this.

## Deliberate exclusions / deferred items

- **Seat-count icon** (`fa-user-check text-gray-400`) left as-is — it sits beside a visible number and is `aria-hidden`, so it's decorative. Not fixed on purpose.
- **Two sibling pages** (`public-foundation-groups.component.html`, `public-project-groups.component.html`) carry the identical `gray-400` contrast failure and hidden-chip-below-`sm` pattern on the same row shape, on anonymous-reachable pages. Out of scope here (different components) — now tracked as #1791 with exact files and line numbers.
- **Truncated group/foundation names have no tooltip** exposing the full string when clipped — pre-existing from the foundation-link work this branch is layered on (#1786), not introduced here. Assistive tech gets the full name via the row's `aria-label`; sighted users on narrow viewports don't. Left as-is.
- **Some regression tests assert Tailwind class strings directly** (contrast colors, `flex-1`/`sm:contents`, `peer` presence) rather than rendered behavior — jsdom computes no layout or contrast, so a class-token assertion is the only available unit-level lock for a display/color fix. Moving these to the e2e/Playwright suite where real CSS applies is a larger scope change not attempted here.

## Test plan

- [x] `yarn ng test --include='**/org-groups.component.spec.ts'` — passes
- [x] Full app suite (`yarn test`) — 724/724 pass
- [x] `yarn lint` — clean (one pre-existing unrelated warning elsewhere)
- [x] `yarn build` — succeeds
- [x] Manual mutation check: removing `class="peer"` from the stretched row link fails exactly the intended hover-regression test, nothing else
- [x] Manual verification in a running dev server, in the integration worktree (all four stacked branches merged) at `localhost:4200/org/groups`, on a real org (Oracle America Inc., 46 groups):
  - **Desktop (1413px)** — foundation link resolves to `text-gray-500`, computed `rgb(98, 116, 142)` = `#62748E` (4.76:1), hover `blue-700`. No `blue-600` remains anywhere on the row. The 46 `sm:contents` wrappers compute to `display: contents`, so the desktop row layout is byte-for-byte the pre-existing one.
  - **Mobile (386px, below the `sm` breakpoint)** — the same wrapper computes to `display: flex`, and the class chip renders visibly (94×23) stacked below the group-name block instead of disappearing. No horizontal overflow: `scrollWidth` equals `clientWidth` at 386px.
  - The `text-gray-400` occurrences that remain on the page are the decorative `fa-user-check` seat icons only, per the exclusion above.
- [ ] Tablet-width (~768px) spot check not performed — the `sm:contents` wrapper's two states were verified at either side of the single `sm` (640px) breakpoint it keys off, and there is no second breakpoint between them.
