### PR TITLE
fix(org-lens): render a tile per behavioral class in groups stat strip

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -26,7 +26,7 @@
       </p>
     </section>
   } @else if (!loaded()) {
-    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="{{ committeeLabel.singular }} participation summary" data-testid="org-groups-skeleton">
+    <section [class]="statGridSkeletonClass" aria-label="{{ committeeLabel.singular }} participation summary" data-testid="org-groups-skeleton">
       <ng-container [ngTemplateOutlet]="statCardsSkeleton" />
     </section>
     <section aria-label="{{ committeeLabel.singular }} list" data-testid="org-groups-list-loading">
@@ -85,7 +85,11 @@
     }
 
     <!-- Stat strip -->
-    <section class="grid grid-cols-2 gap-4 sm:grid-cols-4" aria-label="{{ committeeLabel.singular }} participation summary" data-testid="org-groups-stat-strip">
+    <section
+      [class]="groupsLoading() ? statGridSkeletonClass : statGridLoadedClass"
+      [style.--cols]="statTileCount()"
+      aria-label="{{ committeeLabel.singular }} participation summary"
+      data-testid="org-groups-stat-strip">
       @if (groupsLoading()) {
         <ng-container [ngTemplateOutlet]="statCardsSkeleton" />
       } @else {
@@ -105,22 +109,17 @@
           <p class="mt-1 text-2xl font-semibold text-gray-900">{{ totalSeats() }}</p>
           <p class="text-xs text-gray-500">Total Seats</p>
         </div>
-        <!-- Working groups card -->
-        <div class="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-groups-stat-wg">
-          <div class="flex h-8 w-8 items-center justify-center rounded-full bg-amber-50">
-            <i class="fa-light fa-users-gear text-amber-700 text-sm" aria-hidden="true"></i>
+        <!-- One tile per non-zero behavioral class, largest first, other last -->
+        @for (tile of visibleClassTiles(); track tile.cls) {
+          @let config = behavioralClassConfig[tile.cls];
+          <div class="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4" [attr.data-testid]="'org-groups-stat-' + tile.cls">
+            <div class="flex h-8 w-8 items-center justify-center rounded-full" [class]="config.bgColor">
+              <i [class]="config.icon + ' ' + config.color + ' text-sm'" aria-hidden="true"></i>
+            </div>
+            <p class="mt-1 text-2xl font-semibold text-gray-900" [attr.data-testid]="'org-groups-tile-count-' + tile.cls">{{ tile.count }}</p>
+            <p class="text-xs text-gray-500">{{ config.label }}</p>
           </div>
-          <p class="mt-1 text-2xl font-semibold text-gray-900">{{ behavioralClassCounts()['working-group'] }}</p>
-          <p class="text-xs text-gray-500">Working Groups</p>
-        </div>
-        <!-- SIGs card -->
-        <div class="flex flex-col gap-1 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-groups-stat-sig">
-          <div class="flex h-8 w-8 items-center justify-center rounded-full bg-blue-50">
-            <i class="fa-light fa-comments text-blue-700 text-sm" aria-hidden="true"></i>
-          </div>
-          <p class="mt-1 text-2xl font-semibold text-gray-900">{{ behavioralClassCounts()['special-interest-group'] }}</p>
-          <p class="text-xs text-gray-500">SIGs</p>
-        </div>
+        }
       }
     </section>
 
@@ -248,7 +247,7 @@
   }
 
   <ng-template #statCardsSkeleton>
-    @for (i of [1, 2, 3, 4]; track i) {
+    @for (i of statSkeletonTiles; track i) {
       <div class="flex flex-col gap-2 rounded-lg border border-gray-200 bg-white p-4" data-testid="org-groups-stat-skeleton-card">
         <p-skeleton width="2rem" height="2rem" borderRadius="9999px" />
         <p-skeleton width="3rem" height="1.75rem" />

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -26,7 +26,11 @@
       </p>
     </section>
   } @else if (!loaded()) {
-    <section [class]="statGridSkeletonClass" aria-label="{{ committeeLabel.singular }} participation summary" data-testid="org-groups-skeleton">
+    <section
+      [class]="statGridClass"
+      [style.--cols]="statSkeletonTiles.length"
+      aria-label="{{ committeeLabel.singular }} participation summary"
+      data-testid="org-groups-skeleton">
       <ng-container [ngTemplateOutlet]="statCardsSkeleton" />
     </section>
     <section aria-label="{{ committeeLabel.singular }} list" data-testid="org-groups-list-loading">
@@ -86,8 +90,8 @@
 
     <!-- Stat strip -->
     <section
-      [class]="groupsLoading() ? statGridSkeletonClass : statGridLoadedClass"
-      [style.--cols]="statTileCount()"
+      [class]="statGridClass"
+      [style.--cols]="groupsLoading() ? statSkeletonTiles.length : statTileCount()"
       aria-label="{{ committeeLabel.singular }} participation summary"
       data-testid="org-groups-stat-strip">
       @if (groupsLoading()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -3,15 +3,15 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
-import { COMMITTEE_LABEL } from '@lfx-one/shared/constants';
+import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import type { Account, OrgDropdownOption, OrgLensGroupSummary, OrgLensGroupsResponse } from '@lfx-one/shared/interfaces';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensGroupsService } from '@services/org-lens-groups.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
-import { of, Subject, throwError } from 'rxjs';
-import { describe, expect, it, vi } from 'vitest';
+import { NEVER, Observable, of, Subject, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { signal, type WritableSignal } from '@angular/core';
 
 import { OrgGroupsComponent } from './org-groups.component';
@@ -148,7 +148,7 @@ describe('OrgGroupsComponent', () => {
     expect(has(initialLoad, 'org-groups-stat-strip')).toBe(false);
     expect(has(initialLoad, 'org-groups-list-loading')).toBe(true);
     expect(has(initialLoad, 'org-groups-list')).toBe(false);
-    expect(statSkeletonCards(initialLoad).length).toBe(4);
+    expect(statSkeletonCards(initialLoad).length).toBe(6);
     expect(listSkeletonRows(initialLoad).length).toBe(5);
 
     // groupsLoading() branch — page loaded, but the group fetch never resolves.
@@ -158,7 +158,7 @@ describe('OrgGroupsComponent', () => {
     expect(has(groupsFetching, 'org-groups-list')).toBe(true);
     expect(has(groupsFetching, 'org-groups-list-loading')).toBe(false);
     expect(has(groupsFetching, 'org-groups-stat-total')).toBe(false);
-    expect(statSkeletonCards(groupsFetching).length).toBe(4);
+    expect(statSkeletonCards(groupsFetching).length).toBe(6);
     expect(listSkeletonRows(groupsFetching).length).toBe(5);
   });
 
@@ -570,5 +570,186 @@ describe('OrgGroupsComponent — project label and row/foundation routing', () =
 
     const rowLink = fixture.nativeElement.querySelector('[data-testid="org-groups-row-link-g1"]');
     expect(rowLink?.getAttribute('href')).toBe('/groups/g1');
+  });
+});
+
+/**
+ * GH-1779: the stat strip used to hardcode Working Groups + SIGs as if they were the only
+ * behavioral classes, silently dropping every other class from the total (19 unaccounted groups
+ * on a live org). This spec pins the fix — every non-zero class renders exactly one tile, a
+ * zero-count class (e.g. governing-board, typically 0 since the BFF drops the exact "Board"
+ * category) renders none, and the rendered tiles always sum back to total_groups — plus that the
+ * two loading skeletons agree on a placeholder count so resolving data doesn't jump the tile
+ * count twice.
+ */
+describe('OrgGroupsComponent stat strip', () => {
+  // 4 oversight-committee / 3 working-group / 2 special-interest-group / 1 ambassador-program /
+  // 1 other (Committee) — five of the six classes (governing-board stays 0 for the "renders no
+  // tile" case below), with distinct non-tied counts (other ties ambassador-program at 1 but is
+  // pinned last regardless) so a regression that hardcodes back to a subset of classes — the
+  // original GH-1779 shape — fails here instead of passing on an accidentally-narrow fixture.
+  const RESPONSE: OrgLensGroupsResponse = {
+    groups: [
+      { uid: 'g1', name: 'WG One', category: 'Working Group', org_seat_count: 5 },
+      { uid: 'g2', name: 'WG Two', category: 'Working Group', org_seat_count: 3 },
+      { uid: 'g3', name: 'WG Three', category: 'Working Group', org_seat_count: 1 },
+      { uid: 'g4', name: 'SIG One', category: 'Special Interest Group', org_seat_count: 4 },
+      { uid: 'g5', name: 'SIG Two', category: 'Special Interest Group', org_seat_count: 2 },
+      { uid: 'g6', name: 'Committee One', category: 'Committee', org_seat_count: 1 },
+      { uid: 'g7', name: 'TSC One', category: 'Technical Steering Committee', org_seat_count: 6 },
+      { uid: 'g8', name: 'TSC Two', category: 'Technical Steering Committee', org_seat_count: 5 },
+      { uid: 'g9', name: 'TSC Three', category: 'Technical Steering Committee', org_seat_count: 4 },
+      { uid: 'g10', name: 'TSC Four', category: 'Technical Steering Committee', org_seat_count: 1 },
+      { uid: 'g11', name: 'Ambassador One', category: 'Ambassador', org_seat_count: 2 },
+    ],
+    total_groups: 11,
+    total_seats: 34,
+  };
+
+  let fixture: ComponentFixture<OrgGroupsComponent>;
+
+  async function render(opts: { orgLoaded?: boolean; getGroups?: () => Observable<OrgLensGroupsResponse> } = {}): Promise<void> {
+    const { orgLoaded = true, getGroups = () => of(RESPONSE) } = opts;
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [OrgGroupsComponent],
+      providers: [
+        provideRouter([]),
+        {
+          provide: AccountContextService,
+          useValue: { selectedAccount: signal({ accountId: 'org-1', accountName: 'Org One', uid: 'org-1' } as Account), hasOrgSelectorAccess: signal(true) },
+        },
+        { provide: OrgNavigationService, useValue: { loaded: signal(orgLoaded) } },
+        { provide: OrgRoleGrantsService, useValue: { loaded: signal(orgLoaded) } },
+        { provide: PersonaService, useValue: { personaLoaded: signal(orgLoaded) } },
+        { provide: OrgLensGroupsService, useValue: { getGroups: vi.fn(getGroups) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(OrgGroupsComponent);
+    await fixture.whenStable();
+  }
+
+  function rootElement(): HTMLElement {
+    return fixture.nativeElement as HTMLElement;
+  }
+
+  function statTile(cls: string): HTMLElement | null {
+    return rootElement().querySelector(`[data-testid="org-groups-stat-${cls}"]`);
+  }
+
+  // Count testid is keyed by class, not position, and namespaced as org-groups-tile-count-*
+  // (not org-groups-stat-*) so it can't be picked up by the tile-prefix queries below.
+  function statCount(cls: string): number {
+    return Number(rootElement().querySelector(`[data-testid="org-groups-tile-count-${cls}"]`)?.textContent?.trim());
+  }
+
+  // `div[...]` excludes the enclosing `<section data-testid="org-groups-stat-strip">`, whose own
+  // testid also matches the `^=` prefix.
+  function classTiles(): HTMLElement[] {
+    const all = Array.from(rootElement().querySelectorAll<HTMLElement>('div[data-testid^="org-groups-stat-"]'));
+    return all.filter((el) => !['org-groups-stat-total', 'org-groups-stat-seats'].includes(el.getAttribute('data-testid') ?? ''));
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('renders no tile for a zero-count behavioral class', async () => {
+    await render();
+
+    expect(statTile('governing-board')).toBeNull();
+  });
+
+  it('renders one tile per non-zero behavioral class, labeled from BEHAVIORAL_CLASS_CONFIG', async () => {
+    await render();
+
+    expect(statTile('oversight-committee')?.textContent).toContain(BEHAVIORAL_CLASS_CONFIG['oversight-committee'].label);
+    expect(statTile('working-group')?.textContent).toContain(BEHAVIORAL_CLASS_CONFIG['working-group'].label);
+    expect(statTile('special-interest-group')?.textContent).toContain(BEHAVIORAL_CLASS_CONFIG['special-interest-group'].label);
+    expect(statTile('ambassador-program')?.textContent).toContain(BEHAVIORAL_CLASS_CONFIG['ambassador-program'].label);
+    expect(statTile('other')?.textContent).toContain(BEHAVIORAL_CLASS_CONFIG.other.label);
+    expect(classTiles()).toHaveLength(5);
+  });
+
+  it('renders the correct count on each class tile', async () => {
+    await render();
+
+    expect(statCount('oversight-committee')).toBe(4);
+    expect(statCount('working-group')).toBe(3);
+    expect(statCount('special-interest-group')).toBe(2);
+    expect(statCount('ambassador-program')).toBe(1);
+    expect(statCount('other')).toBe(1);
+  });
+
+  // Independent of the per-class assertions above, so a class silently missing its tile (the
+  // original GH-1779 bug) fails here regardless.
+  it('sums the rendered class tiles to total_groups', async () => {
+    await render();
+
+    const counts = classTiles().map((el) => ({
+      tile: el.getAttribute('data-testid'),
+      count: Number(el.querySelector('[data-testid^="org-groups-tile-count-"]')?.textContent?.trim()),
+    }));
+
+    // Checked before the sum so a tile missing its count element fails with its testid named,
+    // not a bare NaN.
+    expect(counts.filter(({ count }) => !Number.isFinite(count))).toEqual([]);
+    expect(counts.reduce((sum, { count }) => sum + count, 0)).toBe(RESPONSE.total_groups);
+  });
+
+  it('orders the class tiles largest-first, other last', async () => {
+    await render();
+
+    const order = classTiles().map((el) => el.getAttribute('data-testid'));
+    expect(order).toEqual([
+      'org-groups-stat-oversight-committee',
+      'org-groups-stat-working-group',
+      'org-groups-stat-special-interest-group',
+      'org-groups-stat-ambassador-program',
+      'org-groups-stat-other',
+    ]);
+  });
+
+  it('pins the other tile last even when it has the highest count', async () => {
+    await render({
+      getGroups: () =>
+        of({
+          groups: [
+            { uid: 'g1', name: 'WG One', category: 'Working Group', org_seat_count: 1 },
+            { uid: 'g2', name: 'Committee One', category: 'Committee', org_seat_count: 1 },
+            { uid: 'g3', name: 'Committee Two', category: 'Committee', org_seat_count: 1 },
+          ],
+          total_groups: 3,
+          total_seats: 3,
+        }),
+    });
+
+    const order = classTiles().map((el) => el.getAttribute('data-testid'));
+    expect(order).toEqual(['org-groups-stat-working-group', 'org-groups-stat-other']);
+  });
+
+  it('sizes the grid to the actual rendered tile count via --cols', async () => {
+    await render();
+
+    const section = rootElement().querySelector('[data-testid="org-groups-stat-strip"]') as HTMLElement;
+    // --cols must equal actual grid children (any tag, via :scope > *), not just testid-tagged
+    // ones — paired with the completeness check below so an untagged child fails loudly.
+    const gridChildren = section.querySelectorAll(':scope > *').length;
+
+    expect(section.querySelectorAll('[data-testid^="org-groups-stat-"]')).toHaveLength(gridChildren);
+    expect(section.style.getPropertyValue('--cols').trim()).toBe(String(gridChildren));
+  });
+
+  it('renders the same skeleton card count whether org access or group data is still loading', async () => {
+    await render({ orgLoaded: false });
+    const outerSkeleton = fixture.nativeElement.querySelectorAll('[data-testid="org-groups-skeleton"] [data-testid="org-groups-stat-skeleton-card"]');
+
+    await render({ getGroups: () => NEVER });
+    const innerSkeleton = fixture.nativeElement.querySelectorAll('[data-testid="org-groups-stat-strip"] [data-testid="org-groups-stat-skeleton-card"]');
+
+    expect(outerSkeleton.length).toBeGreaterThan(0);
+    expect(outerSkeleton.length).toBe(innerSkeleton.length);
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -148,7 +148,7 @@ describe('OrgGroupsComponent', () => {
     expect(has(initialLoad, 'org-groups-stat-strip')).toBe(false);
     expect(has(initialLoad, 'org-groups-list-loading')).toBe(true);
     expect(has(initialLoad, 'org-groups-list')).toBe(false);
-    expect(statSkeletonCards(initialLoad).length).toBe(6);
+    expect(statSkeletonCards(initialLoad).length).toBe(8);
     expect(listSkeletonRows(initialLoad).length).toBe(5);
 
     // groupsLoading() branch — page loaded, but the group fetch never resolves.
@@ -158,7 +158,7 @@ describe('OrgGroupsComponent', () => {
     expect(has(groupsFetching, 'org-groups-list')).toBe(true);
     expect(has(groupsFetching, 'org-groups-list-loading')).toBe(false);
     expect(has(groupsFetching, 'org-groups-stat-total')).toBe(false);
-    expect(statSkeletonCards(groupsFetching).length).toBe(6);
+    expect(statSkeletonCards(groupsFetching).length).toBe(8);
     expect(listSkeletonRows(groupsFetching).length).toBe(5);
   });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -752,4 +752,35 @@ describe('OrgGroupsComponent stat strip', () => {
     expect(outerSkeleton.length).toBeGreaterThan(0);
     expect(outerSkeleton.length).toBe(innerSkeleton.length);
   });
+
+  // Pins the true max tile count (2 fixed + all 6 behavioral classes non-zero, incl.
+  // governing-board — never exercised by RESPONSE above) against the skeleton's reserved card
+  // count, so a 7th GroupBehavioralClass member — which would grow this max — fails here loudly
+  // instead of silently letting the loaded grid outgrow the skeleton (per dealako's PR #1790
+  // review: statSkeletonTiles' length is type-derived, but nothing asserted the two actually agree
+  // at the true max).
+  it('matches the skeleton reservation when every behavioral class, including governing-board, renders a tile', async () => {
+    await render({
+      getGroups: () =>
+        of({
+          groups: [
+            { uid: 'g1', name: 'Board One', category: 'Board', org_seat_count: 1 },
+            { uid: 'g2', name: 'TSC One', category: 'Technical Steering Committee', org_seat_count: 1 },
+            { uid: 'g3', name: 'WG One', category: 'Working Group', org_seat_count: 1 },
+            { uid: 'g4', name: 'SIG One', category: 'Special Interest Group', org_seat_count: 1 },
+            { uid: 'g5', name: 'Ambassador One', category: 'Ambassador', org_seat_count: 1 },
+            { uid: 'g6', name: 'Committee One', category: 'Committee', org_seat_count: 1 },
+          ],
+          total_groups: 6,
+          total_seats: 6,
+        }),
+    });
+
+    const section = rootElement().querySelector('[data-testid="org-groups-stat-strip"]') as HTMLElement;
+
+    // 6 non-zero classes + the 2 fixed totals — the same 8 the skeleton reserves (see the
+    // toBe(8) skeleton-card assertions in the top-level describe above).
+    expect(classTiles()).toHaveLength(6);
+    expect(section.style.getPropertyValue('--cols').trim()).toBe('8');
+  });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -63,25 +63,30 @@ export class OrgGroupsComponent {
   // doesn't cover. Keep in sync with the stat-strip markup.
   private readonly fixedStatTileCount = 2;
 
-  // Fixed placeholder count for the loading skeletons, set to the true max rendered tile count
-  // (2 fixed + all 6 behavioral classes non-zero — see statGridLoadedClass) so the skeleton and
-  // loaded grid only ever diverge on the zero-classes edge case, per GH-1779's "skeleton tile
-  // count matches the rendered tile count" acceptance criterion.
-  protected readonly statSkeletonTiles: readonly number[] = [1, 2, 3, 4, 5, 6, 7, 8];
+  // Placeholder count for the loading skeletons, derived from BEHAVIORAL_CLASS_CONFIG (one entry
+  // per GroupBehavioralClass member) rather than a hand-maintained literal, so the true max
+  // rendered tile count (2 fixed + every behavioral class non-zero) can't silently drift out of
+  // sync with the type if a class is ever added — see statGridClass for how the grid layout
+  // tracks this same value. Per GH-1779's "skeleton tile count matches the rendered tile count"
+  // acceptance criterion, the skeleton and loaded grid only ever diverge on the zero-classes edge
+  // case (per dealako's PR #1790 review).
+  protected readonly statSkeletonTiles: readonly number[] = Array.from(
+    { length: Object.keys(BEHAVIORAL_CLASS_CONFIG).length + this.fixedStatTileCount },
+    (_, i) => i + 1
+  );
 
-  // Mobile fixed at 2 columns, sm+ fixed at 3. At `lg:` and up, the loaded grid switches to one
-  // equal-width column per tile via --cols (2-8, since a class only tiles when non-zero) — that's
-  // the tightest case, not the roomiest: at 7-8 tiles columns get narrow enough for a longer
-  // label to wrap. Accepted deliberately, since a static per-count cap would reintroduce the
-  // ragged trailing row this grid exists to avoid. The skeleton and loaded grids share this same
-  // base and now share the same max card count (8, see statSkeletonTiles) — layout shift on data
-  // arrival only happens when fewer than 8 tiles end up rendering. The value is a plain --cols
-  // integer rather than a repeat(min(var(--cols),N)) clamp because CSS Grid requires an integer
-  // repeat count and silently drops the whole declaration otherwise (see
-  // events-summary-section.component.html for the same constraint).
+  // Mobile fixed at 2 columns, sm+ fixed at 3. At `lg:` and up, both the skeleton and the loaded
+  // grid switch to one equal-width column per tile via --cols — the skeleton binds it to
+  // statSkeletonTiles.length (see the template), the loaded grid to statTileCount() (2-8, since a
+  // class only tiles when non-zero). Sharing one grid class means the two can never drift out of
+  // sync on layout, only on --cols' value while data is still loading — the tightest live case is
+  // not the roomiest: at 7-8 tiles columns get narrow enough for a longer label to wrap. Accepted
+  // deliberately, since a static per-count cap would reintroduce the ragged trailing row this grid
+  // exists to avoid. The value is a plain --cols integer rather than a repeat(min(var(--cols),N))
+  // clamp because CSS Grid requires an integer repeat count and silently drops the whole
+  // declaration otherwise (see events-summary-section.component.html for the same constraint).
   private readonly statGridBase = 'grid grid-cols-2 gap-4 sm:grid-cols-3';
-  protected readonly statGridSkeletonClass = `${this.statGridBase} lg:grid-cols-8`;
-  protected readonly statGridLoadedClass = `${this.statGridBase} lg:[grid-template-columns:repeat(var(--cols),minmax(0,1fr))]`;
+  protected readonly statGridClass = `${this.statGridBase} lg:[grid-template-columns:repeat(var(--cols),minmax(0,1fr))]`;
 
   // ── Auth / access guards (mirrors org-meetings pattern) ───────────────────
   protected readonly hasNoOrgAccess: Signal<boolean> = computed(

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -63,23 +63,24 @@ export class OrgGroupsComponent {
   // doesn't cover. Keep in sync with the stat-strip markup.
   private readonly fixedStatTileCount = 2;
 
-  // Fixed placeholder count for the loading skeletons — the real tile count is only known once
-  // data resolves, so both skeleton branches render this many cards to avoid a second layout shift.
-  protected readonly statSkeletonTiles: readonly number[] = [1, 2, 3, 4, 5, 6];
+  // Fixed placeholder count for the loading skeletons, set to the true max rendered tile count
+  // (2 fixed + all 6 behavioral classes non-zero — see statGridLoadedClass) so the skeleton and
+  // loaded grid only ever diverge on the zero-classes edge case, per GH-1779's "skeleton tile
+  // count matches the rendered tile count" acceptance criterion.
+  protected readonly statSkeletonTiles: readonly number[] = [1, 2, 3, 4, 5, 6, 7, 8];
 
   // Mobile fixed at 2 columns, sm+ fixed at 3. At `lg:` and up, the loaded grid switches to one
   // equal-width column per tile via --cols (2-8, since a class only tiles when non-zero) — that's
   // the tightest case, not the roomiest: at 7-8 tiles columns get narrow enough for a longer
   // label to wrap. Accepted deliberately, since a static per-count cap would reintroduce the
   // ragged trailing row this grid exists to avoid. The skeleton and loaded grids share this same
-  // base so they don't diverge on classes, but the real tile count (2-8) is only known once data
-  // resolves and the skeleton's card count is fixed at 6 — some layout shift when data arrives is
-  // unavoidable at any breakpoint. The value is a plain --cols integer rather than a
-  // repeat(min(var(--cols),N)) clamp because CSS Grid requires an integer repeat count and
-  // silently drops the whole declaration otherwise (see events-summary-section.component.html
-  // for the same constraint).
+  // base and now share the same max card count (8, see statSkeletonTiles) — layout shift on data
+  // arrival only happens when fewer than 8 tiles end up rendering. The value is a plain --cols
+  // integer rather than a repeat(min(var(--cols),N)) clamp because CSS Grid requires an integer
+  // repeat count and silently drops the whole declaration otherwise (see
+  // events-summary-section.component.html for the same constraint).
   private readonly statGridBase = 'grid grid-cols-2 gap-4 sm:grid-cols-3';
-  protected readonly statGridSkeletonClass = `${this.statGridBase} lg:grid-cols-6`;
+  protected readonly statGridSkeletonClass = `${this.statGridBase} lg:grid-cols-8`;
   protected readonly statGridLoadedClass = `${this.statGridBase} lg:[grid-template-columns:repeat(var(--cols),minmax(0,1fr))]`;
 
   // ── Auth / access guards (mirrors org-meetings pattern) ───────────────────

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -11,6 +11,7 @@ import type {
   BehavioralClassDisplayConfig,
   GroupBehavioralClass,
   OrgDropdownOption,
+  OrgLensGroupClassTile,
   OrgLensGroupSummary,
   OrgLensGroupsResponse,
   OrgLensGroupVm,
@@ -58,6 +59,29 @@ export class OrgGroupsComponent {
 
   protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
 
+  // Total Groups + Total Seats — the two fixed tiles in the template that visibleClassTiles()
+  // doesn't cover. Keep in sync with the stat-strip markup.
+  private readonly fixedStatTileCount = 2;
+
+  // Fixed placeholder count for the loading skeletons — the real tile count is only known once
+  // data resolves, so both skeleton branches render this many cards to avoid a second layout shift.
+  protected readonly statSkeletonTiles: readonly number[] = [1, 2, 3, 4, 5, 6];
+
+  // Mobile fixed at 2 columns, sm+ fixed at 3. At `lg:` and up, the loaded grid switches to one
+  // equal-width column per tile via --cols (2-8, since a class only tiles when non-zero) — that's
+  // the tightest case, not the roomiest: at 7-8 tiles columns get narrow enough for a longer
+  // label to wrap. Accepted deliberately, since a static per-count cap would reintroduce the
+  // ragged trailing row this grid exists to avoid. The skeleton and loaded grids share this same
+  // base so they don't diverge on classes, but the real tile count (2-8) is only known once data
+  // resolves and the skeleton's card count is fixed at 6 — some layout shift when data arrives is
+  // unavoidable at any breakpoint. The value is a plain --cols integer rather than a
+  // repeat(min(var(--cols),N)) clamp because CSS Grid requires an integer repeat count and
+  // silently drops the whole declaration otherwise (see events-summary-section.component.html
+  // for the same constraint).
+  private readonly statGridBase = 'grid grid-cols-2 gap-4 sm:grid-cols-3';
+  protected readonly statGridSkeletonClass = `${this.statGridBase} lg:grid-cols-6`;
+  protected readonly statGridLoadedClass = `${this.statGridBase} lg:[grid-template-columns:repeat(var(--cols),minmax(0,1fr))]`;
+
   // ── Auth / access guards (mirrors org-meetings pattern) ───────────────────
   protected readonly hasNoOrgAccess: Signal<boolean> = computed(
     () => this.orgRoleGrantsService.loaded() && this.personaService.personaLoaded() && !this.accountContext.hasOrgSelectorAccess()
@@ -99,7 +123,10 @@ export class OrgGroupsComponent {
   protected readonly totalGroups: Signal<number> = computed(() => this.groupsData()?.total_groups ?? 0);
   protected readonly totalSeats: Signal<number> = computed(() => this.groupsData()?.total_seats ?? 0);
 
-  protected readonly behavioralClassCounts: Signal<Record<GroupBehavioralClass, number>> = this.initBehavioralClassCounts();
+  private readonly behavioralClassCounts: Signal<Record<GroupBehavioralClass, number>> = this.initBehavioralClassCounts();
+  protected readonly visibleClassTiles: Signal<OrgLensGroupClassTile[]> = this.initVisibleClassTiles();
+
+  protected readonly statTileCount: Signal<number> = computed(() => this.visibleClassTiles().length + this.fixedStatTileCount);
 
   protected readonly isFiltering: Signal<boolean> = this.initIsFiltering();
   private readonly foundationLabelsBySlug: Signal<Map<string, string>> = this.initFoundationLabelsBySlug();
@@ -264,5 +291,22 @@ export class OrgGroupsComponent {
     const raw = this.route.snapshot.queryParamMap.get('type');
     const validKeys = new Set(Object.keys(this.behavioralClassConfig));
     return raw && validKeys.has(raw) ? (raw as GroupBehavioralClass) : '';
+  }
+
+  // Sorted descending by count so the strip reads largest-class-first, not `BEHAVIORAL_CLASS_CONFIG`
+  // key order — except `other`, pinned last regardless of count: it's a catch-all (raw category
+  // "Committee" lands here alongside true miscellany), and leading with it would tell the reader
+  // less than the specific classes it groups. Filters out any class with zero groups —
+  // governing-board is usually 0 here since the BFF drops the exact "Board" category, but a
+  // broader board-ish category (e.g. "Governing Board") can still classify as governing-board and
+  // get its own tile; the filter is generic on count, not a governing-board special case.
+  private initVisibleClassTiles(): Signal<OrgLensGroupClassTile[]> {
+    return computed(() => {
+      const counts = this.behavioralClassCounts();
+      return (Object.keys(counts) as GroupBehavioralClass[])
+        .map((cls) => ({ cls, count: counts[cls] }))
+        .filter((tile) => tile.count > 0)
+        .sort((a, b) => (a.cls === 'other' ? 1 : 0) - (b.cls === 'other' ? 1 : 0) || b.count - a.count);
+    });
   }
 }

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -7,6 +7,7 @@ import {
   BAND_CHIP_CLASS,
   BAND_SIGNAL_FILL,
   BAND_SIGNAL_FILL_LIGHT,
+  BEHAVIORAL_CLASS_CONFIG,
   DELTA_DIRECTION_TEXT_CLASS,
   GRID_COLS_CLASS,
   GRID_DIVIDER_CLASS,
@@ -36,9 +37,18 @@ export default {
     // Org Lens meetings — KPI card icon tints and delta text colors (ORG_MEETINGS_KPI_ICON_CLASS /
     // DELTA_DIRECTION_TEXT_CLASS in @lfx-one/shared, not scanned here)
     ...Object.values(ORG_MEETINGS_KPI_ICON_CLASS).flatMap((classes) => classes.split(' ')),
-    ...Object.values(DELTA_DIRECTION_TEXT_CLASS),
+    ...Object.values(DELTA_DIRECTION_TEXT_CLASS).flatMap((classes) => classes.split(' ')),
     // Groups dashboard engagement stat cards (GROUPS_ENGAGEMENT_ICON_CLASS in @lfx-one/shared, not scanned here)
     ...Object.values(GROUPS_ENGAGEMENT_ICON_CLASS).flatMap((classes) => classes.split(' ')),
+    // Behavioral-class tints — org-groups stat tiles, committee dashboard/table chips, my-groups
+    // cards, and the public group pages all key off this map (BEHAVIORAL_CLASS_CONFIG in
+    // @lfx-one/shared, not scanned here). `.split(' ')` guards against a future multi-token value.
+    // Without this entry, `bg-rose-50` (ambassador-program) specifically was never generated —
+    // its only occurrence in scanned content is the `!`-prefixed `!bg-rose-50` in
+    // transaction-type-style.pipe.ts, which Tailwind extracts as a distinct candidate, so the
+    // bare utility rendered with no background tint on every one of the surfaces above, not just
+    // the new org-groups stat tiles.
+    ...Object.values(BEHAVIORAL_CLASS_CONFIG).flatMap((config) => [config.bgColor, config.color].flatMap((c) => c.split(' '))),
     // Meeting summary modal — dynamic section border/icon colors (applied via [ngClass])
     'border-l-blue-400',
     'border-l-emerald-400',
@@ -53,8 +63,8 @@ export default {
     // Org Lens project bands — chip + signal-bar fill classes (BAND_CHIP_CLASS / BAND_SIGNAL_FILL /
     // BAND_SIGNAL_FILL_LIGHT in @lfx-one/shared, not scanned here)
     ...Object.values(BAND_CHIP_CLASS).flatMap((classes) => classes.split(' ')),
-    ...Object.values(BAND_SIGNAL_FILL),
-    ...Object.values(BAND_SIGNAL_FILL_LIGHT),
+    ...Object.values(BAND_SIGNAL_FILL).flatMap((classes) => classes.split(' ')),
+    ...Object.values(BAND_SIGNAL_FILL_LIGHT).flatMap((classes) => classes.split(' ')),
     // Org Lens projects page — separate band signal-fill map with a red "silent" tier (org-lens-projects.constants.ts, not scanned here)
     'fill-red-500',
     'fill-red-200',

--- a/packages/shared/src/interfaces/org-groups.interface.ts
+++ b/packages/shared/src/interfaces/org-groups.interface.ts
@@ -39,3 +39,9 @@ export interface OrgLensGroupVm extends OrgLensGroupSummary {
    *  two link targets apart. Empty string when projectLabel is empty. */
   projectAriaLabel: string;
 }
+
+/** One non-zero behavioral-class tile rendered in the org-groups stat strip. */
+export interface OrgLensGroupClassTile {
+  cls: GroupBehavioralClass;
+  count: number;
+}


### PR DESCRIPTION
## Summary

- Replaces the org-groups stat strip's hardcoded Working Groups + SIGs tiles with one tile per behavioral class that actually has groups, sorted largest-first with the `other` catch-all pinned last. On a live org the strip previously read 46 / 171 / 19 / 8 (Total Groups / Total Seats / Working Groups / SIGs) — 19 groups silently unaccounted for. It now sums to the total.
- Fixes a latent Tailwind purge bug found while making the tint dynamic: `bg-rose-50` (ambassador-program) was never being generated anywhere in `apps/lfx-one`'s scanned content, so that tile — and the same class on the committee dashboard/table, my-groups cards, and both public group pages — rendered with no background tint. Safelisted `BEHAVIORAL_CLASS_CONFIG`'s classes to fix it everywhere it's consumed.
- Adds `OrgLensGroupClassTile` to `@lfx-one/shared/interfaces` as the tile view-model.

### Stacked on #1788

Third PR in a four-deep stack for epic #1776:

```
main
 └─ #1787  feat/GH-1778             filter bar
     └─ #1788  fix/GH-1783-…        copy tokenization
         └─ #1790  ← this PR        stat strip
             └─ #1789  fix/GH-1782  contrast + mobile chip
```

Base is `fix/GH-1783-groups-loading-and-copy`, not `main`, so the diff is scoped to this branch's own change. Merge bottom-up: #1787, #1788, this, then #1789.

## Test plan

- [x] `yarn lint:check`, `yarn check-types`, `yarn format:check` — clean
- [x] `yarn build` — succeeds (SSR + browser bundles)
- [x] New/updated specs in `org-groups.component.spec.ts` cover: zero-count classes render no tile, non-zero classes render a labeled tile, counts sum to `total_groups`, ordering is largest-first with `other` pinned last even at the highest count, `--cols` matches the actual rendered grid, and both loading skeletons agree on placeholder count — verified via mutation testing that each assertion actually fails on the regression it targets
- [x] Confirmed in the built CSS that `bg-rose-50` and all other `BEHAVIORAL_CLASS_CONFIG` tints now emit
- [x] Manual check on a live org with a mixed class set — **Oracle America Inc., 46 groups**, verified in the integration worktree (all four stacked branches merged) at `localhost:4200/org/groups`:
  - Seven tiles rendered, `--cols="7"` matching the rendered count exactly
  - Order left-to-right: Total Groups 46 · Total Seats 171 · Working Groups 19 · SIGs 8 · Oversight 5 · Ambassadors 1 · **Other 13**
  - `other` correctly pinned last despite outranking SIGs, Oversight and Ambassadors on count — the exact case the sort's `other`-pin exists for
  - Class counts sum back to the total: 19 + 8 + 5 + 1 + 13 = 46 = Total Groups
