### PR TITLE
fix(groups): fix contrast and mobile chip visibility on public group pages

### DIFF
--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
@@ -74,8 +74,9 @@
 
             <!-- Name + meta + behavioral class chip: stacked below `sm`; `sm:contents` folds this
                  wrapper away at `sm+` so the name/meta block and chip become direct flex items of
-                 the row again, reproducing the pre-existing desktop layout (see
-                 org-groups.component.html / PR #1789). -->
+                 the row again, reproducing the pre-existing desktop layout. `display: contents`
+                 gives the wrapper no box of its own at `sm+`, which is why `flex-1`/`min-w-0` live
+                 on the inner meta block rather than here (GH-1791, porting the pattern from #1789). -->
             <div class="flex flex-1 min-w-0 flex-col gap-2 sm:contents" data-testid="public-foundation-groups-item-meta-wrapper">
               <div class="flex flex-1 min-w-0 flex-col gap-0.5" data-testid="public-foundation-groups-item-meta-block">
                 <p class="truncate text-sm font-medium text-gray-900" data-testid="public-foundation-groups-item-name">{{ group.name }}</p>

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
@@ -64,7 +64,7 @@
           <a
             [routerLink]="['/groups', group.uid]"
             role="listitem"
-            class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+            class="flex items-start gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 sm:items-center"
             [attr.data-testid]="'public-foundation-groups-item-' + group.uid"
             [attr.aria-label]="group.name + ', ' + config.label">
             <!-- Icon -->
@@ -72,19 +72,24 @@
               <i [class]="config.icon + ' ' + config.color + ' text-base'" aria-hidden="true"></i>
             </div>
 
-            <!-- Name + meta -->
-            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
-              <p class="truncate text-sm font-medium text-gray-900" data-testid="public-foundation-groups-item-name">{{ group.name }}</p>
-              @if (group.context.project_name) {
-                <p class="truncate text-xs text-gray-400" data-testid="public-foundation-groups-item-project">{{ group.context.project_name }}</p>
-              }
-              @if (group.description) {
-                <p class="truncate text-xs text-gray-500 mt-0.5 hidden sm:block" data-testid="public-foundation-groups-item-desc">{{ group.description }}</p>
-              }
-            </div>
+            <!-- Name + meta + behavioral class chip: stacked below `sm`; `sm:contents` folds this
+                 wrapper away at `sm+` so the name/meta block and chip become direct flex items of
+                 the row again, reproducing the pre-existing desktop layout (see
+                 org-groups.component.html / PR #1789). -->
+            <div class="flex flex-1 min-w-0 flex-col gap-2 sm:contents" data-testid="public-foundation-groups-item-meta-wrapper">
+              <div class="flex flex-1 min-w-0 flex-col gap-0.5" data-testid="public-foundation-groups-item-meta-block">
+                <p class="truncate text-sm font-medium text-gray-900" data-testid="public-foundation-groups-item-name">{{ group.name }}</p>
+                @if (group.context.project_name) {
+                  <p class="truncate text-xs text-gray-500" data-testid="public-foundation-groups-item-project">{{ group.context.project_name }}</p>
+                }
+                @if (group.description) {
+                  <p class="truncate text-xs text-gray-500 mt-0.5 hidden sm:block" data-testid="public-foundation-groups-item-desc">{{ group.description }}</p>
+                }
+              </div>
 
-            <!-- Behavioral class chip -->
-            <lfx-tag [value]="config.label" [severity]="'secondary'" class="shrink-0 hidden sm:flex" />
+              <!-- Behavioral class chip -->
+              <lfx-tag [value]="config.label" [severity]="'secondary'" class="flex w-fit shrink-0" data-testid="public-foundation-groups-item-class-chip" />
+            </div>
 
             <!-- Join mode badge -->
             @if (group.joinLabel) {

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
@@ -75,8 +75,9 @@
             <!-- Name + meta + behavioral class chip: stacked below `sm`; `sm:contents` folds this
                  wrapper away at `sm+` so the name/meta block and chip become direct flex items of
                  the row again, reproducing the pre-existing desktop layout. `display: contents`
-                 gives the wrapper no box of its own at `sm+`, which is why `flex-1`/`min-w-0` live
-                 on the inner meta block rather than here (GH-1791, porting the pattern from #1789). -->
+                 gives the wrapper no box of its own at `sm+`, so its own `flex-1`/`min-w-0` stop
+                 applying there — the inner meta block carries the same classes so it, not the
+                 wrapper, is what grows at `sm+` (GH-1791, porting the pattern from #1789). -->
             <div class="flex flex-1 min-w-0 flex-col gap-2 sm:contents" data-testid="public-foundation-groups-item-meta-wrapper">
               <div class="flex flex-1 min-w-0 flex-col gap-0.5" data-testid="public-foundation-groups-item-meta-block">
                 <p class="truncate text-sm font-medium text-gray-900" data-testid="public-foundation-groups-item-name">{{ group.name }}</p>

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -132,7 +132,11 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     // "drop redundant class" risk the other tests in this file guard against.
     await render({ groups: [group()], total: 1 });
 
-    const row = fixture.nativeElement.querySelector('[data-testid^="public-foundation-groups-item-"]');
+    // Exact testid, not a `^=` prefix match — that prefix is shared by six descendant testids in
+    // this row (meta-wrapper, meta-block, name, project, desc, class-chip), so a prefix query would
+    // silently retarget one of them instead of failing loudly if the row's own testid is ever
+    // dropped or renamed.
+    const row = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]');
     expect(row).not.toBeNull();
     const rowClasses = (row?.className ?? '').split(/\s+/);
     expect(rowClasses).toContain('items-start');

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -78,7 +78,17 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
 
   it('renders the row project-name line with passing gray-500 contrast, not gray-400', async () => {
     await render({
-      groups: [group({ context: { scope: 'foundation', foundation_uid: 'f1', foundation_name: 'UEPF', foundation_slug: 'uepf', project_name: 'Cloud Native Computing Foundation' } })],
+      groups: [
+        group({
+          context: {
+            scope: 'foundation',
+            foundation_uid: 'f1',
+            foundation_name: 'UEPF',
+            foundation_slug: 'uepf',
+            project_name: 'Cloud Native Computing Foundation',
+          },
+        }),
+      ],
       total: 1,
     });
 
@@ -89,7 +99,13 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     expect(line?.className).not.toContain('text-gray-400');
   });
 
-  it('behavioral class chip has no hidden class at any breakpoint', async () => {
+  it('behavioral class chip has no hidden class at any breakpoint, and keeps its explicit flex + shrink-0', async () => {
+    // `flex` and `shrink-0` are asserted, not just the absence of `hidden`, because a "drop
+    // redundant class" pass could silently regress both without failing any other assertion here:
+    // without `flex` the host still renders (it blockifies to `block` as a flex item either way) —
+    // only the strut-height fix `flex` provides would quietly come back. Without `shrink-0` the
+    // chip would default to flex-shrink: 1 once `sm:contents` folds the wrapper away at `sm+`,
+    // letting it get squeezed instead of keeping its natural width.
     await render({ groups: [group()], total: 1 });
 
     const chip = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-class-chip"]');
@@ -101,9 +117,9 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
   });
 
   it('meta wrapper folds to display:contents at sm+, while the inner meta block keeps the growing flex class', async () => {
-    // Regression lock, mirroring org-groups.component.spec.ts (PR #1789): flex-1/min-w-0 must live
-    // on the inner meta block, not the sm:contents wrapper — display:contents gives the wrapper no
-    // box of its own at sm+, so flex classes placed there would silently stop applying.
+    // Regression lock: flex-1/min-w-0 must live on the inner meta block, not the sm:contents
+    // wrapper — display:contents gives the wrapper no box of its own at sm+, so flex classes
+    // placed there would silently stop applying and the block would collapse to content width.
     await render({ groups: [group()], total: 1 });
 
     const wrapper = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-meta-wrapper"]');

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -1,0 +1,121 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { AppService } from '@services/app.service';
+import { GroupService } from '@services/group.service';
+import { LensService } from '@services/lens.service';
+import { ProjectService } from '@services/project.service';
+import { UserService } from '@services/user.service';
+import { of } from 'rxjs';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
+
+import { PublicFoundationGroupsComponent } from './public-foundation-groups.component';
+
+// jsdom doesn't implement matchMedia; PrimeNG's Menubar (rendered inside <lfx-header/>) calls it
+// on init to bind a responsive listener.
+beforeAll(() => {
+  window.matchMedia ??= ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+});
+
+function group(over: Partial<PublicGroupSummary> = {}): PublicGroupSummary {
+  return {
+    uid: 'g1',
+    name: 'WG Identity & Trust',
+    category: 'Working Group',
+    behavioral_class: 'working-group',
+    context: {
+      scope: 'foundation',
+      foundation_uid: 'f1',
+      foundation_name: 'Ultra Ethernet Consortium Fund',
+      foundation_slug: 'uepf',
+    },
+    ...over,
+  };
+}
+
+describe('PublicFoundationGroupsComponent — contrast and responsive row layout (GH-1791)', () => {
+  let fixture: ComponentFixture<PublicFoundationGroupsComponent>;
+
+  async function render(response: PublicGroupDirectoryResponse, slug = 'uepf'): Promise<void> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PublicFoundationGroupsComponent],
+      providers: [
+        { provide: GroupService, useValue: { getPublicFoundationGroups: () => of(response) } },
+        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['foundationSlug', slug]])) } },
+        // <lfx-header/> deps — mocked directly rather than resolving the real LensService ->
+        // PersonaService -> AccountContextService chain, which needs far more than HttpClient.
+        { provide: UserService, useValue: { authenticated: signal(false), getCurrentUserProfile: vi.fn(() => of(null)) } },
+        { provide: LensService, useValue: { setLens: vi.fn() } },
+        { provide: ProjectService, useValue: { searchProjects: vi.fn(() => of([])) } },
+        { provide: AppService, useValue: { toggleMobileSidebar: vi.fn() } },
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PublicFoundationGroupsComponent);
+    await fixture.whenStable();
+  }
+
+  it('renders the row project-name line with passing gray-500 contrast, not gray-400', async () => {
+    await render({
+      groups: [group({ context: { scope: 'foundation', foundation_uid: 'f1', foundation_name: 'UEPF', foundation_slug: 'uepf', project_name: 'Cloud Native Computing Foundation' } })],
+      total: 1,
+    });
+
+    const line = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-project"]');
+    expect(line).not.toBeNull();
+    expect(line?.textContent?.trim()).toBe('Cloud Native Computing Foundation');
+    expect(line?.className).toContain('text-gray-500');
+    expect(line?.className).not.toContain('text-gray-400');
+  });
+
+  it('behavioral class chip has no hidden class at any breakpoint', async () => {
+    await render({ groups: [group()], total: 1 });
+
+    const chip = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-class-chip"]');
+    expect(chip).not.toBeNull();
+    const chipClasses = (chip?.getAttribute('class') ?? '').split(/\s+/);
+    expect(chipClasses.some((c: string) => c === 'hidden' || c.endsWith(':hidden'))).toBe(false);
+    expect(chipClasses).toContain('flex');
+    expect(chipClasses).toContain('shrink-0');
+  });
+
+  it('meta wrapper folds to display:contents at sm+, while the inner meta block keeps the growing flex class', async () => {
+    // Regression lock, mirroring org-groups.component.spec.ts (PR #1789): flex-1/min-w-0 must live
+    // on the inner meta block, not the sm:contents wrapper — display:contents gives the wrapper no
+    // box of its own at sm+, so flex classes placed there would silently stop applying.
+    await render({ groups: [group()], total: 1 });
+
+    const wrapper = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-meta-wrapper"]');
+    const block = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-meta-block"]');
+
+    expect(wrapper).not.toBeNull();
+    expect(block).not.toBeNull();
+    expect(wrapper?.contains(block)).toBe(true);
+    expect(wrapper?.className).toContain('sm:contents');
+
+    const blockClasses = (block?.className ?? '').split(/\s+/);
+    expect(blockClasses).toContain('flex-1');
+    expect(blockClasses).toContain('min-w-0');
+  });
+});

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -118,10 +118,12 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
 
   it('meta wrapper folds to display:contents at sm+, while both wrapper and inner block keep their own growing flex classes', async () => {
     // Regression lock: the wrapper's own flex-1/min-w-0 are load-bearing below `sm`, where it is
-    // still a real flex item of the row and min-w-0 is what lets the truncate'd name/description
-    // actually truncate. At sm+, `display: contents` gives the wrapper no box of its own, so those
-    // classes go inert there — which is why the inner meta block must carry its own copies too, or
-    // the block would collapse to content width once the wrapper stops applying them.
+    // still a real flex item of the row and min-w-0 is what lets the truncated name and
+    // project-name lines actually truncate (the description line is `hidden sm:block`, so it
+    // isn't rendered below `sm` at all). At sm+, `display: contents` gives the wrapper no box of
+    // its own, so those classes go inert there — which is why the inner meta block must carry its
+    // own copies too, or the block would collapse to content width once the wrapper stops applying
+    // them.
     await render({ groups: [group()], total: 1 });
 
     const wrapper = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-meta-wrapper"]');

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -3,36 +3,18 @@
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
-import { AppService } from '@services/app.service';
 import { GroupService } from '@services/group.service';
-import { LensService } from '@services/lens.service';
-import { ProjectService } from '@services/project.service';
-import { UserService } from '@services/user.service';
+import { headerTestProviders, installMatchMediaShim } from '@shared/testing/header-test-providers';
 import { of } from 'rxjs';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import type { PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
 
 import { PublicFoundationGroupsComponent } from './public-foundation-groups.component';
 
-// jsdom doesn't implement matchMedia; PrimeNG's Menubar (rendered inside <lfx-header/>) calls it
-// on init to bind a responsive listener.
-beforeAll(() => {
-  window.matchMedia ??= ((query: string) =>
-    ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }) as unknown as MediaQueryList) as typeof window.matchMedia;
-});
+beforeAll(installMatchMediaShim);
 
 function group(over: Partial<PublicGroupSummary> = {}): PublicGroupSummary {
   return {
@@ -60,12 +42,7 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
       providers: [
         { provide: GroupService, useValue: { getPublicFoundationGroups: () => of(response) } },
         { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['foundationSlug', slug]])) } },
-        // <lfx-header/> deps — mocked directly rather than resolving the real LensService ->
-        // PersonaService -> AccountContextService chain, which needs far more than HttpClient.
-        { provide: UserService, useValue: { authenticated: signal(false), getCurrentUserProfile: vi.fn(() => of(null)) } },
-        { provide: LensService, useValue: { setLens: vi.fn() } },
-        { provide: ProjectService, useValue: { searchProjects: vi.fn(() => of([])) } },
-        { provide: AppService, useValue: { toggleMobileSidebar: vi.fn() } },
+        ...headerTestProviders(),
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -99,7 +76,12 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     expect(line?.className).not.toContain('text-gray-400');
   });
 
-  it('behavioral class chip has no hidden class at any breakpoint, and keeps its explicit flex + shrink-0', async () => {
+  it('behavioral class chip renders its label text and has no hidden class at any breakpoint, keeping its explicit flex + shrink-0', async () => {
+    // The label text itself is asserted, not just the chip's presence — the WCAG 1.4.1 fix this
+    // ticket makes is specifically that the behavioral class gains a *textual* signal on mobile
+    // beside the row icon's color (aria-hidden), so an empty pill would still pass a presence-only
+    // check without fixing the actual defect.
+    //
     // `flex` and `shrink-0` are asserted, not just the absence of `hidden`, because a "drop
     // redundant class" pass could silently regress both without failing any other assertion here:
     // without `flex` the host still renders (it blockifies to `block` as a flex item either way) —
@@ -110,6 +92,7 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
 
     const chip = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-class-chip"]');
     expect(chip).not.toBeNull();
+    expect(chip?.textContent?.trim()).toBe('Working Groups');
     const chipClasses = (chip?.getAttribute('class') ?? '').split(/\s+/);
     expect(chipClasses.some((c: string) => c === 'hidden' || c.endsWith(':hidden'))).toBe(false);
     expect(chipClasses).toContain('flex');
@@ -141,5 +124,18 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     const blockClasses = (block?.className ?? '').split(/\s+/);
     expect(blockClasses).toContain('flex-1');
     expect(blockClasses).toContain('min-w-0');
+  });
+
+  it('row keeps items-start/sm:items-center so the icon top-aligns against the stacked mobile column, not the desktop centering', async () => {
+    // Regression lock: without `items-start`, the icon and chevron would vertically center against
+    // the full two-line stacked column's height on mobile instead of aligning to its top — the same
+    // "drop redundant class" risk the other tests in this file guard against.
+    await render({ groups: [group()], total: 1 });
+
+    const row = fixture.nativeElement.querySelector('[data-testid^="public-foundation-groups-item-"]');
+    expect(row).not.toBeNull();
+    const rowClasses = (row?.className ?? '').split(/\s+/);
+    expect(rowClasses).toContain('items-start');
+    expect(rowClasses).toContain('sm:items-center');
   });
 });

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -132,10 +132,9 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     // "drop redundant class" risk the other tests in this file guard against.
     await render({ groups: [group()], total: 1 });
 
-    // Exact testid, not a `^=` prefix match — that prefix is shared by six descendant testids in
-    // this row (meta-wrapper, meta-block, name, project, desc, class-chip), so a prefix query would
-    // silently retarget one of them instead of failing loudly if the row's own testid is ever
-    // dropped or renamed.
+    // Exact testid, not a `^=` prefix match — that prefix is also carried by every descendant
+    // testid in this row, so a prefix query would silently retarget one of them instead of failing
+    // loudly if the row's own testid is ever dropped or renamed.
     const row = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]');
     expect(row).not.toBeNull();
     const rowClasses = (row?.className ?? '').split(/\s+/);

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -116,10 +116,12 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     expect(chipClasses).toContain('shrink-0');
   });
 
-  it('meta wrapper folds to display:contents at sm+, while the inner meta block keeps the growing flex class', async () => {
-    // Regression lock: flex-1/min-w-0 must live on the inner meta block, not the sm:contents
-    // wrapper — display:contents gives the wrapper no box of its own at sm+, so flex classes
-    // placed there would silently stop applying and the block would collapse to content width.
+  it('meta wrapper folds to display:contents at sm+, while both wrapper and inner block keep their own growing flex classes', async () => {
+    // Regression lock: the wrapper's own flex-1/min-w-0 are load-bearing below `sm`, where it is
+    // still a real flex item of the row and min-w-0 is what lets the truncate'd name/description
+    // actually truncate. At sm+, `display: contents` gives the wrapper no box of its own, so those
+    // classes go inert there — which is why the inner meta block must carry its own copies too, or
+    // the block would collapse to content width once the wrapper stops applying them.
     await render({ groups: [group()], total: 1 });
 
     const wrapper = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-meta-wrapper"]');
@@ -129,6 +131,10 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     expect(block).not.toBeNull();
     expect(wrapper?.contains(block)).toBe(true);
     expect(wrapper?.className).toContain('sm:contents');
+
+    const wrapperClasses = (wrapper?.className ?? '').split(/\s+/);
+    expect(wrapperClasses).toContain('flex-1');
+    expect(wrapperClasses).toContain('min-w-0');
 
     const blockClasses = (block?.className ?? '').split(/\s+/);
     expect(blockClasses).toContain('flex-1');

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
@@ -19,7 +19,7 @@
           }
         </h1>
         @if (foundationName()) {
-          <p class="text-sm text-gray-400" data-testid="public-project-groups-foundation">{{ foundationName() }}</p>
+          <p class="text-sm text-gray-500" data-testid="public-project-groups-foundation">{{ foundationName() }}</p>
         }
         <p class="text-sm text-gray-500" data-testid="public-project-groups-subtitle">
           Discover official working groups, special interest groups, and committees for this project.
@@ -67,7 +67,7 @@
           <a
             [routerLink]="['/groups', group.uid]"
             role="listitem"
-            class="flex items-center gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+            class="flex items-start gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 sm:items-center"
             [attr.data-testid]="'public-project-groups-item-' + group.uid"
             [attr.aria-label]="group.name + ', ' + config.label">
             <!-- Icon -->
@@ -75,16 +75,21 @@
               <i [class]="config.icon + ' ' + config.color + ' text-base'" aria-hidden="true"></i>
             </div>
 
-            <!-- Name + meta -->
-            <div class="flex flex-col gap-0.5 flex-1 min-w-0">
-              <p class="truncate text-sm font-medium text-gray-900" data-testid="public-project-groups-item-name">{{ group.name }}</p>
-              @if (group.description) {
-                <p class="truncate text-xs text-gray-500 mt-0.5 hidden sm:block" data-testid="public-project-groups-item-desc">{{ group.description }}</p>
-              }
-            </div>
+            <!-- Name + meta + behavioral class chip: stacked below `sm`; `sm:contents` folds this
+                 wrapper away at `sm+` so the name/meta block and chip become direct flex items of
+                 the row again, reproducing the pre-existing desktop layout (see
+                 org-groups.component.html / PR #1789). -->
+            <div class="flex flex-1 min-w-0 flex-col gap-2 sm:contents" data-testid="public-project-groups-item-meta-wrapper">
+              <div class="flex flex-1 min-w-0 flex-col gap-0.5" data-testid="public-project-groups-item-meta-block">
+                <p class="truncate text-sm font-medium text-gray-900" data-testid="public-project-groups-item-name">{{ group.name }}</p>
+                @if (group.description) {
+                  <p class="truncate text-xs text-gray-500 mt-0.5 hidden sm:block" data-testid="public-project-groups-item-desc">{{ group.description }}</p>
+                }
+              </div>
 
-            <!-- Behavioral class chip -->
-            <lfx-tag [value]="config.label" [severity]="'secondary'" class="shrink-0 hidden sm:flex" />
+              <!-- Behavioral class chip -->
+              <lfx-tag [value]="config.label" [severity]="'secondary'" class="flex w-fit shrink-0" data-testid="public-project-groups-item-class-chip" />
+            </div>
 
             <!-- Join mode badge -->
             @if (group.joinLabel) {

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
@@ -77,8 +77,9 @@
 
             <!-- Name + meta + behavioral class chip: stacked below `sm`; `sm:contents` folds this
                  wrapper away at `sm+` so the name/meta block and chip become direct flex items of
-                 the row again, reproducing the pre-existing desktop layout (see
-                 org-groups.component.html / PR #1789). -->
+                 the row again, reproducing the pre-existing desktop layout. `display: contents`
+                 gives the wrapper no box of its own at `sm+`, which is why `flex-1`/`min-w-0` live
+                 on the inner meta block rather than here (GH-1791, porting the pattern from #1789). -->
             <div class="flex flex-1 min-w-0 flex-col gap-2 sm:contents" data-testid="public-project-groups-item-meta-wrapper">
               <div class="flex flex-1 min-w-0 flex-col gap-0.5" data-testid="public-project-groups-item-meta-block">
                 <p class="truncate text-sm font-medium text-gray-900" data-testid="public-project-groups-item-name">{{ group.name }}</p>

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
@@ -78,8 +78,9 @@
             <!-- Name + meta + behavioral class chip: stacked below `sm`; `sm:contents` folds this
                  wrapper away at `sm+` so the name/meta block and chip become direct flex items of
                  the row again, reproducing the pre-existing desktop layout. `display: contents`
-                 gives the wrapper no box of its own at `sm+`, which is why `flex-1`/`min-w-0` live
-                 on the inner meta block rather than here (GH-1791, porting the pattern from #1789). -->
+                 gives the wrapper no box of its own at `sm+`, so its own `flex-1`/`min-w-0` stop
+                 applying there — the inner meta block carries the same classes so it, not the
+                 wrapper, is what grows at `sm+` (GH-1791, porting the pattern from #1789). -->
             <div class="flex flex-1 min-w-0 flex-col gap-2 sm:contents" data-testid="public-project-groups-item-meta-wrapper">
               <div class="flex flex-1 min-w-0 flex-col gap-0.5" data-testid="public-project-groups-item-meta-block">
                 <p class="truncate text-sm font-medium text-gray-900" data-testid="public-project-groups-item-name">{{ group.name }}</p>

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -108,10 +108,11 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
 
   it('meta wrapper folds to display:contents at sm+, while both wrapper and inner block keep their own growing flex classes', async () => {
     // Regression lock: the wrapper's own flex-1/min-w-0 are load-bearing below `sm`, where it is
-    // still a real flex item of the row and min-w-0 is what lets the truncate'd name/description
-    // actually truncate. At sm+, `display: contents` gives the wrapper no box of its own, so those
-    // classes go inert there — which is why the inner meta block must carry its own copies too, or
-    // the block would collapse to content width once the wrapper stops applying them.
+    // still a real flex item of the row and min-w-0 is what lets the truncated name line actually
+    // truncate (the description line is `hidden sm:block`, so it isn't rendered below `sm` at
+    // all). At sm+, `display: contents` gives the wrapper no box of its own, so those classes go
+    // inert there — which is why the inner meta block must carry its own copies too, or the block
+    // would collapse to content width once the wrapper stops applying them.
     await render({ groups: [group()], total: 1 });
 
     const wrapper = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-meta-wrapper"]');

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -89,7 +89,13 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     expect(line?.className).not.toContain('text-gray-400');
   });
 
-  it('behavioral class chip has no hidden class at any breakpoint', async () => {
+  it('behavioral class chip has no hidden class at any breakpoint, and keeps its explicit flex + shrink-0', async () => {
+    // `flex` and `shrink-0` are asserted, not just the absence of `hidden`, because a "drop
+    // redundant class" pass could silently regress both without failing any other assertion here:
+    // without `flex` the host still renders (it blockifies to `block` as a flex item either way) —
+    // only the strut-height fix `flex` provides would quietly come back. Without `shrink-0` the
+    // chip would default to flex-shrink: 1 once `sm:contents` folds the wrapper away at `sm+`,
+    // letting it get squeezed instead of keeping its natural width.
     await render({ groups: [group()], total: 1 });
 
     const chip = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-class-chip"]');
@@ -101,9 +107,9 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
   });
 
   it('meta wrapper folds to display:contents at sm+, while the inner meta block keeps the growing flex class', async () => {
-    // Regression lock, mirroring org-groups.component.spec.ts (PR #1789): flex-1/min-w-0 must live
-    // on the inner meta block, not the sm:contents wrapper — display:contents gives the wrapper no
-    // box of its own at sm+, so flex classes placed there would silently stop applying.
+    // Regression lock: flex-1/min-w-0 must live on the inner meta block, not the sm:contents
+    // wrapper — display:contents gives the wrapper no box of its own at sm+, so flex classes
+    // placed there would silently stop applying and the block would collapse to content width.
     await render({ groups: [group()], total: 1 });
 
     const wrapper = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-meta-wrapper"]');

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -121,10 +121,9 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     // "drop redundant class" risk the other tests in this file guard against.
     await render({ groups: [group()], total: 1 });
 
-    // Exact testid, not a `^=` prefix match — that prefix is shared by five descendant testids in
-    // this row (meta-wrapper, meta-block, name, desc, class-chip), so a prefix query would silently
-    // retarget one of them instead of failing loudly if the row's own testid is ever dropped or
-    // renamed.
+    // Exact testid, not a `^=` prefix match — that prefix is also carried by every descendant
+    // testid in this row, so a prefix query would silently retarget one of them instead of failing
+    // loudly if the row's own testid is ever dropped or renamed.
     const row = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]');
     expect(row).not.toBeNull();
     const rowClasses = (row?.className ?? '').split(/\s+/);

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -1,0 +1,121 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { AppService } from '@services/app.service';
+import { GroupService } from '@services/group.service';
+import { LensService } from '@services/lens.service';
+import { ProjectService } from '@services/project.service';
+import { UserService } from '@services/user.service';
+import { of } from 'rxjs';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
+
+import { PublicProjectGroupsComponent } from './public-project-groups.component';
+
+// jsdom doesn't implement matchMedia; PrimeNG's Menubar (rendered inside <lfx-header/>) calls it
+// on init to bind a responsive listener.
+beforeAll(() => {
+  window.matchMedia ??= ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+});
+
+function group(over: Partial<PublicGroupSummary> = {}): PublicGroupSummary {
+  return {
+    uid: 'g1',
+    name: 'WG Identity & Trust',
+    category: 'Working Group',
+    behavioral_class: 'working-group',
+    context: {
+      scope: 'project',
+      foundation_uid: 'f1',
+      foundation_name: 'Cloud Native Computing Foundation',
+      foundation_slug: 'cncf',
+      project_uid: 'p1',
+      project_name: 'Kubernetes',
+      project_slug: 'kubernetes',
+    },
+    ...over,
+  };
+}
+
+describe('PublicProjectGroupsComponent — contrast and responsive row layout (GH-1791)', () => {
+  let fixture: ComponentFixture<PublicProjectGroupsComponent>;
+
+  async function render(response: PublicGroupDirectoryResponse, slug = 'kubernetes'): Promise<void> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PublicProjectGroupsComponent],
+      providers: [
+        { provide: GroupService, useValue: { getPublicProjectGroups: () => of(response) } },
+        { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['projectSlug', slug]])) } },
+        // <lfx-header/> deps — mocked directly rather than resolving the real LensService ->
+        // PersonaService -> AccountContextService chain, which needs far more than HttpClient.
+        { provide: UserService, useValue: { authenticated: signal(false), getCurrentUserProfile: vi.fn(() => of(null)) } },
+        { provide: LensService, useValue: { setLens: vi.fn() } },
+        { provide: ProjectService, useValue: { searchProjects: vi.fn(() => of([])) } },
+        { provide: AppService, useValue: { toggleMobileSidebar: vi.fn() } },
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PublicProjectGroupsComponent);
+    await fixture.whenStable();
+  }
+
+  it('renders the header foundation-name line with passing gray-500 contrast, not gray-400', async () => {
+    await render({ groups: [group()], total: 1 });
+
+    const line = fixture.nativeElement.querySelector('[data-testid="public-project-groups-foundation"]');
+    expect(line).not.toBeNull();
+    expect(line?.textContent?.trim()).toBe('Cloud Native Computing Foundation');
+    expect(line?.className).toContain('text-gray-500');
+    expect(line?.className).not.toContain('text-gray-400');
+  });
+
+  it('behavioral class chip has no hidden class at any breakpoint', async () => {
+    await render({ groups: [group()], total: 1 });
+
+    const chip = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-class-chip"]');
+    expect(chip).not.toBeNull();
+    const chipClasses = (chip?.getAttribute('class') ?? '').split(/\s+/);
+    expect(chipClasses.some((c: string) => c === 'hidden' || c.endsWith(':hidden'))).toBe(false);
+    expect(chipClasses).toContain('flex');
+    expect(chipClasses).toContain('shrink-0');
+  });
+
+  it('meta wrapper folds to display:contents at sm+, while the inner meta block keeps the growing flex class', async () => {
+    // Regression lock, mirroring org-groups.component.spec.ts (PR #1789): flex-1/min-w-0 must live
+    // on the inner meta block, not the sm:contents wrapper — display:contents gives the wrapper no
+    // box of its own at sm+, so flex classes placed there would silently stop applying.
+    await render({ groups: [group()], total: 1 });
+
+    const wrapper = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-meta-wrapper"]');
+    const block = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-meta-block"]');
+
+    expect(wrapper).not.toBeNull();
+    expect(block).not.toBeNull();
+    expect(wrapper?.contains(block)).toBe(true);
+    expect(wrapper?.className).toContain('sm:contents');
+
+    const blockClasses = (block?.className ?? '').split(/\s+/);
+    expect(blockClasses).toContain('flex-1');
+    expect(blockClasses).toContain('min-w-0');
+  });
+});

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -3,36 +3,18 @@
 
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
-import { AppService } from '@services/app.service';
 import { GroupService } from '@services/group.service';
-import { LensService } from '@services/lens.service';
-import { ProjectService } from '@services/project.service';
-import { UserService } from '@services/user.service';
+import { headerTestProviders, installMatchMediaShim } from '@shared/testing/header-test-providers';
 import { of } from 'rxjs';
-import { beforeAll, describe, expect, it, vi } from 'vitest';
+import { beforeAll, describe, expect, it } from 'vitest';
 
 import type { PublicGroupDirectoryResponse, PublicGroupSummary } from '@lfx-one/shared/interfaces';
 
 import { PublicProjectGroupsComponent } from './public-project-groups.component';
 
-// jsdom doesn't implement matchMedia; PrimeNG's Menubar (rendered inside <lfx-header/>) calls it
-// on init to bind a responsive listener.
-beforeAll(() => {
-  window.matchMedia ??= ((query: string) =>
-    ({
-      matches: false,
-      media: query,
-      onchange: null,
-      addListener: vi.fn(),
-      removeListener: vi.fn(),
-      addEventListener: vi.fn(),
-      removeEventListener: vi.fn(),
-      dispatchEvent: vi.fn(),
-    }) as unknown as MediaQueryList) as typeof window.matchMedia;
-});
+beforeAll(installMatchMediaShim);
 
 function group(over: Partial<PublicGroupSummary> = {}): PublicGroupSummary {
   return {
@@ -63,12 +45,7 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
       providers: [
         { provide: GroupService, useValue: { getPublicProjectGroups: () => of(response) } },
         { provide: ActivatedRoute, useValue: { paramMap: of(new Map([['projectSlug', slug]])) } },
-        // <lfx-header/> deps — mocked directly rather than resolving the real LensService ->
-        // PersonaService -> AccountContextService chain, which needs far more than HttpClient.
-        { provide: UserService, useValue: { authenticated: signal(false), getCurrentUserProfile: vi.fn(() => of(null)) } },
-        { provide: LensService, useValue: { setLens: vi.fn() } },
-        { provide: ProjectService, useValue: { searchProjects: vi.fn(() => of([])) } },
-        { provide: AppService, useValue: { toggleMobileSidebar: vi.fn() } },
+        ...headerTestProviders(),
         provideRouter([]),
         provideHttpClient(),
         provideHttpClientTesting(),
@@ -89,7 +66,12 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     expect(line?.className).not.toContain('text-gray-400');
   });
 
-  it('behavioral class chip has no hidden class at any breakpoint, and keeps its explicit flex + shrink-0', async () => {
+  it('behavioral class chip renders its label text and has no hidden class at any breakpoint, keeping its explicit flex + shrink-0', async () => {
+    // The label text itself is asserted, not just the chip's presence — the WCAG 1.4.1 fix this
+    // ticket makes is specifically that the behavioral class gains a *textual* signal on mobile
+    // beside the row icon's color (aria-hidden), so an empty pill would still pass a presence-only
+    // check without fixing the actual defect.
+    //
     // `flex` and `shrink-0` are asserted, not just the absence of `hidden`, because a "drop
     // redundant class" pass could silently regress both without failing any other assertion here:
     // without `flex` the host still renders (it blockifies to `block` as a flex item either way) —
@@ -100,6 +82,7 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
 
     const chip = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-class-chip"]');
     expect(chip).not.toBeNull();
+    expect(chip?.textContent?.trim()).toBe('Working Groups');
     const chipClasses = (chip?.getAttribute('class') ?? '').split(/\s+/);
     expect(chipClasses.some((c: string) => c === 'hidden' || c.endsWith(':hidden'))).toBe(false);
     expect(chipClasses).toContain('flex');
@@ -130,5 +113,18 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     const blockClasses = (block?.className ?? '').split(/\s+/);
     expect(blockClasses).toContain('flex-1');
     expect(blockClasses).toContain('min-w-0');
+  });
+
+  it('row keeps items-start/sm:items-center so the icon top-aligns against the stacked mobile column, not the desktop centering', async () => {
+    // Regression lock: without `items-start`, the icon and chevron would vertically center against
+    // the full two-line stacked column's height on mobile instead of aligning to its top — the same
+    // "drop redundant class" risk the other tests in this file guard against.
+    await render({ groups: [group()], total: 1 });
+
+    const row = fixture.nativeElement.querySelector('[data-testid^="public-project-groups-item-"]');
+    expect(row).not.toBeNull();
+    const rowClasses = (row?.className ?? '').split(/\s+/);
+    expect(rowClasses).toContain('items-start');
+    expect(rowClasses).toContain('sm:items-center');
   });
 });

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -106,10 +106,12 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     expect(chipClasses).toContain('shrink-0');
   });
 
-  it('meta wrapper folds to display:contents at sm+, while the inner meta block keeps the growing flex class', async () => {
-    // Regression lock: flex-1/min-w-0 must live on the inner meta block, not the sm:contents
-    // wrapper — display:contents gives the wrapper no box of its own at sm+, so flex classes
-    // placed there would silently stop applying and the block would collapse to content width.
+  it('meta wrapper folds to display:contents at sm+, while both wrapper and inner block keep their own growing flex classes', async () => {
+    // Regression lock: the wrapper's own flex-1/min-w-0 are load-bearing below `sm`, where it is
+    // still a real flex item of the row and min-w-0 is what lets the truncate'd name/description
+    // actually truncate. At sm+, `display: contents` gives the wrapper no box of its own, so those
+    // classes go inert there — which is why the inner meta block must carry its own copies too, or
+    // the block would collapse to content width once the wrapper stops applying them.
     await render({ groups: [group()], total: 1 });
 
     const wrapper = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-meta-wrapper"]');
@@ -119,6 +121,10 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     expect(block).not.toBeNull();
     expect(wrapper?.contains(block)).toBe(true);
     expect(wrapper?.className).toContain('sm:contents');
+
+    const wrapperClasses = (wrapper?.className ?? '').split(/\s+/);
+    expect(wrapperClasses).toContain('flex-1');
+    expect(wrapperClasses).toContain('min-w-0');
 
     const blockClasses = (block?.className ?? '').split(/\s+/);
     expect(blockClasses).toContain('flex-1');

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -121,7 +121,11 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     // "drop redundant class" risk the other tests in this file guard against.
     await render({ groups: [group()], total: 1 });
 
-    const row = fixture.nativeElement.querySelector('[data-testid^="public-project-groups-item-"]');
+    // Exact testid, not a `^=` prefix match — that prefix is shared by five descendant testids in
+    // this row (meta-wrapper, meta-block, name, desc, class-chip), so a prefix query would silently
+    // retarget one of them instead of failing loudly if the row's own testid is ever dropped or
+    // renamed.
+    const row = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]');
     expect(row).not.toBeNull();
     const rowClasses = (row?.className ?? '').split(/\s+/);
     expect(rowClasses).toContain('items-start');

--- a/apps/lfx-one/src/app/shared/testing/header-test-providers.ts
+++ b/apps/lfx-one/src/app/shared/testing/header-test-providers.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Provider, signal } from '@angular/core';
+import { AppService } from '@services/app.service';
+import { LensService } from '@services/lens.service';
+import { ProjectService } from '@services/project.service';
+import { UserService } from '@services/user.service';
+import { of } from 'rxjs';
+import { vi } from 'vitest';
+
+/**
+ * jsdom doesn't implement matchMedia; PrimeNG's Menubar (rendered inside <lfx-header/>) calls it
+ * on init to bind a responsive listener. Call once, e.g. in a `beforeAll`, before rendering any
+ * component tree that includes <lfx-header/>.
+ */
+export function installMatchMediaShim(): void {
+  window.matchMedia ??= ((query: string) =>
+    ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: vi.fn(),
+      removeListener: vi.fn(),
+      addEventListener: vi.fn(),
+      removeEventListener: vi.fn(),
+      dispatchEvent: vi.fn(),
+    }) as unknown as MediaQueryList) as typeof window.matchMedia;
+}
+
+/**
+ * Minimal mocks for <lfx-header/>'s direct service dependencies (Router is satisfied separately
+ * via `provideRouter([])`) — enough to render it unauthenticated without resolving the real
+ * LensService -> PersonaService -> AccountContextService chain.
+ */
+export function headerTestProviders(): Provider[] {
+  return [
+    { provide: UserService, useValue: { authenticated: signal(false), getCurrentUserProfile: vi.fn(() => of(null)) } },
+    { provide: LensService, useValue: { setLens: vi.fn() } },
+    { provide: ProjectService, useValue: { searchProjects: vi.fn(() => of([])) } },
+    { provide: AppService, useValue: { toggleMobileSidebar: vi.fn() } },
+  ];
+}


### PR DESCRIPTION
## Summary

Ports the two WCAG AA fixes from PR #1789 (`fix/GH-1782`, `/org/groups`) to
the two public group directory pages, per that PR's own explicit scoping
(it named these exact files/lines as out of scope and filed this ticket):

- **Contrast** — `text-gray-400` (`#90A1B9`, 2.63:1 on white) → `text-gray-500`
  (`#62748E`, 4.76:1, passes AA). Applied to the row project-name line in
  `public-foundation-groups.component.html` and the header foundation-name
  line in `public-project-groups.component.html`.
- **Mobile chip visibility** — the behavioral-class chip (Working Group / SIG
  / etc.) was `hidden sm:flex`, disappearing below the `sm` breakpoint and
  leaving only the row icon's color — `aria-hidden`, decorative — as a signal
  on mobile. Now visible at every breakpoint via an `sm:contents` wrapper that
  folds back into the unchanged desktop layout at `sm+`, matching the
  mechanism `org-groups.component.html` will use once #1789 lands.

Both target pages have a simpler row than `org-groups` (no separate
`peer`-hover overlay link — the row `<a>` itself is the flex container), so
the `sm:contents` wrapper sits directly inside it, and `items-center` →
`items-start sm:items-center` was added so the icon top-aligns against the
taller stacked mobile column instead of centering against it.

Neither component had a spec before this branch; both gained one, plus a
shared `apps/lfx-one/src/app/shared/testing/header-test-providers.ts` helper
(matchMedia jsdom shim + `<lfx-header/>` dependency mocks) extracted after
duplicating it once.

## Deliberate exclusions / deferred items

- **`role="listitem"` on the row `<a>`** — pre-existing on both pages (not
  introduced by this branch): an explicit ARIA role on an anchor overrides its
  implicit `link` role, so these rows are announced as plain list items to
  screen readers and drop out of the links rotor — a WCAG 4.1.2 defect.
  `org-groups.component.html` already has the correct pattern (role on a
  wrapping `<div>`, a separate stretched link inside) — copying it here is a
  real markup restructure (overlay anchor, `pointer-events` changes, retested
  focus/hover) well beyond this ticket's two named fixes. Left as-is;
  recommend a follow-up issue under epic #1776.
- **Truncated names have no tooltip/wrap fallback on narrow viewports** —
  pre-existing (the `truncate` classes predate this branch), same issue
  #1789 explicitly deferred for `org-groups` for the identical reason: the
  row's `aria-label` already exposes the full name to assistive tech; the
  gap is sighted narrow-viewport users only.
- **Spec assertions lock Tailwind class tokens, not computed layout/contrast**
  — jsdom evaluates no CSS, so a class-token assertion is the only
  unit-level lock available for a display/color fix, same trade-off
  `org-groups.component.spec.ts` documents for the identical `#1789` pattern.
  Real behavior verification would need the Playwright suite — not attempted
  here.

## Test plan

- [x] `yarn ng test --include='**/public-foundation-groups.component.spec.ts' --include='**/public-project-groups.component.spec.ts'` — 8/8 pass
- [x] Full suite (`yarn test`) — 691/691 pass
- [x] `yarn lint` — clean (one pre-existing unrelated warning in `user.service.ts`)
- [x] `yarn build` — succeeds
- [x] `./check-headers.sh` — passes

Closes #1791