### PR TITLE
fix(org-lens): fold influence trend top-N in SQL

### DIFF
--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -81,6 +81,8 @@ describe('OrgLensProjectDetailService.getTrendBlock', () => {
     expect(sql).toContain('MAX_BY(COMBINED_INFLUENCE_SCORE, SPAN_MONTH)');
     expect(sql).toContain("COALESCE(MAX(ORG_NAME), '') ASC");
     expect(sql).toContain('UNION ALL');
+    expect(sql).toContain('ORDER BY ACCOUNT_ID, SPAN_MONTH ASC');
+    expect(sql).not.toContain('IFF(');
     expect(placeholderCount(sql)).toBe(binds.length);
     expect(binds).toEqual([SLUG, 12, 10, 'All others', 10]);
   });
@@ -119,6 +121,8 @@ describe('OrgLensProjectDetailService.getTrendBlock', () => {
     expect(sql).toContain('ACCOUNT_ID IS NOT NULL');
     expect(sql).toContain("ACCOUNT_ID <> ''");
     expect(sql).toContain('ROW_NUMBER()');
+    expect(sql).toContain('ORDER BY ACCOUNT_ID, BUCKET_INDEX ASC');
+    expect(sql).not.toContain('IFF(');
     expect(placeholderCount(sql)).toBe(binds.length);
     expect(binds).toEqual([SLUG, 10, 'All others', 10]);
   });

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -74,6 +74,8 @@ describe('OrgLensProjectDetailService.getTrendBlock', () => {
 
     const { sql, binds } = trendCall();
     expect(sql).toContain("DATEADD('month', 1 - ?, MAX(SPAN_MONTH) OVER ())");
+    expect(sql).toContain('ACCOUNT_ID IS NOT NULL');
+    expect(sql).toContain("ACCOUNT_ID <> ''");
     expect(sql).toContain('ROW_NUMBER()');
     expect(sql).toContain('GROUP BY ACCOUNT_ID');
     expect(sql).toContain('MAX_BY(COMBINED_INFLUENCE_SCORE, SPAN_MONTH)');
@@ -114,6 +116,8 @@ describe('OrgLensProjectDetailService.getTrendBlock', () => {
     const { sql, binds } = lifetimeCall();
     expect(sql).not.toContain('DATEADD');
     expect(sql).toContain('ORG_LENS_PROJECT_DETAIL_TREND_LIFETIME');
+    expect(sql).toContain('ACCOUNT_ID IS NOT NULL');
+    expect(sql).toContain("ACCOUNT_ID <> ''");
     expect(sql).toContain('ROW_NUMBER()');
     expect(placeholderCount(sql)).toBe(binds.length);
     expect(binds).toEqual([SLUG, 10, 'All others', 10]);

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -1,0 +1,167 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execute } = vi.hoisted(() => ({ execute: vi.fn() }));
+
+vi.mock('./snowflake.service', () => ({
+  SnowflakeService: class {
+    public static getInstance() {
+      return { execute };
+    }
+    public static isMissingObjectError() {
+      return false;
+    }
+  },
+}));
+vi.mock('./valkey.service', () => ({
+  buildOrgCacheKey: () => null,
+  valkeyService: { getJson: vi.fn(), setJson: vi.fn() },
+}));
+vi.mock('@lfx-one/shared/utils', () => ({
+  buildInsightsUrl: () => '',
+  classifyHealthScore: () => 'unavailable',
+}));
+
+import { OrgLensProjectDetailService } from './org-lens-project-detail.service';
+
+const ORG = '0014100000Te2QjAAJ';
+const SLUG = 'k8s';
+
+const heroRow = {
+  PROJECT_NAME: 'Kubernetes',
+  PROJECT_SLUG: SLUG,
+  PROJECT_LOGO_URL: null,
+  FOUNDATION_NAME: 'CNCF',
+  IS_LF_PROJECT: true,
+  DESCRIPTION: null,
+  HEALTH_OVERALL_SCORE: 80,
+  SOFTWARE_VALUE: null,
+  FIRST_COMMIT_TS: null,
+};
+
+function trendCall(): { sql: string; binds: unknown[] } {
+  const call = execute.mock.calls.find(([sql]) => typeof sql === 'string' && sql.includes('ROW_NUMBER()') && sql.includes('SPAN_MONTH'));
+  expect(call).toBeDefined();
+  return { sql: call![0] as string, binds: call![1] as unknown[] };
+}
+
+function lifetimeCall(): { sql: string; binds: unknown[] } {
+  const call = execute.mock.calls.find(([sql]) => typeof sql === 'string' && sql.includes('ROW_NUMBER()') && sql.includes('BUCKET_INDEX'));
+  expect(call).toBeDefined();
+  return { sql: call![0] as string, binds: call![1] as unknown[] };
+}
+
+function placeholderCount(sql: string): number {
+  return (sql.match(/\?/g) ?? []).length;
+}
+
+describe('OrgLensProjectDetailService.getTrendBlock', () => {
+  const service = new OrgLensProjectDetailService();
+
+  beforeEach(() => {
+    execute.mockReset();
+  });
+
+  it('filters 1y to the trailing 12 months and folds top-10 + All others in SQL', async () => {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };
+      return { rows: [] };
+    });
+
+    await service.getTrendBlock(ORG, SLUG, '1y');
+
+    const { sql, binds } = trendCall();
+    expect(sql).toContain("DATEADD('month', 1 - ?, MAX(SPAN_MONTH) OVER ())");
+    expect(sql).toContain('ROW_NUMBER()');
+    expect(sql).toContain('GROUP BY ACCOUNT_ID');
+    expect(sql).toContain('MAX_BY(COMBINED_INFLUENCE_SCORE, SPAN_MONTH)');
+    expect(sql).toContain("COALESCE(MAX(ORG_NAME), '') ASC");
+    expect(sql).toContain('UNION ALL');
+    expect(placeholderCount(sql)).toBe(binds.length);
+    expect(binds).toEqual([SLUG, 12, 10, 'All others', 10]);
+  });
+
+  it('filters 2y to the trailing 24 months with the same fold', async () => {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };
+      return { rows: [] };
+    });
+
+    await service.getTrendBlock(ORG, SLUG, '2y');
+
+    const { binds } = trendCall();
+    expect(binds).toEqual([SLUG, 24, 10, 'All others', 10]);
+  });
+
+  it('folds the lifetime path without a month window', async () => {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };
+      if (sql.includes('BUCKET_GRANULARITY')) {
+        return {
+          rows: [
+            { BUCKET_INDEX: 0, BUCKET_GRANULARITY: 'yearly', BUCKET_START: '2016-01-01', BUCKET_END: '2016-12-31' },
+            { BUCKET_INDEX: 1, BUCKET_GRANULARITY: 'yearly', BUCKET_START: '2017-01-01', BUCKET_END: '2017-12-31' },
+          ],
+        };
+      }
+      return { rows: [] };
+    });
+
+    await service.getTrendBlock(ORG, SLUG, 'all');
+
+    const { sql, binds } = lifetimeCall();
+    expect(sql).not.toContain('DATEADD');
+    expect(sql).toContain('ORG_LENS_PROJECT_DETAIL_TREND_LIFETIME');
+    expect(sql).toContain('ROW_NUMBER()');
+    expect(placeholderCount(sql)).toBe(binds.length);
+    expect(binds).toEqual([SLUG, 10, 'All others', 10]);
+  });
+
+  it('maps already-folded rows without re-folding All others into the named set', async () => {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };
+      return {
+        rows: [
+          { ACCOUNT_ID: 'org-b', ORG_NAME: 'Beta', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 1 },
+          { ACCOUNT_ID: 'org-b', ORG_NAME: 'Beta', ORG_LOGO_URL: '', SPAN_MONTH: '2025-02-01', COMBINED_INFLUENCE_SCORE: 20 },
+          { ACCOUNT_ID: 'org-a', ORG_NAME: 'Alpha', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 2 },
+          { ACCOUNT_ID: 'org-a', ORG_NAME: 'Alpha', ORG_LOGO_URL: '', SPAN_MONTH: '2025-02-01', COMBINED_INFLUENCE_SCORE: 10 },
+          { ACCOUNT_ID: '', ORG_NAME: 'All others', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 30 },
+          { ACCOUNT_ID: '', ORG_NAME: 'All others', ORG_LOGO_URL: '', SPAN_MONTH: '2025-02-01', COMBINED_INFLUENCE_SCORE: 5 },
+        ],
+      };
+    });
+
+    const block = await service.getTrendBlock(ORG, SLUG, '1y');
+
+    expect(block?.trend.map((series) => series.orgName)).toEqual(['Beta', 'Alpha', 'All others']);
+    expect(block?.trend[0]?.combined).toEqual([1, 20]);
+    expect(block?.trend[1]?.combined).toEqual([2, 10]);
+    expect(block?.trend[2]?.combined).toEqual([30, 5]);
+    expect(block?.trend[2]?.accountId).toBe('');
+  });
+
+  it('breaks latest-score ties by organization name then account id', async () => {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };
+      return {
+        rows: [
+          { ACCOUNT_ID: 'acct-z', ORG_NAME: 'Zebra', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 4 },
+          { ACCOUNT_ID: 'acct-a', ORG_NAME: 'Alpha', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 4 },
+        ],
+      };
+    });
+
+    const block = await service.getTrendBlock(ORG, SLUG, '1y');
+
+    expect(block?.trend.map((series) => series.orgName)).toEqual(['Alpha', 'Zebra']);
+  });
+
+  it('returns null when the viewing org has no catalog row for the project', async () => {
+    execute.mockResolvedValue({ rows: [] });
+
+    await expect(service.getTrendBlock(ORG, SLUG, '1y')).resolves.toBeNull();
+  });
+});

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -143,6 +143,46 @@ describe('OrgLensProjectDetailService.getTrendBlock', () => {
     expect(block?.trend[2]?.accountId).toBe('');
   });
 
+  it('zero-fills a missing month on the shared axis instead of shifting later points', async () => {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };
+      return {
+        rows: [
+          { ACCOUNT_ID: 'org-b', ORG_NAME: 'Beta', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 1 },
+          { ACCOUNT_ID: 'org-b', ORG_NAME: 'Beta', ORG_LOGO_URL: '', SPAN_MONTH: '2025-02-01', COMBINED_INFLUENCE_SCORE: 20 },
+          { ACCOUNT_ID: 'org-b', ORG_NAME: 'Beta', ORG_LOGO_URL: '', SPAN_MONTH: '2025-03-01', COMBINED_INFLUENCE_SCORE: 8 },
+          { ACCOUNT_ID: 'org-a', ORG_NAME: 'Alpha', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 2 },
+          { ACCOUNT_ID: 'org-a', ORG_NAME: 'Alpha', ORG_LOGO_URL: '', SPAN_MONTH: '2025-03-01', COMBINED_INFLUENCE_SCORE: 9 },
+        ],
+      };
+    });
+
+    const block = await service.getTrendBlock(ORG, SLUG, '1y');
+
+    expect(block?.trend[0]?.orgName).toBe('Alpha');
+    expect(block?.trend[0]?.combined).toEqual([2, 0, 9]);
+    expect(block?.trend[1]?.orgName).toBe('Beta');
+    expect(block?.trend[1]?.combined).toEqual([1, 20, 8]);
+  });
+
+  it('treats the empty account-id sentinel as All others regardless of org name', async () => {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };
+      return {
+        rows: [
+          { ACCOUNT_ID: 'org-a', ORG_NAME: 'Alpha', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 4 },
+          { ACCOUNT_ID: '', ORG_NAME: 'the rest', ORG_LOGO_URL: '', SPAN_MONTH: '2025-01-01', COMBINED_INFLUENCE_SCORE: 7 },
+        ],
+      };
+    });
+
+    const block = await service.getTrendBlock(ORG, SLUG, '1y');
+
+    expect(block?.trend.map((series) => series.accountId)).toEqual(['org-a', '']);
+    expect(block?.trend[1]?.orgName).toBe('All others');
+    expect(block?.trend[1]?.combined).toEqual([7]);
+  });
+
   it('breaks latest-score ties by organization name then account id', async () => {
     execute.mockImplementation(async (sql: string) => {
       if (sql.includes('PROJECT_NAME')) return { rows: [heroRow] };

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -853,6 +853,8 @@ export class OrgLensProjectDetailService {
           SELECT ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ${periodColumn}, COMBINED_INFLUENCE_SCORE
           FROM ${table}
           WHERE PROJECT_SLUG = ?
+            AND ACCOUNT_ID IS NOT NULL
+            AND ACCOUNT_ID <> ''
           ${windowClause}
         ),
         ranked_orgs AS (

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1351,18 +1351,36 @@ export class OrgLensProjectDetailService {
     return labels.length > 0 ? [...new Set(labels)].join(', ') : 'LFX Insights';
   }
 
-  /** Group flat trend rows into per-org series (combined oldest → newest). */
+  /** Group flat trend rows into per-org series over the shared month axis (oldest → newest). */
   private buildTrendByAccount(rows: TrendRow[]): Map<string, TrendSeries> {
-    const byAccount = new Map<string, TrendSeries>();
+    const scoresByAccount = new Map<string, { orgName: string; orgLogoUrl: string; byMonth: Map<string, number> }>();
+    const months = new Set<string>();
     for (const row of rows) {
-      const key = this.trendSeriesKey(row.ACCOUNT_ID, row.ORG_NAME);
-      if (key === null) continue;
-      let series = byAccount.get(key);
-      if (!series) {
-        series = { accountId: key, orgName: row.ORG_NAME ?? '', orgLogoUrl: row.ORG_LOGO_URL ?? '', combined: [] };
-        byAccount.set(key, series);
+      const ym = this.toYearMonth(row.SPAN_MONTH);
+      if (!ym) continue;
+      months.add(ym);
+      const key = this.trendSeriesKey(row.ACCOUNT_ID);
+      let entry = scoresByAccount.get(key);
+      if (!entry) {
+        entry = {
+          orgName: key === '' ? OrgLensProjectDetailService.trendOthersLabel : (row.ORG_NAME ?? ''),
+          orgLogoUrl: row.ORG_LOGO_URL ?? '',
+          byMonth: new Map(),
+        };
+        scoresByAccount.set(key, entry);
       }
-      series.combined.push(this.round1(this.num(row.COMBINED_INFLUENCE_SCORE)));
+      entry.byMonth.set(ym, this.round1(this.num(row.COMBINED_INFLUENCE_SCORE)));
+    }
+
+    const axis = [...months].sort();
+    const byAccount = new Map<string, TrendSeries>();
+    for (const [accountId, entry] of scoresByAccount) {
+      byAccount.set(accountId, {
+        accountId,
+        orgName: entry.orgName,
+        orgLogoUrl: entry.orgLogoUrl,
+        combined: axis.map((ym) => entry.byMonth.get(ym) ?? 0),
+      });
     }
     return byAccount;
   }
@@ -1379,11 +1397,14 @@ export class OrgLensProjectDetailService {
     const scoresByAccount = new Map<string, { orgName: string; orgLogoUrl: string; byBucket: Map<number, number> }>();
     for (const row of rows) {
       if (row.BUCKET_INDEX === null || row.BUCKET_INDEX === undefined) continue;
-      const key = this.trendSeriesKey(row.ACCOUNT_ID, row.ORG_NAME);
-      if (key === null) continue;
+      const key = this.trendSeriesKey(row.ACCOUNT_ID);
       let entry = scoresByAccount.get(key);
       if (!entry) {
-        entry = { orgName: row.ORG_NAME ?? '', orgLogoUrl: row.ORG_LOGO_URL ?? '', byBucket: new Map() };
+        entry = {
+          orgName: key === '' ? OrgLensProjectDetailService.trendOthersLabel : (row.ORG_NAME ?? ''),
+          orgLogoUrl: row.ORG_LOGO_URL ?? '',
+          byBucket: new Map(),
+        };
         scoresByAccount.set(key, entry);
       }
       entry.byBucket.set(this.num(row.BUCKET_INDEX), this.round1(this.num(row.COMBINED_INFLUENCE_SCORE)));
@@ -1406,7 +1427,7 @@ export class OrgLensProjectDetailService {
     const named: TrendSeries[] = [];
     let others: TrendSeries | undefined;
     for (const series of byAccount.values()) {
-      if (series.orgName === OrgLensProjectDetailService.trendOthersLabel && series.accountId === '') {
+      if (series.accountId === '') {
         others = series;
       } else {
         named.push(series);
@@ -1735,9 +1756,8 @@ export class OrgLensProjectDetailService {
     return Math.round(value * 10) / 10;
   }
 
-  private trendSeriesKey(accountId: string | null, orgName: string | null): string | null {
-    if (!accountId && (orgName ?? '') === OrgLensProjectDetailService.trendOthersLabel) return '';
-    return accountId || null;
+  private trendSeriesKey(accountId: string | null): string {
+    return accountId || '';
   }
 
   private plural(n: number, singular: string, pluralForm: string): string {

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -886,7 +886,7 @@ export class OrgLensProjectDetailService {
         FROM ranked
         WHERE org_rank > ?
         GROUP BY ${periodColumn}
-        ORDER BY IFF(ACCOUNT_ID = '', 1, 0), ACCOUNT_ID, ${periodColumn} ASC
+        ORDER BY ACCOUNT_ID, ${periodColumn} ASC
       `,
       binds
     );

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DEFAULT_LFX_ONE_PLATINUM_SCHEMA, PD_HEALTH_TAG, PD_TIME_RANGE_TYPE, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import { DEFAULT_LFX_ONE_PLATINUM_SCHEMA, PD_HEALTH_TAG, PD_TIME_RANGE_MONTHS, PD_TIME_RANGE_TYPE, VALKEY_CACHE } from '@lfx-one/shared/constants';
 import type {
   OrgLensCardDetailCell,
   OrgLensCardDetailRow,
@@ -217,10 +217,11 @@ interface LeaderboardRow {
  */
 export class OrgLensProjectDetailService {
   // Number of individually-named orgs in the stacked trend; every remaining org is folded into a
-  // single "All others" band server-side so the chart still reflects the FULL project-wide
-  // influence distribution (a raw top-N truncation would drop the tail and inflate the leaders'
-  // normalized shares on projects with many orgs).
+  // single "All others" band in SQL so the chart still reflects the FULL project-wide influence
+  // distribution (a raw top-N truncation would drop the tail and inflate the leaders' normalized
+  // shares on projects with many orgs).
   private static readonly trendNamedOrgCap = 10;
+  private static readonly trendOthersLabel = 'All others';
 
   // Sparklines are emitted as a dense, contiguous, current-month-anchored monthly array; the
   // shipped component maps points to a fixed 36-month label axis by position and slices per range.
@@ -498,7 +499,7 @@ export class OrgLensProjectDetailService {
     // Gate on the (org, slug) catalog row like every other block, so project-wide trend is not
     // served for a project the org has no activity on (and the 404 stays consistent across blocks).
     // `all`: read the adaptive lifetime-bucketed trend + its shared bucket axis (periods[], D7/D9).
-    // 1y/2y: read the trailing recent-monthly trend; the client slices to 12/24 and derives labels.
+    // 1y/2y: read the trailing recent-monthly trend already range-filtered and top-N folded in SQL.
     let block: OrgLensTrendBlock;
     if (range === 'all') {
       const [heroRow, trendRows, axis] = await Promise.all([this.fetchHeroRow(orgUid, slug), this.fetchTrendLifetime(slug), this.fetchLifetimeAxis(slug)]);
@@ -513,7 +514,7 @@ export class OrgLensProjectDetailService {
         periods: axis.map((bucket) => bucket.label),
       };
     } else {
-      const [heroRow, trendRows] = await Promise.all([this.fetchHeroRow(orgUid, slug), this.fetchTrend(slug)]);
+      const [heroRow, trendRows] = await Promise.all([this.fetchHeroRow(orgUid, slug), this.fetchTrend(slug, PD_TIME_RANGE_MONTHS[range])]);
       if (!heroRow) return null;
       block = { trend: this.buildTrendSeries(this.buildTrendByAccount(trendRows)) };
     }
@@ -829,29 +830,63 @@ export class OrgLensProjectDetailService {
     return result.rows;
   }
 
-  private async fetchTrend(slug: string): Promise<TrendRow[]> {
-    const result = await this.snowflakeService.execute<TrendRow>(
-      `
-        SELECT ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, SPAN_MONTH, COMBINED_INFLUENCE_SCORE
-        FROM ${this.trendTable()}
-        WHERE PROJECT_SLUG = ?
-        ORDER BY ACCOUNT_ID, SPAN_MONTH ASC
-      `,
-      [slug]
-    );
-    return result.rows;
+  private async fetchTrend(slug: string, windowMonths: number): Promise<TrendRow[]> {
+    return this.fetchFoldedTrend<TrendRow>(slug, this.trendTable(), 'SPAN_MONTH', windowMonths);
   }
 
   /** All-time trend: per-(account, bucket) combined scores over the project's shared lifetime bucket axis. */
   private async fetchTrendLifetime(slug: string): Promise<TrendLifetimeRow[]> {
-    const result = await this.snowflakeService.execute<TrendLifetimeRow>(
+    return this.fetchFoldedTrend<TrendLifetimeRow>(slug, this.trendLifetimeTable(), 'BUCKET_INDEX');
+  }
+
+  private async fetchFoldedTrend<T>(slug: string, table: string, periodColumn: 'SPAN_MONTH' | 'BUCKET_INDEX', windowMonths?: number): Promise<T[]> {
+    const cap = OrgLensProjectDetailService.trendNamedOrgCap;
+    const others = OrgLensProjectDetailService.trendOthersLabel;
+    const windowClause = windowMonths === undefined ? '' : `QUALIFY ${periodColumn} >= DATEADD('month', 1 - ?, MAX(${periodColumn}) OVER ())`;
+    const binds: (string | number)[] = [slug];
+    if (windowMonths !== undefined) binds.push(windowMonths);
+    binds.push(cap, others, cap);
+
+    const result = await this.snowflakeService.execute<T>(
       `
-        SELECT ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, BUCKET_INDEX, COMBINED_INFLUENCE_SCORE
-        FROM ${this.trendLifetimeTable()}
-        WHERE PROJECT_SLUG = ?
-        ORDER BY ACCOUNT_ID, BUCKET_INDEX ASC
+        WITH windowed AS (
+          SELECT ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ${periodColumn}, COMBINED_INFLUENCE_SCORE
+          FROM ${table}
+          WHERE PROJECT_SLUG = ?
+          ${windowClause}
+        ),
+        ranked_orgs AS (
+          SELECT
+            ACCOUNT_ID,
+            ROW_NUMBER() OVER (
+              ORDER BY MAX_BY(COMBINED_INFLUENCE_SCORE, ${periodColumn}) DESC NULLS LAST,
+                       COALESCE(MAX(ORG_NAME), '') ASC,
+                       ACCOUNT_ID ASC
+            ) AS org_rank
+          FROM windowed
+          GROUP BY ACCOUNT_ID
+        ),
+        ranked AS (
+          SELECT w.ACCOUNT_ID, w.ORG_NAME, w.ORG_LOGO_URL, w.${periodColumn}, w.COMBINED_INFLUENCE_SCORE, r.org_rank
+          FROM windowed w
+          JOIN ranked_orgs r ON r.ACCOUNT_ID = w.ACCOUNT_ID
+        )
+        SELECT ACCOUNT_ID, ORG_NAME, ORG_LOGO_URL, ${periodColumn}, COMBINED_INFLUENCE_SCORE
+        FROM ranked
+        WHERE org_rank <= ?
+        UNION ALL
+        SELECT
+          '' AS ACCOUNT_ID,
+          ? AS ORG_NAME,
+          '' AS ORG_LOGO_URL,
+          ${periodColumn},
+          SUM(COMBINED_INFLUENCE_SCORE) AS COMBINED_INFLUENCE_SCORE
+        FROM ranked
+        WHERE org_rank > ?
+        GROUP BY ${periodColumn}
+        ORDER BY IFF(ACCOUNT_ID = '', 1, 0), ACCOUNT_ID, ${periodColumn} ASC
       `,
-      [slug]
+      binds
     );
     return result.rows;
   }
@@ -1320,12 +1355,12 @@ export class OrgLensProjectDetailService {
   private buildTrendByAccount(rows: TrendRow[]): Map<string, TrendSeries> {
     const byAccount = new Map<string, TrendSeries>();
     for (const row of rows) {
-      const accountId = row.ACCOUNT_ID;
-      if (!accountId) continue;
-      let series = byAccount.get(accountId);
+      const key = this.trendSeriesKey(row.ACCOUNT_ID, row.ORG_NAME);
+      if (key === null) continue;
+      let series = byAccount.get(key);
       if (!series) {
-        series = { accountId, orgName: row.ORG_NAME ?? '', orgLogoUrl: row.ORG_LOGO_URL ?? '', combined: [] };
-        byAccount.set(accountId, series);
+        series = { accountId: key, orgName: row.ORG_NAME ?? '', orgLogoUrl: row.ORG_LOGO_URL ?? '', combined: [] };
+        byAccount.set(key, series);
       }
       series.combined.push(this.round1(this.num(row.COMBINED_INFLUENCE_SCORE)));
     }
@@ -1343,12 +1378,13 @@ export class OrgLensProjectDetailService {
   private buildTrendLifetimeByAccount(rows: TrendLifetimeRow[], axis: number[]): Map<string, TrendSeries> {
     const scoresByAccount = new Map<string, { orgName: string; orgLogoUrl: string; byBucket: Map<number, number> }>();
     for (const row of rows) {
-      const accountId = row.ACCOUNT_ID;
-      if (!accountId || row.BUCKET_INDEX === null || row.BUCKET_INDEX === undefined) continue;
-      let entry = scoresByAccount.get(accountId);
+      if (row.BUCKET_INDEX === null || row.BUCKET_INDEX === undefined) continue;
+      const key = this.trendSeriesKey(row.ACCOUNT_ID, row.ORG_NAME);
+      if (key === null) continue;
+      let entry = scoresByAccount.get(key);
       if (!entry) {
         entry = { orgName: row.ORG_NAME ?? '', orgLogoUrl: row.ORG_LOGO_URL ?? '', byBucket: new Map() };
-        scoresByAccount.set(accountId, entry);
+        scoresByAccount.set(key, entry);
       }
       entry.byBucket.set(this.num(row.BUCKET_INDEX), this.round1(this.num(row.COMBINED_INFLUENCE_SCORE)));
     }
@@ -1365,31 +1401,26 @@ export class OrgLensProjectDetailService {
     return byAccount;
   }
 
-  /**
-   * Wire trend payload: the top-N orgs by most-recent-month combined score as individual series,
-   * plus a single "All others" series that sums EVERY remaining org month-by-month. Folding the
-   * complete tail (rather than truncating it) keeps the payload bounded while preserving the true
-   * project-wide distribution the client normalizes to 100%.
-   */
   private buildTrendSeries(byAccount: Map<string, TrendSeries>): OrgLensProjectTrendSeries[] {
     const latest = (series: TrendSeries): number => series.combined[series.combined.length - 1] ?? 0;
-    const sorted = [...byAccount.values()].sort((a, b) => latest(b) - latest(a));
-    const named = sorted.slice(0, OrgLensProjectDetailService.trendNamedOrgCap);
-    const rest = sorted.slice(OrgLensProjectDetailService.trendNamedOrgCap);
-
-    const series: OrgLensProjectTrendSeries[] = named.map((s) => ({
-      accountId: s.accountId,
-      orgName: s.orgName,
-      orgLogoUrl: s.orgLogoUrl,
-      combined: s.combined,
-    }));
-
-    if (rest.length > 0) {
-      const len = rest.reduce((max, s) => Math.max(max, s.combined.length), 0);
-      const combined = Array.from({ length: len }, (_, i) => this.round1(rest.reduce((sum, s) => sum + (s.combined[i] ?? 0), 0)));
-      series.push({ accountId: '', orgName: 'All others', orgLogoUrl: '', combined });
+    const named: TrendSeries[] = [];
+    let others: TrendSeries | undefined;
+    for (const series of byAccount.values()) {
+      if (series.orgName === OrgLensProjectDetailService.trendOthersLabel && series.accountId === '') {
+        others = series;
+      } else {
+        named.push(series);
+      }
     }
-
+    named.sort((a, b) => latest(b) - latest(a) || a.orgName.localeCompare(b.orgName) || a.accountId.localeCompare(b.accountId));
+    const toWire = (series: TrendSeries): OrgLensProjectTrendSeries => ({
+      accountId: series.accountId,
+      orgName: series.orgName,
+      orgLogoUrl: series.orgLogoUrl,
+      combined: series.combined,
+    });
+    const series = named.map(toWire);
+    if (others !== undefined) series.push(toWire(others));
     return series;
   }
 
@@ -1702,6 +1733,11 @@ export class OrgLensProjectDetailService {
 
   private round1(value: number): number {
     return Math.round(value * 10) / 10;
+  }
+
+  private trendSeriesKey(accountId: string | null, orgName: string | null): string | null {
+    if (!accountId && (orgName ?? '') === OrgLensProjectDetailService.trendOthersLabel) return '';
+    return accountId || null;
   }
 
   private plural(n: number, singular: string, pluralForm: string): string {

--- a/docs/architecture/backend/snowflake-integration.md
+++ b/docs/architecture/backend/snowflake-integration.md
@@ -516,8 +516,8 @@ SNOWFLAKE_ROLE=
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=your-passphrase-here
 
 # Optional: Connection Pool Configuration (defaults shown)
-# SNOWFLAKE_MIN_CONNECTIONS=2
-# SNOWFLAKE_MAX_CONNECTIONS=10
+# SNOWFLAKE_MIN_CONNECTIONS=0
+# SNOWFLAKE_MAX_CONNECTIONS=20
 
 # Optional: Lock Strategy for Query Deduplication (defaults to 'memory')
 # SNOWFLAKE_LOCK_STRATEGY=memory
@@ -539,13 +539,19 @@ SNOWFLAKE_ROLE=
 ```typescript
 // packages/shared/src/constants/snowflake.constant.ts
 export const SNOWFLAKE_CONFIG = {
-  // Timeouts
-  DEFAULT_QUERY_TIMEOUT: 60000, // 60 seconds
+  // Timeouts — DEFAULT_QUERY_TIMEOUT covers pool wait + execution + result transfer
+  DEFAULT_QUERY_TIMEOUT: 15000, // 15 seconds (fail-fast; was 60s)
   CONNECTION_TIMEOUT: 30000, // 30 seconds
+  CONNECTION_ACQUIRE_TIMEOUT: 15000, // 15 seconds
 
   // Pool configuration
-  MIN_CONNECTIONS: 2,
-  MAX_CONNECTIONS: 10,
+  MIN_CONNECTIONS: 0, // on-demand; no eager warm-up
+  MAX_CONNECTIONS: 20,
+  MAX_WAITING_CLIENTS: 10,
+
+  // Circuit breaker (omitted from older copies of this snippet)
+  CIRCUIT_BREAKER_FAILURE_THRESHOLD: 5,
+  CIRCUIT_BREAKER_RESET_TIMEOUT_MS: 60000, // 60 seconds
 
   // Lock management
   LOCK_CLEANUP_INTERVAL: 60000, // 60 seconds
@@ -842,13 +848,18 @@ Solution:
 #### 3. Query Timeout
 
 ```text
-Error: Query execution timeout
-Cause: Query taking longer than configured timeout
+Error: Snowflake query timed out after 15000ms
+Cause: The BFF Promise.race ceiling (SNOWFLAKE_CONFIG.DEFAULT_QUERY_TIMEOUT, 15s)
+  covers pool acquire + warehouse execution + downloading/materializing rows.
+  Snowflake QUERY_HISTORY can still show SUCCESS in <1s while this error fires —
+  that is a result-transfer / over-fetch failure, not a slow warehouse.
 Solution:
-  1. Optimize query with indexes/partitions
-  2. Increase SNOWFLAKE_CONFIG.DEFAULT_QUERY_TIMEOUT
-  3. Consider breaking into smaller queries
-  4. Check Snowflake warehouse size
+  1. Check whether the query returns far more rows than the wire shape needs
+     (fold/filter/limit in SQL; do not raise the timeout to paper over it)
+  2. Confirm QUERY_HISTORY elapsed time; if the warehouse was fast, do not
+     resize the warehouse and do not raise DEFAULT_QUERY_TIMEOUT
+  3. Only if QUERY_HISTORY itself is slow: optimize the SQL, then consider
+     warehouse size as a last resort
 ```
 
 #### 4. Read-Only Validation Failure

--- a/docs/architecture/backend/snowflake-integration.md
+++ b/docs/architecture/backend/snowflake-integration.md
@@ -516,8 +516,8 @@ SNOWFLAKE_ROLE=
 # SNOWFLAKE_PRIVATE_KEY_PASSPHRASE=your-passphrase-here
 
 # Optional: Connection Pool Configuration (defaults shown)
-# SNOWFLAKE_MIN_CONNECTIONS=0
-# SNOWFLAKE_MAX_CONNECTIONS=20
+# SNOWFLAKE_MIN_CONNECTIONS=2
+# SNOWFLAKE_MAX_CONNECTIONS=10
 
 # Optional: Lock Strategy for Query Deduplication (defaults to 'memory')
 # SNOWFLAKE_LOCK_STRATEGY=memory
@@ -539,19 +539,13 @@ SNOWFLAKE_ROLE=
 ```typescript
 // packages/shared/src/constants/snowflake.constant.ts
 export const SNOWFLAKE_CONFIG = {
-  // Timeouts — DEFAULT_QUERY_TIMEOUT covers pool wait + execution + result transfer
-  DEFAULT_QUERY_TIMEOUT: 15000, // 15 seconds (fail-fast; was 60s)
+  // Timeouts
+  DEFAULT_QUERY_TIMEOUT: 60000, // 60 seconds
   CONNECTION_TIMEOUT: 30000, // 30 seconds
-  CONNECTION_ACQUIRE_TIMEOUT: 15000, // 15 seconds
 
   // Pool configuration
-  MIN_CONNECTIONS: 0, // on-demand; no eager warm-up
-  MAX_CONNECTIONS: 20,
-  MAX_WAITING_CLIENTS: 10,
-
-  // Circuit breaker (omitted from older copies of this snippet)
-  CIRCUIT_BREAKER_FAILURE_THRESHOLD: 5,
-  CIRCUIT_BREAKER_RESET_TIMEOUT_MS: 60000, // 60 seconds
+  MIN_CONNECTIONS: 2,
+  MAX_CONNECTIONS: 10,
 
   // Lock management
   LOCK_CLEANUP_INTERVAL: 60000, // 60 seconds
@@ -848,18 +842,13 @@ Solution:
 #### 3. Query Timeout
 
 ```text
-Error: Snowflake query timed out after 15000ms
-Cause: The BFF Promise.race ceiling (SNOWFLAKE_CONFIG.DEFAULT_QUERY_TIMEOUT, 15s)
-  covers pool acquire + warehouse execution + downloading/materializing rows.
-  Snowflake QUERY_HISTORY can still show SUCCESS in <1s while this error fires —
-  that is a result-transfer / over-fetch failure, not a slow warehouse.
+Error: Query execution timeout
+Cause: Query taking longer than configured timeout
 Solution:
-  1. Check whether the query returns far more rows than the wire shape needs
-     (fold/filter/limit in SQL; do not raise the timeout to paper over it)
-  2. Confirm QUERY_HISTORY elapsed time; if the warehouse was fast, do not
-     resize the warehouse and do not raise DEFAULT_QUERY_TIMEOUT
-  3. Only if QUERY_HISTORY itself is slow: optimize the SQL, then consider
-     warehouse size as a last resort
+  1. Optimize query with indexes/partitions
+  2. Increase SNOWFLAKE_CONFIG.DEFAULT_QUERY_TIMEOUT
+  3. Consider breaking into smaller queries
+  4. Check Snowflake warehouse size
 ```
 
 #### 4. Read-Only Validation Failure


### PR DESCRIPTION
## Summary

- Fold the Org Lens Project Detail influence trend in Snowflake: rank organizations by most-recent-period combined score, keep the top 10 named series, and `SUM` the tail into one **All others** band so cold-cache `1y`/`2y` reads no longer materialize hundreds of thousands of rows in the BFF.
- Apply a trailing-month predicate on `SPAN_MONTH` for `1y` (12) and `2y` (24); the lifetime path gets the same org-grain fold without a month window.
- Place monthly series by `SPAN_MONTH` on a shared axis (zero-fill gaps) and identify the All others band by the empty `ACCOUNT_ID` sentinel.

Fixes [LFXV2-3284](https://linuxfoundation.atlassian.net/browse/LFXV2-3284) (split from [LFXV2-3231](https://linuxfoundation.atlassian.net/browse/LFXV2-3231)).

## Test plan

- [x] `yarn workspace lfx-one-ui test:server src/server/services/org-lens-project-detail.service.spec.ts`
- [x] `yarn check-types` and `yarn lint:check`
- [x] `yarn build`
- [ ] Cold `GET /api/orgs/{accountId}/lens/projects/k8s/trend?range=1y` returns in well under 15s with ~11 series (10 named + All others)
- [ ] Same for `range=2y` and `range=all`; chart composition unchanged (latest-period rank, deterministic name/`ACCOUNT_ID` tie-break)
- [ ] Projects with ≤10 orgs have no All others band

[LFXV2-3284]: https://linuxfoundation.atlassian.net/browse/LFXV2-3284?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[LFXV2-3231]: https://linuxfoundation.atlassian.net/browse/LFXV2-3231?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ