### PR TITLE
fix(cla): release Sign CLA after picker dismiss via header X

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -439,8 +439,8 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
       prepare?: () => Observable<PrepareSignResponse>;
       closesWith?: ClaGroupOption | null;
       accountClosesWith?: string | null;
-      dismissGroup?: 'close' | 'destroy';
-      dismissAccount?: 'close' | 'destroy';
+      dismissGroup?: 'close' | 'destroy' | 'hold';
+      dismissAccount?: 'close' | 'destroy' | 'hold';
     } = {}
   ): Promise<ComponentFixture<ProfileClasComponent>> {
     location = { href: HOME };
@@ -527,7 +527,10 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     return () => throwError(() => ({ status, error: { error: message, code: status === 403 ? 'FORBIDDEN' : 'UPSTREAM_ERROR' } }));
   }
 
-  function dialogEvents(closeValue: unknown, dismiss: 'close' | 'destroy'): { onClose: Observable<unknown>; onDestroy: Observable<unknown> } {
+  function dialogEvents(closeValue: unknown, dismiss: 'close' | 'destroy' | 'hold'): { onClose: Observable<unknown>; onDestroy: Observable<unknown> } {
+    if (dismiss === 'hold') {
+      return { onClose: EMPTY, onDestroy: EMPTY };
+    }
     if (dismiss === 'destroy') {
       return { onClose: EMPTY, onDestroy: of(undefined) };
     }
@@ -600,6 +603,18 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     await sign(fixture);
     await Promise.resolve();
     expect(opened.filter((component) => component === ClaGroupSelectComponent)).toHaveLength(2);
+  });
+
+  it('does not spin Sign CLA while the project picker is still open', async () => {
+    const fixture = await setup({ dismissGroup: 'hold' });
+
+    await sign(fixture);
+
+    expect(isStarting(fixture)).toBe(false);
+    expect(getGithubAccounts).not.toHaveBeenCalled();
+
+    await sign(fixture);
+    expect(opened.filter((component) => component === ClaGroupSelectComponent)).toHaveLength(1);
   });
 
   // --- Cardinality (FR-002) -------------------------------------------------

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -704,6 +704,23 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     expect(prepareSign).not.toHaveBeenCalled();
     expect(isStarting(fixture)).toBe(false);
     expect(location.href).toBe(HOME);
+
+    await sign(fixture);
+    await Promise.resolve();
+    expect(opened.filter((component) => component === ClaGroupSelectComponent)).toHaveLength(2);
+  });
+
+  it('does not spin Sign CLA while the account picker is still open', async () => {
+    const fixture = await setup({ dismissAccount: 'hold' });
+
+    await sign(fixture);
+
+    expect(opened).toContain(GithubAccountSelectComponent);
+    expect(isStarting(fixture)).toBe(false);
+    expect(prepareSign).not.toHaveBeenCalled();
+
+    await sign(fixture);
+    expect(opened.filter((component) => component === ClaGroupSelectComponent)).toHaveLength(1);
   });
 
   // --- Where the hand-off address comes from (FR-004, FR-006) ---------------

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -28,7 +28,7 @@ import { MyClasService } from '@services/my-clas.service';
 import { UserService } from '@services/user.service';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService } from 'primeng/dynamicdialog';
-import { Observable, of, Subject, throwError } from 'rxjs';
+import { EMPTY, Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ClaGroupSelectComponent } from './cla-group-select.component';
@@ -439,6 +439,8 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
       prepare?: () => Observable<PrepareSignResponse>;
       closesWith?: ClaGroupOption | null;
       accountClosesWith?: string | null;
+      dismissGroup?: 'close' | 'destroy';
+      dismissAccount?: 'close' | 'destroy';
     } = {}
   ): Promise<ComponentFixture<ProfileClasComponent>> {
     location = { href: HOME };
@@ -453,9 +455,9 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     open = vi.fn((component: unknown) => {
       opened.push(component);
       if (component === GithubAccountSelectComponent) {
-        return { onClose: of('accountClosesWith' in options ? options.accountClosesWith : '12345') };
+        return dialogEvents('accountClosesWith' in options ? options.accountClosesWith : '12345', options.dismissAccount ?? 'close');
       }
-      return { onClose: of('closesWith' in options ? options.closesWith : CLA_GROUP) };
+      return dialogEvents('closesWith' in options ? options.closesWith : CLA_GROUP, options.dismissGroup ?? 'close');
     });
 
     TestBed.configureTestingModule({
@@ -525,6 +527,17 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     return () => throwError(() => ({ status, error: { error: message, code: status === 403 ? 'FORBIDDEN' : 'UPSTREAM_ERROR' } }));
   }
 
+  function dialogEvents(closeValue: unknown, dismiss: 'close' | 'destroy'): { onClose: Observable<unknown>; onDestroy: Observable<unknown> } {
+    if (dismiss === 'destroy') {
+      return { onClose: EMPTY, onDestroy: of(undefined) };
+    }
+    return { onClose: of(closeValue), onDestroy: of(undefined) };
+  }
+
+  function isStarting(fixture: ComponentFixture<ProfileClasComponent>): boolean {
+    return (fixture.componentInstance as any).starting();
+  }
+
   beforeEach(() => {
     TestBed.resetTestingModule();
   });
@@ -571,6 +584,22 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     expect(getGithubAccounts).not.toHaveBeenCalled();
     expect(prepareSign).not.toHaveBeenCalled();
     expect(location.href).toBe(HOME);
+    expect(isStarting(fixture)).toBe(false);
+  });
+
+  it('releases Sign CLA when the project picker is destroyed without onClose (header X)', async () => {
+    const fixture = await setup({ dismissGroup: 'destroy' });
+
+    await sign(fixture);
+    await Promise.resolve();
+
+    expect(getGithubAccounts).not.toHaveBeenCalled();
+    expect(prepareSign).not.toHaveBeenCalled();
+    expect(isStarting(fixture)).toBe(false);
+
+    await sign(fixture);
+    await Promise.resolve();
+    expect(opened.filter((component) => component === ClaGroupSelectComponent)).toHaveLength(2);
   });
 
   // --- Cardinality (FR-002) -------------------------------------------------
@@ -647,6 +676,18 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     await sign(fixture);
 
     expect(prepareSign).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
+    expect(isStarting(fixture)).toBe(false);
+  });
+
+  it('releases Sign CLA when the account picker is destroyed without onClose (header X)', async () => {
+    const fixture = await setup({ dismissAccount: 'destroy' });
+
+    await sign(fixture);
+    await Promise.resolve();
+
+    expect(prepareSign).not.toHaveBeenCalled();
+    expect(isStarting(fixture)).toBe(false);
     expect(location.href).toBe(HOME);
   });
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -74,6 +74,11 @@ export class ProfileClasComponent {
   // signatureID currently resolving a PDF URL (drives the row's spinner + guards double-clicks).
   protected readonly downloadingId = signal<string | null>(null);
 
+  /** True while the chosen group's hand-off URL is being resolved; also guards a double hand-off. */
+  protected readonly starting = signal(false);
+
+  private readonly signDialogOpen = signal(false);
+
   private readonly refresh$ = new BehaviorSubject<void>(undefined);
 
   private readonly state = this.initState();
@@ -102,9 +107,6 @@ export class ProfileClasComponent {
    */
   protected readonly canSign = computed(() => this.myClasM2Enabled() && !this.userService.impersonating());
 
-  /** True while the chosen group's hand-off URL is being resolved; also guards a double hand-off. */
-  protected readonly starting = signal(false);
-
   protected retry(): void {
     this.refresh$.next();
   }
@@ -121,11 +123,8 @@ export class ProfileClasComponent {
    * dialog rule and the sibling profile tabs.
    */
   protected openSignDialog(): void {
-    // Guarded from the moment the picker opens, not from when a group is chosen. `starting` is
-    // only set once the hand-off begins, which leaves the button live for as long as the picker
-    // is open — long enough to open a second one and bind twice.
-    if (!this.myClasM2Enabled() || this.starting()) return;
-    this.starting.set(true);
+    if (!this.myClasM2Enabled() || this.starting() || this.signDialogOpen()) return;
+    this.signDialogOpen.set(true);
 
     const dialogRef = this.dialogService.open(ClaGroupSelectComponent, {
       header: 'Sign a CLA',
@@ -135,7 +134,8 @@ export class ProfileClasComponent {
       dismissableMask: true,
     }) as DynamicDialogRef;
 
-    dialogRef.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((option: ClaGroupOption | null | undefined) => {
+    this.whenDialogSettles<ClaGroupOption>(dialogRef, (option) => {
+      this.signDialogOpen.set(false);
       if (!option) {
         this.starting.set(false);
         return;
@@ -180,8 +180,7 @@ export class ProfileClasComponent {
    * contributor had already signed by the time anyone knew as whom.
    */
   private handOffToConsole(option: ClaGroupOption): void {
-    // Already flagged as in flight by `openSignDialog`, which owns the guard because the window
-    // worth guarding opens with the picker rather than with this call.
+    this.starting.set(true);
     this.myClasService
       .getGithubAccounts()
       .pipe(takeUntilDestroyed(this.destroyRef))
@@ -238,6 +237,9 @@ export class ProfileClasComponent {
       return;
     }
 
+    this.starting.set(false);
+    this.signDialogOpen.set(true);
+
     const dialogRef = this.dialogService.open(GithubAccountSelectComponent, {
       header: 'Choose a GitHub account',
       width: '32rem',
@@ -247,7 +249,8 @@ export class ProfileClasComponent {
       data: { accounts },
     }) as DynamicDialogRef;
 
-    dialogRef.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((githubId: string | null | undefined) => {
+    this.whenDialogSettles<string>(dialogRef, (githubId) => {
+      this.signDialogOpen.set(false);
       if (!githubId) {
         this.starting.set(false);
         return;
@@ -265,6 +268,23 @@ export class ProfileClasComponent {
       }
 
       this.prepareThenHandOff(option, chosen);
+    });
+  }
+
+  private whenDialogSettles<T>(dialogRef: DynamicDialogRef, onSettle: (value: T | null | undefined) => void): void {
+    let closed = false;
+
+    dialogRef.onClose.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe((value: T | null | undefined) => {
+      closed = true;
+      onSettle(value);
+    });
+
+    dialogRef.onDestroy.pipe(take(1), takeUntilDestroyed(this.destroyRef)).subscribe(() => {
+      queueMicrotask(() => {
+        if (!closed) {
+          onSettle(undefined);
+        }
+      });
     });
   }
 


### PR DESCRIPTION
Closes #1797

## Summary
- Release the Sign CLA loading state when the CLA-group (or GitHub-account) picker is dismissed with the header X, Escape, or a mask click.
- PrimeNG 20 destroys a DynamicDialog without emitting `onClose` on those paths, so the button previously stayed spinning until a full reload. Cancel already recovered because it calls `ref.close(null)`.
- Spinner now only runs during the actual hand-off, not while the picker is open.

## Out of scope (intentionally)
- Upgrading PrimeNG to pick up the upstream `onClose` fix.
- Changing search, selection, or prepare-sign behavior.

## Test plan
- [ ] Profile → CLAs (`my-clas-m2-enabled` on): Sign CLA → search/select a group → header **X**. Button returns to idle and can be clicked again.
- [ ] Same flow, **Cancel**: still idle, no hand-off.
- [ ] Same flow, **Continue to sign** with one GitHub account: still hands off.
- [ ] Several GitHub accounts: dismiss the account picker with **X**; Sign CLA is idle again.
- [ ] `yarn workspace lfx-one-ui ng test --include='**/profile-clas.component.spec.ts'`