### PR TITLE
fix(events): treat backfill registrations as attended

### DIFF
--- a/apps/lfx-one/src/server/services/events.service.spec.ts
+++ b/apps/lfx-one/src/server/services/events.service.spec.ts
@@ -1,0 +1,172 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors project.service.spec.ts: the `@lfx-one/shared/*` subpaths aren't wired into this app's
+// vitest config, so each is mocked. The event/url/date helpers are pulled in via importActual
+// rather than stubbed — the backfill match is the behaviour under test here, so a stub would let
+// it regress with the tests still green.
+const snowflakeMocks = vi.hoisted(() => ({
+  execute: vi.fn(),
+}));
+
+vi.mock('@lfx-one/shared/interfaces', () => ({}));
+vi.mock('@lfx-one/shared/constants', () => ({
+  COMING_SOON_SENTINEL: 'coming-soon',
+  DEFAULT_EVENT_SORT_FIELD: 'EVENT_START_DATE',
+  DEFAULT_VISA_REQUEST_SORT_FIELD: 'APPLICATION_DATE',
+  EVENT_SOURCE_BACKFILL: 'backfill',
+  MY_EVENT_STATUS: { ATTENDED: 'Attended', REGISTERED: 'Registered', NOT_REGISTERED: 'Not Registered' },
+  VALID_EVENT_SORT_FIELDS: new Set(['EVENT_NAME', 'PROJECT_NAME', 'EVENT_START_DATE', 'EVENT_CITY']),
+  VALID_VISA_REQUEST_SORT_FIELDS: new Set(['EVENT_NAME', 'EVENT_CITY', 'APPLICATION_DATE']),
+  WHOLE_NUMBER_PATTERN: /^\d+$/,
+}));
+vi.mock('@lfx-one/shared/utils', async () => {
+  const eventUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/event.utils')>(
+    '../../../../../packages/shared/src/utils/event.utils'
+  );
+  const urlUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/url.utils')>(
+    '../../../../../packages/shared/src/utils/url.utils'
+  );
+  const dateUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/date-time.utils')>(
+    '../../../../../packages/shared/src/utils/date-time.utils'
+  );
+  return {
+    isBackfillEventSource: eventUtils.isBackfillEventSource,
+    normalizeToUrl: urlUtils.normalizeToUrl,
+    formatDateToUTC: dateUtils.formatDateToUTC,
+  };
+});
+vi.mock('./snowflake.service', () => ({
+  SnowflakeService: { getInstance: () => ({ execute: snowflakeMocks.execute }) },
+}));
+vi.mock('./user.service', () => ({
+  UserService: class {},
+}));
+vi.mock('./logger.service', () => ({
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
+}));
+
+const { EventsService } = await import('./events.service');
+
+const USER_EMAIL = 'delegate@acme-motors.example';
+
+/** Minimal MyEventRow shaped like a PLATINUM_LFX_ONE.EVENT_REGISTRATIONS row. */
+function buildRow(overrides: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    EVENT_ID: 'evt-1',
+    EVENT_NAME: 'Example Community Summit',
+    EVENT_START_DATE: '2026-08-19T07:00:00.000Z',
+    EVENT_END_DATE: '2026-08-21T07:00:00.000Z',
+    EVENT_LOCATION: null,
+    EVENT_CITY: 'Shanghai',
+    EVENT_COUNTRY: 'China',
+    PROJECT_ID: 'proj-1',
+    PROJECT_NAME: 'Example Foundation',
+    PROJECT_SLUG: 'example',
+    ACCOUNT_NAME: 'Example Account',
+    ACCOUNT_LOGO_URL: null,
+    USER_ROLE: 'Attendee',
+    REGISTRATION_STATUS: 'Accepted',
+    TF_REQUEST_STATUS: null,
+    VL_REQUEST_STATUS: null,
+    GROSS_REVENUE: null,
+    TAX_AMOUNT: null,
+    NET_REVENUE: null,
+    IS_PAST_EVENT: false,
+    EVENT_SOURCE: 'backfill',
+    EVENT_URL: null,
+    EVENT_REGISTRATION_URL: null,
+    USER_ATTENDED: 1,
+    IS_REGISTERED: true,
+    TRAVEL_FUND_END_TS: null,
+    TOTAL_RECORDS: 1,
+    ...overrides,
+  };
+}
+
+describe('EventsService.getMyEvents status derivation', () => {
+  let service: InstanceType<typeof EventsService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    service = new EventsService();
+  });
+
+  async function statusFor(overrides: Record<string, unknown>): Promise<string> {
+    snowflakeMocks.execute.mockResolvedValue({ rows: [buildRow(overrides)] });
+    const result = await service.getMyEvents({} as never, USER_EMAIL, { pageSize: 10, offset: 0 } as never);
+    return result.data[0].status;
+  }
+
+  it('reports Attended for an attended backfill row whose IS_PAST_EVENT snapshot is stale', async () => {
+    // The reported bug: dbt hard-codes user_attended = TRUE for backfill rows, but IS_PAST_EVENT is
+    // a build-time snapshot that can still read FALSE after the event has happened.
+    await expect(statusFor({ EVENT_SOURCE: 'backfill', IS_PAST_EVENT: false, USER_ATTENDED: 1 })).resolves.toBe('Attended');
+  });
+
+  it.each([[' Backfill '], ['BACKFILL']])('matches EVENT_SOURCE %j regardless of case and whitespace', async (source) => {
+    await expect(statusFor({ EVENT_SOURCE: source, IS_PAST_EVENT: false, USER_ATTENDED: 1 })).resolves.toBe('Attended');
+  });
+
+  it('reports Registered for a backfill row the user did not attend', async () => {
+    await expect(statusFor({ EVENT_SOURCE: 'backfill', IS_PAST_EVENT: false, USER_ATTENDED: 0 })).resolves.toBe('Registered');
+  });
+
+  it('still reports Attended for a non-backfill past event', async () => {
+    await expect(statusFor({ EVENT_SOURCE: 'cvent', IS_PAST_EVENT: true, USER_ATTENDED: 1 })).resolves.toBe('Attended');
+  });
+
+  it.each([['cvent'], [null]])('still reports Registered for a non-past event with EVENT_SOURCE %j', async (source) => {
+    await expect(statusFor({ EVENT_SOURCE: source, IS_PAST_EVENT: false, USER_ATTENDED: 1 })).resolves.toBe('Registered');
+  });
+
+  it('still reports Not Registered when the user has no registration', async () => {
+    await expect(statusFor({ EVENT_SOURCE: 'backfill', IS_PAST_EVENT: true, USER_ATTENDED: 1, IS_REGISTERED: false })).resolves.toBe('Not Registered');
+  });
+});
+
+describe('EventsService.getMyEvents past-event SQL', () => {
+  let service: InstanceType<typeof EventsService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    snowflakeMocks.execute.mockResolvedValue({ rows: [] });
+    service = new EventsService();
+  });
+
+  async function sqlFor(options: Record<string, unknown>): Promise<string> {
+    await service.getMyEvents({} as never, USER_EMAIL, { pageSize: 10, offset: 0, ...options } as never);
+    return snowflakeMocks.execute.mock.calls[0][0] as string;
+  }
+
+  it('recomputes the past flag from the dates only for backfill rows', async () => {
+    const sql = await sqlFor({ isPast: true });
+
+    expect(sql).toContain("LOWER(TRIM(EVENT_SOURCE)) = 'backfill'");
+    expect(sql).toContain('COALESCE(EVENT_END_DATE, EVENT_START_DATE) < CURRENT_DATE()');
+    // The ELSE branch is the guarantee that every other source keeps its stored value.
+    expect(sql).toContain('ELSE IS_PAST_EVENT END');
+  });
+
+  it('negates the same expression for the upcoming tab', async () => {
+    const sql = await sqlFor({ isPast: false, affiliatedProjectSlugs: ['example'] });
+
+    expect(sql).toContain('WHERE NOT (CASE WHEN');
+    expect(sql).not.toContain('IS_PAST_EVENT = FALSE');
+  });
+
+  it('selects EVENT_SOURCE in both upcoming CTEs so the UNION ALL column lists stay aligned', async () => {
+    const sql = await sqlFor({ isPast: false, affiliatedProjectSlugs: ['example'] });
+
+    expect(sql.match(/^\s*EVENT_SOURCE,$/gm)).toHaveLength(2);
+    expect(sql).toContain('e.EVENT_SOURCE,');
+  });
+
+  it('selects EVENT_SOURCE in the past branch', async () => {
+    const sql = await sqlFor({ isPast: true });
+
+    expect(sql).toContain('EVENT_SOURCE,');
+  });
+});

--- a/apps/lfx-one/src/server/services/events.service.spec.ts
+++ b/apps/lfx-one/src/server/services/events.service.spec.ts
@@ -3,6 +3,10 @@
 
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+// Imported from source, not through the mocked '@lfx-one/shared/utils' barrel, so the SQL/JS
+// whitespace-agreement assertion below checks the real implementation.
+import { isBackfillEventSource } from '../../../../../packages/shared/src/utils/event.utils';
+
 // Mirrors project.service.spec.ts: the `@lfx-one/shared/*` subpaths aren't wired into this app's
 // vitest config, so each is mocked. The event/url/date helpers are pulled in via importActual
 // rather than stubbed — the backfill match is the behaviour under test here, so a stub would let
@@ -144,7 +148,7 @@ describe('EventsService.getMyEvents past-event SQL', () => {
   it('recomputes the past flag from the dates only for backfill rows', async () => {
     const sql = await sqlFor({ isPast: true });
 
-    expect(sql).toContain("LOWER(TRIM(EVENT_SOURCE)) = 'backfill'");
+    expect(sql).toContain("LOWER(TRIM(EVENT_SOURCE, ' \\t\\n\\r')) = 'backfill'");
     expect(sql).toContain('COALESCE(EVENT_END_DATE, EVENT_START_DATE) < CURRENT_DATE()');
     // The ELSE branch is the guarantee that every other source keeps its stored value.
     expect(sql).toContain('ELSE IS_PAST_EVENT END');
@@ -168,5 +172,55 @@ describe('EventsService.getMyEvents past-event SQL', () => {
     const sql = await sqlFor({ isPast: true });
 
     expect(sql).toContain('EVENT_SOURCE,');
+  });
+
+  it('trims the same whitespace Snowflake-side that isBackfillEventSource trims in JS', async () => {
+    // Snowflake's one-argument TRIM strips only spaces. Without the explicit character set a value
+    // like '\tbackfill\n' would take the ELSE branch in SQL while the mapper called it Attended,
+    // stranding the row in Upcoming with a Past status.
+    const sql = await sqlFor({ isPast: true });
+
+    expect(sql).not.toContain('TRIM(EVENT_SOURCE))');
+    for (const ws of ['\\t', '\\n', '\\r']) {
+      expect(sql).toContain(ws);
+    }
+    expect(isBackfillEventSource('\tbackfill\n')).toBe(true);
+  });
+});
+
+describe('EventsService filter options use the same past-event predicate', () => {
+  let service: InstanceType<typeof EventsService>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    snowflakeMocks.execute.mockResolvedValue({ rows: [] });
+    service = new EventsService();
+  });
+
+  function lastSql(): string {
+    return snowflakeMocks.execute.mock.calls[0][0] as string;
+  }
+
+  // These feed the tab-scoped filter dropdowns. If they kept the raw column, a backfill event could
+  // sit in the Past tab while its foundation stayed in the Upcoming dropdown.
+  it('applies the predicate to the past foundations query', async () => {
+    await service.getEventOrganizations({} as never, USER_EMAIL, { isPast: true } as never);
+
+    expect(lastSql()).toContain("AND (CASE WHEN LOWER(TRIM(EVENT_SOURCE, ' \\t\\n\\r')) = 'backfill'");
+    expect(lastSql()).not.toContain('IS_PAST_EVENT = TRUE');
+  });
+
+  it('applies the negated predicate to the upcoming foundations query', async () => {
+    await service.getEventOrganizations({} as never, USER_EMAIL, { isPast: false, affiliatedProjectSlugs: ['example'] } as never);
+
+    expect(lastSql()).toContain('WHERE NOT (CASE WHEN');
+    expect(lastSql()).not.toContain('IS_PAST_EVENT = FALSE');
+  });
+
+  it('applies the negated predicate to the upcoming countries query', async () => {
+    await service.getUpcomingCountries({} as never);
+
+    expect(lastSql()).toContain('WHERE NOT (CASE WHEN');
+    expect(lastSql()).not.toContain('IS_PAST_EVENT = FALSE');
   });
 });

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -458,7 +458,7 @@ export class EventsService {
         SELECT DISTINCT PROJECT_NAME
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
         WHERE USER_EMAIL = ?
-          AND IS_PAST_EVENT = TRUE
+          AND (${this.isPastEventSql()})
           ${projectNameFilter}
         ORDER BY PROJECT_NAME
       `;
@@ -475,7 +475,7 @@ export class EventsService {
       sql = `
         SELECT DISTINCT PROJECT_NAME
         FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
-        WHERE IS_PAST_EVENT = FALSE
+        WHERE NOT (${this.isPastEventSql()})
           AND ((USER_EMAIL = ? AND REGISTRATION_STATUS = 'Accepted') ${affiliatedFilter})
           ${projectNameFilter}
         ORDER BY PROJECT_NAME
@@ -510,7 +510,7 @@ export class EventsService {
     const sql = `
       SELECT DISTINCT EVENT_COUNTRY
       FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
-      WHERE IS_PAST_EVENT = FALSE
+      WHERE NOT (${this.isPastEventSql()})
         AND EVENT_COUNTRY IS NOT NULL
       ORDER BY EVENT_COUNTRY
     `;
@@ -955,11 +955,16 @@ export class EventsService {
    * it is running. Rows with both dates null yield NULL, which — like the previous
    * `IS_PAST_EVENT = FALSE` comparison — excludes them from both tabs.
    *
+   * TRIM is given an explicit character set because Snowflake's one-argument TRIM strips only
+   * spaces, while isBackfillEventSource() uses JS trim() and so also strips tabs and newlines.
+   * Left unqualified the two would disagree on a value like '\tbackfill\n', taking the ELSE branch
+   * here while the mapper reported Attended — stranding the row in Upcoming with a Past status.
+   *
    * Uses unqualified column names, so it is only valid directly against
    * ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS, not against a projected CTE.
    */
   private isPastEventSql(): string {
-    return `CASE WHEN LOWER(TRIM(EVENT_SOURCE)) = '${EVENT_SOURCE_BACKFILL}'
+    return `CASE WHEN LOWER(TRIM(EVENT_SOURCE, ' \\t\\n\\r')) = '${EVENT_SOURCE_BACKFILL}'
                  THEN COALESCE(EVENT_END_DATE, EVENT_START_DATE) < CURRENT_DATE()
                  ELSE IS_PAST_EVENT END`;
   }

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -7,6 +7,7 @@ import {
   COMING_SOON_SENTINEL,
   DEFAULT_EVENT_SORT_FIELD,
   DEFAULT_VISA_REQUEST_SORT_FIELD,
+  EVENT_SOURCE_BACKFILL,
   MY_EVENT_STATUS,
   VALID_EVENT_SORT_FIELDS,
   VALID_VISA_REQUEST_SORT_FIELDS,
@@ -37,7 +38,7 @@ import {
   VisaRequestRow,
   VisaRequestsResponse,
 } from '@lfx-one/shared/interfaces';
-import { formatDateToUTC, normalizeToUrl } from '@lfx-one/shared/utils';
+import { formatDateToUTC, isBackfillEventSource, normalizeToUrl } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { MicroserviceError } from '../errors';
@@ -133,10 +134,11 @@ export class EventsService {
             PROJECT_SLUG,
             ACCOUNT_NAME,
             ACCOUNT_LOGO_URL,
+            EVENT_SOURCE,
             EVENT_URL,
             EVENT_REGISTRATION_URL
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
-          WHERE IS_PAST_EVENT = FALSE
+          WHERE NOT (${this.isPastEventSql()})
             ${eventIdFilter}
             ${affiliatedFilter}
           QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY EVENT_START_DATE) = 1
@@ -155,11 +157,12 @@ export class EventsService {
             PROJECT_SLUG,
             ACCOUNT_NAME,
             ACCOUNT_LOGO_URL,
+            EVENT_SOURCE,
             EVENT_URL,
             EVENT_REGISTRATION_URL
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
           WHERE USER_EMAIL = ?
-            AND IS_PAST_EVENT = FALSE
+            AND NOT (${this.isPastEventSql()})
             AND REGISTRATION_STATUS = 'Accepted'
             ${eventIdFilter}
           QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY EVENT_START_DATE) = 1
@@ -180,7 +183,7 @@ export class EventsService {
             TRAVEL_FUND_END_TS
           FROM ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS
           WHERE USER_EMAIL = ?
-            AND IS_PAST_EVENT = FALSE
+            AND NOT (${this.isPastEventSql()})
             AND REGISTRATION_STATUS = 'Accepted'
         ),
         combined AS (
@@ -202,6 +205,7 @@ export class EventsService {
           e.PROJECT_SLUG,
           e.ACCOUNT_NAME,
           e.ACCOUNT_LOGO_URL,
+          e.EVENT_SOURCE,
           e.EVENT_URL,
           e.EVENT_REGISTRATION_URL,
           r.USER_ROLE,
@@ -213,6 +217,9 @@ export class EventsService {
           r.NET_REVENUE,
           r.USER_ATTENDED,
           (r.EVENT_ID IS NOT NULL) AS IS_REGISTERED,
+          -- Both CTEs feeding "combined" filter on NOT (isPastEventSql()), so every row reaching
+          -- here is non-past by construction. EVENT_SOURCE is still selected so mapRowToEvent can
+          -- mark an attended-but-not-yet-ended backfill row as Attended.
           FALSE AS IS_PAST_EVENT,
           r.TRAVEL_FUND_END_TS,
           COUNT(*) OVER() AS TOTAL_RECORDS
@@ -256,7 +263,7 @@ export class EventsService {
       });
     } else {
       // Past tab (or no isPast filter): show only the user's own registered events.
-      const isPastFilter = isPast !== undefined ? `AND IS_PAST_EVENT = ${isPast ? 'TRUE' : 'FALSE'}` : '';
+      const isPastFilter = isPast !== undefined ? `AND ${isPast ? '' : 'NOT '}(${this.isPastEventSql()})` : '';
       const eventIdFilter = eventId ? 'AND EVENT_ID = ?' : '';
       const projectNameFilter = projectName ? 'AND PROJECT_NAME = ?' : '';
       const searchQueryFilter = searchQuery ? 'AND EVENT_NAME ILIKE ?' : '';
@@ -285,6 +292,7 @@ export class EventsService {
           TAX_AMOUNT,
           NET_REVENUE,
           IS_PAST_EVENT,
+          EVENT_SOURCE,
           EVENT_URL,
           EVENT_REGISTRATION_URL,
           USER_ATTENDED,
@@ -934,6 +942,28 @@ export class EventsService {
     return { data, total, pageSize: normalizedPageSize, offset: normalizedOffset };
   }
 
+  /**
+   * SQL expression yielding whether an event is past, correcting the stale flag for backfill rows.
+   *
+   * IS_PAST_EVENT is a build-time snapshot of `event_start_date < CURRENT_DATE()` frozen into a
+   * materialized dbt table, so it only refreshes when the model rebuilds. That is only load-bearing
+   * for CSV-backfilled rows, whose synthetic dates can leave the flag wrong indefinitely and strand
+   * an attended event in the Upcoming tab. For those rows recompute from the dates at query time;
+   * every other source keeps the stored column verbatim, so their behaviour is unchanged.
+   *
+   * An event counts as past once it has *ended*, so a multi-day conference stays in Upcoming while
+   * it is running. Rows with both dates null yield NULL, which — like the previous
+   * `IS_PAST_EVENT = FALSE` comparison — excludes them from both tabs.
+   *
+   * Uses unqualified column names, so it is only valid directly against
+   * ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS, not against a projected CTE.
+   */
+  private isPastEventSql(): string {
+    return `CASE WHEN LOWER(TRIM(EVENT_SOURCE)) = '${EVENT_SOURCE_BACKFILL}'
+                 THEN COALESCE(EVENT_END_DATE, EVENT_START_DATE) < CURRENT_DATE()
+                 ELSE IS_PAST_EVENT END`;
+  }
+
   /** Status filter for the past events query (unqualified column names, no IS NULL support). */
   private buildStatusFilter(status: string): { filter: string; binds: string[] } {
     switch (status) {
@@ -1036,7 +1066,9 @@ export class EventsService {
     let status: MyEventStatus;
     if (!row.IS_REGISTERED) {
       status = MY_EVENT_STATUS.NOT_REGISTERED;
-    } else if (row.IS_PAST_EVENT && row.USER_ATTENDED) {
+    } else if (row.USER_ATTENDED && (row.IS_PAST_EVENT || isBackfillEventSource(row.EVENT_SOURCE))) {
+      // Backfill rows are attendance records by construction, so USER_ATTENDED is authoritative for
+      // them even when the event's synthetic dates have not passed yet. See EVENT_SOURCE_BACKFILL.
       status = MY_EVENT_STATUS.ATTENDED;
     } else {
       status = MY_EVENT_STATUS.REGISTERED;

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -956,9 +956,10 @@ export class EventsService {
    * `IS_PAST_EVENT = FALSE` comparison — excludes them from both tabs.
    *
    * TRIM is given an explicit character set because Snowflake's one-argument TRIM strips only
-   * spaces, while isBackfillEventSource() uses JS trim() and so also strips tabs and newlines.
-   * Left unqualified the two would disagree on a value like '\tbackfill\n', taking the ELSE branch
-   * here while the mapper reported Attended — stranding the row in Upcoming with a Past status.
+   * spaces. Left unqualified it would disagree with isBackfillEventSource() on a value like
+   * '\tbackfill\n', taking the ELSE branch here while the mapper reported Attended — stranding the
+   * row in Upcoming with a Past status. The set must stay byte-identical to the one that helper
+   * strips; it deliberately does not use JS trim(), whose whitespace class Snowflake cannot express.
    *
    * Uses unqualified column names, so it is only valid directly against
    * ANALYTICS.PLATINUM_LFX_ONE.EVENT_REGISTRATIONS, not against a projected CTE.

--- a/packages/shared/src/constants/events.constants.ts
+++ b/packages/shared/src/constants/events.constants.ts
@@ -42,6 +42,17 @@ export const MY_EVENT_STATUS = {
   NOT_REGISTERED: 'Not Registered',
 } as const;
 
+/**
+ * EVENT_SOURCE value marking a CSV-imported (backfilled) event registration.
+ *
+ * These rows are attendance records by construction — the upstream dbt model hard-codes
+ * user_attended = TRUE for them because the import only exists for people who were there.
+ * Their IS_PAST_EVENT flag, by contrast, is a build-time snapshot frozen into a materialized
+ * table and can stay stale indefinitely against the synthetic dates these rows carry.
+ * So for backfill rows USER_ATTENDED, not IS_PAST_EVENT, is the authoritative signal.
+ */
+export const EVENT_SOURCE_BACKFILL = 'backfill';
+
 export const VISA_REQUEST_STATUS_OPTIONS: FilterOption[] = [
   { label: 'All Statuses', value: null },
   { label: 'Submitted', value: 'Submitted' },

--- a/packages/shared/src/interfaces/events.interface.ts
+++ b/packages/shared/src/interfaces/events.interface.ts
@@ -78,6 +78,11 @@ export interface MyEventRow {
   /** Null when the user has not registered for this event */
   NET_REVENUE: number | null;
   IS_PAST_EVENT: boolean;
+  /**
+   * Origin of the event record (e.g. 'backfill' for CSV-imported historical attendance).
+   * Null when the upstream row carries no source. See EVENT_SOURCE_BACKFILL.
+   */
+  EVENT_SOURCE: string | null;
   EVENT_URL: string | null;
   EVENT_REGISTRATION_URL: string | null;
   /** Null when the user has not registered for this event */

--- a/packages/shared/src/utils/event.utils.spec.ts
+++ b/packages/shared/src/utils/event.utils.spec.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { isBackfillEventSource } from './event.utils';
+
+describe('isBackfillEventSource', () => {
+  it('matches the canonical value', () => {
+    expect(isBackfillEventSource('backfill')).toBe(true);
+  });
+
+  it.each([['Backfill'], ['BACKFILL'], ['BackFill']])('is case-insensitive for %s', (source) => {
+    expect(isBackfillEventSource(source)).toBe(true);
+  });
+
+  it.each([[' backfill'], ['backfill '], ['  Backfill  '], ['\tbackfill\n']])('tolerates surrounding whitespace in %j', (source) => {
+    expect(isBackfillEventSource(source)).toBe(true);
+  });
+
+  it.each([['cvent'], ['bevy'], ['platform'], ['backfilled'], ['back fill'], ['']])('rejects %j', (source) => {
+    expect(isBackfillEventSource(source)).toBe(false);
+  });
+
+  it.each([[null], [undefined]])('rejects %p without throwing', (source) => {
+    expect(isBackfillEventSource(source)).toBe(false);
+  });
+});

--- a/packages/shared/src/utils/event.utils.spec.ts
+++ b/packages/shared/src/utils/event.utils.spec.ts
@@ -14,9 +14,22 @@ describe('isBackfillEventSource', () => {
     expect(isBackfillEventSource(source)).toBe(true);
   });
 
-  it.each([[' backfill'], ['backfill '], ['  Backfill  '], ['\tbackfill\n']])('tolerates surrounding whitespace in %j', (source) => {
+  it.each([[' backfill'], ['backfill '], ['  Backfill  '], ['\tbackfill\n'], ['\r\nbackfill\t ']])('strips the SQL-aligned whitespace set in %j', (source) => {
     expect(isBackfillEventSource(source)).toBe(true);
   });
+
+  // Deliberate parity boundary: String.prototype.trim() strips these, but Snowflake's
+  // TRIM(EVENT_SOURCE, ' \t\n\r') cannot, and Snowflake has no ECMAScript-whitespace equivalent.
+  // Both sides must agree, so this side is narrowed to match — such a value reads as non-backfill
+  // in JS and SQL alike, and the row falls back to the stored IS_PAST_EVENT.
+  it.each([['\u000Bbackfill'], ['\u000Cbackfill'], ['\u00A0backfill'], ['\uFEFFbackfill'], ['\u2028backfill'], ['\u3000backfill'], ['backfill\u00A0']])(
+    'rejects %j — whitespace that trim() strips but Snowflake TRIM cannot',
+    (source) => {
+      expect(isBackfillEventSource(source)).toBe(false);
+      // Guards the premise above: plain trim() would have matched, which is the divergence avoided.
+      expect(source.trim().toLowerCase()).toBe('backfill');
+    }
+  );
 
   it.each([['cvent'], ['bevy'], ['platform'], ['backfilled'], ['back fill'], ['']])('rejects %j', (source) => {
     expect(isBackfillEventSource(source)).toBe(false);

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -6,11 +6,20 @@ import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
 /**
  * True when an event registration row came from the CSV backfill import.
  *
- * Trimmed and lowercased on purpose: the value originates in hand-maintained import data, so
- * casing and stray whitespace drift. Keep this in sync with the equivalent
- * `LOWER(TRIM(EVENT_SOURCE))` comparison used in the Snowflake queries — the two must agree, or a
- * row can land in one tab while carrying the other tab's status.
+ * Lowercased and whitespace-stripped on purpose: the value originates in hand-maintained import
+ * data, so casing and stray whitespace drift.
+ *
+ * The stripped set is deliberately the four characters `' \t\n\r'` rather than whatever
+ * `String.prototype.trim()` happens to cover. This must agree exactly with the
+ * `LOWER(TRIM(EVENT_SOURCE, ' \t\n\r'))` comparison in EventsService.isPastEventSql(), or a row can
+ * land in one tab while carrying the other tab's status. `trim()` strips a strict superset —
+ * vertical tab, form feed, NBSP (U+00A0), BOM (U+FEFF), U+2028/2029, U+3000 and more — and
+ * Snowflake has no equivalent character class, so parity is only reachable by narrowing this side.
+ *
+ * Consequence: a source value padded with one of those exotic characters matches on neither side,
+ * so the row falls to the `ELSE` branch and keeps the stored IS_PAST_EVENT — the pre-fix behaviour,
+ * which is the safe direction to fail in.
  */
 export function isBackfillEventSource(source: string | null | undefined): boolean {
-  return source?.trim().toLowerCase() === EVENT_SOURCE_BACKFILL;
+  return source?.replace(/^[ \t\n\r]+|[ \t\n\r]+$/g, '').toLowerCase() === EVENT_SOURCE_BACKFILL;
 }

--- a/packages/shared/src/utils/event.utils.ts
+++ b/packages/shared/src/utils/event.utils.ts
@@ -1,0 +1,16 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { EVENT_SOURCE_BACKFILL } from '../constants/events.constants';
+
+/**
+ * True when an event registration row came from the CSV backfill import.
+ *
+ * Trimmed and lowercased on purpose: the value originates in hand-maintained import data, so
+ * casing and stray whitespace drift. Keep this in sync with the equivalent
+ * `LOWER(TRIM(EVENT_SOURCE))` comparison used in the Snowflake queries — the two must agree, or a
+ * row can land in one tab while carrying the other tab's status.
+ */
+export function isBackfillEventSource(source: string | null | undefined): boolean {
+  return source?.trim().toLowerCase() === EVENT_SOURCE_BACKFILL;
+}

--- a/packages/shared/src/utils/index.ts
+++ b/packages/shared/src/utils/index.ts
@@ -60,3 +60,4 @@ export * from './committee-engagement-freshness.utils';
 export * from './public-profile.utils';
 export * from './brand-kit.utils';
 export * from './newsletter.utils';
+export * from './event.utils';


### PR DESCRIPTION
## Summary

- Backfilled event registrations showed **Registered** instead of **Attended**, so the
  **Download Certificate** button never appeared. This is the remaining half of #1695
  (the first half shipped as #1740, the LF Open Source logo on China event certificates).
- Root cause is two upstream properties combining: `silver_fact_event_registrations`
  hard-codes `user_attended = TRUE` for the backfill CTE (correct — a backfill row *is*
  an attendance record), while `IS_PAST_EVENT` is a build-time snapshot of
  `event_start_date < CURRENT_DATE()` frozen into a `+materialized: table` model. The app
  ANDed the two, so `FALSE && TRUE` reported Registered.
- For backfill rows only, recompute the past flag at query time from
  `COALESCE(EVENT_END_DATE, EVENT_START_DATE) < CURRENT_DATE()`, and let `USER_ATTENDED`
  win over the stale flag when deriving status. Every other source keeps the stored
  column verbatim via the `CASE ... ELSE` branch.
- "Past" means the event has **ended**, so a multi-day conference stays in Upcoming while
  it is running.

## Scope

Non-backfill behaviour is unchanged, verified three ways:

- **SQL** — for any non-backfill row the `CASE` returns `IS_PAST_EVENT` verbatim, and
  `NOT (IS_PAST_EVENT)` is truth-table-identical to the previous `IS_PAST_EVENT = FALSE`
  in all three states, NULL included. A NULL `EVENT_SOURCE` makes the `WHEN` comparison
  NULL and falls to `ELSE`.
- **Status derivation** — exhaustively enumerated all 128 combinations of
  `USER_ATTENDED` × `IS_PAST_EVENT` × 8 non-backfill `EVENT_SOURCE` values (including
  `null`, `''`, and the near-miss `'backfilled'`): zero divergence from the old condition.
- **Blast radius** — `mapRowToEvent` has one caller and `MyEventRow` is referenced only
  inside `events.service.ts`. `certificate.service.ts`, `getFoundationEvents`,
  `getEventOrganizations`, and `getUpcomingCountries` are untouched. No frontend change —
  `events-table.component.html` already gates the Download button on `ATTENDED`.

## Trade-off

For backfill rows the tab filter is now a computed expression rather than a stored
boolean, so Snowflake cannot micro-partition-prune on `IS_PAST_EVENT` for them.
Non-backfill rows still hit the stored column on the `ELSE` path, the queries already
filter on `USER_EMAIL`, and the source is a materialized table — impact should be small,
but it is a real change in query shape.

## Upstream defects (documented here, not yet filed)

Both belong to `lf-dbt` and are worked around rather than corrected. To be explicit about
traceability: **no upstream issue has been filed for either yet**, so there is no link to
give. They are recorded here and will be filed against `lf-dbt` as a follow-up; this
app-side workaround should be removed once the warehouse fix lands.

- **`IS_PAST_EVENT` goes stale** — derived from `CURRENT_DATE()` inside a
  `+materialized: table` model, so it only refreshes on rebuild. The reproducing row was
  still `FALSE` days after its start date, which suggests the refresh is not running at
  the hourly cadence the platinum model's header documents.
- **`user_attended` hard-coded for backfill** — set unconditionally to `TRUE`, so
  `USER_ROLE` reads `Attendee` even on a future-dated event. This PR makes the app
  tolerant of that; it does not correct the warehouse.

## Verification

Reviewer trio (general / self-serve conventions / learnings KB) all returned clean.
Preflight green: license headers, format, lint (0 errors), build.
`yarn test` — 3306 tests across 159 files, all passing, including 16 new server specs and
16 new util specs. Test non-vacuity confirmed by reverting the fixes: 6 of 16 server specs fail.

Manual end-to-end against Snowflake is **not** done — local credentials point at a stale
key pair that fails JWT auth, so `getMyEvents` returns an empty list. Needs the shared dev
environment.

Fixes #1695

