### PR TITLE
test(auth): pin encoded-separator fallback on api paths

### DIFF
--- a/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
@@ -172,6 +172,20 @@ describe('authMiddleware route classification', () => {
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'AuthenticationError' }));
   });
 
+  it('returns a 401 (not a login redirect) for an encoded separator on an /api path', async () => {
+    const req = buildReq({ path: '/api/foo/bar%2Fbaz' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    // The catch block's other throw site: `bar%2Fbaz` decodes to `bar/baz`, reintroducing a separator (the `%ZZ`
+    // cases throw inside `decodeURIComponent`). Still `apiFallback` → JSON 401, never an HTML login redirect.
+    expect(res.oidc.login).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'AuthenticationError' }));
+  });
+
   it('returns a 401 (not a login redirect) for a malformed /public/api path so XHR clients get JSON', async () => {
     const req = buildReq({ path: '/public/api/foo/%ZZ' });
     const res = buildRes();
@@ -183,6 +197,20 @@ describe('authMiddleware route classification', () => {
     // be that public route. It fails closed to the API classification (`type: 'api'`, `required`,
     // `tokenRequired`), so an unauthenticated request returns a JSON 401 via `next(AuthenticationError)`
     // rather than an HTML login redirect a fetch/XHR client can't follow.
+    expect(res.oidc.login).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'AuthenticationError' }));
+  });
+
+  it('fails closed for an encoded separator on a /public/api path instead of fail-opening to optional auth', async () => {
+    const req = buildReq({ path: '/public/api/foo%2Fbar' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    // The sharp end of the `encoded path separator` throw: without it this would decode to `/public/api/foo/bar`,
+    // match the `optional` row, and allow the request. Failing closed makes it a JSON 401 instead.
     expect(res.oidc.login).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
     expect(next).toHaveBeenCalledWith(expect.objectContaining({ name: 'AuthenticationError' }));

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -73,7 +73,8 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // Crowdfunding auth start — needs session auth but no bearer token (initiates CF auth-code redirect)
   { pattern: '/api/crowdfunding/auth/start', type: 'api', auth: 'required', tokenRequired: false },
 
-  // Protected API routes - require authentication and token
+  // Protected API routes - require authentication and token. `classifyRoute`'s `apiFallback` mirrors this row's
+  // shape so a malformed/undecodable API path fails closed the same way — keep the two in sync.
   { pattern: '/api', type: 'api', auth: 'required', tokenRequired: true },
 
   // Invite error page — public so unauthenticated users see the error instead of being redirected to login
@@ -124,12 +125,8 @@ function classifyRoute(path: string, config: AuthConfig): RouteAuthConfig {
     auth: config.defaultAuth,
   };
 
-  // Fail-closed classification for malformed input on an API-prefixed path (`/api` or `/public/api`).
-  // Still `required` auth, but preserves `type: 'api'` + `tokenRequired` so a malformed/encoded API
-  // request returns a JSON 401 (not an HTML login redirect that XHR/fetch clients can't follow) and still
-  // triggers bearer-token extraction. Mirrors the `/api` catch-all row in DEFAULT_ROUTE_CONFIG; the
-  // `/public/api` prefix (normally `auth: 'optional'`) also fails closed to `required` here, since a
-  // malformed/undecodable path can't be trusted to be the anonymous public route it appears to be.
+  // Fail-closed classification for a malformed API path — mirrors the `/api` row so XHR/fetch clients get a JSON
+  // 401 (+ bearer extraction), not an HTML redirect. `/public/api` (normally `optional`) also hardens to `required`.
   const apiFallback: RouteAuthConfig = {
     pattern: '/api',
     type: 'api',
@@ -137,8 +134,8 @@ function classifyRoute(path: string, config: AuthConfig): RouteAuthConfig {
     tokenRequired: true,
   };
 
-  // Any API-prefixed path — the raw `/api` mount and the `/public/api` mount both serve JSON, so a
-  // malformed request to either must fail closed to the JSON 401 shape rather than an SSR redirect.
+  // Raw (un-decoded) prefix by design: an encoded `api` prefix that also fails to decode degrades to the SSR
+  // redirect shape instead of the JSON 401 — still fail-closed, and no real fetch/XHR client encodes the prefix.
   const isApiPath = path.startsWith('/api') || path.startsWith('/public/api');
 
   // Decode percent-encoding per segment before matching so the SSR auth boundary matches Angular's
@@ -164,9 +161,8 @@ function classifyRoute(path: string, config: AuthConfig): RouteAuthConfig {
       })
       .join('/');
   } catch {
-    // Decoding failed (malformed escape like `%ZZ`, or an encoded separator `%2F` that would shift
-    // segment boundaries). Fail closed — but keep API-prefixed paths classified as `api` so they get a
-    // JSON 401 with bearer extraction rather than an SSR login redirect.
+    // Decoding failed (`%ZZ`, or a `%2F` separator that would shift segment boundaries). Fail closed, keeping
+    // API paths as `api` so they get a JSON 401 with bearer extraction rather than an SSR login redirect.
     return isApiPath ? apiFallback : fallback;
   }
 


### PR DESCRIPTION
## Summary

Closes out the three deferred polish items from the final review nit on #1471 (`auth.middleware.ts` fail-closed API
fallback), which dealako approved as-is and left as follow-up.

- **Cross-reference the duplicated `/api` policy.** The `apiFallback` literal in `classifyRoute` is field-identical
  to the protected `/api` row in `DEFAULT_ROUTE_CONFIG`, with no compile-time link between them. The route-table row
  now points back at `apiFallback` so the pair reads in both directions. Kept as a comment rather than deriving
  `apiFallback` from `config.routes`: derivation would still have to force `auth: 'required'` to stop a custom
  `optional` `/api` row from making the fail-closed path fail *open*, so it buys little over the cross-reference.
- **Cover the encoded-separator (`%2F`) throw site on API paths.** `classifyRoute`'s `catch` has two throw sites —
  `decodeURIComponent` on a malformed escape, and the explicit `encoded path separator` throw. Only the former was
  pinned on the API branch.
- **Document the raw-prefix degrade on `isApiPath`.** It matches the un-decoded prefix, so a pathological encoded
  `api` prefix that then fails to decode (`/%61pi/foo/%ZZ`) degrades to the SSR redirect shape instead of the JSON
  401. Still fail-closed — only the error shape differs — and unreachable by real clients. Comment only, no
  behavior change.

## On the second test case

The follow-up note specified `/api/foo/bar%2Fbaz`, which is included — but mutation testing showed it does **not**
pin the throw site. With `throw new Error('encoded path separator')` removed, that path decodes through to
`/api/foo/bar/baz`, still matches the `/api` row, and yields the same 401, so the test stays green.

`/public/api/foo%2Fbar` is the case that pins it: without the throw it decodes to `/public/api/foo/bar`, matches the
`optional` row, and fail-opens to an allowed anonymous request. Both cases are included — the first guards the API
classification on the fail-closed branch, the second guards the throw itself.

## Protected files

`apps/lfx-one/src/server/middleware/*` gates request processing for every route, so it needs explicit code-owner
review. Both touched files are in that path:

- `auth.middleware.ts` — **comments only.** No executable line changed: a cross-reference on the
  `DEFAULT_ROUTE_CONFIG` `/api` row, the raw-prefix degrade noted on `isApiPath`, and two existing block comments
  compressed. `git show 0877b5d62 -- <file>` shows no non-comment hunks.
- `auth.middleware.spec.ts` — two added test cases, no production code.

## Notes

- Comments touched in this diff are capped at 2 lines; the `apiFallback` block (6 → 2) and the `catch` block (3 → 2)
  were compressed in passing. Pre-existing long comments elsewhere in the file are out of scope.
- No behavior change. Items 1 and 3 are comments; item 2 is test-only.

Branch carries a descriptive suffix (`test/LFXV2-3254-auth-fallback-polish`) rather than the bare
`type/LFXV2-<n>` form — deliberate, for readability in the branch list.

Refs LFXV2-3254. Follow-up to #1471.
