### PR TITLE
fix(committees): show pending invites regardless of join_mode

### DIFF
--- a/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
+++ b/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
@@ -91,6 +91,8 @@ test.describe('Group Members tab join modes (LFXV2-2690)', () => {
     await gotoMembersTab(page);
 
     await expect(page.getByTestId('filter-pill-pending')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await page.getByTestId('filter-pill-pending').click();
+    await expect(page.getByTestId('invite-row-invite-1')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
   test('member in invite_only group: Invite Someone button visible, not Add Member', async ({ page }) => {

--- a/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
+++ b/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
@@ -29,12 +29,40 @@ function gotoMembersTab(page: Page): Promise<void> {
 test.setTimeout(120_000);
 
 test.describe('Group Members tab join modes (LFXV2-2690)', () => {
-  test('admin: Add Member button visible in closed mode; pending invites section hidden', async ({ page }) => {
+  test('admin: Add Member button visible in closed mode; pending invites section hidden when no invites exist', async ({ page }) => {
     await mockCommitteeApis(page, { committee: baseCommittee({ my_role: 'Chair', writer: true, join_mode: 'closed' }) });
     await gotoMembersTab(page);
 
     await expect(page.getByTestId('add-member-btn')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // Hidden because there are no pending invites in the response, not because of join_mode.
     await expect(page.getByTestId('pending-invites')).toHaveCount(0);
+  });
+
+  test('admin: pending invites section visible in closed mode when invites exist', async ({ page }) => {
+    await mockCommitteeApis(page, { committee: baseCommittee({ my_role: 'Chair', writer: true, join_mode: 'closed' }) });
+
+    // Override the default empty invites mock with a real pending invite.
+    await page.route(`**/api/committees/${COMMITTEE_UID}/invites*`, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            uid: 'invite-1',
+            committee_uid: COMMITTEE_UID,
+            invitee_email: 'pending@example.com',
+            role: 'Member',
+            status: 'pending',
+            created_at: '2026-08-24T16:05:00Z',
+          },
+        ]),
+      });
+    });
+
+    await gotoMembersTab(page);
+
+    await expect(page.getByTestId('pending-invites')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
   test('member in invite_only group: Invite Someone button visible, not Add Member', async ({ page }) => {

--- a/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
+++ b/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
@@ -53,6 +53,8 @@ test.describe('Committee invite banner (GH-1806)', () => {
 
     await gotoCommitteeTabHelper(page, COMMITTEE_UID);
     await expect(page.getByTestId('committee-view-invitation-banner')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    // Banner replaces the Contact Admin CTA — both must not coexist.
+    await expect(page.getByTestId('committee-view-contact-admin-btn')).toHaveCount(0);
   });
 });
 

--- a/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
+++ b/apps/lfx-one/e2e/committee-members-join-mode.spec.ts
@@ -28,6 +28,34 @@ function gotoMembersTab(page: Page): Promise<void> {
 
 test.setTimeout(120_000);
 
+test.describe('Committee invite banner (GH-1806)', () => {
+  test('visitor: invitation banner visible in closed mode when a pending invite exists', async ({ page }) => {
+    // Visitor = my_role null (not yet a member)
+    await mockCommitteeApis(page, { committee: baseCommittee({ my_role: null, writer: false, join_mode: 'closed' }) });
+
+    // Return one pending invite for this visitor from the cross-surface cache endpoint
+    await page.route('**/api/user/pending-invitations*', (route) => {
+      return route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify([
+          {
+            uid: 'invite-visitor-1',
+            committee_uid: COMMITTEE_UID,
+            invitee_email: 'visitor@example.com',
+            role: 'Member',
+            status: 'pending',
+            created_at: '2026-08-24T16:05:00Z',
+          },
+        ]),
+      });
+    });
+
+    await gotoCommitteeTabHelper(page, COMMITTEE_UID);
+    await expect(page.getByTestId('committee-view-invitation-banner')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+  });
+});
+
 test.describe('Group Members tab join modes (LFXV2-2690)', () => {
   test('admin: Add Member button visible in closed mode; pending invites section hidden when no invites exist', async ({ page }) => {
     await mockCommitteeApis(page, { committee: baseCommittee({ my_role: 'Chair', writer: true, join_mode: 'closed' }) });
@@ -35,7 +63,7 @@ test.describe('Group Members tab join modes (LFXV2-2690)', () => {
 
     await expect(page.getByTestId('add-member-btn')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     // Hidden because there are no pending invites in the response, not because of join_mode.
-    await expect(page.getByTestId('pending-invites')).toHaveCount(0);
+    await expect(page.getByTestId('filter-pill-pending')).toHaveCount(0);
   });
 
   test('admin: pending invites section visible in closed mode when invites exist', async ({ page }) => {
@@ -62,7 +90,7 @@ test.describe('Group Members tab join modes (LFXV2-2690)', () => {
 
     await gotoMembersTab(page);
 
-    await expect(page.getByTestId('pending-invites')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('filter-pill-pending')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
   test('member in invite_only group: Invite Someone button visible, not Add Member', async ({ page }) => {

--- a/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/committee-view/committee-view.component.ts
@@ -258,7 +258,7 @@ export class CommitteeViewComponent {
   public readonly inviteToastKey = INVITE_TOAST_KEY;
   public pendingInvitation: Signal<PendingInvitation | null> = computed(() => {
     const committee = this.committee();
-    if (!committee?.uid || !this.isVisitor() || committee.join_mode !== 'invite_only') {
+    if (!committee?.uid || !this.isVisitor()) {
       return null;
     }
     return findPendingInvitationForCommittee(this.invitationService.pendingInvitations(), this.invitationService.resolvedInviteUids(), committee.uid);

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -170,9 +170,7 @@ export class CommitteeMembersComponent implements OnInit {
   // manager's `writer` flag is already true (LFXV2-2059).
   public readonly canManageMembers = computed(() => canManageCommitteeMembers(this.committee()));
   public readonly joinMode = computed(() => this.committee()?.join_mode as JoinMode | undefined);
-  public readonly showPendingInvites = computed(
-    () => this.canManageMembers() && (this.invitesLoading() || this.invites().length > 0)
-  );
+  public readonly showPendingInvites = computed(() => this.canManageMembers() && (this.invitesLoading() || this.invites().length > 0));
   public readonly tabOptions = computed<FilterPillOption[]>(() => {
     const opts: FilterPillOption[] = [{ id: 'all', label: 'All' }];
     if (this.showPendingInvites()) {

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -170,9 +170,8 @@ export class CommitteeMembersComponent implements OnInit {
   // manager's `writer` flag is already true (LFXV2-2059).
   public readonly canManageMembers = computed(() => canManageCommitteeMembers(this.committee()));
   public readonly joinMode = computed(() => this.committee()?.join_mode as JoinMode | undefined);
-  /** Invites are forbidden in closed mode (LFXV2-2690). */
   public readonly showPendingInvites = computed(
-    () => this.canManageMembers() && this.joinMode() !== 'closed' && (this.invitesLoading() || this.invites().length > 0)
+    () => this.canManageMembers() && (this.invitesLoading() || this.invites().length > 0)
   );
   public readonly tabOptions = computed<FilterPillOption[]>(() => {
     const opts: FilterPillOption[] = [{ id: 'all', label: 'All' }];

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -962,7 +962,7 @@ export class CommitteeMembersComponent implements OnInit {
   private initTableRows(): Signal<CommitteeTableRow[]> {
     return computed(() => {
       const memberRows: CommitteeTableRow[] = this.filteredMembers().map((m) => ({ rowType: 'member' as const, data: m }));
-      if (!this.canManageMembers() || this.joinMode() === 'closed') {
+      if (!this.canManageMembers()) {
         return memberRows;
       }
       const inviteRows: CommitteeTableRow[] = this.invites().map((invite) => ({ rowType: 'invite' as const, data: invite }));


### PR DESCRIPTION
## Summary

- Remove `join_mode !== 'invite_only'` guard from the committee detail page `pendingInvitation` signal so invited visitors see the accept/decline banner regardless of the group's current join mode
- Remove `joinMode() !== 'closed'` guard from `showPendingInvites` so managers see the Pending Invites tab on closed groups when invites exist
- Update E2E test to clarify the existing assertion (hidden because no data, not join_mode) and add a new case verifying the tab renders in closed mode when a pending invite is present

## Ticket

[GH-1806](https://github.com/linuxfoundation/lfx-self-serve/issues/1806)