### PR TITLE
perf(projects): bound query-service page scan

### DIFF
--- a/apps/lfx-one/src/server/constants/index.ts
+++ b/apps/lfx-one/src/server/constants/index.ts
@@ -4,6 +4,7 @@
 export * from './gateway.constants';
 export * from './meta.constants';
 export * from './public-profile.constants';
+export * from './query-service.constants';
 export * from './reddit.constants';
 export * from './rewards.constants';
 export * from './weekly-brief.constants';

--- a/apps/lfx-one/src/server/constants/query-service.constants.ts
+++ b/apps/lfx-one/src/server/constants/query-service.constants.ts
@@ -1,0 +1,9 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Page size for `/query/resources` paginated reads. The query service defaults to
+ * 50 and caps at 1000 (lfx-v2-query-service design/types.go); 500 keeps the page
+ * count low without sitting at the upstream maximum.
+ */
+export const QUERY_SERVICE_PAGE_SIZE = 500;

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -212,6 +212,39 @@ describe('ProjectService — create picker methods', () => {
     });
   });
 
+  describe('getProjects', () => {
+    it('requests QUERY_SERVICE_PAGE_SIZE, overriding any caller-supplied page_size', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'a', slug: 'a' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects));
+
+      await service.getProjects(req, { page_size: 10 });
+
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', page_size: 500 });
+    });
+
+    it('follows page_token across pages and returns the accumulated projects', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'a', slug: 'a' }], 'next-token'));
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'b', slug: 'b' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects));
+
+      const result = await service.getProjects(req);
+
+      expect(result.map((p) => p.uid).sort()).toEqual(['a', 'b']);
+      expect(proxyRequest).toHaveBeenCalledTimes(2);
+      expect(proxyRequest.mock.calls[1][4]).toMatchObject({ page_token: 'next-token' });
+    });
+
+    it('excludes the ROOT pseudo-project before the access check', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'root', slug: 'root' }]));
+      addAccessToResources.mockImplementationOnce((_req: Request, projects: Project[]) => Promise.resolve(projects));
+
+      const result = await service.getProjects(req);
+
+      expect(result).toEqual([]);
+      expect(addAccessToResources).toHaveBeenCalledWith(req, [], 'project');
+    });
+  });
+
   describe('getChildProjects', () => {
     it('queries parent=project:<uid> and filters to writer-permitted children', async () => {
       proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'child-1', slug: 'child-1' }]));

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -151,6 +151,7 @@ import {
 import { Request } from 'express';
 import FormData from 'form-data';
 
+import { QUERY_SERVICE_PAGE_SIZE } from '../constants';
 import { MicroserviceError, ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { isInvalidIdentifierError } from '../helpers/snowflake-error.helper';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
@@ -310,6 +311,9 @@ export class ProjectService {
     const params = {
       ...query,
       type: 'project',
+      // Overrides any caller-supplied page_size — the query service's 50-result default turns
+      // a large org's project list into a long sequential page scan (GH-1735).
+      page_size: QUERY_SERVICE_PAGE_SIZE,
     };
 
     const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>


### PR DESCRIPTION
## Summary

- `ProjectService.getProjects` called the `fetchAllQueryResources` helper with no `page_size`, so the query service's default of 50 turned a large org's project list into a long sequential `/query/resources?page_token=…` scan (confirmed ~10s pagination leg in trace).
- Requests `page_size: 500` (matching the de-facto value already used at other call sites) via a new named constant `QUERY_SERVICE_PAGE_SIZE`, overriding any caller-supplied `page_size`.
- No frontend caller sends `page_size` for this endpoint today, and the BFF response contract (`res.json(projects)`, plain array) is unchanged — only the size of individual upstream pages changes.

## Scope boundary

This only bounds the `/query/resources` pagination leg. The trailing `POST /access-check` batch call is intentionally out of scope, tracked separately as #1669/#1670.

Closes #1735

## Test plan

- [x] `yarn workspace lfx-one test:server -- project.service` — 3 new tests + existing suite pass (59 total)
- [x] `yarn lint`, `yarn check-types`, `yarn build` all pass
- [x] `./check-headers.sh` passes
- [x] Post-commit reviewer trio (general, self-serve conventions, learnings) returned clean
- [x] `/lfx-self-serve-pr-readiness` and `/preflight` both green