### PR TITLE
fix(groups): expose public group rows as links, not list items

### DIFF
--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.html
@@ -61,12 +61,23 @@
       <div class="flex flex-col gap-2" role="list" data-testid="public-foundation-groups-list">
         @for (group of groupsVm(); track group.uid) {
           @let config = group.classConfig;
-          <a
-            [routerLink]="['/groups', group.uid]"
+          <div
             role="listitem"
-            class="flex items-start gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 sm:items-center"
-            [attr.data-testid]="'public-foundation-groups-item-' + group.uid"
-            [attr.aria-label]="group.name + ', ' + config.label">
+            class="has-[.peer:hover]:border-blue-200 has-[.peer:hover]:bg-blue-50/30 relative flex items-start gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors sm:items-center"
+            [attr.data-testid]="'public-foundation-groups-item-' + group.uid">
+            <!-- Whole-row click/focus target ("stretched link"), ported from org-groups.component.html
+                 (#1786): role="listitem" belongs on this non-interactive row div, not on an anchor,
+                 which is why the actual link is this separate absolutely-positioned <a> instead. `peer`
+                 lets the row react to this specific link's hover via has-[.peer:hover]: above. Unlike
+                 org-groups, this row has no second nested link, so no pointer-events-none/z-10 handoff
+                 is needed on the content below — don't drop `peer` in a "clean up unused classes" pass,
+                 it's what drives the row's hover highlight. -->
+            <a
+              [routerLink]="['/groups', group.uid]"
+              class="peer absolute inset-0 rounded-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+              [attr.data-testid]="'public-foundation-groups-row-link-' + group.uid"
+              [attr.aria-label]="group.name + ', ' + config.label"></a>
+
             <!-- Icon -->
             <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full" [class]="config.bgColor">
               <i [class]="config.icon + ' ' + config.color + ' text-base'" aria-hidden="true"></i>
@@ -107,7 +118,7 @@
             }
 
             <i class="fa-light fa-chevron-right text-gray-300 text-xs shrink-0" aria-hidden="true"></i>
-          </a>
+          </div>
         }
       </div>
     }

--- a/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-foundation-groups/public-foundation-groups.component.spec.ts
@@ -141,4 +141,48 @@ describe('PublicFoundationGroupsComponent — contrast and responsive row layout
     expect(rowClasses).toContain('items-start');
     expect(rowClasses).toContain('sm:items-center');
   });
+
+  it('exposes the row as a real link, not an anchor carrying role="listitem" (GH-1794)', async () => {
+    // WCAG 4.1.2 regression lock: an explicit role="listitem" on the anchor itself would replace
+    // its implicit link role, dropping the row out of the screen reader links rotor. A class-token
+    // assertion can't catch this — only checking the actual element identity/role can, which is
+    // exactly what the pre-fix markup (role="listitem" directly on the row <a>) would fail.
+    await render({ groups: [group()], total: 1 });
+
+    const row = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]');
+    expect(row).not.toBeNull();
+    expect(row?.tagName).toBe('DIV');
+    expect(row?.getAttribute('role')).toBe('listitem');
+
+    const link = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-row-link-g1"]');
+    expect(link).not.toBeNull();
+    expect(link?.tagName).toBe('A');
+    expect(row?.contains(link)).toBe(true);
+    expect(row).not.toBe(link);
+    // No role attribute at all — the element must rely on its implicit link role, which an <a>
+    // only gets once it has an href (otherwise it maps to `generic`), so that's asserted too.
+    expect(link?.getAttribute('role')).toBeNull();
+    expect(link?.getAttribute('href')).toBe('/groups/g1');
+    expect(link?.getAttribute('aria-label')).toBe('WG Identity & Trust, Working Groups');
+  });
+
+  it('row hover highlight keeps its peer / has-[.peer:hover] pair', async () => {
+    // `peer` on the link and `has-[.peer:hover]:` on the row are the two halves of the row's
+    // hover highlight — a comment alone doesn't stop either half from being dropped as an
+    // apparently-unused class, so both are asserted directly rather than just documented. A
+    // separate test from the GH-1794 role/link assertions above, so a dropped `peer` fails with
+    // a diagnostic naming the hover highlight, not the unrelated a11y fix.
+    await render({ groups: [group()], total: 1 });
+
+    const row = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-item-g1"]');
+    const link = fixture.nativeElement.querySelector('[data-testid="public-foundation-groups-row-link-g1"]');
+    expect(row).not.toBeNull();
+    expect(link).not.toBeNull();
+
+    const linkClasses = (link?.getAttribute('class') ?? '').split(/\s+/);
+    expect(linkClasses).toContain('peer');
+    const rowClasses = (row?.className ?? '').split(/\s+/);
+    expect(rowClasses).toContain('has-[.peer:hover]:border-blue-200');
+    expect(rowClasses).toContain('has-[.peer:hover]:bg-blue-50/30');
+  });
 });

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.html
@@ -64,12 +64,23 @@
       <div class="flex flex-col gap-2" role="list" data-testid="public-project-groups-list">
         @for (group of groupsVm(); track group.uid) {
           @let config = group.classConfig;
-          <a
-            [routerLink]="['/groups', group.uid]"
+          <div
             role="listitem"
-            class="flex items-start gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors hover:border-blue-200 hover:bg-blue-50/30 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500 sm:items-center"
-            [attr.data-testid]="'public-project-groups-item-' + group.uid"
-            [attr.aria-label]="group.name + ', ' + config.label">
+            class="has-[.peer:hover]:border-blue-200 has-[.peer:hover]:bg-blue-50/30 relative flex items-start gap-4 rounded-lg border border-gray-200 bg-white p-4 transition-colors sm:items-center"
+            [attr.data-testid]="'public-project-groups-item-' + group.uid">
+            <!-- Whole-row click/focus target ("stretched link"), ported from org-groups.component.html
+                 (#1786): role="listitem" belongs on this non-interactive row div, not on an anchor,
+                 which is why the actual link is this separate absolutely-positioned <a> instead. `peer`
+                 lets the row react to this specific link's hover via has-[.peer:hover]: above. Unlike
+                 org-groups, this row has no second nested link, so no pointer-events-none/z-10 handoff
+                 is needed on the content below — don't drop `peer` in a "clean up unused classes" pass,
+                 it's what drives the row's hover highlight. -->
+            <a
+              [routerLink]="['/groups', group.uid]"
+              class="peer absolute inset-0 rounded-lg focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+              [attr.data-testid]="'public-project-groups-row-link-' + group.uid"
+              [attr.aria-label]="group.name + ', ' + config.label"></a>
+
             <!-- Icon -->
             <div class="flex h-9 w-9 shrink-0 items-center justify-center rounded-full" [class]="config.bgColor">
               <i [class]="config.icon + ' ' + config.color + ' text-base'" aria-hidden="true"></i>
@@ -107,7 +118,7 @@
             }
 
             <i class="fa-light fa-chevron-right text-gray-300 text-xs shrink-0" aria-hidden="true"></i>
-          </a>
+          </div>
         }
       </div>
     }

--- a/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/groups/public-project-groups/public-project-groups.component.spec.ts
@@ -130,4 +130,48 @@ describe('PublicProjectGroupsComponent — contrast and responsive row layout (G
     expect(rowClasses).toContain('items-start');
     expect(rowClasses).toContain('sm:items-center');
   });
+
+  it('exposes the row as a real link, not an anchor carrying role="listitem" (GH-1794)', async () => {
+    // WCAG 4.1.2 regression lock: an explicit role="listitem" on the anchor itself would replace
+    // its implicit link role, dropping the row out of the screen reader links rotor. A class-token
+    // assertion can't catch this — only checking the actual element identity/role can, which is
+    // exactly what the pre-fix markup (role="listitem" directly on the row <a>) would fail.
+    await render({ groups: [group()], total: 1 });
+
+    const row = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]');
+    expect(row).not.toBeNull();
+    expect(row?.tagName).toBe('DIV');
+    expect(row?.getAttribute('role')).toBe('listitem');
+
+    const link = fixture.nativeElement.querySelector('[data-testid="public-project-groups-row-link-g1"]');
+    expect(link).not.toBeNull();
+    expect(link?.tagName).toBe('A');
+    expect(row?.contains(link)).toBe(true);
+    expect(row).not.toBe(link);
+    // No role attribute at all — the element must rely on its implicit link role, which an <a>
+    // only gets once it has an href (otherwise it maps to `generic`), so that's asserted too.
+    expect(link?.getAttribute('role')).toBeNull();
+    expect(link?.getAttribute('href')).toBe('/groups/g1');
+    expect(link?.getAttribute('aria-label')).toBe('WG Identity & Trust, Working Groups');
+  });
+
+  it('row hover highlight keeps its peer / has-[.peer:hover] pair', async () => {
+    // `peer` on the link and `has-[.peer:hover]:` on the row are the two halves of the row's
+    // hover highlight — a comment alone doesn't stop either half from being dropped as an
+    // apparently-unused class, so both are asserted directly rather than just documented. A
+    // separate test from the GH-1794 role/link assertions above, so a dropped `peer` fails with
+    // a diagnostic naming the hover highlight, not the unrelated a11y fix.
+    await render({ groups: [group()], total: 1 });
+
+    const row = fixture.nativeElement.querySelector('[data-testid="public-project-groups-item-g1"]');
+    const link = fixture.nativeElement.querySelector('[data-testid="public-project-groups-row-link-g1"]');
+    expect(row).not.toBeNull();
+    expect(link).not.toBeNull();
+
+    const linkClasses = (link?.getAttribute('class') ?? '').split(/\s+/);
+    expect(linkClasses).toContain('peer');
+    const rowClasses = (row?.className ?? '').split(/\s+/);
+    expect(rowClasses).toContain('has-[.peer:hover]:border-blue-200');
+    expect(rowClasses).toContain('has-[.peer:hover]:bg-blue-50/30');
+  });
 });


### PR DESCRIPTION
## Summary
- Both public group directory pages (`/foundations/:slug/groups` and `/projects/:slug/groups`) put `role="listitem"` directly on the row `<a>`, which replaces its implicit link role and drops the row out of the screen reader links rotor on pages whose entire purpose is navigation — a WCAG 4.1.2 defect.
- Ports the pattern already shipped in `org-groups.component.html` (#1786): `role="listitem"` moves to a non-interactive wrapping `<div>`; a separate absolutely-positioned "stretched link" `<a>` inside carries the actual navigation (`routerLink`, `aria-label`), tagged `peer` so the row's `has-[.peer:hover]:` classes still highlight it on hover. Focus-visible outline moves to the link so it covers the full row.

## Test plan
- [x] `yarn lint`, `yarn check-types`, `yarn test` (739/739), `yarn build` — all pass against current `main`
- [x] New Vitest assertions in both `*.component.spec.ts` files lock: the row is a `DIV` with `role="listitem"`; a real `<a>` exists inside it with an `href`, no `role` attribute (implicit link role), and the correct `aria-label`; and the `peer`/`has-[.peer:hover]:` hover-highlight pair is present
- [ ] No Playwright coverage added — these two public pages have no existing e2e scaffolding (route stubs/fixtures/helpers), unlike `org-groups`. Standing that up is out of scope for this fix.
- [ ] Full accessibility-tree verification (Chrome DevTools Accessibility pane against prod data, tabbing through rows to confirm keyboard focus/link role) is deferred to the integration validation pass per this repo's per-ticket worktree workflow — not yet performed.

## Notes
- Branch name (`fix/GH-1794-public-groups-link-role`) has a descriptive suffix beyond the strict `fix/GH-1794` convention — pre-assigned target worktree branch, left as-is rather than renamed.

Closes #1794