### PR TITLE
feat(dashboards): add csv export to org groups roster

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -85,6 +85,36 @@
             ariaLabel="Filter by type"
             dataTest="org-groups-type-filter" />
         </div>
+        <!-- pTooltip lives on this wrapper, not the button: a disabled element is removed from the
+             tab order, so a keyboard user could never focus the button to see a tooltip bound to
+             it directly. tabindex + role="note" + aria-label (only while the tooltip has content)
+             give screen-reader users the same explanation a mouse hover gets — mirrors the
+             public-group badge in modules/committees/components/my-groups-card-grid/
+             my-groups-card-grid.component.html (same tabindex="0" + role="note" + aria-label
+             triplet, on a non-focusable host). A sighted keyboard-only user (no screen reader)
+             still gets no visual explanation: deliberately NOT tooltipEvent="both" — PrimeNG
+             resolves its focus target via `querySelector('.p-component')` inside this host, which
+             finds the inner (disabled, unfocusable) <p-button> root rather than this wrapper (the
+             element tabindex="0" actually puts in the tab order), so that listener would never
+             fire. -->
+        <div
+          class="flex items-center gap-2"
+          [pTooltip]="hasNoRowsToExport() ? noRowsToExportLabel : undefined"
+          tooltipPosition="top"
+          [attr.role]="hasNoRowsToExport() ? 'note' : null"
+          [attr.tabindex]="hasNoRowsToExport() ? '0' : null"
+          [attr.aria-label]="hasNoRowsToExport() ? noRowsToExportLabel : null"
+          data-testid="org-groups-export-csv-wrapper">
+          <lfx-button
+            label="Export to CSV"
+            icon="fa-light fa-file-arrow-down"
+            severity="secondary"
+            [outlined]="true"
+            size="small"
+            [disabled]="hasNoRowsToExport()"
+            (onClick)="exportCsv()"
+            data-testid="org-groups-export-csv" />
+        </div>
       </div>
     }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -115,6 +115,15 @@
             (onClick)="exportCsv()"
             data-testid="org-groups-export-csv" />
         </div>
+        <!-- Always-visible fallback for the tooltip: closes the gap for a sighted keyboard-only
+             user (no screen reader), who would otherwise get no explanation at all — see the
+             comment above for why the tooltip itself can't be made to show on keyboard focus.
+             aria-hidden because the wrapper's aria-label already carries this to screen readers;
+             without it, a screen reader landing on the wrapper's role="note" region could read the
+             explanation twice. -->
+        @if (hasNoRowsToExport()) {
+          <span class="text-xs text-gray-500" aria-hidden="true" data-testid="org-groups-export-csv-hint">{{ noRowsToExportLabel }}</span>
+        }
       </div>
     }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -1012,6 +1012,10 @@ describe('OrgGroupsComponent — CSV export', () => {
     return el as HTMLElement;
   }
 
+  function exportHint(fixture: ComponentFixture<OrgGroupsComponent>): HTMLElement | null {
+    return fixture.nativeElement.querySelector('[data-testid="org-groups-export-csv-hint"]');
+  }
+
   it('enables the export button with no tooltip once there are rows to export', async () => {
     const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
 
@@ -1022,6 +1026,7 @@ describe('OrgGroupsComponent — CSV export', () => {
     const wrapper = exportTooltipWrapper(fixture);
     expect(wrapper.hasAttribute('tabindex')).toBe(false);
     expect(wrapper.hasAttribute('role')).toBe(false);
+    expect(exportHint(fixture)).toBeNull();
   });
 
   it('disables the export button and shows "No rows to export" when the active filter matches nothing', async () => {
@@ -1038,6 +1043,11 @@ describe('OrgGroupsComponent — CSV export', () => {
     expect(wrapper.getAttribute('tabindex')).toBe('0');
     expect(wrapper.getAttribute('role')).toBe('note');
     expect(wrapper.getAttribute('aria-label')).toBe('No rows to export');
+    // Always-visible fallback for a sighted keyboard-only user, who gets no hover/focus tooltip —
+    // aria-hidden so a screen reader (already covered by the wrapper's aria-label) doesn't double-read it.
+    const hint = exportHint(fixture);
+    expect(hint?.textContent?.trim()).toBe('No rows to export');
+    expect(hint?.getAttribute('aria-hidden')).toBe('true');
   });
 
   it('exports only the rows the active filter leaves visible, not the full roster', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import type { Account, OrgDropdownOption, OrgLensGroupSummary, OrgLensGroupsResponse } from '@lfx-one/shared/interfaces';
@@ -10,6 +11,7 @@ import { OrgLensGroupsService } from '@services/org-lens-groups.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
+import { Tooltip } from 'primeng/tooltip';
 import { NEVER, Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { signal, type WritableSignal } from '@angular/core';
@@ -138,6 +140,95 @@ async function flushFilterChange(fixture: ComponentFixture<OrgGroupsComponent>):
   await new Promise((resolve) => setTimeout(resolve, 200));
   fixture.detectChanges();
   await fixture.whenStable();
+}
+
+/** data-testid lands on <lfx-button>'s host element, two Angular component boundaries above the
+ *  native <button> PrimeNG's <p-button> actually renders internally — query the descendant. */
+function exportButton(fixture: ComponentFixture<OrgGroupsComponent>): HTMLButtonElement {
+  const el = fixture.nativeElement.querySelector('[data-testid="org-groups-export-csv"] button');
+  if (!el) throw new Error('no native button rendered inside org-groups-export-csv');
+  return el as HTMLButtonElement;
+}
+
+/** pTooltip lives on the wrapper div, not the button — see the template comment for why (a
+ *  disabled element can't be keyboard-focused, so the tooltip/aria explanation would be
+ *  unreachable without it) — rendered on hover via a dynamic overlay rather than a static DOM
+ *  attribute, so read the bound `content` off the Tooltip directive instance instead of asserting
+ *  on hover behavior. */
+function exportTooltip(fixture: ComponentFixture<OrgGroupsComponent>): string | undefined {
+  const content = fixture.debugElement.query(By.css('[data-testid="org-groups-export-csv-wrapper"]'))?.injector.get(Tooltip, null)?.content;
+  return typeof content === 'string' ? content : undefined;
+}
+
+/**
+ * Clicks the export button and captures what downloadCsv() (shared/utils/file.utils.ts) hands to
+ * the browser download APIs — the Blob passed to URL.createObjectURL and the filename set on the
+ * anchor's `download` attribute — without mocking the shared `@lfx-one/shared/utils` module
+ * specifier itself (this repo's Angular unit-test builder doesn't hoist `vi.mock` by specifier the
+ * way plain Vitest does, so a factory-based module mock silently never takes effect here).
+ */
+async function captureExportedCsv(fixture: ComponentFixture<OrgGroupsComponent>): Promise<{ filename: string; rows: string[][] }> {
+  let capturedBlob: Blob | undefined;
+  let capturedFilename: string | undefined;
+  const originalCreateObjectURL = URL.createObjectURL;
+  const originalRevokeObjectURL = URL.revokeObjectURL;
+  URL.createObjectURL = ((blob: Blob) => {
+    capturedBlob = blob;
+    return 'blob:mock-url';
+  }) as typeof URL.createObjectURL;
+  URL.revokeObjectURL = (() => undefined) as typeof URL.revokeObjectURL;
+  const clickSpy = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(function (this: HTMLAnchorElement) {
+    capturedFilename = this.download;
+  });
+
+  try {
+    exportButton(fixture).click();
+  } finally {
+    clickSpy.mockRestore();
+    URL.createObjectURL = originalCreateObjectURL;
+    URL.revokeObjectURL = originalRevokeObjectURL;
+  }
+
+  if (!capturedBlob || capturedFilename === undefined) {
+    throw new Error('exportCsv() did not trigger a download');
+  }
+  const text = (await capturedBlob.text()).replace(new RegExp(String.fromCharCode(0xfeff)), '');
+  const rows = text
+    .split('\r\n')
+    .filter((line) => line.length > 0)
+    .map(parseCsvLine);
+  return { filename: capturedFilename, rows };
+}
+
+/** Quote-aware RFC 4180 cell split, matching escapeCsvCell's quoting (file.utils.ts) — a plain
+ *  `line.split(',')` would misalign columns the moment a cell (e.g. a comma-containing name) is
+ *  quoted. */
+function parseCsvLine(line: string): string[] {
+  const cells: string[] = [];
+  let cur = '';
+  let inQuotes = false;
+  for (let i = 0; i < line.length; i++) {
+    const ch = line[i];
+    if (inQuotes) {
+      if (ch === '"' && line[i + 1] === '"') {
+        cur += '"';
+        i++;
+      } else if (ch === '"') {
+        inQuotes = false;
+      } else {
+        cur += ch;
+      }
+    } else if (ch === '"') {
+      inQuotes = true;
+    } else if (ch === ',') {
+      cells.push(cur);
+      cur = '';
+    } else {
+      cur += ch;
+    }
+  }
+  cells.push(cur);
+  return cells;
 }
 
 describe('OrgGroupsComponent', () => {
@@ -911,5 +1002,125 @@ describe('OrgGroupsComponent stat strip', () => {
     // toBe(8) skeleton-card assertions in the top-level describe above).
     expect(classTiles()).toHaveLength(6);
     expect(section.style.getPropertyValue('--cols').trim()).toBe('8');
+  });
+});
+
+describe('OrgGroupsComponent — CSV export', () => {
+  function exportTooltipWrapper(fixture: ComponentFixture<OrgGroupsComponent>): HTMLElement {
+    const el = fixture.nativeElement.querySelector('[data-testid="org-groups-export-csv-wrapper"]');
+    if (!el) throw new Error('no export tooltip wrapper rendered');
+    return el as HTMLElement;
+  }
+
+  it('enables the export button with no tooltip once there are rows to export', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    expect(exportButton(fixture).disabled).toBe(false);
+    expect(exportTooltip(fixture)).toBeUndefined();
+    // Not a keyboard stop when there's nothing to explain — a stray always-on tabindex/role would
+    // add a no-op tab stop, and wrap the enabled button in a stray "note" role, for no reason.
+    const wrapper = exportTooltipWrapper(fixture);
+    expect(wrapper.hasAttribute('tabindex')).toBe(false);
+    expect(wrapper.hasAttribute('role')).toBe(false);
+  });
+
+  it('disables the export button and shows "No rows to export" when the active filter matches nothing', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    filterForm(fixture).get('search')?.setValue('no-such-group-xyz');
+    await flushFilterChange(fixture);
+
+    expect(exportButton(fixture).disabled).toBe(true);
+    expect(exportTooltip(fixture)).toBe('No rows to export');
+    // Keyboard/screen-reader path: the disabled button itself can't carry focus or an accessible
+    // tooltip, so the always-hoverable wrapper picks up a tab stop + aria-label while it applies.
+    const wrapper = exportTooltipWrapper(fixture);
+    expect(wrapper.getAttribute('tabindex')).toBe('0');
+    expect(wrapper.getAttribute('role')).toBe('note');
+    expect(wrapper.getAttribute('aria-label')).toBe('No rows to export');
+  });
+
+  it('exports only the rows the active filter leaves visible, not the full roster', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    filterForm(fixture).get('foundation')?.setValue('cncf');
+    await flushFilterChange(fixture);
+    expect(renderedItemUids(fixture)).toEqual(['g1', 'g4']);
+
+    const { rows } = await captureExportedCsv(fixture);
+
+    // header + 2 filtered rows only — g2/g3 (not in the 'cncf' foundation) must be excluded.
+    expect(rows).toHaveLength(3);
+    expect(rows.slice(1).map((row) => row[0])).toEqual(['Committee Steering TAG', 'Committee Newsletter']);
+  });
+
+  it('emits the BEHAVIORAL_CLASS_CONFIG label in the Type column, not the raw category string', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    const { rows } = await captureExportedCsv(fixture);
+
+    const [header, ...body] = rows;
+    expect(header).toEqual([COMMITTEE_LABEL.singular, 'Foundation', 'Type', 'Our Seats', `${COMMITTEE_LABEL.singular} UID`]);
+    // g2 (Zephyr Working Group) has raw category "Working Group" — the exported Type column must
+    // carry the display label ("Working Groups"), not that raw upstream string.
+    const zephyrRow = body.find((row) => row[4] === 'g2');
+    expect(zephyrRow?.[2]).toBe(BEHAVIORAL_CLASS_CONFIG['working-group'].label);
+    expect(zephyrRow?.[2]).not.toBe('Working Group');
+  });
+
+  it('names the download with the org slug and today’s date', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    const { filename } = await captureExportedCsv(fixture);
+
+    expect(filename).toMatch(/^org-lens-groups-acme-\d{8}\.csv$/);
+  });
+
+  it('stamps the local date, not the UTC date, in the filename', async () => {
+    // \d{8} alone can't catch a UTC/local-date mismatch, and CI runs UTC (the GitHub-hosted-runner
+    // default — no workflow sets TZ), where local and UTC calendar dates always coincide — a
+    // comparison against the *host's* current TZ would be a permanent no-op there. Pin TZ for this
+    // test so the assertion is unconditional and deterministic on every machine, including CI.
+    // vi.stubEnv (not a hand-rolled save/restore) mirrors the repo's own TZ-pinning precedent
+    // (committee-activity-query.helper.spec.ts) and correctly restores "unset" — a plain
+    // `process.env.TZ = originalTz` would coerce an originally-unset TZ into the literal string
+    // "undefined" and pin the rest of the worker process to UTC instead.
+    try {
+      vi.stubEnv('TZ', 'America/Los_Angeles');
+      vi.useFakeTimers({ toFake: ['Date'] });
+      // 2026-08-25T02:30:00Z is still Aug 24 in America/Los_Angeles (UTC-7 in August).
+      vi.setSystemTime(new Date('2026-08-25T02:30:00Z'));
+      const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+      const { filename } = await captureExportedCsv(fixture);
+
+      expect(filename).toContain('20260824');
+      expect(filename).not.toContain('20260825');
+    } finally {
+      vi.useRealTimers();
+      vi.unstubAllEnvs();
+    }
+  });
+
+  it('falls back to the default slug when accountSlug is the empty-string placeholder (not just null/undefined)', async () => {
+    const { fixture, selectedAccount } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    // Mirrors AccountContextService's PLACEHOLDER_ACCOUNT / toAccount(), which normalize a missing
+    // Snowflake slug to '' rather than null/undefined during org-switch/enrichment windows —
+    // `?? 'org'` would miss this and produce a bare "org-lens-groups--<date>.csv".
+    selectedAccount.update((account) => ({ ...account, accountSlug: '' }));
+
+    const { filename } = await captureExportedCsv(fixture);
+
+    expect(filename).toMatch(/^org-lens-groups-org-\d{8}\.csv$/);
+  });
+
+  it('quotes a comma-containing cell per RFC 4180, and the export still reports the correct value', async () => {
+    const groups: OrgLensGroupSummary[] = [{ uid: 'h1', name: 'Steering, Governance & Ops', category: 'TSC', org_seat_count: 2 }];
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(groups)) });
+
+    const { rows } = await captureExportedCsv(fixture);
+
+    expect(rows[1][0]).toBe('Steering, Governance & Ops');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -16,10 +16,12 @@ import type {
   OrgLensGroupsResponse,
   OrgLensGroupVm,
 } from '@lfx-one/shared/interfaces';
-import { getGroupBehavioralClass } from '@lfx-one/shared/utils';
+import { downloadCsv, getGroupBehavioralClass, localDateStamp } from '@lfx-one/shared/utils';
 import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, debounceTime, distinctUntilChanged, filter, map, of, skip, switchMap, tap } from 'rxjs';
 
+import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
@@ -32,7 +34,17 @@ import { PersonaService } from '@services/persona.service';
 
 @Component({
   selector: 'lfx-org-groups',
-  imports: [EmptyStateComponent, InputTextComponent, NgTemplateOutlet, RouterLink, SelectComponent, SkeletonModule, TagComponent],
+  imports: [
+    ButtonComponent,
+    EmptyStateComponent,
+    InputTextComponent,
+    NgTemplateOutlet,
+    RouterLink,
+    SelectComponent,
+    SkeletonModule,
+    TagComponent,
+    TooltipModule,
+  ],
   templateUrl: './org-groups.component.html',
 })
 export class OrgGroupsComponent {
@@ -57,7 +69,7 @@ export class OrgGroupsComponent {
     type: new FormControl<GroupBehavioralClass | ''>(this.initTypeFromUrl(), { nonNullable: true }),
   });
 
-  protected readonly companyName = computed(() => this.accountContext.selectedAccount()?.accountName ?? '');
+  protected readonly companyName = computed(() => this.accountContext.selectedAccount().accountName);
 
   // Total Groups + Total Seats — the two fixed tiles in the template that visibleClassTiles()
   // doesn't cover. Keep in sync with the stat-strip markup.
@@ -139,6 +151,10 @@ export class OrgGroupsComponent {
   protected readonly foundationOptions: Signal<OrgDropdownOption[]> = this.initFoundationOptions();
   protected readonly typeOptions: Signal<OrgDropdownOption[]> = this.initTypeOptions();
   protected readonly filteredGroups: Signal<OrgLensGroupVm[]> = this.initFilteredGroups();
+  // Single source of truth for the export button's disabled state and its tooltip/aria explanation,
+  // so every binding that reads it can't drift apart (mirrors showRoster's rationale above).
+  protected readonly hasNoRowsToExport: Signal<boolean> = computed(() => this.filteredGroups().length === 0);
+  protected readonly noRowsToExportLabel = 'No rows to export';
 
   public constructor() {
     // State → URL, mirrors org-projects' filterForm.valueChanges → router.navigate pattern. `merge`
@@ -158,6 +174,25 @@ export class OrgGroupsComponent {
 
   protected clearFilters(): void {
     this.filterForm.reset({ search: '', foundation: '', type: '' });
+  }
+
+  // Exports the currently filtered (not the full) roster, in the same order the list renders —
+  // filteredGroups() is exactly what the template's @for iterates, unsorted client-side. Deliberately
+  // no "Total Seats" column: the only per-row candidate (total_members) is unpopulated upstream (#1792)
+  // and isn't even a field on OrgLensGroupSummary; the response-level total_seats is an org-wide
+  // aggregate, not a per-row value.
+  protected exportCsv(): void {
+    const rows = this.filteredGroups();
+    if (!rows.length) {
+      return;
+    }
+    const header = [this.committeeLabel.singular, 'Foundation', 'Type', 'Our Seats', `${this.committeeLabel.singular} UID`];
+    const body = rows.map((g) => [g.name, g.projectLabel, BEHAVIORAL_CLASS_CONFIG[g.cls].label, g.org_seat_count, g.uid]);
+    // accountSlug is normalized to '' (not null/undefined) during org-switch/enrichment windows
+    // (see account-context.service.ts's PLACEHOLDER_ACCOUNT and toAccount()) — `||`, not `??`, so
+    // that empty string also falls back rather than producing a bare "org-lens-groups--<date>.csv".
+    const slug = this.accountContext.selectedAccount().accountSlug || 'org';
+    downloadCsv(`org-lens-groups-${slug}-${localDateStamp()}.csv`, [header, ...body]);
   }
 
   private initGroupsData(): Signal<OrgLensGroupsResponse | null | undefined> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -47,7 +47,7 @@ import type {
   OrgProjectsWorkspaceId,
   SortDirection,
 } from '@lfx-one/shared/interfaces';
-import { buildInsightsUrl, downloadCsv } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, downloadCsv, localDateStamp } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogModule } from 'primeng/dialog';
 import { PopoverModule } from 'primeng/popover';
@@ -544,9 +544,8 @@ export class OrgProjectsComponent {
         p.participants.length,
       ];
     });
-    const date = new Date().toISOString().slice(0, 10).replace(/-/g, '');
     const slug = this.response()?.orgSlug ?? 'org';
-    downloadCsv(`org-lens-projects-${slug}-${date}.csv`, [header, ...body]);
+    downloadCsv(`org-lens-projects-${slug}-${localDateStamp()}.csv`, [header, ...body]);
   }
 
   // Signal-strength bars for an influence band: filled count = rank (Leading 4 → Silent 1 → Non-LF 0),

--- a/packages/shared/src/utils/date-time.utils.spec.ts
+++ b/packages/shared/src/utils/date-time.utils.spec.ts
@@ -1,9 +1,9 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 
-import { formatIsoDateLabel } from './date-time.utils';
+import { formatIsoDateLabel, localDateStamp } from './date-time.utils';
 
 /**
  * The fallback contract is the whole point of this helper: anything that is not a real
@@ -45,5 +45,30 @@ describe('formatIsoDateLabel', () => {
   // time — a day early for anyone west of Greenwich.
   it('does not drift across time zones', () => {
     expect(formatIsoDateLabel('2026-01-01')).toBe('Jan 1, 2026');
+  });
+});
+
+describe('localDateStamp', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllEnvs();
+  });
+
+  it('stamps the local calendar date, not the UTC date', () => {
+    vi.stubEnv('TZ', 'America/Los_Angeles');
+    vi.useFakeTimers();
+    // Still Aug 24 in America/Los_Angeles (UTC-7 in August) — this is exactly the case
+    // `toISOString().slice(0, 10)` gets wrong, reporting the UTC date (Aug 25) instead.
+    vi.setSystemTime(new Date('2026-08-25T02:30:00Z'));
+
+    expect(localDateStamp()).toBe('20260824');
+  });
+
+  it('zero-pads single-digit months and days', () => {
+    vi.stubEnv('TZ', 'America/Los_Angeles');
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-05T20:00:00Z'));
+
+    expect(localDateStamp()).toBe('20260105');
   });
 });

--- a/packages/shared/src/utils/date-time.utils.ts
+++ b/packages/shared/src/utils/date-time.utils.ts
@@ -567,6 +567,18 @@ export function formatShortDate(date: Date): string {
 }
 
 /**
+ * Today's date as `YYYYMMDD` in the caller's local timezone — for stamping CSV/report export
+ * filenames. Deliberately local, not `toISOString()` (which reports the UTC date and stamps
+ * tomorrow's date for any viewer west of UTC exporting in the evening).
+ */
+export function localDateStamp(): string {
+  const now = new Date();
+  const month = String(now.getMonth() + 1).padStart(2, '0');
+  const day = String(now.getDate()).padStart(2, '0');
+  return `${now.getFullYear()}${month}${day}`;
+}
+
+/**
  * Short relative-time label for a future instant ("in 5 min", "in 2 hr", "in
  * 3 days") — the forward-looking counterpart to `formatRelativeTime`, which
  * only reads correctly for past instants (negative diffs there collapse to


### PR DESCRIPTION
## Summary

- Adds an "Export to CSV" button to `/org/groups`, mirroring the existing Org Projects export pattern (same `lfx-button` styling, same shared `downloadCsv` helper, same filename convention).
- Exports the currently filtered roster (not the full list) — columns: Group, Foundation, Type, Our Seats, Group UID. Type uses `BEHAVIORAL_CLASS_CONFIG[cls].label`, not the raw upstream category string.
- Extracts a new `localDateStamp()` shared util (`packages/shared/src/utils/date-time.utils.ts`) for local-timezone (not UTC) date stamping in export filenames, and migrates the sibling Org Projects export onto it, fixing a pre-existing bug there (`toISOString()` stamps tomorrow's date for any viewer west of UTC exporting in the evening).
- Disabled + "No rows to export" state is keyboard/screen-reader accessible (tooltip wrapper carries conditional `tabindex`/`role="note"`/`aria-label`, since a disabled button is removed from the tab order).

## Scope notes

- **Deliberately omits a "Total Seats" column.** The only per-row candidate field, `total_members`, is unpopulated upstream (#1792) and isn't even present on `OrgLensGroupSummary`. The response-level `total_seats` is an org-wide aggregate, not a per-row value, so it isn't a valid substitute.
- **`documentation-tab.component.ts`** has the same UTC-date filename bug this PR fixed in `org-projects.component.ts`, but is left untouched — out of scope for this ticket. Worth a follow-up now that `localDateStamp()` exists.

Closes GH-1781

## Test plan

- [x] `yarn lint` — clean
- [x] `yarn check-types` — clean
- [x] `yarn test` — 743/743 pass, including new coverage for `exportCsv()` (filtered-not-full export, disabled/tooltip state, `Type` column label mapping, empty-slug fallback, RFC 4180 quoting) and `localDateStamp()` (TZ-pinned local-vs-UTC regression test)
- [x] `yarn build` — succeeds
- [x] Manual verification: hover/mouse-event tracing confirmed via a minimal browser test that the tooltip mechanism behaves as documented in code comments