### PR TITLE
perf(meetings): parallelize registrant fan-out, dedupe roster walk (#1731)

### DIFF
--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -75,6 +75,8 @@ vi.mock('../services/logger.service', () => ({
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), warning: vi.fn(), error: vi.fn(), info: vi.fn(), debug: vi.fn() },
 }));
 
+import { resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
+
 import { MeetingController } from './meeting.controller';
 
 function buildReq(query: Record<string, string> = {}): any {
@@ -331,6 +333,23 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
       bearerToken: M2M_TOKEN,
     });
     // req.bearerToken was never swapped to the M2M token at any point the caller's own token was needed.
+    expect(req.bearerToken).toBe(USER_TOKEN);
+  });
+
+  it('restores the caller token and propagates the error when enrichCommitteeRegistrants throws', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: true, committees: [{ uid: COMMITTEE_UID }] }));
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1' }]);
+    const enrichError = new Error('NATS lookup failed');
+    vi.mocked(resolveCommitteeV2UidsToV1Ids).mockRejectedValue(enrichError);
+    const req = buildRegistrantsReq();
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMyMeetingRegistrants(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(enrichError);
+    expect(res.json).not.toHaveBeenCalled();
+    // The M2M token swapped in for the enrichment call must not leak onto req after the throw.
     expect(req.bearerToken).toBe(USER_TOKEN);
   });
 });

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -7,14 +7,18 @@ const MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
 const COMMITTEE_UID = 'b0000000-0000-0000-0000-000000000002';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { meetingSvc, getEffectiveEmailMock, addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedByMock } = vi.hoisted(() => ({
+const { meetingSvc, getEffectiveEmailMock, getUsernameFromAuthMock, generateM2MTokenMock, addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedByMock } =
+  vi.hoisted(() => ({
   meetingSvc: {
     getMeetingRegistrants: vi.fn(),
     getAuthorizedRegistrantsForImport: vi.fn(),
     getMeetingById: vi.fn(),
     getMeetingHostKey: vi.fn(),
+    getMeetingRegistrantsForUser: vi.fn(),
   },
   getEffectiveEmailMock: vi.fn(),
+  getUsernameFromAuthMock: vi.fn(),
+  generateM2MTokenMock: vi.fn(),
   addInvitedStatusToMeetingMock: vi.fn(),
   enrichMeetingsWithCreatedByMock: vi.fn(),
 }));
@@ -33,8 +37,8 @@ vi.mock('@lfx-one/shared/utils', () => ({
   resolveMeetingOwner: vi.fn(() => null),
 }));
 
-vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock, getUsernameFromAuth: vi.fn() }));
-vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock, getUsernameFromAuth: getUsernameFromAuthMock }));
+vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
 vi.mock('../helpers/committee-v1-mapping.helper', () => ({ resolveCommitteeV2UidsToV1Ids: vi.fn() }));
 // Keep the real host-key gate (isWithinHostKeyWindow + applyOrganizerAndHostKeyResult); stub
 // only the registrant-lookup/enrichment helpers so the controller tests don't need M2M plumbing.
@@ -213,5 +217,126 @@ describe('MeetingController.getMeetingById host-key gating', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.host_key).toBeUndefined();
     expect(payload.can_view_host_key).toBe(false);
+  });
+});
+
+// getMyMeetingRegistrants: the gate check (getMeetingRegistrantsForUser) and the meeting fetch
+// (getMeetingById) fan out under Promise.all, and the M2M token is threaded via
+// ApiRequestOptions.bearerToken rather than a req.bearerToken mutation (see meeting.controller.ts).
+describe('MeetingController.getMyMeetingRegistrants', () => {
+  let controller: MeetingController;
+  const USER_TOKEN = 'user-token-abc';
+  const M2M_TOKEN = 'm2m-token-xyz';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new MeetingController();
+    generateM2MTokenMock.mockResolvedValue(M2M_TOKEN);
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    getUsernameFromAuthMock.mockResolvedValue(undefined);
+    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
+  });
+
+  function buildRegistrantsReq(overrides: Record<string, unknown> = {}): any {
+    return { ...buildReq({}), bearerToken: USER_TOKEN, ...overrides };
+  }
+
+  it('grants access to an organizer who is not a registrant', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: true, committees: [] }));
+    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1' }]);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
+
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(
+      expect.anything(),
+      MEETING_UID,
+      false,
+      undefined,
+      false,
+      undefined,
+      { bearerToken: M2M_TOKEN }
+    );
+    expect(res.json).toHaveBeenCalledWith([{ uid: 'r1' }]);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns an empty list for a non-registrant, non-organizer caller without fetching the roster', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: false, committees: [] }));
+    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
+
+    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith([]);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('falls back to username when the caller has no email, and still runs the gate check', async () => {
+    getEffectiveEmailMock.mockReturnValue(undefined);
+    getUsernameFromAuthMock.mockResolvedValue('some-user');
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: false, committees: [] }));
+    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([{ uid: 'r1' }]);
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1' }]);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
+
+    expect(meetingSvc.getMeetingRegistrantsForUser).toHaveBeenCalledWith(expect.anything(), MEETING_UID, undefined, 'some-user', M2M_TOKEN);
+    expect(res.json).toHaveBeenCalledWith([{ uid: 'r1' }]);
+  });
+
+  it('returns an empty list without any upstream fetch when caller has neither email nor username', async () => {
+    getEffectiveEmailMock.mockReturnValue(undefined);
+    getUsernameFromAuthMock.mockResolvedValue(undefined);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
+
+    expect(meetingSvc.getMeetingById).not.toHaveBeenCalled();
+    expect(meetingSvc.getMeetingRegistrantsForUser).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+
+  it('short-circuits with an empty list when the meeting is not found', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(null);
+    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
+
+    expect(meetingSvc.getMeetingRegistrants).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledWith([]);
+  });
+
+  it('identity-race regression: the M2M token never crosses with the caller\'s own token, even when the gate check settles after the meeting fetch', async () => {
+    // getMeetingById resolves immediately; the M2M token generation (and the gate check chained
+    // off it) resolves on a later microtask — out-of-order settlement relative to the fetch above.
+    meetingSvc.getMeetingById.mockImplementation(async () => buildMeeting({ organizer: true, committees: [] }));
+    generateM2MTokenMock.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(M2M_TOKEN), 5)));
+    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
+    const req = buildRegistrantsReq();
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMyMeetingRegistrants(req, res, next);
+
+    // The gate check ran under the M2M token, never the caller's own token.
+    expect(meetingSvc.getMeetingRegistrantsForUser).toHaveBeenCalledWith(expect.anything(), MEETING_UID, 'user@example.com', undefined, M2M_TOKEN);
+    // The roster fetch carried the M2M token via options, not by mutating req.bearerToken.
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false, undefined, {
+      bearerToken: M2M_TOKEN,
+    });
+    // req.bearerToken was never swapped to the M2M token at any point the caller's own token was needed.
+    expect(req.bearerToken).toBe(USER_TOKEN);
   });
 });

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -7,21 +7,19 @@ const MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
 const COMMITTEE_UID = 'b0000000-0000-0000-0000-000000000002';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { meetingSvc, getEffectiveEmailMock, getEffectiveUsernameMock, generateM2MTokenMock, addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedByMock } =
-  vi.hoisted(() => ({
-    meetingSvc: {
-      getMeetingRegistrants: vi.fn(),
-      getAuthorizedRegistrantsForImport: vi.fn(),
-      getMeetingById: vi.fn(),
-      getMeetingHostKey: vi.fn(),
-      getMeetingRegistrantsForUser: vi.fn(),
-    },
-    getEffectiveEmailMock: vi.fn(),
-    getEffectiveUsernameMock: vi.fn(),
-    generateM2MTokenMock: vi.fn(),
-    addInvitedStatusToMeetingMock: vi.fn(),
-    enrichMeetingsWithCreatedByMock: vi.fn(),
-  }));
+const { meetingSvc, getEffectiveEmailMock, generateM2MTokenMock, addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedByMock } = vi.hoisted(() => ({
+  meetingSvc: {
+    getMeetingRegistrants: vi.fn(),
+    getAuthorizedRegistrantsForImport: vi.fn(),
+    getMeetingById: vi.fn(),
+    getMeetingHostKey: vi.fn(),
+    getMeetingRegistrantsByEmail: vi.fn(),
+  },
+  getEffectiveEmailMock: vi.fn(),
+  generateM2MTokenMock: vi.fn(),
+  addInvitedStatusToMeetingMock: vi.fn(),
+  enrichMeetingsWithCreatedByMock: vi.fn(),
+}));
 
 // The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
 vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal());
@@ -37,7 +35,7 @@ vi.mock('@lfx-one/shared/utils', () => ({
   resolveMeetingOwner: vi.fn(() => null),
 }));
 
-vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock, getEffectiveUsername: getEffectiveUsernameMock }));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock }));
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
 vi.mock('../helpers/committee-v1-mapping.helper', () => ({ resolveCommitteeV2UidsToV1Ids: vi.fn() }));
 // Keep the real host-key gate (isWithinHostKeyWindow + applyOrganizerAndHostKeyResult); stub
@@ -222,7 +220,7 @@ describe('MeetingController.getMeetingById host-key gating', () => {
   });
 });
 
-// getMyMeetingRegistrants: the gate check (getMeetingRegistrantsForUser) and the meeting fetch
+// getMyMeetingRegistrants: the gate check (getMeetingRegistrantsByEmail) and the meeting fetch
 // (getMeetingById) fan out under Promise.all, and the M2M token is threaded via
 // ApiRequestOptions.bearerToken rather than a req.bearerToken mutation (see meeting.controller.ts).
 describe('MeetingController.getMyMeetingRegistrants', () => {
@@ -235,8 +233,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
     controller = new MeetingController();
     generateM2MTokenMock.mockResolvedValue(M2M_TOKEN);
     getEffectiveEmailMock.mockReturnValue('user@example.com');
-    getEffectiveUsernameMock.mockReturnValue(undefined);
-    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([]);
     meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
   });
 
@@ -246,7 +243,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
 
   it('grants access to an organizer who is not a registrant', async () => {
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: true, committees: [] }));
-    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([]);
     meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1' }]);
     const res = buildRes();
     const next = vi.fn();
@@ -262,7 +259,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
 
   it('returns an empty list for a non-registrant, non-organizer caller without fetching the roster', async () => {
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: false, committees: [] }));
-    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([]);
     const res = buildRes();
     const next = vi.fn();
 
@@ -273,37 +270,21 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
     expect(next).not.toHaveBeenCalled();
   });
 
-  it('falls back to username when the caller has no email, and still runs the gate check', async () => {
+  it('returns an empty list without any upstream fetch when caller has no email', async () => {
     getEffectiveEmailMock.mockReturnValue(undefined);
-    getEffectiveUsernameMock.mockReturnValue('some-user');
-    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: false, committees: [] }));
-    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([{ uid: 'r1' }]);
-    meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1' }]);
-    const res = buildRes();
-    const next = vi.fn();
-
-    await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
-
-    expect(meetingSvc.getMeetingRegistrantsForUser).toHaveBeenCalledWith(expect.anything(), MEETING_UID, undefined, 'some-user', M2M_TOKEN);
-    expect(res.json).toHaveBeenCalledWith([{ uid: 'r1' }]);
-  });
-
-  it('returns an empty list without any upstream fetch when caller has neither email nor username', async () => {
-    getEffectiveEmailMock.mockReturnValue(undefined);
-    getEffectiveUsernameMock.mockReturnValue(undefined);
     const res = buildRes();
     const next = vi.fn();
 
     await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
 
     expect(meetingSvc.getMeetingById).not.toHaveBeenCalled();
-    expect(meetingSvc.getMeetingRegistrantsForUser).not.toHaveBeenCalled();
+    expect(meetingSvc.getMeetingRegistrantsByEmail).not.toHaveBeenCalled();
     expect(res.json).toHaveBeenCalledWith([]);
   });
 
   it('short-circuits with an empty list when the meeting is not found', async () => {
     meetingSvc.getMeetingById.mockResolvedValue(null);
-    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([]);
     const res = buildRes();
     const next = vi.fn();
 
@@ -318,7 +299,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
     // off it) resolves on a later microtask — out-of-order settlement relative to the fetch above.
     meetingSvc.getMeetingById.mockImplementation(async () => buildMeeting({ organizer: true, committees: [] }));
     generateM2MTokenMock.mockImplementation(() => new Promise((resolve) => setTimeout(() => resolve(M2M_TOKEN), 5)));
-    meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
+    meetingSvc.getMeetingRegistrantsByEmail.mockResolvedValue([]);
     meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
     const req = buildRegistrantsReq();
     const res = buildRes();
@@ -327,7 +308,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
     await controller.getMyMeetingRegistrants(req, res, next);
 
     // The gate check ran under the M2M token, never the caller's own token.
-    expect(meetingSvc.getMeetingRegistrantsForUser).toHaveBeenCalledWith(expect.anything(), MEETING_UID, 'user@example.com', undefined, M2M_TOKEN);
+    expect(meetingSvc.getMeetingRegistrantsByEmail).toHaveBeenCalledWith(expect.anything(), MEETING_UID, 'user@example.com', M2M_TOKEN);
     // The roster fetch carried the M2M token via options, not by mutating req.bearerToken.
     expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false, undefined, {
       bearerToken: M2M_TOKEN,

--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -7,21 +7,21 @@ const MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
 const COMMITTEE_UID = 'b0000000-0000-0000-0000-000000000002';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { meetingSvc, getEffectiveEmailMock, getUsernameFromAuthMock, generateM2MTokenMock, addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedByMock } =
+const { meetingSvc, getEffectiveEmailMock, getEffectiveUsernameMock, generateM2MTokenMock, addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedByMock } =
   vi.hoisted(() => ({
-  meetingSvc: {
-    getMeetingRegistrants: vi.fn(),
-    getAuthorizedRegistrantsForImport: vi.fn(),
-    getMeetingById: vi.fn(),
-    getMeetingHostKey: vi.fn(),
-    getMeetingRegistrantsForUser: vi.fn(),
-  },
-  getEffectiveEmailMock: vi.fn(),
-  getUsernameFromAuthMock: vi.fn(),
-  generateM2MTokenMock: vi.fn(),
-  addInvitedStatusToMeetingMock: vi.fn(),
-  enrichMeetingsWithCreatedByMock: vi.fn(),
-}));
+    meetingSvc: {
+      getMeetingRegistrants: vi.fn(),
+      getAuthorizedRegistrantsForImport: vi.fn(),
+      getMeetingById: vi.fn(),
+      getMeetingHostKey: vi.fn(),
+      getMeetingRegistrantsForUser: vi.fn(),
+    },
+    getEffectiveEmailMock: vi.fn(),
+    getEffectiveUsernameMock: vi.fn(),
+    generateM2MTokenMock: vi.fn(),
+    addInvitedStatusToMeetingMock: vi.fn(),
+    enrichMeetingsWithCreatedByMock: vi.fn(),
+  }));
 
 // The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
 vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal());
@@ -37,7 +37,7 @@ vi.mock('@lfx-one/shared/utils', () => ({
   resolveMeetingOwner: vi.fn(() => null),
 }));
 
-vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock, getUsernameFromAuth: getUsernameFromAuthMock }));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock, getEffectiveUsername: getEffectiveUsernameMock }));
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
 vi.mock('../helpers/committee-v1-mapping.helper', () => ({ resolveCommitteeV2UidsToV1Ids: vi.fn() }));
 // Keep the real host-key gate (isWithinHostKeyWindow + applyOrganizerAndHostKeyResult); stub
@@ -233,7 +233,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
     controller = new MeetingController();
     generateM2MTokenMock.mockResolvedValue(M2M_TOKEN);
     getEffectiveEmailMock.mockReturnValue('user@example.com');
-    getUsernameFromAuthMock.mockResolvedValue(undefined);
+    getEffectiveUsernameMock.mockReturnValue(undefined);
     meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([]);
     meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
   });
@@ -251,15 +251,9 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
 
     await controller.getMyMeetingRegistrants(buildRegistrantsReq(), res, next);
 
-    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(
-      expect.anything(),
-      MEETING_UID,
-      false,
-      undefined,
-      false,
-      undefined,
-      { bearerToken: M2M_TOKEN }
-    );
+    expect(meetingSvc.getMeetingRegistrants).toHaveBeenCalledWith(expect.anything(), MEETING_UID, false, undefined, false, undefined, {
+      bearerToken: M2M_TOKEN,
+    });
     expect(res.json).toHaveBeenCalledWith([{ uid: 'r1' }]);
     expect(next).not.toHaveBeenCalled();
   });
@@ -279,7 +273,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
 
   it('falls back to username when the caller has no email, and still runs the gate check', async () => {
     getEffectiveEmailMock.mockReturnValue(undefined);
-    getUsernameFromAuthMock.mockResolvedValue('some-user');
+    getEffectiveUsernameMock.mockReturnValue('some-user');
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: false, committees: [] }));
     meetingSvc.getMeetingRegistrantsForUser.mockResolvedValue([{ uid: 'r1' }]);
     meetingSvc.getMeetingRegistrants.mockResolvedValue([{ uid: 'r1' }]);
@@ -294,7 +288,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
 
   it('returns an empty list without any upstream fetch when caller has neither email nor username', async () => {
     getEffectiveEmailMock.mockReturnValue(undefined);
-    getUsernameFromAuthMock.mockResolvedValue(undefined);
+    getEffectiveUsernameMock.mockReturnValue(undefined);
     const res = buildRes();
     const next = vi.fn();
 
@@ -317,7 +311,7 @@ describe('MeetingController.getMyMeetingRegistrants', () => {
     expect(res.json).toHaveBeenCalledWith([]);
   });
 
-  it('identity-race regression: the M2M token never crosses with the caller\'s own token, even when the gate check settles after the meeting fetch', async () => {
+  it("identity-race regression: the M2M token never crosses with the caller's own token, even when the gate check settles after the meeting fetch", async () => {
     // getMeetingById resolves immediately; the M2M token generation (and the gate check chained
     // off it) resolves on a later microtask — out-of-order settlement relative to the fetch above.
     meetingSvc.getMeetingById.mockImplementation(async () => buildMeeting({ organizer: true, committees: [] }));

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -36,7 +36,7 @@ import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 import { NatsService } from '../services/nats.service';
 import { UserService } from '../services/user.service';
-import { getEffectiveEmail, getUsernameFromAuth } from '../utils/auth-helper';
+import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 /**
@@ -474,7 +474,7 @@ export class MeetingController {
       // with a different email now passes, widening the gate slightly from the previous
       // email-only check (getMeetingRegistrantsByEmail).
       const userEmail = getEffectiveEmail(req) ?? undefined;
-      const username = (await getUsernameFromAuth(req)) ?? undefined;
+      const username = getEffectiveUsername(req) ?? undefined;
 
       logger.debug(req, 'get_my_meeting_registrants', 'Checking user authentication', {
         meeting_id: uid,
@@ -563,11 +563,15 @@ export class MeetingController {
       // caller's own token — tracked separately in #1903.
       const originalToken = req.bearerToken;
       req.bearerToken = m2mToken;
-      const enrichedRegistrants = await this.enrichCommitteeRegistrants(req, meeting, registrants);
-      if (originalToken !== undefined) {
-        req.bearerToken = originalToken;
-      } else {
-        delete req.bearerToken;
+      let enrichedRegistrants: MeetingRegistrant[];
+      try {
+        enrichedRegistrants = await this.enrichCommitteeRegistrants(req, meeting, registrants);
+      } finally {
+        if (originalToken !== undefined) {
+          req.bearerToken = originalToken;
+        } else {
+          delete req.bearerToken;
+        }
       }
 
       logger.success(req, 'get_my_meeting_registrants', startTime, {

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -473,6 +473,10 @@ export class MeetingController {
       // email OR username (getMeetingRegistrantsForUser) — a registrant added under a username
       // with a different email now passes, widening the gate slightly from the previous
       // email-only check (getMeetingRegistrantsByEmail).
+      //
+      // getEffectiveUsername (not getUsernameFromAuth) deliberately, so this access-control check
+      // honors isImpersonating on the Authelia auth path too. getUsernameFromAuth's other call
+      // sites still have this gap — tracked separately in #1908.
       const userEmail = getEffectiveEmail(req) ?? undefined;
       const username = getEffectiveUsername(req) ?? undefined;
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -36,7 +36,7 @@ import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 import { NatsService } from '../services/nats.service';
 import { UserService } from '../services/user.service';
-import { getEffectiveEmail, getEffectiveUsername } from '../utils/auth-helper';
+import { getEffectiveEmail } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 /**
@@ -469,25 +469,17 @@ export class MeetingController {
         return;
       }
 
-      // Step 1: Resolve the caller's identity up front. The registrant gate check below accepts
-      // email OR username (getMeetingRegistrantsForUser) — a registrant added under a username
-      // with a different email now passes, widening the gate slightly from the previous
-      // email-only check (getMeetingRegistrantsByEmail).
-      //
-      // getEffectiveUsername (not getUsernameFromAuth) deliberately, so this access-control check
-      // honors isImpersonating on the Authelia auth path too. getUsernameFromAuth's other call
-      // sites still have this gap — tracked separately in #1908.
+      // Step 1: Resolve the caller's identity up front. The registrant gate check below is
+      // email-only (getMeetingRegistrantsByEmail), matching the pre-existing authorization surface
+      // — this PR does not widen the gate to also match by username.
       const userEmail = getEffectiveEmail(req) ?? undefined;
-      const username = getEffectiveUsername(req) ?? undefined;
 
       logger.debug(req, 'get_my_meeting_registrants', 'Checking user authentication', {
         meeting_id: uid,
         has_email: !!userEmail,
-        has_username: !!username,
-        user_email: userEmail,
       });
 
-      if (!userEmail && !username) {
+      if (!userEmail) {
         logger.success(req, 'get_my_meeting_registrants', startTime, {
           meeting_id: uid,
           no_email: true,
@@ -507,7 +499,7 @@ export class MeetingController {
         this.meetingService.getMeetingById(req, uid, 'v1_meeting', { access: true }),
         generateM2MToken(req).then((token) => {
           m2mToken = token;
-          return this.meetingService.getMeetingRegistrantsForUser(req, uid, userEmail, username, token);
+          return this.meetingService.getMeetingRegistrantsByEmail(req, uid, userEmail, token);
         }),
       ]);
 

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -36,7 +36,7 @@ import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 import { NatsService } from '../services/nats.service';
 import { UserService } from '../services/user.service';
-import { getEffectiveEmail } from '../utils/auth-helper';
+import { getEffectiveEmail, getUsernameFromAuth } from '../utils/auth-helper';
 import { generateM2MToken } from '../utils/m2m-token.util';
 
 /**
@@ -469,9 +469,44 @@ export class MeetingController {
         return;
       }
 
-      // Step 1: Get the meeting with access check to determine organizer status
-      logger.debug(req, 'get_my_meeting_registrants', 'Fetching meeting details with access check', { meeting_id: uid });
-      const meeting = await this.meetingService.getMeetingById(req, uid, 'v1_meeting', { access: true });
+      // Step 1: Resolve the caller's identity up front. The registrant gate check below accepts
+      // email OR username (getMeetingRegistrantsForUser) — a registrant added under a username
+      // with a different email now passes, widening the gate slightly from the previous
+      // email-only check (getMeetingRegistrantsByEmail).
+      const userEmail = getEffectiveEmail(req) ?? undefined;
+      const username = (await getUsernameFromAuth(req)) ?? undefined;
+
+      logger.debug(req, 'get_my_meeting_registrants', 'Checking user authentication', {
+        meeting_id: uid,
+        has_email: !!userEmail,
+        has_username: !!username,
+        user_email: userEmail,
+      });
+
+      if (!userEmail && !username) {
+        logger.success(req, 'get_my_meeting_registrants', startTime, {
+          meeting_id: uid,
+          no_email: true,
+          registrant_count: 0,
+        });
+        res.json([]);
+        return;
+      }
+
+      // Step 2: Fetch the meeting and run the registrant gate check in parallel — the gate check
+      // depends only on uid + caller identity, not on the meeting payload, so it needn't wait for
+      // the meeting fetch. The gate check runs under an M2M token (captured via `m2mToken`, not by
+      // mutating req.bearerToken) so it isn't gated by the caller's own FGA relations.
+      logger.debug(req, 'get_my_meeting_registrants', 'Fetching meeting and registrant gate check in parallel', { meeting_id: uid });
+      let m2mToken = '';
+      const [meeting, userRegistrantCheck] = await Promise.all([
+        this.meetingService.getMeetingById(req, uid, 'v1_meeting', { access: true }),
+        generateM2MToken(req).then((token) => {
+          m2mToken = token;
+          return this.meetingService.getMeetingRegistrantsForUser(req, uid, userEmail, username, token);
+        }),
+      ]);
+
       if (!meeting) {
         logger.success(req, 'get_my_meeting_registrants', startTime, {
           meeting_id: uid,
@@ -482,106 +517,53 @@ export class MeetingController {
         return;
       }
 
-      // TODO: Reimplement show_meeting_attendees check
-      // // All ITX meetings are treated as having show_meeting_attendees enabled
-      // const showMeetingAttendees = meeting.show_meeting_attendees ?? false;
-
-      // logger.debug(req, 'get_my_meeting_registrants', 'Meeting found, checking show_meeting_attendees', {
-      //   meeting_id: uid,
-      //   show_meeting_attendees: showMeetingAttendees,
-      // });
-
-      // // Step 2-4: Check if show_meeting_attendees is enabled
-      // if (!showMeetingAttendees) {
-      //   logger.success(req, 'get_my_meeting_registrants', startTime, {
-      //     meeting_id: uid,
-      //     show_meeting_attendees: false,
-      //     registrant_count: 0,
-      //   });
-      //   res.json([]);
-      //   return;
-      // }
-
-      // Step 5: Check if current user is a registrant (access control)
-      const userEmail = getEffectiveEmail(req) ?? undefined;
-
-      logger.debug(req, 'get_my_meeting_registrants', 'Checking user authentication', {
-        meeting_id: uid,
-        has_email: !!userEmail,
-        user_email: userEmail,
-      });
-
-      if (!userEmail) {
-        logger.success(req, 'get_my_meeting_registrants', startTime, {
-          meeting_id: uid,
-          no_email: true,
-          registrant_count: 0,
-        });
-        res.json([]);
-        return;
-      }
-
-      // Save original token and setup M2M token for privileged access
-      const originalToken = req.bearerToken;
-      const m2mToken = await generateM2MToken(req);
-      req.bearerToken = m2mToken;
-
-      // Use tags_all to filter by both meeting_id and email
-      logger.debug(req, 'get_my_meeting_registrants', 'Checking if user is a registrant', {
-        meeting_id: uid,
-        user_email: userEmail,
-      });
-      const userRegistrantCheck = await this.meetingService.getMeetingRegistrantsByEmail(req, uid, userEmail);
-
       logger.debug(req, 'get_my_meeting_registrants', 'User registrant check complete', {
         meeting_id: uid,
         user_email: userEmail,
         registrant_count: userRegistrantCheck.length,
       });
 
-      // Step 6: If user is not a registrant, check if they are an organizer
-      if (userRegistrantCheck.length === 0) {
-        if (!meeting.organizer) {
-          logger.success(req, 'get_my_meeting_registrants', startTime, {
-            meeting_id: uid,
-            user_email: userEmail,
-            is_registrant: false,
-            is_organizer: false,
-            registrant_count: 0,
-          });
-          res.json([]);
-          return;
-        }
-
-        logger.debug(req, 'get_my_meeting_registrants', 'User is not a registrant but is an organizer, granting access', {
+      // Step 3: If user is not a registrant, check if they are an organizer
+      if (userRegistrantCheck.length === 0 && !meeting.organizer) {
+        logger.success(req, 'get_my_meeting_registrants', startTime, {
           meeting_id: uid,
           user_email: userEmail,
+          is_registrant: false,
+          is_organizer: false,
+          registrant_count: 0,
         });
+        res.json([]);
+        return;
       }
 
-      // Step 7: User is a registrant or organizer, fetch all registrants using M2M token
+      // Step 4: User is a registrant or organizer, fetch all registrants using the M2M token —
+      // passed via ApiRequestOptions.bearerToken (not a req.bearerToken mutation) so it can't race
+      // against the caller's own token on a shared req.
       logger.debug(req, 'get_my_meeting_registrants', 'Fetching registrants with M2M token', {
         meeting_id: uid,
         user_email: userEmail,
         include_rsvp: includeRsvp,
-      });
-
-      logger.debug(req, 'get_my_meeting_registrants', 'M2M token generated, fetching all registrants', {
-        meeting_id: uid,
         has_m2m_token: !!m2mToken,
       });
 
-      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId);
+      const registrants = await this.meetingService.getMeetingRegistrants(req, uid, includeRsvp, occurrenceId, false, undefined, {
+        bearerToken: m2mToken,
+      });
 
       logger.debug(req, 'get_my_meeting_registrants', 'Fetched all registrants, enriching committee data', {
         meeting_id: uid,
         registrant_count: registrants.length,
       });
 
-      // Enrich committee registrant data with committee details and member info
+      // Enrich committee registrant data with committee details and member info. Kept on a
+      // narrowly-scoped req.bearerToken swap rather than threaded ApiRequestOptions: this call is
+      // sequential (nothing else is in flight on this req), so it carries none of the identity-race
+      // hazard the parallel fan-out above did. Fully re-plumbing CommitteeService's bearerToken
+      // would also need to exclude addAccessToResource/getCallerMembership, which must stay on the
+      // caller's own token — tracked separately in #1903.
+      const originalToken = req.bearerToken;
+      req.bearerToken = m2mToken;
       const enrichedRegistrants = await this.enrichCommitteeRegistrants(req, meeting, registrants);
-
-      // Restore original token (delete if it was undefined to avoid leaving M2M token)
       if (originalToken !== undefined) {
         req.bearerToken = originalToken;
       } else {

--- a/apps/lfx-one/src/server/helpers/meeting-rsvp.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/meeting-rsvp.helper.spec.ts
@@ -1,0 +1,87 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { MeetingRegistrant, MeetingRsvp } from '@lfx-one/shared/interfaces';
+import { describe, expect, it, vi } from 'vitest';
+
+// This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
+// path alias isn't wired here (mirrors meeting.helper.spec.ts / meeting.service.spec.ts), and the
+// real `@lfx-one/shared/utils` barrel transitively needs @angular/compiler outside an Angular
+// bootstrap. Stub `selectApplicableRsvp` with a faithful reimplementation of the real resolver
+// (packages/shared/src/utils/rsvp-calculator.util.ts): most-recently-modified first, a `scope:
+// 'all'` entry wins over any `single`/`this_and_following` entry for an unrelated occurrence.
+// The resolver's own exhaustive behavior (unit normalization, this_and_following anchors, etc.)
+// is covered by rsvp-calculator.util.spec.ts — this stub only needs to preserve the one property
+// that attachRsvpsToRegistrants' delegation depends on (LFXV2-2864).
+vi.mock('@lfx-one/shared/utils', () => ({
+  selectApplicableRsvp: (occurrenceId: string | undefined, rsvps: MeetingRsvp[]): MeetingRsvp | null => {
+    if (rsvps.length === 0) return null;
+    const sorted = [...rsvps].sort((a, b) => new Date(b.modified_at as string).getTime() - new Date(a.modified_at as string).getTime());
+    if (!occurrenceId) return sorted[0];
+    for (const rsvp of sorted) {
+      if (rsvp.scope === 'all') return rsvp;
+      if (rsvp.scope === 'single' && rsvp.occurrence_id === occurrenceId) return rsvp;
+    }
+    return null;
+  },
+}));
+
+import { attachRsvpsToRegistrants, filterRsvpsToActiveRegistrants } from './meeting-rsvp.helper';
+
+const registrant = (uid: string): MeetingRegistrant => ({ uid } as MeetingRegistrant);
+const rsvp = (overrides: Partial<MeetingRsvp>): MeetingRsvp =>
+  ({ registrant_id: 'r1', response_type: 'accepted', ...overrides }) as unknown as MeetingRsvp;
+
+describe('filterRsvpsToActiveRegistrants', () => {
+  it('keeps only RSVPs whose registrant_id matches a currently-active registrant', () => {
+    const registrants = [registrant('r1'), registrant('r2')];
+    const rsvps = [rsvp({ registrant_id: 'r1' }), rsvp({ registrant_id: 'stale-registrant' })];
+
+    const result = filterRsvpsToActiveRegistrants(rsvps, registrants);
+
+    expect(result).toHaveLength(1);
+    expect(result[0].registrant_id).toBe('r1');
+  });
+
+  it('returns an empty array when no RSVPs match', () => {
+    expect(filterRsvpsToActiveRegistrants([rsvp({ registrant_id: 'gone' })], [registrant('r1')])).toEqual([]);
+  });
+});
+
+describe('attachRsvpsToRegistrants', () => {
+  it('attaches null when a registrant has no RSVP', () => {
+    const [result] = attachRsvpsToRegistrants([registrant('r1')], []);
+    expect(result.rsvp).toBeNull();
+  });
+
+  it('attaches the single applicable RSVP when there is exactly one', () => {
+    const [result] = attachRsvpsToRegistrants([registrant('r1')], [rsvp({ registrant_id: 'r1', response_type: 'declined' })]);
+    expect(result.rsvp?.response_type).toBe('declined');
+  });
+
+  it('LFXV2-2864: a newer single decline for an unrelated occurrence does not shadow an older all accept', () => {
+    const olderAllAccept = rsvp({
+      registrant_id: 'r1',
+      scope: 'all' as MeetingRsvp['scope'],
+      response_type: 'accepted',
+      modified_at: '2026-01-01T00:00:00.000Z',
+    });
+    const newerSingleDeclineElsewhere = rsvp({
+      registrant_id: 'r1',
+      scope: 'single' as MeetingRsvp['scope'],
+      occurrence_id: 'occurrence-other',
+      response_type: 'declined',
+      modified_at: '2026-02-01T00:00:00.000Z',
+    });
+
+    const [result] = attachRsvpsToRegistrants([registrant('r1')], [olderAllAccept, newerSingleDeclineElsewhere], 'occurrence-target');
+
+    expect(result.rsvp?.response_type).toBe('accepted');
+  });
+
+  it('does not mutate the input registrant objects', () => {
+    const original = registrant('r1');
+    attachRsvpsToRegistrants([original], [rsvp({ registrant_id: 'r1' })]);
+    expect((original as any).rsvp).toBeUndefined();
+  });
+});

--- a/apps/lfx-one/src/server/helpers/meeting-rsvp.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/meeting-rsvp.helper.spec.ts
@@ -28,9 +28,8 @@ vi.mock('@lfx-one/shared/utils', () => ({
 
 import { attachRsvpsToRegistrants, filterRsvpsToActiveRegistrants } from './meeting-rsvp.helper';
 
-const registrant = (uid: string): MeetingRegistrant => ({ uid } as MeetingRegistrant);
-const rsvp = (overrides: Partial<MeetingRsvp>): MeetingRsvp =>
-  ({ registrant_id: 'r1', response_type: 'accepted', ...overrides }) as unknown as MeetingRsvp;
+const registrant = (uid: string): MeetingRegistrant => ({ uid }) as MeetingRegistrant;
+const rsvp = (overrides: Partial<MeetingRsvp>): MeetingRsvp => ({ registrant_id: 'r1', response_type: 'accepted', ...overrides }) as unknown as MeetingRsvp;
 
 describe('filterRsvpsToActiveRegistrants', () => {
   it('keeps only RSVPs whose registrant_id matches a currently-active registrant', () => {

--- a/apps/lfx-one/src/server/helpers/meeting-rsvp.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting-rsvp.helper.ts
@@ -1,0 +1,59 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { MeetingRegistrant, MeetingRsvp } from '@lfx-one/shared/interfaces';
+import { selectApplicableRsvp } from '@lfx-one/shared/utils';
+
+/**
+ * Filters RSVPs down to those belonging to a currently-active registrant.
+ *
+ * `v1_meeting_rsvp` records persist historical RSVPs including for registrants who have since
+ * been removed or re-registered with a new `registrant_id`. Extracted as a pure function (no
+ * `MeetingService` dependency, unlike `meeting.helper.ts`, to avoid a service↔helper import
+ * cycle) so `MeetingService.getMeetingRsvps` and `MeetingService.getMeetingRegistrants` (when
+ * fetching with `includeRsvp`) can share it against whichever registrant roster each has already
+ * fetched, instead of each walking the registrant roster a second time just to build this same
+ * active-id set (LFXV2-2078).
+ *
+ * @param rsvps - Raw RSVPs, unfiltered
+ * @param registrants - The currently-active registrant roster to filter against
+ */
+export function filterRsvpsToActiveRegistrants(rsvps: MeetingRsvp[], registrants: MeetingRegistrant[]): MeetingRsvp[] {
+  const activeRegistrantIds = new Set(registrants.map((r) => r.uid).filter(Boolean));
+  return rsvps.filter((rsvp) => activeRegistrantIds.has(rsvp.registrant_id));
+}
+
+/**
+ * Attaches each registrant's applicable RSVP (if any) as a `rsvp` field, scoped to `occurrenceId`
+ * when provided. Pure function — groups `rsvps` by `registrant_id`, then delegates the
+ * per-occurrence selection to the shared {@link selectApplicableRsvp} resolver, keeping this
+ * endpoint aligned with the detail-page BFF (`getMeetingRsvpForCurrentUser`) and the counts
+ * calculator (`calculateRsvpCounts`) — a newer `single` decline must not shadow an older `all`
+ * accept on an unrelated occurrence (LFXV2-2864).
+ *
+ * @param registrants - Registrants to enrich (not mutated; new objects returned)
+ * @param rsvps - RSVPs already filtered to active registrants (see {@link filterRsvpsToActiveRegistrants})
+ * @param occurrenceId - Optional occurrence id (seconds or ms) to resolve each registrant's RSVP against
+ */
+export function attachRsvpsToRegistrants<T extends MeetingRegistrant>(
+  registrants: T[],
+  rsvps: MeetingRsvp[],
+  occurrenceId?: string
+): (T & { rsvp: MeetingRsvp | null })[] {
+  const rsvpsByRegistrant = new Map<string, MeetingRsvp[]>();
+  for (const rsvp of rsvps) {
+    const key = rsvp.registrant_id;
+    if (!rsvpsByRegistrant.has(key)) {
+      rsvpsByRegistrant.set(key, []);
+    }
+    rsvpsByRegistrant.get(key)!.push(rsvp);
+  }
+
+  return registrants.map((registrant) => {
+    const registrantRsvps = rsvpsByRegistrant.get(registrant.uid);
+    if (!registrantRsvps || registrantRsvps.length === 0) {
+      return { ...registrant, rsvp: null };
+    }
+    return { ...registrant, rsvp: selectApplicableRsvp(occurrenceId, registrantRsvps) };
+  });
+}

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { Meeting, MeetingRegistrant, MeetingUserInfo, QueryServiceResponse } from '@lfx-one/shared/interfaces';
+import type { Meeting, MeetingRegistrant, MeetingRsvp, MeetingUserInfo, QueryServiceResponse } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // This app's vitest config resolves plain Node modules only — the `@lfx-one/shared/*` tsconfig
@@ -21,6 +21,10 @@ vi.mock('@lfx-one/shared/utils', () => ({
   mapITXResponseToMeetingRsvp: vi.fn(),
   normalizeIndexedMeetingAiSummary: vi.fn(),
   selectPrimaryPastMeetingSummary: vi.fn(),
+  // getMeetingRsvps / getMeetingRegistrants(includeRsvp) delegate occurrence selection to the real
+  // resolver — stubbed here to the "most recent rsvp" since these tests cover roster/page-walk
+  // dedup, not the LFXV2-2864 occurrence-scoping logic (covered in meeting-rsvp.helper.spec.ts).
+  selectApplicableRsvp: vi.fn((_occurrenceId: string | undefined, rsvps: unknown[]) => rsvps[rsvps.length - 1] ?? null),
 }));
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
@@ -429,6 +433,116 @@ describe('MeetingService.getMeetingRegistrants', () => {
 
     expect(result).toHaveLength(1);
     expect(proxyRequest).toHaveBeenCalledTimes(1);
+  });
+
+  it('sends page_size on the roster walk', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    await service.getMeetingRegistrants(req, 'meeting-1');
+
+    const [, , , , query] = proxyRequest.mock.calls[0];
+    expect(query.page_size).toBe(1000);
+  });
+
+  it('threads options.bearerToken through to the roster-walk proxyRequest call', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    await service.getMeetingRegistrants(req, 'meeting-1', false, undefined, false, undefined, { bearerToken: 'm2m-token' });
+
+    const [, , , , , , , options] = proxyRequest.mock.calls[0];
+    expect(options).toEqual({ bearerToken: 'm2m-token' });
+  });
+
+  it('fetches the registrant roster exactly once when includeRsvp is true, not twice via getMeetingRsvps', async () => {
+    const rsvpRecord = (registrantId: string) => ({
+      id: `v1_meeting_rsvp:${registrantId}`,
+      data: { registrant_id: registrantId, response_type: 'accepted' } as unknown as MeetingRsvp,
+    });
+    proxyRequest
+      .mockResolvedValueOnce({ resources: [registrantRecord('a'), registrantRecord('b')] }) // roster walk
+      .mockResolvedValueOnce({ resources: [rsvpRecord('a')] }); // RSVP walk (getRawMeetingRsvps)
+
+    const result = await service.getMeetingRegistrants(req, 'meeting-1', true);
+
+    // Exactly 2 proxyRequest calls total: one roster page, one RSVP page. Prior to the dedup fix,
+    // includeRsvp routed through getMeetingRsvps, which re-walked the roster a second time.
+    expect(proxyRequest).toHaveBeenCalledTimes(2);
+    expect(result).toHaveLength(2);
+    expect((result[0] as any).rsvp).toBeTruthy();
+    expect((result[1] as any).rsvp).toBeNull();
+  });
+
+  it('returns registrants without rsvp data when the RSVP fetch fails, instead of throwing', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] }).mockRejectedValueOnce(new Error('rsvp service down'));
+
+    const result = await service.getMeetingRegistrants(req, 'meeting-1', true);
+
+    expect(result).toHaveLength(1);
+    expect((result[0] as any).rsvp).toBeUndefined();
+  });
+});
+
+describe('MeetingService.getRawMeetingRsvps', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('sends page_size on the RSVP walk and threads options.bearerToken through', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [] });
+
+    await service.getRawMeetingRsvps(req, 'meeting-1', { bearerToken: 'm2m-token' });
+
+    const [, , , , query, , , options] = proxyRequest.mock.calls[0];
+    expect(query.page_size).toBe(1000);
+    expect(options).toEqual({ bearerToken: 'm2m-token' });
+  });
+});
+
+describe('MeetingService.getMeetingRsvps', () => {
+  let service: MeetingService;
+
+  const registrantRecord = (id: string) => ({ id: `v1_meeting_registrant:${id}`, data: { uid: id, email: `${id}@example.com` } as MeetingRegistrant });
+  const rsvpRecord = (registrantId: string) => ({
+    id: `v1_meeting_rsvp:${registrantId}`,
+    data: { registrant_id: registrantId, response_type: 'accepted' } as unknown as MeetingRsvp,
+  });
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('filters RSVPs down to currently-active registrants', async () => {
+    proxyRequest
+      .mockResolvedValueOnce({ resources: [rsvpRecord('a'), rsvpRecord('stale-registrant')] }) // RSVP walk
+      .mockResolvedValueOnce({ resources: [registrantRecord('a')] }); // registrant walk (failOnPartial: true)
+
+    const result = await service.getMeetingRsvps(req, 'meeting-1');
+
+    expect(result).toHaveLength(1);
+    expect(result[0].registrant_id).toBe('a');
+  });
+
+  it('sends page_size on both the RSVP walk and its own registrant walk', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [rsvpRecord('a')] }).mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    await service.getMeetingRsvps(req, 'meeting-1');
+
+    const rsvpQuery = proxyRequest.mock.calls[0][4];
+    const registrantQuery = proxyRequest.mock.calls[1][4];
+    expect(rsvpQuery.page_size).toBe(1000);
+    expect(registrantQuery.page_size).toBe(1000);
+  });
+
+  it('returns RSVPs unfiltered when the registrant fetch fails, rather than hiding data', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [rsvpRecord('a'), rsvpRecord('b')] }).mockRejectedValueOnce(new Error('query service down'));
+
+    const result = await service.getMeetingRsvps(req, 'meeting-1');
+
+    expect(result).toHaveLength(2);
   });
 });
 

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -388,6 +388,24 @@ describe('MeetingService.addMeetingRegistrantSelf', () => {
   });
 });
 
+describe('MeetingService.getMeetingRegistrantsByEmail', () => {
+  let service: MeetingService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new MeetingService();
+  });
+
+  it('sends page_size on the gate-check walk', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [] });
+
+    await service.getMeetingRegistrantsByEmail(req, 'meeting-1', 'user@example.com');
+
+    const [, , , , query] = proxyRequest.mock.calls[0];
+    expect(query.page_size).toBe(1000);
+  });
+});
+
 describe('MeetingService.getMeetingRegistrants', () => {
   let service: MeetingService;
 
@@ -442,6 +460,15 @@ describe('MeetingService.getMeetingRegistrants', () => {
 
     const [, , , , query] = proxyRequest.mock.calls[0];
     expect(query.page_size).toBe(1000);
+  });
+
+  it('clamps page_size to maxResults + 1 instead of always requesting the full 1000', async () => {
+    proxyRequest.mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    await service.getMeetingRegistrants(req, 'meeting-1', false, undefined, true, 50);
+
+    const [, , , , query] = proxyRequest.mock.calls[0];
+    expect(query.page_size).toBe(51);
   });
 
   it('threads options.bearerToken through to the roster-walk proxyRequest call', async () => {
@@ -638,5 +665,16 @@ describe('MeetingService.getAuthorizedRegistrantsForImport', () => {
     // maxResults bounds the fetch itself: one page already exceeds the cap, so pagination never
     // continues even though the fixture's single page doesn't set page_token either way.
     expect(proxyRequest).toHaveBeenCalledTimes(2);
+  });
+
+  it('requests page_size 51, not 1000, since the import cap only needs 51 rows to reject', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_UID, project_uid: 'project-1' });
+    accessCheckSvc.checkSingleAccess.mockResolvedValue(true);
+    proxyRequest.mockResolvedValueOnce(meetingResponse('project-1')).mockResolvedValueOnce({ resources: [registrantRecord('a')] });
+
+    await service.getAuthorizedRegistrantsForImport(req, MEETING_UID, COMMITTEE_UID);
+
+    const [, , , , query] = proxyRequest.mock.calls[1];
+    expect(query.page_size).toBe(51);
   });
 });

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -544,6 +544,21 @@ describe('MeetingService.getMeetingRsvps', () => {
 
     expect(result).toHaveLength(2);
   });
+
+  it('returns the raw RSVP count unchanged when a later registrant page rejects mid-walk', async () => {
+    proxyRequest
+      .mockResolvedValueOnce({ resources: [rsvpRecord('a'), rsvpRecord('b')] }) // RSVP walk (single page)
+      .mockResolvedValueOnce({ resources: [registrantRecord('a')], page_token: 'next' }) // registrant walk, page 1
+      .mockRejectedValueOnce(new Error('query service down')); // registrant walk, page 2 rejects
+
+    const result = await service.getMeetingRsvps(req, 'meeting-1');
+
+    // The registrant walk uses failOnPartial: true, so a page-2 failure throws instead of
+    // returning a truncated roster; getMeetingRsvps catches that and falls back to the
+    // unfiltered RSVP set rather than filtering against an incomplete registrant list.
+    expect(result).toHaveLength(2);
+    expect(result.map((r) => r.registrant_id)).toEqual(['a', 'b']);
+  });
 });
 
 describe('MeetingService.getAuthorizedRegistrantsForImport', () => {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { IMPORT_REGISTRANTS_MAX } from '@lfx-one/shared/constants';
+import { IMPORT_REGISTRANTS_MAX, QUERY_SERVICE_MAX_PAGE_SIZE } from '@lfx-one/shared/constants';
 import { QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
   ApiRequestOptions,
@@ -50,6 +50,7 @@ import { Request } from 'express';
 
 import { AuthorizationError, ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { fetchEntityProject, toEntityProjectFields } from '../helpers/entity-project-enrichment.helper';
+import { attachRsvpsToRegistrants, filterRsvpsToActiveRegistrants } from '../helpers/meeting-rsvp.helper';
 import { pollEndpoint } from '../helpers/poll-endpoint.helper';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { getEffectiveEmail, getEffectiveUsername, getUsernameFromAuth, stripAuthPrefix } from '../utils/auth-helper';
@@ -628,63 +629,65 @@ export class MeetingService {
     includeRsvp: boolean = false,
     occurrenceId?: string,
     failOnPartial: boolean = false,
-    maxResults?: number
+    maxResults?: number,
+    options?: ApiRequestOptions
   ): Promise<MeetingRegistrant[]> {
     // Registrant records carry `parent_refs: ['meeting:<uid>']` but no indexed tags — use `parent`
     // to query parent_refs, matching the working pattern in getMeetingRsvps.
     const params: Record<string, any> = {
       type: 'v1_meeting_registrant',
       parent: `meeting:${meetingUid}`,
+      page_size: QUERY_SERVICE_MAX_PAGE_SIZE,
     };
 
     logger.debug(req, 'get_meeting_registrants', 'Fetching meeting registrants', { meeting_id: meetingUid, params });
 
-    let registrants = await fetchAllQueryResources<MeetingRegistrant>(
+    const registrantsPromise = fetchAllQueryResources<MeetingRegistrant>(
       req,
       (pageToken) =>
-        this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-          ...params,
-          ...(pageToken && { page_token: pageToken }),
-        }),
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRegistrant>>(
+          req,
+          'LFX_V2_SERVICE',
+          '/query/resources',
+          'GET',
+          { ...params, ...(pageToken && { page_token: pageToken }) },
+          undefined,
+          undefined,
+          options
+        ),
       { failOnPartial, maxResults }
     );
 
-    // If include_rsvp is true, fetch RSVP data and attach to registrants.
-    if (includeRsvp) {
-      try {
-        const rsvps = await this.getMeetingRsvps(req, meetingUid);
+    // If include_rsvp is false, the RSVP walk isn't needed at all — skip it rather than fetching
+    // and discarding it.
+    if (!includeRsvp) {
+      return registrantsPromise;
+    }
 
-        // Group RSVPs by registrant_id for lookup.
-        const rsvpsByRegistrant = new Map<string, MeetingRsvp[]>();
-        for (const rsvp of rsvps) {
-          const key = rsvp.registrant_id;
-          if (!rsvpsByRegistrant.has(key)) {
-            rsvpsByRegistrant.set(key, []);
-          }
-          rsvpsByRegistrant.get(key)!.push(rsvp);
-        }
-
-        // Resolve the applicable RSVP per registrant against the caller's occurrence.
-        // Delegating to the shared resolver keeps this endpoint aligned with the
-        // detail-page BFF (`getMeetingRsvpForCurrentUser`) and the counts calculator
-        // (`calculateRsvpCounts`) — a newer `single` decline no longer shadows an
-        // older `all` accept on unrelated occurrences (LFXV2-2864).
-        registrants = registrants.map((registrant) => {
-          const registrantRsvps = rsvpsByRegistrant.get(registrant.uid);
-          if (!registrantRsvps || registrantRsvps.length === 0) {
-            return { ...registrant, rsvp: null };
-          }
-          return { ...registrant, rsvp: selectApplicableRsvp(occurrenceId, registrantRsvps) };
-        });
-      } catch (error) {
+    // Fetch RSVPs via the raw page walk (`getRawMeetingRsvps`) in parallel with the roster fetch,
+    // rather than going through `getMeetingRsvps` — that method does its own registrant-roster
+    // walk to build the active-id filter set, which would re-walk the roster fetched above.
+    // Filtering against the roster we already have is also more consistent than
+    // `getMeetingRsvps`'s independent fetch: the two walks could otherwise diverge on
+    // partial-page failures, attaching RSVPs for registrants that aren't even in the roster being
+    // returned (LFXV2-2078).
+    const [registrants, rsvps] = await Promise.all([
+      registrantsPromise,
+      this.getRawMeetingRsvps(req, meetingUid, options).catch((error) => {
         logger.warning(req, 'get_meeting_registrants', 'Failed to fetch RSVPs for registrants, returning registrants without RSVP data', {
           meeting_id: meetingUid,
           err: error,
         });
-      }
+        return null;
+      }),
+    ]);
+
+    if (rsvps === null) {
+      return registrants;
     }
 
-    return registrants;
+    const activeRsvps = filterRsvpsToActiveRegistrants(rsvps, registrants);
+    return attachRsvpsToRegistrants(registrants, activeRsvps, occurrenceId);
   }
 
   /**
@@ -1395,6 +1398,36 @@ export class MeetingService {
   }
 
   /**
+   * Fetches the raw RSVP page walk for a meeting, with no registrant filtering. Split out of
+   * `getMeetingRsvps` so callers that have already fetched (or are about to fetch) the registrant
+   * roster for another reason — e.g. `getMeetingRegistrants` with `includeRsvp` — can fetch RSVPs
+   * in parallel with that roster fetch instead of going through `getMeetingRsvps`, which would
+   * walk the roster a second time (LFXV2-2078).
+   */
+  public async getRawMeetingRsvps(req: Request, meetingUid: string, options?: ApiRequestOptions): Promise<MeetingRsvp[]> {
+    logger.debug(req, 'get_raw_meeting_rsvps', 'Fetching meeting RSVPs', { meeting_id: meetingUid });
+
+    const rsvpParams = {
+      tags: `meeting_id:${meetingUid}`,
+      type: 'v1_meeting_rsvp',
+      page_size: QUERY_SERVICE_MAX_PAGE_SIZE,
+    };
+
+    return fetchAllQueryResources<MeetingRsvp>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRsvp>>(
+        req,
+        'LFX_V2_SERVICE',
+        '/query/resources',
+        'GET',
+        { ...rsvpParams, ...(pageToken && { page_token: pageToken }) },
+        undefined,
+        undefined,
+        options
+      )
+    );
+  }
+
+  /**
    * Get all RSVPs for a meeting, filtered to current registrants only.
    * The v1_meeting_rsvp records persist historical RSVPs including for registrants
    * who have since been removed or re-registered with a new registrant_id. We filter
@@ -1404,24 +1437,15 @@ export class MeetingService {
     logger.debug(req, 'get_meeting_rsvps', 'Fetching meeting RSVPs', { meeting_id: meetingUid });
 
     try {
-      const rsvpParams = {
-        tags: `meeting_id:${meetingUid}`,
-        type: 'v1_meeting_rsvp',
-      };
-
       const registrantParams = {
         type: 'v1_meeting_registrant',
         parent: `meeting:${meetingUid}`,
+        page_size: QUERY_SERVICE_MAX_PAGE_SIZE,
       };
 
       let registrantsFetchFailed = false;
       const [rsvps, registrants] = await Promise.all([
-        fetchAllQueryResources<MeetingRsvp>(req, (pageToken) =>
-          this.microserviceProxy.proxyRequest<QueryServiceResponse<MeetingRsvp>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-            ...rsvpParams,
-            ...(pageToken && { page_token: pageToken }),
-          })
-        ),
+        this.getRawMeetingRsvps(req, meetingUid),
         fetchAllQueryResources<MeetingRegistrant>(
           req,
           (pageToken) =>
@@ -1445,13 +1469,12 @@ export class MeetingService {
         return rsvps;
       }
 
-      const activeRegistrantIds = new Set(registrants.map((r) => r.uid).filter(Boolean));
-      const filtered = rsvps.filter((rsvp) => activeRegistrantIds.has(rsvp.registrant_id));
+      const filtered = filterRsvpsToActiveRegistrants(rsvps, registrants);
 
       logger.debug(req, 'get_meeting_rsvps', 'Filtered RSVPs to active registrants', {
         meeting_id: meetingUid,
         raw_rsvp_count: rsvps.length,
-        active_registrant_count: activeRegistrantIds.size,
+        registrant_count: registrants.length,
         filtered_rsvp_count: filtered.length,
       });
 

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -634,10 +634,12 @@ export class MeetingService {
   ): Promise<MeetingRegistrant[]> {
     // Registrant records carry `parent_refs: ['meeting:<uid>']` but no indexed tags — use `parent`
     // to query parent_refs, matching the working pattern in getMeetingRsvps.
+    // When maxResults bounds the walk (e.g. rejecting an over-limit roster), only that many
+    // rows are ever needed — cap the page request instead of always pulling the full 1000.
     const params: Record<string, any> = {
       type: 'v1_meeting_registrant',
       parent: `meeting:${meetingUid}`,
-      page_size: QUERY_SERVICE_MAX_PAGE_SIZE,
+      page_size: maxResults ? Math.min(QUERY_SERVICE_MAX_PAGE_SIZE, maxResults + 1) : QUERY_SERVICE_MAX_PAGE_SIZE,
     };
 
     logger.debug(req, 'get_meeting_registrants', 'Fetching meeting registrants', { meeting_id: meetingUid, params });
@@ -750,6 +752,7 @@ export class MeetingService {
       type: 'v1_meeting_registrant',
       parent: '',
       filters: [`email:${normalizedEmail}`, `meeting_id:${meetingUid}`],
+      page_size: QUERY_SERVICE_MAX_PAGE_SIZE,
     };
 
     logger.debug(req, 'get_meeting_registrants_by_email', 'Fetching meeting registrants by email params', {

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -31,6 +31,14 @@ export const MEETING_PASSWORD_HEADER = 'x-meeting-password';
 export const QUERY_SERVICE_FILTERS_OR_BATCH_SIZE = 100;
 
 /**
+ * Upstream ceiling for `page_size` on query-service `/query/resources` requests.
+ * @description The query-service rejects `page_size` above 1000 (`InvalidRangeError`). Passing
+ * this on every paginated walk (registrant rosters, RSVP lists) fetches the fewest possible pages
+ * per walk instead of relying on the service's smaller unstated default.
+ */
+export const QUERY_SERVICE_MAX_PAGE_SIZE = 1000;
+
+/**
  * NATS configuration constants
  * @description Configuration for NATS messaging system used for inter-service communication
  * @readonly


### PR DESCRIPTION
## Summary

Rescoped after #1870 merged and landed a leaner version of most of this PR's original scope (parallelized `getMeetingById` on the public/authenticated meeting routes, and the `ApiRequestOptions.bearerToken` mechanism replacing `req.bearerToken` mutation). This PR now carries only the work still genuinely missing from `main`:

1. `getMyMeetingRegistrants` still swapped `req.bearerToken` for its M2M fan-out — reworked to use `ApiRequestOptions.bearerToken` instead, and to run the meeting fetch and registrant gate check in parallel.
2. The registrant roster was walked twice per request (once for RSVP filtering, once for the response) — deduped into a single roster fetch.
3. `page_size` was never sent on the query-service page walks, so every walk ran at the upstream default (50) instead of the documented ceiling (1000).

All three are covered by new tests, which the original branch (superseded by #1870) did not have.

Refs #1731

## Changes

### `getMyMeetingRegistrants`: M2M fan-out without mutating `req.bearerToken`

- Hop 1 (`Promise.all`): `getMeetingById` runs alongside the registrant gate check (`generateM2MToken(req).then(token => getMeetingRegistrantsByEmail(...))`). The gate check depends only on `uid` + caller identity, not the meeting payload, so it doesn't need to wait on the meeting fetch.
- Hop 2: `getMeetingRegistrants` runs under the M2M token, passed via `ApiRequestOptions.bearerToken` rather than a `req.bearerToken` swap — so it can't race the caller's own token on the same `req`.
- Added an identity-race regression test: asserts the M2M and user-token calls never cross identities under out-of-order promise settlement.

The gate check stays on `getMeetingRegistrantsByEmail` (email-only), matching the pre-existing authorization surface — this PR is a perf change only and does not widen who can pass the registrant gate.

**`enrichCommitteeRegistrants` stays on a narrow `req.bearerToken` swap** — it's the one sequential (non-fanned-out) M2M call left in this handler, so it carries none of the race hazard the parallel fan-out did. The swap is now wrapped in `try/finally` so a thrown error doesn't leave the M2M token on `req.bearerToken` for the rest of the request. Fully re-plumbing `CommitteeService` to accept `ApiRequestOptions.bearerToken` would also need to exclude `addAccessToResource`/`getCallerMembership` (both must stay on the caller's own token) — tracked separately in #1903.

### Registrant roster deduped

- `getMeetingRegistrants` (with `includeRsvp: true`) previously called `getMeetingRsvps`, which did its own independent roster walk to build the active-registrant filter set — the roster was walked twice.
- Split into `getRawMeetingRsvps` (RSVP page walk only) + two pure helpers in the new `helpers/meeting-rsvp.helper.ts`: `filterRsvpsToActiveRegistrants` and `attachRsvpsToRegistrants` (carries the existing per-occurrence RSVP resolution verbatim — load-bearing for LFXV2-2864, regression-tested).
- `getMeetingRegistrants` now fetches the roster once and the raw RSVPs in parallel, then filters/attaches locally.
- `getMeetingRsvps` keeps its existing signature and behavior (including its `registrantsFetchFailed` → unfiltered-RSVPs fallback) for its other, unrelated callers.

### `QUERY_SERVICE_MAX_PAGE_SIZE` applied

Added `QUERY_SERVICE_MAX_PAGE_SIZE = 1000` to `packages/shared/src/constants/api.constants.ts` (verified against the upstream `lfx-v2-query-service` OpenAPI spec: `page_size` max is 1000). Applied at the three call sites that page through the query service for this handler: the roster walk in `getMeetingRegistrants`, the RSVP walk in `getRawMeetingRsvps`, and the roster walk inside `getMeetingRsvps`.

## Superseded by #1870 (dropped from this PR's original scope)

The original five-commit branch also parallelized `public-meeting.controller.ts::getMeetingById` and threaded `m2mToken` as positional parameters through several service/helper methods. #1870 already landed equivalent (and in some cases leaner) coverage for the public route using the `ApiRequestOptions.bearerToken` mechanism `main` now has, so none of that is reintroduced here — this PR builds on top of `main`'s mechanism rather than adding a second, competing one.

## Notes

- **Branch naming:** this branch predates the `type/issue-NNN` convention documented in `.claude/rules/commit-workflow.md` (it's `perf/GH-1731-parallel`, not `perf/issue-1731`). Renaming isn't practical for an already-open PR with an existing review thread, so documenting the deviation here rather than renaming mid-flight.
- **Related issues:** #1903 (`enrichCommitteeRegistrants` M2M threading follow-up).

## Test Plan

- `meeting.controller.spec.ts`: `getMyMeetingRegistrants` — organizer-not-registrant gate, non-registrant/non-organizer short-circuit, no-email short-circuit, meeting-not-found short-circuit, identity-race regression, and the `enrichCommitteeRegistrants`-throws token-restore regression.
- `meeting.service.spec.ts`: roster fetched exactly once when `includeRsvp: true`; `page_size` present on all three walks; `getMeetingRsvps` behavior unchanged for existing callers including the unfiltered-fallback path.
- `meeting-rsvp.helper.spec.ts`: `filterRsvpsToActiveRegistrants` and `attachRsvpsToRegistrants`, including the LFXV2-2864 occurrence-scoping case.
- `yarn check-types`, `yarn lint:check`, and the full affected-spec suite (60 tests) pass locally.
