### PR TITLE
fix(committees): remove legacy none option from member voting status form

### DIFF
--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
@@ -180,6 +180,9 @@
           @if (form().get('voting_status')?.errors?.['required'] && form().get('voting_status')?.touched) {
             <p class="mt-1 text-xs text-red-600">Voting status is required</p>
           }
+          @if (form().get('voting_status')?.errors?.['legacyVotingStatus'] && form().get('voting_status')?.touched) {
+            <p class="mt-1 text-xs text-red-600">This legacy voting status is no longer accepted — select a new status to save</p>
+          }
         </div>
 
         <!-- Voting Status Start and End Dates -->

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.html
@@ -178,10 +178,10 @@
             id="voting-status"
             data-testid="member-form-voting-status"></lfx-select>
           @if (form().get('voting_status')?.errors?.['required'] && form().get('voting_status')?.touched) {
-            <p class="mt-1 text-xs text-red-600">Voting status is required</p>
+            <p role="alert" class="mt-1 text-xs text-red-600">Voting status is required</p>
           }
           @if (form().get('voting_status')?.errors?.['legacyVotingStatus'] && form().get('voting_status')?.touched) {
-            <p class="mt-1 text-xs text-red-600">This legacy voting status is no longer accepted — select a new status to save</p>
+            <p role="alert" class="mt-1 text-xs text-red-600">This voting status is no longer accepted — select a new status to save</p>
           }
         </div>
 

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
@@ -17,6 +17,7 @@ import {
   LINKEDIN_PROFILE_PATTERN,
   MEMBER_FORM_VOTING_STATUSES,
   MEMBER_ROLES,
+  VOTING_STATUSES,
 } from '@lfx-one/shared/constants';
 import {
   Committee,
@@ -25,9 +26,11 @@ import {
   CommitteeUser,
   CreateCommitteeMemberRequest,
   MemberFormValue,
+  MemberFormVotingStatusOption,
   OrganizationResolveResult,
 } from '@lfx-one/shared/interfaces';
 import { buildCommitteeOrganizationPayload, formatDateToISOString, parseISODateString } from '@lfx-one/shared/utils';
+import { acceptedMemberVotingStatus } from '@lfx-one/shared/validators';
 import { CommitteeService } from '@services/committee.service';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -63,7 +66,7 @@ export class MemberFormComponent {
 
   // Member options
   public roleOptions = MEMBER_ROLES;
-  public votingStatusOptions = MEMBER_FORM_VOTING_STATUSES;
+  public votingStatusOptions: MemberFormVotingStatusOption[] = MEMBER_FORM_VOTING_STATUSES;
   public appointedByOptions = APPOINTED_BY_OPTIONS;
   public permissionOptions = [...COMMITTEE_PERMISSION_OPTIONS];
 
@@ -76,6 +79,9 @@ export class MemberFormComponent {
     this.member = this.config.data?.member;
     this.committee = this.config.data?.committee;
     this.wizardMode = this.config.data?.wizardMode || false;
+
+    // Surface a legacy voting status (excluded from the form options) as a display-only option
+    this.votingStatusOptions = this.buildVotingStatusOptions();
 
     // Create form group after committee is assigned so enable_voting validators work
     this.form = signal<FormGroup>(this.createMemberFormGroup());
@@ -262,6 +268,22 @@ export class MemberFormComponent {
     }
   }
 
+  /**
+   * When editing a member whose voting status is excluded from the form options
+   * (legacy `None`, which the committee service rejects on voting-enabled committees),
+   * prepend it as a disabled display-only option so the select renders the member's
+   * current status instead of an empty placeholder.
+   */
+  private buildVotingStatusOptions(): MemberFormVotingStatusOption[] {
+    const legacyStatus = this.isEditing ? this.member?.voting?.status : undefined;
+    if (!legacyStatus || MEMBER_FORM_VOTING_STATUSES.some(({ value }) => value === legacyStatus)) {
+      return MEMBER_FORM_VOTING_STATUSES;
+    }
+
+    const known = VOTING_STATUSES.find(({ value }) => value === legacyStatus);
+    return [{ label: known?.label ?? legacyStatus, value: legacyStatus, disabled: true }, ...MEMBER_FORM_VOTING_STATUSES];
+  }
+
   private buildPermissionArrays(
     username: string,
     member: CommitteeMember,
@@ -315,7 +337,7 @@ export class MemberFormComponent {
         organization_url: new FormControl(''),
         organization_id: new FormControl<string | null>(null),
         role: new FormControl('', this.committee?.enable_voting ? [Validators.required] : []),
-        voting_status: new FormControl('', this.committee?.enable_voting ? [Validators.required] : []),
+        voting_status: new FormControl('', this.committee?.enable_voting ? [Validators.required, acceptedMemberVotingStatus()] : []),
         appointed_by: new FormControl(''),
         role_start: new FormControl(null),
         role_end: new FormControl(null),

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
@@ -11,7 +11,13 @@ import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { SelectComponent } from '@components/select/select.component';
-import { APPOINTED_BY_OPTIONS, COMMITTEE_PERMISSION_OPTIONS, LINKEDIN_PROFILE_PATTERN, MEMBER_FORM_VOTING_STATUSES, MEMBER_ROLES } from '@lfx-one/shared/constants';
+import {
+  APPOINTED_BY_OPTIONS,
+  COMMITTEE_PERMISSION_OPTIONS,
+  LINKEDIN_PROFILE_PATTERN,
+  MEMBER_FORM_VOTING_STATUSES,
+  MEMBER_ROLES,
+} from '@lfx-one/shared/constants';
 import {
   Committee,
   CommitteeMember,

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
@@ -11,7 +11,7 @@ import { CheckboxComponent } from '@components/checkbox/checkbox.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { OrganizationSearchComponent } from '@components/organization-search/organization-search.component';
 import { SelectComponent } from '@components/select/select.component';
-import { APPOINTED_BY_OPTIONS, COMMITTEE_PERMISSION_OPTIONS, LINKEDIN_PROFILE_PATTERN, MEMBER_ROLES, VOTING_STATUSES } from '@lfx-one/shared/constants';
+import { APPOINTED_BY_OPTIONS, COMMITTEE_PERMISSION_OPTIONS, LINKEDIN_PROFILE_PATTERN, MEMBER_FORM_VOTING_STATUSES, MEMBER_ROLES } from '@lfx-one/shared/constants';
 import {
   Committee,
   CommitteeMember,
@@ -57,7 +57,7 @@ export class MemberFormComponent {
 
   // Member options
   public roleOptions = MEMBER_ROLES;
-  public votingStatusOptions = VOTING_STATUSES;
+  public votingStatusOptions = MEMBER_FORM_VOTING_STATUSES;
   public appointedByOptions = APPOINTED_BY_OPTIONS;
   public permissionOptions = [...COMMITTEE_PERMISSION_OPTIONS];
 

--- a/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts
@@ -66,7 +66,7 @@ export class MemberFormComponent {
 
   // Member options
   public roleOptions = MEMBER_ROLES;
-  public votingStatusOptions: MemberFormVotingStatusOption[] = MEMBER_FORM_VOTING_STATUSES;
+  public votingStatusOptions: MemberFormVotingStatusOption[];
   public appointedByOptions = APPOINTED_BY_OPTIONS;
   public permissionOptions = [...COMMITTEE_PERMISSION_OPTIONS];
 
@@ -277,11 +277,11 @@ export class MemberFormComponent {
   private buildVotingStatusOptions(): MemberFormVotingStatusOption[] {
     const legacyStatus = this.isEditing ? this.member?.voting?.status : undefined;
     if (!legacyStatus || MEMBER_FORM_VOTING_STATUSES.some(({ value }) => value === legacyStatus)) {
-      return MEMBER_FORM_VOTING_STATUSES;
+      return [...MEMBER_FORM_VOTING_STATUSES];
     }
 
     const known = VOTING_STATUSES.find(({ value }) => value === legacyStatus);
-    return [{ label: known?.label ?? legacyStatus, value: legacyStatus, disabled: true }, ...MEMBER_FORM_VOTING_STATUSES];
+    return [{ label: known ? known.label : `${legacyStatus} (unrecognized)`, value: legacyStatus, disabled: true }, ...MEMBER_FORM_VOTING_STATUSES];
   }
 
   private buildPermissionArrays(

--- a/packages/shared/src/constants/committees.constants.spec.ts
+++ b/packages/shared/src/constants/committees.constants.spec.ts
@@ -3,7 +3,8 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { SLACK_INCOMING_WEBHOOK_URL_PATTERN } from './committees.constants';
+import { CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
+import { MEMBER_FORM_VOTING_STATUSES, SLACK_INCOMING_WEBHOOK_URL_PATTERN } from './committees.constants';
 
 /**
  * Tests the real, imported constant — not a hand-copied regex literal in a test's own mock, the
@@ -44,5 +45,22 @@ describe('SLACK_INCOMING_WEBHOOK_URL_PATTERN', () => {
     expect(SLACK_INCOMING_WEBHOOK_URL_PATTERN.test('https://hooks.slack.com/')).toBe(false);
     expect(SLACK_INCOMING_WEBHOOK_URL_PATTERN.test('https://hooks.slack.com/services/')).toBe(false);
     expect(SLACK_INCOMING_WEBHOOK_URL_PATTERN.test('https://hooks.slack.com/services/T1/B1/')).toBe(false);
+  });
+});
+
+describe('MEMBER_FORM_VOTING_STATUSES', () => {
+  it('contains exactly the four statuses the committee service accepts', () => {
+    expect(MEMBER_FORM_VOTING_STATUSES.map(({ value }) => value).sort()).toEqual(
+      [
+        CommitteeMemberVotingStatus.VOTING_REP,
+        CommitteeMemberVotingStatus.ALTERNATE_VOTING_REP,
+        CommitteeMemberVotingStatus.OBSERVER,
+        CommitteeMemberVotingStatus.EMERITUS,
+      ].sort()
+    );
+  });
+
+  it('excludes the legacy None status the committee service rejects on voting-enabled committees (LFXV2-2075)', () => {
+    expect(MEMBER_FORM_VOTING_STATUSES.some(({ value }) => value === CommitteeMemberVotingStatus.NONE)).toBe(false);
   });
 });

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -311,6 +311,13 @@ export const MEETING_TO_COMMITTEE_VOTING_STATUS: Record<MeetingAllowedVotingStat
 };
 
 /**
+ * Voting status options for the committee member form.
+ * Excludes None — the committee service rejects it on voting-enabled committees
+ * (LFXV2-2075); it persists only as a legacy value on pre-existing members.
+ */
+export const MEMBER_FORM_VOTING_STATUSES = VOTING_STATUSES.filter(({ value }) => value !== CommitteeMemberVotingStatus.NONE);
+
+/**
  * Available appointment sources for committee members
  * @description Defines how a member was appointed to the committee
  * @readonly

--- a/packages/shared/src/constants/committees.constants.ts
+++ b/packages/shared/src/constants/committees.constants.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { CommitteeMemberAppointedBy, CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
-import { BehavioralClassDisplayConfig, CommitteeCategoryInfo, CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
+import type { BehavioralClassDisplayConfig, CommitteeCategoryInfo, CommitteeTab, GroupBehavioralClass, JoinMode } from '../interfaces/committee.interface';
 import type { MeetingAllowedVotingStatus } from '../interfaces/meeting.interface';
 import { lfxColors } from './colors.constants';
 
@@ -282,12 +282,15 @@ export const VOTING_STATUSES = [
   { label: 'None', value: CommitteeMemberVotingStatus.NONE },
 ];
 
+/** VOTING_STATUSES minus the legacy None value — excluded by both surfaces below, for different reasons. */
+const VOTING_STATUSES_WITHOUT_NONE = VOTING_STATUSES.filter(({ value }) => value !== CommitteeMemberVotingStatus.NONE);
+
 /**
  * Voting status options for meeting committee filters.
  * Excludes None — it is not a selectable value in meeting forms but remains
  * a valid member status. None is treated as Observer for filtering purposes.
  */
-export const MEETING_VOTING_STATUSES = VOTING_STATUSES.filter(({ value }) => value !== CommitteeMemberVotingStatus.NONE);
+export const MEETING_VOTING_STATUSES = VOTING_STATUSES_WITHOUT_NONE;
 
 /** Meeting API voting-status vocabulary — snake_case, unlike the committee domain's display strings. */
 export const MEETING_ALLOWED_VOTING_STATUSES = ['voting_rep', 'alt_voting_rep', 'observer', 'emeritus', 'none'] as const;
@@ -315,7 +318,7 @@ export const MEETING_TO_COMMITTEE_VOTING_STATUS: Record<MeetingAllowedVotingStat
  * Excludes None — the committee service rejects it on voting-enabled committees
  * (LFXV2-2075); it persists only as a legacy value on pre-existing members.
  */
-export const MEMBER_FORM_VOTING_STATUSES = VOTING_STATUSES.filter(({ value }) => value !== CommitteeMemberVotingStatus.NONE);
+export const MEMBER_FORM_VOTING_STATUSES = VOTING_STATUSES_WITHOUT_NONE;
 
 /**
  * Available appointment sources for committee members

--- a/packages/shared/src/interfaces/member.interface.ts
+++ b/packages/shared/src/interfaces/member.interface.ts
@@ -132,6 +132,21 @@ export interface CreateCommitteeMemberOptions {
 }
 
 /**
+ * Voting-status option for the member form select
+ * @description Legacy values excluded from MEMBER_FORM_VOTING_STATUSES (e.g. None) are
+ * appended as disabled display-only options during edit so the select renders the
+ * member's current status instead of an empty placeholder
+ */
+export interface MemberFormVotingStatusOption {
+  /** Display label */
+  label: string;
+  /** Voting status value */
+  value: CommitteeMemberVotingStatus;
+  /** Display-only: rendered for legacy values but not selectable */
+  disabled?: boolean;
+}
+
+/**
  * Raw form values from the member form dialog
  * @description Typed shape of the FormGroup.getRawValue() output in MemberFormComponent
  */

--- a/packages/shared/src/validators/committee.validators.spec.ts
+++ b/packages/shared/src/validators/committee.validators.spec.ts
@@ -1,0 +1,40 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { AbstractControl } from '@angular/forms';
+import { describe, expect, it } from 'vitest';
+
+import { MEMBER_FORM_VOTING_STATUSES } from '../constants/committees.constants';
+import { CommitteeMemberVotingStatus } from '../enums/committee-member.enum';
+import { acceptedMemberVotingStatus } from './committee.validators';
+
+// ValidatorFn only reads control.value, so a bare object stands in for an AbstractControl.
+function control(value: unknown): AbstractControl {
+  return { value } as AbstractControl;
+}
+
+describe('acceptedMemberVotingStatus', () => {
+  const validate = acceptedMemberVotingStatus();
+
+  it('passes for null, undefined, and empty string (optional field)', () => {
+    expect(validate(control(null))).toBeNull();
+    expect(validate(control(undefined))).toBeNull();
+    expect(validate(control(''))).toBeNull();
+  });
+
+  it('passes for every status in the member form option set', () => {
+    for (const { value } of MEMBER_FORM_VOTING_STATUSES) {
+      expect(validate(control(value))).toBeNull();
+    }
+  });
+
+  it('rejects the legacy None status with the legacyVotingStatus error (LFXV2-2075)', () => {
+    expect(validate(control(CommitteeMemberVotingStatus.NONE))).toEqual({
+      legacyVotingStatus: { value: CommitteeMemberVotingStatus.NONE },
+    });
+  });
+
+  it('rejects unknown values with the same error shape', () => {
+    expect(validate(control('Chair'))).toEqual({ legacyVotingStatus: { value: 'Chair' } });
+  });
+});

--- a/packages/shared/src/validators/committee.validators.ts
+++ b/packages/shared/src/validators/committee.validators.ts
@@ -1,0 +1,28 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import type { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+import { MEMBER_FORM_VOTING_STATUSES } from '../constants/committees.constants';
+
+/**
+ * Validator that rejects voting statuses outside the member form's accepted set.
+ * Legacy members may carry `None` — a value the committee service rejects on
+ * voting-enabled committees (LFXV2-2075) — so an untouched legacy value must fail
+ * validation and force the user to pick an accepted status before saving.
+ *
+ * @returns ValidatorFn that returns { legacyVotingStatus: { value } } if invalid
+ */
+export function acceptedMemberVotingStatus(): ValidatorFn {
+  const accepted = new Set(MEMBER_FORM_VOTING_STATUSES.map(({ value }) => value));
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+
+    // Allow empty values to pass (pair with Validators.required when the field is mandatory)
+    if (value === null || value === undefined || value === '') {
+      return null;
+    }
+
+    return accepted.has(value) ? null : { legacyVotingStatus: { value } };
+  };
+}

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+export * from './committee.validators';
 export * from './date.validators';
 export * from './https-url.validator';
 export * from './linux-alias.validator';


### PR DESCRIPTION
## Summary

When creating or editing a committee member, the voting status dropdown offered "None" as a selectable option. The committee service rejects "None" on voting-enabled committees (LFXV2-2075) — it only persists as a legacy value on pre-existing members — so the option set users up for a save-time failure. This PR removes "None" from the member form's options while keeping it available in filter dropdowns and legacy display paths.

Closes #1810

## Behavior changes

| Before | After |
|---|---|
| The voting status dropdown in the add/edit committee member form offered "None" as a selectable option; picking it on a voting-enabled committee failed when the backend rejected the value on save. | "None" no longer appears in the member form's voting status dropdown — only statuses the backend accepts can be selected. "None" still shows in filter dropdowns and on pre-existing members who already carry it. |

## Technical changes

`packages/shared/src/constants/committees.constants.ts` — Shared constants

- Adds `MEMBER_FORM_VOTING_STATUSES`, derived from `VOTING_STATUSES` with the legacy `None` value filtered out, with a doc comment noting the committee-service rejection (LFXV2-2075)
- Leaves `VOTING_STATUSES` untouched so filter dropdowns and legacy display paths continue to surface `None`

`apps/lfx-one/src/app/modules/committees/components/member-form/member-form.component.ts` — Committee member form

- Swaps `votingStatusOptions` from `VOTING_STATUSES` to `MEMBER_FORM_VOTING_STATUSES` so `None` is no longer selectable on member create/edit
