### PR TITLE
fix(projects): log unresolved project UIDs

### DIFF
--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -9,11 +9,12 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // vitest config, so every runtime (non-type-only) import needs a stub. `ProjectService`'s
 // constructor also builds `NatsService`/`SnowflakeService`/`ETagService`; the Snowflake-backed
 // suites below use only the `execute` mock, while the others stay trivial.
-const { proxyRequest, addAccessToResources, checkAccess, execute } = vi.hoisted(() => ({
+const { proxyRequest, addAccessToResources, checkAccess, execute, warning } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   addAccessToResources: vi.fn(),
   checkAccess: vi.fn(),
   execute: vi.fn(),
+  warning: vi.fn(),
 }));
 
 vi.mock('@lfx-one/shared/constants', () => ({
@@ -81,7 +82,7 @@ vi.mock('./nats.service', () => ({ NatsService: class {} }));
 vi.mock('./etag.service', () => ({ ETagService: class {} }));
 vi.mock('./snowflake.service', () => ({ SnowflakeService: { getInstance: () => ({ execute }) } }));
 vi.mock('./logger.service', () => ({
-  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
+  logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning, debug: vi.fn(), info: vi.fn(), sanitize: (v: unknown) => v },
 }));
 
 import type { Request } from 'express';
@@ -1071,5 +1072,54 @@ describe('ProjectService — a failed OPTIONAL email breakdown is flagged, not s
     const result = await service.getEmailCtr('tlf', undefined, EMAIL_CTR_PERIOD);
 
     expect(result.breakdownUnavailable).toBe(true);
+  });
+});
+
+describe('ProjectService — getProjectsByIds', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    warning.mockReset();
+    service = new ProjectService();
+  });
+
+  it('warns once with only UIDs omitted from a successful batch', async () => {
+    proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'resolved', slug: 'resolved' }]));
+
+    const result = await service.getProjectsByIds(req, ['resolved', 'missing']);
+
+    expect([...result.keys()]).toEqual(['resolved']);
+    expect(warning).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(req, 'get_projects_by_ids', 'Project batch response omitted requested UIDs', {
+      missing_uids: ['missing'],
+    });
+  });
+
+  it('does not warn when every requested UID resolves', async () => {
+    proxyRequest.mockResolvedValueOnce(
+      pageOf([
+        { uid: 'one', slug: 'one' },
+        { uid: 'two', slug: 'two' },
+      ])
+    );
+
+    const result = await service.getProjectsByIds(req, ['one', 'two']);
+
+    expect([...result.keys()]).toEqual(['one', 'two']);
+    expect(warning).not.toHaveBeenCalled();
+  });
+
+  it('preserves the failed-batch warning and empty-map fallback', async () => {
+    proxyRequest.mockRejectedValueOnce(new Error('query failed'));
+
+    const result = await service.getProjectsByIds(req, ['one', 'two']);
+
+    expect(result.size).toBe(0);
+    expect(warning).toHaveBeenCalledOnce();
+    expect(warning).toHaveBeenCalledWith(req, 'get_projects_by_ids', 'Batched project fetch failed for batch, skipping', {
+      batch_size: 2,
+      error: 'query failed',
+    });
   });
 });

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -529,26 +529,7 @@ export class ProjectService {
       batches.push(idArray.slice(i, i + BATCH_SIZE));
     }
 
-    const batchResults = await Promise.all(
-      batches.map((batch) =>
-        fetchAllQueryResources<Project>(
-          req,
-          (pageToken) =>
-            this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-              type: 'project',
-              filters_or: batch.map((uid) => `uid:${uid}`),
-              ...(pageToken && { page_token: pageToken }),
-            }),
-          { failOnPartial: true }
-        ).catch((error) => {
-          logger.warning(req, 'get_projects_by_ids', 'Batched project fetch failed for batch, skipping', {
-            batch_size: batch.length,
-            error: error instanceof Error ? error.message : String(error),
-          });
-          return [] as Project[];
-        })
-      )
-    );
+    const batchResults = await Promise.all(batches.map((batch) => this.fetchProjectBatchByIds(req, batch)));
 
     // ROOT is an administrative pseudo-project — never surface it even if a caller accidentally passes its UID.
     const byUid = new Map<string, Project>();
@@ -7446,6 +7427,46 @@ export class ProjectService {
         originalError: error instanceof Error ? error : new Error(String(error)),
       });
     }
+  }
+
+  /**
+   * Fetches one bounded UID batch and preserves the existing fail-soft behavior.
+   * Only fully successful paginated responses are checked for omitted UIDs.
+   */
+  private async fetchProjectBatchByIds(req: Request, batch: string[]): Promise<Project[]> {
+    try {
+      const projects = await fetchAllQueryResources<Project>(
+        req,
+        (pageToken) =>
+          this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+            type: 'project',
+            filters_or: batch.map((uid) => `uid:${uid}`),
+            ...(pageToken && { page_token: pageToken }),
+          }),
+        { failOnPartial: true }
+      );
+      this.warnOnMissingProjectUids(req, batch, projects);
+      return projects;
+    } catch (error) {
+      logger.warning(req, 'get_projects_by_ids', 'Batched project fetch failed for batch, skipping', {
+        batch_size: batch.length,
+        error: error instanceof Error ? error.message : String(error),
+      });
+      return [];
+    }
+  }
+
+  /**
+   * Emits one bounded warning containing only requested UIDs absent from a successful batch response.
+   */
+  private warnOnMissingProjectUids(req: Request, requestedUids: string[], projects: Project[]): void {
+    const returnedUids = new Set(projects.map((project) => project?.uid).filter((uid): uid is string => !!uid));
+    const missingUids = requestedUids.filter((uid) => !returnedUids.has(uid));
+    if (missingUids.length === 0) return;
+
+    logger.warning(req, 'get_projects_by_ids', 'Project batch response omitted requested UIDs', {
+      missing_uids: missingUids,
+    });
   }
 
   /**


### PR DESCRIPTION
## Summary
- warn when a successful batched project lookup omits requested UIDs
- include only `missing_uids` in the structured warning
- preserve existing failed-batch logging and empty-map fallback behavior

Closes #1785

## Verification evidence
- changed-file Prettier and ESLint checks passed
- `corepack yarn check-types` passed
- `corepack yarn build` passed
- server suite passed: 69 files, 1,662 tests
- committed regression coverage passed 3/3 cases using synthetic identifiers only:
  - partial success warned with only `<missing-uid>`
  - complete success emitted no warning
  - failed batch retained the existing warning and empty-map fallback
- local BFF connected successfully to Development NATS through a kubectl port-forward
- authenticated local endpoint returned HTTP 200 without an upstream persona error
- focused Chromium local-server smoke test passed

The full Playwright suite was not used as an acceptance signal because unchanged baseline marketing tests require the unavailable `dev-toolbar` feature flag. No real user names, project names, or resource identifiers are included in this evidence.