### PR TITLE
fix(org-lens): wire warehouse v2 health score into org lens

### DIFF
--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -41,7 +41,6 @@ const heroRow = {
   FOUNDATION_NAME: 'CNCF',
   IS_LF_PROJECT: true,
   DESCRIPTION: null,
-  HEALTH_OVERALL_SCORE: 80,
   SOFTWARE_VALUE: null,
   FIRST_COMMIT_TS: null,
 };
@@ -233,19 +232,19 @@ describe('OrgLensProjectDetailService.getHeroBlock health mapping', () => {
     });
   }
 
-  it('prefers the raw v2 score over the raw v1 score when the v2 category is unrecognized and both raw scores are present', async () => {
-    mockHeroRow({ HEALTH_OVERALL_SCORE: 90, HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' });
+  it('falls back to the raw v2 score when the v2 category is unrecognized', async () => {
+    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' });
 
     const block = await service.getHeroBlock(ORG, SLUG);
 
     expect(block?.hero.health).toBe('fair');
   });
 
-  it('falls back to the raw v1 score when v2 is entirely absent (project not yet backfilled)', async () => {
-    mockHeroRow({ HEALTH_OVERALL_SCORE: 90, HEALTH_OVERALL_SCORE_V2: null, HEALTH_SCORE_CATEGORY_V2: null });
+  it('returns null health when no v2 score or category is present', async () => {
+    mockHeroRow({ HEALTH_OVERALL_SCORE_V2: null, HEALTH_SCORE_CATEGORY_V2: null });
 
     const block = await service.getHeroBlock(ORG, SLUG);
 
-    expect(block?.hero.health).toBe('excellent');
+    expect(block?.hero.health).toBeNull();
   });
 });

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.spec.ts
@@ -19,10 +19,15 @@ vi.mock('./valkey.service', () => ({
   buildOrgCacheKey: () => null,
   valkeyService: { getJson: vi.fn(), setJson: vi.fn() },
 }));
-vi.mock('@lfx-one/shared/utils', () => ({
-  buildInsightsUrl: () => '',
-  classifyHealthScore: () => 'unavailable',
-}));
+// See org-lens-projects.service.spec.ts for why this delegates to the real classification utils instead of stubbing.
+vi.mock('@lfx-one/shared/utils', async () => {
+  const actual = await import('../../../../../packages/shared/src/utils/insights.utils');
+  return {
+    buildInsightsUrl: () => '',
+    classifyHealthScore: actual.classifyHealthScore,
+    normalizeHealthScoreCategoryV2: actual.normalizeHealthScoreCategoryV2,
+  };
+});
 
 import { OrgLensProjectDetailService } from './org-lens-project-detail.service';
 
@@ -211,5 +216,36 @@ describe('OrgLensProjectDetailService.getTrendBlock', () => {
     execute.mockResolvedValue({ rows: [] });
 
     await expect(service.getTrendBlock(ORG, SLUG, '1y')).resolves.toBeNull();
+  });
+});
+
+describe('OrgLensProjectDetailService.getHeroBlock health mapping', () => {
+  const service = new OrgLensProjectDetailService();
+
+  beforeEach(() => {
+    execute.mockReset();
+  });
+
+  function mockHeroRow(overrides: Record<string, unknown>): void {
+    execute.mockImplementation(async (sql: string) => {
+      if (sql.includes('PROJECT_NAME')) return { rows: [{ ...heroRow, ...overrides }] };
+      return { rows: [] };
+    });
+  }
+
+  it('prefers the raw v2 score over the raw v1 score when the v2 category is unrecognized and both raw scores are present', async () => {
+    mockHeroRow({ HEALTH_OVERALL_SCORE: 90, HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' });
+
+    const block = await service.getHeroBlock(ORG, SLUG);
+
+    expect(block?.hero.health).toBe('fair');
+  });
+
+  it('falls back to the raw v1 score when v2 is entirely absent (project not yet backfilled)', async () => {
+    mockHeroRow({ HEALTH_OVERALL_SCORE: 90, HEALTH_OVERALL_SCORE_V2: null, HEALTH_SCORE_CATEGORY_V2: null });
+
+    const block = await service.getHeroBlock(ORG, SLUG);
+
+    expect(block?.hero.health).toBe('excellent');
   });
 });

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -20,7 +20,7 @@ import type {
   OrgLensProjectTrendSeries,
   OrgLensTrendBlock,
 } from '@lfx-one/shared/interfaces';
-import { buildInsightsUrl, classifyHealthScore } from '@lfx-one/shared/utils';
+import { buildInsightsUrl, classifyHealthScore, normalizeHealthScoreCategoryV2 } from '@lfx-one/shared/utils';
 
 import { toIsoDate } from '../helpers/date-format.helper';
 import { escapeSqlLikePattern } from '../helpers/validation.helper';
@@ -35,6 +35,8 @@ interface HeroRow {
   IS_LF_PROJECT: boolean | null;
   DESCRIPTION: string | null;
   HEALTH_OVERALL_SCORE: number | null;
+  HEALTH_OVERALL_SCORE_V2: number | null;
+  HEALTH_SCORE_CATEGORY_V2: string | null;
   SOFTWARE_VALUE: number | null;
   FIRST_COMMIT_TS: Date | string | null;
 }
@@ -741,7 +743,8 @@ export class OrgLensProjectDetailService {
     const result = await this.snowflakeService.execute<HeroRow>(
       `
         SELECT PROJECT_NAME, PROJECT_SLUG, PROJECT_LOGO_URL, FOUNDATION_NAME, IS_LF_PROJECT,
-               DESCRIPTION, HEALTH_OVERALL_SCORE, SOFTWARE_VALUE, FIRST_COMMIT_TS
+               DESCRIPTION, HEALTH_OVERALL_SCORE, HEALTH_OVERALL_SCORE_V2, HEALTH_SCORE_CATEGORY_V2,
+               SOFTWARE_VALUE, FIRST_COMMIT_TS
         FROM ${this.projectsTable()}
         WHERE ACCOUNT_ID = ? AND PROJECT_SLUG = ?
         LIMIT 1
@@ -1521,12 +1524,15 @@ export class OrgLensProjectDetailService {
       lfxInsightsUrl: buildInsightsUrl(`/project/${slug}`),
       firstCommit: toIsoDate(row.FIRST_COMMIT_TS),
       softwareValueUsd: row.SOFTWARE_VALUE ?? null,
-      health: this.mapHealth(row.HEALTH_OVERALL_SCORE),
+      health: this.mapHealth(row),
       foundationLabel,
     };
   }
 
-  private mapHealth(score: number | null): OrgLensProjectHealth | null {
+  private mapHealth(row: Pick<HeroRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
+    const v2 = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
+    if (v2) return v2;
+    const score = row.HEALTH_OVERALL_SCORE;
     if (score === null || score === undefined) return null;
     return classifyHealthScore(score);
   }

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1529,10 +1529,10 @@ export class OrgLensProjectDetailService {
     };
   }
 
-  private mapHealth(row: Pick<HeroRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
+  private mapHealth(row: Pick<HeroRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
     const v2 = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
     if (v2) return v2;
-    const score = row.HEALTH_OVERALL_SCORE;
+    const score = row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2;
     if (score === null || score === undefined) return null;
     return classifyHealthScore(score);
   }

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -34,7 +34,6 @@ interface HeroRow {
   FOUNDATION_NAME: string | null;
   IS_LF_PROJECT: boolean | null;
   DESCRIPTION: string | null;
-  HEALTH_OVERALL_SCORE: number | null;
   HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
   SOFTWARE_VALUE: number | null;
@@ -743,7 +742,7 @@ export class OrgLensProjectDetailService {
     const result = await this.snowflakeService.execute<HeroRow>(
       `
         SELECT PROJECT_NAME, PROJECT_SLUG, PROJECT_LOGO_URL, FOUNDATION_NAME, IS_LF_PROJECT,
-               DESCRIPTION, HEALTH_OVERALL_SCORE, HEALTH_OVERALL_SCORE_V2, HEALTH_SCORE_CATEGORY_V2,
+               DESCRIPTION, HEALTH_OVERALL_SCORE_V2, HEALTH_SCORE_CATEGORY_V2,
                SOFTWARE_VALUE, FIRST_COMMIT_TS
         FROM ${this.projectsTable()}
         WHERE ACCOUNT_ID = ? AND PROJECT_SLUG = ?
@@ -1529,10 +1528,10 @@ export class OrgLensProjectDetailService {
     };
   }
 
-  private mapHealth(row: Pick<HeroRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
+  private mapHealth(row: Pick<HeroRow, 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
     const v2 = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
     if (v2) return v2;
-    const score = row.HEALTH_OVERALL_SCORE_V2 ?? row.HEALTH_OVERALL_SCORE;
+    const score = row.HEALTH_OVERALL_SCORE_V2;
     if (score === null || score === undefined) return null;
     return classifyHealthScore(score);
   }

--- a/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-project-detail.service.ts
@@ -1532,7 +1532,7 @@ export class OrgLensProjectDetailService {
   private mapHealth(row: Pick<HeroRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): OrgLensProjectHealth | null {
     const v2 = normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2);
     if (v2) return v2;
-    const score = row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2;
+    const score = row.HEALTH_OVERALL_SCORE_V2 ?? row.HEALTH_OVERALL_SCORE;
     if (score === null || score === undefined) return null;
     return classifyHealthScore(score);
   }

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -54,7 +54,6 @@ function projectsRow(overrides: Record<string, unknown> = {}) {
     TREND_DIRECTION: null,
     COMBINED_SCORE_SERIES: null,
     DBT_RUN_AT: null,
-    HEALTH_OVERALL_SCORE: null,
     HEALTH_OVERALL_SCORE_V2: null,
     HEALTH_SCORE_CATEGORY_V2: null,
     HEALTH_CONTRIBUTOR_PERCENTAGE: null,
@@ -82,39 +81,31 @@ describe('OrgLensProjectsService health score mapping', () => {
     execute.mockReset();
   });
 
-  it('classifies via the v1 score when no v2 category is present', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: 90 }));
+  it('classifies via the raw v2 score when no v2 category is present', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 90 }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('excellent');
   });
 
-  it('prefers the warehouse v2 category over the v1 score when both are present', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: 10, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
+  it('prefers the warehouse v2 category over the raw v2 score when both are present', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 10, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('fair');
   });
 
-  it('falls back to the raw v2 score when v1 is null and the v2 category is unrecognized', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: null, HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
+  it('falls back to the raw v2 score when the v2 category is unrecognized', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
 
     expect(response.projects[0]?.health).toBe('fair');
   });
 
-  it('prefers the raw v2 score over the raw v1 score when the v2 category is unrecognized and both raw scores are present', async () => {
-    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: 90, HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
-
-    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
-
-    expect(response.projects[0]?.health).toBe('fair');
-  });
-
-  it('marks health unavailable when neither v1 nor v2 score is present', async () => {
+  it('marks health unavailable when no v2 score is present', async () => {
     mockProjectsRow(projectsRow());
 
     const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -106,6 +106,14 @@ describe('OrgLensProjectsService health score mapping', () => {
     expect(response.projects[0]?.health).toBe('fair');
   });
 
+  it('prefers the raw v2 score over the raw v1 score when the v2 category is unrecognized and both raw scores are present', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: 90, HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('fair');
+  });
+
   it('marks health unavailable when neither v1 nor v2 score is present', async () => {
     mockProjectsRow(projectsRow());
 

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -1,0 +1,116 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const { execute } = vi.hoisted(() => ({ execute: vi.fn() }));
+
+vi.mock('./snowflake.service', () => ({
+  SnowflakeService: class {
+    public static getInstance() {
+      return { execute };
+    }
+  },
+}));
+vi.mock('./valkey.service', () => ({
+  buildOrgCacheKey: () => null,
+  valkeyService: { getJson: vi.fn(), setJson: vi.fn() },
+}));
+// The real barrel (`@lfx-one/shared/utils`) re-exports every shared util, some of which touch Angular
+// platform APIs that aren't available under this server-only, non-Angular vitest environment. Mock the
+// barrel but delegate to the real implementations via a direct relative import, so this spec exercises
+// actual classification logic instead of stubs.
+vi.mock('@lfx-one/shared/utils', async () => {
+  const actual = await import('../../../../../packages/shared/src/utils/insights.utils');
+  return {
+    classifyHealthScore: actual.classifyHealthScore,
+    normalizeHealthScoreCategoryV2: actual.normalizeHealthScoreCategoryV2,
+  };
+});
+
+import { OrgLensProjectsService } from './org-lens-projects.service';
+
+const ACCOUNT_ID = '0014100000Te2QjAAJ';
+const ORG_NAME = 'Acme Corp';
+
+function projectsRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ACCOUNT_ID,
+    PROJECT_ID: 'proj-1',
+    PROJECT_SLUG: 'k8s',
+    PROJECT_NAME: 'Kubernetes',
+    PROJECT_LOGO_URL: null,
+    FOUNDATION_ID: null,
+    FOUNDATION_SLUG: 'cncf',
+    FOUNDATION_NAME: 'CNCF',
+    FOUNDATION_LOGO_URL: null,
+    TECHNICAL_INFLUENCE: null,
+    ECOSYSTEM_INFLUENCE: null,
+    INFLUENCE_SCORE: 0,
+    PRIOR_YEAR_SCORE: 0,
+    DELTA_PCT: 0,
+    TECHNICAL_DELTA_PCT: 0,
+    ECOSYSTEM_DELTA_PCT: 0,
+    TREND_DIRECTION: null,
+    COMBINED_SCORE_SERIES: null,
+    DBT_RUN_AT: null,
+    HEALTH_OVERALL_SCORE: null,
+    HEALTH_OVERALL_SCORE_V2: null,
+    HEALTH_SCORE_CATEGORY_V2: null,
+    HEALTH_CONTRIBUTOR_PERCENTAGE: null,
+    HEALTH_POPULARITY_PERCENTAGE: null,
+    HEALTH_DEVELOPMENT_PERCENTAGE: null,
+    HEALTH_SECURITY_PERCENTAGE: null,
+    DESCRIPTION: null,
+    ...overrides,
+  };
+}
+
+function mockProjectsRow(row: ReturnType<typeof projectsRow>): void {
+  execute.mockImplementation(async (sql: string) => {
+    if (sql.includes('ORG_LENS_PROJECTS\n')) {
+      return { rows: [row] };
+    }
+    return { rows: [] };
+  });
+}
+
+describe('OrgLensProjectsService health score mapping', () => {
+  const service = new OrgLensProjectsService();
+
+  beforeEach(() => {
+    execute.mockReset();
+  });
+
+  it('classifies via the v1 score when no v2 category is present', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: 90 }));
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('excellent');
+  });
+
+  it('prefers the warehouse v2 category over the v1 score when both are present', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: 10, HEALTH_SCORE_CATEGORY_V2: 'Fair' }));
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('fair');
+  });
+
+  it('falls back to the raw v2 score when v1 is null and the v2 category is unrecognized', async () => {
+    mockProjectsRow(projectsRow({ HEALTH_OVERALL_SCORE: null, HEALTH_OVERALL_SCORE_V2: 50, HEALTH_SCORE_CATEGORY_V2: 'Typo' }));
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('fair');
+  });
+
+  it('marks health unavailable when neither v1 nor v2 score is present', async () => {
+    mockProjectsRow(projectsRow());
+
+    const response = await service.getProjects(ACCOUNT_ID, ORG_NAME, null);
+
+    expect(response.projects[0]?.health).toBe('unavailable');
+  });
+});

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.spec.ts
@@ -68,7 +68,7 @@ function projectsRow(overrides: Record<string, unknown> = {}) {
 
 function mockProjectsRow(row: ReturnType<typeof projectsRow>): void {
   execute.mockImplementation(async (sql: string) => {
-    if (sql.includes('ORG_LENS_PROJECTS\n')) {
+    if (sql.includes('ORG_LENS_PROJECTS')) {
       return { rows: [row] };
     }
     return { rows: [] };

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -569,11 +569,15 @@ export class OrgLensProjectsService {
   }
 
   private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2'>): boolean {
-    return (row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2) !== null && (row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2) !== undefined;
+    return (row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2) != null;
   }
 
-  private mapHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_SCORE_CATEGORY_V2'>): Exclude<HealthScore, 'unavailable'> {
-    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE ?? 0);
+  private mapHealthScore(
+    row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>
+  ): Exclude<HealthScore, 'unavailable'> {
+    // Falls back to whichever raw score is present (v1, else v2) rather than defaulting to 0, so a row with an
+    // unrecognized v2 category and no v1 score doesn't get silently misclassified as critical.
+    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2 ?? 0);
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -575,9 +575,10 @@ export class OrgLensProjectsService {
   private mapHealthScore(
     row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>
   ): Exclude<HealthScore, 'unavailable'> {
-    // Falls back to whichever raw score is present (v1, else v2); the trailing `?? 0` is an unreachable
-    // safety net since callers only invoke this when hasHealthScore() has confirmed one of the two exists.
-    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2 ?? 0);
+    // Prefers the v2 raw score over v1 (v2 is the score we're migrating to; v1 is only for projects Snowflake
+    // hasn't backfilled yet). The trailing `?? 0` is an unreachable safety net since callers only invoke this
+    // when hasHealthScore() has confirmed one of the two exists.
+    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE_V2 ?? row.HEALTH_OVERALL_SCORE ?? 0);
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -15,7 +15,7 @@ import {
   ORG_PROJECTS_SEARCH_PRELOAD_LIMIT,
   VALKEY_CACHE,
 } from '@lfx-one/shared/constants';
-import { classifyHealthScore } from '@lfx-one/shared/utils';
+import { classifyHealthScore, normalizeHealthScoreCategoryV2 } from '@lfx-one/shared/utils';
 import type {
   HealthScore,
   InfluenceBand,
@@ -407,6 +407,8 @@ export class OrgLensProjectsService {
         FOUNDATION_NAME,
         FOUNDATION_LOGO_URL,
         HEALTH_OVERALL_SCORE,
+        HEALTH_OVERALL_SCORE_V2,
+        HEALTH_SCORE_CATEGORY_V2,
         HEALTH_CONTRIBUTOR_PERCENTAGE,
         HEALTH_POPULARITY_PERCENTAGE,
         HEALTH_DEVELOPMENT_PERCENTAGE,
@@ -418,7 +420,7 @@ export class OrgLensProjectsService {
     // mapProject fills unselected org-relative metrics with placeholders and maps health from the columns above.
     // Split on computed health: present → 'health-only' (Health renders); NULL → 'unavailable' (all-Unavailable row).
     return result.rows.map((row) => {
-      const hasHealthScore = row.HEALTH_OVERALL_SCORE !== null && row.HEALTH_OVERALL_SCORE !== undefined;
+      const hasHealthScore = this.hasHealthScore(row);
       // Emit both discriminators: metricsState for the new frontend, noActivityYet so a still-running pre-close-out
       // frontend keeps treating these as unavailable during a rolling deploy.
       return {
@@ -454,6 +456,8 @@ export class OrgLensProjectsService {
         COMBINED_SCORE_SERIES,
         DBT_RUN_AT,
         HEALTH_OVERALL_SCORE,
+        HEALTH_OVERALL_SCORE_V2,
+        HEALTH_SCORE_CATEGORY_V2,
         HEALTH_CONTRIBUTOR_PERCENTAGE,
         HEALTH_POPULARITY_PERCENTAGE,
         HEALTH_DEVELOPMENT_PERCENTAGE,
@@ -490,14 +494,13 @@ export class OrgLensProjectsService {
 
   private mapProject(row: OrgLensProjectRow, peopleRows: OrgLensProjectPersonRow[]): OrgLensProject {
     const people = peopleRows.filter((person) => person.PROJECT_SLUG === row.PROJECT_SLUG);
-    const healthScore = row.HEALTH_OVERALL_SCORE;
-    const hasHealthScore = healthScore !== null && healthScore !== undefined;
+    const hasHealthScore = this.hasHealthScore(row);
     return {
       slug: row.PROJECT_SLUG,
       name: row.PROJECT_NAME,
       logoUrl: row.PROJECT_LOGO_URL ?? '',
       foundation: this.mapFoundation(row),
-      health: hasHealthScore ? this.mapHealthScore(healthScore) : 'unavailable',
+      health: hasHealthScore ? this.mapHealthScore(row) : 'unavailable',
       // These 'silent'/'non-lf' fallbacks are only user-visible for real (activity) rows. For no-activity rows the
       // UI shows "Unavailable" and compareInfluenceAvailability sinks them past measured rows, so the fallback band
       // is never compared against a measured one — it only affects the (tied) ordering of two no-activity rows.
@@ -565,8 +568,12 @@ export class OrgLensProjectsService {
     return value === 'up' || value === 'down' || value === 'flat' ? value : 'flat';
   }
 
-  private mapHealthScore(score: number): Exclude<HealthScore, 'unavailable'> {
-    return classifyHealthScore(score);
+  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2'>): boolean {
+    return (row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2) !== null && (row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2) !== undefined;
+  }
+
+  private mapHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_SCORE_CATEGORY_V2'>): Exclude<HealthScore, 'unavailable'> {
+    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE ?? 0);
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -406,7 +406,6 @@ export class OrgLensProjectsService {
         FOUNDATION_SLUG,
         FOUNDATION_NAME,
         FOUNDATION_LOGO_URL,
-        HEALTH_OVERALL_SCORE,
         HEALTH_OVERALL_SCORE_V2,
         HEALTH_SCORE_CATEGORY_V2,
         HEALTH_CONTRIBUTOR_PERCENTAGE,
@@ -455,7 +454,6 @@ export class OrgLensProjectsService {
         TREND_DIRECTION,
         COMBINED_SCORE_SERIES,
         DBT_RUN_AT,
-        HEALTH_OVERALL_SCORE,
         HEALTH_OVERALL_SCORE_V2,
         HEALTH_SCORE_CATEGORY_V2,
         HEALTH_CONTRIBUTOR_PERCENTAGE,
@@ -568,17 +566,14 @@ export class OrgLensProjectsService {
     return value === 'up' || value === 'down' || value === 'flat' ? value : 'flat';
   }
 
-  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2'>): boolean {
-    return (row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2) != null;
+  private hasHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE_V2'>): boolean {
+    return row.HEALTH_OVERALL_SCORE_V2 != null;
   }
 
-  private mapHealthScore(
-    row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>
-  ): Exclude<HealthScore, 'unavailable'> {
-    // Prefers the v2 raw score over v1 (v2 is the score we're migrating to; v1 is only for projects Snowflake
-    // hasn't backfilled yet). The trailing `?? 0` is an unreachable safety net since callers only invoke this
-    // when hasHealthScore() has confirmed one of the two exists.
-    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE_V2 ?? row.HEALTH_OVERALL_SCORE ?? 0);
+  private mapHealthScore(row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>): Exclude<HealthScore, 'unavailable'> {
+    // The trailing `?? 0` is an unreachable safety net since callers only invoke this when hasHealthScore()
+    // has confirmed HEALTH_OVERALL_SCORE_V2 is present.
+    return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE_V2 ?? 0);
   }
 
   private mapHealthMetrics(row: OrgLensProjectRow): OrgLensProject['healthMetrics'] {

--- a/apps/lfx-one/src/server/services/org-lens-projects.service.ts
+++ b/apps/lfx-one/src/server/services/org-lens-projects.service.ts
@@ -575,8 +575,8 @@ export class OrgLensProjectsService {
   private mapHealthScore(
     row: Pick<OrgLensProjectRow, 'HEALTH_OVERALL_SCORE' | 'HEALTH_OVERALL_SCORE_V2' | 'HEALTH_SCORE_CATEGORY_V2'>
   ): Exclude<HealthScore, 'unavailable'> {
-    // Falls back to whichever raw score is present (v1, else v2) rather than defaulting to 0, so a row with an
-    // unrecognized v2 category and no v1 score doesn't get silently misclassified as critical.
+    // Falls back to whichever raw score is present (v1, else v2); the trailing `?? 0` is an unreachable
+    // safety net since callers only invoke this when hasHealthScore() has confirmed one of the two exists.
     return normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2) ?? classifyHealthScore(row.HEALTH_OVERALL_SCORE ?? row.HEALTH_OVERALL_SCORE_V2 ?? 0);
   }
 

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -257,6 +257,8 @@ export interface OrgLensProjectRow {
   COMBINED_SCORE_SERIES: unknown;
   DBT_RUN_AT: string | Date | null;
   HEALTH_OVERALL_SCORE: number | null;
+  HEALTH_OVERALL_SCORE_V2: number | null;
+  HEALTH_SCORE_CATEGORY_V2: string | null;
   HEALTH_CONTRIBUTOR_PERCENTAGE: number | null;
   HEALTH_POPULARITY_PERCENTAGE: number | null;
   HEALTH_DEVELOPMENT_PERCENTAGE: number | null;

--- a/packages/shared/src/interfaces/org-lens-projects.interface.ts
+++ b/packages/shared/src/interfaces/org-lens-projects.interface.ts
@@ -256,7 +256,6 @@ export interface OrgLensProjectRow {
   TREND_DIRECTION: string | null;
   COMBINED_SCORE_SERIES: unknown;
   DBT_RUN_AT: string | Date | null;
-  HEALTH_OVERALL_SCORE: number | null;
   HEALTH_OVERALL_SCORE_V2: number | null;
   HEALTH_SCORE_CATEGORY_V2: string | null;
   HEALTH_CONTRIBUTOR_PERCENTAGE: number | null;

--- a/packages/shared/src/utils/insights.utils.spec.ts
+++ b/packages/shared/src/utils/insights.utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { classifyHealthScore } from './insights.utils';
+import { classifyHealthScore, normalizeHealthScoreCategoryV2 } from './insights.utils';
 
 describe('classifyHealthScore', () => {
   it.each([
@@ -24,5 +24,22 @@ describe('classifyHealthScore', () => {
   it('places the five bands in a strictly worsening order as the score drops', () => {
     const order = [90, 70, 50, 30, 10].map(classifyHealthScore);
     expect(order).toEqual(['excellent', 'healthy', 'fair', 'concerning', 'critical']);
+  });
+});
+
+describe('normalizeHealthScoreCategoryV2', () => {
+  it.each([
+    ['Excellent', 'excellent'],
+    ['Healthy', 'healthy'],
+    ['Fair', 'fair'],
+    ['Concerning', 'concerning'],
+    ['Critical', 'critical'],
+    ['CRITICAL', 'critical'],
+  ] as const)('normalizes %s to %s', (category, band) => {
+    expect(normalizeHealthScoreCategoryV2(category)).toBe(band);
+  });
+
+  it.each([null, undefined, '', 'Typo', 'unavailable'])('returns null for %s', (category) => {
+    expect(normalizeHealthScoreCategoryV2(category)).toBeNull();
   });
 });

--- a/packages/shared/src/utils/insights.utils.ts
+++ b/packages/shared/src/utils/insights.utils.ts
@@ -77,6 +77,22 @@ export function classifyHealthScore(score: number): Exclude<HealthScore, 'unavai
   return 'critical';
 }
 
+const HEALTH_SCORE_CATEGORIES = new Set<Exclude<HealthScore, 'unavailable'>>(['excellent', 'healthy', 'fair', 'concerning', 'critical']);
+
+/**
+ * Normalizes the warehouse-computed `health_score_category_v2` column (lf-dbt's `get_health_score_category_v2`
+ * macro, e.g. "Excellent"/"Fair"/"Concerning") into the lowercase `HealthScore` band. Returns `null` for
+ * unset/unrecognized values so callers can fall back to `classifyHealthScore` on the v1 score for projects
+ * the warehouse hasn't backfilled with a v2 category yet.
+ */
+export function normalizeHealthScoreCategoryV2(category: string | null | undefined): Exclude<HealthScore, 'unavailable'> | null {
+  if (!category) {
+    return null;
+  }
+  const lower = category.toLowerCase() as Exclude<HealthScore, 'unavailable'>;
+  return HEALTH_SCORE_CATEGORIES.has(lower) ? lower : null;
+}
+
 function encodePathSegments(path: string): string {
   if (!path) {
     return '';


### PR DESCRIPTION
## Summary
- Selects the warehouse-computed `HEALTH_OVERALL_SCORE_V2` and `HEALTH_SCORE_CATEGORY_V2` columns (lf-dbt) in both the Org Lens Projects table and the project-detail hero, and classifies through the warehouse category first, falling back to the v1 numeric score then the raw v2 score.
- Adds `normalizeHealthScoreCategoryV2` to `@lfx-one/shared/utils` as the shared normalization point so both consumers can never disagree.
- Fixes the project-detail hero's `mapHealth`, which previously fell back only to the v1 score and never the raw v2 score — a project with a null v1 score but a real v2 score could classify differently in the hero than in the Projects table.

## Context
IN-1220 shipped v1→v2 label/color renaming plus a defensive legacy-band mapping utility, explicitly noting it "ships independently of dbt model changes (IN-1219)." IN-1219's warehouse columns have since landed, but nothing wired the Self Serve BFF to actually select and use them — this PR closes that gap. No new ticket was opened for this follow-up; the commits reference IN-1220 for traceability instead of a new LFXV2 ticket.

## Trade-offs
- Branch name and commit ticket format (`IN-1220`) don't match this repo's `LFXV2-`/`GH-` convention, since the underlying gap traces back to an Insights-tracked ticket rather than a new lfx-self-serve ticket.
- Boundary-value classification math (score thresholds 80/60/40/20) is not re-tested at the service layer — it's already exhaustively covered by `packages/shared/src/utils/insights.utils.spec.ts`; the new service-level tests focus on the fallback-chain wiring instead.

## Test plan
- [x] `yarn vitest run` — 70 files / 1669 tests passing
- [x] `yarn build` — production build succeeds
- [x] `yarn lint:check` / `yarn format:check` / `check-headers.sh` — clean
- [ ] Manual QA: Org Lens Projects table and project-detail hero show matching health classifications for warehouse-backed v2 rows