### PR TITLE
feat(dashboards): add org seat holders drawer to groups list

### DIFF
--- a/apps/lfx-one/e2e/helpers/org-groups.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-groups.helper.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: MIT
 
 /**
- * Shared fixtures/mocks for `/org/groups` row specs (GH-1784).
+ * Shared fixtures/mocks for `/org/groups` row and seat-holders-drawer specs (GH-1784, GH-1780).
  *
- * Used by both `org-groups-row-link.spec.ts` (click-routing) and
- * `org-groups-row-link-robust.spec.ts` (data-testid contract) so the two specs can't drift apart
- * on the fixture they both depend on — a robust spec certifying a contract the content spec no
- * longer exercises is exactly the failure mode this file exists to prevent.
+ * Used by each content/`-robust` spec pair — `org-groups-row-link(.spec|-robust.spec).ts` for the
+ * row itself, `org-groups-seat-holders-drawer(.spec|-robust.spec).ts` for the drawer — so no pair
+ * can drift apart on the fixture they both depend on. A robust spec certifying a contract the
+ * content spec no longer exercises (or vice versa) is exactly the failure mode this file exists to
+ * prevent.
  */
 
 import { expect, Page, test } from '@playwright/test';
@@ -102,6 +103,89 @@ export async function stubGroups(page: Page): Promise<void> {
   await page.route(/\/api\/orgs\/[^/]+\/lens\/groups$/, (route) => {
     if (route.request().method() !== 'GET') return route.fallback();
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(groupsResponse()) });
+  });
+}
+
+// Seat holders for the seat-holders-drawer specs (GH-1780). GROUP_UID gets two seats (proves a
+// per-seat testid/row is scoped to the seat, not the group) across two people; SECOND_GROUP_UID
+// gets one, on a different person — proves the drawer scopes by committeeUid, not just "any seat".
+export const SEAT_TRANSPORT_1 = 'seat-transport-1';
+export const SEAT_TRANSPORT_2 = 'seat-transport-2';
+export const SEAT_STORAGE_1 = 'seat-storage-1';
+
+export function committeeMembersResponse() {
+  const person = (email: string, fullName: string) => ({
+    email,
+    firstName: fullName.split(' ')[0],
+    lastName: fullName.split(' ')[1] ?? '',
+    fullName,
+    jobTitle: null,
+    initials: fullName
+      .split(' ')
+      .map((p) => p[0])
+      .join(''),
+  });
+
+  return {
+    orgUid: MOCK_ACCOUNT_ID,
+    assignments: [
+      {
+        seatId: SEAT_TRANSPORT_1,
+        memberUid: SEAT_TRANSPORT_1,
+        committeeUid: GROUP_UID,
+        committeeName: 'Transport Working Group',
+        committeeCategory: 'Working Group',
+        projectUid: 'uepf-root',
+        foundationSlug: 'uepf',
+        foundationName: 'Ultra Ethernet Consortium Fund',
+        role: 'Chair',
+        votingStatus: 'Voting Rep',
+        appointedBy: 'Membership Entitlement',
+        isOrgEditable: true,
+        reason: null,
+        person: person('jane@acme-motors.example', 'Jane Doe'),
+      },
+      {
+        seatId: SEAT_TRANSPORT_2,
+        memberUid: SEAT_TRANSPORT_2,
+        committeeUid: GROUP_UID,
+        committeeName: 'Transport Working Group',
+        committeeCategory: 'Working Group',
+        projectUid: 'uepf-root',
+        foundationSlug: 'uepf',
+        foundationName: 'Ultra Ethernet Consortium Fund',
+        role: 'Member',
+        votingStatus: 'Non-voting',
+        appointedBy: 'Manual',
+        isOrgEditable: false,
+        reason: 'Not a membership-entitlement seat',
+        person: person('sam@acme-motors.example', 'Sam Lee'),
+      },
+      {
+        seatId: SEAT_STORAGE_1,
+        memberUid: SEAT_STORAGE_1,
+        committeeUid: SECOND_GROUP_UID,
+        committeeName: 'Storage Working Group',
+        committeeCategory: 'Working Group',
+        projectUid: 'cncf-root',
+        foundationSlug: 'cncf',
+        foundationName: 'Cloud Native Computing Foundation',
+        role: 'Member',
+        votingStatus: 'Non-voting',
+        appointedBy: 'Manual',
+        isOrgEditable: false,
+        reason: 'Not a membership-entitlement seat',
+        person: person('john@acme-motors.example', 'John Smith'),
+      },
+    ],
+    stats: { individualCount: 3, committeeCount: 2, foundationsCovered: 2 },
+  };
+}
+
+export async function stubCommitteeMembers(page: Page, response: unknown = committeeMembersResponse()): Promise<void> {
+  await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(response) });
   });
 }
 

--- a/apps/lfx-one/e2e/helpers/org-groups.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-groups.helper.ts
@@ -56,14 +56,15 @@ export function groupsResponse() {
   };
 }
 
-export function skipWhenAuthMissing(page: Page): void {
-  try {
-    const { hostname } = new URL(page.url());
-    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
-      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
-    }
-  } catch {
-    // Malformed URL — let the test run and surface a useful failure.
+// Gated on env vars rather than on URL sniffing so genuine auth-flow regressions (expired
+// storageState, broken Auth0 login helper) still fail loudly when creds ARE configured —
+// URL-based detection silently turned those into green skips instead. Matches the pattern in
+// groups-view-toggle.spec.ts.
+const AUTH_CREDS_PRESENT = !!process.env.TEST_USERNAME && !!process.env.TEST_PASSWORD;
+
+export function skipWhenAuthMissing(): void {
+  if (!AUTH_CREDS_PRESENT) {
+    test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
   }
 }
 
@@ -190,12 +191,12 @@ export async function stubCommitteeMembers(page: Page, response: unknown = commi
 }
 
 export async function gotoGroups(page: Page): Promise<void> {
+  skipWhenAuthMissing();
   await page.goto('/', { waitUntil: 'domcontentloaded' });
-  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
   await page.reload({ waitUntil: 'domcontentloaded' });
 
   await page.goto(GROUPS_URL, { waitUntil: 'domcontentloaded' });
-  skipWhenAuthMissing(page);
   await expect(page).not.toHaveURL(/auth0\.com/);
 
   if (!page.url().includes('/org/groups')) {

--- a/apps/lfx-one/e2e/helpers/org-groups.helper.ts
+++ b/apps/lfx-one/e2e/helpers/org-groups.helper.ts
@@ -196,6 +196,7 @@ export async function gotoGroups(page: Page): Promise<void> {
 
   await page.goto(GROUPS_URL, { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
 
   if (!page.url().includes('/org/groups')) {
     test.skip(true, 'org-lens-enabled flag appears off — /org/groups redirected away');

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -93,10 +93,12 @@ test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)
     await expect(button).toBeVisible();
     expect(await button.evaluate((el) => el.tagName)).toBe('BUTTON');
 
-    // Asserts the button's own testid, not collectSeatTestIds()'s output — that helper only ever
-    // locates on the 'group-seat-holder-' prefix, so anything it returns starts with that prefix by
-    // construction and could never demonstrate the no-shared-stem invariant either way.
-    const buttonTestId = await button.getAttribute('data-testid');
-    expect(buttonTestId?.startsWith('group-seat-holder-')).toBe(false);
+    // Asserts the structural property directly, not a fact about the two hard-coded string literals
+    // used to locate `row`/`button` above (which is trivially true regardless of what the button's
+    // testid actually is — both a prior fixed version of this line and its predecessor were
+    // tautological this same way). `row.locator(...)` matches descendants only, so the row's own
+    // testid doesn't self-match — this fails only if something nested under the row reuses the row's
+    // stem, which is exactly what would make collectSeatTestIds()'s prefix match over-collect it.
+    await expect(row.locator('[data-testid^="group-seat-holder-"]')).toHaveCount(0);
   });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -7,97 +7,70 @@
  * Companion to `org-groups-seat-holders-drawer.spec.ts`, which owns click-routing/content behavior
  * for the same drawer. This file stays focused on the data-testid contract in isolation, mirroring
  * `org-groups-row-link-robust.spec.ts`'s split for the row itself: a per-seat testid must be
- * uid-scoped (not shared across rows in the same committee, and not shared across drawer opens for
- * different committees), so a component swap that keeps the same visible copy but breaks the
- * testid scope still fails here even though the content spec would still pass.
+ * uid-scoped — not shared across rows within one committee's roster (first test below), and not
+ * reused across drawer opens for a different committee (second test below) — so a component swap
+ * that keeps the same visible copy but breaks either scope still fails here even though the
+ * content spec would still pass.
  */
 
-import { expect, test } from '@playwright/test';
+import { expect, Page, test } from '@playwright/test';
 
-import { GROUP_UID, MOCK_ACCOUNT_ID, stubAccountContext, stubGroups, gotoGroups } from './helpers/org-groups.helper';
+import {
+  GROUP_UID,
+  SEAT_STORAGE_1,
+  SEAT_TRANSPORT_1,
+  SEAT_TRANSPORT_2,
+  SECOND_GROUP_UID,
+  stubAccountContext,
+  stubCommitteeMembers,
+  stubGroups,
+  gotoGroups,
+} from './helpers/org-groups.helper';
 
 test.setTimeout(120_000);
 
-const SEAT_A = 'seat-transport-1';
-const SEAT_B = 'seat-transport-2';
-
-function committeeMembersResponse() {
-  const person = (email: string, fullName: string) => ({
-    email,
-    firstName: fullName.split(' ')[0],
-    lastName: fullName.split(' ')[1] ?? '',
-    fullName,
-    jobTitle: null,
-    initials: fullName
-      .split(' ')
-      .map((p) => p[0])
-      .join(''),
-  });
-
-  return {
-    orgUid: MOCK_ACCOUNT_ID,
-    assignments: [
-      {
-        seatId: SEAT_A,
-        memberUid: SEAT_A,
-        committeeUid: GROUP_UID,
-        committeeName: 'Transport Working Group',
-        committeeCategory: 'Working Group',
-        projectUid: 'uepf-root',
-        foundationSlug: 'uepf',
-        foundationName: 'Ultra Ethernet Consortium Fund',
-        role: 'Chair',
-        votingStatus: 'Voting Rep',
-        appointedBy: 'Membership Entitlement',
-        isOrgEditable: true,
-        reason: null,
-        person: person('jane@acme-motors.example', 'Jane Doe'),
-      },
-      {
-        seatId: SEAT_B,
-        memberUid: SEAT_B,
-        committeeUid: GROUP_UID,
-        committeeName: 'Transport Working Group',
-        committeeCategory: 'Working Group',
-        projectUid: 'uepf-root',
-        foundationSlug: 'uepf',
-        foundationName: 'Ultra Ethernet Consortium Fund',
-        role: 'Member',
-        votingStatus: 'Non-voting',
-        appointedBy: 'Manual',
-        isOrgEditable: false,
-        reason: 'Not a membership-entitlement seat',
-        person: person('sam@acme-motors.example', 'Sam Lee'),
-      },
-    ],
-    stats: { individualCount: 2, committeeCount: 1, foundationsCovered: 1 },
-  };
+async function collectSeatTestIds(page: Page): Promise<string[]> {
+  const values = await page.locator('[data-testid^="group-seat-holder-"]').evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
+  return values.filter((v): v is string => v !== null);
 }
 
 test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)', () => {
   test.beforeEach(async ({ page }) => {
     await stubAccountContext(page);
     await stubGroups(page);
-    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeMembersResponse()) });
-    });
+    await stubCommitteeMembers(page);
     await gotoGroups(page);
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
-    await expect(page.getByTestId('group-seat-holders-drawer')).toBeVisible();
+    // Wait for the roster itself, not just the drawer shell — the shell (and its loading spinner)
+    // renders before the fetch resolves, so a wait on the shell alone lets every test below run
+    // against a still-loading drawer and pass vacuously.
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
   });
 
   test('renders the drawer chrome testids', async ({ page }) => {
     await expect(page.getByTestId('group-seat-holders-drawer-title')).toBeVisible();
     await expect(page.getByTestId('group-seat-holders-drawer-subtitle')).toBeVisible();
     await expect(page.getByTestId('group-seat-holders-drawer-view-group-link')).toBeVisible();
-    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
   });
 
-  test('each seat row gets its own seatId-scoped testid, not a testid shared across rows', async ({ page }) => {
-    const ids = await page.locator('[data-testid^="group-seat-holder-"]').evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
+  test('each seat row within one committee gets its own seatId-scoped testid, not a testid shared across rows', async ({ page }) => {
+    const ids = await collectSeatTestIds(page);
 
-    expect(ids.slice().sort()).toEqual([`group-seat-holder-${SEAT_A}`, `group-seat-holder-${SEAT_B}`].sort());
+    expect(ids.slice().sort()).toEqual([`group-seat-holder-${SEAT_TRANSPORT_1}`, `group-seat-holder-${SEAT_TRANSPORT_2}`].sort());
+  });
+
+  test("opening a different committee produces its own seat testids, not the previous committee's", async ({ page }) => {
+    const firstCommitteeIds = await collectSeatTestIds(page);
+
+    await page.keyboard.press('Escape');
+    await expect(page.getByTestId('group-seat-holders-drawer')).toBeHidden();
+    await page.getByTestId(`org-groups-item-seats-${SECOND_GROUP_UID}`).click();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+
+    const secondCommitteeIds = await collectSeatTestIds(page);
+
+    expect(secondCommitteeIds).toEqual([`group-seat-holder-${SEAT_STORAGE_1}`]);
+    expect(firstCommitteeIds.some((id) => secondCommitteeIds.includes(id))).toBe(false);
   });
 
   test('the loading/empty/error state testids are mutually exclusive once the drawer settles', async ({ page }) => {

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -7,15 +7,16 @@
  * Companion to `org-groups-seat-holders-drawer.spec.ts`, which owns click-routing/content behavior
  * for the same drawer. This file stays focused on the data-testid contract in isolation, mirroring
  * `org-groups-row-link-robust.spec.ts`'s split for the row itself: a per-seat testid must be
- * uid-scoped — not shared across rows within one committee's roster (first test below), and not
- * reused across drawer opens for a different committee (second test below) — so a component swap
- * that keeps the same visible copy but breaks either scope still fails here even though the
- * content spec would still pass.
+ * uid-scoped — not shared across rows within one committee's roster (see "each seat row within one
+ * committee..." below), and not reused across drawer opens for a different committee (see
+ * "opening a different committee..." below) — so a component swap that keeps the same visible copy
+ * but breaks either scope still fails here even though the content spec would still pass.
  */
 
 import { expect, Page, test } from '@playwright/test';
 
 import {
+  DATA_LOAD_TIMEOUT,
   GROUP_UID,
   SEAT_STORAGE_1,
   SEAT_TRANSPORT_1,
@@ -44,7 +45,7 @@ test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)
     // Wait for the roster itself, not just the drawer shell — the shell (and its loading spinner)
     // renders before the fetch resolves, so a wait on the shell alone lets every test below run
     // against a still-loading drawer and pass vacuously.
-    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 
   test('renders the drawer chrome testids', async ({ page }) => {
@@ -65,7 +66,7 @@ test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)
     await page.keyboard.press('Escape');
     await expect(page.getByTestId('group-seat-holders-drawer')).toBeHidden();
     await page.getByTestId(`org-groups-item-seats-${SECOND_GROUP_UID}`).click();
-    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     const secondCommitteeIds = await collectSeatTestIds(page);
 

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -93,12 +93,11 @@ test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)
     await expect(button).toBeVisible();
     expect(await button.evaluate((el) => el.tagName)).toBe('BUTTON');
 
-    // Asserts the structural property directly, not a fact about the two hard-coded string literals
-    // used to locate `row`/`button` above (which is trivially true regardless of what the button's
-    // testid actually is — both a prior fixed version of this line and its predecessor were
-    // tautological this same way). `row.locator(...)` matches descendants only, so the row's own
-    // testid doesn't self-match — this fails only if something nested under the row reuses the row's
-    // stem, which is exactly what would make collectSeatTestIds()'s prefix match over-collect it.
+    // `row.locator(...)` matches descendants only, so the row's own testid doesn't self-match — this
+    // fails iff something nested under the row reuses the row's 'group-seat-holder-' stem, which is
+    // what would make collectSeatTestIds()'s prefix match over-collect it. Redundant with the "each
+    // seat row..." test above (its exact-set assertion would also fail on the same regression) —
+    // kept anyway as defense-in-depth that localizes the failure to this one row.
     await expect(row.locator('[data-testid^="group-seat-holder-"]')).toHaveCount(0);
   });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -93,7 +93,10 @@ test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)
     await expect(button).toBeVisible();
     expect(await button.evaluate((el) => el.tagName)).toBe('BUTTON');
 
-    const ids = await collectSeatTestIds(page);
-    expect(ids).not.toContain(`seat-holder-person-${SEAT_TRANSPORT_1}`);
+    // Asserts the button's own testid, not collectSeatTestIds()'s output — that helper only ever
+    // locates on the 'group-seat-holder-' prefix, so anything it returns starts with that prefix by
+    // construction and could never demonstrate the no-shared-stem invariant either way.
+    const buttonTestId = await button.getAttribute('data-testid');
+    expect(buttonTestId?.startsWith('group-seat-holder-')).toBe(false);
   });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -75,7 +75,9 @@ test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)
   });
 
   test('the loading/empty/error state testids are mutually exclusive once the drawer settles', async ({ page }) => {
+    await expect(page.getByTestId('group-seat-holders-drawer-loading')).toHaveCount(0);
     await expect(page.getByTestId('group-seat-holders-drawer-empty')).toHaveCount(0);
     await expect(page.getByTestId('group-seat-holders-drawer-error')).toHaveCount(0);
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
   });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -1,0 +1,107 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Groups — seat-holders drawer data-testid contract — Structural Tests (GH-1780).
+ *
+ * Companion to `org-groups-seat-holders-drawer.spec.ts`, which owns click-routing/content behavior
+ * for the same drawer. This file stays focused on the data-testid contract in isolation, mirroring
+ * `org-groups-row-link-robust.spec.ts`'s split for the row itself: a per-seat testid must be
+ * uid-scoped (not shared across rows in the same committee, and not shared across drawer opens for
+ * different committees), so a component swap that keeps the same visible copy but breaks the
+ * testid scope still fails here even though the content spec would still pass.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { GROUP_UID, MOCK_ACCOUNT_ID, stubAccountContext, stubGroups, gotoGroups } from './helpers/org-groups.helper';
+
+test.setTimeout(120_000);
+
+const SEAT_A = 'seat-transport-1';
+const SEAT_B = 'seat-transport-2';
+
+function committeeMembersResponse() {
+  const person = (email: string, fullName: string) => ({
+    email,
+    firstName: fullName.split(' ')[0],
+    lastName: fullName.split(' ')[1] ?? '',
+    fullName,
+    jobTitle: null,
+    initials: fullName
+      .split(' ')
+      .map((p) => p[0])
+      .join(''),
+  });
+
+  return {
+    orgUid: MOCK_ACCOUNT_ID,
+    assignments: [
+      {
+        seatId: SEAT_A,
+        memberUid: SEAT_A,
+        committeeUid: GROUP_UID,
+        committeeName: 'Transport Working Group',
+        committeeCategory: 'Working Group',
+        projectUid: 'uepf-root',
+        foundationSlug: 'uepf',
+        foundationName: 'Ultra Ethernet Consortium Fund',
+        role: 'Chair',
+        votingStatus: 'Voting Rep',
+        appointedBy: 'Membership Entitlement',
+        isOrgEditable: true,
+        reason: null,
+        person: person('jane@acme-motors.example', 'Jane Doe'),
+      },
+      {
+        seatId: SEAT_B,
+        memberUid: SEAT_B,
+        committeeUid: GROUP_UID,
+        committeeName: 'Transport Working Group',
+        committeeCategory: 'Working Group',
+        projectUid: 'uepf-root',
+        foundationSlug: 'uepf',
+        foundationName: 'Ultra Ethernet Consortium Fund',
+        role: 'Member',
+        votingStatus: 'Non-voting',
+        appointedBy: 'Manual',
+        isOrgEditable: false,
+        reason: 'Not a membership-entitlement seat',
+        person: person('sam@acme-motors.example', 'Sam Lee'),
+      },
+    ],
+    stats: { individualCount: 2, committeeCount: 1, foundationsCovered: 1 },
+  };
+}
+
+test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubAccountContext(page);
+    await stubGroups(page);
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeMembersResponse()) });
+    });
+    await gotoGroups(page);
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+    await expect(page.getByTestId('group-seat-holders-drawer')).toBeVisible();
+  });
+
+  test('renders the drawer chrome testids', async ({ page }) => {
+    await expect(page.getByTestId('group-seat-holders-drawer-title')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-drawer-subtitle')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-drawer-view-group-link')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+  });
+
+  test('each seat row gets its own seatId-scoped testid, not a testid shared across rows', async ({ page }) => {
+    const ids = await page.locator('[data-testid^="group-seat-holder-"]').evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
+
+    expect(ids.slice().sort()).toEqual([`group-seat-holder-${SEAT_A}`, `group-seat-holder-${SEAT_B}`].sort());
+  });
+
+  test('the loading/empty/error state testids are mutually exclusive once the drawer settles', async ({ page }) => {
+    await expect(page.getByTestId('group-seat-holders-drawer-empty')).toHaveCount(0);
+    await expect(page.getByTestId('group-seat-holders-drawer-error')).toHaveCount(0);
+  });
+});

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -30,8 +30,11 @@ import {
 
 test.setTimeout(120_000);
 
+// `li[...]`, not the bare attribute selector — the per-row person button's testid
+// ('group-seat-holder-person-{seatId}') shares the same prefix as the row's own
+// ('group-seat-holder-{seatId}'), and an unscoped `^=` selector would match both.
 async function collectSeatTestIds(page: Page): Promise<string[]> {
-  const values = await page.locator('[data-testid^="group-seat-holder-"]').evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
+  const values = await page.locator('li[data-testid^="group-seat-holder-"]').evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
   return values.filter((v): v is string => v !== null);
 }
 

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer-robust.spec.ts
@@ -30,11 +30,8 @@ import {
 
 test.setTimeout(120_000);
 
-// `li[...]`, not the bare attribute selector — the per-row person button's testid
-// ('group-seat-holder-person-{seatId}') shares the same prefix as the row's own
-// ('group-seat-holder-{seatId}'), and an unscoped `^=` selector would match both.
 async function collectSeatTestIds(page: Page): Promise<string[]> {
-  const values = await page.locator('li[data-testid^="group-seat-holder-"]').evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
+  const values = await page.locator('[data-testid^="group-seat-holder-"]').evaluateAll((els) => els.map((el) => el.getAttribute('data-testid')));
   return values.filter((v): v is string => v !== null);
 }
 
@@ -82,5 +79,21 @@ test.describe('Org Groups — seat holders drawer data-testid contract (GH-1780)
     await expect(page.getByTestId('group-seat-holders-drawer-empty')).toHaveCount(0);
     await expect(page.getByTestId('group-seat-holders-drawer-error')).toHaveCount(0);
     await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+  });
+
+  // The person-open button's testid ('seat-holder-person-{seatId}') deliberately does NOT share the
+  // row's own stem ('group-seat-holder-{seatId}') — a shared stem is exactly what collectSeatTestIds()
+  // above guards against via its `[data-testid^="group-seat-holder-"]` prefix match, which would
+  // otherwise pick up both the row and its nested button. Asserts nesting (a real DOM descendant, not
+  // just two matching elements anywhere on the page) and tag (a real <button>, not a div handler).
+  test('each row nests a real <button> for opening the person-detail drawer, under its own non-colliding testid', async ({ page }) => {
+    const row = page.getByTestId(`group-seat-holder-${SEAT_TRANSPORT_1}`);
+    const button = row.getByTestId(`seat-holder-person-${SEAT_TRANSPORT_1}`);
+
+    await expect(button).toBeVisible();
+    expect(await button.evaluate((el) => el.tagName)).toBe('BUTTON');
+
+    const ids = await collectSeatTestIds(page);
+    expect(ids).not.toContain(`seat-holder-person-${SEAT_TRANSPORT_1}`);
   });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -75,7 +75,13 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
     // earlier one for a matching request, so this replaces the fixture roster for this test only.
     await stubCommitteeMembers(page, { orgUid: MOCK_ACCOUNT_ID, assignments: [], stats: { individualCount: 0, committeeCount: 0, foundationsCovered: 0 } });
 
+    // Waits on the actual request, not just the resulting DOM — a broken orgUid/committeeUid
+    // binding that never issues the request would render this same empty state (seatHolderVms
+    // defaults to []), so asserting the DOM alone wouldn't catch that regression.
+    const responsePromise = page.waitForResponse(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/);
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+    const response = await responsePromise;
+    expect(response.status()).toBe(200);
 
     await expect(page.getByTestId('group-seat-holders-drawer-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -1,0 +1,111 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Org Groups — seat-holders drawer trigger (GH-1780). Covers what jsdom unit specs can't: that
+ * clicking the row's seat-count button (now a third independently-clickable target inside the
+ * row's stretched link, alongside the row body and the foundation link — see
+ * org-groups-row-link.spec.ts) opens the drawer WITHOUT firing the row's `/groups/:uid`
+ * stretched-link navigation, and that the drawer's own "View group page" link still reaches it.
+ */
+
+import { expect, test } from '@playwright/test';
+
+import { GROUP_UID, MOCK_ACCOUNT_ID, SECOND_GROUP_UID, stubAccountContext, stubGroups, gotoGroups } from './helpers/org-groups.helper';
+
+test.setTimeout(120_000);
+
+function committeeMembersResponse() {
+  const person = (email: string, fullName: string) => ({
+    email,
+    firstName: fullName.split(' ')[0],
+    lastName: fullName.split(' ')[1] ?? '',
+    fullName,
+    jobTitle: null,
+    initials: fullName
+      .split(' ')
+      .map((p) => p[0])
+      .join(''),
+  });
+
+  return {
+    orgUid: MOCK_ACCOUNT_ID,
+    assignments: [
+      {
+        seatId: 'seat-transport-1',
+        memberUid: 'seat-transport-1',
+        committeeUid: GROUP_UID,
+        committeeName: 'Transport Working Group',
+        committeeCategory: 'Working Group',
+        projectUid: 'uepf-root',
+        foundationSlug: 'uepf',
+        foundationName: 'Ultra Ethernet Consortium Fund',
+        role: 'Chair',
+        votingStatus: 'Voting Rep',
+        appointedBy: 'Membership Entitlement',
+        isOrgEditable: true,
+        reason: null,
+        person: person('jane@acme-motors.example', 'Jane Doe'),
+      },
+      {
+        seatId: 'seat-storage-1',
+        memberUid: 'seat-storage-1',
+        committeeUid: SECOND_GROUP_UID,
+        committeeName: 'Storage Working Group',
+        committeeCategory: 'Working Group',
+        projectUid: 'cncf-root',
+        foundationSlug: 'cncf',
+        foundationName: 'Cloud Native Computing Foundation',
+        role: 'Member',
+        votingStatus: 'Non-voting',
+        appointedBy: 'Manual',
+        isOrgEditable: false,
+        reason: 'Not a membership-entitlement seat',
+        person: person('john@acme-motors.example', 'John Smith'),
+      },
+    ],
+    stats: { individualCount: 2, committeeCount: 2, foundationsCovered: 2 },
+  };
+}
+
+test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
+  test.beforeEach(async ({ page }) => {
+    await stubAccountContext(page);
+    await stubGroups(page);
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeMembersResponse()) });
+    });
+    await gotoGroups(page);
+  });
+
+  test('clicking the seat count opens the drawer without navigating to the group detail page', async ({ page }) => {
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+
+    await expect(page.getByTestId('group-seat-holders-drawer')).toBeVisible();
+    expect(page.url()).not.toContain(`/groups/${GROUP_UID}`);
+  });
+
+  test('the drawer shows only the seat holders for the clicked group', async ({ page }) => {
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+
+    await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('Jane Doe');
+    await expect(page.getByTestId('group-seat-holders-drawer')).not.toContainText('John Smith');
+  });
+
+  test('the second row opens the drawer scoped to its own committee, not the first row', async ({ page }) => {
+    await page.getByTestId(`org-groups-item-seats-${SECOND_GROUP_UID}`).click();
+
+    await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('John Smith');
+    await expect(page.getByTestId('group-seat-holders-drawer')).not.toContainText('Jane Doe');
+  });
+
+  test('the drawer\'s "View group page" link navigates to the public group detail page', async ({ page }) => {
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+    await expect(page.getByTestId('group-seat-holders-drawer')).toBeVisible();
+
+    await page.getByTestId('group-seat-holders-drawer-view-group-link').click();
+    await page.waitForURL((url) => url.pathname.startsWith(`/groups/${GROUP_UID}`));
+    expect(page.url()).toContain(`/groups/${GROUP_UID}`);
+  });
+});

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -7,102 +7,53 @@
  * row's stretched link, alongside the row body and the foundation link — see
  * org-groups-row-link.spec.ts) opens the drawer WITHOUT firing the row's `/groups/:uid`
  * stretched-link navigation, and that the drawer's own "View group page" link still reaches it.
+ *
+ * Companion to `org-groups-seat-holders-drawer-robust.spec.ts`, which owns the drawer's
+ * data-testid contract. Both share their fixture via `helpers/org-groups.helper.ts`.
  */
 
 import { expect, test } from '@playwright/test';
 
-import { GROUP_UID, MOCK_ACCOUNT_ID, SECOND_GROUP_UID, stubAccountContext, stubGroups, gotoGroups } from './helpers/org-groups.helper';
+import { GROUP_UID, MOCK_ACCOUNT_ID, SECOND_GROUP_UID, stubAccountContext, stubCommitteeMembers, stubGroups, gotoGroups } from './helpers/org-groups.helper';
 
 test.setTimeout(120_000);
-
-function committeeMembersResponse() {
-  const person = (email: string, fullName: string) => ({
-    email,
-    firstName: fullName.split(' ')[0],
-    lastName: fullName.split(' ')[1] ?? '',
-    fullName,
-    jobTitle: null,
-    initials: fullName
-      .split(' ')
-      .map((p) => p[0])
-      .join(''),
-  });
-
-  return {
-    orgUid: MOCK_ACCOUNT_ID,
-    assignments: [
-      {
-        seatId: 'seat-transport-1',
-        memberUid: 'seat-transport-1',
-        committeeUid: GROUP_UID,
-        committeeName: 'Transport Working Group',
-        committeeCategory: 'Working Group',
-        projectUid: 'uepf-root',
-        foundationSlug: 'uepf',
-        foundationName: 'Ultra Ethernet Consortium Fund',
-        role: 'Chair',
-        votingStatus: 'Voting Rep',
-        appointedBy: 'Membership Entitlement',
-        isOrgEditable: true,
-        reason: null,
-        person: person('jane@acme-motors.example', 'Jane Doe'),
-      },
-      {
-        seatId: 'seat-storage-1',
-        memberUid: 'seat-storage-1',
-        committeeUid: SECOND_GROUP_UID,
-        committeeName: 'Storage Working Group',
-        committeeCategory: 'Working Group',
-        projectUid: 'cncf-root',
-        foundationSlug: 'cncf',
-        foundationName: 'Cloud Native Computing Foundation',
-        role: 'Member',
-        votingStatus: 'Non-voting',
-        appointedBy: 'Manual',
-        isOrgEditable: false,
-        reason: 'Not a membership-entitlement seat',
-        person: person('john@acme-motors.example', 'John Smith'),
-      },
-    ],
-    stats: { individualCount: 2, committeeCount: 2, foundationsCovered: 2 },
-  };
-}
 
 test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
   test.beforeEach(async ({ page }) => {
     await stubAccountContext(page);
     await stubGroups(page);
-    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeMembersResponse()) });
-    });
+    await stubCommitteeMembers(page);
     await gotoGroups(page);
   });
 
   test('clicking the seat count opens the drawer without navigating to the group detail page', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
 
-    await expect(page.getByTestId('group-seat-holders-drawer')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
     expect(page.url()).not.toContain(`/groups/${GROUP_UID}`);
   });
 
   test('the drawer shows only the seat holders for the clicked group', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
 
     await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('Jane Doe');
+    await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('Sam Lee');
     await expect(page.getByTestId('group-seat-holders-drawer')).not.toContainText('John Smith');
   });
 
   test('the second row opens the drawer scoped to its own committee, not the first row', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${SECOND_GROUP_UID}`).click();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
 
     await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('John Smith');
     await expect(page.getByTestId('group-seat-holders-drawer')).not.toContainText('Jane Doe');
+    await expect(page.getByTestId('group-seat-holders-drawer')).not.toContainText('Sam Lee');
   });
 
   test('the drawer\'s "View group page" link navigates to the public group detail page', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
-    await expect(page.getByTestId('group-seat-holders-drawer')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
 
     await page.getByTestId('group-seat-holders-drawer-view-group-link').click();
     await page.waitForURL((url) => url.pathname.startsWith(`/groups/${GROUP_UID}`));
@@ -112,13 +63,7 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
   test('shows the empty state when no assignment matches the clicked group', async ({ page }) => {
     // Overrides the beforeEach stub — a later-registered page.route takes precedence over an
     // earlier one for a matching request, so this replaces the fixture roster for this test only.
-    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) =>
-      route.fulfill({
-        status: 200,
-        contentType: 'application/json',
-        body: JSON.stringify({ orgUid: MOCK_ACCOUNT_ID, assignments: [], stats: { individualCount: 0, committeeCount: 0, foundationsCovered: 0 } }),
-      })
-    );
+    await stubCommitteeMembers(page, { orgUid: MOCK_ACCOUNT_ID, assignments: [], stats: { individualCount: 0, committeeCount: 0, foundationsCovered: 0 } });
 
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
 

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -19,6 +19,7 @@ import {
   GROUP_UID,
   MOCK_ACCOUNT_ID,
   SECOND_GROUP_UID,
+  committeeMembersResponse,
   stubAccountContext,
   stubCommitteeMembers,
   stubGroups,
@@ -91,5 +92,26 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
 
     await expect(page.getByTestId('group-seat-holders-drawer-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('group-seat-holders-drawer-empty')).not.toBeVisible();
+  });
+
+  test('the "Try again" button recovers from a failed fetch without closing the drawer', async ({ page }) => {
+    let requestCount = 0;
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      requestCount += 1;
+      if (requestCount === 1) {
+        return route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'internal error' }) });
+      }
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(committeeMembersResponse()) });
+    });
+
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+    await expect(page.getByTestId('group-seat-holders-drawer-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId('group-seat-holders-drawer-retry').click();
+
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('Jane Doe');
+    expect(requestCount).toBe(2);
   });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -78,4 +78,18 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
 
     await expect(page.getByTestId('group-seat-holders-drawer-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
+
+  test('shows the error state when the committee-members fetch fails', async ({ page }) => {
+    // Overrides the beforeEach stub with a failing response, not a fixture — stubCommitteeMembers
+    // always fulfills with 200, so a genuine upstream failure needs its own route registration.
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      return route.fulfill({ status: 500, contentType: 'application/json', body: JSON.stringify({ error: 'internal error' }) });
+    });
+
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+
+    await expect(page.getByTestId('group-seat-holders-drawer-error')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('group-seat-holders-drawer-empty')).not.toBeVisible();
+  });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -108,4 +108,20 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
     await page.waitForURL((url) => url.pathname.startsWith(`/groups/${GROUP_UID}`));
     expect(page.url()).toContain(`/groups/${GROUP_UID}`);
   });
+
+  test('shows the empty state when no assignment matches the clicked group', async ({ page }) => {
+    // Overrides the beforeEach stub — a later-registered page.route takes precedence over an
+    // earlier one for a matching request, so this replaces the fixture roster for this test only.
+    await page.route(/\/api\/orgs\/[^/]+\/lens\/people\/committee-members$/, (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ orgUid: MOCK_ACCOUNT_ID, assignments: [], stats: { individualCount: 0, committeeCount: 0, foundationsCovered: 0 } }),
+      })
+    );
+
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+
+    await expect(page.getByTestId('group-seat-holders-drawer-empty')).toBeVisible();
+  });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -14,7 +14,16 @@
 
 import { expect, test } from '@playwright/test';
 
-import { GROUP_UID, MOCK_ACCOUNT_ID, SECOND_GROUP_UID, stubAccountContext, stubCommitteeMembers, stubGroups, gotoGroups } from './helpers/org-groups.helper';
+import {
+  DATA_LOAD_TIMEOUT,
+  GROUP_UID,
+  MOCK_ACCOUNT_ID,
+  SECOND_GROUP_UID,
+  stubAccountContext,
+  stubCommitteeMembers,
+  stubGroups,
+  gotoGroups,
+} from './helpers/org-groups.helper';
 
 test.setTimeout(120_000);
 
@@ -29,13 +38,13 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
   test('clicking the seat count opens the drawer without navigating to the group detail page', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
 
-    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     expect(page.url()).not.toContain(`/groups/${GROUP_UID}`);
   });
 
   test('the drawer shows only the seat holders for the clicked group', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
-    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('Jane Doe');
     await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('Sam Lee');
@@ -44,7 +53,7 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
 
   test('the second row opens the drawer scoped to its own committee, not the first row', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${SECOND_GROUP_UID}`).click();
-    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('John Smith');
     await expect(page.getByTestId('group-seat-holders-drawer')).not.toContainText('Jane Doe');
@@ -53,7 +62,7 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
 
   test('the drawer\'s "View group page" link navigates to the public group detail page', async ({ page }) => {
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
-    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
 
     await page.getByTestId('group-seat-holders-drawer-view-group-link').click();
     await page.waitForURL((url) => url.pathname.startsWith(`/groups/${GROUP_UID}`));
@@ -67,6 +76,6 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
 
     await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
 
-    await expect(page.getByTestId('group-seat-holders-drawer-empty')).toBeVisible();
+    await expect(page.getByTestId('group-seat-holders-drawer-empty')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
   });
 });

--- a/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
+++ b/apps/lfx-one/e2e/org-groups-seat-holders-drawer.spec.ts
@@ -18,6 +18,7 @@ import {
   DATA_LOAD_TIMEOUT,
   GROUP_UID,
   MOCK_ACCOUNT_ID,
+  SEAT_TRANSPORT_1,
   SECOND_GROUP_UID,
   committeeMembersResponse,
   stubAccountContext,
@@ -119,5 +120,32 @@ test.describe('Org Groups — seat holders drawer (GH-1780)', () => {
     await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('group-seat-holders-drawer')).toContainText('Jane Doe');
     expect(requestCount).toBe(2);
+  });
+
+  // Mirrors org-people-board-tab.spec.ts's "clicking a board member name opens the person-detail
+  // drawer on Governance from table seats (no fetch)" — same opener shape (no personKey, so the
+  // personKey-keyed detail fetch must never fire), same stacked-on-top drawer, different source list.
+  test('clicking a seat holder opens the shared person-detail drawer on Governance, stacked on top', async ({ page }) => {
+    let personDetailCalls = 0;
+    await page.route('**/api/orgs/*/lens/people/*/detail', (route) => {
+      personDetailCalls += 1;
+      return route.fulfill({ status: 500, body: 'unexpected personKey-based detail fetch' });
+    });
+
+    await page.getByTestId(`org-groups-item-seats-${GROUP_UID}`).click();
+    await expect(page.getByTestId('group-seat-holders-list')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await page.getByTestId(`seat-holder-person-${SEAT_TRANSPORT_1}`).click();
+
+    await expect(page.getByTestId('person-detail-drawer-header')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(page.getByTestId('person-detail-drawer-header')).toContainText('Jane Doe');
+    await expect(page.getByTestId('person-detail-drawer-tab-governance')).toHaveAttribute('aria-selected', 'true');
+
+    // Stacked on top of, not instead of, the seat-holders drawer.
+    await expect(page.getByTestId('group-seat-holders-drawer')).toBeVisible();
+    const drawer = page.getByTestId('person-detail-drawer');
+    await expect(drawer).toContainText('Ultra Ethernet Consortium Fund · Transport Working Group');
+
+    expect(personDetailCalls).toBe(0);
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -35,19 +35,19 @@
     </div>
   </ng-template>
 
+  <!-- Persistent (always rendered) so the live region exists before any state change, per ARIA
+       live-region guidance — a node that only appears already containing its final text isn't
+       reliably announced. Covers all three states in one place, including what a "Try again"
+       click can cause (failure -> success, or failure -> failure again): the visible content
+       between a repeat error and a fresh one looks identical without reading it, and the button
+       the user activated is gone from the DOM either way. Deliberately NOT on the roster's own
+       wrapper below — that would re-announce every name/role/voting pill as one utterance on
+       every successful load, which is worse than the silence this fixes. -->
+  <p class="sr-only" role="status" aria-live="polite">{{ statusMessage() }}</p>
+
   <div class="flex flex-col gap-4 h-full">
     @if (loading()) {
-      <!-- role="status"/aria-live scoped to this branch only — matches the established pattern in
-           total-members-drawer.component.html — not the whole @if chain: putting it on a shared
-           wrapper would re-announce the entire roster (name, role, voting pill for every row) as
-           one utterance whenever the list finishes loading, which is worse than the silence it
-           would fix. -->
-      <div
-        class="flex items-center justify-center py-16"
-        role="status"
-        aria-live="polite"
-        aria-label="Loading seat holders"
-        data-testid="group-seat-holders-drawer-loading">
+      <div class="flex items-center justify-center py-16" data-testid="group-seat-holders-drawer-loading">
         <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
       </div>
     } @else if (error()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -1,0 +1,71 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<p-drawer
+  [(visible)]="visible"
+  position="right"
+  [modal]="true"
+  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full"
+  data-testid="group-seat-holders-drawer">
+  <ng-template #header>
+    <div class="flex items-start gap-3 w-full">
+      <div class="flex items-center justify-center w-10 h-10 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
+        <i class="fa-light fa-user-check text-lg" aria-hidden="true"></i>
+      </div>
+      <div class="flex flex-col gap-0.5 min-w-0">
+        <h2 class="text-base font-semibold text-gray-900 truncate" data-testid="group-seat-holders-drawer-title">{{ groupName() }}</h2>
+        <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
+          {{ seatCount() }} {{ seatCount() === 1 ? 'seat' : 'seats' }}
+        </p>
+        <a
+          [routerLink]="['/groups', groupUid()]"
+          class="w-fit text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 hover:underline"
+          [attr.aria-label]="'View public group page for ' + groupName()"
+          data-testid="group-seat-holders-drawer-view-group-link">
+          View group page
+          <i class="fa-light fa-arrow-up-right-from-square ml-0.5 text-[10px]" aria-hidden="true"></i>
+        </a>
+      </div>
+    </div>
+  </ng-template>
+
+  <div class="flex flex-col gap-4 h-full">
+    @if (loading()) {
+      <div class="flex items-center justify-center py-16">
+        <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
+      </div>
+    } @else if (error()) {
+      <div class="flex flex-col items-center justify-center py-16 text-center" data-testid="group-seat-holders-drawer-error">
+        <i class="fa-light fa-triangle-exclamation text-3xl text-amber-500 mb-3" aria-hidden="true"></i>
+        <p class="text-sm text-gray-700">Unable to load seat holders.</p>
+        <p class="text-xs text-gray-500">Please close and reopen the drawer to try again.</p>
+      </div>
+    } @else if ((seatHolders() ?? []).length === 0) {
+      <div class="flex flex-col items-center justify-center py-16 text-center" data-testid="group-seat-holders-drawer-empty">
+        <i class="fa-light fa-users text-3xl text-gray-300 mb-3" aria-hidden="true"></i>
+        <p class="text-sm text-gray-500">No seat holders found for this group.</p>
+      </div>
+    } @else {
+      <ul class="flex flex-col divide-y divide-gray-100" data-testid="group-seat-holders-list">
+        @for (assignment of seatHolders(); track assignment.seatId) {
+          <li class="flex items-center gap-3 py-3" [attr.data-testid]="'group-seat-holder-' + assignment.seatId">
+            <lfx-person-avatar
+              [avatarUrl]="assignment.person.avatarUrl"
+              [name]="assignment.person.fullName"
+              [initials]="assignment.person.initials"
+              [identity]="assignment.person.email" />
+            <div class="flex flex-col gap-0.5 min-w-0 flex-1">
+              <span class="text-sm font-medium text-gray-900 truncate">{{ assignment.person.fullName }}</span>
+              <span class="text-xs text-gray-500 truncate">{{ assignment.role }}</span>
+            </div>
+            <span
+              class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0"
+              [class]="votingStatusPillClass(assignment.votingStatus)">
+              {{ assignment.votingStatus || 'Non-voting' }}
+            </span>
+          </li>
+        }
+      </ul>
+    }
+  </div>
+</p-drawer>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -18,7 +18,14 @@
           @if (displayedCount() === null) {
             Seat holders
           } @else {
-            {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat' : 'seats' }}
+            <!-- "seat holders", not "seats" — the row's own badge already reads "N seats" for a
+                 different number (org_seat_count, distinct people; see displayedCount() above),
+                 and both can be on screen at once. "Seat holders" is this drawer's own established
+                 term (see the empty state and the row's trigger aria-label) so it doesn't collide
+                 with the row's wording while staying accurate for both this and the error-state
+                 count (a genuinely different unit, but "how many people hold a seat" is a
+                 reasonable read of it too). -->
+            {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat holder' : 'seat holders' }}
           }
         </p>
         <a

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -87,37 +87,35 @@
       <ul class="flex flex-col divide-y divide-gray-100" data-testid="group-seat-holders-list">
         @for (assignment of seatHolderVms(); track assignment.seatId) {
           <li class="flex items-center gap-3 py-3" [attr.data-testid]="'group-seat-holder-' + assignment.seatId">
-            <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+            <lfx-person-avatar
+              [avatarUrl]="assignment.person.avatarUrl"
+              [name]="assignment.person.fullName"
+              [initials]="assignment.person.initials"
+              [identity]="assignment.person.email" />
+            <div class="flex flex-col gap-0.5 min-w-0 flex-1">
               <!-- Opens the shared person-detail drawer stacked on top (drawer-over-drawer, see
-                   onPersonClick()). Wraps avatar + name only, not the role line or the pill below
+                   onPersonClick()). Wraps the name only, not the avatar above or the role line below
                    — a real <button>, not a div with a click handler, so it's keyboard-reachable and
-                   announces as a button. A row with no usable identity (no name AND no email — the
-                   'Unknown member' fallback) stays plain text: there is nothing to open a drawer on. -->
+                   announces as a button. Name-only, not avatar+name (unlike the
+                   training-employees-drawer precedent this pattern is otherwise copied from): the
+                   role line and pill must stay outside the button, and pulling the avatar in too would
+                   either drag the role line in with it or leave the role line starting under the
+                   avatar instead of aligned with the name — this keeps the original two-line layout.
+                   A row with no usable identity (no name AND no email — the 'Unknown member' fallback)
+                   stays plain text: there is nothing to open a drawer on. -->
               @if (assignment.person.fullName || assignment.person.email) {
                 <button
                   type="button"
-                  class="flex min-w-0 items-center gap-3 bg-transparent p-0 text-left"
+                  class="w-fit min-w-0 bg-transparent p-0 text-left"
                   [attr.aria-label]="'View details for ' + (assignment.person.fullName || assignment.person.email)"
-                  [attr.data-testid]="'group-seat-holder-person-' + assignment.seatId"
+                  [attr.data-testid]="'seat-holder-person-' + assignment.seatId"
                   (click)="onPersonClick(assignment)">
-                  <lfx-person-avatar
-                    [avatarUrl]="assignment.person.avatarUrl"
-                    [name]="assignment.person.fullName"
-                    [initials]="assignment.person.initials"
-                    [identity]="assignment.person.email" />
                   <span class="text-sm font-medium text-gray-900 break-words hover:underline">
                     {{ assignment.person.fullName || assignment.person.email }}
                   </span>
                 </button>
               } @else {
-                <div class="flex min-w-0 items-center gap-3">
-                  <lfx-person-avatar
-                    [avatarUrl]="assignment.person.avatarUrl"
-                    [name]="assignment.person.fullName"
-                    [initials]="assignment.person.initials"
-                    [identity]="assignment.person.email" />
-                  <span class="text-sm font-medium text-gray-900 break-words">Unknown member</span>
-                </div>
+                <span class="text-sm font-medium text-gray-900 break-words">Unknown member</span>
               }
               <span class="text-xs text-gray-500 break-words">{{ assignment.role || '—' }}</span>
             </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -1,14 +1,6 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<!-- Outside <p-drawer> deliberately: p-drawer's own content is *ngIf'd on `visible`, so a node
-     inside it is destroyed and recreated fresh on every open — a freshly-inserted node's initial
-     text is generally not reliably announced by screen readers, only later mutations to an
-     already-present node are. This node survives across opens (and across closes — see
-     statusMessage()'s own comment), so even the very first "Loading seat holders…" is a mutation
-     on a node that was already there, not content set once at insertion time. -->
-<p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ statusMessage() }}</p>
-
 <p-drawer
   [(visible)]="visible"
   position="right"
@@ -61,6 +53,16 @@
       </div>
     </div>
   </ng-template>
+
+  <!-- Inside <p-drawer>, deliberately not hoisted out: the panel is aria-modal="true" (via [pt]
+       above), and content outside a modal's subtree is unreliable for AT to reach while it's open
+       — a sibling live region would be announced inconsistently at best. Staying inside means this
+       node IS destroyed and recreated on every open, so its first render can't carry the real
+       status text (a freshly-inserted node's initial text is generally not announced, only later
+       mutations to an already-present node are) — contentRevealed starts false so the node mounts
+       empty, then flips true one tick after onDrawerShow() so the real text arrives as a genuine
+       mutation instead. -->
+  <p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ contentRevealed() ? statusMessage() : '' }}</p>
 
   <div class="flex flex-col gap-4 h-full">
     @if (loading()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -17,15 +17,17 @@
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
           @if (displayedCount() === null) {
             Seat holders
-          } @else {
-            <!-- "seat holders", not "seats" — the row's own badge already reads "N seats" for a
-                 different number (org_seat_count, distinct people; see displayedCount() above),
-                 and both can be on screen at once. "Seat holders" is this drawer's own established
-                 term (see the empty state and the row's trigger aria-label) so it doesn't collide
-                 with the row's wording while staying accurate for both this and the error-state
-                 count (a genuinely different unit, but "how many people hold a seat" is a
-                 reasonable read of it too). -->
+          } @else if (error()) {
+            <!-- error(): displayedCount() is seatCount() (org_seat_count) — genuinely distinct
+                 people, so "seat holders" is the accurate noun here. See the else branch for why
+                 the loaded case uses a different one. -->
             {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat holder' : 'seat holders' }}
+          } @else {
+            <!-- Loaded: displayedCount() is seatHolders().length — one row per SEAT/role
+                 assignment, not one per person (see GroupSeatHoldersDrawerComponent.displayedCount)
+                 — so "seat assignments" is the accurate noun; "seat holders" would misdescribe a
+                 person holding two roles as two seat holders. -->
+            {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat assignment' : 'seat assignments' }}
           }
         </p>
         <a

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -24,9 +24,9 @@
           }
         </p>
         <a
-          [routerLink]="['/groups', groupUid()]"
+          [routerLink]="['/groups', committeeUid()]"
           class="w-fit text-xs font-medium text-blue-600 transition-colors hover:text-blue-700 hover:underline"
-          [attr.aria-label]="'View public group page for ' + groupName()"
+          [attr.aria-label]="'View group page for ' + groupName()"
           data-testid="group-seat-holders-drawer-view-group-link">
           View group page
           <i class="fa-light fa-arrow-up-right-from-square ml-0.5 text-[10px]" aria-hidden="true"></i>
@@ -44,7 +44,13 @@
       <div class="flex flex-col items-center justify-center py-16 text-center" data-testid="group-seat-holders-drawer-error">
         <i class="fa-light fa-triangle-exclamation text-3xl text-amber-500 mb-3" aria-hidden="true"></i>
         <p class="text-sm text-gray-700">Unable to load seat holders.</p>
-        <p class="text-xs text-gray-500">Please close and reopen the drawer to try again.</p>
+        <button
+          type="button"
+          class="mt-3 text-sm font-medium text-blue-600 transition-colors hover:text-blue-700 hover:underline"
+          (click)="retry()"
+          data-testid="group-seat-holders-drawer-retry">
+          Try again
+        </button>
       </div>
     } @else if (seatHolderVms().length === 0) {
       <div class="flex flex-col items-center justify-center py-16 text-center" data-testid="group-seat-holders-drawer-empty">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -17,17 +17,8 @@
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
           @if (displayedCount() === null) {
             Seat holders
-          } @else if (error()) {
-            <!-- error(): displayedCount() is seatCount() (org_seat_count) — genuinely distinct
-                 people, so "seat holders" is the accurate noun here. See the else branch for why
-                 the loaded case uses a different one. -->
-            {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat holder' : 'seat holders' }}
           } @else {
-            <!-- Loaded: displayedCount() is seatHolders().length — one row per SEAT/role
-                 assignment, not one per person (see GroupSeatHoldersDrawerComponent.displayedCount)
-                 — so "seat assignments" is the accurate noun; "seat holders" would misdescribe a
-                 person holding two roles as two seat holders. -->
-            {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat assignment' : 'seat assignments' }}
+            {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat holder' : 'seat holders' }}
           }
         </p>
         <a

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -15,7 +15,7 @@
       <div class="flex flex-col gap-0.5 min-w-0">
         <h2 class="text-base font-semibold text-gray-900 truncate" data-testid="group-seat-holders-drawer-title">{{ groupName() }}</h2>
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
-          {{ seatCount() }} {{ seatCount() === 1 ? 'seat' : 'seats' }}
+          {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat' : 'seats' }}
         </p>
         <a
           [routerLink]="['/groups', groupUid()]"
@@ -40,14 +40,14 @@
         <p class="text-sm text-gray-700">Unable to load seat holders.</p>
         <p class="text-xs text-gray-500">Please close and reopen the drawer to try again.</p>
       </div>
-    } @else if ((seatHolders() ?? []).length === 0) {
+    } @else if (seatHolderVms().length === 0) {
       <div class="flex flex-col items-center justify-center py-16 text-center" data-testid="group-seat-holders-drawer-empty">
         <i class="fa-light fa-users text-3xl text-gray-300 mb-3" aria-hidden="true"></i>
         <p class="text-sm text-gray-500">No seat holders found for this group.</p>
       </div>
     } @else {
       <ul class="flex flex-col divide-y divide-gray-100" data-testid="group-seat-holders-list">
-        @for (assignment of seatHolders(); track assignment.seatId) {
+        @for (assignment of seatHolderVms(); track assignment.seatId) {
           <li class="flex items-center gap-3 py-3" [attr.data-testid]="'group-seat-holder-' + assignment.seatId">
             <lfx-person-avatar
               [avatarUrl]="assignment.person.avatarUrl"
@@ -58,9 +58,7 @@
               <span class="text-sm font-medium text-gray-900 truncate">{{ assignment.person.fullName }}</span>
               <span class="text-xs text-gray-500 truncate">{{ assignment.role }}</span>
             </div>
-            <span
-              class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0"
-              [class]="votingStatusPillClass(assignment.votingStatus)">
+            <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0" [class]="assignment.votingStatusPillClass">
               {{ assignment.votingStatus || 'Non-voting' }}
             </span>
           </li>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -17,7 +17,7 @@
   }"
   (onShow)="onDrawerShow()"
   (onHide)="onDrawerHide()"
-  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full">
+  styleClass="xl:w-[45%] lg:w-[55%] md:w-[70%] sm:w-[90%] w-full">
   <ng-template #header>
     <div class="flex items-start gap-3 w-full">
       <div class="flex items-center justify-center w-10 h-10 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -1,19 +1,31 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
+<!-- Outside <p-drawer> deliberately: p-drawer's own content is *ngIf'd on `visible`, so a node
+     inside it is destroyed and recreated fresh on every open — a freshly-inserted node's initial
+     text is generally not reliably announced by screen readers, only later mutations to an
+     already-present node are. This node survives across opens (and across closes — see
+     statusMessage()'s own comment), so even the very first "Loading seat holders…" is a mutation
+     on a node that was already there, not content set once at insertion time. -->
+<p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ statusMessage() }}</p>
+
 <p-drawer
   [(visible)]="visible"
   position="right"
   [modal]="true"
   [ariaCloseLabel]="'Close panel'"
   [pt]="{
-    root: { role: 'dialog', 'aria-modal': 'true', 'aria-labelledby': 'group-seat-holders-drawer-title' },
+    root: {
+      role: 'dialog',
+      'aria-modal': 'true',
+      'aria-labelledby': 'group-seat-holders-drawer-title',
+      'data-testid': 'group-seat-holders-drawer',
+    },
     pcCloseButton: { root: { 'data-testid': 'group-seat-holders-drawer-close' } },
   }"
   (onShow)="onDrawerShow()"
   (onHide)="onDrawerHide()"
-  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full"
-  data-testid="group-seat-holders-drawer">
+  styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full">
   <ng-template #header>
     <div class="flex items-start gap-3 w-full">
       <div class="flex items-center justify-center w-10 h-10 rounded-full bg-blue-100 text-blue-600 flex-shrink-0">
@@ -49,10 +61,6 @@
       </div>
     </div>
   </ng-template>
-
-  <!-- Persistent (not scoped to one @if branch below) so a repeat error or a "Try again" success
-       both mutate this node's text and get announced, even when the visible content looks the same. -->
-  <p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ statusMessage() }}</p>
 
   <div class="flex flex-col gap-4 h-full">
     @if (loading()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -56,12 +56,9 @@
 
   <!-- Inside <p-drawer>, deliberately not hoisted out: the panel is aria-modal="true" (via [pt]
        above), and content outside a modal's subtree is unreliable for AT to reach while it's open
-       — a sibling live region would be announced inconsistently at best. Staying inside means this
-       node IS destroyed and recreated on every open, so its first render can't carry the real
-       status text (a freshly-inserted node's initial text is generally not announced, only later
-       mutations to an already-present node are) — contentRevealed (reset false on every close, see
-       its own comment in the .ts) keeps the node's first paint on each open empty, then flips true
-       one tick later so the real text arrives as a genuine mutation instead. -->
+       — a sibling live region would be announced inconsistently at best. That means this node IS
+       destroyed and recreated on every open; contentRevealed (see its own comment in the .ts)
+       handles what that implies for the first paint. -->
   <p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ contentRevealed() ? statusMessage() : '' }}</p>
 
   <div class="flex flex-col gap-4 h-full">
@@ -90,15 +87,38 @@
       <ul class="flex flex-col divide-y divide-gray-100" data-testid="group-seat-holders-list">
         @for (assignment of seatHolderVms(); track assignment.seatId) {
           <li class="flex items-center gap-3 py-3" [attr.data-testid]="'group-seat-holder-' + assignment.seatId">
-            <lfx-person-avatar
-              [avatarUrl]="assignment.person.avatarUrl"
-              [name]="assignment.person.fullName"
-              [initials]="assignment.person.initials"
-              [identity]="assignment.person.email" />
-            <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-              <span class="text-sm font-medium text-gray-900 break-words">
-                {{ assignment.person.fullName || assignment.person.email || 'Unknown member' }}
-              </span>
+            <div class="flex min-w-0 flex-1 flex-col gap-0.5">
+              <!-- Opens the shared person-detail drawer stacked on top (drawer-over-drawer, see
+                   onPersonClick()). Wraps avatar + name only, not the role line or the pill below
+                   — a real <button>, not a div with a click handler, so it's keyboard-reachable and
+                   announces as a button. A row with no usable identity (no name AND no email — the
+                   'Unknown member' fallback) stays plain text: there is nothing to open a drawer on. -->
+              @if (assignment.person.fullName || assignment.person.email) {
+                <button
+                  type="button"
+                  class="flex min-w-0 items-center gap-3 bg-transparent p-0 text-left"
+                  [attr.aria-label]="'View details for ' + (assignment.person.fullName || assignment.person.email)"
+                  [attr.data-testid]="'group-seat-holder-person-' + assignment.seatId"
+                  (click)="onPersonClick(assignment)">
+                  <lfx-person-avatar
+                    [avatarUrl]="assignment.person.avatarUrl"
+                    [name]="assignment.person.fullName"
+                    [initials]="assignment.person.initials"
+                    [identity]="assignment.person.email" />
+                  <span class="text-sm font-medium text-gray-900 break-words hover:underline">
+                    {{ assignment.person.fullName || assignment.person.email }}
+                  </span>
+                </button>
+              } @else {
+                <div class="flex min-w-0 items-center gap-3">
+                  <lfx-person-avatar
+                    [avatarUrl]="assignment.person.avatarUrl"
+                    [name]="assignment.person.fullName"
+                    [initials]="assignment.person.initials"
+                    [identity]="assignment.person.email" />
+                  <span class="text-sm font-medium text-gray-900 break-words">Unknown member</span>
+                </div>
+              }
               <span class="text-xs text-gray-500 break-words">{{ assignment.role || '—' }}</span>
             </div>
             <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0" [class]="assignment.votingStatusPillClass">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -35,12 +35,19 @@
     </div>
   </ng-template>
 
-  <!-- aria-live announces the outcome of a "Try again" retry (success -> the list, or another
-       error) to screen-reader users, who otherwise get no signal that anything changed once the
-       button they activated disappears from the DOM. -->
-  <div class="flex flex-col gap-4 h-full" role="status" aria-live="polite">
+  <div class="flex flex-col gap-4 h-full">
     @if (loading()) {
-      <div class="flex items-center justify-center py-16" data-testid="group-seat-holders-drawer-loading">
+      <!-- role="status"/aria-live scoped to this branch only — matches the established pattern in
+           total-members-drawer.component.html — not the whole @if chain: putting it on a shared
+           wrapper would re-announce the entire roster (name, role, voting pill for every row) as
+           one utterance whenever the list finishes loading, which is worse than the silence it
+           would fix. -->
+      <div
+        class="flex items-center justify-center py-16"
+        role="status"
+        aria-live="polite"
+        aria-label="Loading seat holders"
+        data-testid="group-seat-holders-drawer-loading">
         <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
       </div>
     } @else if (error()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -13,7 +13,7 @@
         <i class="fa-light fa-user-check text-lg" aria-hidden="true"></i>
       </div>
       <div class="flex flex-col gap-0.5 min-w-0">
-        <h2 class="text-base font-semibold text-gray-900 truncate" [title]="groupName()" data-testid="group-seat-holders-drawer-title">
+        <h2 class="text-base font-semibold text-gray-900" data-testid="group-seat-holders-drawer-title">
           {{ groupName() }}
         </h2>
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
@@ -78,10 +78,10 @@
               [initials]="assignment.person.initials"
               [identity]="assignment.person.email" />
             <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-              <span class="text-sm font-medium text-gray-900 truncate" [title]="assignment.person.fullName || assignment.person.email || 'Unknown member'">
+              <span class="text-sm font-medium text-gray-900">
                 {{ assignment.person.fullName || assignment.person.email || 'Unknown member' }}
               </span>
-              <span class="text-xs text-gray-500 truncate">{{ assignment.role || '—' }}</span>
+              <span class="text-xs text-gray-500">{{ assignment.role || '—' }}</span>
             </div>
             <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0" [class]="assignment.votingStatusPillClass">
               {{ assignment.votingStatus || 'Non-voting' }}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -31,7 +31,7 @@
 
   <div class="flex flex-col gap-4 h-full">
     @if (loading()) {
-      <div class="flex items-center justify-center py-16">
+      <div class="flex items-center justify-center py-16" data-testid="group-seat-holders-drawer-loading">
         <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>
       </div>
     } @else if (error()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -5,6 +5,13 @@
   [(visible)]="visible"
   position="right"
   [modal]="true"
+  [ariaCloseLabel]="'Close panel'"
+  [pt]="{
+    root: { role: 'dialog', 'aria-modal': 'true', 'aria-labelledby': 'group-seat-holders-drawer-title' },
+    pcCloseButton: { root: { 'data-testid': 'group-seat-holders-drawer-close' } },
+  }"
+  (onShow)="onDrawerShow()"
+  (onHide)="onDrawerHide()"
   styleClass="xl:w-[40%] lg:w-[50%] md:w-[65%] sm:w-[85%] w-full"
   data-testid="group-seat-holders-drawer">
   <ng-template #header>
@@ -13,7 +20,10 @@
         <i class="fa-light fa-user-check text-lg" aria-hidden="true"></i>
       </div>
       <div class="flex flex-col gap-0.5 min-w-0">
-        <h2 class="text-base font-semibold text-gray-900 break-words" data-testid="group-seat-holders-drawer-title">
+        <!-- tabindex="-1": not in Tab order, but focusable via onDrawerShow() moving focus here on
+             open — it's also the element aria-labelledby points at, so a screen reader announces
+             the group name immediately on focus, the way a dialog title normally would. -->
+        <h2 #titleRef tabindex="-1" class="text-base font-semibold text-gray-900 break-words" data-testid="group-seat-holders-drawer-title">
           {{ groupName() }}
         </h2>
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -35,15 +35,16 @@
     </div>
   </ng-template>
 
-  <!-- Persistent (always rendered) so the live region exists before any state change, per ARIA
-       live-region guidance — a node that only appears already containing its final text isn't
-       reliably announced. Covers all three states in one place, including what a "Try again"
-       click can cause (failure -> success, or failure -> failure again): the visible content
-       between a repeat error and a fresh one looks identical without reading it, and the button
-       the user activated is gone from the DOM either way. Deliberately NOT on the roster's own
-       wrapper below — that would re-announce every name/role/voting pill as one utterance on
-       every successful load, which is worse than the silence this fixes. -->
-  <p class="sr-only" role="status" aria-live="polite">{{ statusMessage() }}</p>
+  <!-- Persists across every state change for as long as the drawer stays open (p-drawer's own
+       content is *ngIf'd on `visible`, so this rides in already showing the first message on
+       open — the persistence that matters here is across the loading/error/loaded transitions
+       *within* one open, not the initial mount). Covers all three states in one place, including
+       what a "Try again" click can cause (failure -> success, or failure -> failure again): the
+       visible content between a repeat error and a fresh one looks identical without reading it,
+       and the button the user activated is gone from the DOM either way. Deliberately NOT on the
+       roster's own wrapper below — that would re-announce every name/role/voting pill as one
+       utterance on every successful load, which is worse than the silence this fixes. -->
+  <p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ statusMessage() }}</p>
 
   <div class="flex flex-col gap-4 h-full">
     @if (loading()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -23,7 +23,12 @@
         <!-- tabindex="-1": not in Tab order, but focusable via onDrawerShow() moving focus here on
              open — it's also the element aria-labelledby points at, so a screen reader announces
              the group name immediately on focus, the way a dialog title normally would. -->
-        <h2 #titleRef tabindex="-1" class="text-base font-semibold text-gray-900 break-words" data-testid="group-seat-holders-drawer-title">
+        <h2
+          #titleRef
+          id="group-seat-holders-drawer-title"
+          tabindex="-1"
+          class="text-base font-semibold text-gray-900 break-words"
+          data-testid="group-seat-holders-drawer-title">
           {{ groupName() }}
         </h2>
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -13,7 +13,9 @@
         <i class="fa-light fa-user-check text-lg" aria-hidden="true"></i>
       </div>
       <div class="flex flex-col gap-0.5 min-w-0">
-        <h2 class="text-base font-semibold text-gray-900 truncate" data-testid="group-seat-holders-drawer-title">{{ groupName() }}</h2>
+        <h2 class="text-base font-semibold text-gray-900 truncate" [title]="groupName()" data-testid="group-seat-holders-drawer-title">
+          {{ groupName() }}
+        </h2>
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
           @if (displayedCount() === null) {
             Seat holders
@@ -59,7 +61,9 @@
               [initials]="assignment.person.initials"
               [identity]="assignment.person.email" />
             <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-              <span class="text-sm font-medium text-gray-900 truncate">{{ assignment.person.fullName || assignment.person.email || 'Unknown member' }}</span>
+              <span class="text-sm font-medium text-gray-900 truncate" [title]="assignment.person.fullName || assignment.person.email || 'Unknown member'">
+                {{ assignment.person.fullName || assignment.person.email || 'Unknown member' }}
+              </span>
               <span class="text-xs text-gray-500 truncate">{{ assignment.role || '—' }}</span>
             </div>
             <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0" [class]="assignment.votingStatusPillClass">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -35,7 +35,10 @@
     </div>
   </ng-template>
 
-  <div class="flex flex-col gap-4 h-full">
+  <!-- aria-live announces the outcome of a "Try again" retry (success -> the list, or another
+       error) to screen-reader users, who otherwise get no signal that anything changed once the
+       button they activated disappears from the DOM. -->
+  <div class="flex flex-col gap-4 h-full" role="status" aria-live="polite">
     @if (loading()) {
       <div class="flex items-center justify-center py-16" data-testid="group-seat-holders-drawer-loading">
         <i class="fa-light fa-spinner-third fa-spin text-2xl text-gray-400" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -13,7 +13,7 @@
         <i class="fa-light fa-user-check text-lg" aria-hidden="true"></i>
       </div>
       <div class="flex flex-col gap-0.5 min-w-0">
-        <h2 class="text-base font-semibold text-gray-900" data-testid="group-seat-holders-drawer-title">
+        <h2 class="text-base font-semibold text-gray-900 break-words" data-testid="group-seat-holders-drawer-title">
           {{ groupName() }}
         </h2>
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
@@ -78,10 +78,10 @@
               [initials]="assignment.person.initials"
               [identity]="assignment.person.email" />
             <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-              <span class="text-sm font-medium text-gray-900">
+              <span class="text-sm font-medium text-gray-900 break-words">
                 {{ assignment.person.fullName || assignment.person.email || 'Unknown member' }}
               </span>
-              <span class="text-xs text-gray-500">{{ assignment.role || '—' }}</span>
+              <span class="text-xs text-gray-500 break-words">{{ assignment.role || '—' }}</span>
             </div>
             <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0" [class]="assignment.votingStatusPillClass">
               {{ assignment.votingStatus || 'Non-voting' }}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -59,9 +59,9 @@
        — a sibling live region would be announced inconsistently at best. Staying inside means this
        node IS destroyed and recreated on every open, so its first render can't carry the real
        status text (a freshly-inserted node's initial text is generally not announced, only later
-       mutations to an already-present node are) — contentRevealed starts false so the node mounts
-       empty, then flips true one tick after onDrawerShow() so the real text arrives as a genuine
-       mutation instead. -->
+       mutations to an already-present node are) — contentRevealed (reset false on every close, see
+       its own comment in the .ts) keeps the node's first paint on each open empty, then flips true
+       one tick later so the real text arrives as a genuine mutation instead. -->
   <p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ contentRevealed() ? statusMessage() : '' }}</p>
 
   <div class="flex flex-col gap-4 h-full">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -15,7 +15,11 @@
       <div class="flex flex-col gap-0.5 min-w-0">
         <h2 class="text-base font-semibold text-gray-900 truncate" data-testid="group-seat-holders-drawer-title">{{ groupName() }}</h2>
         <p class="text-sm text-gray-500 truncate" data-testid="group-seat-holders-drawer-subtitle">
-          {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat' : 'seats' }}
+          @if (displayedCount() === null) {
+            Seat holders
+          } @else {
+            {{ displayedCount() }} {{ displayedCount() === 1 ? 'seat' : 'seats' }}
+          }
         </p>
         <a
           [routerLink]="['/groups', groupUid()]"
@@ -55,8 +59,8 @@
               [initials]="assignment.person.initials"
               [identity]="assignment.person.email" />
             <div class="flex flex-col gap-0.5 min-w-0 flex-1">
-              <span class="text-sm font-medium text-gray-900 truncate">{{ assignment.person.fullName }}</span>
-              <span class="text-xs text-gray-500 truncate">{{ assignment.role }}</span>
+              <span class="text-sm font-medium text-gray-900 truncate">{{ assignment.person.fullName || assignment.person.email || 'Unknown member' }}</span>
+              <span class="text-xs text-gray-500 truncate">{{ assignment.role || '—' }}</span>
             </div>
             <span class="inline-block rounded-full border px-2 py-0.5 text-xs font-medium flex-shrink-0" [class]="assignment.votingStatusPillClass">
               {{ assignment.votingStatus || 'Non-voting' }}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.html
@@ -35,15 +35,8 @@
     </div>
   </ng-template>
 
-  <!-- Persists across every state change for as long as the drawer stays open (p-drawer's own
-       content is *ngIf'd on `visible`, so this rides in already showing the first message on
-       open — the persistence that matters here is across the loading/error/loaded transitions
-       *within* one open, not the initial mount). Covers all three states in one place, including
-       what a "Try again" click can cause (failure -> success, or failure -> failure again): the
-       visible content between a repeat error and a fresh one looks identical without reading it,
-       and the button the user activated is gone from the DOM either way. Deliberately NOT on the
-       roster's own wrapper below — that would re-announce every name/role/voting pill as one
-       utterance on every successful load, which is worse than the silence this fixes. -->
+  <!-- Persistent (not scoped to one @if branch below) so a repeat error or a "Try again" success
+       both mutate this node's text and get announced, even when the visible content looks the same. -->
   <p class="sr-only" role="status" aria-live="polite" data-testid="group-seat-holders-drawer-status">{{ statusMessage() }}</p>
 
   <div class="flex flex-col gap-4 h-full">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -738,6 +738,34 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(instance.displayedCount()).toBeNull();
   });
 
+  // tap only clears `loading` on a real fetch emission — the missing-identifier branch emits
+  // `of(null)` without going through that fetch pipeline at all, so it has to clear the flag
+  // itself. Otherwise a drawer left `loading` by a mid-fetch close (previous test) that reopens
+  // with a since-cleared identifier would render a permanent spinner instead of the blank
+  // placeholder this branch intends.
+  it('clears a loading flag left by a mid-fetch close if the drawer reopens with a missing identifier', async () => {
+    await setup(vi.fn().mockReturnValue(NEVER));
+
+    fixture.componentRef.setInput('orgUid', 'org-1');
+    fixture.componentRef.setInput('committeeUid', 'c-1');
+    fixture.componentRef.setInput('groupName', 'Storage Working Group');
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+
+    const instance = fixture.componentInstance as unknown as { loading: () => boolean };
+    expect(instance.loading()).toBe(true);
+
+    fixture.componentRef.setInput('visible', false);
+    await fixture.whenStable();
+    expect(instance.loading()).toBe(true);
+
+    fixture.componentRef.setInput('committeeUid', '');
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+
+    expect(instance.loading()).toBe(false);
+  });
+
   it('renders a member with no name and no email as "Unknown member", not a blank row', async () => {
     await setup(
       vi.fn().mockReturnValue(

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -307,6 +307,55 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(text()).not.toContain('Non-voting');
   });
 
+  // isVotingStatus() alone treats "Observer" as voting (same as "Voting Rep"), so a plain
+  // voting/non-voting boolean tie-break would still depend on array order between two seats that
+  // are both "voting" by that measure but read differently to a user. Put Observer first so this
+  // only passes if the merge ranks by status, not by array order.
+  it('prefers a true voting seat over an Observer seat, not just any isVotingStatus() match', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Alternate', votingStatus: 'Observer' }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Chair', votingStatus: 'Voting Rep', memberUid: 'seat-2' }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    // Roles always join regardless of merge winner ("Alternate, Chair" is expected here); it's
+    // the voting-status pill specifically that must not be "Observer".
+    expect(text()).toContain('Voting Rep');
+    expect(text()).not.toContain('Observer');
+  });
+
+  // The server dedupes org_seat_count on a trimmed, lowercased email — two seats for the same
+  // person differing only in casing/whitespace must merge here too, or the header count would
+  // overcount relative to the row's own badge for this case.
+  it('merges two seats for the same person whose emails differ only in case or whitespace', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Chair', person: person({ email: 'Jane@Example.org  ' }) }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Member', memberUid: 'seat-2', person: person({ email: '  jane@example.org' }) }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(subtitleText()).toBe('1 seat holder');
+    expect(rowNames()).toHaveLength(1);
+  });
+
   // org_seat_count collapses every blank-email seat into one bucket server-side; this drawer
   // deliberately does not mirror that (see the seatHolderVms comment) because merging two
   // unrelated people under one "Unknown member" row would be a worse bug than the resulting

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -285,6 +285,55 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(names[0]).toContain('Chair, Member');
   });
 
+  // Which of a merged person's two seats "wins" for the voting-status pill must not depend on
+  // upstream array order — pin it explicitly by putting the non-voting seat first.
+  it("prefers a voting seat over a non-voting one when merging a person's voting-status pill", async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Member', votingStatus: 'Non-voting' }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Chair', votingStatus: 'Voting Rep', memberUid: 'seat-2' }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(text()).toContain('Voting Rep');
+    expect(text()).not.toContain('Non-voting');
+  });
+
+  // org_seat_count collapses every blank-email seat into one bucket server-side; this drawer
+  // deliberately does not mirror that (see the seatHolderVms comment) because merging two
+  // unrelated people under one "Unknown member" row would be a worse bug than the resulting
+  // header/badge mismatch for this rare case.
+  it('does not merge two different blank-email seats into one row', async () => {
+    await setup(
+      vi.fn().mockReturnValue(
+        of(
+          response([
+            assignment({ seatId: 's-1', committeeUid: 'c-1', person: { email: '', firstName: '', lastName: '', fullName: '', jobTitle: null, initials: '' } }),
+            assignment({
+              seatId: 's-2',
+              committeeUid: 'c-1',
+              memberUid: 'seat-2',
+              person: { email: '', firstName: '', lastName: '', fullName: '', jobTitle: null, initials: '' },
+            }),
+          ])
+        )
+      )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(subtitleText()).toBe('2 seat holders');
+    expect(rowNames()).toHaveLength(2);
+  });
+
   it('sorts seat holders by display name', async () => {
     await setup(
       vi

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -813,7 +813,14 @@ describe('GroupSeatHoldersDrawerComponent', () => {
       const panel = dialogPanel();
       expect(panel).toBeTruthy();
       expect(panel?.getAttribute('aria-modal')).toBe('true');
-      expect(panel?.getAttribute('aria-labelledby')).toBe('group-seat-holders-drawer-title');
+
+      // Resolves the id, not just matches the attribute string — a dangling aria-labelledby (no
+      // element with that id) leaves the dialog with no accessible name and would pass a check
+      // that only compares the attribute's text.
+      const labelledById = panel?.getAttribute('aria-labelledby') ?? '';
+      const labelElement = document.getElementById(labelledById);
+      expect(labelElement).toBeTruthy();
+      expect(labelElement?.textContent?.trim()).toBe('Storage Working Group');
     });
 
     it('moves focus into the panel on open, away from the element that triggered it', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -93,11 +93,8 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     return (document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '').replace(/\s+/g, ' ').trim();
   }
 
-  // `li[...]`, not the bare attribute selector — the per-row person button's testid
-  // ('group-seat-holder-person-{seatId}') shares the same prefix as the row's own
-  // ('group-seat-holder-{seatId}'), and an unscoped `^=` selector would match both.
   function rowNames(): string[] {
-    return Array.from(document.querySelectorAll('li[data-testid^="group-seat-holder-"]')).map((li) => li.textContent?.trim() ?? '');
+    return Array.from(document.querySelectorAll('[data-testid^="group-seat-holder-"]')).map((li) => li.textContent?.trim() ?? '');
   }
 
   function statusMessage(): string | null {
@@ -918,7 +915,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   // governanceSeats, no personKey — these rows carry no warehouse personKey).
   describe('person-detail drawer stacking', () => {
     function personButton(seatId: string): HTMLElement | null {
-      return document.querySelector(`[data-testid="group-seat-holder-person-${seatId}"]`);
+      return document.querySelector(`[data-testid="seat-holder-person-${seatId}"]`);
     }
 
     it("calls PersonDetailDrawerService.open once, with defaultTab 'governance' and the person's real email", async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -741,8 +741,8 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   // tap only clears `loading` on a real fetch emission — the missing-identifier branch emits
   // `of(null)` without going through that fetch pipeline at all, so it has to clear the flag
   // itself. Otherwise a drawer left `loading` by a mid-fetch close (previous test) that reopens
-  // with a since-cleared identifier would render a permanent spinner instead of the blank
-  // placeholder this branch intends.
+  // with a since-cleared identifier would render a permanent spinner instead of falling through
+  // to the empty state (what a null `seatHolders` actually renders here).
   it('clears a loading flag left by a mid-fetch close if the drawer reopens with a missing identifier', async () => {
     await setup(vi.fn().mockReturnValue(NEVER));
 
@@ -762,8 +762,11 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.componentRef.setInput('committeeUid', '');
     fixture.componentRef.setInput('visible', true);
     await fixture.whenStable();
+    fixture.detectChanges();
 
     expect(instance.loading()).toBe(false);
+    // The DOM-visible half of the same claim: no permanent spinner, not the internal flag alone.
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-loading"]')).toBeNull();
   });
 
   it('renders a member with no name and no email as "Unknown member", not a blank row', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -77,8 +77,8 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   }
 
   // Normalized + exact, not a substring `.toContain` — the wording is singular/plural sensitive
-  // ("1 seat assignment" vs "1 seat assignments"), and a substring check on the singular form
-  // stays green even if the code always renders the plural.
+  // ("1 seat holder" vs "1 seat holders"), and a substring check on the singular form stays green
+  // even if the code always renders the plural.
   function subtitleText(): string {
     return (document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '').replace(/\s+/g, ' ').trim();
   }
@@ -188,20 +188,17 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
   });
 
-  // seatCount() (the row's org_seat_count, distinct PEOPLE, deduped by email server-side) and this
-  // list (one row per SEAT/role assignment) can genuinely disagree — a person holding two roles on
-  // the committee is one of the cases. The header must show the real, loaded count once settled,
-  // not the row's count — worded "seat assignments", not "seat holders", since that's the unit
-  // this branch actually counts (see the displayedCount comment and the template's error()/else
-  // split).
-  it('shows the loaded row count as "seat assignments" once settled, even when it differs from the row seatCount', async () => {
+  // seatCount() (the row's org_seat_count) and seatHolders().length (this list) are both
+  // best-effort counts and can genuinely disagree — see the displayedCount comment. The header
+  // must show the real, loaded count once settled, not the row's precomputed one.
+  it('shows the loaded row count once settled, even when it differs from the row seatCount', async () => {
     await setup(
       vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-1' })])))
     );
 
     await open('org-1', 'c-1', 'Storage Working Group', 1);
 
-    expect(subtitleText()).toBe('2 seat assignments');
+    expect(subtitleText()).toBe('2 seat holders');
   });
 
   // The header shows a plain "Seat holders" placeholder while loading, not a borrowed seatCount()
@@ -223,9 +220,8 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   // A failed fetch resolves seatHolders() to [] (see the outer catchError), not null — the
   // error() branch is the one place seatCount() IS shown post-load, since there's no real list at
   // all in that state for it to later disagree with (contrast: loading() shows a blank
-  // placeholder, because there the real list is still coming). "Seat holders" is the accurate
-  // noun here (unlike the loaded-list case above) because seatCount() genuinely counts people.
-  it('shows the row seatCount as "seat holders" on a failed fetch, not 0', async () => {
+  // placeholder, because there the real list is still coming).
+  it('shows the row seatCount in the header on a failed fetch, not 0', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
 
@@ -235,7 +231,19 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(subtitleText()).toBe('7 seat holders');
   });
 
-  it('recovers cleanly on retry after a failure: error clears, real "seat assignments" count comes back', async () => {
+  // Exercises the singular form on the error branch specifically — the loaded branch's singular
+  // form is covered separately below, and the two branches read different signals
+  // (seatCount() vs seatHolders().length), so one covering the other's singular case isn't implied.
+  it('uses the singular "seat holder" on the error branch too, not just the loaded branch', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
+
+    await open('org-1', 'c-1', 'Storage Working Group', 1);
+
+    expect(subtitleText()).toBe('1 seat holder');
+  });
+
+  it('recovers cleanly on retry after a failure: error clears, real count comes back', async () => {
     const impl = vi
       .fn()
       .mockReturnValueOnce(throwError(() => new Error('boom')))
@@ -254,7 +262,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.detectChanges();
 
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
-    expect(subtitleText()).toBe('1 seat assignment');
+    expect(subtitleText()).toBe('1 seat holder');
   });
 
   // Defensive coverage, not a currently-reachable path: org-groups.component.ts closes this
@@ -281,7 +289,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await setup(impl);
 
     await open('org-1', 'c-1', 'Storage Working Group', 3);
-    expect(subtitleText()).toBe('3 seat assignments');
+    expect(subtitleText()).toBe('3 seat holders');
 
     fixture.componentRef.setInput('orgUid', 'org-2');
     await fixture.whenStable();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -410,6 +410,26 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(text()).not.toContain('Emeritus');
   });
 
+  it('prefers an unrecognized-but-voting status over an explicit "None" seat when merging', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Member', votingStatus: 'None' }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Delegate', votingStatus: 'Proxy Rep', memberUid: 'seat-2' }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(text()).toContain('Proxy Rep');
+    expect(text()).not.toContain('None');
+  });
+
   // The server dedupes org_seat_count on a trimmed, lowercased email — two seats for the same
   // person differing only in casing/whitespace must merge here too, or the header count would
   // overcount relative to the row's own badge for this case.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -90,7 +90,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   }
 
   function statusMessage(): string | null {
-    return document.querySelector('[role="status"]')?.textContent?.trim() ?? null;
+    return document.querySelector('[data-testid="group-seat-holders-drawer-status"]')?.textContent?.trim() ?? null;
   }
 
   it('does not fetch until the drawer is opened', async () => {
@@ -364,6 +364,50 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     // the voting-status pill specifically that must not be "Observer".
     expect(text()).toContain('Voting Rep');
     expect(text()).not.toContain('Observer');
+  });
+
+  // These two pin the exact pairs the old bespoke 3-tier rank got wrong: it tied Emeritus with
+  // Voting Rep (both mapped to isVotingStatus()=true), and ranked Emeritus ahead of Observer —
+  // the reverse of VOTING_STATUS_PRIORITY. Both tests fail under that old rank and pass only
+  // under the shared VOTING_STATUS_PRIORITY-driven one.
+  it('prefers Voting Rep over Emeritus when merging (not tied, per VOTING_STATUS_PRIORITY)', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Past Chair', votingStatus: 'Emeritus' }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Chair', votingStatus: 'Voting Rep', memberUid: 'seat-2' }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(text()).toContain('Voting Rep');
+    expect(text()).not.toContain('Emeritus');
+  });
+
+  it('prefers Observer over Emeritus when merging (Emeritus ranks below Observer, not above)', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Past Chair', votingStatus: 'Emeritus' }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Alternate', votingStatus: 'Observer', memberUid: 'seat-2' }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(text()).toContain('Observer');
+    expect(text()).not.toContain('Emeritus');
   });
 
   // The server dedupes org_seat_count on a trimmed, lowercased email — two seats for the same

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -281,10 +281,10 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    // The spinner is the deterministic signal that the refetch actually started (loading() true)
-    // before checking the header text it gates — the header assertion alone previously proved
-    // vulnerable to running ahead of that write.
-    expect(document.querySelector('.fa-spinner-third')).toBeTruthy();
+    // The loading testid is the deterministic signal that the refetch actually started
+    // (loading() true) before checking the header text it gates — the header assertion alone
+    // previously proved vulnerable to running ahead of that write.
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-loading"]')).toBeTruthy();
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('9 seats');
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).not.toContain('3 seats');
   });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -5,11 +5,15 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
-import type { CommitteeMemberAssignment, OrgPeopleCommitteeMembersResponse } from '@lfx-one/shared/interfaces';
+import type { CommitteeMemberAssignment, CommitteeMemberPerson, OrgPeopleCommitteeMembersResponse } from '@lfx-one/shared/interfaces';
 import { NEVER, of, throwError } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { GroupSeatHoldersDrawerComponent } from './group-seat-holders-drawer.component';
+
+function person(overrides: Partial<CommitteeMemberPerson> = {}): CommitteeMemberPerson {
+  return { email: 'jane@example.org', firstName: 'Jane', lastName: 'Doe', fullName: 'Jane Doe', jobTitle: null, initials: 'JD', ...overrides };
+}
 
 function assignment(overrides: Partial<CommitteeMemberAssignment> = {}): CommitteeMemberAssignment {
   return {
@@ -26,7 +30,7 @@ function assignment(overrides: Partial<CommitteeMemberAssignment> = {}): Committ
     appointedBy: 'Membership Entitlement',
     isOrgEditable: true,
     reason: null,
-    person: { email: 'jane@example.org', firstName: 'Jane', lastName: 'Doe', fullName: 'Jane Doe', jobTitle: null, initials: 'JD' },
+    person: person(),
     ...overrides,
   };
 }
@@ -61,12 +65,10 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture = TestBed.createComponent(GroupSeatHoldersDrawerComponent);
   }
 
-  async function open(orgUid: string, committeeUid: string, groupName = 'Storage Working Group', seatCount = 1): Promise<void> {
+  async function open(orgUid: string, committeeUid: string, groupName = 'Storage Working Group'): Promise<void> {
     fixture.componentRef.setInput('orgUid', orgUid);
     fixture.componentRef.setInput('committeeUid', committeeUid);
-    fixture.componentRef.setInput('groupUid', committeeUid);
     fixture.componentRef.setInput('groupName', groupName);
-    fixture.componentRef.setInput('seatCount', seatCount);
     fixture.componentRef.setInput('visible', true);
     await fixture.whenStable();
     fixture.detectChanges();
@@ -81,6 +83,10 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   // even if the code always renders the plural.
   function subtitleText(): string {
     return (document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '').replace(/\s+/g, ' ').trim();
+  }
+
+  function rowNames(): string[] {
+    return Array.from(document.querySelectorAll('[data-testid="group-seat-holders-list"] li')).map((li) => li.textContent?.trim() ?? '');
   }
 
   it('does not fetch until the drawer is opened', async () => {
@@ -100,8 +106,8 @@ describe('GroupSeatHoldersDrawerComponent', () => {
         .mockReturnValue(
           of(
             response([
-              assignment({ seatId: 's-1', committeeUid: 'c-1', person: { ...assignment().person, fullName: 'Jane Doe' } }),
-              assignment({ seatId: 's-2', committeeUid: 'c-2', person: { ...assignment().person, fullName: 'John Smith' } }),
+              assignment({ seatId: 's-1', committeeUid: 'c-1', person: person({ fullName: 'Jane Doe' }) }),
+              assignment({ seatId: 's-2', committeeUid: 'c-2', person: person({ email: 'john@example.org', fullName: 'John Smith' }) }),
             ])
           )
         )
@@ -114,7 +120,13 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   });
 
   it('fetches once per org and reuses the cached roster for a different committee', async () => {
-    await setup(vi.fn().mockReturnValue(of(response([assignment({ committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-2' })]))));
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(response([assignment({ committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-2', person: person({ email: 'john@example.org' }) })]))
+        )
+    );
 
     await open('org-1', 'c-1');
     expect(getCommitteeMembers).toHaveBeenCalledTimes(1);
@@ -130,8 +142,8 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await setup(
       vi
         .fn()
-        .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1', person: { ...assignment().person, fullName: 'Org One Person' } })])))
-        .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1', person: { ...assignment().person, fullName: 'Org Two Person' } })])))
+        .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1', person: person({ fullName: 'Org One Person' }) })])))
+        .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1', person: person({ fullName: 'Org Two Person' }) })])))
     );
 
     await open('org-1', 'c-1');
@@ -188,50 +200,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
   });
 
-  // seatCount() (the row's org_seat_count) and seatHolders().length (this list) are both
-  // best-effort counts and can genuinely disagree — see the displayedCount comment. The header
-  // must show the real, loaded count once settled, not the row's precomputed one.
-  it('shows the loaded row count once settled, even when it differs from the row seatCount', async () => {
-    await setup(
-      vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-1' })])))
-    );
-
-    await open('org-1', 'c-1', 'Storage Working Group', 1);
-
-    expect(subtitleText()).toBe('2 seat holders');
-  });
-
-  // The header shows a plain "Seat holders" placeholder while loading, not a borrowed seatCount()
-  // — seatCount() counts a different thing (see above), so using it as a loading placeholder would
-  // risk visibly flipping to a different, correct number once the real list arrives.
-  it('shows a blank "Seat holders" placeholder while the fetch is pending, not the row seatCount', async () => {
-    await setup(vi.fn().mockReturnValue(NEVER));
-
-    fixture.componentRef.setInput('orgUid', 'org-1');
-    fixture.componentRef.setInput('committeeUid', 'c-1');
-    fixture.componentRef.setInput('seatCount', 7);
-    fixture.componentRef.setInput('visible', true);
-    await fixture.whenStable();
-    fixture.detectChanges();
-
-    expect(subtitleText()).toBe('Seat holders');
-  });
-
-  // A failed fetch resolves seatHolders() to [] (see the outer catchError), not null — the
-  // error() branch is the one place seatCount() IS shown post-load, since there's no real list at
-  // all in that state for it to later disagree with (contrast: loading() shows a blank
-  // placeholder, because there the real list is still coming).
-  it('shows the row seatCount in the header on a failed fetch, not 0', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
-
-    await open('org-1', 'c-1', 'Storage Working Group', 7);
-
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
-    expect(subtitleText()).toBe('7 seat holders');
-  });
-
-  it('recovers cleanly on retry after a failure: error clears, real count comes back', async () => {
+  it('the "Try again" button in the error state retries the fetch without closing the drawer', async () => {
     const impl = vi
       .fn()
       .mockReturnValueOnce(throwError(() => new Error('boom')))
@@ -239,18 +208,102 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     await setup(impl);
 
-    await open('org-1', 'c-1', 'Storage Working Group', 7);
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
+    await open('org-1', 'c-1');
+    const retryButton = document.querySelector('[data-testid="group-seat-holders-drawer-retry"]') as HTMLButtonElement | null;
+    expect(retryButton).toBeTruthy();
 
-    fixture.componentRef.setInput('visible', false);
-    await fixture.whenStable();
-    fixture.detectChanges();
-    fixture.componentRef.setInput('visible', true);
+    retryButton!.click();
     await fixture.whenStable();
     fixture.detectChanges();
 
+    expect(impl).toHaveBeenCalledTimes(2);
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
     expect(subtitleText()).toBe('1 seat holder');
+  });
+
+  it('shows a blank "Seat holders" placeholder while the fetch is pending', async () => {
+    await setup(vi.fn().mockReturnValue(NEVER));
+
+    await open('org-1', 'c-1');
+
+    expect(subtitleText()).toBe('Seat holders');
+  });
+
+  it('shows a blank "Seat holders" placeholder on error too, not a stale count', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
+
+    await open('org-1', 'c-1');
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
+    expect(subtitleText()).toBe('Seat holders');
+  });
+
+  it('shows the loaded row count once settled', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', person: person({ fullName: 'Jane Doe' }) }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', person: person({ email: 'john@example.org', fullName: 'John Smith' }) }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(subtitleText()).toBe('2 seat holders');
+  });
+
+  // org_seat_count (the row's badge) dedupes by email server-side, so a person holding two seats
+  // on the same committee counts once there — the drawer's list must match, both in the header
+  // count and in the rendered rows, or the row's "1 seat" and the drawer's "2 seat holders" (plus
+  // two identical-looking rows) would read as a bug rather than the same fact stated twice.
+  it('groups multiple assignments for the same person into one row with both roles joined', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Chair' }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Member', memberUid: 'seat-2' }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(subtitleText()).toBe('1 seat holder');
+    const names = rowNames();
+    expect(names).toHaveLength(1);
+    expect(names[0]).toContain('Jane Doe');
+    expect(names[0]).toContain('Chair, Member');
+  });
+
+  it('sorts seat holders by display name', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', person: person({ email: 'zeb@example.org', fullName: 'Zeb Ashe' }) }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', person: person({ email: 'amy@example.org', fullName: 'Amy Zorn' }) }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    const names = rowNames();
+    expect(names[0]).toContain('Amy Zorn');
+    expect(names[1]).toContain('Zeb Ashe');
   });
 
   // Defensive coverage, not a currently-reachable path: org-groups.component.ts closes this
@@ -267,16 +320,16 @@ describe('GroupSeatHoldersDrawerComponent', () => {
       .mockReturnValueOnce(
         of(
           response([
-            assignment({ seatId: 's-1', committeeUid: 'c-1' }),
-            assignment({ seatId: 's-2', committeeUid: 'c-1' }),
-            assignment({ seatId: 's-3', committeeUid: 'c-1' }),
+            assignment({ seatId: 's-1', committeeUid: 'c-1', person: person({ fullName: 'Person One' }) }),
+            assignment({ seatId: 's-2', committeeUid: 'c-1', person: person({ email: 'two@example.org', fullName: 'Person Two' }) }),
+            assignment({ seatId: 's-3', committeeUid: 'c-1', person: person({ email: 'three@example.org', fullName: 'Person Three' }) }),
           ])
         )
       )
       .mockReturnValueOnce(NEVER);
     await setup(impl);
 
-    await open('org-1', 'c-1', 'Storage Working Group', 3);
+    await open('org-1', 'c-1');
     expect(subtitleText()).toBe('3 seat holders');
 
     fixture.componentRef.setInput('orgUid', 'org-2');

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -219,4 +219,29 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
   });
+
+  // The retry itself resolves seatHolders() to [] too (loading resets error() but the stale []
+  // from the failed attempt is still what's there until the retry settles) — displayedCount must
+  // stay pinned to seatCount() through that window as well, not just the error state itself.
+  it('keeps the pre-loaded seatCount in the header while a post-failure retry is still in flight', async () => {
+    const impl = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => new Error('boom')))
+      .mockReturnValueOnce(NEVER);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(impl);
+
+    await open('org-1', 'c-1', 'Storage Working Group', 7);
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
+
+    fixture.componentRef.setInput('visible', false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
+  });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -1,0 +1,205 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
+import type { CommitteeMemberAssignment, OrgPeopleCommitteeMembersResponse } from '@lfx-one/shared/interfaces';
+import { NEVER, of, throwError } from 'rxjs';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { GroupSeatHoldersDrawerComponent } from './group-seat-holders-drawer.component';
+
+function assignment(overrides: Partial<CommitteeMemberAssignment> = {}): CommitteeMemberAssignment {
+  return {
+    seatId: 'seat-1',
+    memberUid: 'seat-1',
+    committeeUid: 'c-1',
+    committeeName: 'Steering Committee',
+    committeeCategory: 'Committee',
+    projectUid: 'p-1',
+    foundationSlug: 'cncf',
+    foundationName: 'CNCF',
+    role: 'Chair',
+    votingStatus: 'Voting Rep',
+    appointedBy: 'Membership Entitlement',
+    isOrgEditable: true,
+    reason: null,
+    person: { email: 'jane@example.org', firstName: 'Jane', lastName: 'Doe', fullName: 'Jane Doe', jobTitle: null, initials: 'JD' },
+    ...overrides,
+  };
+}
+
+function response(assignments: CommitteeMemberAssignment[]): OrgPeopleCommitteeMembersResponse {
+  return { orgUid: 'org-1', assignments, stats: { individualCount: assignments.length, committeeCount: 1, foundationsCovered: 1 } };
+}
+
+describe('GroupSeatHoldersDrawerComponent', () => {
+  let fixture: ComponentFixture<GroupSeatHoldersDrawerComponent>;
+  let getCommitteeMembers: ReturnType<typeof vi.fn>;
+
+  // p-drawer renders into document.body, not the fixture host, and a previous test's overlay
+  // otherwise survives into the next one — mirrors event-detail-drawer.component.spec.ts.
+  afterEach(() => {
+    fixture?.destroy();
+    document.body.innerHTML = '';
+  });
+
+  async function setup(impl: ReturnType<typeof vi.fn>): Promise<void> {
+    getCommitteeMembers = impl;
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [GroupSeatHoldersDrawerComponent],
+      providers: [{ provide: CommitteeMembersService, useValue: { getCommitteeMembers } }, provideNoopAnimations(), provideRouter([])],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(GroupSeatHoldersDrawerComponent);
+  }
+
+  async function open(orgUid: string, committeeUid: string, groupName = 'Storage Working Group', seatCount = 1): Promise<void> {
+    fixture.componentRef.setInput('orgUid', orgUid);
+    fixture.componentRef.setInput('committeeUid', committeeUid);
+    fixture.componentRef.setInput('groupUid', committeeUid);
+    fixture.componentRef.setInput('groupName', groupName);
+    fixture.componentRef.setInput('seatCount', seatCount);
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+  }
+
+  function text(): string {
+    return document.body.textContent ?? '';
+  }
+
+  it('does not fetch until the drawer is opened', async () => {
+    await setup(vi.fn().mockReturnValue(of(response([]))));
+
+    fixture.componentRef.setInput('orgUid', 'org-1');
+    fixture.componentRef.setInput('committeeUid', 'c-1');
+    await fixture.whenStable();
+
+    expect(getCommitteeMembers).not.toHaveBeenCalled();
+  });
+
+  it('filters the roster to the requested committee', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', person: { ...assignment().person, fullName: 'Jane Doe' } }),
+              assignment({ seatId: 's-2', committeeUid: 'c-2', person: { ...assignment().person, fullName: 'John Smith' } }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(text()).toContain('Jane Doe');
+    expect(text()).not.toContain('John Smith');
+  });
+
+  it('fetches once per org and reuses the cached roster for a different committee', async () => {
+    await setup(vi.fn().mockReturnValue(of(response([assignment({ committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-2' })]))));
+
+    await open('org-1', 'c-1');
+    expect(getCommitteeMembers).toHaveBeenCalledTimes(1);
+
+    fixture.componentRef.setInput('committeeUid', 'c-2');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getCommitteeMembers).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when the org changes, so a switched-to org never renders the previous org roster', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1', person: { ...assignment().person, fullName: 'Org One Person' } })])))
+        .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1', person: { ...assignment().person, fullName: 'Org Two Person' } })])))
+    );
+
+    await open('org-1', 'c-1');
+    expect(text()).toContain('Org One Person');
+
+    fixture.componentRef.setInput('orgUid', 'org-2');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(getCommitteeMembers).toHaveBeenCalledTimes(2);
+    expect(text()).toContain('Org Two Person');
+    expect(text()).not.toContain('Org One Person');
+  });
+
+  it('renders the empty state when no assignment matches the committee', async () => {
+    await setup(vi.fn().mockReturnValue(of(response([assignment({ committeeUid: 'other-committee' })]))));
+
+    await open('org-1', 'c-1');
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-empty"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
+  });
+
+  it('shows a distinct error state on fetch failure and logs it', async () => {
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
+
+    await open('org-1', 'c-1');
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-empty"]')).toBeNull();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it('retries the fetch on the next open after a failure', async () => {
+    const impl = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => new Error('boom')))
+      .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1' })])));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(impl);
+
+    await open('org-1', 'c-1');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
+
+    fixture.componentRef.setInput('visible', false);
+    await fixture.whenStable();
+    fixture.detectChanges();
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(impl).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
+  });
+
+  it('shows the loaded row count in the header, not the possibly-stale seatCount input', async () => {
+    // Deliberately mismatched: seatCount() (deduped-by-person) says 1, but two seat rows match.
+    await setup(
+      vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-1' })])))
+    );
+
+    await open('org-1', 'c-1', 'Storage Working Group', 1);
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('2 seats');
+  });
+
+  it('renders the pre-loaded seatCount in the header before the fetch resolves', async () => {
+    // NEVER: the fetch stays pending, so seatHolders() stays null and displayedCount() must fall
+    // back to the row's precomputed seatCount() rather than reading 0 while still loading.
+    await setup(vi.fn().mockReturnValue(NEVER));
+
+    fixture.componentRef.setInput('orgUid', 'org-1');
+    fixture.componentRef.setInput('committeeUid', 'c-1');
+    fixture.componentRef.setInput('seatCount', 7);
+    fixture.componentRef.setInput('visible', true);
+    fixture.detectChanges();
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
+  });
+});

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -845,7 +845,12 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     // freshly-inserted-content problem this whole mechanism exists to avoid. Checked synchronously
     // right after the reopen's own render, before awaiting whenStable() again (which would let the
     // afterNextRender hook fire and mask a broken reset).
-    it("re-mounts the status region empty on a reopen, not carrying over the previous open's revealed state", async () => {
+    //
+    // Also closes the loop past that empty first paint: asserting only the empty half would stay
+    // green even if a regression stopped contentRevealed from re-flipping to true on later opens
+    // (e.g. a revealRef that isn't re-registered), silently leaving the live region permanently
+    // unannounced from the second open onward — worse than the bug this reset exists to fix.
+    it("re-mounts the status region empty on a reopen, not carrying over the previous open's revealed state, then reveals it again", async () => {
       await setup(vi.fn().mockReturnValue(of(response([]))));
 
       await open('org-1', 'c-1');
@@ -856,8 +861,11 @@ describe('GroupSeatHoldersDrawerComponent', () => {
 
       fixture.componentRef.setInput('visible', true);
       fixture.detectChanges();
-
       expect(statusMessage()).toBe('');
+
+      await fixture.whenStable();
+      fixture.detectChanges();
+      expect(statusMessage()).toBe('0 seat holders loaded.');
     });
 
     it('moves focus into the panel on open, away from the element that triggered it', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -765,8 +765,11 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.detectChanges();
 
     expect(instance.loading()).toBe(false);
-    // The DOM-visible half of the same claim: no permanent spinner, not the internal flag alone.
+    // The DOM-visible half of the same claim: no permanent spinner, not the internal flag alone —
+    // and the positive control (the empty state that should replace it) so this can't pass on a
+    // template regression that drops the whole @if chain rather than actually clearing loading.
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-loading"]')).toBeNull();
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-empty"]')).toBeTruthy();
   });
 
   it('renders a member with no name and no email as "Unknown member", not a blank row', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -89,6 +89,10 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     return Array.from(document.querySelectorAll('[data-testid="group-seat-holders-list"] li')).map((li) => li.textContent?.trim() ?? '');
   }
 
+  function statusMessage(): string | null {
+    return document.querySelector('[role="status"]')?.textContent?.trim() ?? null;
+  }
+
   it('does not fetch until the drawer is opened', async () => {
     await setup(vi.fn().mockReturnValue(of(response([]))));
 
@@ -219,6 +223,35 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(impl).toHaveBeenCalledTimes(2);
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
     expect(subtitleText()).toBe('1 seat holder');
+  });
+
+  // The single persistent role="status" region is the only signal a screen-reader user gets that
+  // a retry changed anything — the button they activated is removed from the DOM either way, and
+  // a repeat error looks identical to the first one without reading it.
+  it('announces the loaded count through the persistent status region after a successful retry', async () => {
+    const impl = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => new Error('boom')))
+      .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1' })])));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(impl);
+
+    await open('org-1', 'c-1');
+    expect(statusMessage()).toBe('Unable to load seat holders.');
+
+    (document.querySelector('[data-testid="group-seat-holders-drawer-retry"]') as HTMLButtonElement).click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(statusMessage()).toBe('1 seat holder loaded.');
+  });
+
+  it('announces the loading state through the persistent status region', async () => {
+    await setup(vi.fn().mockReturnValue(NEVER));
+
+    await open('org-1', 'c-1');
+
+    expect(statusMessage()).toBe('Loading seat holders…');
   });
 
   it('shows a blank "Seat holders" placeholder while the fetch is pending', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -76,6 +76,13 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     return document.body.textContent ?? '';
   }
 
+  // Normalized + exact, not a substring `.toContain` — the wording is singular/plural sensitive
+  // ("1 seat assignment" vs "1 seat assignments"), and a substring check on the singular form
+  // stays green even if the code always renders the plural.
+  function subtitleText(): string {
+    return (document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '').replace(/\s+/g, ' ').trim();
+  }
+
   it('does not fetch until the drawer is opened', async () => {
     await setup(vi.fn().mockReturnValue(of(response([]))));
 
@@ -184,15 +191,17 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   // seatCount() (the row's org_seat_count, distinct PEOPLE, deduped by email server-side) and this
   // list (one row per SEAT/role assignment) can genuinely disagree — a person holding two roles on
   // the committee is one of the cases. The header must show the real, loaded count once settled,
-  // not the row's count.
-  it('shows the loaded row count in the header once settled, even when it differs from the row seatCount', async () => {
+  // not the row's count — worded "seat assignments", not "seat holders", since that's the unit
+  // this branch actually counts (see the displayedCount comment and the template's error()/else
+  // split).
+  it('shows the loaded row count as "seat assignments" once settled, even when it differs from the row seatCount', async () => {
     await setup(
       vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-1' })])))
     );
 
     await open('org-1', 'c-1', 'Storage Working Group', 1);
 
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('2 seat holders');
+    expect(subtitleText()).toBe('2 seat assignments');
   });
 
   // The header shows a plain "Seat holders" placeholder while loading, not a borrowed seatCount()
@@ -208,26 +217,25 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    const subtitle = document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '';
-    expect(subtitle).toContain('Seat holders');
-    expect(subtitle).not.toContain('7');
+    expect(subtitleText()).toBe('Seat holders');
   });
 
   // A failed fetch resolves seatHolders() to [] (see the outer catchError), not null — the
   // error() branch is the one place seatCount() IS shown post-load, since there's no real list at
   // all in that state for it to later disagree with (contrast: loading() shows a blank
-  // placeholder, because there the real list is still coming).
-  it('shows the row seatCount in the header on a failed fetch, not 0', async () => {
+  // placeholder, because there the real list is still coming). "Seat holders" is the accurate
+  // noun here (unlike the loaded-list case above) because seatCount() genuinely counts people.
+  it('shows the row seatCount as "seat holders" on a failed fetch, not 0', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
 
     await open('org-1', 'c-1', 'Storage Working Group', 7);
 
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seat holders');
+    expect(subtitleText()).toBe('7 seat holders');
   });
 
-  it('recovers cleanly on retry after a failure: error clears, real count comes back', async () => {
+  it('recovers cleanly on retry after a failure: error clears, real "seat assignments" count comes back', async () => {
     const impl = vi
       .fn()
       .mockReturnValueOnce(throwError(() => new Error('boom')))
@@ -246,7 +254,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.detectChanges();
 
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('1 seat holder');
+    expect(subtitleText()).toBe('1 seat assignment');
   });
 
   // Defensive coverage, not a currently-reachable path: org-groups.component.ts closes this
@@ -273,7 +281,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await setup(impl);
 
     await open('org-1', 'c-1', 'Storage Working Group', 3);
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('3 seat holders');
+    expect(subtitleText()).toBe('3 seat assignments');
 
     fixture.componentRef.setInput('orgUid', 'org-2');
     await fixture.whenStable();
@@ -285,9 +293,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     // (loading() true) before checking the header text it gates — the header assertion alone
     // previously proved vulnerable to running ahead of that write.
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-loading"]')).toBeTruthy();
-    const subtitle = document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '';
-    expect(subtitle).toContain('Seat holders');
-    expect(subtitle).not.toContain('3');
+    expect(subtitleText()).toBe('Seat holders');
   });
 
   it('renders a member with no name and no email as "Unknown member", not a blank row', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -181,8 +181,11 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
   });
 
-  it('shows the loaded row count in the header, not the possibly-stale seatCount input', async () => {
-    // Deliberately mismatched: seatCount() (deduped-by-person) says 1, but two seat rows match.
+  // seatCount() (the row's org_seat_count, distinct PEOPLE, deduped by email server-side) and this
+  // list (one row per SEAT/role assignment) can genuinely disagree — a person holding two roles on
+  // the committee is one of the cases. The header must show the real, loaded count once settled,
+  // not the row's count.
+  it('shows the loaded row count in the header once settled, even when it differs from the row seatCount', async () => {
     await setup(
       vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-1' })])))
     );
@@ -192,9 +195,10 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('2 seats');
   });
 
-  it('renders the pre-loaded seatCount in the header before the fetch resolves', async () => {
-    // NEVER: the fetch stays pending, so seatHolders() stays null and displayedCount() must fall
-    // back to the row's precomputed seatCount() rather than reading 0 while still loading.
+  // The header shows a plain "Seat holders" placeholder while loading, not a borrowed seatCount()
+  // — seatCount() counts a different thing (see above), so using it as a loading placeholder would
+  // risk visibly flipping to a different, correct number once the real list arrives.
+  it('shows a blank "Seat holders" placeholder while the fetch is pending, not the row seatCount', async () => {
     await setup(vi.fn().mockReturnValue(NEVER));
 
     fixture.componentRef.setInput('orgUid', 'org-1');
@@ -204,13 +208,16 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await fixture.whenStable();
     fixture.detectChanges();
 
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
+    const subtitle = document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '';
+    expect(subtitle).toContain('Seat holders');
+    expect(subtitle).not.toContain('7');
   });
 
-  // A failed fetch resolves seatHolders() to [] (see the outer catchError), not null — without
-  // excluding the error() branch from displayedCount's fallback, the header would read "0 seats"
-  // instead of the row's already-known count right next to the "Unable to load" panel.
-  it('keeps the pre-loaded seatCount in the header on a failed fetch, not 0', async () => {
+  // A failed fetch resolves seatHolders() to [] (see the outer catchError), not null — the
+  // error() branch is the one place seatCount() IS shown post-load, since there's no real list at
+  // all in that state for it to later disagree with (contrast: loading() shows a blank
+  // placeholder, because there the real list is still coming).
+  it('shows the row seatCount in the header on a failed fetch, not 0', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
 
@@ -220,13 +227,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
   });
 
-  // Closing the drawer (visible: false) routes through the `!visible` branch of initSeatHolders,
-  // which resets seatHolders() to null — so this retry path was already covered by the plain
-  // `?? seatCount()` fallback even before the loading() guard existed. It's kept as a regression
-  // test for the retry flow itself (error clears, correct count reappears), not as coverage for
-  // the loading() guard specifically — see "keeps the new row seatCount in the header while an
-  // org-switch refetch is in flight..." below for the scenario that actually needs it.
-  it('recovers cleanly on retry after a failure: error clears, count comes back', async () => {
+  it('recovers cleanly on retry after a failure: error clears, real count comes back', async () => {
     const impl = vi
       .fn()
       .mockReturnValueOnce(throwError(() => new Error('boom')))
@@ -250,13 +251,13 @@ describe('GroupSeatHoldersDrawerComponent', () => {
 
   // Defensive coverage, not a currently-reachable path: org-groups.component.ts closes this
   // drawer on every org switch (its orgUid$ subscription), so today a trigger change shouldn't
-  // arrive with the drawer still open. IF one ever did, the cache would rebuild for the new
-  // orgUid and start a real refetch, but toSignal keeps emitting the *previous* org's array until
-  // that fetch resolves — without the loading() guard, displayedCount would read the stale
-  // previous-org row count instead of the new row's seatCount(). Awaits stability twice: the
-  // orgUid write has to propagate through toObservable's effect before the switchMap/loading()
-  // write lands, and asserting after only one flush was observed to occasionally race ahead of it.
-  it('keeps the new row seatCount in the header while an org-switch refetch is in flight, not the previous org roster length', async () => {
+  // arrive with the drawer still open. IF one ever did, the cache would rebuild for the new orgUid
+  // and start a real refetch — this proves the header falls back to the blank placeholder rather
+  // than leaking the previous org's stale row count while that refetch is in flight. Awaits
+  // stability twice: the orgUid write has to propagate through toObservable's effect before the
+  // switchMap/loading() write lands, and asserting after only one flush was observed to
+  // occasionally race ahead of it.
+  it('shows the blank placeholder, not the previous org roster length, while an org-switch refetch is in flight', async () => {
     const impl = vi
       .fn()
       .mockReturnValueOnce(
@@ -274,7 +275,6 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await open('org-1', 'c-1', 'Storage Working Group', 3);
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('3 seats');
 
-    fixture.componentRef.setInput('seatCount', 9);
     fixture.componentRef.setInput('orgUid', 'org-2');
     await fixture.whenStable();
     fixture.detectChanges();
@@ -285,7 +285,28 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     // (loading() true) before checking the header text it gates — the header assertion alone
     // previously proved vulnerable to running ahead of that write.
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-loading"]')).toBeTruthy();
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('9 seats');
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).not.toContain('3 seats');
+    const subtitle = document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '';
+    expect(subtitle).toContain('Seat holders');
+    expect(subtitle).not.toContain('3');
+  });
+
+  it('renders a member with no name and no email as "Unknown member", not a blank row', async () => {
+    await setup(
+      vi.fn().mockReturnValue(
+        of(
+          response([
+            assignment({
+              role: '',
+              person: { email: '', firstName: '', lastName: '', fullName: '', jobTitle: null, initials: '' },
+            }),
+          ])
+        )
+      )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(text()).toContain('Unknown member');
+    expect(text()).toContain('—');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -679,6 +679,65 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(instance.statusMessage()).toBe('2 seat holders loaded.');
   });
 
+  // The close-preserves-state fix above (EMPTY, not null, while `visible` is false) must not leak
+  // the closed drawer's roster into a *different* group opened next — closing only defers the
+  // clear, it doesn't skip it forever.
+  it("does not carry a closed committee's roster into a reopen for a different committee", async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', person: person({ fullName: 'Committee One Person' }) }),
+              assignment({ seatId: 's-2', committeeUid: 'c-2', person: person({ email: 'two@example.org', fullName: 'Committee Two Person' }) }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+    expect(text()).toContain('Committee One Person');
+
+    fixture.componentRef.setInput('visible', false);
+    await fixture.whenStable();
+
+    fixture.componentRef.setInput('committeeUid', 'c-2');
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(text()).toContain('Committee Two Person');
+    expect(text()).not.toContain('Committee One Person');
+  });
+
+  // The first-ever open for an org is always mid-fetch when the leave animation could start (the
+  // cache doesn't exist yet). `finalize` fires on unsubscribe as well as completion, so it would
+  // clear `loading` when switchMap tears the pipeline down on close — with `seatHolders` still
+  // null, that renders the empty state and a false "0 seat holders" announcement during the same
+  // close animation the EMPTY guard exists to protect. `tap` (used instead) only runs on a real
+  // emission, so closing mid-fetch must leave `loading` — and therefore the blank placeholder
+  // state, not a false empty result — exactly as it was.
+  it('does not clear the loading state to a false empty result when the drawer closes mid-fetch', async () => {
+    await setup(vi.fn().mockReturnValue(NEVER));
+
+    fixture.componentRef.setInput('orgUid', 'org-1');
+    fixture.componentRef.setInput('committeeUid', 'c-1');
+    fixture.componentRef.setInput('groupName', 'Storage Working Group');
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+
+    const instance = fixture.componentInstance as unknown as { loading: () => boolean; displayedCount: () => number | null };
+    expect(instance.loading()).toBe(true);
+    expect(instance.displayedCount()).toBeNull();
+
+    fixture.componentRef.setInput('visible', false);
+    await fixture.whenStable();
+
+    expect(instance.loading()).toBe(true);
+    expect(instance.displayedCount()).toBeNull();
+  });
+
   it('renders a member with no name and no email as "Unknown member", not a blank row', async () => {
     await setup(
       vi.fn().mockReturnValue(

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -220,14 +220,16 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
   });
 
-  // The retry itself resolves seatHolders() to [] too (loading resets error() but the stale []
-  // from the failed attempt is still what's there until the retry settles) — displayedCount must
-  // stay pinned to seatCount() through that window as well, not just the error state itself.
-  it('keeps the pre-loaded seatCount in the header while a post-failure retry is still in flight', async () => {
+  // Closing the drawer (visible: false) routes through the `!visible` branch of initSeatHolders,
+  // which resets seatHolders() to null — so this retry path was already covered by the plain
+  // `?? seatCount()` fallback even before the loading() guard existed. It's kept as a regression
+  // test for the retry flow itself (error clears, correct count reappears), not as coverage for
+  // the loading() guard specifically — see the next test for the scenario that actually needs it.
+  it('recovers cleanly on retry after a failure: error clears, count comes back', async () => {
     const impl = vi
       .fn()
       .mockReturnValueOnce(throwError(() => new Error('boom')))
-      .mockReturnValueOnce(NEVER);
+      .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1' })])));
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     await setup(impl);
 
@@ -242,6 +244,38 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.detectChanges();
 
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('1 seat');
+  });
+
+  // The scenario the loading() guard actually protects: the drawer stays OPEN across an org
+  // switch (visible never goes false, so seatHolders() never resets to null). The cache rebuilds
+  // for the new orgUid and a real refetch starts, but toSignal keeps emitting the previous org's
+  // array until the new fetch resolves — without the loading() guard, displayedCount would read
+  // the stale previous-org row count instead of the new row's seatCount().
+  it('keeps the new row seatCount in the header while an org-switch refetch is in flight, not the previous org roster length', async () => {
+    const impl = vi
+      .fn()
+      .mockReturnValueOnce(
+        of(
+          response([
+            assignment({ seatId: 's-1', committeeUid: 'c-1' }),
+            assignment({ seatId: 's-2', committeeUid: 'c-1' }),
+            assignment({ seatId: 's-3', committeeUid: 'c-1' }),
+          ])
+        )
+      )
+      .mockReturnValueOnce(NEVER);
+    await setup(impl);
+
+    await open('org-1', 'c-1', 'Storage Working Group', 3);
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('3 seats');
+
+    fixture.componentRef.setInput('seatCount', 9);
+    fixture.componentRef.setInput('orgUid', 'org-2');
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('9 seats');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).not.toContain('3 seats');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -192,7 +192,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
 
     await open('org-1', 'c-1', 'Storage Working Group', 1);
 
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('2 seats');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('2 seat holders');
   });
 
   // The header shows a plain "Seat holders" placeholder while loading, not a borrowed seatCount()
@@ -224,7 +224,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await open('org-1', 'c-1', 'Storage Working Group', 7);
 
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seat holders');
   });
 
   it('recovers cleanly on retry after a failure: error clears, real count comes back', async () => {
@@ -246,7 +246,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.detectChanges();
 
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('1 seat');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('1 seat holder');
   });
 
   // Defensive coverage, not a currently-reachable path: org-groups.component.ts closes this
@@ -273,7 +273,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     await setup(impl);
 
     await open('org-1', 'c-1', 'Storage Working Group', 3);
-    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('3 seats');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('3 seat holders');
 
     fixture.componentRef.setInput('orgUid', 'org-2');
     await fixture.whenStable();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -223,6 +223,49 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(impl).toHaveBeenCalledTimes(2);
   });
 
+  // The success-path counterpart to the failure-guard test above — same race (a superseded org's
+  // shareReplay(1) source, still subscribed under refCount:false, resolves after the switch), but
+  // landing as a SUCCESS instead of an error. Without a cache-entry-identity guard on the success tap
+  // (mirroring the one the catchError branch already had), org-1's late roster would silently
+  // overwrite fullOrgAssignments, corrupting onPersonClick()'s governanceSeats for org-2's person even
+  // though the visible list (a separately-scoped fetch) still correctly shows org-2's roster.
+  it("does not let a stale, since-superseded org's late SUCCESS overwrite the current org's fullOrgAssignments", async () => {
+    const orgOneSubject = new Subject<OrgPeopleCommitteeMembersResponse>();
+    const orgTwoSubject = new Subject<OrgPeopleCommitteeMembersResponse>();
+    const impl = vi.fn((orgUid: string) => (orgUid === 'org-1' ? orgOneSubject.asObservable() : orgTwoSubject.asObservable()));
+    await setup(impl as unknown as ReturnType<typeof vi.fn>);
+
+    await open('org-1', 'c-1');
+    expect(impl).toHaveBeenCalledTimes(1);
+
+    fixture.componentRef.setInput('orgUid', 'org-2');
+    await fixture.whenStable();
+    expect(impl).toHaveBeenCalledTimes(2);
+
+    // Org-2 (the current org) resolves first.
+    orgTwoSubject.next(
+      response([assignment({ seatId: 's-2', committeeUid: 'c-1', person: person({ fullName: 'Org Two Person', email: 'two@example.org' }) })])
+    );
+    orgTwoSubject.complete();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    // Org-1's now-orphaned fetch resolves late, after the switch away from it.
+    orgOneSubject.next(
+      response([assignment({ seatId: 's-1', committeeUid: 'c-1', person: person({ fullName: 'Org One Person', email: 'one@example.org' }) })])
+    );
+    orgOneSubject.complete();
+    await fixture.whenStable();
+
+    document.querySelector<HTMLElement>('[data-testid^="seat-holder-person-"]')!.click();
+
+    expect(drawerOpen).toHaveBeenCalledTimes(1);
+    const call = drawerOpen.mock.calls[0][0];
+    expect(call.name).toBe('Org Two Person');
+    expect(call.email).toBe('two@example.org');
+    expect(call.governanceSeats).toHaveLength(1);
+  });
+
   it('renders the empty state when no assignment matches the committee', async () => {
     await setup(vi.fn().mockReturnValue(of(response([assignment({ committeeUid: 'other-committee' })]))));
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -231,9 +231,11 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(subtitleText()).toBe('7 seat holders');
   });
 
-  // Exercises the singular form on the error branch specifically — the loaded branch's singular
-  // form is covered separately below, and the two branches read different signals
-  // (seatCount() vs seatHolders().length), so one covering the other's singular case isn't implied.
+  // Pins the singular form on the error branch's displayedCount() source (seatCount()), so a
+  // future re-split of the header wording (branching the noun by error()/loaded() again, as an
+  // earlier round of this did) can't quietly regress it. Today both branches share one ternary,
+  // so this is redundant with the loaded branch's singular assertion below — kept anyway as a
+  // tripwire for that specific regression.
   it('uses the singular "seat holder" on the error branch too, not just the loaded branch', async () => {
     vi.spyOn(console, 'error').mockImplementation(() => undefined);
     await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -86,7 +86,7 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   }
 
   function rowNames(): string[] {
-    return Array.from(document.querySelectorAll('[data-testid="group-seat-holders-list"] li')).map((li) => li.textContent?.trim() ?? '');
+    return Array.from(document.querySelectorAll('[data-testid^="group-seat-holder-"]')).map((li) => li.textContent?.trim() ?? '');
   }
 
   function statusMessage(): string | null {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -6,7 +6,7 @@ import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
 import type { CommitteeMemberAssignment, CommitteeMemberPerson, OrgPeopleCommitteeMembersResponse } from '@lfx-one/shared/interfaces';
-import { NEVER, of, throwError } from 'rxjs';
+import { NEVER, of, Subject, throwError } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
 
 import { GroupSeatHoldersDrawerComponent } from './group-seat-holders-drawer.component';
@@ -128,18 +128,29 @@ describe('GroupSeatHoldersDrawerComponent', () => {
       vi
         .fn()
         .mockReturnValue(
-          of(response([assignment({ committeeUid: 'c-1' }), assignment({ seatId: 's-2', committeeUid: 'c-2', person: person({ email: 'john@example.org' }) })]))
+          of(
+            response([
+              assignment({ committeeUid: 'c-1', person: person({ fullName: 'Jane Doe' }) }),
+              assignment({ seatId: 's-2', committeeUid: 'c-2', person: person({ email: 'john@example.org', fullName: 'John Smith' }) }),
+            ])
+          )
         )
     );
 
     await open('org-1', 'c-1');
     expect(getCommitteeMembers).toHaveBeenCalledTimes(1);
+    expect(text()).toContain('Jane Doe');
+    expect(text()).not.toContain('John Smith');
 
     fixture.componentRef.setInput('committeeUid', 'c-2');
     await fixture.whenStable();
     fixture.detectChanges();
 
+    // No second fetch, but the cached roster still gets re-filtered to the new committee — proves
+    // the cache-reuse path actually serves the right rows, not just that it skips the HTTP call.
     expect(getCommitteeMembers).toHaveBeenCalledTimes(1);
+    expect(text()).toContain('John Smith');
+    expect(text()).not.toContain('Jane Doe');
   });
 
   it('refetches when the org changes, so a switched-to org never renders the previous org roster', async () => {
@@ -160,6 +171,48 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(getCommitteeMembers).toHaveBeenCalledTimes(2);
     expect(text()).toContain('Org Two Person');
     expect(text()).not.toContain('Org One Person');
+  });
+
+  // shareReplay(1)'s default refCount:false keeps org-1's underlying fetch subscribed even after
+  // switchMap moves on to org-2 — so a slow org-1 failure can still land after the switch. Its
+  // catchError guard (`if (this.cache?.orgUid === orgUid)`) must recognize it's stale and leave
+  // org-2's cache entry alone; without the guard this would null out the org-2 entry currently in
+  // `this.cache`, forcing an unnecessary refetch on the next open.
+  it("does not let a stale, since-superseded org's fetch failure clobber the current org's cache", async () => {
+    const orgOneSubject = new Subject<OrgPeopleCommitteeMembersResponse>();
+    const orgTwoSubject = new Subject<OrgPeopleCommitteeMembersResponse>();
+    const impl = vi.fn((orgUid: string) => (orgUid === 'org-1' ? orgOneSubject.asObservable() : orgTwoSubject.asObservable()));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(impl as unknown as ReturnType<typeof vi.fn>);
+
+    await open('org-1', 'c-1');
+    expect(impl).toHaveBeenCalledTimes(1);
+
+    fixture.componentRef.setInput('orgUid', 'org-2');
+    await fixture.whenStable();
+    expect(impl).toHaveBeenCalledTimes(2);
+
+    // Org-1's now-orphaned fetch fails after the switch away from it.
+    orgOneSubject.error(new Error('stale org-1 failure'));
+    await fixture.whenStable();
+
+    orgTwoSubject.next(response([assignment({ committeeUid: 'c-1', person: person({ fullName: 'Org Two Person' }) })]));
+    orgTwoSubject.complete();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(text()).toContain('Org Two Person');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
+
+    // Close and reopen for the same (org-2) committee — a third call would mean the stale org-1
+    // failure wrongly nulled org-2's cache entry.
+    fixture.componentRef.setInput('visible', false);
+    await fixture.whenStable();
+    fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(impl).toHaveBeenCalledTimes(2);
   });
 
   it('renders the empty state when no assignment matches the committee', async () => {
@@ -223,6 +276,38 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(impl).toHaveBeenCalledTimes(2);
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
     expect(subtitleText()).toBe('1 seat holder');
+  });
+
+  it('stays in the error state across a retry that also fails, and a later retry can still recover', async () => {
+    const impl = vi
+      .fn()
+      .mockReturnValueOnce(throwError(() => new Error('first failure')))
+      .mockReturnValueOnce(throwError(() => new Error('second failure')))
+      .mockReturnValueOnce(of(response([assignment({ committeeUid: 'c-1' })])));
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(impl);
+
+    await open('org-1', 'c-1');
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
+    expect(statusMessage()).toBe('Unable to load seat holders.');
+
+    let retryButton = document.querySelector('[data-testid="group-seat-holders-drawer-retry"]') as HTMLButtonElement | null;
+    retryButton!.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(impl).toHaveBeenCalledTimes(2);
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
+    expect(statusMessage()).toBe('Unable to load seat holders.');
+
+    // A third retry succeeds — the error -> error transition didn't leave the pipeline stuck.
+    retryButton = document.querySelector('[data-testid="group-seat-holders-drawer-retry"]') as HTMLButtonElement | null;
+    retryButton!.click();
+    await fixture.whenStable();
+    fixture.detectChanges();
+
+    expect(impl).toHaveBeenCalledTimes(3);
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeNull();
   });
 
   // The single persistent role="status" region is the only signal a screen-reader user gets that
@@ -316,6 +401,24 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(names).toHaveLength(1);
     expect(names[0]).toContain('Jane Doe');
     expect(names[0]).toContain('Chair, Member');
+  });
+
+  it('sorts the joined role label alphabetically, independent of upstream seat order', async () => {
+    await setup(
+      vi.fn().mockReturnValue(
+        of(
+          response([
+            // Deliberately reversed alphabetical order — the merged label must not just mirror it.
+            assignment({ seatId: 's-1', committeeUid: 'c-1', role: 'Vice Chair' }),
+            assignment({ seatId: 's-2', committeeUid: 'c-1', role: 'Alternate', memberUid: 'seat-2' }),
+          ])
+        )
+      )
+    );
+
+    await open('org-1', 'c-1');
+
+    expect(rowNames()[0]).toContain('Alternate, Vice Chair');
   });
 
   // Which of a merged person's two seats "wins" for the voting-status pill must not depend on
@@ -538,6 +641,42 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     // previously proved vulnerable to running ahead of that write.
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-loading"]')).toBeTruthy();
     expect(subtitleText()).toBe('Seat holders');
+  });
+
+  // p-drawer keeps the panel mounted through its leave animation — real-world, the roster and
+  // header must survive that window rather than flash to "0 seat holders" (and announce it as
+  // such) while the panel is still sliding out. This test's harness runs noop animations, under
+  // which *ngIf unmounts the panel content synchronously — so the DOM itself can't be used to
+  // observe the race here; it asserts on the underlying signal state that feeds that content
+  // instead (protected fields read directly, the way the DOM would see them if still mounted).
+  it('keeps the loaded roster and count signals intact when the drawer closes, instead of clearing to zero', async () => {
+    await setup(
+      vi
+        .fn()
+        .mockReturnValue(
+          of(
+            response([
+              assignment({ seatId: 's-1', committeeUid: 'c-1', person: person({ fullName: 'Person One' }) }),
+              assignment({ seatId: 's-2', committeeUid: 'c-1', person: person({ email: 'two@example.org', fullName: 'Person Two' }) }),
+            ])
+          )
+        )
+    );
+
+    await open('org-1', 'c-1');
+    const instance = fixture.componentInstance as unknown as {
+      displayedCount: () => number | null;
+      seatHolderVms: () => unknown[];
+      statusMessage: () => string;
+    };
+    expect(instance.displayedCount()).toBe(2);
+
+    fixture.componentRef.setInput('visible', false);
+    await fixture.whenStable();
+
+    expect(instance.displayedCount()).toBe(2);
+    expect(instance.seatHolderVms()).toHaveLength(2);
+    expect(instance.statusMessage()).toBe('2 seat holders loaded.');
   });
 
   it('renders a member with no name and no email as "Unknown member", not a blank row', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -41,9 +41,12 @@ describe('GroupSeatHoldersDrawerComponent', () => {
 
   // p-drawer renders into document.body, not the fixture host, and a previous test's overlay
   // otherwise survives into the next one — mirrors event-detail-drawer.component.spec.ts.
+  // restoreAllMocks undoes the console.error spies a couple of tests below install — without it
+  // those spies leak into every later test in the file and silently swallow real console errors.
   afterEach(() => {
     fixture?.destroy();
     document.body.innerHTML = '';
+    vi.restoreAllMocks();
   });
 
   async function setup(impl: ReturnType<typeof vi.fn>): Promise<void> {
@@ -198,8 +201,22 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.componentRef.setInput('committeeUid', 'c-1');
     fixture.componentRef.setInput('seatCount', 7);
     fixture.componentRef.setInput('visible', true);
+    await fixture.whenStable();
     fixture.detectChanges();
 
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
+  });
+
+  // A failed fetch resolves seatHolders() to [] (see the outer catchError), not null — without
+  // excluding the error() branch from displayedCount's fallback, the header would read "0 seats"
+  // instead of the row's already-known count right next to the "Unable to load" panel.
+  it('keeps the pre-loaded seatCount in the header on a failed fetch, not 0', async () => {
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
+    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
+
+    await open('org-1', 'c-1', 'Storage Working Group', 7);
+
+    expect(document.querySelector('[data-testid="group-seat-holders-drawer-error"]')).toBeTruthy();
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('7 seats');
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -791,4 +791,62 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(text()).toContain('Unknown member');
     expect(text()).toContain('—');
   });
+
+  // PrimeNG's p-drawer sets role="complementary" on its panel and doesn't manage focus at all —
+  // no autofocus on open, no restore on close. These pin the fix layered on top: dialog semantics
+  // via [pt], and focus movement via (onShow)/(onHide). document.activeElement, not a class token
+  // or a testid's mere presence, is the only thing that actually proves focus moved.
+  describe('focus management', () => {
+    function dialogPanel(): Element | null {
+      return document.querySelector('[role="dialog"]');
+    }
+
+    function closeButton(): HTMLElement | null {
+      return document.querySelector('[data-testid="group-seat-holders-drawer-close"]');
+    }
+
+    it('marks the panel as a labelled modal dialog', async () => {
+      await setup(vi.fn().mockReturnValue(of(response([]))));
+
+      await open('org-1', 'c-1');
+
+      const panel = dialogPanel();
+      expect(panel).toBeTruthy();
+      expect(panel?.getAttribute('aria-modal')).toBe('true');
+      expect(panel?.getAttribute('aria-labelledby')).toBe('group-seat-holders-drawer-title');
+    });
+
+    it('moves focus into the panel on open, away from the element that triggered it', async () => {
+      await setup(vi.fn().mockReturnValue(of(response([]))));
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+      expect(document.activeElement).toBe(trigger);
+
+      await open('org-1', 'c-1');
+
+      const title = document.querySelector('[data-testid="group-seat-holders-drawer-title"]');
+      expect(document.activeElement).toBe(title);
+      expect(document.activeElement).not.toBe(trigger);
+
+      document.body.removeChild(trigger);
+    });
+
+    it('restores focus to the triggering element when the close button is activated', async () => {
+      await setup(vi.fn().mockReturnValue(of(response([]))));
+      const trigger = document.createElement('button');
+      document.body.appendChild(trigger);
+      trigger.focus();
+
+      await open('org-1', 'c-1');
+      expect(document.activeElement).not.toBe(trigger);
+
+      closeButton()!.click();
+      await fixture.whenStable();
+
+      expect(document.activeElement).toBe(trigger);
+
+      document.body.removeChild(trigger);
+    });
+  });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -231,20 +231,6 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(subtitleText()).toBe('7 seat holders');
   });
 
-  // Pins the singular form on the error branch's displayedCount() source (seatCount()), so a
-  // future re-split of the header wording (branching the noun by error()/loaded() again, as an
-  // earlier round of this did) can't quietly regress it. Today both branches share one ternary,
-  // so this is redundant with the loaded branch's singular assertion below — kept anyway as a
-  // tripwire for that specific regression.
-  it('uses the singular "seat holder" on the error branch too, not just the loaded branch', async () => {
-    vi.spyOn(console, 'error').mockImplementation(() => undefined);
-    await setup(vi.fn().mockReturnValue(throwError(() => new Error('boom'))));
-
-    await open('org-1', 'c-1', 'Storage Working Group', 1);
-
-    expect(subtitleText()).toBe('1 seat holder');
-  });
-
   it('recovers cleanly on retry after a failure: error clears, real count comes back', async () => {
     const impl = vi
       .fn()

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -224,7 +224,8 @@ describe('GroupSeatHoldersDrawerComponent', () => {
   // which resets seatHolders() to null — so this retry path was already covered by the plain
   // `?? seatCount()` fallback even before the loading() guard existed. It's kept as a regression
   // test for the retry flow itself (error clears, correct count reappears), not as coverage for
-  // the loading() guard specifically — see the next test for the scenario that actually needs it.
+  // the loading() guard specifically — see "keeps the new row seatCount in the header while an
+  // org-switch refetch is in flight..." below for the scenario that actually needs it.
   it('recovers cleanly on retry after a failure: error clears, count comes back', async () => {
     const impl = vi
       .fn()
@@ -247,11 +248,14 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('1 seat');
   });
 
-  // The scenario the loading() guard actually protects: the drawer stays OPEN across an org
-  // switch (visible never goes false, so seatHolders() never resets to null). The cache rebuilds
-  // for the new orgUid and a real refetch starts, but toSignal keeps emitting the previous org's
-  // array until the new fetch resolves — without the loading() guard, displayedCount would read
-  // the stale previous-org row count instead of the new row's seatCount().
+  // Defensive coverage, not a currently-reachable path: org-groups.component.ts closes this
+  // drawer on every org switch (its orgUid$ subscription), so today a trigger change shouldn't
+  // arrive with the drawer still open. IF one ever did, the cache would rebuild for the new
+  // orgUid and start a real refetch, but toSignal keeps emitting the *previous* org's array until
+  // that fetch resolves — without the loading() guard, displayedCount would read the stale
+  // previous-org row count instead of the new row's seatCount(). Awaits stability twice: the
+  // orgUid write has to propagate through toObservable's effect before the switchMap/loading()
+  // write lands, and asserting after only one flush was observed to occasionally race ahead of it.
   it('keeps the new row seatCount in the header while an org-switch refetch is in flight, not the previous org roster length', async () => {
     const impl = vi
       .fn()
@@ -274,7 +278,13 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     fixture.componentRef.setInput('orgUid', 'org-2');
     await fixture.whenStable();
     fixture.detectChanges();
+    await fixture.whenStable();
+    fixture.detectChanges();
 
+    // The spinner is the deterministic signal that the refetch actually started (loading() true)
+    // before checking the header text it gates — the header assertion alone previously proved
+    // vulnerable to running ahead of that write.
+    expect(document.querySelector('.fa-spinner-third')).toBeTruthy();
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).toContain('9 seats');
     expect(document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent).not.toContain('3 seats');
   });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -5,6 +5,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
+import { PersonDetailDrawerService } from '@services/person-detail-drawer.service';
 import type { CommitteeMemberAssignment, CommitteeMemberPerson, OrgPeopleCommitteeMembersResponse } from '@lfx-one/shared/interfaces';
 import { NEVER, of, Subject, throwError } from 'rxjs';
 import { afterEach, describe, expect, it, vi } from 'vitest';
@@ -42,6 +43,7 @@ function response(assignments: CommitteeMemberAssignment[]): OrgPeopleCommitteeM
 describe('GroupSeatHoldersDrawerComponent', () => {
   let fixture: ComponentFixture<GroupSeatHoldersDrawerComponent>;
   let getCommitteeMembers: ReturnType<typeof vi.fn>;
+  let drawerOpen: ReturnType<typeof vi.fn>;
 
   // p-drawer renders into document.body, not the fixture host, and a previous test's overlay
   // otherwise survives into the next one — mirrors event-detail-drawer.component.spec.ts.
@@ -55,11 +57,17 @@ describe('GroupSeatHoldersDrawerComponent', () => {
 
   async function setup(impl: ReturnType<typeof vi.fn>): Promise<void> {
     getCommitteeMembers = impl;
+    drawerOpen = vi.fn();
 
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
       imports: [GroupSeatHoldersDrawerComponent],
-      providers: [{ provide: CommitteeMembersService, useValue: { getCommitteeMembers } }, provideNoopAnimations(), provideRouter([])],
+      providers: [
+        { provide: CommitteeMembersService, useValue: { getCommitteeMembers } },
+        { provide: PersonDetailDrawerService, useValue: { open: drawerOpen } },
+        provideNoopAnimations(),
+        provideRouter([]),
+      ],
     }).compileComponents();
 
     fixture = TestBed.createComponent(GroupSeatHoldersDrawerComponent);
@@ -85,8 +93,11 @@ describe('GroupSeatHoldersDrawerComponent', () => {
     return (document.querySelector('[data-testid="group-seat-holders-drawer-subtitle"]')?.textContent ?? '').replace(/\s+/g, ' ').trim();
   }
 
+  // `li[...]`, not the bare attribute selector — the per-row person button's testid
+  // ('group-seat-holder-person-{seatId}') shares the same prefix as the row's own
+  // ('group-seat-holder-{seatId}'), and an unscoped `^=` selector would match both.
   function rowNames(): string[] {
-    return Array.from(document.querySelectorAll('[data-testid^="group-seat-holder-"]')).map((li) => li.textContent?.trim() ?? '');
+    return Array.from(document.querySelectorAll('li[data-testid^="group-seat-holder-"]')).map((li) => li.textContent?.trim() ?? '');
   }
 
   function statusMessage(): string | null {
@@ -899,6 +910,105 @@ describe('GroupSeatHoldersDrawerComponent', () => {
       expect(document.activeElement).toBe(trigger);
 
       document.body.removeChild(trigger);
+    });
+  });
+
+  // Stacked person-detail drawer (GH-1780 follow-up) — training-employees-drawer's proven
+  // drawer-over-drawer precedent, adapted for the committee-members opener shape (pre-supplied
+  // governanceSeats, no personKey — these rows carry no warehouse personKey).
+  describe('person-detail drawer stacking', () => {
+    function personButton(seatId: string): HTMLElement | null {
+      return document.querySelector(`[data-testid="group-seat-holder-person-${seatId}"]`);
+    }
+
+    it("calls PersonDetailDrawerService.open once, with defaultTab 'governance' and the person's real email", async () => {
+      await setup(vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', person: person({ fullName: 'Jane Doe', email: 'jane@example.org' }) })]))));
+
+      await open('org-1', 'c-1');
+      personButton('s-1')!.click();
+
+      expect(drawerOpen).toHaveBeenCalledTimes(1);
+      expect(drawerOpen).toHaveBeenCalledWith(expect.objectContaining({ name: 'Jane Doe', defaultTab: 'governance', email: 'jane@example.org' }));
+    });
+
+    // The obvious implementation passes only the assignments for the open committee, so the
+    // Governance tab would show a single seat next to the same person showing every seat on the
+    // People page. this.cache.assignments$ (mirrored into fullOrgAssignments) already holds the
+    // org's full, unfiltered roster — the committee filter is applied downstream of it, not to it.
+    it("includes the person's seats from other committees, not just the one whose drawer is open", async () => {
+      await setup(
+        vi.fn().mockReturnValue(
+          of(
+            response([
+              assignment({
+                seatId: 's-1',
+                committeeUid: 'c-1',
+                committeeName: 'Steering Committee',
+                person: person({ fullName: 'Jane Doe', email: 'jane@example.org' }),
+              }),
+              assignment({
+                seatId: 's-2',
+                committeeUid: 'c-2',
+                committeeName: 'Storage Working Group',
+                person: person({ fullName: 'Jane Doe', email: 'jane@example.org' }),
+              }),
+            ])
+          )
+        )
+      );
+
+      await open('org-1', 'c-1');
+      personButton('s-1')!.click();
+
+      const call = drawerOpen.mock.calls[0][0];
+      expect(call.governanceSeats).toHaveLength(2);
+      expect(call.governanceSeats.map((s: { committeeName: string }) => s.committeeName).sort()).toEqual(
+        ['Steering Committee', 'Storage Working Group'].sort()
+      );
+    });
+
+    // Mirrors initSeatHolderVms()'s own grouping key: match by email when there is one, otherwise
+    // fall back to the clicked seat's own memberUid — two different blank-email people must never
+    // be bucketed together just because neither has an email.
+    it('matches a blank-email seat by memberUid, not merging it with a different blank-email person', async () => {
+      await setup(
+        vi
+          .fn()
+          .mockReturnValue(
+            of(
+              response([
+                assignment({ seatId: 's-1', memberUid: 'm-1', person: person({ fullName: 'Alex Kim', email: '' }) }),
+                assignment({ seatId: 's-2', memberUid: 'm-2', person: person({ fullName: 'Sam Lee', email: '' }) }),
+              ])
+            )
+          )
+      );
+
+      await open('org-1', 'c-1');
+      personButton('s-1')!.click();
+
+      const call = drawerOpen.mock.calls[0][0];
+      expect(call.name).toBe('Alex Kim');
+      expect(call.governanceSeats).toHaveLength(1);
+    });
+
+    it("renders no button for an 'Unknown member' row (no name and no email)", async () => {
+      await setup(
+        vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', person: person({ fullName: '', email: '', firstName: '', lastName: '' }) })])))
+      );
+
+      await open('org-1', 'c-1');
+
+      expect(personButton('s-1')).toBeNull();
+      expect(document.querySelector('[data-testid="group-seat-holder-s-1"]')?.textContent).toContain('Unknown member');
+    });
+
+    it("exposes a 'View details for {name}' accessible name on the button", async () => {
+      await setup(vi.fn().mockReturnValue(of(response([assignment({ seatId: 's-1', person: person({ fullName: 'Jane Doe' }) })]))));
+
+      await open('org-1', 'c-1');
+
+      expect(personButton('s-1')?.getAttribute('aria-label')).toBe('View details for Jane Doe');
     });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -823,6 +823,22 @@ describe('GroupSeatHoldersDrawerComponent', () => {
       expect(labelElement?.textContent?.trim()).toBe('Storage Working Group');
     });
 
+    // AT is specified to treat content outside an open aria-modal dialog's subtree as
+    // unreachable — a live region placed as a *sibling* of the dialog (however well-intentioned,
+    // e.g. to survive being torn down on close) would be unreliable for exactly the announcements
+    // it exists to make. Pins that the region stays inside, structurally, not just that its text
+    // is eventually correct.
+    it('keeps the live status region inside the dialog panel, not as a sibling of it', async () => {
+      await setup(vi.fn().mockReturnValue(of(response([]))));
+
+      await open('org-1', 'c-1');
+
+      const panel = dialogPanel();
+      const status = document.querySelector('[data-testid="group-seat-holders-drawer-status"]');
+      expect(status).toBeTruthy();
+      expect(panel?.contains(status)).toBe(true);
+    });
+
     it('moves focus into the panel on open, away from the element that triggered it', async () => {
       await setup(vi.fn().mockReturnValue(of(response([]))));
       const trigger = document.createElement('button');

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.spec.ts
@@ -839,6 +839,27 @@ describe('GroupSeatHoldersDrawerComponent', () => {
       expect(panel?.contains(status)).toBe(true);
     });
 
+    // contentRevealed must reset on every close, not just get set-then-immediately-reflipped by
+    // onDrawerShow() on the *next* open — otherwise a reopen's freshly-created status node would
+    // carry the stale "revealed" state from the previous open on its very first paint, exactly the
+    // freshly-inserted-content problem this whole mechanism exists to avoid. Checked synchronously
+    // right after the reopen's own render, before awaiting whenStable() again (which would let the
+    // afterNextRender hook fire and mask a broken reset).
+    it("re-mounts the status region empty on a reopen, not carrying over the previous open's revealed state", async () => {
+      await setup(vi.fn().mockReturnValue(of(response([]))));
+
+      await open('org-1', 'c-1');
+      expect(statusMessage()).toBe('0 seat holders loaded.');
+
+      fixture.componentRef.setInput('visible', false);
+      await fixture.whenStable();
+
+      fixture.componentRef.setInput('visible', true);
+      fixture.detectChanges();
+
+      expect(statusMessage()).toBe('');
+    });
+
     it('moves focus into the panel on open, away from the element that triggered it', async () => {
       await setup(vi.fn().mockReturnValue(of(response([]))));
       const trigger = document.createElement('button');

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -24,12 +24,11 @@ export class GroupSeatHoldersDrawerComponent {
   public readonly visible = model<boolean>(false);
   public readonly orgUid = input<string>('');
   public readonly committeeUid = input<string>('');
-  public readonly groupUid = input<string>('');
   public readonly groupName = input<string>('');
-  public readonly seatCount = input<number>(0);
 
   protected readonly loading = signal(false);
   protected readonly error = signal(false);
+  private readonly retryTick = signal(0);
 
   // getCommitteeMembers(orgUid) always drains the org's FULL, non-truncated committee roster —
   // there's no server-side committeeUid filter (committee-service's seats endpoint doesn't offer
@@ -41,27 +40,41 @@ export class GroupSeatHoldersDrawerComponent {
 
   private readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
 
-  // Number for the "N seat holders" header. Best-effort, not a strict person count in either
-  // branch: seatCount() (org_seat_count) collapses blank-email seats together server-side (see
-  // apps/lfx-one/src/server/services/org-lens-groups.service.ts's seenEmails), and
-  // seatHolders().length (one row per seat/role assignment) counts a person with two roles here
-  // as two. Shown null while loading — renders as a bare "Seat holders" placeholder rather than
-  // borrowing seatCount() as a stand-in that could visibly change once the real list arrives —
-  // and as seatCount() on error, since there's no real list at all in that state to fall back to.
-  protected readonly displayedCount: Signal<number | null> = computed(() => {
-    if (this.loading()) return null;
-    if (this.error()) return this.seatCount();
-    return this.seatHolders()?.length ?? null;
+  // Grouped by person (email, falling back to memberUid when blank) and sorted by display name —
+  // a person holding two roles on this committee renders as one row with both roles joined,
+  // instead of an identical avatar/name row repeated. This is also what keeps the header count
+  // (below) matching the row's own org_seat_count (distinct people, deduped by email
+  // server-side — see org-lens-groups.service.ts): both now count the same thing. Precomputes the
+  // voting-status pill class per row so the template stays a flat binding.
+  protected readonly seatHolderVms: Signal<CommitteeMemberSeatHolderVm[]> = computed(() => {
+    const byPerson = new Map<string, { assignment: CommitteeMemberAssignment; roles: string[] }>();
+    for (const a of this.seatHolders() ?? []) {
+      const key = a.person.email || a.memberUid;
+      const existing = byPerson.get(key);
+      if (existing) {
+        if (a.role && !existing.roles.includes(a.role)) existing.roles.push(a.role);
+      } else {
+        byPerson.set(key, { assignment: a, roles: a.role ? [a.role] : [] });
+      }
+    }
+    return Array.from(byPerson.values())
+      .map(({ assignment, roles }) => ({ ...assignment, role: roles.join(', '), votingStatusPillClass: votingStatusPillClass(assignment.votingStatus) }))
+      .sort((a, b) => (a.person.fullName || a.person.email).localeCompare(b.person.fullName || b.person.email));
   });
 
-  // Precomputes the voting-status pill class per row so the template stays a flat binding
-  // (no function call on every change-detection pass).
-  protected readonly seatHolderVms: Signal<CommitteeMemberSeatHolderVm[]> = computed(() =>
-    (this.seatHolders() ?? []).map((a) => ({ ...a, votingStatusPillClass: votingStatusPillClass(a.votingStatus) }))
-  );
+  // null while loading or on error — there's no trustworthy number to show in either case, so the
+  // header renders a bare "Seat holders" placeholder rather than asserting a count next to a
+  // spinner or an error message. The real, deduped-by-person row count otherwise.
+  protected readonly displayedCount: Signal<number | null> = computed(() => (this.loading() || this.error() ? null : this.seatHolderVms().length));
+
+  protected retry(): void {
+    this.retryTick.update((n) => n + 1);
+  }
 
   private initSeatHolders(): Signal<CommitteeMemberAssignment[] | null> {
-    const trigger$ = toObservable(computed(() => ({ visible: this.visible(), orgUid: this.orgUid(), committeeUid: this.committeeUid() })));
+    const trigger$ = toObservable(
+      computed(() => ({ visible: this.visible(), orgUid: this.orgUid(), committeeUid: this.committeeUid(), retryTick: this.retryTick() }))
+    );
 
     return toSignal(
       trigger$.pipe(
@@ -78,7 +91,8 @@ export class GroupSeatHoldersDrawerComponent {
                 catchError((err: unknown) => {
                   // Drop the cache — but only if it's still this orgUid's entry, so a fetch for a
                   // since-switched-to org can't be clobbered by a slower, now-stale failure — so the
-                  // next drawer open retries the fetch instead of replaying the same error forever.
+                  // next drawer open (or Try again click) retries the fetch instead of replaying the
+                  // same error forever.
                   if (this.cache?.orgUid === orgUid) {
                     this.cache = null;
                   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -43,11 +43,14 @@ export class GroupSeatHoldersDrawerComponent {
 
   // Filtered-list length once loaded, falling back to the row's precomputed seatCount() before
   // that — keeps the header in sync with the rendered rows (each row is one seat/assignment, same
-  // unit the header counts) instead of drifting from a separately-sourced number. The error()
-  // branch is excluded from that fallback: a failed fetch resolves seatHolders() to [] (not null,
-  // see the outer catchError below), which would otherwise read "0 seats" next to the error panel
-  // instead of the row's already-known count.
-  protected readonly displayedCount: Signal<number> = computed(() => (this.error() ? this.seatCount() : (this.seatHolders()?.length ?? this.seatCount())));
+  // unit the header counts) instead of drifting from a separately-sourced number. loading()/error()
+  // both bypass that fallback deliberately: a failed fetch (or a retry currently in flight after
+  // one) resolves seatHolders() to [] rather than null (see the outer catchError below), which
+  // would otherwise read "0 seats" next to the spinner or the error panel instead of the row's
+  // already-known count.
+  protected readonly displayedCount: Signal<number> = computed(() =>
+    this.loading() || this.error() ? this.seatCount() : (this.seatHolders()?.length ?? this.seatCount())
+  );
 
   // Precomputes the voting-status pill class per row so the template stays a flat binding
   // (no function call on every change-detection pass).

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -118,8 +118,7 @@ export class GroupSeatHoldersDrawerComponent {
     this.previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     this.titleRef()?.nativeElement.focus();
 
-    // Belt-and-braces, not the sole guarantee — initSeatHolders()'s !visible branch is what
-    // actually resets this for every close path (see contentRevealed's own comment).
+    // Belt-and-braces, not the sole guarantee — see contentRevealed's own comment.
     this.contentRevealed.set(false);
     this.revealRef?.destroy();
     this.revealRef = afterNextRender(() => this.contentRevealed.set(true), { injector: this.injector });
@@ -182,14 +181,13 @@ export class GroupSeatHoldersDrawerComponent {
             // Keeps the last-loaded state on screen through p-drawer's leave animation instead of
             // flashing to an empty result and a false "0 seat holders" announcement.
             //
-            // Also the one place every close path passes through, unlike (onHide) (see its own
-            // comment) — so it's where contentRevealed must reset, not onDrawerShow(). PrimeNG
-            // fires onShow from its animation-start callback, which runs *after* *ngIf="visible"
-            // has already inserted the live region for that open; resetting only in onDrawerShow()
-            // would leave a stale `true` from the previous open sitting on the node's very first
-            // paint on every reopen, exactly the "freshly-inserted node's initial text" problem
-            // contentRevealed exists to prevent.
+            // Also where contentRevealed resets — the one path every close goes through, unlike
+            // (onHide) (see its own comment). See contentRevealed's own comment for why. Destroys
+            // any pending reveal too, so an externally-driven close (no onHide) can't have its
+            // afterNextRender callback fire after this reset and re-set contentRevealed to true.
             this.contentRevealed.set(false);
+            this.revealRef?.destroy();
+            this.revealRef = null;
             return EMPTY;
           }
           if (!orgUid || !committeeUid) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -53,9 +53,12 @@ export class GroupSeatHoldersDrawerComponent {
   private readonly titleRef = viewChild<ElementRef<HTMLHeadingElement>>('titleRef');
   private previouslyFocusedElement: HTMLElement | null = null;
 
-  // Gates the live region's real text (see statusMessage()'s comment and the template) — starts
-  // false on every open so the freshly-mounted node's first paint is empty, then flips true after
-  // the next render so the real text arrives as a mutation on an already-painted node.
+  // Gates the live region's real text (see statusMessage()'s comment and the template). Reset to
+  // false on every close (initSeatHolders()'s !visible branch — the one path every close goes
+  // through), not on show: PrimeNG's onShow fires after *ngIf="visible" has already inserted the
+  // node for that open, so resetting only there would leave a stale `true` from the previous open
+  // sitting on the very first paint of every reopen. Flips true via afterNextRender() after the
+  // next render, so the real text always arrives as a mutation on an already-painted node.
   protected readonly contentRevealed = signal(false);
   private revealRef: AfterRenderRef | null = null;
 
@@ -115,6 +118,8 @@ export class GroupSeatHoldersDrawerComponent {
     this.previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     this.titleRef()?.nativeElement.focus();
 
+    // Belt-and-braces, not the sole guarantee — initSeatHolders()'s !visible branch is what
+    // actually resets this for every close path (see contentRevealed's own comment).
     this.contentRevealed.set(false);
     this.revealRef?.destroy();
     this.revealRef = afterNextRender(() => this.contentRevealed.set(true), { injector: this.injector });
@@ -173,9 +178,20 @@ export class GroupSeatHoldersDrawerComponent {
     return toSignal(
       trigger$.pipe(
         switchMap(({ visible, orgUid, committeeUid }) => {
-          // Keeps the last-loaded state on screen through p-drawer's leave animation instead of
-          // flashing to an empty result and a false "0 seat holders" announcement.
-          if (!visible) return EMPTY;
+          if (!visible) {
+            // Keeps the last-loaded state on screen through p-drawer's leave animation instead of
+            // flashing to an empty result and a false "0 seat holders" announcement.
+            //
+            // Also the one place every close path passes through, unlike (onHide) (see its own
+            // comment) — so it's where contentRevealed must reset, not onDrawerShow(). PrimeNG
+            // fires onShow from its animation-start callback, which runs *after* *ngIf="visible"
+            // has already inserted the live region for that open; resetting only in onDrawerShow()
+            // would leave a stale `true` from the previous open sitting on the node's very first
+            // paint on every reopen, exactly the "freshly-inserted node's initial text" problem
+            // contentRevealed exists to prevent.
+            this.contentRevealed.set(false);
+            return EMPTY;
+          }
           if (!orgUid || !committeeUid) {
             // Emits (unlike !visible above), so it resets loading/error itself — tap below only
             // clears loading on a real fetch emission, which this branch never reaches.

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -114,18 +114,12 @@ export class GroupSeatHoldersDrawerComponent {
     return toSignal(
       trigger$.pipe(
         switchMap(({ visible, orgUid, committeeUid }) => {
-          // p-drawer keeps the panel mounted through its ~150ms leave animation — emitting null
-          // the instant `visible` flips false would replace the roster with the empty state (and
-          // the live region with a false "0 seat holders" announcement) while the panel is still
-          // sliding out. EMPTY leaves the last-loaded state as-is; the next real open re-fetches.
+          // Keeps the last-loaded state on screen through p-drawer's leave animation instead of
+          // flashing to an empty result and a false "0 seat holders" announcement.
           if (!visible) return EMPTY;
           if (!orgUid || !committeeUid) {
-            // Unlike the !visible branch above, this one does emit — so it must clear loading/error
-            // itself. `tap` only clears `loading` on a real fetch emission (see below), so without
-            // this a drawer closed mid-fetch and then reopened with a still-missing identifier would
-            // render a permanent spinner instead of falling through to the empty state — a null
-            // `seatHolders` makes `seatHolderVms()` `[]`, which is the template's `length === 0`
-            // branch, a different state than the `loading`/`error`-gated blank header placeholder.
+            // Emits (unlike !visible above), so it resets loading/error itself — tap below only
+            // clears loading on a real fetch emission, which this branch never reaches.
             this.error.set(false);
             this.loading.set(false);
             return of(null);
@@ -160,12 +154,8 @@ export class GroupSeatHoldersDrawerComponent {
               this.error.set(true);
               return of([] as CommitteeMemberAssignment[]);
             }),
-            // tap, not finalize: finalize also fires on unsubscribe (switchMap tearing this down
-            // because the drawer closed mid-fetch), which would clear `loading` — with nothing yet
-            // in `seatHolders`, that renders the empty state and a false "0 seat holders"
-            // announcement during the very close animation the EMPTY guard above exists to protect.
-            // tap only runs on an actual emission (the map above, or catchError's fallback), so a
-            // closed-mid-fetch drawer keeps showing its spinner state until a real result arrives.
+            // tap, not finalize — finalize also fires on unsubscribe (a mid-fetch close), which
+            // would clear `loading` before any real result exists, defeating the EMPTY guard above.
             tap(() => this.loading.set(false))
           );
         })

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -5,7 +5,7 @@ import { Component, computed, inject, input, model, signal, type Signal } from '
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
-import { votingStatusPillClass } from '@lfx-one/shared/constants';
+import { isVotingStatus, votingStatusPillClass } from '@lfx-one/shared/constants';
 import type { CommitteeMemberAssignment, CommitteeMemberSeatHolderVm } from '@lfx-one/shared/interfaces';
 import { DrawerModule } from 'primeng/drawer';
 import { catchError, finalize, map, of, shareReplay, switchMap, throwError, type Observable } from 'rxjs';
@@ -40,27 +40,15 @@ export class GroupSeatHoldersDrawerComponent {
 
   private readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
 
-  // Grouped by person (email, falling back to memberUid when blank) and sorted by display name —
-  // a person holding two roles on this committee renders as one row with both roles joined,
-  // instead of an identical avatar/name row repeated. This is also what keeps the header count
-  // (below) matching the row's own org_seat_count (distinct people, deduped by email
-  // server-side — see org-lens-groups.service.ts): both now count the same thing. Precomputes the
-  // voting-status pill class per row so the template stays a flat binding.
-  protected readonly seatHolderVms: Signal<CommitteeMemberSeatHolderVm[]> = computed(() => {
-    const byPerson = new Map<string, { assignment: CommitteeMemberAssignment; roles: string[] }>();
-    for (const a of this.seatHolders() ?? []) {
-      const key = a.person.email || a.memberUid;
-      const existing = byPerson.get(key);
-      if (existing) {
-        if (a.role && !existing.roles.includes(a.role)) existing.roles.push(a.role);
-      } else {
-        byPerson.set(key, { assignment: a, roles: a.role ? [a.role] : [] });
-      }
-    }
-    return Array.from(byPerson.values())
-      .map(({ assignment, roles }) => ({ ...assignment, role: roles.join(', '), votingStatusPillClass: votingStatusPillClass(assignment.votingStatus) }))
-      .sort((a, b) => (a.person.fullName || a.person.email).localeCompare(b.person.fullName || b.person.email));
-  });
+  // Grouped by person and sorted by display name — a person holding two roles on this committee
+  // renders as one row with both roles joined, instead of an identical avatar/name row repeated.
+  // This also keeps the header count (below) matching the row's own org_seat_count (distinct
+  // people, deduped by email server-side — see org-lens-groups.service.ts) for the common case:
+  // seats that carry an email. It does NOT match for multiple blank-email seats on the same
+  // committee — org_seat_count collapses all of those into one server-side, while this groups
+  // each by memberUid instead (a shared bucket would merge unrelated people under one "Unknown
+  // member" row, which is worse than the rarer count mismatch it would avoid).
+  protected readonly seatHolderVms: Signal<CommitteeMemberSeatHolderVm[]> = this.initSeatHolderVms();
 
   // null while loading or on error — there's no trustworthy number to show in either case, so the
   // header renders a bare "Seat holders" placeholder rather than asserting a count next to a
@@ -69,6 +57,30 @@ export class GroupSeatHoldersDrawerComponent {
 
   protected retry(): void {
     this.retryTick.update((n) => n + 1);
+  }
+
+  private initSeatHolderVms(): Signal<CommitteeMemberSeatHolderVm[]> {
+    return computed(() => {
+      const byPerson = new Map<string, { assignment: CommitteeMemberAssignment; roles: string[] }>();
+      for (const a of this.seatHolders() ?? []) {
+        const key = a.person.email || a.memberUid;
+        const existing = byPerson.get(key);
+        if (!existing) {
+          byPerson.set(key, { assignment: a, roles: a.role ? [a.role] : [] });
+          continue;
+        }
+        if (a.role && !existing.roles.includes(a.role)) existing.roles.push(a.role);
+        // The merged row's other fields (voting status, seatId, ...) come from one representative
+        // assignment — prefer a voting one so the pill doesn't depend on upstream array order for
+        // a person holding both a voting and a non-voting seat on this committee.
+        if (!isVotingStatus(existing.assignment.votingStatus) && isVotingStatus(a.votingStatus)) {
+          existing.assignment = a;
+        }
+      }
+      return Array.from(byPerson.values())
+        .map(({ assignment, roles }) => ({ ...assignment, role: roles.join(', '), votingStatusPillClass: votingStatusPillClass(assignment.votingStatus) }))
+        .sort((a, b) => (a.person.fullName || a.person.email).localeCompare(b.person.fullName || b.person.email));
+    });
   }
 
   private initSeatHolders(): Signal<CommitteeMemberAssignment[] | null> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -43,13 +43,18 @@ export class GroupSeatHoldersDrawerComponent {
 
   // seatCount() (the row's org_seat_count) and this drawer's list count genuinely DIFFERENT
   // things: org_seat_count is distinct PEOPLE, deduped by email server-side (see
-  // org-lens-groups.service.ts), while seatHolders() is one row per SEAT/role assignment — a
-  // person holding two roles on this committee, or two blank-email seats, makes them disagree for
-  // real, not just "not loaded yet". So the header shows null (renders as a plain "Seat holders"
-  // placeholder, no number) while loading, rather than borrowing seatCount() as a stand-in that
-  // would visibly flip to a different, correct number once the real list arrives. seatCount() is
-  // used only in the error state, as the best available number when there's no real list at all to
-  // compare it against — and there's no later "settle" moment there for it to disagree with.
+  // apps/lfx-one/src/server/services/org-lens-groups.service.ts's seenEmails/org_seat_count —
+  // NOT the client-side org-lens-groups.service.ts under app/shared/services, which is a thin
+  // HTTP wrapper with no dedup logic), while seatHolders() is one row per SEAT/role assignment —
+  // a person holding two roles on this committee, or two blank-email seats, makes them disagree
+  // for real, not just "not loaded yet". Two consequences, handled differently:
+  //  - While loading, the header shows null (renders as a plain "Seat holders" placeholder, no
+  //    number) rather than borrowing seatCount() as a stand-in that would visibly flip to a
+  //    different, correct number once the real list arrives.
+  //  - Once settled, the header can legitimately show a different number than the row's own
+  //    "N seats" badge (both visible on screen at once, drawer over the row) — the template's
+  //    "seat assignments" wording (not "seats") is deliberate, to keep that from reading as the
+  //    same count getting it wrong.
   protected readonly displayedCount: Signal<number | null> = computed(() => {
     if (this.loading()) return null;
     if (this.error()) return this.seatCount();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -8,7 +8,7 @@ import { CommitteeMembersService } from '@modules/dashboards/org/org-people/serv
 import { votingStatusPillClass, votingStatusRank } from '@lfx-one/shared/constants';
 import type { CommitteeMemberAssignment, CommitteeMemberSeatHolderVm } from '@lfx-one/shared/interfaces';
 import { DrawerModule } from 'primeng/drawer';
-import { catchError, EMPTY, finalize, map, of, shareReplay, switchMap, throwError, type Observable } from 'rxjs';
+import { catchError, EMPTY, map, of, shareReplay, switchMap, tap, throwError, type Observable } from 'rxjs';
 
 import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
 
@@ -150,7 +150,13 @@ export class GroupSeatHoldersDrawerComponent {
               this.error.set(true);
               return of([] as CommitteeMemberAssignment[]);
             }),
-            finalize(() => this.loading.set(false))
+            // tap, not finalize: finalize also fires on unsubscribe (switchMap tearing this down
+            // because the drawer closed mid-fetch), which would clear `loading` — with nothing yet
+            // in `seatHolders`, that renders the empty state and a false "0 seat holders"
+            // announcement during the very close animation the EMPTY guard above exists to protect.
+            // tap only runs on an actual emission (the map above, or catchError's fallback), so a
+            // closed-mid-fetch drawer keeps showing its spinner state until a real result arrives.
+            tap(() => this.loading.set(false))
           );
         })
       ),

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -123,7 +123,9 @@ export class GroupSeatHoldersDrawerComponent {
             // Unlike the !visible branch above, this one does emit — so it must clear loading/error
             // itself. `tap` only clears `loading` on a real fetch emission (see below), so without
             // this a drawer closed mid-fetch and then reopened with a still-missing identifier would
-            // render a permanent spinner instead of the blank placeholder this branch intends.
+            // render a permanent spinner instead of falling through to the empty state, which is
+            // what a null `seatHolders` actually renders here (`displayedCount` is 0, not null — the
+            // `loading`/`error`-gated blank placeholder is a different state than this one).
             this.error.set(false);
             this.loading.set(false);
             return of(null);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -43,8 +43,11 @@ export class GroupSeatHoldersDrawerComponent {
 
   // Filtered-list length once loaded, falling back to the row's precomputed seatCount() before
   // that — keeps the header in sync with the rendered rows (each row is one seat/assignment, same
-  // unit the header counts) instead of drifting from a separately-sourced number.
-  protected readonly displayedCount: Signal<number> = computed(() => this.seatHolders()?.length ?? this.seatCount());
+  // unit the header counts) instead of drifting from a separately-sourced number. The error()
+  // branch is excluded from that fallback: a failed fetch resolves seatHolders() to [] (not null,
+  // see the outer catchError below), which would otherwise read "0 seats" next to the error panel
+  // instead of the row's already-known count.
+  protected readonly displayedCount: Signal<number> = computed(() => (this.error() ? this.seatCount() : (this.seatHolders()?.length ?? this.seatCount())));
 
   // Precomputes the voting-status pill class per row so the template stays a flat binding
   // (no function call on every change-detection pass).

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -123,9 +123,9 @@ export class GroupSeatHoldersDrawerComponent {
             // Unlike the !visible branch above, this one does emit — so it must clear loading/error
             // itself. `tap` only clears `loading` on a real fetch emission (see below), so without
             // this a drawer closed mid-fetch and then reopened with a still-missing identifier would
-            // render a permanent spinner instead of falling through to the empty state, which is
-            // what a null `seatHolders` actually renders here (`displayedCount` is 0, not null — the
-            // `loading`/`error`-gated blank placeholder is a different state than this one).
+            // render a permanent spinner instead of falling through to the empty state — a null
+            // `seatHolders` makes `seatHolderVms()` `[]`, which is the template's `length === 0`
+            // branch, a different state than the `loading`/`error`-gated blank header placeholder.
             this.error.set(false);
             this.loading.set(false);
             return of(null);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -45,13 +45,14 @@ export class GroupSeatHoldersDrawerComponent {
   // that — keeps the header in sync with the rendered rows (each row is one seat/assignment, same
   // unit the header counts) instead of drifting from a separately-sourced number. loading() and
   // error() each bypass that fallback for a different reason:
-  //  - loading(): a trigger change that keeps the drawer open (an org switch — see the cache
-  //    rebuild below) starts a real refetch, but toSignal keeps emitting the LAST value until the
-  //    new one arrives — seatHolders() briefly holds the *previous* org's array, not null. Without
-  //    this guard the header would show the previous org's seat count under the new org's name.
-  //    (A committeeUid-only change replays synchronously from the cached shareReplay and never
-  //    observably hits this window; closing the drawer resets seatHolders() to null via the
-  //    `!visible` branch below, which the ?? fallback already handles on its own.)
+  //  - loading(): defensive. org-groups.component.ts closes this drawer on every org switch
+  //    (see its orgUid$ subscription), so today a trigger change should never arrive with the
+  //    drawer still open. If one ever did — an org switch while visible stays true — toSignal
+  //    would keep emitting the *previous* org's array until the new fetch resolves (see the cache
+  //    rebuild below), and without this guard the header would show that stale count under the
+  //    new org's name. (A committeeUid-only change replays synchronously from the cached
+  //    shareReplay and never observably hits this window; closing the drawer resets seatHolders()
+  //    to null via the `!visible` branch below, which the ?? fallback already handles on its own.)
   //  - error(): the outer catchError resolves seatHolders() to [] (not null), which would
   //    otherwise read "0 seats" next to the error panel instead of the row's already-known count.
   protected readonly displayedCount: Signal<number> = computed(() =>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -41,18 +41,13 @@ export class GroupSeatHoldersDrawerComponent {
 
   private readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
 
-  // seatCount() (the row's org_seat_count) and this drawer's list count genuinely DIFFERENT
-  // things: org_seat_count is distinct PEOPLE, deduped by email server-side (see
-  // apps/lfx-one/src/server/services/org-lens-groups.service.ts's seenEmails/org_seat_count —
-  // NOT the client-side org-lens-groups.service.ts under app/shared/services, which is a thin
-  // HTTP wrapper with no dedup logic), while seatHolders() is one row per SEAT/role assignment —
-  // a person holding two roles on this committee, or two blank-email seats, makes them disagree
-  // for real, not just "not loaded yet". The template branches its wording on which case this is,
-  // not just on the number, so the label always matches the actual unit: "N seat holders" only
-  // for the error-state seatCount() (genuinely distinct people), "N seat assignments" once loaded
-  // for real (this list, one row per role — "seat holders" would misdescribe a person who holds
-  // two roles as two seat holders), and a bare "Seat holders" placeholder while loading (no number
-  // at all, so there's nothing to mislabel).
+  // Number for the "N seat holders" header. Best-effort, not a strict person count in either
+  // branch: seatCount() (org_seat_count) collapses blank-email seats together server-side (see
+  // apps/lfx-one/src/server/services/org-lens-groups.service.ts's seenEmails), and
+  // seatHolders().length (one row per seat/role assignment) counts a person with two roles here
+  // as two. Shown null while loading — renders as a bare "Seat holders" placeholder rather than
+  // borrowing seatCount() as a stand-in that could visibly change once the real list arrives —
+  // and as seatCount() on error, since there's no real list at all in that state to fall back to.
   protected readonly displayedCount: Signal<number | null> = computed(() => {
     if (this.loading()) return null;
     if (this.error()) return this.seatCount();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -47,14 +47,12 @@ export class GroupSeatHoldersDrawerComponent {
   // NOT the client-side org-lens-groups.service.ts under app/shared/services, which is a thin
   // HTTP wrapper with no dedup logic), while seatHolders() is one row per SEAT/role assignment —
   // a person holding two roles on this committee, or two blank-email seats, makes them disagree
-  // for real, not just "not loaded yet". Two consequences, handled differently:
-  //  - While loading, the header shows null (renders as a plain "Seat holders" placeholder, no
-  //    number) rather than borrowing seatCount() as a stand-in that would visibly flip to a
-  //    different, correct number once the real list arrives.
-  //  - Once settled, the header can legitimately show a different number than the row's own
-  //    "N seats" badge (both visible on screen at once, drawer over the row) — the template's
-  //    "seat assignments" wording (not "seats") is deliberate, to keep that from reading as the
-  //    same count getting it wrong.
+  // for real, not just "not loaded yet". The template branches its wording on which case this is,
+  // not just on the number, so the label always matches the actual unit: "N seat holders" only
+  // for the error-state seatCount() (genuinely distinct people), "N seat assignments" once loaded
+  // for real (this list, one row per role — "seat holders" would misdescribe a person who holds
+  // two roles as two seat holders), and a bare "Seat holders" placeholder while loading (no number
+  // at all, so there's nothing to mislabel).
   protected readonly displayedCount: Signal<number | null> = computed(() => {
     if (this.loading()) return null;
     if (this.error()) return this.seatCount();

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -41,23 +41,20 @@ export class GroupSeatHoldersDrawerComponent {
 
   private readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
 
-  // Filtered-list length once loaded, falling back to the row's precomputed seatCount() before
-  // that — keeps the header in sync with the rendered rows (each row is one seat/assignment, same
-  // unit the header counts) instead of drifting from a separately-sourced number. loading() and
-  // error() each bypass that fallback for a different reason:
-  //  - loading(): defensive. org-groups.component.ts closes this drawer on every org switch
-  //    (see its orgUid$ subscription), so today a trigger change should never arrive with the
-  //    drawer still open. If one ever did — an org switch while visible stays true — toSignal
-  //    would keep emitting the *previous* org's array until the new fetch resolves (see the cache
-  //    rebuild below), and without this guard the header would show that stale count under the
-  //    new org's name. (A committeeUid-only change replays synchronously from the cached
-  //    shareReplay and never observably hits this window; closing the drawer resets seatHolders()
-  //    to null via the `!visible` branch below, which the ?? fallback already handles on its own.)
-  //  - error(): the outer catchError resolves seatHolders() to [] (not null), which would
-  //    otherwise read "0 seats" next to the error panel instead of the row's already-known count.
-  protected readonly displayedCount: Signal<number> = computed(() =>
-    this.loading() || this.error() ? this.seatCount() : (this.seatHolders()?.length ?? this.seatCount())
-  );
+  // seatCount() (the row's org_seat_count) and this drawer's list count genuinely DIFFERENT
+  // things: org_seat_count is distinct PEOPLE, deduped by email server-side (see
+  // org-lens-groups.service.ts), while seatHolders() is one row per SEAT/role assignment — a
+  // person holding two roles on this committee, or two blank-email seats, makes them disagree for
+  // real, not just "not loaded yet". So the header shows null (renders as a plain "Seat holders"
+  // placeholder, no number) while loading, rather than borrowing seatCount() as a stand-in that
+  // would visibly flip to a different, correct number once the real list arrives. seatCount() is
+  // used only in the error state, as the best available number when there's no real list at all to
+  // compare it against — and there's no later "settle" moment there for it to disagree with.
+  protected readonly displayedCount: Signal<number | null> = computed(() => {
+    if (this.loading()) return null;
+    if (this.error()) return this.seatCount();
+    return this.seatHolders()?.length ?? null;
+  });
 
   // Precomputes the voting-status pill class per row so the template stays a flat binding
   // (no function call on every change-detection pass).

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -5,22 +5,12 @@ import { Component, computed, inject, input, model, signal, type Signal } from '
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
-import { isVotingStatus, votingStatusPillClass } from '@lfx-one/shared/constants';
+import { votingStatusPillClass, votingStatusRank } from '@lfx-one/shared/constants';
 import type { CommitteeMemberAssignment, CommitteeMemberSeatHolderVm } from '@lfx-one/shared/interfaces';
 import { DrawerModule } from 'primeng/drawer';
 import { catchError, finalize, map, of, shareReplay, switchMap, throwError, type Observable } from 'rxjs';
 
 import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
-
-// Ranks a merged row's representative voting status deterministically (not by upstream array
-// order): a true voting status (isVotingStatus) outranks "Observer", which outranks
-// non-voting/blank. "Observer" is a real, distinct value in this domain — isVotingStatus() alone
-// would fold it in with true voting statuses (see org-people/helpers/governance-seats.helper.ts,
-// which preserves the same distinction for a different drawer).
-function votingStatusRank(status: string | null | undefined): number {
-  if ((status ?? '').trim().toLowerCase() === 'observer') return 1;
-  return isVotingStatus(status) ? 2 : 0;
-}
 
 /** Org Lens — Groups list drill-down (GH-1780). Shows the org's seat holders for one committee, without leaving the roster. */
 @Component({
@@ -65,6 +55,18 @@ export class GroupSeatHoldersDrawerComponent {
   // spinner or an error message. The real, deduped-by-person row count otherwise.
   protected readonly displayedCount: Signal<number | null> = computed(() => (this.loading() || this.error() ? null : this.seatHolderVms().length));
 
+  // Text for a single persistent sr-only live region (see the template) — covers all three state
+  // transitions, including the ones a "Try again" click can cause (failure -> success, or failure
+  // -> failure again). A screen-reader user gets no other signal that anything changed: the button
+  // they activated is removed from the DOM either way, and the visible content between a repeat
+  // error and a fresh one looks identical without reading it.
+  protected readonly statusMessage: Signal<string> = computed(() => {
+    if (this.loading()) return 'Loading seat holders…';
+    if (this.error()) return 'Unable to load seat holders.';
+    const count = this.seatHolderVms().length;
+    return `${count} seat holder${count === 1 ? '' : 's'} loaded.`;
+  });
+
   protected retry(): void {
     this.retryTick.update((n) => n + 1);
   }
@@ -73,9 +75,11 @@ export class GroupSeatHoldersDrawerComponent {
     return computed(() => {
       const byPerson = new Map<string, { assignment: CommitteeMemberAssignment; roles: string[] }>();
       for (const a of this.seatHolders() ?? []) {
-        // Normalized the same way the server dedupes org_seat_count (trim + lowercase), so two
-        // seats for the same person that differ only in email casing/whitespace still merge.
-        const key = a.person.email.trim().toLowerCase() || a.memberUid;
+        // The BFF mapper already normalizes person.email to trim+lowercase before this drawer
+        // ever sees it (committee-seat-assignment.mapper.ts) — this repeats that normalization
+        // defensively, mirroring the server's own org_seat_count dedupe key, so a future mapper
+        // change can't silently split one person's seats into separate rows here.
+        const key = (a.person.email ?? '').trim().toLowerCase() || a.memberUid;
         const existing = byPerson.get(key);
         if (!existing) {
           byPerson.set(key, { assignment: a, roles: a.role ? [a.role] : [] });
@@ -83,9 +87,10 @@ export class GroupSeatHoldersDrawerComponent {
         }
         if (a.role && !existing.roles.includes(a.role)) existing.roles.push(a.role);
         // The merged row's other fields (voting status, seatId, ...) come from one representative
-        // assignment — rank by votingStatusRank rather than array order, so the pill can't flip
-        // between loads for a person holding two differently-ranked seats on this committee.
-        if (votingStatusRank(a.votingStatus) > votingStatusRank(existing.assignment.votingStatus)) {
+        // assignment — rank by the shared VOTING_STATUS_PRIORITY order (lower is better) rather
+        // than array order, so the pill can't flip between loads for a person holding two
+        // differently-ranked seats on this committee.
+        if (votingStatusRank(a.votingStatus) < votingStatusRank(existing.assignment.votingStatus)) {
           existing.assignment = a;
         }
       }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -8,7 +8,7 @@ import { CommitteeMembersService } from '@modules/dashboards/org/org-people/serv
 import { votingStatusPillClass, votingStatusRank } from '@lfx-one/shared/constants';
 import type { CommitteeMemberAssignment, CommitteeMemberSeatHolderVm } from '@lfx-one/shared/interfaces';
 import { DrawerModule } from 'primeng/drawer';
-import { catchError, finalize, map, of, shareReplay, switchMap, throwError, type Observable } from 'rxjs';
+import { catchError, EMPTY, finalize, map, of, shareReplay, switchMap, throwError, type Observable } from 'rxjs';
 
 import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
 
@@ -95,7 +95,13 @@ export class GroupSeatHoldersDrawerComponent {
         }
       }
       return Array.from(byPerson.values())
-        .map(({ assignment, roles }) => ({ ...assignment, role: roles.join(', '), votingStatusPillClass: votingStatusPillClass(assignment.votingStatus) }))
+        .map(({ assignment, roles }) => ({
+          ...assignment,
+          // Sorted so the label can't flip between loads based on upstream seat ordering — the
+          // same determinism the voting-status pill above already gets from votingStatusRank.
+          role: [...roles].sort((a, b) => a.localeCompare(b)).join(', '),
+          votingStatusPillClass: votingStatusPillClass(assignment.votingStatus),
+        }))
         .sort((a, b) => (a.person.fullName || a.person.email).localeCompare(b.person.fullName || b.person.email));
     });
   }
@@ -108,7 +114,12 @@ export class GroupSeatHoldersDrawerComponent {
     return toSignal(
       trigger$.pipe(
         switchMap(({ visible, orgUid, committeeUid }) => {
-          if (!visible || !orgUid || !committeeUid) return of(null);
+          // p-drawer keeps the panel mounted through its ~150ms leave animation — emitting null
+          // the instant `visible` flips false would replace the roster with the empty state (and
+          // the live region with a false "0 seat holders" announcement) while the panel is still
+          // sliding out. EMPTY leaves the last-loaded state as-is; the next real open re-fetches.
+          if (!visible) return EMPTY;
+          if (!orgUid || !committeeUid) return of(null);
           this.error.set(false);
           this.loading.set(true);
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -6,7 +6,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
 import { votingStatusPillClass } from '@lfx-one/shared/constants';
-import type { CommitteeMemberAssignment } from '@lfx-one/shared/interfaces';
+import type { CommitteeMemberAssignment, CommitteeMemberSeatHolderVm } from '@lfx-one/shared/interfaces';
 import { DrawerModule } from 'primeng/drawer';
 import { catchError, finalize, map, of, shareReplay, switchMap, throwError, type Observable } from 'rxjs';
 
@@ -30,16 +30,27 @@ export class GroupSeatHoldersDrawerComponent {
 
   protected readonly loading = signal(false);
   protected readonly error = signal(false);
-  protected readonly votingStatusPillClass = votingStatusPillClass;
 
   // getCommitteeMembers(orgUid) always drains the org's FULL, non-truncated committee roster —
   // there's no server-side committeeUid filter (committee-service's seats endpoint doesn't offer
   // one). The OSPO persona this drawer serves opens it for several groups in one sitting, so a
-  // fresh fetch per open would re-trigger that full drain every time — cache the observable per
-  // orgUid (stable for the page's lifetime) and just re-filter it client-side on each open.
-  private assignments$: Observable<CommitteeMemberAssignment[]> | null = null;
+  // fresh fetch per open would re-trigger that full drain every time — cache the observable, keyed
+  // by orgUid so an in-place org switch (OrgGroupsComponent isn't destroyed/recreated on switch,
+  // see its orgUid$ subscription) rebuilds it instead of replaying the previous org's roster.
+  private cache: { orgUid: string; assignments$: Observable<CommitteeMemberAssignment[]> } | null = null;
 
-  protected readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
+  private readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
+
+  // Filtered-list length once loaded, falling back to the row's precomputed seatCount() before
+  // that — keeps the header in sync with the rendered rows (each row is one seat/assignment, same
+  // unit the header counts) instead of drifting from a separately-sourced number.
+  protected readonly displayedCount: Signal<number> = computed(() => this.seatHolders()?.length ?? this.seatCount());
+
+  // Precomputes the voting-status pill class per row so the template stays a flat binding
+  // (no function call on every change-detection pass).
+  protected readonly seatHolderVms: Signal<CommitteeMemberSeatHolderVm[]> = computed(() =>
+    (this.seatHolders() ?? []).map((a) => ({ ...a, votingStatusPillClass: votingStatusPillClass(a.votingStatus) }))
+  );
 
   private initSeatHolders(): Signal<CommitteeMemberAssignment[] | null> {
     const trigger$ = toObservable(computed(() => ({ visible: this.visible(), orgUid: this.orgUid(), committeeUid: this.committeeUid() })));
@@ -51,22 +62,29 @@ export class GroupSeatHoldersDrawerComponent {
           this.error.set(false);
           this.loading.set(true);
 
-          if (!this.assignments$) {
-            this.assignments$ = this.committeeMembersService.getCommitteeMembers(orgUid).pipe(
-              map((response) => response.assignments),
-              catchError((err: unknown) => {
-                // Drop the cache on failure so the next drawer open retries the fetch instead of
-                // replaying the same error forever.
-                this.assignments$ = null;
-                return throwError(() => err);
-              }),
-              shareReplay(1)
-            );
+          if (!this.cache || this.cache.orgUid !== orgUid) {
+            this.cache = {
+              orgUid,
+              assignments$: this.committeeMembersService.getCommitteeMembers(orgUid).pipe(
+                map((response) => response.assignments),
+                catchError((err: unknown) => {
+                  // Drop the cache — but only if it's still this orgUid's entry, so a fetch for a
+                  // since-switched-to org can't be clobbered by a slower, now-stale failure — so the
+                  // next drawer open retries the fetch instead of replaying the same error forever.
+                  if (this.cache?.orgUid === orgUid) {
+                    this.cache = null;
+                  }
+                  return throwError(() => err);
+                }),
+                shareReplay(1)
+              ),
+            };
           }
 
-          return this.assignments$.pipe(
+          return this.cache.assignments$.pipe(
             map((assignments) => assignments.filter((a) => a.committeeUid === committeeUid)),
-            catchError(() => {
+            catchError((err: unknown) => {
+              console.error('Failed to load group seat holders:', err);
               this.error.set(true);
               return of([] as CommitteeMemberAssignment[]);
             }),

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -119,7 +119,15 @@ export class GroupSeatHoldersDrawerComponent {
           // the live region with a false "0 seat holders" announcement) while the panel is still
           // sliding out. EMPTY leaves the last-loaded state as-is; the next real open re-fetches.
           if (!visible) return EMPTY;
-          if (!orgUid || !committeeUid) return of(null);
+          if (!orgUid || !committeeUid) {
+            // Unlike the !visible branch above, this one does emit — so it must clear loading/error
+            // itself. `tap` only clears `loading` on a real fetch emission (see below), so without
+            // this a drawer closed mid-fetch and then reopened with a still-missing identifier would
+            // render a permanent spinner instead of the blank placeholder this branch intends.
+            this.error.set(false);
+            this.loading.set(false);
+            return of(null);
+          }
           this.error.set(false);
           this.loading.set(true);
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -19,6 +19,7 @@ import {
 } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
+import { toDrawerGovernanceSeats } from '@modules/dashboards/org/org-people/helpers/governance-seats.helper';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
 import { votingStatusPillClass, votingStatusRank } from '@lfx-one/shared/constants';
 import type { CommitteeMemberAssignment, CommitteeMemberSeatHolderVm } from '@lfx-one/shared/interfaces';
@@ -26,6 +27,7 @@ import { DrawerModule } from 'primeng/drawer';
 import { catchError, EMPTY, map, of, shareReplay, switchMap, tap, throwError, type Observable } from 'rxjs';
 
 import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
+import { PersonDetailDrawerService } from '@services/person-detail-drawer.service';
 
 /** Org Lens — Groups list drill-down (GH-1780). Shows the org's seat holders for one committee, without leaving the roster. */
 @Component({
@@ -35,6 +37,7 @@ import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.c
 })
 export class GroupSeatHoldersDrawerComponent {
   private readonly committeeMembersService = inject(CommitteeMembersService);
+  private readonly personDetailDrawer = inject(PersonDetailDrawerService);
   private readonly platformId = inject(PLATFORM_ID);
   private readonly injector = inject(Injector);
 
@@ -69,6 +72,13 @@ export class GroupSeatHoldersDrawerComponent {
   // by orgUid so an in-place org switch (OrgGroupsComponent isn't destroyed/recreated on switch,
   // see its orgUid$ subscription) rebuilds it instead of replaying the previous org's roster.
   private cache: { orgUid: string; assignments$: Observable<CommitteeMemberAssignment[]> } | null = null;
+
+  // The org's full, unfiltered roster — same array cache.assignments$ resolves to, mirrored into a
+  // signal so onPersonClick() can read it synchronously (a click handler can't await an Observable).
+  // Populated by the same cache-building tap() below, so it's never stale relative to `cache` and
+  // never re-fetches on its own. Used to find a clicked person's seats on every committee they hold,
+  // not just the one whose drawer is open — see onPersonClick()'s comment for why that matters.
+  private readonly fullOrgAssignments = signal<CommitteeMemberAssignment[]>([]);
 
   private readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
 
@@ -105,6 +115,35 @@ export class GroupSeatHoldersDrawerComponent {
 
   protected retry(): void {
     this.retryTick.update((n) => n + 1);
+  }
+
+  // Opens the shared person-detail drawer stacked on top of this one (drawer-over-drawer — proven
+  // by training-employees-drawer, no "close this drawer first" dance needed since [modal]="true"
+  // gives both drawers their own focus trap). Governance seats are the person's FULL org roster,
+  // not just this committee's assignments filtered to committeeUid — a row here is one committee by
+  // construction, but the same person likely holds seats on others, and the drawer's Governance tab
+  // is meant to show all of them, matching what the People page's own opener does for the same
+  // person. fullOrgAssignments (not seatHolders/seatHolderVms, both committeeUid-filtered) is the
+  // one place this component already holds that full list.
+  protected onPersonClick(vm: CommitteeMemberSeatHolderVm): void {
+    const normalizedEmail = (vm.person.email ?? '').trim().toLowerCase();
+    // Mirrors initSeatHolderVms()'s own grouping key: match by email when there is one, otherwise
+    // fall back to this exact seat's memberUid — never bucket two blank-email people together.
+    const seats = this.fullOrgAssignments().filter((a) =>
+      normalizedEmail ? (a.person.email ?? '').trim().toLowerCase() === normalizedEmail : a.memberUid === vm.memberUid
+    );
+    // vm.person.email is the grouping key and can itself be blank — source the real email from
+    // whichever seat actually carries one, mirroring committee-members.component.ts's onPersonClick.
+    const email = seats.find((a) => a.person.email)?.person.email;
+    this.personDetailDrawer.open({
+      name: vm.person.fullName,
+      title: vm.person.jobTitle,
+      initials: vm.person.initials,
+      avatarUrl: vm.person.avatarUrl,
+      defaultTab: 'governance',
+      governanceSeats: toDrawerGovernanceSeats(seats),
+      email,
+    });
   }
 
   // PrimeNG's p-drawer doesn't move focus into the panel on open or restore it on close — it only
@@ -205,6 +244,7 @@ export class GroupSeatHoldersDrawerComponent {
               orgUid,
               assignments$: this.committeeMembersService.getCommitteeMembers(orgUid).pipe(
                 map((response) => response.assignments),
+                tap((assignments) => this.fullOrgAssignments.set(assignments)),
                 catchError((err: unknown) => {
                   // Drop the cache — but only if it's still this orgUid's entry, so a fetch for a
                   // since-switched-to org can't be clobbered by a slower, now-stale failure — so the

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -1,7 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Component, computed, inject, input, model, signal, type Signal } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { Component, computed, ElementRef, inject, input, model, PLATFORM_ID, signal, viewChild, type Signal } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
@@ -20,6 +21,7 @@ import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.c
 })
 export class GroupSeatHoldersDrawerComponent {
   private readonly committeeMembersService = inject(CommitteeMembersService);
+  private readonly platformId = inject(PLATFORM_ID);
 
   public readonly visible = model<boolean>(false);
   public readonly orgUid = input<string>('');
@@ -29,6 +31,12 @@ export class GroupSeatHoldersDrawerComponent {
   protected readonly loading = signal(false);
   protected readonly error = signal(false);
   private readonly retryTick = signal(0);
+
+  // The drawer's real panel is PrimeNG-managed and moved to document.body (appendTo: 'body'), so
+  // it isn't reachable as a child of this component's own host element — this is a template ref
+  // into our own #header ng-template (which PrimeNG embeds into that panel), not a DOM query.
+  private readonly titleRef = viewChild<ElementRef<HTMLHeadingElement>>('titleRef');
+  private previouslyFocusedElement: HTMLElement | null = null;
 
   // getCommitteeMembers(orgUid) always drains the org's FULL, non-truncated committee roster —
   // there's no server-side committeeUid filter (committee-service's seats endpoint doesn't offer
@@ -69,6 +77,26 @@ export class GroupSeatHoldersDrawerComponent {
 
   protected retry(): void {
     this.retryTick.update((n) => n + 1);
+  }
+
+  // PrimeNG's p-drawer doesn't move focus into the panel on open or restore it on close — it only
+  // traps Tab/Shift+Tab once focus is already inside (pFocusTrap, applied unconditionally on its
+  // container). Captures the triggering element before moving focus in, so it can be restored on
+  // (onHide) — which fires for Escape and the close button, not for an externally-driven close
+  // (e.g. `visible.set(false)` on an org switch), where "restore focus to the trigger" wouldn't
+  // mean anything since the org, and likely the trigger itself, has changed.
+  protected onDrawerShow(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    this.previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+    this.titleRef()?.nativeElement.focus();
+  }
+
+  protected onDrawerHide(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    if (this.previouslyFocusedElement?.isConnected) {
+      this.previouslyFocusedElement.focus();
+    }
+    this.previouslyFocusedElement = null;
   }
 
   private initSeatHolderVms(): Signal<CommitteeMemberSeatHolderVm[]> {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -63,11 +63,14 @@ export class GroupSeatHoldersDrawerComponent {
   // spinner or an error message. The real, deduped-by-person row count otherwise.
   protected readonly displayedCount: Signal<number | null> = computed(() => (this.loading() || this.error() ? null : this.seatHolderVms().length));
 
-  // Text for a single persistent sr-only live region (see the template) — covers all three state
-  // transitions, including the ones a "Try again" click can cause (failure -> success, or failure
-  // -> failure again). A screen-reader user gets no other signal that anything changed: the button
-  // they activated is removed from the DOM either way, and the visible content between a repeat
-  // error and a fresh one looks identical without reading it.
+  // Text for the persistent sr-only live region (see the template, mounted as a sibling of
+  // <p-drawer> so it outlives every open/close and every internal @if branch — including while
+  // `visible` is false during the close animation, matching seatHolderVms/displayedCount's own
+  // "preserve last state through close" behavior above, not just the drawer's visible content).
+  // Covers all three state transitions, including the ones a "Try again" click can cause (failure
+  // -> success, or failure -> failure again) — the button the user activated is removed from the
+  // DOM either way, and the visible content between a repeat error and a fresh one looks identical
+  // without reading it.
   protected readonly statusMessage: Signal<string> = computed(() => {
     if (this.loading()) return 'Loading seat holders…';
     if (this.error()) return 'Unable to load seat holders.';

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -75,9 +75,10 @@ export class GroupSeatHoldersDrawerComponent {
 
   // The org's full, unfiltered roster — same array cache.assignments$ resolves to, mirrored into a
   // signal so onPersonClick() can read it synchronously (a click handler can't await an Observable).
-  // Populated by the same cache-building tap() below, so it's never stale relative to `cache` and
-  // never re-fetches on its own. Used to find a clicked person's seats on every committee they hold,
-  // not just the one whose drawer is open — see onPersonClick()'s comment for why that matters.
+  // Populated by the same cache-building tap() below, guarded there against a superseded org's
+  // request landing late (see that tap's comment) — never re-fetches on its own. Used to find a
+  // clicked person's seats on every committee they hold, not just the one whose drawer is open — see
+  // onPersonClick()'s comment for why that matters.
   private readonly fullOrgAssignments = signal<CommitteeMemberAssignment[]>([]);
 
   private readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
@@ -201,10 +202,10 @@ export class GroupSeatHoldersDrawerComponent {
           ...assignment,
           // Sorted so the label can't flip between loads based on upstream seat ordering — the
           // same determinism the voting-status pill above already gets from votingStatusRank.
-          role: [...roles].sort((a, b) => a.localeCompare(b)).join(', '),
+          role: [...roles].sort((a, b) => a.localeCompare(b, 'en-US')).join(', '),
           votingStatusPillClass: votingStatusPillClass(assignment.votingStatus),
         }))
-        .sort((a, b) => (a.person.fullName || a.person.email).localeCompare(b.person.fullName || b.person.email));
+        .sort((a, b) => (a.person.fullName || a.person.email).localeCompare(b.person.fullName || b.person.email, 'en-US'));
     });
   }
 
@@ -240,17 +241,26 @@ export class GroupSeatHoldersDrawerComponent {
           this.loading.set(true);
 
           if (!this.cache || this.cache.orgUid !== orgUid) {
-            this.cache = {
+            // Captured by reference so both callbacks below can check they're still the live cache
+            // entry — not just the same orgUid. shareReplay(1)'s default refCount:false keeps a
+            // superseded org's request subscribed even after switchMap moves on, and an orgUid-only
+            // check is defeated by an A→B→A sequence: the first A's in-flight request can still land
+            // after the roster has been rebuilt for a reborn A (same orgUid, a different entry).
+            // Guards the success write here too, not just the error drop below — previously only the
+            // error path was guarded, so a superseded org's roster could silently overwrite
+            // fullOrgAssignments after a fast switch, corrupting onPersonClick()'s governanceSeats for
+            // a person the visible list still attributes to the current org.
+            const entry: NonNullable<typeof this.cache> = {
               orgUid,
               assignments$: this.committeeMembersService.getCommitteeMembers(orgUid).pipe(
                 map((response) => response.assignments),
-                tap((assignments) => this.fullOrgAssignments.set(assignments)),
+                tap((assignments) => {
+                  if (this.cache === entry) this.fullOrgAssignments.set(assignments);
+                }),
                 catchError((err: unknown) => {
-                  // Drop the cache — but only if it's still this orgUid's entry, so a fetch for a
-                  // since-switched-to org can't be clobbered by a slower, now-stale failure — so the
-                  // next drawer open (or Try again click) retries the fetch instead of replaying the
-                  // same error forever.
-                  if (this.cache?.orgUid === orgUid) {
+                  // Retries on the next drawer open (or Try again click) instead of replaying the same
+                  // error forever — but only if this failure is still live; see the entry comment above.
+                  if (this.cache === entry) {
                     this.cache = null;
                   }
                   return throwError(() => err);
@@ -258,6 +268,7 @@ export class GroupSeatHoldersDrawerComponent {
                 shareReplay(1)
               ),
             };
+            this.cache = entry;
           }
 
           return this.cache.assignments$.pipe(

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -1,0 +1,80 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, input, model, signal, type Signal } from '@angular/core';
+import { toObservable, toSignal } from '@angular/core/rxjs-interop';
+import { RouterLink } from '@angular/router';
+import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
+import { votingStatusPillClass } from '@lfx-one/shared/constants';
+import type { CommitteeMemberAssignment } from '@lfx-one/shared/interfaces';
+import { DrawerModule } from 'primeng/drawer';
+import { catchError, finalize, map, of, shareReplay, switchMap, throwError, type Observable } from 'rxjs';
+
+import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
+
+/** Org Lens — Groups list drill-down (GH-1780). Shows the org's seat holders for one committee, without leaving the roster. */
+@Component({
+  selector: 'lfx-group-seat-holders-drawer',
+  imports: [DrawerModule, PersonAvatarComponent, RouterLink],
+  templateUrl: './group-seat-holders-drawer.component.html',
+})
+export class GroupSeatHoldersDrawerComponent {
+  private readonly committeeMembersService = inject(CommitteeMembersService);
+
+  public readonly visible = model<boolean>(false);
+  public readonly orgUid = input<string>('');
+  public readonly committeeUid = input<string>('');
+  public readonly groupUid = input<string>('');
+  public readonly groupName = input<string>('');
+  public readonly seatCount = input<number>(0);
+
+  protected readonly loading = signal(false);
+  protected readonly error = signal(false);
+  protected readonly votingStatusPillClass = votingStatusPillClass;
+
+  // getCommitteeMembers(orgUid) always drains the org's FULL, non-truncated committee roster —
+  // there's no server-side committeeUid filter (committee-service's seats endpoint doesn't offer
+  // one). The OSPO persona this drawer serves opens it for several groups in one sitting, so a
+  // fresh fetch per open would re-trigger that full drain every time — cache the observable per
+  // orgUid (stable for the page's lifetime) and just re-filter it client-side on each open.
+  private assignments$: Observable<CommitteeMemberAssignment[]> | null = null;
+
+  protected readonly seatHolders: Signal<CommitteeMemberAssignment[] | null> = this.initSeatHolders();
+
+  private initSeatHolders(): Signal<CommitteeMemberAssignment[] | null> {
+    const trigger$ = toObservable(computed(() => ({ visible: this.visible(), orgUid: this.orgUid(), committeeUid: this.committeeUid() })));
+
+    return toSignal(
+      trigger$.pipe(
+        switchMap(({ visible, orgUid, committeeUid }) => {
+          if (!visible || !orgUid || !committeeUid) return of(null);
+          this.error.set(false);
+          this.loading.set(true);
+
+          if (!this.assignments$) {
+            this.assignments$ = this.committeeMembersService.getCommitteeMembers(orgUid).pipe(
+              map((response) => response.assignments),
+              catchError((err: unknown) => {
+                // Drop the cache on failure so the next drawer open retries the fetch instead of
+                // replaying the same error forever.
+                this.assignments$ = null;
+                return throwError(() => err);
+              }),
+              shareReplay(1)
+            );
+          }
+
+          return this.assignments$.pipe(
+            map((assignments) => assignments.filter((a) => a.committeeUid === committeeUid)),
+            catchError(() => {
+              this.error.set(true);
+              return of([] as CommitteeMemberAssignment[]);
+            }),
+            finalize(() => this.loading.set(false))
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -2,7 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 import { isPlatformBrowser } from '@angular/common';
-import { Component, computed, ElementRef, inject, input, model, PLATFORM_ID, signal, viewChild, type Signal } from '@angular/core';
+import {
+  afterNextRender,
+  type AfterRenderRef,
+  Component,
+  computed,
+  ElementRef,
+  inject,
+  input,
+  Injector,
+  model,
+  PLATFORM_ID,
+  signal,
+  viewChild,
+  type Signal,
+} from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RouterLink } from '@angular/router';
 import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
@@ -22,6 +36,7 @@ import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.c
 export class GroupSeatHoldersDrawerComponent {
   private readonly committeeMembersService = inject(CommitteeMembersService);
   private readonly platformId = inject(PLATFORM_ID);
+  private readonly injector = inject(Injector);
 
   public readonly visible = model<boolean>(false);
   public readonly orgUid = input<string>('');
@@ -37,6 +52,12 @@ export class GroupSeatHoldersDrawerComponent {
   // into our own #header ng-template (which PrimeNG embeds into that panel), not a DOM query.
   private readonly titleRef = viewChild<ElementRef<HTMLHeadingElement>>('titleRef');
   private previouslyFocusedElement: HTMLElement | null = null;
+
+  // Gates the live region's real text (see statusMessage()'s comment and the template) — starts
+  // false on every open so the freshly-mounted node's first paint is empty, then flips true after
+  // the next render so the real text arrives as a mutation on an already-painted node.
+  protected readonly contentRevealed = signal(false);
+  private revealRef: AfterRenderRef | null = null;
 
   // getCommitteeMembers(orgUid) always drains the org's FULL, non-truncated committee roster —
   // there's no server-side committeeUid filter (committee-service's seats endpoint doesn't offer
@@ -63,14 +84,15 @@ export class GroupSeatHoldersDrawerComponent {
   // spinner or an error message. The real, deduped-by-person row count otherwise.
   protected readonly displayedCount: Signal<number | null> = computed(() => (this.loading() || this.error() ? null : this.seatHolderVms().length));
 
-  // Text for the persistent sr-only live region (see the template, mounted as a sibling of
-  // <p-drawer> so it outlives every open/close and every internal @if branch — including while
-  // `visible` is false during the close animation, matching seatHolderVms/displayedCount's own
-  // "preserve last state through close" behavior above, not just the drawer's visible content).
-  // Covers all three state transitions, including the ones a "Try again" click can cause (failure
-  // -> success, or failure -> failure again) — the button the user activated is removed from the
-  // DOM either way, and the visible content between a repeat error and a fresh one looks identical
-  // without reading it.
+  // Text for the sr-only live region (see the template). Lives inside <p-drawer>'s content
+  // deliberately, not hoisted out — the panel is aria-modal="true", and AT is specified to treat
+  // content outside an open modal's subtree as unreachable, so a sibling region would be
+  // unreliable in a different way than the problem it would fix. Being inside means this node is
+  // destroyed and recreated on every open (see contentRevealed's comment for how that's handled).
+  // Once revealed, covers all three state transitions, including the ones a "Try again" click can
+  // cause (failure -> success, or failure -> failure again) — the button the user activated is
+  // removed from the DOM either way, and the visible content between a repeat error and a fresh
+  // one looks identical without reading it.
   protected readonly statusMessage: Signal<string> = computed(() => {
     if (this.loading()) return 'Loading seat holders…';
     if (this.error()) return 'Unable to load seat holders.';
@@ -92,10 +114,16 @@ export class GroupSeatHoldersDrawerComponent {
     if (!isPlatformBrowser(this.platformId)) return;
     this.previouslyFocusedElement = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     this.titleRef()?.nativeElement.focus();
+
+    this.contentRevealed.set(false);
+    this.revealRef?.destroy();
+    this.revealRef = afterNextRender(() => this.contentRevealed.set(true), { injector: this.injector });
   }
 
   protected onDrawerHide(): void {
     if (!isPlatformBrowser(this.platformId)) return;
+    this.revealRef?.destroy();
+    this.revealRef = null;
     if (this.previouslyFocusedElement?.isConnected) {
       this.previouslyFocusedElement.focus();
     }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -12,6 +12,16 @@ import { catchError, finalize, map, of, shareReplay, switchMap, throwError, type
 
 import { PersonAvatarComponent } from '@components/person-avatar/person-avatar.component';
 
+// Ranks a merged row's representative voting status deterministically (not by upstream array
+// order): a true voting status (isVotingStatus) outranks "Observer", which outranks
+// non-voting/blank. "Observer" is a real, distinct value in this domain — isVotingStatus() alone
+// would fold it in with true voting statuses (see org-people/helpers/governance-seats.helper.ts,
+// which preserves the same distinction for a different drawer).
+function votingStatusRank(status: string | null | undefined): number {
+  if ((status ?? '').trim().toLowerCase() === 'observer') return 1;
+  return isVotingStatus(status) ? 2 : 0;
+}
+
 /** Org Lens — Groups list drill-down (GH-1780). Shows the org's seat holders for one committee, without leaving the roster. */
 @Component({
   selector: 'lfx-group-seat-holders-drawer',
@@ -63,7 +73,9 @@ export class GroupSeatHoldersDrawerComponent {
     return computed(() => {
       const byPerson = new Map<string, { assignment: CommitteeMemberAssignment; roles: string[] }>();
       for (const a of this.seatHolders() ?? []) {
-        const key = a.person.email || a.memberUid;
+        // Normalized the same way the server dedupes org_seat_count (trim + lowercase), so two
+        // seats for the same person that differ only in email casing/whitespace still merge.
+        const key = a.person.email.trim().toLowerCase() || a.memberUid;
         const existing = byPerson.get(key);
         if (!existing) {
           byPerson.set(key, { assignment: a, roles: a.role ? [a.role] : [] });
@@ -71,9 +83,9 @@ export class GroupSeatHoldersDrawerComponent {
         }
         if (a.role && !existing.roles.includes(a.role)) existing.roles.push(a.role);
         // The merged row's other fields (voting status, seatId, ...) come from one representative
-        // assignment — prefer a voting one so the pill doesn't depend on upstream array order for
-        // a person holding both a voting and a non-voting seat on this committee.
-        if (!isVotingStatus(existing.assignment.votingStatus) && isVotingStatus(a.votingStatus)) {
+        // assignment — rank by votingStatusRank rather than array order, so the pill can't flip
+        // between loads for a person holding two differently-ranked seats on this committee.
+        if (votingStatusRank(a.votingStatus) > votingStatusRank(existing.assignment.votingStatus)) {
           existing.assignment = a;
         }
       }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/components/group-seat-holders-drawer/group-seat-holders-drawer.component.ts
@@ -43,11 +43,17 @@ export class GroupSeatHoldersDrawerComponent {
 
   // Filtered-list length once loaded, falling back to the row's precomputed seatCount() before
   // that — keeps the header in sync with the rendered rows (each row is one seat/assignment, same
-  // unit the header counts) instead of drifting from a separately-sourced number. loading()/error()
-  // both bypass that fallback deliberately: a failed fetch (or a retry currently in flight after
-  // one) resolves seatHolders() to [] rather than null (see the outer catchError below), which
-  // would otherwise read "0 seats" next to the spinner or the error panel instead of the row's
-  // already-known count.
+  // unit the header counts) instead of drifting from a separately-sourced number. loading() and
+  // error() each bypass that fallback for a different reason:
+  //  - loading(): a trigger change that keeps the drawer open (an org switch — see the cache
+  //    rebuild below) starts a real refetch, but toSignal keeps emitting the LAST value until the
+  //    new one arrives — seatHolders() briefly holds the *previous* org's array, not null. Without
+  //    this guard the header would show the previous org's seat count under the new org's name.
+  //    (A committeeUid-only change replays synchronously from the cached shareReplay and never
+  //    observably hits this window; closing the drawer resets seatHolders() to null via the
+  //    `!visible` branch below, which the ?? fallback already handles on its own.)
+  //  - error(): the outer catchError resolves seatHolders() to [] (not null), which would
+  //    otherwise read "0 seats" next to the error panel instead of the row's already-known count.
   protected readonly displayedCount: Signal<number> = computed(() =>
     this.loading() || this.error() ? this.seatCount() : (this.seatHolders()?.length ?? this.seatCount())
   );

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -343,4 +343,9 @@
     [orgUid]="orgUid()"
     [committeeUid]="selectedGroup()?.uid ?? ''"
     [groupName]="selectedGroup()?.name ?? ''" />
+
+  <!-- Not rendered by lfx-group-seat-holders-drawer itself — the training precedent mounts the
+       person drawer from the page, not the inner drawer, so it isn't torn down/rebuilt on every
+       seat-holders open/close and there's exactly one instance for the whole page to stack on. -->
+  <lfx-person-detail-drawer />
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -293,11 +293,21 @@
                     [attr.data-testid]="'org-groups-item-class-chip-' + group.uid" />
                 </div>
 
-                <!-- Seat count -->
-                <div class="flex items-center gap-1 shrink-0 text-sm text-gray-600" [attr.data-testid]="'org-groups-item-seats-' + group.uid">
+                <!-- Seat-holders drawer trigger. Sits inside the pointer-events-none content wrapper
+                     above, so it needs the same pointer-events-auto relative z-10 treatment as the
+                     foundation link (see the row's stretched-link comment) to be independently
+                     clickable/tabbable without firing the row's /groups/:uid link. Its own
+                     aria-label keeps it distinguishable from both the row's ariaLabel and the
+                     foundation link's projectAriaLabel. -->
+                <button
+                  type="button"
+                  class="pointer-events-auto relative z-10 flex shrink-0 items-center gap-1 rounded text-sm text-gray-600 transition-colors hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
+                  [attr.aria-label]="'View seat holders for ' + group.name"
+                  [attr.data-testid]="'org-groups-item-seats-' + group.uid"
+                  (click)="onSeatHoldersClick(group)">
                   <i class="fa-light fa-user-check text-gray-400 text-xs" aria-hidden="true"></i>
                   <span>{{ group.org_seat_count }}</span>
-                </div>
+                </button>
 
                 <i class="fa-light fa-chevron-right text-gray-300 text-xs shrink-0" aria-hidden="true"></i>
               </div>
@@ -330,4 +340,12 @@
       </div>
     }
   </ng-template>
+
+  <lfx-group-seat-holders-drawer
+    [(visible)]="seatHoldersDrawerVisible"
+    [orgUid]="orgUid()"
+    [committeeUid]="selectedGroup()?.uid ?? ''"
+    [groupUid]="selectedGroup()?.uid ?? ''"
+    [groupName]="selectedGroup()?.name ?? ''"
+    [seatCount]="selectedGroup()?.org_seat_count ?? 0" />
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -293,12 +293,9 @@
                     [attr.data-testid]="'org-groups-item-class-chip-' + group.uid" />
                 </div>
 
-                <!-- Seat-holders drawer trigger. Sits inside the pointer-events-none content wrapper
-                     above, so it needs the same pointer-events-auto relative z-10 treatment as the
-                     foundation link (see the row's stretched-link comment) to be independently
-                     clickable/tabbable without firing the row's /groups/:uid link. Its own
-                     aria-label keeps it distinguishable from both the row's ariaLabel and the
-                     foundation link's projectAriaLabel. -->
+                <!-- Seat-holders drawer trigger — needs the same pointer-events-auto/relative/z-10
+                     treatment as the foundation link (see the row's stretched-link comment) to stay
+                     independently clickable without firing the row's /groups/:uid link. -->
                 <button
                   type="button"
                   class="pointer-events-auto relative z-10 flex shrink-0 items-center gap-1 rounded text-sm text-gray-600 transition-colors hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -302,7 +302,7 @@
                 <button
                   type="button"
                   class="pointer-events-auto relative z-10 flex shrink-0 items-center gap-1 rounded text-sm text-gray-600 transition-colors hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
-                  [attr.aria-label]="'View seat holders for ' + group.name"
+                  [attr.aria-label]="'View ' + group.org_seat_count + ' seat holders for ' + group.name"
                   [attr.data-testid]="'org-groups-item-seats-' + group.uid"
                   (click)="onSeatHoldersClick(group)">
                   <i class="fa-light fa-user-check text-gray-400 text-xs" aria-hidden="true"></i>
@@ -345,7 +345,5 @@
     [(visible)]="seatHoldersDrawerVisible"
     [orgUid]="orgUid()"
     [committeeUid]="selectedGroup()?.uid ?? ''"
-    [groupUid]="selectedGroup()?.uid ?? ''"
-    [groupName]="selectedGroup()?.name ?? ''"
-    [seatCount]="selectedGroup()?.org_seat_count ?? 0" />
+    [groupName]="selectedGroup()?.name ?? ''" />
 </main>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -302,7 +302,7 @@
                 <button
                   type="button"
                   class="pointer-events-auto relative z-10 flex shrink-0 items-center gap-1 rounded text-sm text-gray-600 transition-colors hover:text-blue-700 focus-visible:outline focus-visible:outline-2 focus-visible:outline-blue-500"
-                  [attr.aria-label]="'View ' + group.org_seat_count + ' seat holders for ' + group.name"
+                  [attr.aria-label]="group.seatHoldersTriggerAriaLabel"
                   [attr.data-testid]="'org-groups-item-seats-' + group.uid"
                   (click)="onSeatHoldersClick(group)">
                   <i class="fa-light fa-user-check text-gray-400 text-xs" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -13,6 +13,7 @@ import { OrgLensGroupsService } from '@services/org-lens-groups.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
+import { PersonDetailDrawerService } from '@services/person-detail-drawer.service';
 import { Tooltip } from 'primeng/tooltip';
 import { NEVER, Observable, of, Subject, throwError } from 'rxjs';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
@@ -54,6 +55,29 @@ async function render(options: RenderOptions = {}): Promise<Rendered> {
       // CommitteeMembersService needs a stub too — otherwise DI resolves the real service, which
       // needs a real HttpClient this testing module never provides.
       { provide: CommitteeMembersService, useValue: { getCommitteeMembers: () => NEVER } },
+      // <lfx-person-detail-drawer /> (GH-1780 follow-up — stacked on the seat-holders drawer) is
+      // also unconditionally mounted. It reads the service's full signal surface, not just `open`
+      // (see person-detail-drawer.component.ts/.html) — a bare `{ open: vi.fn() }` stub, sufficient
+      // for group-seat-holders-drawer.component.spec.ts's own tests of the click-to-open call, would
+      // leave every other read undefined and throw at render. Kept closed throughout (isOpen false,
+      // activeContext null) — none of this file's tests click a seat-holder row deep enough to open
+      // it; that behavior is covered by group-seat-holders-drawer.component.spec.ts itself.
+      {
+        provide: PersonDetailDrawerService,
+        useValue: {
+          isOpen: signal(false),
+          activeContext: signal(null),
+          activeTab: signal('events'),
+          loading: signal(false),
+          error: signal(false),
+          emailError: signal(false),
+          detail: signal(null),
+          companyEmails: signal([]),
+          open: vi.fn(),
+          close: vi.fn(),
+          setTab: vi.fn(),
+        },
+      },
       // p-drawer's synthetic `@panelState` animation throws NG05105 without this — mirrors
       // event-detail-drawer.component.spec.ts. Needed once a test actually opens the seat-holders
       // drawer (setting seatHoldersDrawerVisible true), not for tests that never do.
@@ -906,6 +930,24 @@ describe('OrgGroupsComponent stat strip', () => {
         { provide: PersonaService, useValue: { personaLoaded: signal(orgLoaded) } },
         { provide: OrgLensGroupsService, useValue: { getGroups: vi.fn(getGroups) } },
         { provide: CommitteeMembersService, useValue: { getCommitteeMembers: () => NEVER } },
+        // See the top-level render()'s own comment — <lfx-person-detail-drawer /> needs the full
+        // signal surface, not just `open`.
+        {
+          provide: PersonDetailDrawerService,
+          useValue: {
+            isOpen: signal(false),
+            activeContext: signal(null),
+            activeTab: signal('events'),
+            loading: signal(false),
+            error: signal(false),
+            emailError: signal(false),
+            detail: signal(null),
+            companyEmails: signal([]),
+            open: vi.fn(),
+            close: vi.fn(),
+            setTab: vi.fn(),
+          },
+        },
       ],
     }).compileComponents();
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -6,6 +6,7 @@ import { By } from '@angular/platform-browser';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import type { Account, OrgDropdownOption, OrgLensGroupSummary, OrgLensGroupsResponse } from '@lfx-one/shared/interfaces';
+import { CommitteeMembersService } from '@modules/dashboards/org/org-people/services/committee-members.service';
 import { AccountContextService } from '@services/account-context.service';
 import { OrgLensGroupsService } from '@services/org-lens-groups.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
@@ -48,6 +49,10 @@ async function render(options: RenderOptions = {}): Promise<Rendered> {
       { provide: OrgRoleGrantsService, useValue: { loaded: signal(true) } },
       { provide: PersonaService, useValue: { personaLoaded: signal(true) } },
       { provide: OrgLensGroupsService, useValue: { getGroups } },
+      // The seat-holders drawer (GH-1780) is unconditionally mounted, so its injected
+      // CommitteeMembersService needs a stub too — otherwise DI resolves the real service, which
+      // needs a real HttpClient this testing module never provides.
+      { provide: CommitteeMembersService, useValue: { getCommitteeMembers: () => NEVER } },
       // Real Router (via provideRouter) so the rendered group rows' [routerLink] (createUrlTree, etc.)
       // keeps working; only `navigate` — the method the URL-sync subscription actually calls — is spied on.
       provideRouter([]),
@@ -844,6 +849,7 @@ describe('OrgGroupsComponent stat strip', () => {
         { provide: OrgRoleGrantsService, useValue: { loaded: signal(orgLoaded) } },
         { provide: PersonaService, useValue: { personaLoaded: signal(orgLoaded) } },
         { provide: OrgLensGroupsService, useValue: { getGroups: vi.fn(getGroups) } },
+        { provide: CommitteeMembersService, useValue: { getCommitteeMembers: () => NEVER } },
       ],
     }).compileComponents();
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -34,6 +34,31 @@ interface Rendered {
   selectedAccount: WritableSignal<Account>;
 }
 
+// <lfx-person-detail-drawer /> (GH-1780 follow-up — stacked on the seat-holders drawer) is
+// unconditionally mounted, so its injected PersonDetailDrawerService needs the full signal surface
+// it reads, not just `open` (see person-detail-drawer.component.ts/.html) — a bare `{ open: vi.fn() }`
+// stub, sufficient for group-seat-holders-drawer.component.spec.ts's own tests of the click-to-open
+// call, would leave every other read undefined and throw at render. Kept closed throughout (isOpen
+// false, activeContext null) — neither testing module in this file clicks a seat-holder row deep
+// enough to open it; that behavior is covered by group-seat-holders-drawer.component.spec.ts itself.
+// A shared factory, not one literal reused by reference, so each test module gets its own vi.fn()
+// spies instead of accumulating call history across tests.
+function personDrawerStub() {
+  return {
+    isOpen: signal(false),
+    activeContext: signal(null),
+    activeTab: signal('events'),
+    loading: signal(false),
+    error: signal(false),
+    emailError: signal(false),
+    detail: signal(null),
+    companyEmails: signal([]),
+    open: vi.fn(),
+    close: vi.fn(),
+    setTab: vi.fn(),
+  };
+}
+
 async function render(options: RenderOptions = {}): Promise<Rendered> {
   const { accountName = 'Acme Motors, Inc.', orgNavigationLoaded = true, getGroups = () => of(emptyGroupsResponse()), queryParams = {} } = options;
 
@@ -55,29 +80,7 @@ async function render(options: RenderOptions = {}): Promise<Rendered> {
       // CommitteeMembersService needs a stub too — otherwise DI resolves the real service, which
       // needs a real HttpClient this testing module never provides.
       { provide: CommitteeMembersService, useValue: { getCommitteeMembers: () => NEVER } },
-      // <lfx-person-detail-drawer /> (GH-1780 follow-up — stacked on the seat-holders drawer) is
-      // also unconditionally mounted. It reads the service's full signal surface, not just `open`
-      // (see person-detail-drawer.component.ts/.html) — a bare `{ open: vi.fn() }` stub, sufficient
-      // for group-seat-holders-drawer.component.spec.ts's own tests of the click-to-open call, would
-      // leave every other read undefined and throw at render. Kept closed throughout (isOpen false,
-      // activeContext null) — none of this file's tests click a seat-holder row deep enough to open
-      // it; that behavior is covered by group-seat-holders-drawer.component.spec.ts itself.
-      {
-        provide: PersonDetailDrawerService,
-        useValue: {
-          isOpen: signal(false),
-          activeContext: signal(null),
-          activeTab: signal('events'),
-          loading: signal(false),
-          error: signal(false),
-          emailError: signal(false),
-          detail: signal(null),
-          companyEmails: signal([]),
-          open: vi.fn(),
-          close: vi.fn(),
-          setTab: vi.fn(),
-        },
-      },
+      { provide: PersonDetailDrawerService, useValue: personDrawerStub() },
       // p-drawer's synthetic `@panelState` animation throws NG05105 without this — mirrors
       // event-detail-drawer.component.spec.ts. Needed once a test actually opens the seat-holders
       // drawer (setting seatHoldersDrawerVisible true), not for tests that never do.
@@ -930,24 +933,7 @@ describe('OrgGroupsComponent stat strip', () => {
         { provide: PersonaService, useValue: { personaLoaded: signal(orgLoaded) } },
         { provide: OrgLensGroupsService, useValue: { getGroups: vi.fn(getGroups) } },
         { provide: CommitteeMembersService, useValue: { getCommitteeMembers: () => NEVER } },
-        // See the top-level render()'s own comment — <lfx-person-detail-drawer /> needs the full
-        // signal surface, not just `open`.
-        {
-          provide: PersonDetailDrawerService,
-          useValue: {
-            isOpen: signal(false),
-            activeContext: signal(null),
-            activeTab: signal('events'),
-            loading: signal(false),
-            error: signal(false),
-            emailError: signal(false),
-            detail: signal(null),
-            companyEmails: signal([]),
-            open: vi.fn(),
-            close: vi.fn(),
-            setTab: vi.fn(),
-          },
-        },
+        { provide: PersonDetailDrawerService, useValue: personDrawerStub() },
       ],
     }).compileComponents();
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -3,6 +3,7 @@
 
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { ActivatedRoute, convertToParamMap, provideRouter, Router } from '@angular/router';
 import { BEHAVIORAL_CLASS_CONFIG, COMMITTEE_LABEL } from '@lfx-one/shared/constants';
 import type { Account, OrgDropdownOption, OrgLensGroupSummary, OrgLensGroupsResponse } from '@lfx-one/shared/interfaces';
@@ -53,6 +54,10 @@ async function render(options: RenderOptions = {}): Promise<Rendered> {
       // CommitteeMembersService needs a stub too — otherwise DI resolves the real service, which
       // needs a real HttpClient this testing module never provides.
       { provide: CommitteeMembersService, useValue: { getCommitteeMembers: () => NEVER } },
+      // p-drawer's synthetic `@panelState` animation throws NG05105 without this — mirrors
+      // event-detail-drawer.component.spec.ts. Needed once a test actually opens the seat-holders
+      // drawer (setting seatHoldersDrawerVisible true), not for tests that never do.
+      provideNoopAnimations(),
       // Real Router (via provideRouter) so the rendered group rows' [routerLink] (createUrlTree, etc.)
       // keeps working; only `navigate` — the method the URL-sync subscription actually calls — is spied on.
       provideRouter([]),
@@ -138,6 +143,23 @@ function typeOptions(fixture: ComponentFixture<OrgGroupsComponent>): OrgDropdown
 
 function foundationOptions(fixture: ComponentFixture<OrgGroupsComponent>): OrgDropdownOption[] {
   return (fixture.componentInstance as unknown as { foundationOptions: () => OrgDropdownOption[] }).foundationOptions();
+}
+
+/** seatHoldersDrawerVisible/selectedGroup are `protected` — same cast convention as filterForm above. */
+function seatHoldersDrawerState(fixture: ComponentFixture<OrgGroupsComponent>): { visible: boolean; selectedGroupUid: string | null } {
+  const instance = fixture.componentInstance as unknown as {
+    seatHoldersDrawerVisible: () => boolean;
+    selectedGroup: () => { uid: string } | null;
+  };
+  return { visible: instance.seatHoldersDrawerVisible(), selectedGroupUid: instance.selectedGroup()?.uid ?? null };
+}
+
+/** Row seat-count testid doubles as the drawer trigger — see org-groups.component.html. */
+function clickSeatHoldersTrigger(fixture: ComponentFixture<OrgGroupsComponent>, uid: string): void {
+  const el = fixture.nativeElement.querySelector(`[data-testid="org-groups-item-seats-${uid}"]`) as HTMLButtonElement | null;
+  if (!el) throw new Error(`no seat-holders trigger rendered for ${uid}`);
+  el.click();
+  fixture.detectChanges();
 }
 
 /** Lets the real `debounceTime(150)` on the filter form settle, then flushes change detection. */
@@ -450,6 +472,21 @@ describe('OrgGroupsComponent', () => {
     await flushFilterChange(fixture);
 
     expect(renderedItemUids(fixture)).toEqual(['g1', 'g2', 'g3', 'g4']);
+  });
+
+  // OrgGroupsComponent isn't destroyed on an in-place org switch, so a seat-holders drawer left
+  // open (or its selected group left set) would otherwise mismatch the new org — see the drawer's
+  // own orgUid-keyed cache and group-seat-holders-drawer.component.ts for the other half of this.
+  it('closes the seat-holders drawer and clears the selected group when the selected org switches', async () => {
+    const { fixture, selectedAccount } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    clickSeatHoldersTrigger(fixture, 'g1');
+    expect(seatHoldersDrawerState(fixture)).toEqual({ visible: true, selectedGroupUid: 'g1' });
+
+    selectedAccount.set({ accountId: 'acc-2', accountName: 'Vendor Corp', accountSlug: 'vendor-corp', membershipTier: '', uid: 'org-uid-2' });
+    await flushFilterChange(fixture);
+
+    expect(seatHoldersDrawerState(fixture)).toEqual({ visible: false, selectedGroupUid: null });
   });
 
   it('clearing filters restores the full list in the original (seat-desc, name-asc) order', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -155,10 +155,11 @@ function seatHoldersDrawerState(fixture: ComponentFixture<OrgGroupsComponent>): 
 }
 
 /** Row seat-count testid doubles as the drawer trigger — see org-groups.component.html. */
-function clickSeatHoldersTrigger(fixture: ComponentFixture<OrgGroupsComponent>, uid: string): void {
+async function clickSeatHoldersTrigger(fixture: ComponentFixture<OrgGroupsComponent>, uid: string): Promise<void> {
   const el = fixture.nativeElement.querySelector(`[data-testid="org-groups-item-seats-${uid}"]`) as HTMLButtonElement | null;
   if (!el) throw new Error(`no seat-holders trigger rendered for ${uid}`);
   el.click();
+  await fixture.whenStable();
   fixture.detectChanges();
 }
 
@@ -480,7 +481,7 @@ describe('OrgGroupsComponent', () => {
   it('closes the seat-holders drawer and clears the selected group when the selected org switches', async () => {
     const { fixture, selectedAccount } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
 
-    clickSeatHoldersTrigger(fixture, 'g1');
+    await clickSeatHoldersTrigger(fixture, 'g1');
     expect(seatHoldersDrawerState(fixture)).toEqual({ visible: true, selectedGroupUid: 'g1' });
 
     selectedAccount.set({ accountId: 'acc-2', accountName: 'Vendor Corp', accountSlug: 'vendor-corp', membershipTier: '', uid: 'org-uid-2' });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -490,6 +490,16 @@ describe('OrgGroupsComponent', () => {
     expect(seatHoldersDrawerState(fixture)).toEqual({ visible: false, selectedGroupUid: null });
   });
 
+  // WCAG 2.5.3 Label in Name: the trigger's only visible text is the seat count, so its accessible
+  // name must include that number, not just the group name — otherwise a screen-reader user loses
+  // the count entirely and a voice-control user can't target the button by its visible label.
+  it('includes the seat count in the seat-holders trigger aria-label, not just the group name', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    const trigger = fixture.nativeElement.querySelector('[data-testid="org-groups-item-seats-g1"]');
+    expect(trigger?.getAttribute('aria-label')).toBe('View 10 seat holders for Committee Steering TAG');
+  });
+
   it('clearing filters restores the full list in the original (seat-desc, name-asc) order', async () => {
     const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.spec.ts
@@ -500,6 +500,14 @@ describe('OrgGroupsComponent', () => {
     expect(trigger?.getAttribute('aria-label')).toBe('View 10 seat holders for Committee Steering TAG');
   });
 
+  it('uses the singular "seat holder" in the trigger aria-label for a single-seat group', async () => {
+    const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
+
+    // g4 (Committee Newsletter) has org_seat_count: 1 in buildGroups().
+    const trigger = fixture.nativeElement.querySelector('[data-testid="org-groups-item-seats-g4"]');
+    expect(trigger?.getAttribute('aria-label')).toBe('View 1 seat holder for Committee Newsletter');
+  });
+
   it('clearing filters restores the full list in the original (seat-desc, name-asc) order', async () => {
     const { fixture } = await render({ getGroups: () => of(groupsResponse(buildGroups())) });
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -32,11 +32,14 @@ import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
 
+import { GroupSeatHoldersDrawerComponent } from './components/group-seat-holders-drawer/group-seat-holders-drawer.component';
+
 @Component({
   selector: 'lfx-org-groups',
   imports: [
     ButtonComponent,
     EmptyStateComponent,
+    GroupSeatHoldersDrawerComponent,
     InputTextComponent,
     NgTemplateOutlet,
     RouterLink,
@@ -70,6 +73,7 @@ export class OrgGroupsComponent {
   });
 
   protected readonly companyName = computed(() => this.accountContext.selectedAccount().accountName);
+  protected readonly orgUid = computed(() => this.accountContext.selectedAccount().uid ?? '');
 
   // Total Groups + Total Seats — the two fixed tiles in the template that visibleClassTiles()
   // doesn't cover. Keep in sync with the stat-strip markup.
@@ -156,6 +160,10 @@ export class OrgGroupsComponent {
   protected readonly hasNoRowsToExport: Signal<boolean> = computed(() => this.filteredGroups().length === 0);
   protected readonly noRowsToExportLabel = 'No rows to export';
 
+  // ── Seat holders drawer (GH-1780) ──────────────────────────────────────────
+  protected readonly seatHoldersDrawerVisible = signal(false);
+  protected readonly selectedGroup = signal<OrgLensGroupVm | null>(null);
+
   public constructor() {
     // State → URL, mirrors org-projects' filterForm.valueChanges → router.navigate pattern. `merge`
     // preserves unrelated params (e.g. ?project=, utm_*); null at default lets merge strip an owned key.
@@ -174,6 +182,11 @@ export class OrgGroupsComponent {
 
   protected clearFilters(): void {
     this.filterForm.reset({ search: '', foundation: '', type: '' });
+  }
+
+  protected onSeatHoldersClick(group: OrgLensGroupVm): void {
+    this.selectedGroup.set(group);
+    this.seatHoldersDrawerVisible.set(true);
   }
 
   // Exports the currently filtered (not the full) roster, in the same order the list renders —

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -24,6 +24,7 @@ import { catchError, debounceTime, distinctUntilChanged, filter, map, of, skip, 
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
+import { PersonDetailDrawerComponent } from '@components/person-detail-drawer/person-detail-drawer.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TagComponent } from '@components/tag/tag.component';
 import { AccountContextService } from '@services/account-context.service';
@@ -42,6 +43,7 @@ import { GroupSeatHoldersDrawerComponent } from './components/group-seat-holders
     GroupSeatHoldersDrawerComponent,
     InputTextComponent,
     NgTemplateOutlet,
+    PersonDetailDrawerComponent,
     RouterLink,
     SelectComponent,
     SkeletonModule,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -247,7 +247,8 @@ export class OrgGroupsComponent {
         const ariaLabel = `${g.name}, ${BEHAVIORAL_CLASS_CONFIG[cls].label}, ${g.org_seat_count} ${seatWord}` + (projectLabel ? `, ${projectLabel}` : '');
         // See org-groups.component.html for why this links to /org/memberships, not /org/projects.
         const projectAriaLabel = projectLabel ? `View ${projectLabel} membership details` : '';
-        return { ...g, cls, projectLabel, ariaLabel, projectAriaLabel };
+        const seatHoldersTriggerAriaLabel = `View ${g.org_seat_count} seat holder${g.org_seat_count === 1 ? '' : 's'} for ${g.name}`;
+        return { ...g, cls, projectLabel, ariaLabel, projectAriaLabel, seatHoldersTriggerAriaLabel };
       })
     );
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -177,7 +177,14 @@ export class OrgGroupsComponent {
     // A filter value from the previous org (e.g. its foundation slug) would almost never match the
     // next org's roster. `skip(1)` so the URL-seeded initial filter survives first load — only an
     // actual org switch clears it, mirroring committee-members' resetAllState() on orgUid$.
-    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => this.clearFilters());
+    // Also closes the seat-holders drawer: OrgGroupsComponent isn't destroyed on an org switch, so
+    // a drawer left open would otherwise keep the previous org's selectedGroup (and, via its own
+    // orgUid-keyed cache, would just show the new org's roster filtered by the old org's committeeUid).
+    this.orgUid$.pipe(skip(1), takeUntilDestroyed()).subscribe(() => {
+      this.clearFilters();
+      this.seatHoldersDrawerVisible.set(false);
+      this.selectedGroup.set(null);
+    });
   }
 
   protected clearFilters(): void {

--- a/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
@@ -4,6 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { isVotingStatus, votingStatusPillClass, votingStatusRank } from './org-people-committee-members.constants';
+import { VOTING_STATUS_PRIORITY } from './persona.constants';
 
 describe('isVotingStatus', () => {
   it('treats a named voting status as voting', () => {
@@ -68,5 +69,19 @@ describe('votingStatusRank', () => {
 
   it('is case-insensitive and whitespace-trimmed for listed statuses', () => {
     expect(votingStatusRank('  voting rep  ')).toBe(votingStatusRank('Voting Rep'));
+  });
+
+  it('never ranks a non-voting status ahead of a listed voting status', () => {
+    // Guards the NONE_RANK fallback: if "None" were ever renamed/removed from
+    // VOTING_STATUS_PRIORITY, an unguarded findIndex (-1) would invert this.
+    expect(votingStatusRank('Non-voting')).toBeGreaterThan(votingStatusRank('Voting Rep'));
+    expect(votingStatusRank('None')).toBeGreaterThan(votingStatusRank('Voting Rep'));
+  });
+
+  it('relies on "None" actually being present in VOTING_STATUS_PRIORITY', () => {
+    // NONE_RANK's fallback (list length) only fires if this ever goes false — pin the
+    // precondition directly so a rename/removal fails here, at the source, not just at
+    // the numeric boundary above.
+    expect(VOTING_STATUS_PRIORITY.map((p) => p.toLowerCase())).toContain('none');
   });
 });

--- a/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it } from 'vitest';
+
+import { isVotingStatus, votingStatusPillClass, votingStatusRank } from './org-people-committee-members.constants';
+
+describe('isVotingStatus', () => {
+  it('treats a named voting status as voting', () => {
+    expect(isVotingStatus('Voting Rep')).toBe(true);
+  });
+
+  it('treats an unrecognized non-blank status as voting (open-world)', () => {
+    expect(isVotingStatus('Chair Emeritus')).toBe(true);
+  });
+
+  it.each(['Non-voting', 'None', '', '  ', null, undefined])('treats %j as non-voting', (status) => {
+    expect(isVotingStatus(status)).toBe(false);
+  });
+
+  it('is case-insensitive and whitespace-trimmed for the closed-world exclusions', () => {
+    expect(isVotingStatus('  NONE  ')).toBe(false);
+    expect(isVotingStatus('non-VOTING')).toBe(false);
+  });
+});
+
+describe('votingStatusPillClass', () => {
+  it('returns the emerald voting classes for a voting status', () => {
+    expect(votingStatusPillClass('Voting Rep')).toContain('emerald');
+  });
+
+  it('returns the neutral slate classes for a non-voting status', () => {
+    expect(votingStatusPillClass('None')).toContain('slate');
+  });
+});
+
+describe('votingStatusRank', () => {
+  // Full ordering, lowest (best) to highest (worst) rank — the table an off-by-one in the
+  // boundary constant would fail immediately rather than only on hand-picked pairs.
+  it('ranks statuses lowest (best) to highest (worst) in this order', () => {
+    const ranks = {
+      votingRep: votingStatusRank('Voting Rep'),
+      altVotingRep: votingStatusRank('Alternate Voting Rep'),
+      observer: votingStatusRank('Observer'),
+      emeritus: votingStatusRank('Emeritus'),
+      unrecognizedVoting: votingStatusRank('Chair Emeritus'),
+      none: votingStatusRank('None'),
+      nonVoting: votingStatusRank('Non-voting'),
+      blank: votingStatusRank(''),
+      nullish: votingStatusRank(null),
+    };
+
+    expect(ranks.votingRep).toBeLessThan(ranks.altVotingRep);
+    expect(ranks.altVotingRep).toBeLessThan(ranks.observer);
+    expect(ranks.observer).toBeLessThan(ranks.emeritus);
+    // The regression this file guards: an unrecognized-but-voting status must rank ABOVE
+    // (numerically below) "None", not below it — a bare `length`-derived offset got this
+    // backwards once already (see git history on this file).
+    expect(ranks.emeritus).toBeLessThan(ranks.unrecognizedVoting);
+    expect(ranks.unrecognizedVoting).toBeLessThan(ranks.none);
+    // "Non-voting" isn't itself in VOTING_STATUS_PRIORITY but is semantically identical to
+    // "None" per isVotingStatus — they must tie, not rank arbitrarily far apart.
+    expect(ranks.nonVoting).toBe(ranks.none);
+    expect(ranks.none).toBeLessThan(ranks.blank);
+    expect(ranks.blank).toBe(Infinity);
+    expect(ranks.nullish).toBe(Infinity);
+  });
+
+  it('is case-insensitive and whitespace-trimmed for listed statuses', () => {
+    expect(votingStatusRank('  voting rep  ')).toBe(votingStatusRank('Voting Rep'));
+  });
+});

--- a/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
@@ -96,7 +96,9 @@ describe('noneRankFor', () => {
   });
 
   it('resolves the real VOTING_STATUS_PRIORITY to "None"\'s actual index (sanity: "None" is present)', () => {
-    expect(noneRankFor(VOTING_STATUS_PRIORITY)).toBe(VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === 'none'));
+    // A concrete literal, not `VOTING_STATUS_PRIORITY.findIndex(...)` re-run — that would mirror
+    // noneRankFor's own implementation and pass even if both regressed identically.
+    expect(noneRankFor(VOTING_STATUS_PRIORITY)).toBe(4);
     expect(noneRankFor(VOTING_STATUS_PRIORITY)).not.toBe(VOTING_STATUS_PRIORITY.length);
   });
 });

--- a/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
@@ -89,7 +89,7 @@ describe('noneRankFor', () => {
   // The actual regression this guards: without it, a "None"-less list would resolve via
   // `findIndex`'s -1, which — used as a rank boundary — goes negative and ranks every unlisted
   // status ahead of every listed one, including "Voting Rep". The list-length fallback keeps
-  // unlisted statuses tied at the bottom instead.
+  // unlisted statuses sorted below every listed one instead.
   it('falls back to the list length, not -1, when the list has no "None" entry', () => {
     expect(noneRankFor(['Voting Rep', 'Observer'])).toBe(2);
     expect(noneRankFor([])).toBe(0);

--- a/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { isVotingStatus, votingStatusPillClass, votingStatusRank } from './org-people-committee-members.constants';
+import { isVotingStatus, noneRankFor, votingStatusPillClass, votingStatusRank } from './org-people-committee-members.constants';
 import { VOTING_STATUS_PRIORITY } from './persona.constants';
 
 describe('isVotingStatus', () => {
@@ -72,16 +72,31 @@ describe('votingStatusRank', () => {
   });
 
   it('never ranks a non-voting status ahead of a listed voting status', () => {
-    // Guards the NONE_RANK fallback: if "None" were ever renamed/removed from
-    // VOTING_STATUS_PRIORITY, an unguarded findIndex (-1) would invert this.
     expect(votingStatusRank('Non-voting')).toBeGreaterThan(votingStatusRank('Voting Rep'));
     expect(votingStatusRank('None')).toBeGreaterThan(votingStatusRank('Voting Rep'));
   });
+});
 
-  it('relies on "None" actually being present in VOTING_STATUS_PRIORITY', () => {
-    // NONE_RANK's fallback (list length) only fires if this ever goes false — pin the
-    // precondition directly so a rename/removal fails here, at the source, not just at
-    // the numeric boundary above.
-    expect(VOTING_STATUS_PRIORITY.map((p) => p.toLowerCase())).toContain('none');
+describe('noneRankFor', () => {
+  it('returns the index of "None" when the list carries one', () => {
+    expect(noneRankFor(['Voting Rep', 'Observer', 'None'])).toBe(2);
+  });
+
+  it('is case-insensitive', () => {
+    expect(noneRankFor(['Voting Rep', 'NONE'])).toBe(1);
+  });
+
+  // The actual regression this guards: without it, a "None"-less list would resolve via
+  // `findIndex`'s -1, which — used as a rank boundary — goes negative and ranks every unlisted
+  // status ahead of every listed one, including "Voting Rep". The list-length fallback keeps
+  // unlisted statuses tied at the bottom instead.
+  it('falls back to the list length, not -1, when the list has no "None" entry', () => {
+    expect(noneRankFor(['Voting Rep', 'Observer'])).toBe(2);
+    expect(noneRankFor([])).toBe(0);
+  });
+
+  it('resolves the real VOTING_STATUS_PRIORITY to "None"\'s actual index (sanity: "None" is present)', () => {
+    expect(noneRankFor(VOTING_STATUS_PRIORITY)).toBe(VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === 'none'));
+    expect(noneRankFor(VOTING_STATUS_PRIORITY)).not.toBe(VOTING_STATUS_PRIORITY.length);
   });
 });

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -42,17 +42,23 @@ export function votingStatusPillClass(status: string | null | undefined): string
   return isVotingStatus(status) ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
 }
 
-/** Rank of "None" within `VOTING_STATUS_PRIORITY` — the boundary `votingStatusRank` ranks against. */
-const NONE_RANK = VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === 'none');
+/** Numeric rank of "None" within `VOTING_STATUS_PRIORITY` (lower = higher priority) — the
+ *  boundary `votingStatusRank` ranks against. Falls back to the list's length (worse than every
+ *  listed status) if "None" is ever renamed or removed, so a lookup miss can't go negative and
+ *  invert the whole ordering — it would instead rank everything as more voting than "Voting Rep",
+ *  which fails loudly (every merge picks the unlisted status) rather than silently. */
+const NONE_INDEX = VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === 'none');
+const NONE_RANK = NONE_INDEX === -1 ? VOTING_STATUS_PRIORITY.length : NONE_INDEX;
 
 /** Ranks a voting status by `VOTING_STATUS_PRIORITY` (lower = higher priority — "Voting Rep" is 0)
  *  for picking the best of several seats/statuses for one person — see
  *  `multi-persona-dashboard.component.ts`'s `pickByPriority` for the sibling usage this mirrors.
- *  A status outside the list still counts as voting per `isVotingStatus` — ranked just above
- *  `NONE_RANK` (not `Infinity`), so it can't lose a tie-break to an explicitly non-voting seat.
- *  A non-blank, non-listed status that `isVotingStatus` rejects (e.g. "Non-voting", which isn't
- *  itself in the priority list) ties with "None" at `NONE_RANK` rather than ranking arbitrarily
- *  far below it. Blank/falsy is `Infinity` (always loses, including to "Non-voting"/"None"). */
+ *  A status outside the list still counts as voting per `isVotingStatus` — ranked at
+ *  `NONE_RANK - 0.5`, numerically below (so higher-priority than) `NONE_RANK` but above every
+ *  listed status, so it can't lose a tie-break to an explicitly non-voting seat. A non-blank,
+ *  non-listed status that `isVotingStatus` rejects (e.g. "Non-voting", which isn't itself in the
+ *  priority list) ties with "None" at `NONE_RANK` rather than ranking arbitrarily far below it.
+ *  Blank/falsy is `Infinity` (always loses, including to "Non-voting"/"None"). */
 export function votingStatusRank(status: string | null | undefined): number {
   const s = (status ?? '').trim().toLowerCase();
   if (!s) return Infinity;

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -46,10 +46,10 @@ export function votingStatusPillClass(status: string | null | undefined): string
  *  priority) — the boundary `votingStatusRank` ranks against. Exported (not inlined into a module
  *  constant) so a "None"-less list — the case this guards — is directly testable; production code
  *  only ever calls it with `VOTING_STATUS_PRIORITY`. If "None" is missing, `findIndex` returns -1;
- *  falling back to the list's length instead means an unlisted voting status ties at the bottom
- *  (worse than every listed status) rather than the -1 case, which would go negative and invert
- *  the whole ordering — every unlisted voting status would then rank *ahead of* "Voting Rep"
- *  (rank -1.5 vs 0) instead of behind it. */
+ *  falling back to the list's length instead keeps unlisted statuses sorted below every listed
+ *  status rather than the -1 case, which would go negative and invert the whole ordering — every
+ *  unlisted voting status would then rank *ahead of* "Voting Rep" (rank -1.5 vs 0) instead of
+ *  behind it. */
 export function noneRankFor(priority: readonly string[]): number {
   const index = priority.findIndex((p) => p.toLowerCase() === 'none');
   return index === -1 ? priority.length : index;

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -42,23 +42,31 @@ export function votingStatusPillClass(status: string | null | undefined): string
   return isVotingStatus(status) ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
 }
 
-/** Numeric rank of "None" within `VOTING_STATUS_PRIORITY` (lower = higher priority) — the
- *  boundary `votingStatusRank` ranks against. Falls back to the list's length (worse than every
- *  listed status) if "None" is ever renamed or removed, so a lookup miss can't go negative and
- *  invert the whole ordering — it would instead rank everything as more voting than "Voting Rep",
- *  which fails loudly (every merge picks the unlisted status) rather than silently. */
-const NONE_INDEX = VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === 'none');
-const NONE_RANK = NONE_INDEX === -1 ? VOTING_STATUS_PRIORITY.length : NONE_INDEX;
+/** Numeric rank "None" resolves to within a `VOTING_STATUS_PRIORITY`-shaped list (lower = higher
+ *  priority) — the boundary `votingStatusRank` ranks against. Exported (not inlined into a module
+ *  constant) so a "None"-less list — the case this guards — is directly testable; production code
+ *  only ever calls it with `VOTING_STATUS_PRIORITY`. If "None" is missing, `findIndex` returns -1;
+ *  falling back to the list's length instead means an unlisted voting status ties at the bottom
+ *  (worse than every listed status) rather than the -1 case, which would go negative and invert
+ *  the whole ordering — every unlisted voting status would then rank *ahead of* "Voting Rep"
+ *  (rank -1.5 vs 0) instead of behind it. */
+export function noneRankFor(priority: readonly string[]): number {
+  const index = priority.findIndex((p) => p.toLowerCase() === 'none');
+  return index === -1 ? priority.length : index;
+}
+
+const NONE_RANK = noneRankFor(VOTING_STATUS_PRIORITY);
 
 /** Ranks a voting status by `VOTING_STATUS_PRIORITY` (lower = higher priority — "Voting Rep" is 0)
  *  for picking the best of several seats/statuses for one person — see
  *  `multi-persona-dashboard.component.ts`'s `pickByPriority` for the sibling usage this mirrors.
  *  A status outside the list still counts as voting per `isVotingStatus` — ranked at
  *  `NONE_RANK - 0.5`, numerically below (so higher-priority than) `NONE_RANK` but above every
- *  listed status, so it can't lose a tie-break to an explicitly non-voting seat. A non-blank,
- *  non-listed status that `isVotingStatus` rejects (e.g. "Non-voting", which isn't itself in the
- *  priority list) ties with "None" at `NONE_RANK` rather than ranking arbitrarily far below it.
- *  Blank/falsy is `Infinity` (always loses, including to "Non-voting"/"None"). */
+ *  other listed status ("Voting Rep" through "Emeritus"), so it can't lose a tie-break to an
+ *  explicitly non-voting seat. A non-blank, non-listed status that `isVotingStatus` rejects (e.g.
+ *  "Non-voting", which isn't itself in the priority list) ties with "None" at `NONE_RANK` rather
+ *  than ranking arbitrarily far below it. Blank/falsy is `Infinity` (always loses, including to
+ *  "Non-voting"/"None"). */
 export function votingStatusRank(status: string | null | undefined): number {
   const s = (status ?? '').trim().toLowerCase();
   if (!s) return Infinity;

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -42,12 +42,15 @@ export function votingStatusPillClass(status: string | null | undefined): string
   return isVotingStatus(status) ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
 }
 
-/** Ranks a voting status by `VOTING_STATUS_PRIORITY` (lower = higher priority — "Voting Rep" is 0);
- *  unrecognized or blank statuses rank last (`Infinity`), so they never displace a recognized one.
- *  The single ranking shared by any "pick the best of several seats/statuses for one person" case —
- *  see `multi-persona-dashboard.component.ts`'s `pickByPriority` for the sibling usage this mirrors. */
+/** Ranks a voting status by `VOTING_STATUS_PRIORITY` (lower = higher priority — "Voting Rep" is 0)
+ *  for picking the best of several seats/statuses for one person — see
+ *  `multi-persona-dashboard.component.ts`'s `pickByPriority` for the sibling usage this mirrors.
+ *  A status outside the list still counts as voting per `isVotingStatus` — ranked worse than every
+ *  named status but better than "None", not `Infinity`, so it can't lose a tie-break to an
+ *  explicitly non-voting seat. Blank/falsy is `Infinity` (always loses). */
 export function votingStatusRank(status: string | null | undefined): number {
   const s = (status ?? '').trim().toLowerCase();
   const index = VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === s);
-  return index === -1 ? Infinity : index;
+  if (index !== -1) return index;
+  return isVotingStatus(status) ? VOTING_STATUS_PRIORITY.length - 0.5 : Infinity;
 }

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { CommitteeMembersSortColumn, OrgPeopleCommitteeMembersResponse } from '../interfaces';
+import { VOTING_STATUS_PRIORITY } from './persona.constants';
 
 /** committee-service `committee_category` value that the People → Committee tab EXCLUDES (FR-003). Compared case-insensitively. */
 export const COMMITTEE_CATEGORY_BOARD = 'Board';
@@ -39,4 +40,14 @@ export function isVotingStatus(status: string | null | undefined): boolean {
 /** Tailwind pill classes for a voting status — emerald when voting, neutral slate when "Non-voting"/"None"/empty. Delegates to `isVotingStatus` (D-102). */
 export function votingStatusPillClass(status: string | null | undefined): string {
   return isVotingStatus(status) ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
+}
+
+/** Ranks a voting status by `VOTING_STATUS_PRIORITY` (lower = higher priority — "Voting Rep" is 0);
+ *  unrecognized or blank statuses rank last (`Infinity`), so they never displace a recognized one.
+ *  The single ranking shared by any "pick the best of several seats/statuses for one person" case —
+ *  see `multi-persona-dashboard.component.ts`'s `pickByPriority` for the sibling usage this mirrors. */
+export function votingStatusRank(status: string | null | undefined): number {
+  const s = (status ?? '').trim().toLowerCase();
+  const index = VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === s);
+  return index === -1 ? Infinity : index;
 }

--- a/packages/shared/src/constants/org-people-committee-members.constants.ts
+++ b/packages/shared/src/constants/org-people-committee-members.constants.ts
@@ -42,15 +42,21 @@ export function votingStatusPillClass(status: string | null | undefined): string
   return isVotingStatus(status) ? 'border-emerald-200 bg-emerald-50 text-emerald-700' : 'border-slate-300 bg-slate-50 text-slate-600';
 }
 
+/** Rank of "None" within `VOTING_STATUS_PRIORITY` — the boundary `votingStatusRank` ranks against. */
+const NONE_RANK = VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === 'none');
+
 /** Ranks a voting status by `VOTING_STATUS_PRIORITY` (lower = higher priority — "Voting Rep" is 0)
  *  for picking the best of several seats/statuses for one person — see
  *  `multi-persona-dashboard.component.ts`'s `pickByPriority` for the sibling usage this mirrors.
- *  A status outside the list still counts as voting per `isVotingStatus` — ranked worse than every
- *  named status but better than "None", not `Infinity`, so it can't lose a tie-break to an
- *  explicitly non-voting seat. Blank/falsy is `Infinity` (always loses). */
+ *  A status outside the list still counts as voting per `isVotingStatus` — ranked just above
+ *  `NONE_RANK` (not `Infinity`), so it can't lose a tie-break to an explicitly non-voting seat.
+ *  A non-blank, non-listed status that `isVotingStatus` rejects (e.g. "Non-voting", which isn't
+ *  itself in the priority list) ties with "None" at `NONE_RANK` rather than ranking arbitrarily
+ *  far below it. Blank/falsy is `Infinity` (always loses, including to "Non-voting"/"None"). */
 export function votingStatusRank(status: string | null | undefined): number {
   const s = (status ?? '').trim().toLowerCase();
+  if (!s) return Infinity;
   const index = VOTING_STATUS_PRIORITY.findIndex((p) => p.toLowerCase() === s);
   if (index !== -1) return index;
-  return isVotingStatus(status) ? VOTING_STATUS_PRIORITY.length - 0.5 : Infinity;
+  return isVotingStatus(status) ? NONE_RANK - 0.5 : NONE_RANK;
 }

--- a/packages/shared/src/interfaces/org-groups.interface.ts
+++ b/packages/shared/src/interfaces/org-groups.interface.ts
@@ -38,6 +38,9 @@ export interface OrgLensGroupVm extends OrgLensGroupSummary {
    *  set) — distinguishes it from the row's own aria-label so screen-reader users can tell the
    *  two link targets apart. Empty string when projectLabel is empty. */
   projectAriaLabel: string;
+  /** Pre-computed accessible name for the seat-holders drawer trigger — includes the count itself
+   *  (WCAG 2.5.3 Label in Name: the trigger's only visible text is the number), pluralized. */
+  seatHoldersTriggerAriaLabel: string;
 }
 
 /** One non-zero behavioral-class tile rendered in the org-groups stat strip. */

--- a/packages/shared/src/interfaces/org-people-committee-members.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.interface.ts
@@ -47,11 +47,6 @@ export interface CommitteeMemberAssignment {
   person: CommitteeMemberPerson;
 }
 
-/** A `CommitteeMemberAssignment` decorated for a read-only display list (e.g. the Groups seat-holders drawer) — adds the voting-status pill class so the template stays a flat binding instead of calling a function on every change-detection pass. */
-export interface CommitteeMemberSeatHolderVm extends CommitteeMemberAssignment {
-  votingStatusPillClass: string;
-}
-
 /** Filter-independent stat tiles, computed once at the BFF from the full (unfiltered) roster. */
 export interface CommitteeMemberStats {
   /** Distinct lowercased emails. */

--- a/packages/shared/src/interfaces/org-people-committee-members.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.interface.ts
@@ -47,6 +47,11 @@ export interface CommitteeMemberAssignment {
   person: CommitteeMemberPerson;
 }
 
+/** A `CommitteeMemberAssignment` decorated for a read-only display list (e.g. the Groups seat-holders drawer) — adds the voting-status pill class so the template stays a flat binding instead of calling a function on every change-detection pass. */
+export interface CommitteeMemberSeatHolderVm extends CommitteeMemberAssignment {
+  votingStatusPillClass: string;
+}
+
 /** Filter-independent stat tiles, computed once at the BFF from the full (unfiltered) roster. */
 export interface CommitteeMemberStats {
   /** Distinct lowercased emails. */

--- a/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
+++ b/packages/shared/src/interfaces/org-people-committee-members.internal.interface.ts
@@ -1,8 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Spec 027 — client-only view-model types for the People → Committee tab. Derived from the wire
-// `CommitteeMemberAssignment[]` on render; NOT part of the BFF envelope.
+// Spec 027 — client-only view-model types derived from the wire `CommitteeMemberAssignment[]` on
+// render; NOT part of the BFF envelope. Originally scoped to the People → Committee tab; GH-1780
+// added CommitteeMemberSeatHolderVm for the Groups list's seat-holders drawer, which reuses the
+// same wire type.
 
 import type { CommitteeMemberAssignment } from './org-people-committee-members.interface';
 
@@ -37,6 +39,11 @@ export interface CommitteeMemberAssignmentVm extends CommitteeMemberAssignment {
   showFoundationLabel: boolean;
   /** Precomputed tooltip for the sub-row Edit pencil — encodes (canEdit × isOrgEditable × reason) so the template stays a flat binding (no nested ternary). */
   editTooltip: string;
+}
+
+/** A `CommitteeMemberAssignment` decorated for a read-only display list (the Groups seat-holders drawer, GH-1780) — adds the voting-status pill class so the template stays a flat binding instead of calling a function on every change-detection pass. Deliberately its own (lean) type rather than reusing `CommitteeMemberAssignmentVm`: that one's extra fields (`showFoundationLabel`, `editTooltip`) are specific to the expanded People-tab sub-row and have no meaning in the drawer's flat list. */
+export interface CommitteeMemberSeatHolderVm extends CommitteeMemberAssignment {
+  votingStatusPillClass: string;
 }
 
 /** A person group with its sub-rows pre-sorted (foundation A→Z, then committee A→Z) + decorated. */


### PR DESCRIPTION
## Summary

- Adds a drawer to the org Groups list (`/org/groups`) so an OSPO lead can see which of their org's people hold seats on a group, without leaving the roster or re-filtering People → Committee by hand.
- Clicking a seat holder in that drawer opens the shared person-detail drawer, stacked on top, on the Governance tab — governance seats are sourced from the person's full org roster (not just the committee whose drawer is open), matching what the People page shows for the same person.

## Follow-ups filed (not blocking this PR)

- #1845 — a single Escape press closes both stacked drawers at once (PrimeNG binds a document-level Escape listener per open `p-drawer` instance, with no topmost-only semantics across two independent instances). Verified live against prod data; closing via each drawer's own X button works correctly. Shipping as a known limitation.
- #1847 — pre-existing (unmodified by this branch) server/client seat-count dedupe mismatch for committees with multiple blank-email seats, found during the full-branch review sweep. Out of scope here since it's unrelated code on `main`.

## Test plan

- [x] `yarn test` — 939/939 passing, including 41 new/updated specs on `group-seat-holders-drawer.component.spec.ts` and updated `org-groups.component.spec.ts`
- [x] `yarn lint` / `yarn build` / `yarn format:check` / `./check-headers.sh` — all clean
- [x] Mutation-tested the new regression tests (cross-committee governance seats, the reopen live-region reset, the non-colliding-testid e2e assertion) — each confirmed to fail with the right diagnostic when the underlying fix is reverted
- [x] Verified live in the browser against prod data (`/org/groups`, Oracle America Inc.): drawer opens, seat holders render, person-detail drawer stacks on top with the correct cross-committee Governance seats, focus management works (moves into the panel on open, restores to the trigger on close)
- [x] Post-commit reviewer trio (general + self-serve convention + learnings) run after every commit, all rounds clean; full-branch sweep against `origin/main` clean aside from the two follow-ups filed above
- [x] `/lfx-self-serve-pr-readiness` — READY WITH CHANGES; rebased onto `origin/main` (was 4 behind); remaining SHOULD_FIXes (branch name, a few commit headers over the 72-char team-style target) are non-blocking per this repo's own documented tolerance

Closes #1780