### PR TITLE
feat(campaigns): read campaign-service brief metrics and action items

### DIFF
--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -1444,7 +1444,7 @@ describe('CampaignController.getBriefMetrics', () => {
     const res = buildRes();
     const next = vi.fn() as unknown as NextFunction;
 
-    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1', window: 'last_7_days' }), res, next);
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief_id: 'b-1', window: 'last_7_days' }), res, next);
 
     expect(getBriefMetrics).toHaveBeenCalledWith(expect.anything(), 'cncf', 'b-1', 'last_7_days');
     expect(res.json).toHaveBeenCalledWith(payload);
@@ -1460,7 +1460,7 @@ describe('CampaignController.getBriefMetrics', () => {
   it('passes undefined when no window is given, rather than a default', async () => {
     getBriefMetrics.mockResolvedValue({ brief_id: 'b-1', window: 'last_30_days', rows: [], ok_count: 0, action_items: [] });
 
-    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1' }), buildRes(), vi.fn() as unknown as NextFunction);
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief_id: 'b-1' }), buildRes(), vi.fn() as unknown as NextFunction);
 
     expect(getBriefMetrics).toHaveBeenCalledWith(expect.anything(), 'cncf', 'b-1', undefined);
   });
@@ -1473,7 +1473,7 @@ describe('CampaignController.getBriefMetrics', () => {
   it('refuses an unrecognised window instead of dropping it', async () => {
     const next = vi.fn() as unknown as NextFunction;
 
-    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1', window: 'last_90_days' }), buildRes(), next);
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief_id: 'b-1', window: 'last_90_days' }), buildRes(), next);
 
     expect(getBriefMetrics).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(expect.any(ServiceValidationError));
@@ -1485,22 +1485,22 @@ describe('CampaignController.getBriefMetrics', () => {
    * another foundation's brief on their behalf.
    */
   it.each([
-    ['no brief', { project: 'cncf' }],
-    ['no project', { brief: 'b-1' }],
-    ['a blank brief', { project: 'cncf', brief: '   ' }],
-    ['a blank project', { project: '   ', brief: 'b-1' }],
+    ['no brief_id', { project: 'cncf' }],
+    ['no project', { brief_id: 'b-1' }],
+    ['a blank brief_id', { project: 'cncf', brief_id: '   ' }],
+    ['a blank project', { project: '   ', brief_id: 'b-1' }],
     // Repeated params, which Express parses as arrays. `project` and `brief` are covered by the
     // blank guard above once an array collapses to `''`; `window` is NOT — it is legitimately
     // optional, so "absent" is a valid state and a malformed value that reads as absent would
     // fail OPEN, serving the per-platform default under a window the caller never chose.
-    ['a repeated project param, which Express parses as an array', { project: ['tlf', 'cncf'], brief: 'b-1' }],
-    ['a repeated brief param, which Express parses as an array', { project: 'cncf', brief: ['b-1', 'b-2'] }],
-    ['a repeated window param, which Express parses as an array', { project: 'cncf', brief: 'b-1', window: ['today', 'today'] }],
+    ['a repeated project param, which Express parses as an array', { project: ['tlf', 'cncf'], brief_id: 'b-1' }],
+    ['a repeated brief_id param, which Express parses as an array', { project: 'cncf', brief_id: ['b-1', 'b-2'] }],
+    ['a repeated window param, which Express parses as an array', { project: 'cncf', brief_id: 'b-1', window: ['today', 'today'] }],
     // PRESENT-BUT-EMPTY is malformed, not absent. `?window=` arrives as a string, so treating it
     // as "no window given" would skip the enum check and serve the default — the same fail-open
     // shape as the array case, one layer in. Only an OMITTED parameter may default.
-    ['an empty window param', { project: 'cncf', brief: 'b-1', window: '' }],
-    ['a whitespace-only window param', { project: 'cncf', brief: 'b-1', window: '   ' }],
+    ['an empty window param', { project: 'cncf', brief_id: 'b-1', window: '' }],
+    ['a whitespace-only window param', { project: 'cncf', brief_id: 'b-1', window: '   ' }],
   ])('refuses a request with %s', async (_label, query) => {
     const next = vi.fn() as unknown as NextFunction;
 
@@ -1516,7 +1516,7 @@ describe('CampaignController.getBriefMetrics', () => {
     const res = buildRes();
     const next = vi.fn() as unknown as NextFunction;
 
-    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1' }), res, next);
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief_id: 'b-1' }), res, next);
 
     expect(res.json).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledWith(expect.any(Error));

--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -19,6 +19,7 @@ const {
   searchHubSpotEmails,
   toggleCampaignStatus,
   listBriefCampaigns,
+  getBriefMetrics,
   legacyUpdateStatus,
   isServerFeatureEnabled,
   logger,
@@ -32,6 +33,7 @@ const {
   searchHubSpotEmails: vi.fn(),
   toggleCampaignStatus: vi.fn(),
   listBriefCampaigns: vi.fn(),
+  getBriefMetrics: vi.fn(),
   legacyUpdateStatus: vi.fn(),
   isServerFeatureEnabled: vi.fn(),
   logger: { startOperation: vi.fn(() => 0), success: vi.fn(), error: vi.fn(), warning: vi.fn(), debug: vi.fn(), info: vi.fn() },
@@ -52,6 +54,7 @@ vi.mock('../services/campaign-service.service', async (importOriginal) => {
       public searchHubSpotEmails = searchHubSpotEmails;
       public toggleCampaignStatus = toggleCampaignStatus;
       public listBriefCampaigns = listBriefCampaigns;
+      public getBriefMetrics = getBriefMetrics;
     },
   };
 });
@@ -1416,5 +1419,93 @@ describe('CampaignController.listBriefCampaigns', () => {
 
     expect(res.json).not.toHaveBeenCalled();
     expect(next).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * What is only decidable at this layer: which query parameters are required, and whether a value
+ * the wire contract cannot represent is refused here rather than sent and silently reinterpreted.
+ */
+describe('CampaignController.getBriefMetrics', () => {
+  let controller: CampaignController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new CampaignController();
+  });
+
+  function metricsReq(query: Record<string, unknown>): Request {
+    return { query, path: '/api/campaigns/brief/metrics' } as unknown as Request;
+  }
+
+  it('reads the brief and passes a valid window through', async () => {
+    const payload = { brief_id: 'b-1', window: 'last_7_days', rows: [], ok_count: 0, action_items: [] };
+    getBriefMetrics.mockResolvedValue(payload);
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1', window: 'last_7_days' }), res, next);
+
+    expect(getBriefMetrics).toHaveBeenCalledWith(expect.anything(), 'cncf', 'b-1', 'last_7_days');
+    expect(res.json).toHaveBeenCalledWith(payload);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Omitted rather than defaulted here, so campaign-service applies its PER-PLATFORM default.
+   * Defaulting to `last_30_days` at this layer would be a guaranteed failure on X Ads, which
+   * caps a request's range at 7 days and rejects a wider explicit window.
+   */
+  it('passes undefined when no window is given, rather than a default', async () => {
+    getBriefMetrics.mockResolvedValue({ brief_id: 'b-1', window: 'last_30_days', rows: [], ok_count: 0, action_items: [] });
+
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1' }), buildRes(), vi.fn() as unknown as NextFunction);
+
+    expect(getBriefMetrics).toHaveBeenCalledWith(expect.anything(), 'cncf', 'b-1', undefined);
+  });
+
+  /**
+   * REFUSED, not dropped. Dropping an unrecognised window would serve a different period than the
+   * caller asked for, and the response's own `window` field would report the default as though it
+   * had been requested — so the caller could not detect the substitution from the response alone.
+   */
+  it('refuses an unrecognised window instead of dropping it', async () => {
+    const next = vi.fn() as unknown as NextFunction;
+
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1', window: 'last_90_days' }), buildRes(), next);
+
+    expect(getBriefMetrics).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(ServiceValidationError));
+  });
+
+  /**
+   * `brief` is required because this read is brief-scoped, and `project` because
+   * `/foundation/campaigns` is reachable by an ED of any foundation — a default here would read
+   * another foundation's brief on their behalf.
+   */
+  it.each([
+    ['no brief', { project: 'cncf' }],
+    ['no project', { brief: 'b-1' }],
+    ['a blank brief', { project: 'cncf', brief: '   ' }],
+    ['a blank project', { project: '   ', brief: 'b-1' }],
+  ])('refuses a request with %s', async (_label, query) => {
+    const next = vi.fn() as unknown as NextFunction;
+
+    await controller.getBriefMetrics(metricsReq(query), buildRes(), next);
+
+    expect(getBriefMetrics).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(ServiceValidationError));
+  });
+
+  /** A failed upstream read reaches the error middleware, never a 200 the caller reads as data. */
+  it('forwards an upstream failure to next rather than answering with a body', async () => {
+    getBriefMetrics.mockRejectedValue(new Error('upstream exploded'));
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await controller.getBriefMetrics(metricsReq({ project: 'cncf', brief: 'b-1' }), res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledWith(expect.any(Error));
   });
 });

--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -1453,8 +1453,9 @@ describe('CampaignController.getBriefMetrics', () => {
 
   /**
    * Omitted rather than defaulted here, so campaign-service applies its PER-PLATFORM default.
-   * Defaulting to `last_30_days` at this layer would be a guaranteed failure on X Ads, which
-   * caps a request's range at 7 days and rejects a wider explicit window.
+   * Upstream resolves the default per row, per platform (`last_7_days` for X Ads, `last_30_days`
+   * elsewhere), and an explicit window overrides that for every row. Defaulting here would not
+   * fail — it would DISCARD the fallback, turning a servable X row into an `unsupported` one.
    */
   it('passes undefined when no window is given, rather than a default', async () => {
     getBriefMetrics.mockResolvedValue({ brief_id: 'b-1', window: 'last_30_days', rows: [], ok_count: 0, action_items: [] });
@@ -1495,6 +1496,11 @@ describe('CampaignController.getBriefMetrics', () => {
     ['a repeated project param, which Express parses as an array', { project: ['tlf', 'cncf'], brief: 'b-1' }],
     ['a repeated brief param, which Express parses as an array', { project: 'cncf', brief: ['b-1', 'b-2'] }],
     ['a repeated window param, which Express parses as an array', { project: 'cncf', brief: 'b-1', window: ['today', 'today'] }],
+    // PRESENT-BUT-EMPTY is malformed, not absent. `?window=` arrives as a string, so treating it
+    // as "no window given" would skip the enum check and serve the default — the same fail-open
+    // shape as the array case, one layer in. Only an OMITTED parameter may default.
+    ['an empty window param', { project: 'cncf', brief: 'b-1', window: '' }],
+    ['a whitespace-only window param', { project: 'cncf', brief: 'b-1', window: '   ' }],
   ])('refuses a request with %s', async (_label, query) => {
     const next = vi.fn() as unknown as NextFunction;
 

--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -1488,6 +1488,13 @@ describe('CampaignController.getBriefMetrics', () => {
     ['no project', { brief: 'b-1' }],
     ['a blank brief', { project: 'cncf', brief: '   ' }],
     ['a blank project', { project: '   ', brief: 'b-1' }],
+    // Repeated params, which Express parses as arrays. `project` and `brief` are covered by the
+    // blank guard above once an array collapses to `''`; `window` is NOT — it is legitimately
+    // optional, so "absent" is a valid state and a malformed value that reads as absent would
+    // fail OPEN, serving the per-platform default under a window the caller never chose.
+    ['a repeated project param, which Express parses as an array', { project: ['tlf', 'cncf'], brief: 'b-1' }],
+    ['a repeated brief param, which Express parses as an array', { project: 'cncf', brief: ['b-1', 'b-2'] }],
+    ['a repeated window param, which Express parses as an array', { project: 'cncf', brief: 'b-1', window: ['today', 'today'] }],
   ])('refuses a request with %s', async (_label, query) => {
     const next = vi.fn() as unknown as NextFunction;
 

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -713,10 +713,13 @@ export class CampaignController {
    * response, whose `window` field would report the default as though it had been requested.
    */
   public async getBriefMetrics(req: Request, res: Response, next: NextFunction): Promise<void> {
-    const briefId = typeof req.query['brief'] === 'string' ? req.query['brief'].trim() : '';
+    // `brief_id`, matching `listBriefCampaigns`, `createCampaign` and `persistBrief` — and matching
+    // what `campaign.service.ts` already sends for `/api/campaigns/list`. A lone `brief` here would
+    // give the first UI integration a spurious 400 for copying the established param pair.
+    const briefId = typeof req.query['brief_id'] === 'string' ? req.query['brief_id'].trim() : '';
     if (briefId.length === 0) {
       next(
-        ServiceValidationError.forField('brief', 'a brief is required to read its campaign metrics', {
+        ServiceValidationError.forField('brief_id', 'a brief is required to read its campaign metrics', {
           operation: 'campaign_brief_metrics',
           service: 'campaign_controller',
         })

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -699,10 +699,16 @@ export class CampaignController {
    * the ad account — while this is BRIEF-scoped. A consumer swapping one for the other narrows
    * what an operator sees, which is why `brief` is required rather than defaulted.
    *
-   * `window` is optional and is NOT defaulted here. campaign-service applies a per-platform
-   * default that is not uniformly 30 days — X Ads caps a request at 7 — so sending one on the
-   * caller's behalf would turn an omitted window into a guaranteed failure on that platform. An
-   * unrecognised value is refused rather than dropped: dropping it would silently serve a
+   * `window` is optional and is NOT defaulted here, so campaign-service can resolve the default
+   * PER ROW, PER PLATFORM: `defaultMetricsWindowFor` (`internal/service/brief.go`) runs inside
+   * the fan-out and yields `last_7_days` for X Ads — whose stats endpoint caps a query at 7 days
+   * — and `last_30_days` for everything else. An explicit window overrides that for EVERY row.
+   *
+   * So sending `last_30_days` on the caller's behalf would not fail the request; it would
+   * DISCARD the per-platform fallback and turn a servable X row into an `unsupported` one, while
+   * the other rows carried on unchanged. Losing a row quietly is the cost, not an error.
+   *
+   * An unrecognised value is refused rather than dropped: dropping it would silently serve a
    * different window than the caller asked for, and a caller cannot detect that from the
    * response, whose `window` field would report the default as though it had been requested.
    */
@@ -752,8 +758,12 @@ export class CampaignController {
       );
       return;
     }
-    const rawWindow = windowParam === undefined ? '' : windowParam.trim();
-    if (rawWindow.length > 0 && !CAMPAIGN_METRICS_WINDOWS.includes(rawWindow as CampaignMetricsWindow)) {
+    // PRESENT-BUT-EMPTY is malformed, not absent. `?window=` and `?window=%20` arrive as a string,
+    // and treating them as "no window given" would skip the enum check and serve the default —
+    // the same fail-open shape as the array case above, one layer in. Only an OMITTED parameter
+    // may default; every supplied value must be in the enum.
+    const rawWindow = windowParam === undefined ? undefined : windowParam.trim();
+    if (rawWindow !== undefined && !CAMPAIGN_METRICS_WINDOWS.includes(rawWindow as CampaignMetricsWindow)) {
       next(
         ServiceValidationError.forField('window', `window must be one of: ${CAMPAIGN_METRICS_WINDOWS.join(', ')}`, {
           operation: 'campaign_brief_metrics',
@@ -762,7 +772,7 @@ export class CampaignController {
       );
       return;
     }
-    const window = rawWindow.length > 0 ? (rawWindow as CampaignMetricsWindow) : undefined;
+    const window = rawWindow as CampaignMetricsWindow | undefined;
 
     const startTime = logger.startOperation(req, 'campaign_brief_metrics', { briefId, projectSlug, window });
 

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -6,11 +6,11 @@ import { NextFunction, Request, Response } from 'express';
 import type {
   BulkKeywordActionRequest,
   CampaignBriefLoadResult,
-  CampaignMetricsWindow,
   CampaignBriefOutput,
   CampaignBriefRefineRequest,
   CampaignBriefRequest,
   CampaignCreateRequest,
+  CampaignMetricsWindow,
   CampaignPlatform,
   CampaignSSEEventType,
   CampaignStatusUpdateRequest,

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -6,6 +6,7 @@ import { NextFunction, Request, Response } from 'express';
 import type {
   BulkKeywordActionRequest,
   CampaignBriefLoadResult,
+  CampaignMetricsWindow,
   CampaignBriefOutput,
   CampaignBriefRefineRequest,
   CampaignBriefRequest,
@@ -17,7 +18,7 @@ import type {
   CampaignToggleStatus,
   FlushableResponse,
 } from '@lfx-one/shared/interfaces';
-import { CAMPAIGN_DELIVERY_TYPES, CAMPAIGN_PLATFORMS, VALID_CAMPAIGN_TOGGLE_STATUSES } from '@lfx-one/shared/constants';
+import { CAMPAIGN_DELIVERY_TYPES, CAMPAIGN_METRICS_WINDOWS, CAMPAIGN_PLATFORMS, VALID_CAMPAIGN_TOGGLE_STATUSES } from '@lfx-one/shared/constants';
 
 import { META_ACCOUNTS, REDDIT_ACCOUNTS } from '../constants';
 import { ServiceValidationError } from '../errors';
@@ -679,6 +680,84 @@ export class CampaignController {
       // `status` is logged on every arm, `unreadable` included: it is the one outcome that says
       // a stored brief exists and this build cannot open it, and nothing else would record it.
       logger.success(req, 'campaign_load_brief', startTime, { eventSlug, projectSlug, status: result.status, briefId: result.briefId });
+      res.json(result);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * Read campaign-service's own metrics and action items for one brief.
+   *
+   * Distinct from `getMonitorData` and its three per-platform siblings below, which query the ad
+   * platforms directly and derive action items from FOUR rule engines in this BFF. Those engines
+   * disagree with each other and with campaign-service on the low-CTR threshold, the impression
+   * floor beneath which CTR is judged at all, and whether a paused campaign raises anything. This
+   * route exposes the single-source version; nothing is cut over to it yet.
+   *
+   * The two are NOT interchangeable. The monitor routes are ACCOUNT-scoped — every campaign in
+   * the ad account — while this is BRIEF-scoped. A consumer swapping one for the other narrows
+   * what an operator sees, which is why `brief` is required rather than defaulted.
+   *
+   * `window` is optional and is NOT defaulted here. campaign-service applies a per-platform
+   * default that is not uniformly 30 days — X Ads caps a request at 7 — so sending one on the
+   * caller's behalf would turn an omitted window into a guaranteed failure on that platform. An
+   * unrecognised value is refused rather than dropped: dropping it would silently serve a
+   * different window than the caller asked for, and a caller cannot detect that from the
+   * response, whose `window` field would report the default as though it had been requested.
+   */
+  public async getBriefMetrics(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const briefId = typeof req.query['brief'] === 'string' ? req.query['brief'].trim() : '';
+    if (briefId.length === 0) {
+      next(
+        ServiceValidationError.forField('brief', 'a brief is required to read its campaign metrics', {
+          operation: 'campaign_brief_metrics',
+          service: 'campaign_controller',
+        })
+      );
+      return;
+    }
+
+    // Refused, not defaulted, for the reason `loadBrief` refuses: `/foundation/campaigns` is
+    // reachable by an ED of any foundation, and a constant here would read another foundation's
+    // brief on their behalf.
+    const projectSlug = typeof req.query['project'] === 'string' ? req.query['project'].trim() : '';
+    if (projectSlug.length === 0) {
+      next(
+        ServiceValidationError.forField('project', 'no foundation is selected; reload the campaigns page from the sidebar', {
+          operation: 'campaign_brief_metrics',
+          service: 'campaign_controller',
+        })
+      );
+      return;
+    }
+
+    const rawWindow = typeof req.query['window'] === 'string' ? req.query['window'].trim() : '';
+    if (rawWindow.length > 0 && !CAMPAIGN_METRICS_WINDOWS.includes(rawWindow as CampaignMetricsWindow)) {
+      next(
+        ServiceValidationError.forField('window', `window must be one of: ${CAMPAIGN_METRICS_WINDOWS.join(', ')}`, {
+          operation: 'campaign_brief_metrics',
+          service: 'campaign_controller',
+        })
+      );
+      return;
+    }
+    const window = rawWindow.length > 0 ? (rawWindow as CampaignMetricsWindow) : undefined;
+
+    const startTime = logger.startOperation(req, 'campaign_brief_metrics', { briefId, projectSlug, window });
+
+    try {
+      const result = await this.campaignServiceClient.getBriefMetrics(req, projectSlug, briefId, window);
+      // `okCount` beside `rowCount` deliberately: they are the pair that says whether an empty
+      // `action_items` is an all-clear or a blind spot, and a log carrying only the row count
+      // would answer the easier question.
+      logger.success(req, 'campaign_brief_metrics', startTime, {
+        briefId,
+        projectSlug,
+        rowCount: result.rows.length,
+        okCount: result.ok_count,
+        actionItemCount: result.action_items.length,
+      });
       res.json(result);
     } catch (error) {
       next(error);

--- a/apps/lfx-one/src/server/controllers/campaign.controller.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.ts
@@ -732,7 +732,27 @@ export class CampaignController {
       return;
     }
 
-    const rawWindow = typeof req.query['window'] === 'string' ? req.query['window'].trim() : '';
+    // ABSENT and MALFORMED are separated before the enum check, because collapsing them makes the
+    // malformed case fail OPEN. A repeated `?window=a&window=b` arrives as an ARRAY, and a
+    // `typeof === 'string'` test alone turns that into `''` — indistinguishable from "no window
+    // given", so the enum check is skipped and the read proceeds on the per-platform default.
+    // That is the substitution this method refuses by design: the response's own `window` field
+    // would then report a period the caller never asked for, as though it had. `project` and
+    // `brief` are safe from the same shape only because an array collapses to `''` and THEIR
+    // guard refuses empty; `window` is legitimately optional, so it has no such backstop.
+    // Matches the repeated-param handling `persistBrief`, `loadBrief` and `searchHubSpotEmails`
+    // already carry.
+    const windowParam = req.query['window'];
+    if (windowParam !== undefined && typeof windowParam !== 'string') {
+      next(
+        ServiceValidationError.forField('window', 'window must be given at most once', {
+          operation: 'campaign_brief_metrics',
+          service: 'campaign_controller',
+        })
+      );
+      return;
+    }
+    const rawWindow = windowParam === undefined ? '' : windowParam.trim();
     if (rawWindow.length > 0 && !CAMPAIGN_METRICS_WINDOWS.includes(rawWindow as CampaignMetricsWindow)) {
       next(
         ServiceValidationError.forField('window', `window must be one of: ${CAMPAIGN_METRICS_WINDOWS.join(', ')}`, {

--- a/apps/lfx-one/src/server/routes/campaigns.route.ts
+++ b/apps/lfx-one/src/server/routes/campaigns.route.ts
@@ -22,6 +22,11 @@ router.post('/brief/generate', (req, res, next) => campaignController.generateBr
 router.post('/brief/refine', (req, res, next) => campaignController.refineBrief(req, res, next));
 router.post('/brief/persist', (req, res, next) => campaignController.persistBrief(req, res, next));
 router.get('/brief', (req, res, next) => campaignController.loadBrief(req, res, next));
+// campaign-service's OWN metrics and action items for one brief. Distinct from `/monitor` and its
+// per-platform siblings below, which read the ad platforms directly and derive action items from
+// four separate rule engines in this BFF. Brief-scoped where those are account-scoped, so it is
+// not a drop-in replacement for them; nothing is cut over to it yet.
+router.get('/brief/metrics', (req, res, next) => campaignController.getBriefMetrics(req, res, next));
 router.post('/create', (req, res, next) => campaignController.createCampaign(req, res, next));
 router.get('/list', (req, res, next) => campaignController.listBriefCampaigns(req, res, next));
 router.get('/jobs/:jobId', (req, res, next) => campaignController.getJobStatus(req, res, next));

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -2359,3 +2359,106 @@ describe('CampaignServiceClient.listBriefCampaigns', () => {
     expect(result).toEqual({ campaigns: [], possiblyStale: true, statusToggleEnabled: false });
   });
 });
+
+describe('CampaignServiceClient.getBriefMetrics', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  /**
+   * The window is the proxy's FIFTH argument, which is `query`. The SIXTH is the request body.
+   * Passing it in the body position sends NO query string and raises no type error — both
+   * parameters are optional and loosely typed — so campaign-service would apply per-platform
+   * defaults while the caller believed it had asked for a window.
+   *
+   * Asserted positionally rather than with `objectContaining`, because the defect this pins is
+   * entirely about WHICH position the value lands in.
+   */
+  it('sends the window as a query parameter, not a body', async () => {
+    proxyRequest.mockResolvedValue({ brief_id: 'b-1', window: 'last_7_days', rows: [], ok_count: 0, action_items: [] });
+
+    await new CampaignServiceClient().getBriefMetrics(req, 'cncf', 'b-1', 'last_7_days');
+
+    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/cncf/briefs/b-1/metrics', 'GET', { window: 'last_7_days' });
+    // The body position must be EMPTY. Without this the previous assertion still passes when a
+    // future edit adds a body, and the query would keep working while the body silently shipped.
+    expect(proxyRequest.mock.calls[0]).toHaveLength(5);
+  });
+
+  /**
+   * Omitted, not defaulted to `last_30_days`. campaign-service's default is per-platform and is
+   * not uniformly 30 days: X Ads caps a request at 7 and REJECTS a wider explicit window, so
+   * defaulting here would turn "no window specified" into a guaranteed failure on that platform.
+   */
+  it('sends no window at all when the caller specifies none', async () => {
+    proxyRequest.mockResolvedValue({ brief_id: 'b-1', window: 'last_30_days', rows: [], ok_count: 0, action_items: [] });
+
+    await new CampaignServiceClient().getBriefMetrics(req, 'cncf', 'b-1');
+
+    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_CAMPAIGN_SERVICE', '/projects/cncf/briefs/b-1/metrics', 'GET', undefined);
+  });
+
+  /** Both segments are encoded: an unencoded slug would silently change the path. */
+  it('encodes both path segments', async () => {
+    proxyRequest.mockResolvedValue({ brief_id: 'b/1', window: 'last_30_days', rows: [], ok_count: 0, action_items: [] });
+
+    await new CampaignServiceClient().getBriefMetrics(req, 'a b', 'b/1');
+
+    expect(proxyRequest.mock.calls[0][2]).toBe('/projects/a%20b/briefs/b%2F1/metrics');
+  });
+
+  /**
+   * An empty segment makes `/projects//briefs//metrics` — a DIFFERENT route that 404s at the
+   * gateway. A caller cannot tell that from campaign-service answering "no such brief", so the
+   * request is refused before it is sent rather than after.
+   */
+  it.each([
+    ['no project', '', 'b-1'],
+    ['no brief id', 'cncf', ''],
+  ])('refuses a request with %s without calling the proxy', async (_label, slug, brief) => {
+    await expect(new CampaignServiceClient().getBriefMetrics(req, slug, brief)).rejects.toThrow(/requires both the project and the brief/);
+
+    expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  /**
+   * The row shape is returned VERBATIM. A failed row carries no `metrics`, and this client must
+   * not zero-fill it on the way through — that substitution is what turns an outage into a
+   * measured zero, and it is the whole reason the row carries a status.
+   */
+  it('passes a failed row through without inventing metrics for it', async () => {
+    proxyRequest.mockResolvedValue({
+      brief_id: 'b-1',
+      window: 'last_30_days',
+      rows: [
+        {
+          campaign_id: 'c-1',
+          platform: 'linkedin-ads',
+          status: 'ok',
+          metrics: {
+            campaign_id: 'c-1',
+            platform_campaign_id: 'p-1',
+            window: 'last_30_days',
+            impressions: 1840,
+            clicks: 212,
+            cost_micros: 1284000,
+            ctr: 0.1152,
+          },
+          pacing: { pct: 94.2, label: 'normal' },
+        },
+        { campaign_id: 'c-2', platform: 'reddit-ads', status: 'failed', reason: 'the platform read failed' },
+      ],
+      ok_count: 1,
+      action_items: [],
+    });
+
+    const result = await new CampaignServiceClient().getBriefMetrics(req, 'cncf', 'b-1');
+
+    expect(result.rows[1].metrics).toBeUndefined();
+    expect(result.rows[1].status).toBe('failed');
+    // ok_count must survive too: it is what tells a consumer that an empty action_items list
+    // covers only 1 of the 2 campaigns.
+    expect(result.ok_count).toBe(1);
+    expect(result.rows).toHaveLength(2);
+  });
+});

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -36,6 +36,8 @@ vi.mock('./microservice-proxy.service', () => ({
 vi.mock('./logger.service', () => ({ logger }));
 
 import { JOB_LOST_MESSAGE } from '@lfx-one/shared/constants';
+import { readFileSync } from 'node:fs';
+
 import type { Request } from 'express';
 
 import type { CampaignBriefOutput } from '@lfx-one/shared/interfaces';
@@ -2419,6 +2421,92 @@ describe('CampaignServiceClient.getBriefMetrics', () => {
     await expect(new CampaignServiceClient().getBriefMetrics(req, slug, brief)).rejects.toThrow(/requires both the project and the brief/);
 
     expect(proxyRequest).not.toHaveBeenCalled();
+  });
+
+  /**
+   * `conversions` and the `no_conversions` rule are part of the contract and must survive the
+   * round trip. Both were MISSING from the first version of these types: the fidelity check that
+   * approved them compared against a campaign-service worktree parked on an older feature branch
+   * rather than against `origin/main`, so it confirmed an outdated contract.
+   *
+   * `conversions` is FRACTIONAL and OPTIONAL, and those two properties are the whole point.
+   * Absent means "this channel does not report it" — Meta, X, Reddit and email never do — which
+   * is not a measured 0, so a consumer must not default it. And 0.4 of a conversion is real under
+   * data-driven attribution, so it must not be rounded or floored to zero.
+   */
+  it('preserves a fractional conversions value and the no_conversions rule', async () => {
+    proxyRequest.mockResolvedValue({
+      brief_id: 'b-1',
+      window: 'last_30_days',
+      rows: [
+        {
+          campaign_id: 'c-1',
+          platform: 'google-ads',
+          status: 'ok',
+          metrics: {
+            campaign_id: 'c-1',
+            platform_campaign_id: 'p-1',
+            window: 'last_30_days',
+            impressions: 1840,
+            clicks: 212,
+            cost_micros: 1284000,
+            ctr: 0.1152,
+            conversions: 0.4,
+          },
+          pacing: { pct: 94.2, label: 'normal' },
+        },
+        // Reddit never reports a campaign-level conversion count, so the field is ABSENT here —
+        // not zero. The two rows together are what make the distinction assertable.
+        {
+          campaign_id: 'c-2',
+          platform: 'reddit-ads',
+          status: 'ok',
+          metrics: { campaign_id: 'c-2', platform_campaign_id: 'p-2', window: 'last_30_days', impressions: 10, clicks: 1, cost_micros: 0, ctr: 0.1 },
+          pacing: { label: 'unknown' },
+        },
+      ],
+      ok_count: 2,
+      action_items: [
+        {
+          rule: 'no_conversions',
+          priority: 'MED',
+          campaign_id: 'c-1',
+          platform: 'google-ads',
+          issue: 'No conversions recorded',
+          action: 'Check conversion tracking',
+        },
+      ],
+    });
+
+    const result = await new CampaignServiceClient().getBriefMetrics(req, 'cncf', 'b-1');
+
+    // Neither rounded nor floored to 0 — 0.4 of a conversion is a real value.
+    expect(result.rows[0].metrics?.conversions).toBe(0.4);
+    // ABSENT stays absent. Defaulting it to 0 would claim Reddit measured zero conversions.
+    expect(result.rows[1].metrics?.conversions).toBeUndefined();
+    expect(result.action_items[0].rule).toBe('no_conversions');
+  });
+
+  /**
+   * Pins the two fields against the SHARED TYPES rather than against this file's own fixture.
+   *
+   * The test above cannot do that job: server specs are typechecked by nothing — `tsconfig.spec.json`
+   * includes only `src/app/**` — and `proxyRequest` is an untyped `vi.fn()`, so deleting
+   * `conversions` and `no_conversions` from the interfaces leaves it green. That is precisely how
+   * both fields went missing in the first place, and a test that cannot detect their removal is
+   * not coverage.
+   *
+   * So this reads the declarations as TEXT. Crude, but it is the only assertion here that fails
+   * when the type loses the field, and the failure names what to restore.
+   */
+  it('keeps conversions and the no_conversions rule declared in the shared types', () => {
+    const declarations = readFileSync(new URL('../../../../../packages/shared/src/interfaces/campaign.interface.ts', import.meta.url), 'utf8');
+
+    // Optional, because ABSENT means "this channel does not report it" and is not a measured 0.
+    expect(declarations).toContain('conversions?: number;');
+    // The fifth rule. campaign-service can return it, so an exhaustive consumer that has never
+    // heard of it would drop or mishandle a real action item.
+    expect(declarations).toMatch(/rule: .*'no_conversions'/);
   });
 
   /**

--- a/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.spec.ts
@@ -2388,9 +2388,10 @@ describe('CampaignServiceClient.getBriefMetrics', () => {
   });
 
   /**
-   * Omitted, not defaulted to `last_30_days`. campaign-service's default is per-platform and is
-   * not uniformly 30 days: X Ads caps a request at 7 and REJECTS a wider explicit window, so
-   * defaulting here would turn "no window specified" into a guaranteed failure on that platform.
+   * Omitted, not defaulted to `last_30_days`. campaign-service resolves the default PER ROW —
+   * `last_7_days` for X Ads, `last_30_days` elsewhere — and an explicit window overrides that for
+   * every row, so defaulting here would DISCARD the fallback and turn a servable X row into an
+   * `unsupported` one rather than failing outright.
    */
   it('sends no window at all when the caller specifies none', async () => {
     proxyRequest.mockResolvedValue({ brief_id: 'b-1', window: 'last_30_days', rows: [], ok_count: 0, action_items: [] });

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -4,10 +4,12 @@
 import { CAMPAIGN_GOALS, CAMPAIGN_PLATFORMS, JOB_LOST_MESSAGE } from '@lfx-one/shared/constants';
 import type {
   ApiResponse,
+  BriefMetrics,
   CampaignBriefLoadResult,
   CampaignServiceCreateResult,
   CampaignBriefOutput,
   CampaignBriefPersistResult,
+  CampaignMetricsWindow,
   HubSpotEmailSearchResult,
   HubSpotMarketingEmail,
   CampaignEventDetails,
@@ -1042,6 +1044,66 @@ export class CampaignServiceClient {
         possiblyTruncated: false,
       };
     }
+  }
+
+  /**
+   * Read live metrics for EVERY campaign on a brief, in one request.
+   *
+   * This is the read that makes campaign-service's `action_items` reachable at all. Until now
+   * nothing in this app called it: the Optimize tab derives its action items from FOUR separate
+   * rule engines in this BFF (`campaign-metrics.service.ts`, `linkedin-ads.service.ts`,
+   * `reddit-ads.service.ts`, `meta-ads.service.ts`), which disagree with each other and with
+   * campaign-service on the low-CTR threshold, the impression floor beneath which CTR is not
+   * judged, and whether a paused campaign raises anything at all.
+   *
+   * Nothing is cut over here. This adds the read; the tab keeps its existing source until a
+   * caller is wired, because the two are not equivalent in SCOPE — see below.
+   *
+   * ## Brief-scoped, where the existing engines are account-scoped
+   *
+   * The BFF engines query each ad platform directly and report on every campaign in the ad
+   * account. This reports on the campaigns campaign-service has adopted onto ONE brief. Swapping
+   * one for the other narrows what an operator sees, so a consumer must pass the brief it means
+   * — there is no "all campaigns" call here, and constructing one by fanning out over briefs
+   * needs the brief ids from the Query Service, which owns brief lists (rule 3).
+   *
+   * ## Failures are per-row, and are not measurements
+   *
+   * A brief spans several platforms and each read can fail independently, so one campaign's
+   * failure must not fail the request. Every campaign gets a row; only `status === 'ok'` carries
+   * `metrics`, and a failed row omits it rather than zero-filling. Callers MUST NOT default a
+   * missing `metrics` to zeroes — that is precisely the substitution that renders an outage as a
+   * performance result, and it is the defect this row shape exists to prevent.
+   *
+   * For the same reason `ok_count` travels alongside `rows`: an empty `action_items` is not an
+   * all-clear if half the rows could not be read.
+   *
+   * ## The window is a QUERY parameter
+   *
+   * Passed as the proxy's fifth argument, which is `query` — the sixth is the request body. A
+   * window sent in the body position would reach the wire as no window at all, with no type
+   * error, and campaign-service would silently apply per-platform defaults instead.
+   *
+   * Omitted when the caller does not specify one, rather than defaulted here to `last_30_days`.
+   * The default is per-platform upstream and is NOT uniformly 30 days: X Ads caps a request's
+   * range at 7 days and REJECTS a wider explicit window, so sending one here would turn an
+   * omitted window into a guaranteed failure on that platform.
+   */
+  public async getBriefMetrics(req: Request, projectSlug: string, briefId: string, window?: CampaignMetricsWindow): Promise<BriefMetrics> {
+    if (projectSlug === '' || briefId === '') {
+      // Refused rather than sent, for the reason `loadBrief` and `searchHubSpotEmails` refuse: an
+      // empty segment makes `/projects//briefs//metrics`, a DIFFERENT route that 404s at the
+      // gateway. A gateway 404 is not campaign-service saying the brief does not exist, and a
+      // caller cannot tell the two apart from the status code alone.
+      throw new Error('A brief metrics read requires both the project and the brief it is scoped to.');
+    }
+    return this.microserviceProxy.proxyRequest<BriefMetrics>(
+      req,
+      'LFX_V2_CAMPAIGN_SERVICE',
+      `/projects/${encodeURIComponent(projectSlug)}/briefs/${encodeURIComponent(briefId)}/metrics`,
+      'GET',
+      window ? { window } : undefined
+    );
   }
 
   /**

--- a/apps/lfx-one/src/server/services/campaign-service.service.ts
+++ b/apps/lfx-one/src/server/services/campaign-service.service.ts
@@ -1084,10 +1084,14 @@ export class CampaignServiceClient {
    * window sent in the body position would reach the wire as no window at all, with no type
    * error, and campaign-service would silently apply per-platform defaults instead.
    *
-   * Omitted when the caller does not specify one, rather than defaulted here to `last_30_days`.
-   * The default is per-platform upstream and is NOT uniformly 30 days: X Ads caps a request's
-   * range at 7 days and REJECTS a wider explicit window, so sending one here would turn an
-   * omitted window into a guaranteed failure on that platform.
+   * Omitted when the caller does not specify one, rather than defaulted here, because upstream
+   * resolves the default PER ROW: `defaultMetricsWindowFor` runs inside the fan-out and gives
+   * X Ads `last_7_days` (its stats endpoint caps a query at 7 days) and everything else
+   * `last_30_days`. An explicit window overrides that for every row.
+   *
+   * Defaulting here would therefore DISCARD the per-platform fallback rather than fail: an X row
+   * that would have been served at 7 days comes back `unsupported`, and the other rows report
+   * normally. The lost row is quiet, which is why the default belongs upstream.
    */
   public async getBriefMetrics(req: Request, projectSlug: string, briefId: string, window?: CampaignMetricsWindow): Promise<BriefMetrics> {
     if (projectSlug === '' || briefId === '') {

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -717,3 +717,16 @@ export const JOB_LOST_MESSAGE = 'Lost connection to the campaign creation proces
  * user actually wants — scrolling 4,000 rows is not.
  */
 export const HUBSPOT_TEMPLATE_RENDER_LIMIT = 100;
+
+/**
+ * Every reporting window campaign-service accepts, as a runtime list.
+ *
+ * `CampaignMetricsWindow` is a compile-time type and cannot check a query string, so a BFF route
+ * taking `?window=` needs this to reject a value before it reaches the wire. Kept beside the type
+ * and derived from the same source (`metricsWindowEnum`, `design/brief.go`) so the two cannot
+ * drift: a value accepted here but absent from the type — or the reverse — would be a 400 the
+ * caller cannot predict from the published contract.
+ *
+ * Order is the enum's, widening then calendar-relative; nothing depends on it.
+ */
+export const CAMPAIGN_METRICS_WINDOWS = ['today', 'yesterday', 'last_7_days', 'last_14_days', 'last_30_days', 'this_month', 'last_month'] as const;

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1685,9 +1685,13 @@ export interface CampaignStatusUpdateResult {
  * The reporting windows campaign-service accepts. Mirrors `metricsWindowEnum` in
  * `design/brief.go` — the seven values of `model.MetricsWindow`.
  *
- * An explicit window always wins. Omit it and campaign-service applies a PER-PLATFORM default,
- * which is not always `last_30_days`: X Ads caps a request's range at 7 days and REJECTS a wider
- * explicit window rather than narrowing it, so it defaults to `last_7_days`.
+ * An explicit window always wins, for EVERY row. Omit it and campaign-service picks the default
+ * per row, per platform — `last_7_days` for X Ads, whose stats endpoint caps a query at 7 days,
+ * and `last_30_days` for everything else.
+ *
+ * That fallback applies ONLY to an omitted window. An explicit window a platform cannot serve is
+ * not silently narrowed: on the single-campaign read it is a 400, and on the brief-wide read it
+ * comes back as that row's `status: 'unsupported'` while the other rows still report.
  */
 export type CampaignMetricsWindow = (typeof CAMPAIGN_METRICS_WINDOWS)[number];
 

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1,6 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { CAMPAIGN_METRICS_WINDOWS } from '../constants/campaign.constants';
+
 // ---------------------------------------------------------------------------
 // Platform & Phase
 // ---------------------------------------------------------------------------
@@ -1677,4 +1679,148 @@ export interface CampaignStatusUpdateResult {
    * "what was asked for". Absent on the legacy path, whose SDK calls return no row.
    */
   serviceStatus?: string;
+}
+
+/**
+ * The reporting windows campaign-service accepts. Mirrors `metricsWindowEnum` in
+ * `design/brief.go` — the seven values of `model.MetricsWindow`.
+ *
+ * An explicit window always wins. Omit it and campaign-service applies a PER-PLATFORM default,
+ * which is not always `last_30_days`: X Ads caps a request's range at 7 days and REJECTS a wider
+ * explicit window rather than narrowing it, so it defaults to `last_7_days`.
+ */
+export type CampaignMetricsWindow = (typeof CAMPAIGN_METRICS_WINDOWS)[number];
+
+/**
+ * Whether a row in a brief-wide metrics read carries a measurement. ONLY `ok` does.
+ *
+ * Mirrors `briefMetricsRowStatusEnum`. The values are the failure modes the single-campaign
+ * endpoint expresses as distinct HTTP responses, which an aggregate cannot do — one campaign's
+ * 409 must not fail the other five:
+ *
+ * - `ok` — the read succeeded.
+ * - `unsupported` — no metrics dispatcher for the platform, or the window is unservable there.
+ *   Retrying is pointless; a narrower window may help.
+ * - `not_ready` — no platform campaign id yet, or no data for the window. Common and benign: a
+ *   staged email draft reads this way until a human sends it. NOT a failure to surface as one.
+ * - `connection_problem` — the connection cannot serve this campaign. An operator repairs it;
+ *   retrying never helps.
+ * - `failed` — the platform read itself failed. Transient; retrying may succeed.
+ */
+export type BriefMetricsRowStatus = 'ok' | 'unsupported' | 'not_ready' | 'connection_problem' | 'failed';
+
+/** The pacing band `pct` falls into. `unknown` means no pacing could be derived — NOT "on plan". */
+export type CampaignPacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending' | 'unknown';
+
+/** Email-channel counters. Present only for the email channel (HubSpot); absent for ad platforms. */
+export interface CampaignServiceEmailMetrics {
+  sent: number;
+  delivered: number;
+  opens: number;
+  clicks: number;
+  bounces: number;
+  unsubscribes: number;
+}
+
+/** One campaign's measurement, as campaign-service reports it. */
+export interface CampaignServiceCampaignMetrics {
+  campaign_id: string;
+  platform_campaign_id: string;
+  window: CampaignMetricsWindow;
+  /** Impressions over the window on an ad platform; opens to date on the email channel. */
+  impressions: number;
+  clicks: number;
+  /**
+   * Cost in MICRO-UNITS of the platform's OWN native currency — USD for LinkedIn/Reddit, X's
+   * billing unit for Twitter. campaign-service performs no FX conversion, so these must never be
+   * summed across platforms: the result would carry no currency and no meaning. Always 0 on the
+   * email channel, which bills no per-send cost; do not blend that 0 into a cross-channel CPA.
+   */
+  cost_micros: number;
+  /** Clicks/Impressions, 0 when impressions is 0. */
+  ctr: number;
+  email?: CampaignServiceEmailMetrics;
+}
+
+/** Spend against the flight-prorated plan, for ONE campaign. Never total or average across rows. */
+export interface CampaignServicePacing {
+  /**
+   * Spend as a percentage of what this campaign should have spent BY NOW.
+   *
+   * ABSENT when pacing is not computable — never zero-filled, because 0% is a claim about spend.
+   * Read `label === 'unknown'` for that case rather than defaulting this to 0.
+   */
+  pct?: number;
+  label: CampaignPacingLabel;
+}
+
+/**
+ * One campaign's slot in a brief-wide metrics read.
+ *
+ * Every campaign on the brief gets a row, INCLUDING ones that could not be read — that is the
+ * point of the type. `metrics` is present if and only if `status === 'ok'`, and absent otherwise
+ * rather than zero-filled, so a consumer can tell "measured zero" from "could not measure". A
+ * zero-filled row is the exact substitution that turns a failed read into a performance result.
+ */
+export interface BriefMetricsRow {
+  campaign_id: string;
+  platform: string;
+  status: BriefMetricsRowStatus;
+  /** Present if and ONLY if `status` is `ok`. Never zero-filled — a zero is a claim. */
+  metrics?: CampaignServiceCampaignMetrics;
+  /** Why this row carries no measurement, in consumer-safe wording. Absent when `status` is `ok`. */
+  reason?: string;
+  /** Absent unless `status` is `ok`. On an `ok` row it is always present. */
+  pacing?: CampaignServicePacing;
+}
+
+/**
+ * One thing an operator should look at, derived by campaign-service from the readable rows.
+ *
+ * `rule` is a STABLE TOKEN — group, filter or link on it. `issue` and `action` are for humans and
+ * may be reworded, so keying on that prose would break silently when it is.
+ *
+ * Distinct from the BFF's own `CampaignActionItem`, which four platform services derive
+ * independently and which disagree with each other and with this one on CTR thresholds,
+ * impression floors and how paused campaigns are treated. This is the single-source version.
+ */
+export interface BriefMetricsActionItem {
+  rule: 'zero_delivery' | 'underspending' | 'budget_constrained' | 'low_ctr';
+  priority: 'HIGH' | 'MED';
+  campaign_id: string;
+  platform: string;
+  issue: string;
+  action: string;
+}
+
+/**
+ * A brief-wide metrics read: `GET /projects/{projectId}/briefs/{briefId}/metrics`.
+ *
+ * There is deliberately NO cross-channel cost total — see `cost_micros`. Impressions and clicks
+ * are unitless and could be summed, but campaign-service leaves that to the consumer alongside
+ * `ok_count` rather than presenting a whole-brief figure the row set may not support.
+ */
+export interface BriefMetrics {
+  brief_id: string;
+  /**
+   * The window REQUESTED for this read. Per-platform defaults still apply when it is omitted, so
+   * an individual row may cover a NARROWER window than this — each row's own `metrics.window`
+   * records what that row actually covers.
+   */
+  window: CampaignMetricsWindow;
+  /** One row per campaign on the brief, in a stable order. Includes rows that could not be read. */
+  rows: BriefMetricsRow[];
+  /**
+   * How many rows carry a measurement. Compare against `rows.length` before presenting ANY
+   * cross-campaign total — a total over 2 of 6 campaigns is not the brief's performance.
+   */
+  ok_count: number;
+  /**
+   * What an operator should look at, derived from the READABLE rows.
+   *
+   * Empty means nothing was flagged among those rows. It is NOT a claim that every row was
+   * readable — unreadable rows raise no items — so check `ok_count` against `rows.length` before
+   * rendering an empty list as an all-clear.
+   */
+  action_items: BriefMetricsActionItem[];
 }

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1713,8 +1713,16 @@ export type CampaignMetricsWindow = (typeof CAMPAIGN_METRICS_WINDOWS)[number];
  */
 export type BriefMetricsRowStatus = 'ok' | 'unsupported' | 'not_ready' | 'connection_problem' | 'failed';
 
-/** The pacing band `pct` falls into. `unknown` means no pacing could be derived — NOT "on plan". */
-export type CampaignPacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending' | 'unknown';
+/**
+ * The pacing band `pct` falls into. `unknown` means no pacing could be derived — NOT "on plan".
+ *
+ * `CampaignService*` prefixed, matching its siblings here, because it is the ONLY five-member
+ * variant: `PacingLabel`, `MetaPacingLabel`, `LinkedInPacingLabel` and `RedditPacingLabel` are
+ * all four-member BFF types with no `unknown`. Under the generic `Campaign` name this is the one
+ * a reader grabs by mistake, and `unknown` is precisely the member whose absence causes a
+ * non-computable pacing to be rendered as a number.
+ */
+export type CampaignServicePacingLabel = 'underspending' | 'normal' | 'constrained' | 'overspending' | 'unknown';
 
 /** Email-channel counters. Present only for the email channel (HubSpot); absent for ad platforms. */
 export interface CampaignServiceEmailMetrics {
@@ -1771,7 +1779,7 @@ export interface CampaignServicePacing {
    * Read `label === 'unknown'` for that case rather than defaulting this to 0.
    */
   pct?: number;
-  label: CampaignPacingLabel;
+  label: CampaignServicePacingLabel;
 }
 
 /**
@@ -1784,6 +1792,11 @@ export interface CampaignServicePacing {
  */
 export interface BriefMetricsRow {
   campaign_id: string;
+  /**
+   * `string`, not `CampaignPlatform`: upstream's platform enum includes `hubspot` (the email
+   * channel) alongside the six ad channels, and `CampaignPlatform` has no member for it. The
+   * union would be wrong here rather than merely loose.
+   */
   platform: string;
   status: BriefMetricsRowStatus;
   /** Present if and ONLY if `status` is `ok`. Never zero-filled — a zero is a claim. */
@@ -1793,6 +1806,16 @@ export interface BriefMetricsRow {
   /** Absent unless `status` is `ok`. On an `ok` row it is always present. */
   pacing?: CampaignServicePacing;
 }
+
+/**
+ * How urgently an action item wants attention.
+ *
+ * Deliberately TWO members where the four BFF siblings (`ActionPriority`, `MetaActionPriority`,
+ * `LinkedInActionPriority`, `RedditActionPriority`) carry three: campaign-service emits only
+ * HIGH and MED, so a `'LOW'` here would declare a value the endpoint cannot return. Named rather
+ * than inlined so the narrowing reads as intentional instead of as an omission.
+ */
+export type BriefMetricsActionPriority = 'HIGH' | 'MED';
 
 /**
  * One thing an operator should look at, derived by campaign-service from the readable rows.
@@ -1806,8 +1829,9 @@ export interface BriefMetricsRow {
  */
 export interface BriefMetricsActionItem {
   rule: 'zero_delivery' | 'underspending' | 'budget_constrained' | 'low_ctr' | 'no_conversions';
-  priority: 'HIGH' | 'MED';
+  priority: BriefMetricsActionPriority;
   campaign_id: string;
+  /** `string` for the same reason as `BriefMetricsRow.platform` — `hubspot` is in scope. */
   platform: string;
   issue: string;
   action: string;

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1739,6 +1739,22 @@ export interface CampaignServiceCampaignMetrics {
   cost_micros: number;
   /** Clicks/Impressions, 0 when impressions is 0. */
   ctr: number;
+  /**
+   * Conversions attributed to this campaign over the window.
+   *
+   * FRACTIONAL, and deliberately not an integer: Google Ads and Microsoft both type this as a
+   * double and credit PARTIAL conversions under data-driven, position-based and offline
+   * attribution, so 0.4 of a conversion is a real value. Do not round it, and in particular do
+   * not treat a value below 1 as zero.
+   *
+   * ABSENT means "not measured here", which is NOT a measured 0. Meta, X, Reddit and the email
+   * channel never report a campaign-level conversion count, and Microsoft omits it whenever the
+   * ConversionsQualified column is missing or any row's cell is blank — that column is only
+   * populated for accounts wired for Universal Event Tracking, and a partial column summed as
+   * though it were complete would understate the campaign. So a consumer must not render an
+   * absent value as zero or fold it into a conversion total.
+   */
+  conversions?: number;
   email?: CampaignServiceEmailMetrics;
 }
 
@@ -1785,7 +1801,7 @@ export interface BriefMetricsRow {
  * impression floors and how paused campaigns are treated. This is the single-source version.
  */
 export interface BriefMetricsActionItem {
-  rule: 'zero_delivery' | 'underspending' | 'budget_constrained' | 'low_ctr';
+  rule: 'zero_delivery' | 'underspending' | 'budget_constrained' | 'low_ctr' | 'no_conversions';
   priority: 'HIGH' | 'MED';
   campaign_id: string;
   platform: string;


### PR DESCRIPTION
LFXV2-3314's Go half shipped some time ago: campaign-service derives action items in `internal/service/rules/` and returns them on `GET /projects/{projectId}/briefs/{briefId}/metrics`, where `action_items` is a **required** field.

Nothing in this app could reach them. There was no client method, no BFF route and no shared type — so the Optimize tab still derives its own action items from **four separate rule engines in this BFF** (`campaign-metrics.service.ts`, `linkedin-ads.service.ts`, `reddit-ads.service.ts`, `meta-ads.service.ts`). Those four disagree with each other and with campaign-service on the low-CTR threshold, the impression floor beneath which CTR is judged at all, and whether a paused campaign raises anything.

**This PR adds the read only.** No UI change, no rules deleted, no cutover.

## Why no cutover here

The two sources are not interchangeable, and swapping them would be a silent scope change:

- The BFF engines are **account-scoped** — every campaign in the ad account.
- This is **brief-scoped** — the campaigns campaign-service has adopted onto one brief.

The Optimize tab holds no brief id today and takes no brief input, so wiring it is a separate change with its own decisions. Building a whole-account view on top of this would need brief ids from the **Query Service**, which owns brief lists by design (rule 3) — `GET /projects/{id}/briefs` is `find-brief`, requiring `event_slug` and returning one brief.

## What is here

- `getBriefMetrics` on the campaign-service client
- `GET /api/campaigns/brief/metrics`, requiring both `project` and `brief`
- `BriefMetrics` + row, pacing, metrics, action-item and email types in `packages/shared`

## Three contract details worth reviewing

**A failed row carries no metrics, and stays that way.** Only `status === 'ok'` carries `metrics`; every other status omits it rather than zero-filling. The client passes that through untouched. Zero-filling is exactly what renders an outage as a measured zero, which is why the row carries a status at all. `ok_count` travels with `rows` so an empty `action_items` cannot be read as an all-clear when half the rows were unreadable.

**`window` is the proxy's fifth argument, which is `query`.** The sixth is the body. A window sent in the body position reaches the wire as *no window*, with no type error, and campaign-service would silently apply defaults.

**`window` is refused when unrecognised and omitted when absent — never defaulted.** The upstream default is per-platform and is not uniformly 30 days: X Ads caps a request's range at 7 days and *rejects* a wider explicit window rather than narrowing it, so defaulting to `last_30_days` here would be a guaranteed failure on that platform. An unrecognised value is refused rather than dropped, because dropping it would serve a different period than the caller asked for and the response's own `window` field would report the default as though it had been requested.

`CampaignMetricsWindow` is derived from `CAMPAIGN_METRICS_WINDOWS` so the compile-time type and the runtime list the route validates against cannot drift.

## Verification

Type and enum fidelity are checked **mechanically against `git show origin/main:design/brief.go`** — all six types match their Go `Required()` sets field for field on required-vs-optional, and all four enums match member-for-member in order.

> The first version of this PR got that wrong and said so anyway. The check ran against a campaign-service **worktree parked on an older feature branch**, so it confirmed an outdated contract and reported clean while two fields were missing: the optional fractional `conversions` on `campaign-metrics`, and the fifth rule `no_conversions`. Both were caught in review and are fixed. Re-running against `origin/main` now finds no drift.

Every guard is pinned by a test that fails when it is reverted, and only it:

| Mutation | Test that fails |
|---|---|
| `window` moved to the body position | sends the window as a query parameter |
| invalid window dropped instead of refused | refuses an unrecognised window |
| window defaulted to `last_30_days` | passes undefined when no window is given |
| empty-segment guard removed | refuses a request with no project / no brief |
| failed row zero-filled | passes a failed row through without inventing metrics |
| repeated `?window=` (array) accepted | refuses a repeated window param |
| `conversions` / `no_conversions` removed from the types | keeps them declared in the shared types |

One caveat worth stating: **server specs are typechecked by nothing** — `tsconfig.spec.json` includes only `src/app/**` — and `proxyRequest` is an untyped `vi.fn()`. So the first test for the two restored fields could not fail on their removal, which is how they went missing. The declaration test above is the one that binds; it was verified by re-running the same mutation.

1846 server specs and 990 app specs pass; both tsconfigs typecheck (`build` alone does not typecheck specs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011hmLaFyc1zTDesXktgvRpe
