### PR TITLE
fix(committees): exclude LF Staff seats with no voting status from engagement metrics

### DIFF
--- a/apps/lfx-one/e2e/committee-engagement.spec.ts
+++ b/apps/lfx-one/e2e/committee-engagement.spec.ts
@@ -95,6 +95,13 @@ test.describe('Committee engagement — members table (flag on)', () => {
     await expect(page.getByTestId('members-engagement-chip-m-emeritus')).toContainText('Emeritus');
     await expect(page.getByTestId('members-engagement-chip-m-lf-staff')).toContainText('LF Staff');
     await expect(page.getByTestId('members-engagement-chip-m-lf-staff-none')).toContainText('LF Staff');
+    // The chip text alone doesn't prove the reported bug's second symptom stays fixed — the tooltip
+    // (resolveEngagementContext) is a separate code path that could regress to the generic
+    // "attended X of Y invited meetings" role-context branch while classification still renders
+    // correctly. Hover and assert the actual exclusion tooltip text.
+    await page.getByTestId('members-engagement-chip-m-lf-staff-none').hover();
+    await expect(page.locator('.p-tooltip')).toBeVisible({ timeout: ELEMENT_TIMEOUT });
+    await expect(page.locator('.p-tooltip')).toContainText('LF Staff seat — excluded from engagement metrics; attendance expectations do not apply');
     // An LF Staff member who is a real Voting Rep classifies on real attendance, NOT the neutral
     // LF Staff tier.
     await expect(page.getByTestId('members-engagement-chip-m-lf-staff-rep')).toContainText('High');

--- a/apps/lfx-one/e2e/committee-engagement.spec.ts
+++ b/apps/lfx-one/e2e/committee-engagement.spec.ts
@@ -87,12 +87,16 @@ test.describe('Committee engagement — members table (flag on)', () => {
     await expect(page.getByTestId('members-engagement-chip-m-medium')).toContainText('Medium');
     await expect(page.getByTestId('members-engagement-chip-m-low')).toContainText('Low');
     await expect(page.getByTestId('members-engagement-chip-m-inactive-invited')).toContainText('Inactive');
-    // Emeritus and LF Staff + Observer both render their own neutral tier — never
-    // Low/Inactive/at-risk styling.
+    // Emeritus, LF Staff + Observer, and LF Staff + no voting status all render their own neutral
+    // tier — never Low/Inactive/at-risk styling. m-lf-staff-none's classification is fixture-mocked
+    // ('LF Staff' hardcoded below), so this only proves the UI renders it correctly, not that the
+    // tenure-grace decision is right — that's covered directly in
+    // committee-engagement-classifier.utils.spec.ts's classifyCommitteeEngagement cases.
     await expect(page.getByTestId('members-engagement-chip-m-emeritus')).toContainText('Emeritus');
     await expect(page.getByTestId('members-engagement-chip-m-lf-staff')).toContainText('LF Staff');
+    await expect(page.getByTestId('members-engagement-chip-m-lf-staff-none')).toContainText('LF Staff');
     // An LF Staff member who is a real Voting Rep classifies on real attendance, NOT the neutral
-    // LF Staff tier (LFXV2-3101 follow-up, Jordan Evans review).
+    // LF Staff tier.
     await expect(page.getByTestId('members-engagement-chip-m-lf-staff-rep')).toContainText('High');
 
     // computed_at is null in the fixture → the daily-refresh freshness fallback.
@@ -120,6 +124,7 @@ test.describe('Committee engagement — members table (flag on)', () => {
     await expect(page.getByText('Nova Neverasked')).toHaveCount(0);
     await expect(page.getByText('Evan Emeritus')).toHaveCount(0);
     await expect(page.getByText('Sam Staffer')).toHaveCount(0);
+    await expect(page.getByText('Alex Nonstatus')).toHaveCount(0);
     // Real 80% attendance — not at-risk, filtered out same as any other well-engaged member.
     await expect(page.getByText('Priya Repstaff')).toHaveCount(0);
   });
@@ -151,6 +156,13 @@ test.describe('Committee engagement — members table (flag on)', () => {
 
     await expect(page.getByTestId('members-engagement-meetings-m-high')).toHaveText('—', { timeout: ELEMENT_TIMEOUT });
     await expect(page.getByTestId('members-engagement-chip-m-high')).toHaveText('—');
+    // `engagementDataAvailable()` gates the chip render for every row (committee-members.component.
+    // html), so every classification — including m-lf-staff-none's — renders the same em-dash here
+    // regardless of what degradedClassification computed; that delegation isn't observable on this
+    // path or the live path above (both fixture-mock the classification directly rather than
+    // deriving it). isLfStaffNonVotingSeat's own decision table is covered directly in
+    // committee-engagement-classifier.utils.spec.ts's classifyCommitteeEngagement cases.
+    await expect(page.getByTestId('members-engagement-chip-m-lf-staff-none')).toHaveText('—');
     // A degraded response zeroes every row, so the At Risk chip would be a permanent "(0)" — hidden.
     await expect(page.getByTestId('members-chip-atRisk')).toHaveCount(0);
     // The roster stays fully functional.
@@ -202,12 +214,37 @@ test.describe('Committee engagement — overview summary (flag on)', () => {
     test.skip(!flagOn, 'wg-engagement-metrics flag appears OFF for this test user — see file header for the LD precondition');
 
     await expect(summary.getByTestId('committee-engagement-summary-attendance-rate')).toContainText('78%', { timeout: ELEMENT_TIMEOUT });
-    // 4/6, not 4/8 — the denominator is eligible_count (roster minus Emeritus/LF Staff+Observer),
+    // 4/6, not 4/9 — the denominator is eligible_count (roster minus Emeritus/non-voting LF Staff),
     // not total_count. active_count is 4 (m-high, m-medium, m-low, m-lf-staff-rep — the real Voting
     // Rep LF Staff member counts like any other real member).
     await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('4/6');
     await expect(summary.getByTestId('committee-engagement-summary-at-risk')).toContainText('2');
     await expect(summary.getByTestId('committee-engagement-summary-freshness')).toHaveText('Updated daily');
+  });
+
+  test('renders an em-dash, not "0/0", for a committee whose roster is entirely excluded from active_count (GH-1848)', async ({ page }) => {
+    await mockCommitteeShell(page);
+    // Only `summary` is overridden — the active-members row this assertion targets reads only
+    // `summary.eligible_count`/`active_count`, not `members[]`, so the roster itself can stay the
+    // default mixed fixture (the rest of the response, notably `data_available: true`, also stays
+    // default, which is what keeps the metrics block rendered at all instead of falling into the
+    // coming-soon state). The attendance-rate row is a different story — it re-derives its own gate
+    // from `members[]` (`hasInvitedRateEligibleMember`), and the default fixture's roster still has
+    // an invited rate-eligible member, so it renders a real percentage here rather than an em-dash;
+    // that's fine, this test doesn't assert on it. `eligible_count: 0` here stands in for the real-world
+    // shape GH-1848 makes reachable: a committee without voting where every seat is Emeritus or
+    // non-voting LF Staff, so the ratio's denominator is genuinely 0.
+    await mockEngagementApi(page, (window) => {
+      const base = buildEngagementResponse(window);
+      return { ...base, summary: { ...base.summary, attendance_rate: 0, active_count: 0, eligible_count: 0, at_risk_count: 0 } };
+    });
+    await gotoEngagementCommitteeTab(page, 'overview');
+
+    const summary = page.getByTestId('committee-overview-engagement-summary');
+    const flagOn = await appearsWithin(summary, ELEMENT_TIMEOUT);
+    test.skip(!flagOn, 'wg-engagement-metrics flag appears OFF for this test user — see file header for the LD precondition');
+
+    await expect(summary.getByTestId('committee-engagement-summary-active-members')).toContainText('—', { timeout: ELEMENT_TIMEOUT });
   });
 
   test('degraded response shows the calm coming-soon state, not an error', async ({ page }) => {

--- a/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
+++ b/apps/lfx-one/e2e/helpers/committee-engagement.helper.ts
@@ -5,15 +5,30 @@
  * Shared fixtures/mocks for the committee engagement UI specs (LFXV2-1705).
  *
  * The engagement fixture exercises all six classification tiers the BFF can serve (High / Medium /
- * Low / Inactive / Emeritus / LF Staff, LFXV2-3101) over seven fixture scenarios (Inactive appears
- * twice: with and without invites) on a roster whose uids match the mocked `/members` response, so
+ * Low / Inactive / Emeritus / LF Staff, LFXV2-3101) over nine fixture scenarios (High, Inactive, and
+ * the LF Staff *tier* each appear twice — m-lf-staff (Observer) and m-lf-staff-none (no voting
+ * status, broadened in GH-1848) both classify LF Staff; the roster's second LF Staff-*role* seat,
+ * m-lf-staff-rep, deliberately does NOT — it's a real Voting Rep) on a roster whose uids match the
+ * mocked `/members` response, so
  * the Members-table join and the At-Risk filter behave exactly as they would against the real
  * endpoint. Specs mock the BFF over `page.route` and stay independent of the server's
  * ENGAGEMENT_BACKEND mode.
  */
 
 import { COMMITTEE_ENGAGEMENT_DEFAULT_WINDOW } from '@lfx-one/shared/constants';
+import { CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
 import type { CommitteeEngagementResponse, CommitteeEngagementWindow, CommitteeMemberEngagement } from '@lfx-one/shared/interfaces';
+// Deep-imported (not the `@lfx-one/shared/utils` category barrel — mirroring the existing e2e
+// precedent for deep `utils` imports in org-roi-summary.spec.ts / org-roi-projects.spec.ts /
+// org-roi-project-detail.spec.ts / past-meeting-ai-summary-visibility.spec.ts) because the barrel's
+// `index.ts` re-exports every utils
+// file, including ones that import `@angular/forms`/`@angular/common/http`; Playwright's own module
+// loader can't JIT-compile those. This single file's own runtime imports (both Angular-free:
+// `../constants/committee-engagement.constants` and `../enums`) don't pull any of that in today, so
+// importing it directly sidesteps the barrel entirely instead of hand-copying its predicate — but
+// that's a property of its current import graph, not a guarantee; re-check if this file ever gains
+// a new runtime dependency.
+import { isCommitteeMemberActiveEligible, isLfStaffNonVotingSeat } from '@lfx-one/shared/utils/committee-engagement-classifier.utils';
 import { expect, Locator, Page, test } from '@playwright/test';
 
 export const PAGE_LOAD_TIMEOUT = 30_000;
@@ -62,7 +77,10 @@ export function buildEngagementCommittee(): Record<string, unknown> {
     is_foundation: false,
     parent_uid: null,
     parent_project_uid: 'e2e-project-uid',
-    total_members: 8,
+    // Derived from ROSTER (declared below — safe, this function's body only runs at call time,
+    // after the module has fully evaluated) rather than a hand-maintained literal, so adding a
+    // roster seed can't silently desync this count again.
+    total_members: ROSTER.length,
     created_at: '2025-01-15T00:00:00Z',
     updated_at: '2026-06-01T00:00:00Z',
     member_visibility: 'basic_profile',
@@ -88,15 +106,17 @@ const ROSTER: RosterSeed[] = [
   { uid: 'm-inactive-invited', first: 'Ira', last: 'Skipsall', role: 'None', votingStatus: 'Voting Rep' },
   { uid: 'm-inactive-never', first: 'Nova', last: 'Neverasked', role: 'None', votingStatus: 'Observer' },
   { uid: 'm-emeritus', first: 'Evan', last: 'Emeritus', role: 'None', votingStatus: 'Emeritus' },
-  // Mirrors the live bug the ticket was filed from (LFXV2-3101): an LF Staff seat added as an
-  // Observer with no real attendance expectation, which must render its own neutral tier, never
-  // Low/Inactive/at-risk styling.
+  // An LF Staff seat added as an Observer, with no real attendance expectation — must render its
+  // own neutral tier, never Low/Inactive/at-risk styling.
   { uid: 'm-lf-staff', first: 'Sam', last: 'Staffer', role: 'LF Staff', votingStatus: 'Observer' },
-  // LFXV2-3101 follow-up (Jordan Evans review): an LF Staff member who is a real Voting Rep — an
-  // ED or staff member serving as a genuine board/committee voting representative — must classify
-  // and count normally, NOT as the neutral LF Staff tier. Only the Observer-status staff seat above
-  // is excluded.
+  // An LF Staff member who is a real Voting Rep — an ED or staff member serving as a genuine
+  // board/committee voting representative — must classify and count normally, NOT as the neutral
+  // LF Staff tier. Only a non-voting staff seat (Observer, or no voting status at all) is excluded.
   { uid: 'm-lf-staff-rep', first: 'Priya', last: 'Repstaff', role: 'LF Staff', votingStatus: 'Voting Rep' },
+  // A committee without voting leaves staff seats with no voting status recorded at all, not
+  // Observer. Must render the same neutral LF Staff tier as m-lf-staff above, not the
+  // tenure-grace High tier (GH-1848).
+  { uid: 'm-lf-staff-none', first: 'Alex', last: 'Nonstatus', role: 'LF Staff', votingStatus: 'None' },
 ];
 
 export function buildRoster(): Record<string, unknown>[] {
@@ -112,76 +132,121 @@ export function buildRoster(): Record<string, unknown>[] {
   }));
 }
 
+// The 30d/ytd engagement row per roster seat (COMMITTEE_ENGAGEMENT_SUPPORTED_WINDOWS is
+// ['30d', '90d', 'ytd'] — only 90d differs, via MEMBER_WINDOW_OVERRIDES below; ytd falls through to
+// these same numbers, same as the ternary this replaced). Every row but m-high is window-
+// independent, so one seat-identity array covers the non-90d windows instead of duplicating them.
+const MEMBER_SEATS: CommitteeMemberEngagement[] = [
+  { uid: 'm-high', attended: 12, invited: 12, rate: 1, classification: 'High', role: 'Chair', voting_status: 'Voting Rep', committee_meetings: 12 },
+  { uid: 'm-medium', attended: 7, invited: 12, rate: 0.58, classification: 'Medium', role: 'None', voting_status: 'Voting Rep', committee_meetings: 12 },
+  { uid: 'm-low', attended: 2, invited: 10, rate: 0.2, classification: 'Low', role: 'None', voting_status: 'Observer', committee_meetings: 12 },
+  {
+    uid: 'm-inactive-invited',
+    attended: 0,
+    invited: 8,
+    rate: 0,
+    classification: 'Inactive',
+    role: 'None',
+    voting_status: 'Voting Rep',
+    committee_meetings: 12,
+  },
+  {
+    uid: 'm-inactive-never',
+    attended: 0,
+    invited: 0,
+    rate: 0,
+    classification: 'Inactive',
+    role: 'None',
+    voting_status: 'Observer',
+    committee_meetings: 12,
+  },
+  { uid: 'm-emeritus', attended: 1, invited: 10, rate: 0.1, classification: 'Emeritus', role: 'None', voting_status: 'Emeritus', committee_meetings: 12 },
+  {
+    uid: 'm-lf-staff',
+    attended: 0,
+    invited: 8,
+    rate: 0,
+    classification: 'LF Staff',
+    role: 'LF Staff',
+    voting_status: 'Observer',
+    committee_meetings: 12,
+  },
+  {
+    uid: 'm-lf-staff-rep',
+    attended: 8,
+    invited: 10,
+    rate: 0.8,
+    classification: 'High',
+    role: 'LF Staff',
+    voting_status: 'Voting Rep',
+    committee_meetings: 12,
+  },
+  {
+    uid: 'm-lf-staff-none',
+    attended: 0,
+    invited: 0,
+    rate: 0,
+    classification: 'LF Staff',
+    role: 'LF Staff',
+    voting_status: 'None',
+    committee_meetings: 12,
+  },
+];
+
+// 90d-window overrides, keyed by uid — only m-high differs from the 30d numbers above. Typed to the
+// attendance-count fields only (not the full row) so an override can't silently change a seat's
+// uid/role/voting_status for one window and escape the drift guard below, which only validates
+// MEMBER_SEATS. classification is excluded from the Pick too, but for a different reason: it isn't
+// drift-guarded on either array (see the guard's own comment on that gap) — excluding it here just
+// stops a window from flipping a seat's tier, it doesn't add coverage that was missing before.
+const MEMBER_WINDOW_OVERRIDES: Record<string, Partial<Pick<CommitteeMemberEngagement, 'attended' | 'invited' | 'rate' | 'committee_meetings'>>> = {
+  'm-high': { attended: 20, invited: 24, rate: 0.83, committee_meetings: 24 },
+};
+
+// ROSTER and MEMBER_SEATS are meant to stay 1:1 by uid, AND agree on role/voting status (every
+// roster seed gets an engagement row under the same uid with the same seat type, so the
+// Members-table join behaves as it would against the real endpoint — see this file's module doc);
+// nothing else enforces that pairing. role/voting_status matter here, not just uid: the engagement
+// row's copy feeds production classification (classifyCommitteeEngagement / isLfStaffNonVotingSeat;
+// this file's degradedClassification mirrors only the seat-type short-circuits, not the rate tiers)
+// and the chip tooltip (committee-members.component.ts's resolveEngagementContext), while the
+// roster's copy separately drives the members-table chip filters (initChipFilteredMembers) —
+// editing one without the other would pass a uid-only guard and only surface later as a confusing
+// tier/chip mismatch, which is why this guard compares seat type too. It still does NOT check each
+// row's hand-written `classification` against role/voting_status/attendance — that's on the editor
+// making a seat-type change.
+//
+// Runs at module load (not inside buildEngagementResponse) so a drift throws at import time —
+// Playwright reports this as a suite-collection error pointing at this exact file and line —
+// rather than inside a page.route handler, where the same throw would surface indirectly as a
+// hung/timed-out request instead.
+const rosterSeats = ROSTER.map((seat) => `${seat.uid}|${seat.role}|${seat.votingStatus}`).join(',');
+const memberSeats = MEMBER_SEATS.map((m) => `${m.uid}|${m.role}|${m.voting_status}`).join(',');
+if (memberSeats !== rosterSeats) {
+  throw new Error(`committee-engagement fixture drift: engagement rows [${memberSeats}] don't match ROSTER [${rosterSeats}]`);
+}
+
 /**
- * One engagement response per window; the 90d numbers differ from 30d so a window switch is
- * observable in the UI, not just on the network. `at_risk_count: 2` = m-low (Low) +
- * m-inactive-invited (Inactive with invites); m-inactive-never, m-emeritus, and m-lf-staff are
- * excluded by rule — m-lf-staff-rep is NOT excluded (real Voting Rep, LFXV2-3101 follow-up) and
- * counts like any other real member. `eligible_count: 6` = the 8-member roster minus m-emeritus and
- * m-lf-staff (the active_count ratio's denominator, LFXV2-3101 review fix — NOT total_count, which
- * stays the full roster size). `active_count`/`eligible_count`/`at_risk_count`/`attendance_rate` are
- * fixture literals, not derived from `members[]` below — they don't need to recompute when a
- * member's numbers change, only to stay a plausible, internally-consistent snapshot.
+ * One engagement response per window; the 90d numbers differ from 30d (via
+ * `MEMBER_WINDOW_OVERRIDES`) so a window switch is observable in the UI, not just on the network.
+ * `at_risk_count: 2` = m-low (Low) + m-inactive-invited (Inactive with invites); m-inactive-never,
+ * m-emeritus, m-lf-staff, and m-lf-staff-none are excluded by rule (Observer and None respectively,
+ * GH-1848) — m-lf-staff-rep is NOT excluded (real Voting Rep, LFXV2-3101 follow-up) and counts like
+ * any other real member. `eligible_count` is derived from `isCommitteeMemberActiveEligible` (the
+ * real active_count/eligible_count denominator rule) rather than a hand-maintained literal, so it
+ * can't drift from MEMBER_SEATS the way a re-typed count could. `active_count`/`at_risk_count`/
+ * `attendance_rate` stay fixture literals — they don't need to recompute when a member's numbers
+ * change, only to stay a plausible, internally-consistent snapshot alongside the derived count.
  */
 export function buildEngagementResponse(window: CommitteeEngagementWindow, overrides: Partial<CommitteeEngagementResponse> = {}): CommitteeEngagementResponse {
-  const is90d = window === '90d';
+  const windowOverrides = window === '90d' ? MEMBER_WINDOW_OVERRIDES : {};
+  const members: CommitteeMemberEngagement[] = MEMBER_SEATS.map((seat) => ({ ...seat, ...windowOverrides[seat.uid] }));
+  const eligibleCount = members.filter((m) => isCommitteeMemberActiveEligible({ role: m.role, votingStatus: m.voting_status })).length;
   return {
-    members: [
-      {
-        uid: 'm-high',
-        attended: is90d ? 20 : 12,
-        invited: is90d ? 24 : 12,
-        rate: is90d ? 0.83 : 1,
-        classification: 'High',
-        role: 'Chair',
-        voting_status: 'Voting Rep',
-        committee_meetings: is90d ? 24 : 12,
-      },
-      { uid: 'm-medium', attended: 7, invited: 12, rate: 0.58, classification: 'Medium', role: 'None', voting_status: 'Voting Rep', committee_meetings: 12 },
-      { uid: 'm-low', attended: 2, invited: 10, rate: 0.2, classification: 'Low', role: 'None', voting_status: 'Observer', committee_meetings: 12 },
-      {
-        uid: 'm-inactive-invited',
-        attended: 0,
-        invited: 8,
-        rate: 0,
-        classification: 'Inactive',
-        role: 'None',
-        voting_status: 'Voting Rep',
-        committee_meetings: 12,
-      },
-      {
-        uid: 'm-inactive-never',
-        attended: 0,
-        invited: 0,
-        rate: 0,
-        classification: 'Inactive',
-        role: 'None',
-        voting_status: 'Observer',
-        committee_meetings: 12,
-      },
-      { uid: 'm-emeritus', attended: 1, invited: 10, rate: 0.1, classification: 'Emeritus', role: 'None', voting_status: 'Emeritus', committee_meetings: 12 },
-      {
-        uid: 'm-lf-staff',
-        attended: 0,
-        invited: 8,
-        rate: 0,
-        classification: 'LF Staff',
-        role: 'LF Staff',
-        voting_status: 'Observer',
-        committee_meetings: 12,
-      },
-      {
-        uid: 'm-lf-staff-rep',
-        attended: 8,
-        invited: 10,
-        rate: 0.8,
-        classification: 'High',
-        role: 'LF Staff',
-        voting_status: 'Voting Rep',
-        committee_meetings: 12,
-      },
-    ],
-    summary: { attendance_rate: 0.78, active_count: 4, eligible_count: 6, total_count: 8, at_risk_count: 2 },
+    members,
+    // total_count is the full roster size; derived from the array actually returned so the two
+    // can't desync.
+    summary: { attendance_rate: 0.78, active_count: 4, eligible_count: eligibleCount, total_count: members.length, at_risk_count: 2 },
     computed_at: null,
     data_available: true,
     data_source: 'live',
@@ -189,10 +254,21 @@ export function buildEngagementResponse(window: CommitteeEngagementWindow, overr
   };
 }
 
-/** Degraded-path classification: role/voting_status stay populated (roster passthroughs) even when every count zeroes out, so the Emeritus/LF Staff+Observer seat-type short-circuits still apply — see `CommitteeEngagementResponse.data_available`'s doc. LF Staff alone is NOT enough (LFXV2-3101 follow-up) — m-lf-staff-rep (Voting Rep) must still degrade to Inactive like any other real member. */
+/**
+ * Degraded-path classification: role/voting_status stay populated (roster passthroughs) even when
+ * every count zeroes out, so the Emeritus/LF Staff+non-voting seat-type short-circuits still apply
+ * — see `CommitteeEngagementResponse.data_available`'s doc. LF Staff alone is NOT enough (LFXV2-3101
+ * follow-up) — m-lf-staff-rep (Voting Rep) must still degrade to Inactive like any other real
+ * member. Delegates to the real `isLfStaffNonVotingSeat` (deep-imported above) rather than hand-
+ * copying it, so this fixture can't silently drift from production's decision table (GH-1848).
+ * This function's output isn't itself asserted on — the degraded UI renders every row's chip as a
+ * plain em-dash regardless of classification, per `engagementDataAvailable()`'s gate in
+ * committee-members.component.html — but the delegation still closes the drift risk of a second,
+ * hand-maintained copy of the condition.
+ */
 function degradedClassification(member: { voting_status: string; role: string }): CommitteeMemberEngagement['classification'] {
-  if (member.voting_status === 'Emeritus') return 'Emeritus';
-  if (member.role === 'LF Staff' && member.voting_status === 'Observer') return 'LF Staff';
+  if (member.voting_status === CommitteeMemberVotingStatus.EMERITUS) return 'Emeritus';
+  if (isLfStaffNonVotingSeat({ role: member.role, votingStatus: member.voting_status })) return 'LF Staff';
   return 'Inactive';
 }
 
@@ -208,9 +284,13 @@ export function buildDegradedEngagementResponse(window: CommitteeEngagementWindo
       committee_meetings: 0,
       classification: degradedClassification(m),
     })),
-    // eligible_count stays 6 (not zeroed) — roster-known independent of engagement data, same as
-    // total_count. See CommitteeEngagementSummary.eligible_count's doc.
-    summary: { attendance_rate: 0, active_count: 0, eligible_count: 6, total_count: 8, at_risk_count: 0 },
+    // eligible_count and total_count stay roster-known (not zeroed) — spread from `base.summary`
+    // rather than re-typed, so this can't drift from the fixture it's built on. See
+    // CommitteeEngagementSummary.eligible_count's doc. A field added to that interface later
+    // defaults to "roster-known, carries over from base" here unless explicitly zeroed above —
+    // revisit this spread when the interface gains a field in the same attendance-derived class as
+    // attendance_rate/active_count/at_risk_count.
+    summary: { ...base.summary, attendance_rate: 0, active_count: 0, at_risk_count: 0 },
     data_available: false,
   };
 }

--- a/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.html
@@ -39,7 +39,7 @@
       <div class="flex flex-col divide-y divide-gray-100">
         <div
           class="flex items-center gap-3 py-2.5"
-          pTooltip="Personal attendance across all invited roster members, including Emeritus seats but excluding LF Staff seats"
+          pTooltip="Personal attendance across all invited roster members, including Emeritus seats but excluding non-voting LF Staff seats"
           tooltipPosition="top"
           tooltipEvent="both"
           tabindex="0"
@@ -52,7 +52,7 @@
         </div>
         <div
           class="flex items-center gap-3 py-2.5"
-          pTooltip="Both active count and the total shown here exclude Emeritus and LF Staff seats — see the committee roster for the full member count"
+          pTooltip="Both active count and the total shown here exclude Emeritus and non-voting LF Staff seats — see the committee roster for the full member count"
           tooltipPosition="top"
           tooltipEvent="both"
           tabindex="0"

--- a/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.spec.ts
@@ -1,0 +1,151 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { CommitteeEngagementResponse, CommitteeMemberEngagement } from '@lfx-one/shared/interfaces';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { CommitteeEngagementSummaryComponent } from './committee-engagement-summary.component';
+
+/**
+ * Covers the GH-1848 accessibility fix through the actual template bindings — the row's rendered
+ * text and its `aria-label` attribute — not just the computed signals that feed them, so a spec
+ * stays green only if `[attr.aria-label]="activeMembersAriaLabel()"`, `[attr.aria-label]=
+ * "attendanceRateAriaLabel()"`, and their label interpolations (in
+ * committee-engagement-summary.component.html's active-members and attendance-rate rows) are all
+ * wired correctly. No flag, no server, no Playwright. These are the two branches on this card with
+ * no other coverage besides a Playwright test that self-skips when the LD flag reads off.
+ */
+const RATE_ELIGIBLE_MEMBER: CommitteeMemberEngagement = {
+  uid: 'm-1',
+  attended: 5,
+  invited: 6,
+  rate: 0.83,
+  classification: 'High',
+  role: 'None',
+  voting_status: 'Voting Rep',
+  committee_meetings: 6,
+};
+
+const NON_VOTING_LF_STAFF_MEMBER: CommitteeMemberEngagement = {
+  uid: 'm-2',
+  attended: 0,
+  invited: 0,
+  rate: 0,
+  classification: 'LF Staff',
+  role: 'LF Staff',
+  voting_status: 'None',
+  committee_meetings: 6,
+};
+
+const RATE_ELIGIBLE_MEMBER_NEVER_INVITED: CommitteeMemberEngagement = {
+  uid: 'm-3',
+  attended: 0,
+  invited: 0,
+  rate: 0,
+  classification: 'Inactive',
+  role: 'None',
+  voting_status: 'Observer',
+  committee_meetings: 6,
+};
+
+function response(
+  overrides: Partial<CommitteeEngagementResponse['summary']> = {},
+  members: CommitteeMemberEngagement[] = [RATE_ELIGIBLE_MEMBER]
+): CommitteeEngagementResponse {
+  return {
+    members,
+    summary: { attendance_rate: 0.78, active_count: 4, eligible_count: 6, total_count: 9, at_risk_count: 2, ...overrides },
+    computed_at: null,
+    data_available: true,
+    data_source: 'live',
+  };
+}
+
+describe('CommitteeEngagementSummaryComponent', () => {
+  let fixture: ComponentFixture<CommitteeEngagementSummaryComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({ imports: [CommitteeEngagementSummaryComponent] }).compileComponents();
+    fixture = TestBed.createComponent(CommitteeEngagementSummaryComponent);
+  });
+
+  function activeMembersRow(): HTMLElement {
+    const el = fixture.nativeElement.querySelector('[data-testid="committee-engagement-summary-active-members"]');
+    if (!el) throw new Error('active-members row not rendered');
+    return el as HTMLElement;
+  }
+
+  function attendanceRateRow(): HTMLElement {
+    const el = fixture.nativeElement.querySelector('[data-testid="committee-engagement-summary-attendance-rate"]');
+    if (!el) throw new Error('attendance-rate row not rendered');
+    return el as HTMLElement;
+  }
+
+  it('renders the active/eligible ratio and embeds it in the aria-label when eligible_count is nonzero', async () => {
+    fixture.componentRef.setInput('engagement', response());
+    await fixture.whenStable();
+
+    expect(activeMembersRow().textContent).toContain('4/6');
+    expect(activeMembersRow().getAttribute('aria-label')).toContain('4/6');
+    expect(activeMembersRow().getAttribute('aria-label')).not.toContain('not available');
+  });
+
+  it('renders an em-dash, not "0/0", and says "not available" in the aria-label when eligible_count is 0 (GH-1848)', async () => {
+    fixture.componentRef.setInput('engagement', response({ eligible_count: 0, active_count: 0 }));
+    await fixture.whenStable();
+
+    const row = activeMembersRow();
+    expect(row.textContent).toContain('—');
+    expect(row.textContent).not.toContain('0/0');
+    const ariaLabel = row.getAttribute('aria-label') ?? '';
+    expect(ariaLabel).toContain('not available');
+    // The single '—' from the label must not be interpolated raw next to the sentence's own
+    // em-dash separator — that reads as two indistinguishable dashes to a screen reader.
+    expect(ariaLabel).not.toMatch(/—\s*—/);
+  });
+
+  it('renders a real attendance rate and embeds it in the aria-label when a rate-eligible member exists', async () => {
+    fixture.componentRef.setInput('engagement', response());
+    await fixture.whenStable();
+
+    expect(attendanceRateRow().textContent).toContain('78%');
+    expect(attendanceRateRow().getAttribute('aria-label')).toContain('78%');
+    expect(attendanceRateRow().getAttribute('aria-label')).not.toContain('not available');
+  });
+
+  it('renders an em-dash, not "0%", and says "not available" in the aria-label when every member is a non-voting LF Staff seat (GH-1848)', async () => {
+    fixture.componentRef.setInput('engagement', response({ attendance_rate: 0 }, [NON_VOTING_LF_STAFF_MEMBER]));
+    await fixture.whenStable();
+
+    const row = attendanceRateRow();
+    expect(row.textContent).toContain('—');
+    expect(row.textContent).not.toContain('0%');
+    const ariaLabel = row.getAttribute('aria-label') ?? '';
+    expect(ariaLabel).toContain('not available');
+    expect(ariaLabel).not.toMatch(/—\s*—/);
+  });
+
+  it('renders an em-dash, not "0%", and says "not available" in the aria-label when every rate-eligible member simply has zero invites this window', async () => {
+    fixture.componentRef.setInput('engagement', response({ attendance_rate: 0 }, [RATE_ELIGIBLE_MEMBER_NEVER_INVITED, NON_VOTING_LF_STAFF_MEMBER]));
+    await fixture.whenStable();
+
+    const row = attendanceRateRow();
+    expect(row.textContent).toContain('—');
+    expect(row.textContent).not.toContain('0%');
+    const ariaLabel = row.getAttribute('aria-label') ?? '';
+    expect(ariaLabel).toContain('not available');
+    expect(ariaLabel).not.toMatch(/—\s*—/);
+  });
+
+  it('shows the calm unavailable state, not the metrics row, when there is no engagement response at all', async () => {
+    fixture.componentRef.setInput('engagement', null);
+    await fixture.whenStable();
+
+    expect(fixture.nativeElement.querySelector('[data-testid="committee-engagement-summary-unavailable-state"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="committee-engagement-summary-active-members"]')).toBeNull();
+    // The underlying signals still degrade sensibly even though nothing renders them in this state.
+    expect(fixture.componentInstance.activeMembersLabel()).toBe('—');
+    expect(fixture.componentInstance.attendanceRateLabel()).toBe('—');
+  });
+});

--- a/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-engagement-summary/committee-engagement-summary.component.ts
@@ -7,7 +7,12 @@ import { FilterPillsComponent } from '@components/filter-pills/filter-pills.comp
 import { TagComponent } from '@components/tag/tag.component';
 import { COMMITTEE_ENGAGEMENT_DEFAULT_WINDOW, COMMITTEE_ENGAGEMENT_WINDOW_OPTIONS } from '@lfx-one/shared/constants';
 import { CommitteeEngagementResponse, CommitteeEngagementWindow } from '@lfx-one/shared/interfaces';
-import { formatCommitteeEngagementFreshness, formatCommitteeEngagementRatePercent, toCommitteeEngagementWindow } from '@lfx-one/shared/utils';
+import {
+  formatCommitteeEngagementFreshness,
+  formatCommitteeEngagementRatePercent,
+  isCommitteeMemberRateEligible,
+  toCommitteeEngagementWindow,
+} from '@lfx-one/shared/utils';
 import { SkeletonModule } from 'primeng/skeleton';
 import { TooltipModule } from 'primeng/tooltip';
 
@@ -35,7 +40,7 @@ export class CommitteeEngagementSummaryComponent {
 
   public readonly windowOptions = COMMITTEE_ENGAGEMENT_WINDOW_OPTIONS;
 
-  // Computed signals — inline per component-organization.md (all simple projections)
+  // Computed signals — inline per component-organization.md
   public readonly dataAvailable: Signal<boolean> = computed(() => this.engagement()?.data_available === true);
   public readonly isMock: Signal<boolean> = computed(() => this.engagement()?.data_source === 'mock');
   public readonly freshnessLabel: Signal<string> = computed(() => formatCommitteeEngagementFreshness(this.engagement()?.computed_at ?? null));
@@ -43,29 +48,66 @@ export class CommitteeEngagementSummaryComponent {
     const option = COMMITTEE_ENGAGEMENT_WINDOW_OPTIONS.find((o) => o.id === this.engagementWindow());
     return option?.fullLabel ?? option?.label ?? this.engagementWindow();
   });
+  // `attendance_rate` sums only rate-eligible members' attended/invited (non-voting LF Staff
+  // excluded, Emeritus included — see CommitteeEngagementSummary.attendance_rate's doc); the server
+  // has no single "rate-eligible seat count" field to gate this the way `eligible_count` gates
+  // active members below, but `members[]` carries every roster member's role/voting_status/invited,
+  // so calling the same isCommitteeMemberRateEligible predicate the server sums with, plus an
+  // `invited > 0` check, re-derives whether the sum has any real contributor client-side — a rate-
+  // eligible member with zero invites this window contributes nothing either, reaching the same `0`
+  // via `computeCommitteeEngagementRate`'s `invited <= 0` sentinel. Without this gate, either shape
+  // (GH-1848: no rate-eligible member at all, or one that exists but was never invited) rendered a
+  // literal `0%` — the same false "nobody shows up" signal the eligible_count guard below exists to
+  // remove from active members, just affirmative instead of a 0/0 ratio.
+  private readonly hasInvitedRateEligibleMember: Signal<boolean> = computed(() =>
+    (this.engagement()?.members ?? []).some((m) => m.invited > 0 && isCommitteeMemberRateEligible({ role: m.role, votingStatus: m.voting_status }))
+  );
+  // `summary` is non-optional on CommitteeEngagementResponse, so `!summary` only fires when
+  // `engagement()` itself is null — but attendanceRateLabel and attendanceRateAriaLabel both need
+  // the same "is there a real rate to show" answer, so it's hoisted once rather than risking the
+  // two checks drifting apart (a mismatch here would let the aria-label's 'not available' branch
+  // miss, interpolating attendanceRateLabel()'s raw '—' next to the sentence's own em-dash — the
+  // exact double-dash failure activeMembersAriaLabel's analogous guard, below, already avoids by
+  // deriving hasEligibleMembers from `summary` directly).
+  private readonly hasAttendanceRate: Signal<boolean> = computed(() => !!this.engagement()?.summary && this.hasInvitedRateEligibleMember());
   public readonly attendanceRateLabel: Signal<string> = computed(() => {
     const summary = this.engagement()?.summary;
-    return summary ? formatCommitteeEngagementRatePercent(summary.attendance_rate) : '—';
+    if (!summary || !this.hasAttendanceRate()) return '—';
+    return formatCommitteeEngagementRatePercent(summary.attendance_rate);
   });
   // Denominator is eligible_count, NOT total_count (LFXV2-3101 review fix) — total_count includes
-  // Emeritus/LF Staff seats that active_count's numerator always excludes, so active_count/
-  // total_count could never reach 100% for a committee that seats either. See
-  // CommitteeEngagementSummary.eligible_count's doc.
+  // Emeritus/non-voting LF Staff seats that active_count's numerator always excludes, so
+  // active_count/total_count could never reach 100% for a committee that seats either. See
+  // CommitteeEngagementSummary.eligible_count's doc. `eligible_count === 0` (a roster made up
+  // entirely of Emeritus/non-voting-LF-Staff seats, GH-1848) is the source-of-truth condition for
+  // the '—' fallback below (both the display label and, via `hasEligibleMembers`, the aria-label) —
+  // rather than the literal "0/0", which would read as a data failure on a real, populated
+  // committee.
+  private readonly hasEligibleMembers: Signal<boolean> = computed(() => (this.engagement()?.summary?.eligible_count ?? 0) > 0);
   public readonly activeMembersLabel: Signal<string> = computed(() => {
     const summary = this.engagement()?.summary;
-    return summary ? `${summary.active_count}/${summary.eligible_count}` : '—';
+    if (!summary || !this.hasEligibleMembers()) return '—';
+    return `${summary.active_count}/${summary.eligible_count}`;
   });
   public readonly atRiskCount: Signal<number> = computed(() => this.engagement()?.summary?.at_risk_count ?? 0);
   // Explicit aria-labels below embed the displayed value/window — a screen-reader user focusing
   // the tooltip host must hear the metric itself, not just its explanation (LFXV2-1705 review).
-  public readonly attendanceRateAriaLabel: Signal<string> = computed(
-    () =>
-      `Attendance Rate: ${this.attendanceRateLabel()} — personal attendance across all invited roster members, including Emeritus seats but excluding LF Staff seats`
-  );
-  public readonly activeMembersAriaLabel: Signal<string> = computed(
-    () =>
-      `Active Members (${this.windowLabel()}): ${this.activeMembersLabel()} — both active count and the denominator exclude Emeritus and LF Staff seats; the full roster count is shown separately elsewhere on the page`
-  );
+  // Spells out "not available" rather than interpolating attendanceRateLabel()'s '—' glyph directly,
+  // for the same reason activeMembersAriaLabel below does — a raw '—' next to the sentence's own
+  // em-dash separator reads as two indistinguishable dashes to a screen reader.
+  public readonly attendanceRateAriaLabel: Signal<string> = computed(() => {
+    const spokenValue = this.hasAttendanceRate() ? this.attendanceRateLabel() : 'not available';
+    return `Attendance Rate: ${spokenValue} — personal attendance across all invited roster members, including Emeritus seats but excluding non-voting LF Staff seats`;
+  });
+  // Spells out "not available" rather than interpolating activeMembersLabel()'s '—' glyph directly
+  // — a raw '—' immediately followed by the sentence's own '—' separator reads as two consecutive
+  // dashes with no spoken distinction between them. Branches on `hasEligibleMembers` (the source
+  // condition), not on comparing the rendered label string against the '—' glyph, so a future
+  // change to the placeholder glyph can't silently revert this without also changing the condition.
+  public readonly activeMembersAriaLabel: Signal<string> = computed(() => {
+    const spokenValue = this.hasEligibleMembers() ? this.activeMembersLabel() : 'not available';
+    return `Active Members (${this.windowLabel()}): ${spokenValue} — both active count and the denominator exclude Emeritus and non-voting LF Staff seats; the full roster count is shown separately elsewhere on the page`;
+  });
 
   public onWindowChange(windowId: string): void {
     // filter-pills emits a plain string id — only forward values the endpoint actually accepts.

--- a/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/committee-members/committee-members.component.ts
@@ -50,6 +50,7 @@ import {
   formatCommitteeEngagementFreshness,
   formatCommitteeEngagementMeetings,
   isCommitteeEngagementRowAtRisk,
+  isLfStaffNonVotingSeat,
   isVotingRep,
   resolveCommitteeMemberPermission,
   toCommitteeEngagementWindow,
@@ -939,9 +940,10 @@ export class CommitteeMembersComponent implements OnInit {
   }
 
   /**
-   * Tooltip context for the engagement chip. Emeritus and LF Staff+Observer (LFXV2-3101, narrowed
-   * to this two-part condition in a follow-up review — an LF Staff member who is a real Voting Rep
-   * or Alternate Voting Rep is a genuine participant, not excluded) both get a neutral explainer —
+   * Tooltip context for the engagement chip. Emeritus and LF Staff+non-voting (Observer, or no
+   * voting status at all — LFXV2-3101, narrowed to this two-part condition in a follow-up review
+   * and broadened to cover `None` in GH-1848 — an LF Staff member who is a real Voting Rep or
+   * Alternate Voting Rep is a genuine participant, not excluded) both get a neutral explainer —
    * neither renders with at-risk styling, and neither's classification is driven by their real
    * attendance numbers, so this tooltip states the exclusion rather than the numbers themselves
    * (the Meetings column still shows the real attended/invited count for every row, chip-neutral
@@ -953,7 +955,7 @@ export class CommitteeMembersComponent implements OnInit {
     if (row.voting_status === CommitteeMemberVotingStatus.EMERITUS) {
       return 'Emeritus seat — honorific status; attendance expectations do not apply';
     }
-    if (row.role === CommitteeMemberRole.LF_STAFF && row.voting_status === CommitteeMemberVotingStatus.OBSERVER) {
+    if (isLfStaffNonVotingSeat({ role: row.role, votingStatus: row.voting_status })) {
       return 'LF Staff seat — excluded from engagement metrics; attendance expectations do not apply';
     }
     if (row.role === CommitteeMemberRole.CHAIR || row.role === CommitteeMemberRole.VICE_CHAIR || row.role === CommitteeMemberRole.LF_STAFF) {

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.spec.ts
@@ -1,7 +1,42 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
+
+// Mirrors committee-engagement.service.spec.ts: the
+// `@lfx-one/shared/utils` barrel transitively pulls in Angular (form.utils.ts, meeting.utils.ts,
+// vote.utils.ts import @angular/forms / @angular/common/http), which this Node-environment suite
+// can't load — so it needs a stub. Unlike `@lfx-one/shared/enums` (imported at runtime by the
+// helper under test, committee-engagement-mock.helper.ts, not by this spec file directly), which
+// resolves cleanly through the package's built `exports` map and so needs no stub — under `yarn
+// test`, where turbo.json's `test.dependsOn: ["^build"]` guarantees `packages/shared/dist` exists
+// first; a bare `yarn test:server` on a clean tree bypasses turbo and needs `yarn build` run first
+// too. The predicate is deep-imported from its real implementation (not hand-copied) so a decision-
+// table change there fails this suite too (GH-1848); its own boundary behavior is exhaustively
+// covered in packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts.
+vi.mock('@lfx-one/shared/utils', async () => {
+  const actual = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/committee-engagement-classifier.utils')>(
+    '../../../../../packages/shared/src/utils/committee-engagement-classifier.utils'
+  );
+  // A plain `{ isLfStaffNonVotingSeat }` object would make any *other* barrel export the helper
+  // under test starts using resolve to `undefined` — surfacing as an opaque "X is not a function"
+  // wherever it's called, far from this mock. The Proxy throws immediately, at the missing
+  // property, naming this file as the place to add the new export.
+  return new Proxy(
+    { isLfStaffNonVotingSeat: actual.isLfStaffNonVotingSeat },
+    {
+      get(target, prop, receiver) {
+        // `'then'` is probed by JS's own Promise-resolution algorithm (this factory is async, and
+        // its return value gets duck-typed) — answering `undefined` here says "not a thenable"
+        // without tripping the guard below.
+        if (prop === 'then' || prop in target) return Reflect.get(target, prop, receiver);
+        throw new Error(
+          `committee-engagement-mock.helper.spec.ts's '@lfx-one/shared/utils' mock doesn't stub '${String(prop)}' — add it to the mock in this file (the real barrel can't load in this Node-environment suite; see the comment above).`
+        );
+      },
+    }
+  );
+});
 
 import { generateMockEngagementRows } from './committee-engagement-mock.helper';
 
@@ -195,6 +230,18 @@ describe('generateMockEngagementRows', () => {
       expect(rows.some((r) => r.MEMBER_VOTING_STATUS === 'Emeritus')).toBe(true);
     });
 
+    it('never promotes a real LF Staff member with a real None voting status to the fabricated Emeritus fallback, same as Observer (GH-1848)', () => {
+      // Regression: a real 'None' voting status (the norm on a committee without voting) is just as
+      // load-bearing for the exclusion as 'Observer' since GH-1848 broadened isLfStaffNonVotingSeat.
+      const roster = [member('m0', { role: { name: 'LF Staff' } as never, voting: { status: 'None' } as never }), ...ROSTER.slice(1)];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m0 = rows.find((r) => r.MEMBER_USER_ID === 'm0');
+      expect(m0?.MEMBER_ROLE).toBe('LF Staff');
+      expect(m0?.MEMBER_VOTING_STATUS).not.toBe('Emeritus');
+      // Someone else on the roster still demonstrates the Emeritus scenario.
+      expect(rows.some((r) => r.MEMBER_VOTING_STATUS === 'Emeritus')).toBe(true);
+    });
+
     it('never assigns the Orlin case to a real Emeritus member, even if they are the most-recently-joined real member — a different eligible member takes it instead', () => {
       // Regression: buildAttendanceProfile checks isEmeritus before the Orlin slot, so an
       // Emeritus candidate would silently absorb the role without ever rendering forced counts —
@@ -251,7 +298,30 @@ describe('generateMockEngagementRows', () => {
       expect(m1).toMatchObject({ INVITED_COUNT_30D: 5, ATTENDED_COUNT_30D: 5, MEMBER_JOINED_AT: secondMostRecentJoin });
     });
 
-    it('DOES assign the Orlin case to a real LF Staff + Voting Rep member — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
+    it('never assigns the Orlin case to a real LF Staff member with a real None voting status, same as Observer (GH-1848)', () => {
+      const mostRecentJoin = new Date(Date.now() - 27 * 24 * 60 * 60 * 1000).toISOString();
+      const secondMostRecentJoin = new Date(Date.now() - 28 * 24 * 60 * 60 * 1000).toISOString();
+      const roster = [
+        member('m0', { role: { name: 'LF Staff' } as never, voting: { status: 'None' } as never, created_at: mostRecentJoin }),
+        member('m1', { voting: { status: 'Voting Rep' } as never, created_at: secondMostRecentJoin }),
+        ...ROSTER.slice(2),
+      ];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m0 = rows.find((r) => r.MEMBER_USER_ID === 'm0');
+      const m1 = rows.find((r) => r.MEMBER_USER_ID === 'm1');
+      expect(m0?.MEMBER_ROLE).toBe('LF Staff');
+      expect(m0).not.toMatchObject({
+        INVITED_COUNT_30D: 5,
+        ATTENDED_COUNT_30D: 5,
+        INVITED_COUNT_90D: 5,
+        ATTENDED_COUNT_90D: 5,
+        INVITED_COUNT_YTD: 5,
+        ATTENDED_COUNT_YTD: 5,
+      });
+      expect(m1).toMatchObject({ INVITED_COUNT_30D: 5, ATTENDED_COUNT_30D: 5, MEMBER_JOINED_AT: secondMostRecentJoin });
+    });
+
+    it('DOES assign the Orlin case to a real LF Staff + Voting Rep member — only non-voting staff seats are excluded (LFXV2-3101 follow-up)', () => {
       // A real Voting Rep who happens to be LF Staff never classifies 'LF Staff' under the
       // narrowed rule, so they're eligible for the Orlin slot exactly like any other real member.
       const mostRecentJoin = new Date(Date.now() - 27 * 24 * 60 * 60 * 1000).toISOString();
@@ -306,7 +376,27 @@ describe('generateMockEngagementRows', () => {
       });
     });
 
-    it('DOES assign a reserved demo pattern to a real LF Staff + Voting Rep member at slot 2 — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
+    it('never assigns a reserved Inactive/Low/Medium demo pattern to a real LF Staff member with a real None voting status, same as Observer (GH-1848)', () => {
+      const roster = [ROSTER[0], ROSTER[1], member('m2', { role: { name: 'LF Staff' } as never, voting: { status: 'None' } as never }), ...ROSTER.slice(3)];
+      const rows = generateMockEngagementRows('committee-1', roster);
+      const m2 = rows.find((r) => r.MEMBER_USER_ID === 'm2');
+      const m3 = rows.find((r) => r.MEMBER_USER_ID === 'm3');
+      expect(m2?.MEMBER_ROLE).toBe('LF Staff');
+      for (const suffix of ['30D', '90D', 'YTD'] as const) {
+        expect(m3?.[`INVITED_COUNT_${suffix}`]).toBeGreaterThan(0);
+        expect(m3?.[`ATTENDED_COUNT_${suffix}`]).toBe(0);
+      }
+      expect(m2).not.toMatchObject({
+        INVITED_COUNT_30D: m3?.INVITED_COUNT_30D,
+        ATTENDED_COUNT_30D: 0,
+        INVITED_COUNT_90D: m3?.INVITED_COUNT_90D,
+        ATTENDED_COUNT_90D: 0,
+        INVITED_COUNT_YTD: m3?.INVITED_COUNT_YTD,
+        ATTENDED_COUNT_YTD: 0,
+      });
+    });
+
+    it('DOES assign a reserved demo pattern to a real LF Staff + Voting Rep member at slot 2 — only non-voting staff seats are excluded (LFXV2-3101 follow-up)', () => {
       const roster = [
         ROSTER[0],
         ROSTER[1],

--- a/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
+++ b/apps/lfx-one/src/server/helpers/committee-engagement-mock.helper.ts
@@ -3,6 +3,7 @@
 
 import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
 import type { CommitteeEngagementWarehouseRow, CommitteeMember } from '@lfx-one/shared/interfaces';
+import { isLfStaffNonVotingSeat } from '@lfx-one/shared/utils';
 import crypto from 'crypto';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -35,15 +36,16 @@ const ORLIN_FORCED_COUNTS = { invited: 5, attended: 5 };
  * `MEMBER_VOTING_STATUS` prefers the real `voting.status` too — including a real `'None'`, which is
  * itself a recorded status and never overwritten — falling back to a hash-derived placeholder only
  * for members with no usable real status (no `voting` recorded, or a blank/falsy `status`). Any
- * real `role: 'LF Staff'` member with `voting.status: 'Observer'` (LFXV2-3101) is excluded from the Emeritus-fallback promotion, the
- * Orlin slot, and the reserved Inactive/Low/Medium demo-pattern pool, the same way a real (or
- * promoted) `Emeritus` member is excluded from the Orlin/demo pools — both roster facts always
- * short-circuit `classifyCommitteeEngagement` regardless of fabricated numbers, so assigning either
- * one a reserved slot would silently swallow it rather than render it. Two scenarios (`Emeritus`,
- * "the Orlin case" — see below) are guaranteed visible somewhere in the roster whenever that's
- * possible without overriding a real, known value; when every member's real data already rules a
- * scenario out (e.g. every member has a real non-`Emeritus` status), that scenario simply isn't
- * demonstrated for this specific committee rather than being faked.
+ * real `role: 'LF Staff'` member whose `voting.status` is `'Observer'` (real or organically
+ * hash-derived) or a real `'None'` is excluded from the
+ * Emeritus-fallback promotion, the Orlin slot, and the reserved Inactive/Low/Medium demo-pattern pool,
+ * the same way a real (or promoted) `Emeritus` member is excluded from the Orlin/demo pools — both
+ * roster facts always short-circuit `classifyCommitteeEngagement` regardless of fabricated numbers,
+ * so assigning either one a reserved slot would silently swallow it rather than render it. Two
+ * scenarios (`Emeritus`, "the Orlin case" — see below) are guaranteed visible somewhere in the roster
+ * whenever that's possible without overriding a real, known value; when every member's real data
+ * already rules a scenario out (e.g. every member has a real non-`Emeritus` status), that scenario
+ * simply isn't demonstrated for this specific committee rather than being faked.
  *
  * Every number is derived from stable inputs only — `committeeUid`, `member.uid`, `window`,
  * the member's real `created_at`/`voting.status` where present, the rest of the roster's identity
@@ -68,13 +70,14 @@ interface MemberIdentity {
 
 interface RosterPlan {
   identities: MemberIdentity[];
-  /** Sorted index of the member demonstrating the "Orlin case" (forced low-but-100%-rate counts); `null` when no member (excluding any `Emeritus` or real `LF Staff` + `Observer`, LFXV2-3101) can take the role without contradicting real tenure data. */
+  /** Sorted index of the member demonstrating the "Orlin case" (forced low-but-100%-rate counts); `null` when no member (excluding any `Emeritus` or `LF Staff`-role member whose voting status is Observer (real or organic) or a real None) can take the role without contradicting real tenure data. */
   orlinIndex: number | null;
   /** Tenure (days) to use for `orlinIndex` when that member has no real join date — computed per committee so the forced counts stay plausible against this committee's own real 30-day meeting cadence; unused when `orlinIndex` is `null` or has real tenure data. */
   orlinFallbackJoinedDaysAgo: number;
   /**
-   * Every sorted index except `orlinIndex`, any `Emeritus` member (real or promoted), and any real
-   * `LF Staff` + `Observer` member (LFXV2-3101), in order — i.e. every member eligible for a reserved pattern.
+   * Every sorted index except `orlinIndex`, any `Emeritus` member (real or promoted), and any
+   * `LF Staff`-role member whose voting status is Observer (real or organic) or a real None
+   * in order — i.e. every member eligible for a reserved pattern.
    * Only the first `DEMO_ATTENDANCE_PROFILES.length` of these actually receive one
    * (Inactive/Low/Medium); the rest are organic. Kept as a plain eligibility list rather than
    * pre-sliced so `buildAttendanceProfile` can compute the same boundary once, from `indexOf`, for
@@ -90,25 +93,27 @@ interface RosterPlan {
  * - `Emeritus`: real `voting.status` wins for every member — including a real `None`, which is a
  *   recorded status like any other, not an absence of one; if nothing on the roster is naturally
  *   `Emeritus`, the first member with no usable real status (no `voting` recorded, or a blank/falsy
- *   `status`) is promoted — but only that one case, and never a real `LF Staff` + `Observer` member
- *   (LFXV2-3101, narrowed to this two-part condition in a follow-up review): promoting one to a
- *   fabricated Emeritus profile would render the wrong chip (`Emeritus` instead of `LF Staff`) and,
- *   since Emeritus is deliberately not rate-excluded, feed its fabricated high-invite/
- *   near-zero-attendance numbers into `attendance_rate` — the exact depression the LF Staff
- *   carve-out exists to prevent. (A real `LF Staff` member with no real voting status who gets
- *   organically hash-assigned a non-`Observer` status — e.g. `Voting Rep` — is NOT excluded from
- *   this promotion: they'd never have classified `LF Staff` anyway under the narrowed rule, so
- *   nothing is silently swallowed by promoting them.) If every member already has a real, known
- *   status (including a committee where everyone is `None` — the common case for a committee
- *   without voting enabled), no member is promoted; this committee's mock output just won't
- *   include an `Emeritus` row. This trades away some demo value (Emeritus is what proves the
- *   classifier's Emeritus short-circuit and the `active_count` exclusion) for the stronger
- *   guarantee of never relabeling a real, recorded status — the same trade this file makes for
- *   tenure data (see the "Known trade-off" note below).
+ *   `status`) is promoted — but only that one case, and never a real `LF Staff` member whose voting
+ *   status is `Observer` or `None`: promoting one to a fabricated Emeritus
+ *   profile would render the wrong chip (`Emeritus` instead of `LF Staff`) and, since Emeritus is
+ *   deliberately not rate-excluded, feed its fabricated high-invite/near-zero-attendance numbers
+ *   into `attendance_rate` — the exact depression the LF Staff carve-out exists to prevent. (A real
+ *   `LF Staff` member with no real voting status who gets organically hash-assigned a real voting
+ *   seat — `Voting Rep` or `Alternate Voting Rep`, never `Observer` (`organicVotingStatus` can still
+ *   land on `Observer`, which stays excluded here just like a real one) — is NOT excluded from this
+ *   promotion: they'd never have classified `LF Staff` anyway under the narrowed rule, so nothing is
+ *   silently swallowed by promoting them.)
+ *   If every member already has a real, known status (including a committee where everyone is
+ *   `None` — the common case for a committee without voting enabled), no member is promoted; this
+ *   committee's mock output just won't include an `Emeritus` row. This trades away some demo value
+ *   (Emeritus is what proves the classifier's Emeritus short-circuit and the `active_count`
+ *   exclusion) for the stronger guarantee of never relabeling a real, recorded status — the same
+ *   trade this file makes for tenure data (see the "Known trade-off" note below).
  * - "The Orlin case": eligible candidates exclude every `Emeritus` member (real or promoted) and
- *   every real `LF Staff` + `Observer` member (LFXV2-3101) — the Emeritus and LF Staff profiles
- *   both always take precedence in `classifyCommitteeEngagement`, so either candidate would
- *   silently swallow the slot without ever rendering it as the intended demo tier. Among the rest,
+ *   every `LF Staff`-role member whose voting status is `Observer` (real or organic) or a real
+ *   `None` — the Emeritus and LF Staff profiles both always take
+ *   precedence in `classifyCommitteeEngagement`, so either candidate would silently swallow the slot
+ *   without ever rendering it as the intended demo tier. Among the rest,
  *   the most-recently real-joined member is used *only* if their tenure is at least `minOrlinTenureDays` *and* less
  *   than `WINDOW_30D_DAYS` — the upper bound keeps this specifically the "joined *recently*" case
  *   (the ticket's literal example) rather than any tenured member who happens to clear the lower
@@ -148,49 +153,53 @@ function planRosterIdentities(committeeUid: string, sortedMembers: CommitteeMemb
   const votingStatuses = realVotingStatuses.map(
     (real, index) => real ?? organicVotingStatus(hashToUnitInterval(`${committeeUid}:${sortedMembers[index]?.uid}:voting-status`))
   );
-  // `LF Staff` + `Observer` voting status (LFXV2-3101, narrowed in a follow-up review per Jordan
-  // Evans — a real Voting Rep or Alternate Voting Rep who happens to be LF Staff is a genuine
-  // participant and must NOT be excluded here) always classifies `LF Staff` regardless of
-  // attendance numbers, exactly like Emeritus always classifies `Emeritus` — a matching member
-  // assigned the Emeritus-fallback promotion, the Orlin slot, or a reserved Inactive/Low/Medium
-  // demo pattern would silently swallow whichever one it's assigned to (and, for the Emeritus
-  // promotion specifically, would also let a fabricated high-invite/near-zero-attendance Emeritus
-  // profile feed the rate sum, since Emeritus is deliberately NOT rate-excluded — the exact
-  // depression this ticket exists to prevent). Hoisted above the Emeritus-fallback block below so
-  // that block can exclude it too. `MEMBER_ROLE` is always the roster's real role (see the module
-  // doc), so this is a real exclusion, not a hash-derived one — `votingStatuses[index]` may still
-  // be organic/hash-derived when the member has no real recorded status, exactly like the
-  // production check (`isLfStaffObserverSeat` in `committee-engagement-classifier.utils.ts`) treats
-  // a real-or-fallback `MEMBER_VOTING_STATUS` identically either way.
-  const isLfStaffObserver = (index: number): boolean =>
-    sortedMembers[index]?.role?.name === CommitteeMemberRole.LF_STAFF && votingStatuses[index] === CommitteeMemberVotingStatus.OBSERVER;
+  // `LF Staff` + no real voting seat (Observer, or no voting status at all; a real Voting Rep or
+  // Alternate Voting Rep who happens to be LF Staff is a genuine participant and must NOT be
+  // excluded here) always classifies `LF Staff` regardless of attendance numbers, exactly like
+  // Emeritus always classifies `Emeritus` — a matching member assigned the Emeritus-fallback
+  // promotion, the Orlin slot, or a reserved Inactive/Low/Medium demo pattern would silently
+  // swallow whichever one it's assigned to (and, for the Emeritus promotion specifically, would
+  // also let a fabricated high-invite/near-zero-attendance Emeritus profile feed the rate sum,
+  // since Emeritus is deliberately NOT rate-excluded — the exact depression this ticket exists to
+  // prevent). Hoisted above the Emeritus-fallback block below so that block can exclude it too.
+  // `MEMBER_ROLE` is always the roster's real role (see the module doc), so this is a real
+  // exclusion, not a hash-derived one — `votingStatuses[index]` may still be organic/hash-derived
+  // when the member has no real recorded status, exactly like the production check
+  // (`isLfStaffNonVotingSeat`, imported from `committee-engagement-classifier.utils.ts` rather than
+  // re-derived here so the two can't drift apart again) treats a real-or-fallback
+  // `MEMBER_VOTING_STATUS` identically either way — `Observer` (real or organic, per
+  // `organicVotingStatus` below) or a real `None` (never organic — `organicVotingStatus` never
+  // produces it).
+  const isLfStaffNonVoting = (index: number): boolean =>
+    isLfStaffNonVotingSeat({ role: sortedMembers[index]?.role?.name, votingStatus: votingStatuses[index] });
 
   // The two fallback assignments below both prefer "the first member with no real data of the
   // relevant kind" — on a roster with no real data at all (e.g. a bare test fixture), that's the
   // same index for both, so the second fallback must skip whichever index the first one already
   // claimed, or one member would need to simultaneously be Emeritus and the Orlin case. Both also
-  // skip any real LF Staff + Observer member — see the comment on `isLfStaffObserver` above.
+  // skip any LF Staff-role member whose voting status (real or organic) is non-voting — see the
+  // comment on `isLfStaffNonVoting` above.
   let emeritusFallbackIndex = -1;
   if (!votingStatuses.includes(CommitteeMemberVotingStatus.EMERITUS)) {
-    emeritusFallbackIndex = realVotingStatuses.findIndex((real, index) => real === null && !isLfStaffObserver(index));
+    emeritusFallbackIndex = realVotingStatuses.findIndex((real, index) => real === null && !isLfStaffNonVoting(index));
     if (emeritusFallbackIndex !== -1) votingStatuses[emeritusFallbackIndex] = CommitteeMemberVotingStatus.EMERITUS;
   }
 
   const isEmeritus = (index: number): boolean => votingStatuses[index] === CommitteeMemberVotingStatus.EMERITUS;
 
   let orlinIndex = realJoinedDaysAgo.reduce<number | null>((mostRecentIndex, days, index) => {
-    if (days === null || days < minOrlinTenureDays || days >= WINDOW_30D_DAYS || isEmeritus(index) || isLfStaffObserver(index)) return mostRecentIndex;
+    if (days === null || days < minOrlinTenureDays || days >= WINDOW_30D_DAYS || isEmeritus(index) || isLfStaffNonVoting(index)) return mostRecentIndex;
     if (mostRecentIndex === null || days < (realJoinedDaysAgo[mostRecentIndex] as number)) return index;
     return mostRecentIndex;
   }, null);
   if (orlinIndex === null) {
-    const fallbackIndex = realJoinedDaysAgo.findIndex((days, index) => days === null && !isEmeritus(index) && !isLfStaffObserver(index));
+    const fallbackIndex = realJoinedDaysAgo.findIndex((days, index) => days === null && !isEmeritus(index) && !isLfStaffNonVoting(index));
     orlinIndex = fallbackIndex === -1 ? null : fallbackIndex;
   }
 
   const demoAttendanceIndices = sortedMembers
     .map((_, index) => index)
-    .filter((index) => index !== orlinIndex && !isEmeritus(index) && !isLfStaffObserver(index));
+    .filter((index) => index !== orlinIndex && !isEmeritus(index) && !isLfStaffNonVoting(index));
 
   return {
     identities: sortedMembers.map((_, index) => ({
@@ -245,8 +254,8 @@ interface AttendanceProfile {
 /**
  * The three attendance *patterns* (never identity) demonstrating Inactive/Low/Medium, assigned in
  * `RosterPlan.demoAttendanceIndices` order (not fixed sorted positions — see `planRosterIdentities`
- * for why the assignable set excludes the Orlin slot, any real-Emeritus member, and any real
- * `LF Staff` + `Observer` member).
+ * for why the assignable set excludes the Orlin slot, any real-Emeritus member, and any `LF Staff`-
+ * role member whose voting status is `Observer` (real or organic) or a real `None`).
  */
 const DEMO_ATTENDANCE_PROFILES: Omit<AttendanceProfile, 'joinedDaysAgo'>[] = [
   { invitationRate: 0.8, attendanceRateOverride: 0 }, // Inactive: invited but never attends.

--- a/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.spec.ts
@@ -4,10 +4,16 @@
 import type { Request } from 'express';
 import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
 
-// Mirrors project.service.spec.ts: the `@lfx-one/shared/*` alias isn't wired into this app's
-// vitest config, so every runtime import needs a stub. The classifier functions are deep-imported
-// from their real implementation (not hand-copied) so a decision-table change there fails this
-// suite too; their own boundary behavior is exhaustively covered in
+// The `@lfx-one/shared/utils` barrel transitively pulls in Angular (form.utils.ts,
+// meeting.utils.ts, vote.utils.ts import @angular/forms / @angular/common/http), which this
+// Node-environment suite can't load — so it needs a stub, below. `@lfx-one/shared/constants` is
+// ALSO stubbed below, but for a different reason: it resolves fine on its own (it's Angular-free
+// and reaches this suite through the package's built `exports` map, same as `@lfx-one/shared/enums`
+// — imported at runtime by committee-engagement.service.ts, not by this spec file, and left
+// unstubbed) — the stub here exists to pin `DEFAULT_LFX_ONE_PLATINUM_SCHEMA`/`VALKEY_CACHE` to known
+// test values, not to work around a resolution failure. The classifier functions are deep-imported
+// from their real implementation (not hand-copied) so a decision-table change there fails this suite
+// too; their own boundary behavior is exhaustively covered in
 // packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts.
 const {
   execute,
@@ -288,7 +294,27 @@ describe('CommitteeEngagementService.getCommitteeEngagement', () => {
       expect(result.summary.active_count).toBe(0);
     });
 
-    it('does NOT classify an LF Staff + Voting Rep member as "LF Staff" — only Observer-status staff seats are excluded (LFXV2-3101 follow-up, Jordan Evans review)', async () => {
+    it('classifies an LF Staff member with no voting status recorded and no matching row as "LF Staff", not the tenure-grace "High" (GH-1848)', async () => {
+      // The exact reported bug: a committee with no voting leaves staff seats with no voting.status
+      // on the roster, and this member's row is also individually missing (e.g. added since the
+      // model's last refresh) — so `member.voting?.status || row?.MEMBER_VOTING_STATUS` both resolve
+      // undefined and fall all the way through to the `CommitteeMemberVotingStatus.NONE` sentinel.
+      // `recentJoin` makes `joinedWithinWindow` genuinely true, so without the fix this would
+      // tenure-grace to 'High' on a literal 0/0 seat (case 3) instead of short-circuiting to
+      // 'LF Staff' the same way an Observer seat already did.
+      const recentJoin = new Date(Date.now() - 5 * 24 * 60 * 60 * 1000).toISOString();
+      getCommitteeMembers.mockResolvedValueOnce([member('m1'), member('staff', { role: { name: 'LF Staff' } as never, created_at: recentJoin })]);
+      generateMockEngagementRows.mockReturnValueOnce([row({ MEMBER_USER_ID: 'm1', INVITED_COUNT_30D: 10, ATTENDED_COUNT_30D: 10 })]);
+
+      const result = await service.getCommitteeEngagement(req, 'committee-1', '30d');
+
+      const staffMember = result.members.find((m) => m.uid === 'staff');
+      expect(staffMember).toMatchObject({ role: 'LF Staff', voting_status: 'None', invited: 0, attended: 0, classification: 'LF Staff' });
+      expect(result.summary.active_count).toBe(1); // only m1 — the staff seat is excluded, not tenure-graced in
+      expect(result.summary.eligible_count).toBe(1);
+    });
+
+    it('does NOT classify an LF Staff + Voting Rep member as "LF Staff" — only non-voting staff seats are excluded (LFXV2-3101 follow-up, Jordan Evans review)', async () => {
       getCommitteeMembers.mockResolvedValueOnce([member('m1')]);
       // row()'s default MEMBER_VOTING_STATUS is 'Voting Rep' — deliberately left unset here to
       // exercise that default, not overridden to Observer.

--- a/apps/lfx-one/src/server/services/committee-engagement.service.ts
+++ b/apps/lfx-one/src/server/services/committee-engagement.service.ts
@@ -341,38 +341,22 @@ export class CommitteeEngagementService {
       // violated in practice (a mismatched grain assumption, a future live-read bug) rather than
       // assuming it's already broken — an unclamped value here would produce a >100% rate.
       const attended = Math.min(counts.attended, counts.invited);
-      // `votingStatus` prefers the LIVE roster value first, warehouse `MEMBER_VOTING_STATUS` as the
-      // fallback for the same "no matching row" reason both fields fall back to the roster below
-      // (Cursor Bugbot follow-up, LFXV2-3101: this used to be warehouse-first, but `role` just below
-      // is roster-first, and once `isLfStaffObserverSeat` — `committee-engagement-classifier.utils.
-      // ts` — started combining both fields into one exclusion condition, that asymmetry became a
-      // real bug: a member promoted from Observer to a real Voting/Alternate Rep on the live roster
-      // would keep `role`'s LF Staff value fresh but `votingStatus` could still read the stale
-      // pre-promotion `Observer` from the warehouse until the dbt model's next refresh, incorrectly
-      // keeping them in the neutral LF Staff tier). Matching `role`'s precedence direction here
-      // means both fields a combined exclusion check reads are equally fresh, closing that gap —
-      // and, as a side effect, an Emeritus promotion/demotion (which depends on this same field
-      // alone) now also reflects on the roster immediately rather than lagging a refresh, which was
-      // never a deliberate design choice to preserve, just the pre-ticket default. `||`, not `??`,
-      // so a blank passthrough falls through too; the real enum value ('None' included) is always a
-      // non-empty string. Last-resort default is the documented `None` sentinel rather than '' —
-      // matching the mock generator's own voting-status posture, though its actual default differs
-      // (`organicVotingStatus()` hash-derives a rep status, never `None`), since that's mock mode's
-      // own no-real-data-fabrication concern, not a contract this live/degraded path needs to match.
+      // `votingStatus` and `role` both prefer the LIVE roster value first, warehouse
+      // `MEMBER_VOTING_STATUS`/`MEMBER_ROLE` as the fallback when the roster value is missing.
+      // Both need the same precedence direction: `isLfStaffNonVotingSeat` combines the two fields
+      // into one exclusion condition, so if one were roster-first and the other warehouse-first, a
+      // member promoted from Observer to a real Voting Rep on the live roster could keep one field
+      // fresh and the other stale until the warehouse model's next refresh, landing them in the
+      // wrong tier. `member.role?.name` is also typed (`CommitteeMemberRole`), unlike the
+      // warehouse's untyped `MEMBER_ROLE` string, so a live-mode spelling/casing mismatch degrades
+      // to the roster's known-good value instead of silently defeating the exclusion. `||`, not
+      // `??`, so a blank roster passthrough falls through to the warehouse value too. Last-resort
+      // default for `votingStatus` is the `None` sentinel — `isLfStaffNonVotingSeat` treats `None`
+      // as an exclusion trigger for `role: 'LF Staff'`, so an LF Staff member with no roster status
+      // AND no usable warehouse status now reads as excluded even if they're a real Voting Rep with
+      // no recorded status yet — the same accepted trade `groups-engagement-stats.service.ts`
+      // documents for its own blank-`MEMBER_VOTING_STATUS` fallback.
       const votingStatus = member.voting?.status || row?.MEMBER_VOTING_STATUS || CommitteeMemberVotingStatus.NONE;
-      // `role` also prefers the LIVE roster value first (LFXV2-3101 review fix). Before this ticket
-      // `role` was pure passthrough display text, so precedence never mattered functionally; now it
-      // also decides the `LF Staff` exclusion (`isCommitteeMemberRateEligible` et al.), and a
-      // warehouse-first order would let a role promoted or demoted on the roster stay silently wrong
-      // here until the dbt model's next refresh — reintroducing exactly the display/chip
-      // contradiction this ticket exists to remove. `member.role?.name` is also a typed
-      // `CommitteeMemberRole`, unlike `row?.MEMBER_ROLE` (an untyped warehouse string) — preferring
-      // it first means a live-mode `MEMBER_ROLE` spelling/casing mismatch degrades to the roster's
-      // known-good value instead of silently defeating the LF Staff exclusion checks everywhere
-      // `role` is used (see `isLfStaffObserverSeat` in `committee-engagement-classifier.utils.ts`
-      // for the exact, narrower-than-role-alone condition, LFXV2-3101 follow-up). The warehouse
-      // value remains the fallback for the same "no matching row" reason `votingStatus` falls back
-      // to the roster above.
       const role = member.role?.name || row?.MEMBER_ROLE || CommitteeMemberRole.NONE;
       // Same roster-fallback reasoning as role/voting-status above, but checked independently
       // rather than value-selected: a value-selection fallback (`row value || roster value`) would

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.spec.ts
@@ -433,7 +433,64 @@ describe('GroupsEngagementStatsService', () => {
       expect(result.active_members).toBe(0);
     });
 
-    it('does NOT exclude an LF Staff + Voting Rep member from active_members — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', async () => {
+    it('excludes an LF Staff member with a literal None voting status from active_members, same as Observer (GH-1848)', async () => {
+      getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+      execute.mockResolvedValueOnce({
+        rows: [
+          activeMemberRow({
+            COMMITTEE_ID: 'committee-1',
+            MEMBER_USER_ID: 'm1',
+            ATTENDED_COUNT_30D: 10,
+            MEMBER_ROLE: 'LF Staff',
+            MEMBER_VOTING_STATUS: 'None',
+          }),
+        ],
+      });
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(result.active_members).toBe(0);
+    });
+
+    it('excludes an LF Staff member with a blank warehouse voting status — normalized to None the same way the detail page falls back (GH-1848)', async () => {
+      getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+      execute.mockResolvedValueOnce({
+        rows: [
+          activeMemberRow({
+            COMMITTEE_ID: 'committee-1',
+            MEMBER_USER_ID: 'm1',
+            ATTENDED_COUNT_30D: 10,
+            MEMBER_ROLE: 'LF Staff',
+            MEMBER_VOTING_STATUS: '',
+          }),
+        ],
+      });
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(result.active_members).toBe(0);
+    });
+
+    it('still counts a non-staff member with a blank warehouse voting status — the None normalization is not itself an exclusion (GH-1848)', async () => {
+      getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
+      execute.mockResolvedValueOnce({
+        rows: [
+          activeMemberRow({
+            COMMITTEE_ID: 'committee-1',
+            MEMBER_USER_ID: 'm1',
+            ATTENDED_COUNT_30D: 10,
+            MEMBER_ROLE: 'None',
+            MEMBER_VOTING_STATUS: '',
+          }),
+        ],
+      });
+
+      const result = await service.getEngagementStats(buildReq());
+
+      expect(result.active_members).toBe(1);
+    });
+
+    it('does NOT exclude an LF Staff + Voting Rep member from active_members — only non-voting staff seats are excluded (LFXV2-3101 follow-up)', async () => {
       getMyCommitteeUids.mockResolvedValue(new Set(['committee-1']));
       execute.mockResolvedValueOnce({
         // MEMBER_VOTING_STATUS defaults to 'Voting Rep' — deliberately left unset here.

--- a/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
+++ b/apps/lfx-one/src/server/services/groups-engagement-stats.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import { GROUPS_ENGAGEMENT_CHUNK_CONCURRENCY, VALKEY_CACHE } from '@lfx-one/shared/constants';
+import { CommitteeMemberVotingStatus } from '@lfx-one/shared/enums';
 import { CommitteeEngagementWarehouseRow, GroupsEngagementStats } from '@lfx-one/shared/interfaces';
 import { isCommitteeMemberActive, isJoinedWithinWindow } from '@lfx-one/shared/utils';
 import { Request } from 'express';
@@ -73,20 +74,32 @@ function resolveBackend(): 'mock' | 'live' {
  * surfaces can't disagree on *that* logic — but this rollup is warehouse-row-anchored only (no live
  * roster join per visible committee, which would reintroduce the N+1 fetch this endpoint exists to
  * avoid), so it can still diverge from the per-committee detail page for: a roster member the model
- * hasn't picked up yet (a very recent join); a blank `MEMBER_VOTING_STATUS` the detail page would
- * otherwise resolve via the roster's own `voting.status`; or a blank/unparseable `MEMBER_JOINED_AT`
- * the detail page would still resolve via the roster's own `created_at` (`buildResponse` ORs both
- * sources when the roster join has at least one match for that committee; this rollup only has the
- * warehouse row, never a roster fallback); or an `LF Staff` seat whose role changed on the live
- * roster more recently than the dbt model's last refresh (LFXV2-3101) — `MEMBER_ROLE` (unlike the
- * roster fallbacks above) IS a column on this same `platinum_lfx_one_committee_meeting_attendance`
- * table `ActiveMemberRow` already reads, so selecting it and passing `role: row.MEMBER_ROLE` into
- * `classificationInput` costs nothing extra (no roster join, no N+1) and closes the gap for the
- * common case — but this rollup has no live roster at all to prefer, unlike the detail page's
- * roster-first precedence (`committee-engagement.service.ts`'s `role` resolution, LFXV2-3101 review
- * fix: `member.role?.name || row?.MEMBER_ROLE`). So a role promoted onto (or demoted off) the live
+ * hasn't picked up yet (a very recent join); a blank `MEMBER_VOTING_STATUS`, normalized to
+ * `CommitteeMemberVotingStatus.NONE` here since there's no roster join to prefer instead (see
+ * below); a blank/unparseable `MEMBER_JOINED_AT` the detail page would still resolve via the
+ * roster's own `created_at` (`buildResponse` ORs both sources when the roster join has at least one
+ * match for that committee; this rollup only has the warehouse row, never a roster fallback); or an
+ * `LF Staff` seat whose role changed on the live roster more recently than the dbt model's last
+ * refresh — `MEMBER_ROLE` (unlike the roster fallbacks above) IS a column on this same
+ * `platinum_lfx_one_committee_meeting_attendance` table `ActiveMemberRow` already reads, so
+ * selecting it and passing `role: row.MEMBER_ROLE` into `classificationInput` costs nothing extra
+ * (no roster join, no N+1) and closes the gap for the common case — but this rollup has no live
+ * roster at all to prefer, unlike the detail page's roster-first precedence
+ * (`committee-engagement.service.ts`'s `role` resolution:
+ * `member.role?.name || row?.MEMBER_ROLE`). So a role promoted onto (or demoted off) the live
  * roster lands on the detail page immediately but only reaches this rollup at the model's next
  * refresh — a real, if narrow, divergence window, same family as the other three above.
+ *
+ * On the blank-`MEMBER_VOTING_STATUS` case specifically: this rollup applies the same last-resort
+ * `|| CommitteeMemberVotingStatus.NONE` fallback `buildResponse` falls back to only after its own
+ * roster/warehouse precedence is exhausted (without this, a blank warehouse value would match
+ * neither `Observer` nor `None` and silently escape `isCommitteeMemberActive`'s LF Staff
+ * exclusion here). This closes one divergence but can open a narrow one in the opposite direction:
+ * an LF Staff seat whose warehouse `MEMBER_VOTING_STATUS` is blank but whose live roster
+ * `voting.status` is a real `Voting Rep`/`Alternate Voting Rep` is excluded here (no roster join to
+ * prefer the real value, same reasoning as the `MEMBER_ROLE` gap above) while the detail page
+ * includes them — the right trade given this rollup's no-roster-join constraint, not a regression
+ * to fix.
  *
  * A larger case in the same family, deliberately NOT wired the same way: this rollup dedupes purely
  * on the warehouse's own `MEMBER_USER_ID` with no roster join at all, so a committee whose
@@ -158,8 +171,9 @@ export class GroupsEngagementStatsService {
 
   /**
    * Counts distinct active members (attended >=1 meeting in the trailing 30 days, or joined within
-   * it, excluding Emeritus and LF Staff+Observer seats — `isCommitteeMemberActive`, the same
-   * function LFXV2-1705/LFXV2-3101 use) across the *covered* subset of committees the caller can see
+   * it, excluding Emeritus and LF Staff+non-voting (Observer or `None`) seats —
+   * `isCommitteeMemberActive`, the same function the detail page uses) across the
+   * *covered* subset of committees the caller can see
    * (`getMyCommitteeUids` — "mine" semantics, no scope param, per LFXV2-1711). A member is counted
    * once even if active on multiple covered
    * committees — the model's grain is one row per `(committee_id, member_user_id)`, so a member on
@@ -252,7 +266,13 @@ export class GroupsEngagementStatsService {
           const classificationInput = {
             attended: Math.min(Math.max(row.ATTENDED_COUNT_30D, 0), invited),
             invited, // unused by isCommitteeMemberActive; kept only for the clamp above
-            votingStatus: row.MEMBER_VOTING_STATUS,
+            // `|| NONE`, matching committee-engagement.service.ts's `buildResponse` fallback: a
+            // blank warehouse `MEMBER_VOTING_STATUS` (no roster join here to resolve it another
+            // way) must normalize to the same `'None'` sentinel the detail page falls back to, or
+            // an LF Staff seat with no voting status recorded would silently escape the
+            // isCommitteeMemberActive exclusion this rollup and the detail page are meant to agree
+            // on (GH-1848).
+            votingStatus: row.MEMBER_VOTING_STATUS || CommitteeMemberVotingStatus.NONE,
             role: row.MEMBER_ROLE,
             joinedWithinWindow: isJoinedWithinWindow(row.MEMBER_JOINED_AT, windowStart),
           };

--- a/packages/shared/src/interfaces/committee-engagement.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.interface.ts
@@ -14,29 +14,24 @@ export type CommitteeEngagementDataSource = 'mock' | 'live';
  * Engagement tier derived in the BFF from the member's personal attendance rate.
  * `Emeritus` and `LF Staff` are both seat-type overrides, not rate tiers — neither ever classifies
  * `Inactive`/`Low` regardless of real attendance: `Emeritus` members are on the roster for
- * legacy/honorific reasons, and an LF Staff member with Observer voting status (LFXV2-3101) carries
- * no real attendance expectation, so treating either as disengaged would be noise, not signal. An
- * LF Staff member who is a real Voting Rep or Alternate Voting Rep is NOT covered by this
- * override — see `isLfStaffObserverSeat` in `committee-engagement-classifier.utils.ts`.
+ * legacy/honorific reasons, and an LF Staff member with Observer voting status, or no voting status
+ * at all, carries no real attendance expectation. An LF Staff member who is a real Voting Rep or
+ * Alternate Voting Rep is NOT covered by this override — see `isLfStaffNonVotingSeat` in
+ * `committee-engagement-classifier.utils.ts`.
  */
 export type CommitteeEngagementClassification = 'High' | 'Medium' | 'Low' | 'Inactive' | 'Emeritus' | 'LF Staff';
 
 /**
- * Classification inputs beyond the raw counts, per LFXV2-1705's finalized model semantics
- * (`platinum_lfx_one_committee_meeting_attendance`, `lf-dbt#2694`): `votingStatus` (`'Emeritus'`
- * short-circuits to a neutral tier), `role`+`votingStatus` together (LF Staff + Observer
- * short-circuits to a neutral tier, LFXV2-3101 — see `isLfStaffObserverSeat`'s doc for why this is
- * a two-part condition, not `role` alone), and `joinedWithinWindow` (whether `member_joined_at`
- * falls after the requested window's start — tenure clipping, so a brand-new member's zero invites
- * doesn't read as disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role`'s
- * key is required (value may be `undefined`), not optional — a construction site that forgets it
- * should get a compile error, not silently reintroduce the bug this ticket fixes (an unmeasured LF
- * Staff+Observer seat counting toward the rate/active sums again). Both current consumers populate
- * it today:
- * `committee-engagement.service.ts` resolves it roster-first, warehouse `MEMBER_ROLE` as a fallback
- * (LFXV2-3101 review fix — see that call site's own comment for why); `groups-engagement-stats.
- * service.ts` has no live roster to prefer, so it passes warehouse `MEMBER_ROLE` directly (see that
- * class's own doc for the resulting freshness lag versus the roster-first detail page).
+ * Classification inputs beyond the raw counts: `votingStatus` (`'Emeritus'` short-circuits to a
+ * neutral tier), `role`+`votingStatus` together (LF Staff + no real voting seat short-circuits to
+ * a neutral tier — see `isLfStaffNonVotingSeat`'s doc for why this is a two-part condition, not
+ * `role` alone), and `joinedWithinWindow` (whether `member_joined_at` falls after the requested
+ * window's start — tenure clipping, so a brand-new member's zero invites doesn't read as
+ * disengagement). Consumed by `committee-engagement-classifier.utils.ts`. `role`'s key is required
+ * (value may be `undefined`), not optional — a construction site that forgets it should get a
+ * compile error, not silently drop the LF Staff exclusion. `committee-engagement.service.ts`
+ * resolves it roster-first with warehouse `MEMBER_ROLE` as a fallback; `groups-engagement-stats.
+ * service.ts` has no live roster to prefer, so it passes warehouse `MEMBER_ROLE` directly.
  */
 export interface CommitteeEngagementClassificationInput {
   attended: number;
@@ -57,9 +52,9 @@ export interface CommitteeMemberEngagement {
   /** `attended / invited`, 0 when `invited` is 0, rounded to 2 decimal places. */
   rate: number;
   classification: CommitteeEngagementClassification;
-  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — passthrough for the UI to call out distinctly; also drives the `LF Staff` classification (LFXV2-3101, together with `voting_status === 'Observer'` — see `isLfStaffObserverSeat`) and its `attendance_rate`/`active_count` exclusion. */
+  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — passthrough for the UI to call out distinctly; also drives the `LF Staff` classification (together with `voting_status` — see `isLfStaffNonVotingSeat`) and its `attendance_rate`/`active_count` exclusion. */
   role: string;
-  /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'` — passthrough, drives the `Emeritus` classification. */
+  /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'`, `'None'` — drives the `Emeritus` classification directly, and (together with `role`) feeds the `LF Staff` exclusion via `isLfStaffNonVotingSeat` — not just a display passthrough. */
   voting_status: string;
   /** Committee-wide meeting count for the window, regardless of who was invited — an informational "invitation rate" signal (`invited / committee_meetings`), never the rate denominator. */
   committee_meetings: number;
@@ -68,45 +63,47 @@ export interface CommitteeMemberEngagement {
 /** Aggregate stats for `GET /api/committees/:uid/engagement`. */
 export interface CommitteeEngagementSummary {
   /**
-   * `sum(attended) / sum(invited)` across the full committee roster, excluding LF Staff+Observer
-   * seats (LFXV2-3101 — a staff seat with no real participation expectation shouldn't depress a
-   * committee's rate; an LF Staff member who is a real Voting Rep or Alternate Voting Rep is NOT
-   * excluded — see `isLfStaffObserverSeat`), but NOT Emeritus-excluded — a committee with an
-   * Emeritus member (high invitation rate, low real attendance, by design) can still show a
-   * depressed rate here alongside an `active_count` that ignores that same member. A UI surfacing
-   * both side-by-side should call this out rather than let them appear to contradict. Known,
-   * accepted edge case: a roster made up entirely of LF Staff+Observer seats (no non-excluded
-   * member ever invited) reports `0` here via the same `invited <= 0` sentinel an empty/
-   * never-invited roster already reports — indistinguishable from "no data yet" at this field
-   * alone. Not disambiguated by a separate value, consistent with how this field already overloads
-   * `0` for "nobody was invited" before this ticket.
+   * `sum(attended) / sum(invited)` across the full committee roster, excluding LF Staff+non-voting
+   * seats (a staff seat with no real participation expectation shouldn't depress a committee's
+   * rate; a real Voting Rep or Alternate Voting Rep is NOT excluded — see `isLfStaffNonVotingSeat`),
+   * but NOT Emeritus-excluded — a committee with an Emeritus member (high invitation rate, low real
+   * attendance, by design) can still show a depressed rate here alongside an `active_count` that
+   * ignores that same member. A UI surfacing both side-by-side should call this out.
+   * Edge case: a roster made up entirely of LF Staff+non-voting seats reports `0` here via the same
+   * `invited <= 0` sentinel an empty/never-invited roster reports — indistinguishable from "no data
+   * yet" at this field alone. The UI-facing consumer
+   * (`CommitteeEngagementSummaryComponent.attendanceRateLabel`) re-derives the rate-eligible
+   * population from `members[]` via `isCommitteeMemberRateEligible` and renders `'—'` instead of a
+   * literal `0%` when no rate-eligible member has any invites this window, mirroring
+   * `eligible_count`'s `activeMembersLabel` guard below. A future change that filters or truncates
+   * `members[]` would silently defeat that gate.
    */
   attendance_rate: number;
   /**
-   * Count of non-Emeritus, non-LF-Staff+Observer members with real attendance this window, or who
+   * Count of non-Emeritus, non-LF-Staff+non-voting members with real attendance this window, or who
    * joined within it (active by definition of being newly on the roster) — broader than "classified
    * High/Medium": a Low-classified member with some real attendance still counts here. See
-   * `committee-engagement-classifier.utils.ts`'s `isCommitteeMemberActive`. The "joined within it"
-   * clause only applies when `data_available` is `true` — on a zero-row committee, or one whose
-   * rows exist but don't join to any roster member, tenure alone can't imply active (see
-   * `data_available`'s doc), so this is `0` there regardless of roster join dates. Display this as
-   * a ratio against `eligible_count`, NOT `total_count` — see `eligible_count`'s doc for why.
+   * `isCommitteeMemberActive`. The "joined within it" clause only applies when `data_available` is
+   * `true` (see that field's doc). Display as a ratio against `eligible_count`, NOT `total_count`.
    */
   active_count: number;
   /**
    * Roster members NOT excluded from `active_count`'s population — i.e. not Emeritus, not LF
-   * Staff+Observer (`isCommitteeMemberActiveEligible`, LFXV2-3101 review fix). The correct
-   * denominator for displaying `active_count` as a ratio: `total_count` includes Emeritus/LF
-   * Staff+Observer seats that `active_count`'s numerator always excludes, so `active_count /
-   * total_count` can never reach 100% for a committee that seats either, regardless of real
-   * participation — the same shape of bug this ticket fixed for the At-Risk filter, just showing up
-   * in the ratio instead. Attendance-independent, so — unlike `active_count`/`at_risk_count`/
-   * `attendance_rate` — this does NOT zero out when `data_available` is `false`: `role`/
-   * `voting_status` are roster passthroughs that stay populated regardless (see `data_available`'s
-   * doc), so this is roster-known the same way `total_count` is.
+   * Staff+non-voting (`isCommitteeMemberActiveEligible`). The correct denominator for displaying
+   * `active_count` as a ratio: `total_count` includes Emeritus/LF Staff+non-voting seats that
+   * `active_count`'s numerator always excludes, so `active_count / total_count` can never reach
+   * 100% for a committee that seats either, regardless of real participation.
+   * Attendance-independent, so — unlike `active_count`/`at_risk_count`/`attendance_rate` — this
+   * does NOT zero out when `data_available` is `false`: `role`/`voting_status` are roster
+   * passthroughs that stay populated regardless. Reaches `0` for a roster made up entirely of
+   * Emeritus and/or non-voting-LF-Staff seats — a different population than `attendance_rate`
+   * sums over (Emeritus is excluded here but feeds `attendance_rate`'s sum), so the two fields' `0`
+   * cases don't imply each other either direction. The UI-facing consumer
+   * (`CommitteeEngagementSummaryComponent.activeMembersLabel`) renders `'—'` rather than the
+   * literal `active_count/eligible_count` ratio when this is `0`.
    */
   eligible_count: number;
-  /** Full committee roster size (including members with no engagement data, and including Emeritus/LF Staff+Observer seats — use `eligible_count`, not this field, as the `active_count` ratio's denominator). */
+  /** Full committee roster size (including members with no engagement data, and including Emeritus/LF Staff+non-voting seats — use `eligible_count`, not this field, as the `active_count` ratio's denominator). */
   total_count: number;
   /** Members classified Low, plus members invited within the window who attended nothing (badge reads Inactive, but there is signal to act on — unlike a member never invited). */
   at_risk_count: number;
@@ -124,44 +121,28 @@ export interface CommitteeEngagementResponse {
   computed_at: string | null;
   /**
    * `false`: the live read couldn't produce *usable*, roster-joined rows — either the query itself
-   * errored (the model isn't synced yet for this committee, or the role isn't granted on it), it ran
-   * and returned zero rows for this `committee_uid` (the model is roster-anchored and retains
-   * zero-activity members, so a real, currently-populated committee should always yield >=1 row;
-   * zero rows most likely means this committee isn't covered by the model yet, not that engagement
-   * is genuinely zero for everyone), or it returned rows but none of them key to any roster member at
-   * all (a total join-key mismatch — the warehouse's `MEMBER_USER_ID` values don't correspond to any
-   * `CommitteeMember.uid` for this committee). All three degrade identically from the caller's point
-   * of view. Every member then shows zeroed counts and classifies `Inactive` — except a roster
-   * member with a real `Emeritus` voting status, which still classifies `Emeritus`, or a roster
-   * member with `role: 'LF Staff'` AND `voting_status: 'Observer'` (LFXV2-3101, both fields — see
-   * `isLfStaffObserverSeat`), which still classifies `LF Staff` — both are seat-type facts
-   * independent of whether any engagement data exists. The tenure-grace `High`
-   * exception (a member who genuinely joined within the requested window, classified `High` instead
-   * of `Inactive` off zero invites) does NOT apply when `data_available` is `false` — with no usable
-   * data for the whole committee, there is no engagement data to correlate tenure against, so every
-   * non-Emeritus, non-LF-Staff member classifies `Inactive` and `summary`'s computed fields (`attendance_rate`,
-   * `active_count`, `at_risk_count`) are all `0` — `total_count` and `eligible_count` still reflect
-   * the roster regardless, since both are roster-known independent of engagement data. Asserting `High` (or a
-   * nonzero `active_count`) on literal 0/0 counts would contradict `data_available: false` and
-   * `attendance_rate: 0` in the same payload. The tenure-grace exception only fires when
-   * `data_available` is `true` — i.e. the committee has rows AND at least one roster member matched
-   * one — and this *specific* member's row is individually missing (e.g. a roster member added since
-   * the model's last daily refresh): the committee has real, roster-joinable data, just not yet for
-   * this member. `role`/`voting_status` are roster passthroughs and stay populated regardless of
-   * whether a warehouse row matched, in both cases.
+   * errored, it ran and returned zero rows for this `committee_uid` (the model is roster-anchored,
+   * so a real, currently-populated committee should always yield >=1 row — zero rows most likely
+   * means this committee isn't covered by the model yet), or it returned rows but none of them key
+   * to any roster member at all. All three degrade identically. Every member then shows zeroed
+   * counts and classifies `Inactive` — except a roster member with a real `Emeritus` voting status
+   * (still classifies `Emeritus`) or `role: 'LF Staff'` + non-voting `voting_status` (still
+   * classifies `LF Staff`) — both are seat-type facts independent of whether any engagement data
+   * exists. The tenure-grace `High` exception does NOT apply when `data_available` is `false`: with
+   * no usable data for the whole committee, there's no engagement data to correlate tenure against,
+   * so `summary`'s computed fields (`attendance_rate`, `active_count`, `at_risk_count`) are all `0`
+   * — `total_count`/`eligible_count` still reflect the roster, since both are roster-known
+   * independent of engagement data. The tenure-grace exception only fires when `data_available` is
+   * `true` and this *specific* member's row is individually missing (e.g. added since the model's
+   * last daily refresh).
    *
-   * `true`: a mock-backend response for a non-empty roster (`ENGAGEMENT_BACKEND=mock`, explicit
-   * opt-in and blocked in production — a mock response for a committee with zero roster members is
-   * the one degenerate case that still reports `false`, since there's trivially no member to match);
-   * or a live query — fresh or a cache hit (the row cache is keyed on the committee uid; the cached
-   * array's length picks the TTL and derives this flag on a hit, so a hit never assumes `true` — but
-   * the roster join itself always re-runs against a freshly-fetched roster on every request, cached
-   * rows included) — that returned >=1 row matching at least one roster member by uid.
+   * `true`: a mock-backend response for a non-empty roster (a mock response for a committee with
+   * zero roster members is the one degenerate case that still reports `false`); or a live query —
+   * fresh or a cache hit — that returned >=1 row matching at least one roster member by uid.
    *
    * The UI should key its "no data available" placeholder state off this flag rather than inferring
    * it from all-zero numbers — `members[]` is roster-complete either way, with `role`/`voting_status`
-   * always populated and counts zeroed on `false` (see above for the roster-Emeritus and roster-LF-
-   * Staff exceptions, and the tenure-grace exception's `data_available:true`-only condition).
+   * always populated and counts zeroed on `false`.
    */
   data_available: boolean;
   /**

--- a/packages/shared/src/interfaces/committee-engagement.internal.interface.ts
+++ b/packages/shared/src/interfaces/committee-engagement.internal.interface.ts
@@ -26,9 +26,9 @@ export interface CommitteeEngagementWarehouseRow {
   MEMBER_USER_ID: string;
   /** When the member joined the committee roster — used for tenure clipping (see the classifier). */
   MEMBER_JOINED_AT: string | Date | null;
-  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — `'LF Staff'` together with `MEMBER_VOTING_STATUS === 'Observer'` short-circuits classification and excludes the row from the rate/active sums (LFXV2-3101; `role` alone is not enough — a real Voting Rep who happens to be LF Staff is not excluded). */
+  /** e.g. `'Chair'`, `'Vice Chair'`, `'None'` — `'LF Staff'` together with `MEMBER_VOTING_STATUS` being `'Observer'` or `'None'` short-circuits classification and excludes the row from the rate/active sums (`role` alone is not enough — a real Voting Rep who happens to be LF Staff is not excluded). */
   MEMBER_ROLE: string;
-  /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'` — `'Emeritus'` short-circuits classification. */
+  /** e.g. `'Voting Rep'`, `'Observer'`, `'Emeritus'`, `'None'` — `'Emeritus'` short-circuits classification; `'None'` (the norm on committees without voting) is load-bearing for the LF Staff exclusion above, not just a display passthrough — may also come back blank/falsy from the warehouse, which callers normalize to the `'None'` sentinel (see `committee-engagement.service.ts` and `groups-engagement-stats.service.ts`). */
   MEMBER_VOTING_STATUS: string;
   INVITED_COUNT_30D: number;
   ATTENDED_COUNT_30D: number;

--- a/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
+++ b/packages/shared/src/interfaces/groups-engagement-stats.interface.ts
@@ -20,9 +20,9 @@
 export interface GroupsEngagementStats {
   /**
    * Distinct members active on any *covered* visible committee — attended >=1 meeting in the
-   * trailing 30 days, or joined within it (tenure grace), excluding Emeritus and LF Staff+Observer
-   * seats (`isCommitteeMemberActive`, the same rule LFXV2-1705/LFXV2-3101 use — an LF Staff member
-   * who is a real Voting Rep or Alternate Voting Rep is NOT excluded). A member active on multiple visible
+   * trailing 30 days, or joined within it (tenure grace), excluding Emeritus and LF Staff+non-voting
+   * (Observer or `None`) seats (`isCommitteeMemberActive` — a real Voting Rep or Alternate Voting
+   * Rep is NOT excluded). A member active on multiple visible
    * committees is counted once, not once per committee. `null` only when `coverage.covered` is `0`
    * or the computation failed — see this interface's doc comment for exactly which cases that
    * covers.

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.spec.ts
@@ -12,12 +12,14 @@ import {
   isCommitteeMemberAtRisk,
   isCommitteeMemberRateEligible,
   isJoinedWithinWindow,
+  isLfStaffNonVotingSeat,
 } from './committee-engagement-classifier.utils';
 
 const VOTING_REP = CommitteeMemberVotingStatus.VOTING_REP;
 const ALTERNATE_VOTING_REP = CommitteeMemberVotingStatus.ALTERNATE_VOTING_REP;
 const OBSERVER = CommitteeMemberVotingStatus.OBSERVER;
 const EMERITUS = CommitteeMemberVotingStatus.EMERITUS;
+const NONE = CommitteeMemberVotingStatus.NONE;
 const CHAIR = CommitteeMemberRole.CHAIR;
 const LF_STAFF = CommitteeMemberRole.LF_STAFF;
 
@@ -53,7 +55,8 @@ describe('classifyCommitteeEngagement — decision table', () => {
     expect(classifyCommitteeEngagement({ attended: 10, invited: 10, votingStatus: EMERITUS, joinedWithinWindow: false })).toBe('Emeritus');
   });
 
-  // Row 2 (LFXV2-3101): LF Staff + Observer wins too, regardless of real numbers.
+  // Row 2 (LFXV2-3101, broadened GH-1848): LF Staff + no real voting seat (Observer, or no voting
+  // status at all) wins too, regardless of real numbers.
   it('classifies LF Staff regardless of a low real attendance rate (0/0), when voting status is Observer', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 0, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
   });
@@ -62,18 +65,35 @@ describe('classifyCommitteeEngagement — decision table', () => {
     expect(classifyCommitteeEngagement({ attended: 5, invited: 5, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
   });
 
+  // GH-1848: on a committee with no voting, staff seats never get assigned a voting status and
+  // resolve to the 'None' sentinel — previously this fell through the Observer-only carve-out and
+  // tenure-graced a literal 0/0 seat to 'High'; that was the exact reported bug.
+  it('classifies LF Staff (not the tenure-grace High) for a 0/0 staff seat with no voting status, even joined within the window', () => {
+    expect(classifyCommitteeEngagement({ attended: 0, invited: 0, votingStatus: NONE, role: LF_STAFF, joinedWithinWindow: true })).toBe('LF Staff');
+  });
+
+  it('classifies LF Staff for real attendance too, when voting status is None', () => {
+    expect(classifyCommitteeEngagement({ attended: 3, invited: 5, votingStatus: NONE, role: LF_STAFF, joinedWithinWindow: false })).toBe('LF Staff');
+  });
+
   it('does not broaden the LF Staff carve-out to non-staff Observers', () => {
     expect(classifyCommitteeEngagement({ attended: 2, invited: 10, votingStatus: OBSERVER, joinedWithinWindow: false })).toBe('Low');
+  });
+
+  it('does not broaden the None carve-out beyond staff — a non-staff member with no voting status still classifies on attendance/tenure normally', () => {
+    expect(classifyCommitteeEngagement({ attended: 0, invited: 0, votingStatus: NONE, joinedWithinWindow: true })).toBe('High');
+    expect(classifyCommitteeEngagement({ attended: 0, invited: 3, votingStatus: NONE, joinedWithinWindow: false })).toBe('Inactive');
   });
 
   it('does not broaden the LF Staff carve-out to a real Chair with zero attendance', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 3, votingStatus: VOTING_REP, role: CHAIR, joinedWithinWindow: false })).toBe('Inactive');
   });
 
-  // LFXV2-3101 follow-up (Jordan Evans review): an LF Staff member who is also a real Voting Rep
-  // or Alternate Voting Rep (an ED or staff member serving as a board/committee representative)
-  // is a genuine participant and must classify/count normally — only the Observer-status staff
-  // seat is excluded, not every LF Staff member regardless of their real voting role.
+  // LFXV2-3101 follow-up (Jordan Evans review), broadened GH-1848: an LF Staff member who is also
+  // a real Voting Rep or Alternate Voting Rep (an ED or staff member serving as a board/committee
+  // representative) is a genuine participant and must classify/count normally — only a staff seat
+  // with no real voting role (Observer or None) is excluded, not every LF Staff member regardless
+  // of their real voting role.
   it('does NOT classify LF Staff for a real Voting Rep who happens to be LF Staff — classifies on real attendance instead', () => {
     expect(classifyCommitteeEngagement({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe('High');
   });
@@ -82,6 +102,12 @@ describe('classifyCommitteeEngagement — decision table', () => {
     expect(classifyCommitteeEngagement({ attended: 0, invited: 5, votingStatus: ALTERNATE_VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(
       'Inactive'
     );
+  });
+
+  // Staff + Emeritus: Emeritus wins first in the decision order regardless of role, and this
+  // behavior is unchanged by the GH-1848 broadening (Emeritus is neither Observer nor None).
+  it('classifies Emeritus (not LF Staff) for a staff member with Emeritus voting status', () => {
+    expect(classifyCommitteeEngagement({ attended: 1, invited: 20, votingStatus: EMERITUS, role: LF_STAFF, joinedWithinWindow: false })).toBe('Emeritus');
   });
 
   // Row 3: no invites yet, joined within window — "the Orlin case", but the invited=0 variant.
@@ -167,6 +193,10 @@ describe('isCommitteeMemberAtRisk', () => {
     expect(isCommitteeMemberAtRisk({ attended: 0, invited: 20, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe(false);
   });
 
+  it('is never true for an LF Staff member with no voting status, same as Observer (GH-1848)', () => {
+    expect(isCommitteeMemberAtRisk({ attended: 0, invited: 20, votingStatus: NONE, role: LF_STAFF, joinedWithinWindow: false })).toBe(false);
+  });
+
   it('is still true for a non-staff Observer with a low real rate (the carve-out is role-based, not voting-status-based)', () => {
     expect(isCommitteeMemberAtRisk({ attended: 10, invited: 100, votingStatus: OBSERVER, joinedWithinWindow: false })).toBe(true);
   });
@@ -199,7 +229,11 @@ describe('isCommitteeMemberActive', () => {
     expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: true })).toBe(false);
   });
 
-  it('is true for a real Voting Rep who happens to be LF Staff — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
+  it('is always false for LF Staff + no voting status, same as Observer (GH-1848)', () => {
+    expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: NONE, role: LF_STAFF, joinedWithinWindow: true })).toBe(false);
+  });
+
+  it('is true for a real Voting Rep who happens to be LF Staff — only non-voting staff seats are excluded (LFXV2-3101 follow-up)', () => {
     expect(isCommitteeMemberActive({ attended: 5, invited: 5, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(true);
   });
 });
@@ -211,6 +245,10 @@ describe('isCommitteeMemberActiveEligible (LFXV2-3101 review fix — the active_
 
   it('is false for LF Staff, for the same reason', () => {
     expect(isCommitteeMemberActiveEligible({ votingStatus: OBSERVER, role: LF_STAFF })).toBe(false);
+  });
+
+  it('is false for LF Staff with no voting status, same as Observer (GH-1848)', () => {
+    expect(isCommitteeMemberActiveEligible({ votingStatus: NONE, role: LF_STAFF })).toBe(false);
   });
 
   it('is true for a real member regardless of attendance — eligibility is attendance-independent, unlike isCommitteeMemberActive', () => {
@@ -225,31 +263,36 @@ describe('isCommitteeMemberActiveEligible (LFXV2-3101 review fix — the active_
 
 describe('isCommitteeMemberRateEligible (LFXV2-3101)', () => {
   it('is false for LF Staff + Observer, regardless of real attendance', () => {
-    expect(isCommitteeMemberRateEligible({ attended: 8, invited: 8, votingStatus: OBSERVER, role: LF_STAFF, joinedWithinWindow: false })).toBe(false);
+    expect(isCommitteeMemberRateEligible({ votingStatus: OBSERVER, role: LF_STAFF })).toBe(false);
   });
 
-  it('is true for a real Voting Rep who happens to be LF Staff — only Observer-status staff seats are excluded (LFXV2-3101 follow-up)', () => {
-    expect(isCommitteeMemberRateEligible({ attended: 8, invited: 8, votingStatus: VOTING_REP, role: LF_STAFF, joinedWithinWindow: false })).toBe(true);
+  it('is false for LF Staff with no voting status, same as Observer (GH-1848)', () => {
+    expect(isCommitteeMemberRateEligible({ votingStatus: NONE, role: LF_STAFF })).toBe(false);
+  });
+
+  it('is true for a real Voting Rep who happens to be LF Staff — only non-voting staff seats are excluded (LFXV2-3101 follow-up)', () => {
+    expect(isCommitteeMemberRateEligible({ votingStatus: VOTING_REP, role: LF_STAFF })).toBe(true);
   });
 
   it('is true for Emeritus — unlike every other rule in this file, Emeritus is NOT rate-excluded', () => {
-    expect(isCommitteeMemberRateEligible({ attended: 1, invited: 20, votingStatus: EMERITUS, joinedWithinWindow: false })).toBe(true);
+    expect(isCommitteeMemberRateEligible({ votingStatus: EMERITUS, role: undefined })).toBe(true);
   });
 
-  it('is true for a real Chair with zero attendance (the carve-out is role-based, not a broad exclusion)', () => {
-    expect(isCommitteeMemberRateEligible({ attended: 0, invited: 3, votingStatus: VOTING_REP, role: CHAIR, joinedWithinWindow: false })).toBe(true);
+  it('is true for a real Chair regardless of attendance — the carve-out is role-based, not a broad exclusion, and this predicate is attendance-independent', () => {
+    expect(isCommitteeMemberRateEligible({ votingStatus: VOTING_REP, role: CHAIR })).toBe(true);
   });
 
   it('is true for a member with no role set at all (undefined, not LF Staff)', () => {
-    expect(isCommitteeMemberRateEligible({ attended: 5, invited: 10, votingStatus: VOTING_REP, joinedWithinWindow: false })).toBe(true);
+    expect(isCommitteeMemberRateEligible({ votingStatus: VOTING_REP, role: undefined })).toBe(true);
   });
 
-  it('is true for a member who is BOTH Emeritus and LF Staff — the LF Staff rate exclusion is scoped to Observer voting status specifically, and Emeritus is never voting-status Observer', () => {
-    // LFXV2-3101 follow-up: the LF Staff exclusion only fires for role === LF_STAFF &&
-    // votingStatus === Observer. An Emeritus+LF-Staff member's votingStatus is Emeritus, not
-    // Observer, so isLfStaffObserverSeat is false here — they classify Emeritus (voting status
-    // wins first in the classifier) and are rate-eligible via the ordinary Emeritus-inclusion rule,
-    // not excluded a second way by role.
+  it('is true for a member who is BOTH Emeritus and LF Staff — the LF Staff rate exclusion is scoped to non-voting status (Observer or None) specifically, and Emeritus is neither', () => {
+    // LFXV2-3101 follow-up, broadened GH-1848: the LF Staff exclusion only fires for
+    // role === LF_STAFF && (votingStatus === Observer || votingStatus === None). An
+    // Emeritus+LF-Staff member's votingStatus is Emeritus, not Observer or None, so
+    // isLfStaffNonVotingSeat is false here — they classify Emeritus (voting status wins first in
+    // the classifier) and are rate-eligible via the ordinary Emeritus-inclusion rule, not excluded
+    // a second way by role.
     const input = { attended: 1, invited: 20, votingStatus: EMERITUS, role: LF_STAFF, joinedWithinWindow: false };
     expect(classifyCommitteeEngagement(input)).toBe('Emeritus');
     expect(isCommitteeMemberRateEligible(input)).toBe(true);
@@ -285,5 +328,32 @@ describe('isJoinedWithinWindow', () => {
 
   it('accepts a Date instance directly, not just a string', () => {
     expect(isJoinedWithinWindow(new Date('2024-06-15T00:00:00.000Z'), windowStart)).toBe(true);
+  });
+});
+
+describe('isLfStaffNonVotingSeat (LFXV2-3101, broadened GH-1848)', () => {
+  it('is true for LF Staff + Observer', () => {
+    expect(isLfStaffNonVotingSeat({ role: LF_STAFF, votingStatus: OBSERVER })).toBe(true);
+  });
+
+  it('is true for LF Staff + None', () => {
+    expect(isLfStaffNonVotingSeat({ role: LF_STAFF, votingStatus: NONE })).toBe(true);
+  });
+
+  it('is false for LF Staff + a real voting seat', () => {
+    expect(isLfStaffNonVotingSeat({ role: LF_STAFF, votingStatus: VOTING_REP })).toBe(false);
+    expect(isLfStaffNonVotingSeat({ role: LF_STAFF, votingStatus: ALTERNATE_VOTING_REP })).toBe(false);
+  });
+
+  it('is false for LF Staff + Emeritus (Emeritus wins first in the classifier, not this predicate)', () => {
+    expect(isLfStaffNonVotingSeat({ role: LF_STAFF, votingStatus: EMERITUS })).toBe(false);
+  });
+
+  it('is false for a non-staff Observer — the carve-out is role-based, not voting-status-based', () => {
+    expect(isLfStaffNonVotingSeat({ role: CHAIR, votingStatus: OBSERVER })).toBe(false);
+  });
+
+  it('is false for a non-staff member with no voting status', () => {
+    expect(isLfStaffNonVotingSeat({ role: undefined, votingStatus: NONE })).toBe(false);
   });
 });

--- a/packages/shared/src/utils/committee-engagement-classifier.utils.ts
+++ b/packages/shared/src/utils/committee-engagement-classifier.utils.ts
@@ -6,15 +6,11 @@ import { CommitteeMemberRole, CommitteeMemberVotingStatus } from '../enums';
 import type { CommitteeEngagementClassification, CommitteeEngagementClassificationInput } from '../interfaces/committee-engagement.interface';
 
 /**
- * `attended / invited`, 0 when nobody was invited. Clamps `attended` to `invited` so a warehouse
- * data-quality glitch can't produce a rate over 1 — the finalized model's own dbt tests are
- * expected to enforce `attended <= invited` as a grain invariant, but this is a defensive clamp
- * against that guarantee being violated in practice (a future live-read bug, a stale cache entry),
- * not a sign the invariant is known to be unenforced. Always personal `attended/invited`, never
- * `attended/committee_meetings` — the real model's `committee_meetings_*` column is a committee-wide
- * total that would misclassify a tenure-limited member (e.g. the ticket's Orlin example:
- * `invited_ytd=5, attended_ytd=5` reads as 100%, but `5/committee_meetings` would read as ~36% and
- * wrongly land him in At-Risk).
+ * `attended / invited`, 0 when nobody was invited. Clamps `attended` to `invited` as a defensive
+ * guard against warehouse data quality, not because a rate over 1 is expected. Always personal
+ * `attended/invited`, never `attended/committee_meetings` — the latter is a committee-wide total
+ * that would misclassify a tenure-limited member (e.g. `invited=5, attended=5` reads 100%, but
+ * `5/committee_meetings` could read far lower and wrongly flag them At-Risk).
  */
 function rawCommitteeEngagementRate(attended: number, invited: number): number {
   if (invited <= 0) return 0;
@@ -24,59 +20,56 @@ function rawCommitteeEngagementRate(attended: number, invited: number): number {
 
 /**
  * `rawCommitteeEngagementRate`, rounded to 2 decimal places for display. Classification uses the
- * unrounded rate (`classifyCommitteeEngagement`) — thresholding the rounded value would flip a
- * rate like 0.395 into the `Medium` bucket (rounds to 0.40) despite falling under the `medium`
- * threshold before rounding. Unaffected by seat type or tenure — those change the classification
- * tier, never the underlying number, so an Emeritus member's real (low) rate is still visible.
+ * unrounded rate — thresholding the rounded value would flip e.g. 0.395 into `Medium` (rounds to
+ * 0.40) despite falling under the threshold before rounding. Unaffected by seat type or tenure, so
+ * an Emeritus member's real (low) rate is still visible here.
  */
 export function computeCommitteeEngagementRate(attended: number, invited: number): number {
   return Math.round(rawCommitteeEngagementRate(attended, invited) * 100) / 100;
 }
 
 /**
- * Whether a member is an LF Staff seat with Observer voting status specifically — the actual
- * exclusion condition every "LF Staff" rule in this file keys on, not `role === LF_STAFF` alone
- * (LFXV2-3101 follow-up review fix). Staff seats are typically added as an Observer with no real
- * meeting-attendance expectation, which is what the exclusion exists to protect — but an LF Staff
- * member who is a Voting Rep or Alternate Voting Rep (e.g. an ED or staff member serving as a real
- * board/committee voting representative) is a genuine participant and should classify/count
- * normally, the same as any other member. Excluding them anyway would silence real engagement
- * signal for exactly the population — real participants — every rule in this file exists to
- * measure. Scoped to `role`+`Observer` specifically, not broadened to every Observer regardless of
- * role: a non-staff Observer can still have real engagement expectations depending on the
- * community, so excluding all Observers would hide genuine disengagement signal in the other
- * direction.
+ * Whether a member is an LF Staff seat with no real voting seat — `role === LF_STAFF` alone is not
+ * enough; also requires `votingStatus` to be `Observer` or `None` (the latter is the norm on
+ * committees with voting disabled, since the member form hides the Role/Voting Status fields
+ * entirely there — but that's a UI default, not a guarantee: API/import/legacy data can still set
+ * a real voting status). Neither Observer nor no-status carries a real attendance expectation,
+ * which is what the exclusion protects; an LF Staff member who is a genuine Voting Rep, Alternate
+ * Voting Rep, or Emeritus (a fifth status this predicate doesn't match — see
+ * `classifyCommitteeEngagement`'s Emeritus-wins-first precedence below) classifies/counts normally.
+ * Scoped to `role`+`(Observer|None)` specifically, not every Observer/None regardless of role — a
+ * non-staff member with either status can still have real engagement expectations.
  */
-function isLfStaffObserverSeat(input: Pick<CommitteeEngagementClassificationInput, 'role' | 'votingStatus'>): boolean {
-  return input.role === CommitteeMemberRole.LF_STAFF && input.votingStatus === CommitteeMemberVotingStatus.OBSERVER;
+export function isLfStaffNonVotingSeat(input: Pick<CommitteeEngagementClassificationInput, 'role' | 'votingStatus'>): boolean {
+  return (
+    input.role === CommitteeMemberRole.LF_STAFF &&
+    (input.votingStatus === CommitteeMemberVotingStatus.OBSERVER || input.votingStatus === CommitteeMemberVotingStatus.NONE)
+  );
 }
 
 /**
- * Decision order (see the ticket's Jira thread for the full rationale):
- * 1. `Emeritus` voting status always wins — on the roster for legacy/honorific reasons, real
- *    attendance (often ~5%, per the model's real observed data) shouldn't read as disengagement.
- * 2. `LF Staff` + `Observer` wins next (LFXV2-3101) — see `isLfStaffObserverSeat`'s doc for exactly
- *    why it's this two-part condition and not `role` alone.
+ * Decision order:
+ * 1. `Emeritus` voting status always wins — on the roster for legacy/honorific reasons, low real
+ *    attendance shouldn't read as disengagement.
+ * 2. `LF Staff` + no real voting seat wins next — see `isLfStaffNonVotingSeat`'s doc.
  * 3. No invites yet, but joined within the window: no real opportunity has existed, so this can't
- *    be `Inactive` — tenure, not disengagement. Classified `High` (active by definition) rather
- *    than a new tier, since the ticket's classification set is fixed.
- * 4. No invites, and been a member the whole window: a genuine no-signal veteran — unchanged from
- *    the original rule.
- * 5-7. Invited at least once: threshold on the real (unrounded) rate as before.
+ *    be `Inactive` — tenure, not disengagement. Classified `High` (active by definition).
+ * 4. No invites, and been a member the whole window: a genuine no-signal veteran.
+ * 5-7. Invited at least once: threshold on the real (unrounded) rate.
  * 8. Invited at least once, attended nothing: a real disengagement signal regardless of tenure —
- *    unlike case 3, they had an actual opportunity and skipped every one of them, so tenure does
- *    not protect this case.
+ *    unlike case 3, they had an actual opportunity and skipped every one of them.
  */
 export function classifyCommitteeEngagement(input: CommitteeEngagementClassificationInput): CommitteeEngagementClassification {
   const { attended, invited, votingStatus, joinedWithinWindow } = input;
   if (votingStatus === CommitteeMemberVotingStatus.EMERITUS) return 'Emeritus';
-  if (isLfStaffObserverSeat(input)) return 'LF Staff';
+  if (isLfStaffNonVotingSeat(input)) return 'LF Staff';
   if (invited <= 0) return joinedWithinWindow ? 'High' : 'Inactive';
 
   const rate = rawCommitteeEngagementRate(attended, invited);
   // `<=`, not `===`: defensive against `rawCommitteeEngagementRate`'s internal clamp ever being
-  // weakened, not because a negative rate is reachable today — by this point `invited > 0` (line
-  // 53) and `attended` is clamped to `[0, invited]`, so `rate` is always in `[0, 1]`.
+  // weakened, not because a negative rate is reachable today — by this point the `invited <= 0`
+  // guard above has returned, so `invited > 0`, and `attended` is clamped to `[0, invited]`, so
+  // `rate` is always in `[0, 1]`.
   if (rate <= 0) return 'Inactive';
   if (rate >= COMMITTEE_ENGAGEMENT_RATE_THRESHOLDS.high) return 'High';
   if (rate >= COMMITTEE_ENGAGEMENT_RATE_THRESHOLDS.medium) return 'Medium';
@@ -87,9 +80,8 @@ export function classifyCommitteeEngagement(input: CommitteeEngagementClassifica
  * `Low` members are at risk by definition. A member invited within the window who attended
  * nothing is at risk too, even though `classifyCommitteeEngagement` also calls them `Inactive` —
  * that tier's other member (never invited at all) has no signal to act on, but this one does.
- * `Emeritus`, `LF Staff`+`Observer` (LFXV2-3101), and the tenure-grace `High` (case 3 above) are
- * never at-risk — none of them match `Low` or `Inactive`, so no extra exclusion logic is needed
- * here.
+ * `Emeritus`, `LF Staff`+non-voting, and the tenure-grace `High` never match `Low` or `Inactive`,
+ * so no extra exclusion logic is needed here.
  */
 export function isCommitteeMemberAtRisk(input: CommitteeEngagementClassificationInput): boolean {
   const classification = classifyCommitteeEngagement(input);
@@ -97,18 +89,16 @@ export function isCommitteeMemberAtRisk(input: CommitteeEngagementClassification
 }
 
 /**
- * The "Active Members x/y" summary rule — deliberately broader than "classified High/Medium":
- * per the ticket, the numerator is members with *any* real attendance this window, plus members
- * who joined within it (active by definition of being newly on the roster), excluding Emeritus
- * and LF Staff+Observer seats (LFXV2-3101, see `isLfStaffObserverSeat`'s doc for the two-part
- * condition). This function doesn't delegate to `classifyCommitteeEngagement`, so both exclusions
- * need their own explicit check here, same as the classifier's. A `Low`-classified member (some
- * attendance, just under the Medium threshold) still counts here — this is a distinct rule from
- * `classifyCommitteeEngagement`, not a rollup of its tiers.
+ * The "Active Members x/y" summary rule — deliberately broader than "classified High/Medium": the
+ * numerator is members with *any* real attendance this window, plus members who joined within it,
+ * excluding Emeritus and LF Staff+non-voting seats. Doesn't delegate to `classifyCommitteeEngagement`,
+ * so both exclusions need their own explicit check here. A `Low`-classified member (some
+ * attendance, just under the Medium threshold) still counts — this is a distinct rule, not a
+ * rollup of the classifier's tiers.
  */
 export function isCommitteeMemberActive(input: CommitteeEngagementClassificationInput): boolean {
   if (input.votingStatus === CommitteeMemberVotingStatus.EMERITUS) return false;
-  if (isLfStaffObserverSeat(input)) return false;
+  if (isLfStaffNonVotingSeat(input)) return false;
   return input.attended > 0 || input.joinedWithinWindow;
 }
 
@@ -116,61 +106,49 @@ export function isCommitteeMemberActive(input: CommitteeEngagementClassification
  * Whether a member belongs to the population `active_count` is measured over — i.e. whether they
  * could ever contribute to it, independent of whether *this* member happens to be active right
  * now. This is `CommitteeEngagementSummary.eligible_count`'s per-member rule, the correct
- * denominator for displaying `active_count` as a ratio (LFXV2-3101 review fix): counting Emeritus
- * and LF Staff+Observer seats in the denominator while `isCommitteeMemberActive` always excludes
- * them from the numerator means a committee that seats either could never read 100% active
- * regardless of real participation — the same shape of bug the ticket fixed for the At-Risk
- * filter, just showing up in the ratio instead. Attendance-independent by design (unlike
- * `isCommitteeMemberActive`, which mixes the exclusion with an attendance check) — a
+ * denominator for displaying `active_count` as a ratio: counting Emeritus and LF Staff+non-voting
+ * seats in the denominator while `isCommitteeMemberActive` always excludes them from the numerator
+ * means a committee that seats either could never read 100% active regardless of real
+ * participation. Attendance-independent by design (unlike `isCommitteeMemberActive`) — a
  * never-attended non-Emeritus/non-staff member is still eligible, just not active.
  */
 export function isCommitteeMemberActiveEligible(input: Pick<CommitteeEngagementClassificationInput, 'votingStatus' | 'role'>): boolean {
-  return input.votingStatus !== CommitteeMemberVotingStatus.EMERITUS && !isLfStaffObserverSeat(input);
+  return input.votingStatus !== CommitteeMemberVotingStatus.EMERITUS && !isLfStaffNonVotingSeat(input);
 }
 
 /**
  * Whether a member's `attended`/`invited` counts should feed the committee-wide `attendance_rate`
- * sum (LFXV2-3101) — `LF Staff`+`Observer` seats are excluded, Emeritus seats deliberately are NOT
- * (see `CommitteeEngagementSummary.attendance_rate`'s doc for why the two aren't symmetric here,
- * unlike every other rule in this file). Exported as its own named predicate, not left as an
- * inline check at the one call site, so this asymmetry is stated once in the module that owns
- * every other classification rule, rather than risking a second, easily-missed copy.
+ * sum — `LF Staff`+non-voting seats are excluded, Emeritus seats deliberately are NOT (see
+ * `CommitteeEngagementSummary.attendance_rate`'s doc for why the two aren't symmetric here).
+ * Named predicate, not an inline check, so both `committee-engagement.service.ts` (the sum) and
+ * `CommitteeEngagementSummaryComponent.hasInvitedRateEligibleMember` (the UI gate, which also
+ * requires `invited > 0`) call the same condition. Parameter narrowed to `role`/`votingStatus` so
+ * a caller without `attended`/`invited`/`joinedWithinWindow` — like the UI — can call it directly,
+ * mirroring `isCommitteeMemberActiveEligible` above.
  *
- * Delegates to `isLfStaffObserverSeat`, independent of `classifyCommitteeEngagement`'s tier — a
- * member who is BOTH a real Emeritus (`votingStatus`) and a real LF Staff+Observer seat classifies
- * `Emeritus` (voting status wins first in the classifier's decision order) and renders the
- * Emeritus chip, but is still excluded from the rate sum here, since the exclusion is deliberately
- * seat-type-based, not classification-based. Rare in practice (an honorific legacy seat is not
- * usually also an active staff seat) but not undefined behavior: the check simply doesn't care
- * what tier the member displayed as.
+ * Delegates to `isLfStaffNonVotingSeat`: an `LF Staff` member with a real `Emeritus` voting status
+ * is NOT excluded here — the same reason they classify `Emeritus` rather than `LF Staff` in
+ * `classifyCommitteeEngagement`. One check, one answer; no case where the two disagree.
  *
- * `input.role`'s and `input.votingStatus`'s values are whatever the caller resolved — for
- * `committee-engagement.service.ts` today that's the live roster's value first for BOTH fields,
- * warehouse `MEMBER_ROLE`/`MEMBER_VOTING_STATUS` only as the fallback when the roster value is
- * missing (Cursor Bugbot follow-up, LFXV2-3101: `votingStatus` used to stay warehouse-first even
- * after `role` was flipped roster-first, which meant a member promoted from Observer to a real
- * Voting/Alternate Rep could keep a stale warehouse `Observer` and stay incorrectly excluded here
- * until the next dbt refresh — this predicate combines both fields into one condition via
- * `isLfStaffObserverSeat`, so both need equally fresh precedence or the combination itself goes
- * stale even when each field individually wouldn't). The roster's typed `CommitteeMemberRole`/
- * `CommitteeMemberVotingStatus` are also safer match targets than the warehouse's untyped strings.
+ * `input.role`/`input.votingStatus` are whatever the caller resolved.
+ * `committee-engagement.service.ts` resolves the live roster's value first for both fields,
+ * falling back to warehouse `MEMBER_ROLE`/`MEMBER_VOTING_STATUS` only when the roster value is
+ * missing — both fields need equally fresh precedence, since combining a fresh `role` with a
+ * stale warehouse `votingStatus` (or vice versa) would make this predicate wrong even when
+ * neither field alone is.
  */
-export function isCommitteeMemberRateEligible(input: CommitteeEngagementClassificationInput): boolean {
-  return !isLfStaffObserverSeat(input);
+export function isCommitteeMemberRateEligible(input: Pick<CommitteeEngagementClassificationInput, 'role' | 'votingStatus'>): boolean {
+  return !isLfStaffNonVotingSeat(input);
 }
 
 /**
  * `false` (fail-safe: no tenure protection) for a missing or unparseable join date. Shared between
- * `committee-engagement.service.ts` (per-member tenure clipping for `GET /:uid/engagement`) and
- * `groups-engagement-stats.service.ts` (the `active_members` rollup for `GET /engagement-stats`) so
- * both apply identical `member_joined_at` semantics from the LFXV2-1705 dbt model. This function is
- * one shared piece of a broader intent (LFXV2-1711: the two surfaces shouldn't disagree), not a
- * guarantee of exact agreement by itself — the groups rollup is warehouse-row-anchored only (no live
- * roster join per committee), so it can still diverge from the detail page's `window=30d` count for
- * a roster member the model hasn't picked up yet, a blank `MEMBER_VOTING_STATUS`, or a blank/
- * unparseable `MEMBER_JOINED_AT` — the detail page resolves all three via a live roster fetch (see
- * `groups-engagement-stats.service.ts`'s class doc). It also doesn't
- * apply at 90d/ytd, which the groups rollup doesn't compute at all (always the 30d definition).
+ * `committee-engagement.service.ts` (per-member tenure clipping) and
+ * `groups-engagement-stats.service.ts` (the `active_members` rollup) so both apply identical
+ * `member_joined_at` semantics — not a guarantee of exact agreement between the two: the rollup is
+ * warehouse-row-anchored only (no live roster join), so it can still diverge from the detail
+ * page's `window=30d` count for a roster member the model hasn't picked up yet. Also doesn't apply
+ * at 90d/ytd, which the rollup doesn't compute (always the 30d definition).
  */
 export function isJoinedWithinWindow(joinedAt: string | Date | null, windowStart: Date): boolean {
   if (!joinedAt) return false;


### PR DESCRIPTION
## Summary

On committees with no voting enabled, LF Staff members typically have no recorded `voting_status` (the `'None'` sentinel), rather than the `'Observer'` status the previous exclusion rule keyed on. This let those seats fall through the LF Staff engagement exclusion, producing two misleading symptoms reported in production:

- The engagement chip read **"High"** (tenure-grace applied to a literal 0/0 attendance count).
- The tooltip read **"LF Staff — attended 0 of 0 invited meetings"**.

This broadens `isLfStaffObserverSeat` (renamed `isLfStaffNonVotingSeat`, now exported) to also match a `'None'` voting status, so a non-voting LF Staff seat gets the same neutral treatment as an Observer LF Staff seat. It does **not** broaden the carve-out for a genuine Voting Rep / Alternate Voting Rep LF Staff member, or for Emeritus — both keep classifying on real participation, per the LFXV2-3101 follow-up this extends.

Also closes a related gap: `groups-engagement-stats.service.ts`'s rollup was still treating a blank warehouse `MEMBER_VOTING_STATUS` as unresolved rather than normalizing it to `None`, so an LF Staff seat could escape exclusion there even after the committee-detail path was fixed. And the summary card now renders `—` instead of a literal `0%`/`0/0` when a committee's roster is entirely excluded from a metric — the same class of misleading-zero bug, one level up.

## Verified against the real reported committee

The fix requires `role === 'LF Staff'` to be resolvable for the affected members. The member-add form hides **both** the Role and Voting Status fields when `committee?.enable_voting` is false, so this needed checking against real data rather than assumed. Fetched the live roster for the reported committee ("LFX Extended Leadership Team", `57253516-4361-42b4-af5e-4e312333e301`) directly:

- **24 of 26 members have `role: "LF Staff"` populated**, `voting_status` blank on all of them — exactly the reported bug shape. The fix fires for them.
- 2 members have blank `role` (a pre-existing, unrelated data gap — they wouldn't have matched the old Observer-only rule either).

Also visually verified in the running app: with a live member's `voting_status` patched to `'None'` and `attended`/`invited` forced to `0/0` (matching the exact reported shape), the row renders the neutral gray **"LF Staff"** chip — not "High" — with tooltip *"LF Staff seat — excluded from engagement metrics; attendance expectations do not apply"*.

## Known behavior change: blank warehouse voting status on a *voting-enabled* committee

The `|| CommitteeMemberVotingStatus.NONE` fallback (both `committee-engagement.service.ts` and `groups-engagement-stats.service.ts`) conflates "recorded as non-voting" with "not synced yet." On a committee that *does* run votes, an LF Staff member whose real voting status hasn't synced to the warehouse yet is now silently excluded from `attendance_rate`/`active_count`, where they previously counted (as an unresolved/blank status, not explicitly excluded). This is inherent to broadening the `None` sentinel to mean "non-voting" — a deliberate trade-off for this fix, not something this PR mitigates further.

## Documented trade-offs

- **Deep import in e2e helper** (`e2e/helpers/committee-engagement.helper.ts`): imports `@lfx-one/shared/utils/committee-engagement-classifier.utils` directly rather than the `@lfx-one/shared/utils` barrel. The barrel transitively re-exports files that import `@angular/forms`/`@angular/common/http`, which Playwright's module loader can't JIT-compile. Four existing e2e files already do this (`org-roi-summary.spec.ts`, `org-roi-projects.spec.ts`, `org-roi-project-detail.spec.ts`, `past-meeting-ai-summary-visibility.spec.ts`).
- **Client-side rate-eligibility re-derivation**: `CommitteeEngagementSummaryComponent` re-derives whether any rate-eligible member has invites this window by scanning `members[]`, rather than the BFF exposing that fact directly (the way `eligible_count` does for the active-members metric). Verified correct and covered by tests; a follow-up could move this server-side to remove the duplicated predicate and the "don't truncate `members[]`" coupling documented in the interface file.

## Test plan

- [x] `yarn lint:check`, `yarn check-types`, `yarn format:check` — all pass
- [x] `yarn test` — shared + server + app suites all pass
- [x] `yarn build` — succeeds
- [x] `npx playwright test --list` on `committee-engagement.spec.ts` / `committee-engagement-robust.spec.ts` — 42 tests discovered, no errors
- [x] New/updated coverage: `isLfStaffNonVotingSeat` decision table, `committee-engagement.service.ts` regression test for the exact reported bug shape, `groups-engagement-stats.service.ts` blank-status normalization, `committee-engagement-summary.component.spec.ts` em-dash/aria-label guards
- [x] Manual verification against the real "LFX Extended Leadership Team" committee data (see above)

Fixes #1848. Extends the LFXV2-3101 follow-up narrowing (staff+Observer → staff+non-voting).
