### PR TITLE
feat(clas): send contact CLA manager requests

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.spec.ts
@@ -34,8 +34,8 @@ describe('buildContactClaManagerMenuItems', () => {
     expect(buildContactClaManagerMenuItems(agreement({ status: 'revoked' }), dialog)).toEqual([]);
   });
 
-  it('offers only Request Removal on a Valid ECLA', () => {
-    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'valid' }), dialog))).toEqual(['Request Removal']);
+  it('offers Request Removal and Contact CLA Manager on a Valid ECLA', () => {
+    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'valid' }), dialog))).toEqual(['Request Removal', 'Contact CLA Manager']);
   });
 
   it('offers approval, removal, and contact on Needs-attention + not_on_approval_list', () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.html
@@ -31,7 +31,7 @@ SPDX-License-Identifier: MIT
     <label class="mt-4 mb-2 text-sm font-medium text-slate-700" for="cla-manager-message">
       Message
       @if (messageRequired) {
-        <span class="text-red-500">*</span>
+        <span class="text-red-500" aria-hidden="true">*</span>
       } @else {
         <span class="font-normal text-slate-400">(optional)</span>
       }

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.html
@@ -28,15 +28,47 @@ SPDX-License-Identifier: MIT
       }
     </div>
 
-    <label class="mt-4 mb-2 text-sm font-medium text-slate-700" for="cla-manager-message">Message</label>
+    <label class="mt-4 mb-2 text-sm font-medium text-slate-700" for="cla-manager-message">
+      Message
+      @if (messageRequired) {
+        <span class="text-red-500">*</span>
+      } @else {
+        <span class="font-normal text-slate-400">(optional)</span>
+      }
+    </label>
+    <!-- No native [maxlength] — it counts UTF-16 units and would block an emoji-heavy message below
+         the producer's real code-point limit; messageError and the counter enforce the cap instead. -->
     <lfx-textarea
       class="block w-full"
       [form]="form"
       control="message"
       [rows]="3"
       styleClass="w-full cla-manager-message"
-      placeholder="Add a note for the CLA manager…"
+      [placeholder]="messageRequired ? 'Write your message to the CLA manager…' : 'Add a note for the CLA manager…'"
+      [describedBy]="visibleMessageError() ? 'cla-manager-message-error' : ''"
+      [invalid]="!!visibleMessageError()"
+      [required]="messageRequired"
       id="cla-manager-message" />
+    <div class="mt-1 flex justify-between">
+      @if (visibleMessageError() === 'required') {
+        <p id="cla-manager-message-error" class="text-xs text-red-500" role="alert" data-testid="contact-cla-manager-message-error">A message is required.</p>
+      } @else if (visibleMessageError() === 'too-long') {
+        <p id="cla-manager-message-error" class="text-xs text-red-500" role="alert" data-testid="contact-cla-manager-message-error">
+          Message must be {{ messageMaxLength }} characters or fewer.
+        </p>
+      } @else {
+        <span></span>
+      }
+      <span
+        class="text-xs text-slate-400"
+        role="status"
+        aria-live="polite"
+        aria-atomic="true"
+        [attr.aria-label]="messageLength() + ' of ' + messageMaxLength + ' characters used'"
+        data-testid="contact-cla-manager-message-counter">
+        {{ messageLength() }}/{{ messageMaxLength }}
+      </span>
+    </div>
   }
 
   @if (sendError()) {

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.html
@@ -61,9 +61,6 @@ SPDX-License-Identifier: MIT
       }
       <span
         class="text-xs text-slate-400"
-        role="status"
-        aria-live="polite"
-        aria-atomic="true"
         [attr.aria-label]="messageLength() + ' of ' + messageMaxLength + ' characters used'"
         data-testid="contact-cla-manager-message-counter">
         {{ messageLength() }}/{{ messageMaxLength }}

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.spec.ts
@@ -4,6 +4,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
+import { CLA_MANAGER_MESSAGE_MAX_LENGTH } from '@lfx-one/shared/constants';
 import type { ClaManager, ClaManagerList, ClaManagerRequestMode, ClaManagerRequestResult, ContactClaManagerDialogData } from '@lfx-one/shared/interfaces';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -37,7 +38,7 @@ describe('ContactClaManagerComponent', () => {
       of<ClaManagerRequestResult>({
         requestId: 'r-1',
         signatureId: SIG,
-        requestType: mode === 'contact' ? 'approval' : mode,
+        requestType: mode,
         status: 'sent',
         recipients: [JANE.lfUsername],
       })
@@ -76,12 +77,25 @@ describe('ContactClaManagerComponent', () => {
     fixture.detectChanges();
   }
 
+  function typeMessage(value: string): void {
+    (fixture.componentInstance as any).messageControl.setValue(value);
+    fixture.detectChanges();
+  }
+
+  function sendEnabled(): boolean {
+    return (fixture.componentInstance as unknown as { canSend: () => boolean }).canSend();
+  }
+
   beforeEach(async () => {
     await setup('approval');
   });
 
   it('shows v17 approval copy naming the project', () => {
     expect(query('contact-cla-manager-hint')?.textContent).toContain('re-approve your ECLA for CNCF');
+  });
+
+  it('leaves the message optional for approval, so it carries no aria-required', () => {
+    expect(fixture.nativeElement.querySelector('textarea')?.getAttribute('aria-required')).toBeNull();
   });
 
   it('checks every manager by default', () => {
@@ -134,22 +148,147 @@ describe('ContactClaManagerComponent', () => {
     expect(createClaManagerRequest).toHaveBeenCalledWith(SIG, expect.objectContaining({ requestType: 'removal' }));
   });
 
-  it('does not POST on contact Send', async () => {
-    await setup('contact');
-    expect(query('contact-cla-manager-hint')?.textContent).toContain('Send a message to the CLA manager(s) for CNCF');
+  it('leaves the message optional for approval and removal', async () => {
+    expect(sendEnabled()).toBe(true);
+
+    await setup('removal');
+    expect(sendEnabled()).toBe(true);
+  });
+
+  it('reports a recorded approval/removal as a request, not a message', async () => {
+    createClaManagerRequest.mockReturnValue(
+      of<ClaManagerRequestResult>({ requestId: 'r-1', signatureId: SIG, requestType: 'approval', status: 'recorded', recipients: ['jdoe'] })
+    );
 
     send();
     fixture.detectChanges();
     await fixture.whenStable();
 
-    expect(createClaManagerRequest).not.toHaveBeenCalled();
-    expect(close).toHaveBeenCalledWith(null);
-    expect(add).toHaveBeenCalledWith(
-      expect.objectContaining({
-        severity: 'info',
-        summary: 'Message not sent',
-      })
-    );
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Request recorded' }));
+  });
+
+  describe('contact mode', () => {
+    beforeEach(async () => {
+      await setup('contact');
+    });
+
+    it('shows contact copy and marks the message required', () => {
+      expect(query('contact-cla-manager-hint')?.textContent).toContain('Send a message to the CLA manager(s) for CNCF');
+      expect((fixture.componentInstance as unknown as { messageRequired: boolean }).messageRequired).toBe(true);
+      // The asterisk is decorative, so assistive tech only learns the field is mandatory from this.
+      expect(fixture.nativeElement.querySelector('textarea')?.getAttribute('aria-required')).toBe('true');
+    });
+
+    it('posts requestType contact with the message and the checked LF usernames', async () => {
+      typeMessage('  who owns our approved list?  ');
+      send();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(createClaManagerRequest).toHaveBeenCalledWith(SIG, {
+        requestType: 'contact',
+        recipients: expect.arrayContaining(['jdoe', 'akim']),
+        message: 'who owns our approved list?',
+      });
+      expect(close).toHaveBeenCalled();
+      expect(add).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Message sent' }));
+    });
+
+    it('reports a recorded contact as a message, not a request', async () => {
+      createClaManagerRequest.mockReturnValue(
+        of<ClaManagerRequestResult>({ requestId: 'r-1', signatureId: SIG, requestType: 'contact', status: 'recorded', recipients: ['jdoe'] })
+      );
+      typeMessage('hello');
+      send();
+      fixture.detectChanges();
+      await fixture.whenStable();
+
+      expect(add).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Message recorded', severity: 'info' }));
+    });
+
+    it('keeps Send disabled and posts nothing while the message is blank', () => {
+      expect(sendEnabled()).toBe(false);
+
+      send();
+      expect(createClaManagerRequest).not.toHaveBeenCalled();
+    });
+
+    // Opening to a red "required" line would scold the contributor for not having started.
+    it('withholds the required error until the field has been edited', () => {
+      expect(query('contact-cla-manager-message-error')).toBeNull();
+      expect(query('contact-cla-manager-message-counter')?.textContent).toContain(`0/${CLA_MANAGER_MESSAGE_MAX_LENGTH}`);
+    });
+
+    it('keeps Send disabled for a whitespace-only message', () => {
+      typeMessage('   \n\t ');
+
+      expect(sendEnabled()).toBe(false);
+      expect(query('contact-cla-manager-message-error')?.textContent).toContain('A message is required.');
+
+      send();
+      expect(createClaManagerRequest).not.toHaveBeenCalled();
+    });
+
+    it('enables Send once a non-blank message is typed', () => {
+      typeMessage('please add me back');
+
+      expect(sendEnabled()).toBe(true);
+      expect(query('contact-cla-manager-message-error')).toBeNull();
+    });
+
+    it('accepts a message exactly at the cap', () => {
+      typeMessage('x'.repeat(CLA_MANAGER_MESSAGE_MAX_LENGTH));
+
+      expect(sendEnabled()).toBe(true);
+    });
+
+    it('blocks Send one code point over the cap and says so', () => {
+      typeMessage('x'.repeat(CLA_MANAGER_MESSAGE_MAX_LENGTH + 1));
+
+      expect(sendEnabled()).toBe(false);
+      expect(query('contact-cla-manager-message-error')?.textContent).toContain(`${CLA_MANAGER_MESSAGE_MAX_LENGTH} characters or fewer`);
+
+      send();
+      expect(createClaManagerRequest).not.toHaveBeenCalled();
+    });
+
+    // Emoji are two UTF-16 units each, so a UTF-16 cap would reject this at roughly half the
+    // producer's real rune allowance.
+    it('counts an emoji-only message by code point, not UTF-16 unit', () => {
+      typeMessage('🙂'.repeat(CLA_MANAGER_MESSAGE_MAX_LENGTH));
+
+      expect(sendEnabled()).toBe(true);
+    });
+
+    it('still requires at least one recipient', () => {
+      typeMessage('please add me back');
+      uncheck('jdoe');
+      uncheck('akim');
+
+      expect(sendEnabled()).toBe(false);
+      send();
+      expect(createClaManagerRequest).not.toHaveBeenCalled();
+    });
+
+    it('surfaces the shared inline failure copy when the POST fails', async () => {
+      createClaManagerRequest.mockReturnValue(throwError(() => new Error('boom')));
+      typeMessage('hello');
+      send();
+      fixture.detectChanges();
+      await fixture.whenStable();
+      fixture.detectChanges();
+
+      expect(fixture.nativeElement.textContent).toContain("Couldn't send the request. Try again.");
+      expect(close).not.toHaveBeenCalled();
+    });
+  });
+
+  it('caps the message for approval too, without requiring one', async () => {
+    typeMessage('x'.repeat(CLA_MANAGER_MESSAGE_MAX_LENGTH + 1));
+    expect(sendEnabled()).toBe(false);
+
+    typeMessage('');
+    expect(sendEnabled()).toBe(true);
   });
 
   it('shows support copy and no Send when no managers resolve', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.ts
@@ -6,8 +6,8 @@ import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
 import { CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_MODAL_COPY } from '@lfx-one/shared/constants';
 import type { ClaManagerRequestResult, ClaManagerView, ContactClaManagerDialogData } from '@lfx-one/shared/interfaces';
-import { codePointLength } from '@lfx-one/shared/utils';
-import { maxCodePointsValidator, trimmedRequired } from '@lfx-one/shared/validators';
+import { codePointLength, sanitizePlainText } from '@lfx-one/shared/utils';
+import { plainTextMessageValidator } from '@lfx-one/shared/validators';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { take } from 'rxjs';
@@ -57,9 +57,7 @@ export class ContactClaManagerComponent {
   protected readonly managerForm = new FormGroup({});
   protected readonly messageControl = new FormControl('', {
     nonNullable: true,
-    validators: this.messageRequired
-      ? [trimmedRequired(), maxCodePointsValidator(CLA_MANAGER_MESSAGE_MAX_LENGTH)]
-      : [maxCodePointsValidator(CLA_MANAGER_MESSAGE_MAX_LENGTH)],
+    validators: [plainTextMessageValidator({ required: this.messageRequired, max: CLA_MANAGER_MESSAGE_MAX_LENGTH })],
   });
   protected readonly form = new FormGroup({
     message: this.messageControl,
@@ -76,7 +74,9 @@ export class ContactClaManagerComponent {
 
   protected readonly messageError: Signal<'required' | 'too-long' | null> = this.initMessageError();
   protected readonly visibleMessageError = computed(() => (this.messageEdited() ? this.messageError() : null));
-  protected readonly messageLength = computed(() => codePointLength(this.messageValue()));
+  // Counts what the cap actually measures, so the counter cannot read under the limit while the
+  // control is invalid (or the reverse).
+  protected readonly messageLength = computed(() => codePointLength(sanitizePlainText(this.messageValue())));
 
   protected readonly hasManagers = computed(() => this.managers().length > 0);
   protected readonly canSend = computed(
@@ -124,7 +124,7 @@ export class ContactClaManagerComponent {
     this.sending.set(true);
     this.sendError.set(false);
 
-    const message = this.messageControl.value.trim();
+    const message = sanitizePlainText(this.messageControl.value);
     this.myClasService
       .createClaManagerRequest(this.data.signatureId, {
         requestType: this.data.mode,

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager.component.ts
@@ -1,11 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import { CLA_MANAGER_MODAL_COPY } from '@lfx-one/shared/constants';
+import { CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_MODAL_COPY } from '@lfx-one/shared/constants';
 import type { ClaManagerRequestResult, ClaManagerView, ContactClaManagerDialogData } from '@lfx-one/shared/interfaces';
+import { codePointLength } from '@lfx-one/shared/utils';
+import { maxCodePointsValidator, trimmedRequired } from '@lfx-one/shared/validators';
 import { MessageService } from 'primeng/api';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 import { take } from 'rxjs';
@@ -17,9 +19,9 @@ import { TextareaComponent } from '@components/textarea/textarea.component';
 import { MyClasService } from '@services/my-clas.service';
 
 /**
- * Shared Contact CLA Manager modal (#1372 / #1574). Three copy modes; approval and removal
- * POST to the producer; contact Send is a documented no-op (the producer email always claims an
- * Approved-List change) and tells the contributor that nothing was sent.
+ * Shared Contact CLA Manager modal (#1372 / #1574). Three copy modes, all POSTing the matching
+ * `requestType` to the producer. Contact differs only in what it asks for: no change, which is
+ * why its message is required rather than optional.
  */
 @Component({
   selector: 'lfx-contact-cla-manager',
@@ -41,6 +43,9 @@ export class ContactClaManagerComponent {
   };
   protected readonly copy = CLA_MANAGER_MODAL_COPY[this.data.mode];
   protected readonly hint = this.copy.hint(this.data.projectName);
+  protected readonly messageMaxLength = CLA_MANAGER_MESSAGE_MAX_LENGTH;
+  /** Contact asks for no change, so the message is the request. Approval and removal keep it optional. */
+  protected readonly messageRequired = this.data.mode === 'contact';
 
   protected readonly loading = signal(true);
   protected readonly loadError = signal(false);
@@ -50,16 +55,41 @@ export class ContactClaManagerComponent {
   protected readonly selectedCount = signal(0);
 
   protected readonly managerForm = new FormGroup({});
+  protected readonly messageControl = new FormControl('', {
+    nonNullable: true,
+    validators: this.messageRequired
+      ? [trimmedRequired(), maxCodePointsValidator(CLA_MANAGER_MESSAGE_MAX_LENGTH)]
+      : [maxCodePointsValidator(CLA_MANAGER_MESSAGE_MAX_LENGTH)],
+  });
   protected readonly form = new FormGroup({
-    message: new FormControl('', { nonNullable: true }),
+    message: this.messageControl,
     managers: this.managerForm,
   });
 
+  // Zoneless change detection cannot see `messageControl.errors`, so the validators' verdict is
+  // mirrored into a signal on every `valueChanges`.
+  private readonly messageErrors = signal(this.messageControl.errors);
+  private readonly messageValue = signal('');
+  // Withholds the error until the contributor has actually typed. Opening a contact modal to a red
+  // "required" line would scold them for not having started; the label's `*` carries it until then.
+  private readonly messageEdited = signal(false);
+
+  protected readonly messageError: Signal<'required' | 'too-long' | null> = this.initMessageError();
+  protected readonly visibleMessageError = computed(() => (this.messageEdited() ? this.messageError() : null));
+  protected readonly messageLength = computed(() => codePointLength(this.messageValue()));
+
   protected readonly hasManagers = computed(() => this.managers().length > 0);
-  protected readonly canSend = computed(() => this.selectedCount() > 0 && !this.sending() && !this.loading() && this.hasManagers());
+  protected readonly canSend = computed(
+    () => this.selectedCount() > 0 && this.messageError() === null && !this.sending() && !this.loading() && this.hasManagers()
+  );
 
   public constructor() {
     this.managerForm.valueChanges.pipe(takeUntilDestroyed()).subscribe(() => this.syncSelectedCount());
+    this.messageControl.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => {
+      this.messageValue.set(value);
+      this.messageErrors.set(this.messageControl.errors);
+      this.messageEdited.set(true);
+    });
 
     this.myClasService
       .getClaManagers(this.data.signatureId)
@@ -91,22 +121,10 @@ export class ContactClaManagerComponent {
   protected onSend(): void {
     if (!this.canSend()) return;
 
-    // Contact is a product-complete no-op: the producer has no contact requestType, and posting
-    // approval/removal would tell the manager to change the Approved List.
-    if (this.data.mode === 'contact') {
-      this.messageService.add({
-        severity: 'info',
-        summary: 'Message not sent',
-        detail: "Contacting CLA managers isn't available yet — no message was sent.",
-      });
-      this.ref.close(null);
-      return;
-    }
-
     this.sending.set(true);
     this.sendError.set(false);
 
-    const message = this.form.controls.message.value.trim();
+    const message = this.messageControl.value.trim();
     this.myClasService
       .createClaManagerRequest(this.data.signatureId, {
         requestType: this.data.mode,
@@ -135,14 +153,21 @@ export class ContactClaManagerComponent {
 
   private onSent(result: ClaManagerRequestResult): void {
     this.sending.set(false);
+    const receipt = this.copy.receipt[result.status];
     this.messageService.add({
       severity: result.status === 'sent' ? 'success' : 'info',
-      summary: result.status === 'sent' ? 'Request sent' : 'Request recorded',
-      detail:
-        result.status === 'sent'
-          ? 'The CLA manager(s) you selected will be notified.'
-          : 'The request was recorded, but no CLA manager email could be delivered.',
+      summary: receipt.summary,
+      detail: receipt.detail,
     });
     this.ref.close(result);
+  }
+
+  private initMessageError(): Signal<'required' | 'too-long' | null> {
+    return computed(() => {
+      const errors = this.messageErrors();
+      if (errors?.['maxCodePoints']) return 'too-long';
+      if (errors?.['trimmedRequired']) return 'required';
+      return null;
+    });
   }
 }

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -226,7 +226,7 @@ describe('ProfileClasComponent', () => {
   it('shows a disabled Download PDF item with a Covered by Corporate CLA line on an ECLA row', async () => {
     await render([agreement({ id: 's-ecla', kind: 'ECLA', pdfAvailable: false, companyName: 'Acme' })]);
 
-    expect(menuItems('s-ecla').map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal']);
+    expect(menuItems('s-ecla').map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal', 'Contact CLA Manager']);
     expect(menuItems('s-ecla')[0]).toMatchObject({ disabled: true, escape: false });
   });
 
@@ -259,7 +259,7 @@ describe('ProfileClasComponent', () => {
     ]);
 
     const items = menuItems('s-ecla');
-    expect(items.map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal', 'Manage in CCLA Console']);
+    expect(items.map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal', 'Contact CLA Manager', 'Manage in CCLA Console']);
 
     // PrimeNG's menu renders no `rel`, so the item opens through `command` to keep noopener/noreferrer.
     const open = vi.spyOn(window, 'open').mockReturnValue(null);
@@ -273,10 +273,10 @@ describe('ProfileClasComponent', () => {
     expect(menuItems('s-icla').map((item) => item.label)).toEqual(['Download PDF']);
 
     await render([agreement({ id: 's-ecla', kind: 'ECLA', pdfAvailable: false, companyName: 'Acme', claManager: true })]);
-    expect(menuItems('s-ecla').map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal']);
+    expect(menuItems('s-ecla').map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal', 'Contact CLA Manager']);
 
     await render([agreement({ id: 's-ecla', kind: 'ECLA', pdfAvailable: false, companyName: 'Acme', claGroupId: 'g-anuket-005', claManager: false })]);
-    expect(menuItems('s-ecla').map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal']);
+    expect(menuItems('s-ecla').map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal', 'Contact CLA Manager']);
   });
 
   it('reads manager status off the row rather than spending a managers GET per ECLA', async () => {

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.html
@@ -15,5 +15,6 @@
     [maxlength]="maxlength() || null"
     [attr.aria-describedby]="describedBy() || null"
     [attr.aria-invalid]="invalid() ? true : null"
+    [attr.aria-required]="required() ? true : null"
     [attr.data-test]="dataTest()"></textarea>
 </ng-container>

--- a/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
+++ b/apps/lfx-one/src/app/shared/components/textarea/textarea.component.ts
@@ -28,4 +28,6 @@ export class TextareaComponent {
   public describedBy = input<string>();
   /** Marks the control invalid for assistive tech (wired to aria-invalid). */
   public invalid = input<boolean>(false);
+  /** Marks the control mandatory for assistive tech (wired to aria-required). */
+  public required = input<boolean>(false);
 }

--- a/apps/lfx-one/src/app/shared/services/my-clas.service.ts
+++ b/apps/lfx-one/src/app/shared/services/my-clas.service.ts
@@ -83,8 +83,9 @@ export class MyClasService {
   }
 
   /**
-   * Asks the CLA backend to email the selected managers for an approval or removal request.
-   * Does not invalidate or re-approve the signature. Contact mode must not call this.
+   * Asks the CLA backend to email the selected managers for an approval, removal, or contact
+   * request. Does not invalidate or re-approve the signature. A contact request must carry a
+   * non-blank `message` — it asks for no change, so the message is the whole of it.
    */
   public createClaManagerRequest(signatureId: string, body: ClaManagerRequest): Observable<ClaManagerRequestResult> {
     return this.http.post<ClaManagerRequestResult>(`/api/me/clas/${encodeURIComponent(signatureId)}/cla-manager-requests`, body).pipe(take(1));

--- a/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
@@ -469,8 +469,9 @@ describe('ClasController.createClaManagerRequest', () => {
     });
   });
 
-  // The producer refuses a blank contact message; answering here keeps it a usable 400.
-  it.each([undefined, '', '   \n\t '])('rejects a contact request whose message is %j', async (message) => {
+  // The producer refuses a blank contact message; answering here keeps it a usable 400. The
+  // control-character case is blank only after sanitization, which is what the producer validates.
+  it.each([undefined, '', '   \n\t ', '\x07\x1b', ' \r\n \x07 \t '])('rejects a contact request whose message is %j', async (message) => {
     const res = buildRes();
 
     await new ClasController().createClaManagerRequest(
@@ -505,6 +506,24 @@ describe('ClasController.createClaManagerRequest', () => {
     );
 
     expect(createClaManagerRequest).toHaveBeenCalled();
+  });
+
+  // The producer strips control characters before it measures, so they must not consume the cap.
+  it('does not count stripped control characters against the message cap', async () => {
+    createClaManagerRequest.mockResolvedValue(receipt);
+
+    await new ClasController().createClaManagerRequest(
+      { params: { signatureId: SIGNATURE_ID }, body: body({ message: `${'x'.repeat(4096)}${'\x07'.repeat(50)}` }) } as any,
+      buildRes(),
+      vi.fn()
+    );
+
+    expect(createClaManagerRequest).toHaveBeenCalledWith(
+      expect.anything(),
+      SIGNATURE_ID,
+      expect.anything(),
+      expect.objectContaining({ message: 'x'.repeat(4096) })
+    );
   });
 
   it('rejects an empty recipient list', async () => {

--- a/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
@@ -484,6 +484,21 @@ describe('ClasController.createClaManagerRequest', () => {
     expect(createClaManagerRequest).not.toHaveBeenCalled();
   });
 
+  // `String({})` is "[object Object]" — that would pass the contact blank check and then fail
+  // the producer's string schema after a gateway round trip.
+  it.each([{}, 12, true, ['hi']])('rejects a contact message that is not a string (%j)', async (message) => {
+    const res = buildRes();
+
+    await new ClasController().createClaManagerRequest(
+      { params: { signatureId: SIGNATURE_ID }, body: body({ requestType: 'contact', message }) } as any,
+      res,
+      vi.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(createClaManagerRequest).not.toHaveBeenCalled();
+  });
+
   it('still accepts approval and removal with no message at all', async () => {
     createClaManagerRequest.mockResolvedValue(receipt);
 

--- a/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.spec.ts
@@ -444,13 +444,67 @@ describe('ClasController.createClaManagerRequest', () => {
     });
   });
 
-  it.each(['contact', '', 'approve', undefined])('rejects %p as a request type', async (requestType) => {
+  it.each(['', 'approve', 'CONTACT', undefined])('rejects %p as a request type', async (requestType) => {
     const res = buildRes();
 
     await new ClasController().createClaManagerRequest({ params: { signatureId: SIGNATURE_ID }, body: body({ requestType }) } as any, res, vi.fn());
 
     expect(res.status).toHaveBeenCalledWith(400);
     expect(createClaManagerRequest).not.toHaveBeenCalled();
+  });
+
+  it('forwards a contact request carrying a message', async () => {
+    createClaManagerRequest.mockResolvedValue({ ...receipt, requestType: 'contact' as const });
+
+    await new ClasController().createClaManagerRequest(
+      { params: { signatureId: SIGNATURE_ID }, body: body({ requestType: 'contact', message: '  who owns our list?  ' }) } as any,
+      buildRes(),
+      vi.fn()
+    );
+
+    expect(createClaManagerRequest).toHaveBeenCalledWith(expect.anything(), SIGNATURE_ID, resolvedIdentity, {
+      requestType: 'contact',
+      recipients: ['jdoe'],
+      message: 'who owns our list?',
+    });
+  });
+
+  // The producer refuses a blank contact message; answering here keeps it a usable 400.
+  it.each([undefined, '', '   \n\t '])('rejects a contact request whose message is %j', async (message) => {
+    const res = buildRes();
+
+    await new ClasController().createClaManagerRequest(
+      { params: { signatureId: SIGNATURE_ID }, body: body({ requestType: 'contact', message }) } as any,
+      res,
+      vi.fn()
+    );
+
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(createClaManagerRequest).not.toHaveBeenCalled();
+  });
+
+  it('still accepts approval and removal with no message at all', async () => {
+    createClaManagerRequest.mockResolvedValue(receipt);
+
+    for (const requestType of ['approval', 'removal'] as const) {
+      createClaManagerRequest.mockClear();
+      await new ClasController().createClaManagerRequest({ params: { signatureId: SIGNATURE_ID }, body: body({ requestType }) } as any, buildRes(), vi.fn());
+
+      expect(createClaManagerRequest).toHaveBeenCalledWith(expect.anything(), SIGNATURE_ID, resolvedIdentity, { requestType, recipients: ['jdoe'] });
+    }
+  });
+
+  // Emoji are two UTF-16 units each; counting units would reject at half the producer's rune cap.
+  it('measures the message cap in code points, matching the producer rune limit', async () => {
+    createClaManagerRequest.mockResolvedValue(receipt);
+
+    await new ClasController().createClaManagerRequest(
+      { params: { signatureId: SIGNATURE_ID }, body: body({ message: '🙂'.repeat(4096) }) } as any,
+      buildRes(),
+      vi.fn()
+    );
+
+    expect(createClaManagerRequest).toHaveBeenCalled();
   });
 
   it('rejects an empty recipient list', async () => {

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -266,9 +266,17 @@ export class ClasController {
         return;
       }
 
+      // Do not `String(message)`: an object body becomes "[object Object]" and would pass the
+      // contact blank check, then fail the producer's `type: string` schema after the round trip.
+      const rawMessage = body?.message;
+      if (rawMessage !== undefined && rawMessage !== null && typeof rawMessage !== 'string') {
+        res.status(400).json({ message: 'Message must be a string' });
+        return;
+      }
+
       // Sanitized, because the producer validates and stores the sanitized text: control
       // characters other than newline and tab never reach it, so they must not count here.
-      const trimmedMessage = sanitizePlainText(String(body?.message ?? ''));
+      const trimmedMessage = sanitizePlainText(rawMessage ?? '');
       // Code points, not UTF-16 units, to match the producer's go-swagger rune cap — see
       // CLA_MANAGER_MESSAGE_MAX_LENGTH.
       if (codePointLength(trimmedMessage) > CLA_MANAGER_MESSAGE_MAX_LENGTH) {

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -7,7 +7,9 @@
 // EasyCLA re-verifies each key belongs to the caller and owns the signature, so the
 // upstream endpoint — not this controller — is the ownership authorization boundary.
 
-import { CLA_GROUP_SEARCH_MIN_CHARS } from '@lfx-one/shared/constants';
+import { CLA_GROUP_SEARCH_MIN_CHARS, CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
+import type { ClaManagerRequestType } from '@lfx-one/shared/interfaces';
+import { codePointLength } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError } from '../errors';
@@ -42,6 +44,10 @@ function parseManagerRecipients(raw: unknown): string[] | null {
     recipients.push(trimmed);
   }
   return recipients;
+}
+
+function isClaManagerRequestType(value: string): value is ClaManagerRequestType {
+  return CLA_MANAGER_REQUEST_TYPES.some((requestType) => requestType === value);
 }
 
 export class ClasController {
@@ -231,8 +237,8 @@ export class ClasController {
   }
 
   // POST /api/me/clas/:signatureId/cla-manager-requests
-  // Approval or removal notice to selected CLA managers. Blocked during impersonation at the
-  // route. Contact mode never reaches this handler — the client does not call it.
+  // Approval, removal, or contact notice to selected CLA managers. Blocked during impersonation
+  // at the route.
   public async createClaManagerRequest(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'create_cla_manager_request');
 
@@ -249,8 +255,8 @@ export class ClasController {
 
       const body = req.body as { requestType?: unknown; recipients?: unknown; message?: unknown } | undefined;
       const requestType = String(body?.requestType ?? '').trim();
-      if (requestType !== 'approval' && requestType !== 'removal') {
-        res.status(400).json({ message: 'A request type of approval or removal is required' });
+      if (!isClaManagerRequestType(requestType)) {
+        res.status(400).json({ message: 'A request type of approval, removal, or contact is required' });
         return;
       }
 
@@ -261,8 +267,18 @@ export class ClasController {
       }
 
       const trimmedMessage = String(body?.message ?? '').trim();
-      if (trimmedMessage.length > 4096) {
+      // Code points, not UTF-16 units, to match the producer's go-swagger rune cap — see
+      // CLA_MANAGER_MESSAGE_MAX_LENGTH.
+      if (codePointLength(trimmedMessage) > CLA_MANAGER_MESSAGE_MAX_LENGTH) {
         res.status(400).json({ message: 'Message is too long' });
+        return;
+      }
+
+      // A contact request asks for no change, so the message is the whole of it. The producer
+      // refuses a blank one; answering here keeps that a 400 with usable copy rather than an
+      // opaque upstream rejection after a gateway round trip.
+      if (requestType === 'contact' && !trimmedMessage) {
+        res.status(400).json({ message: 'A message is required to contact the CLA manager(s)' });
         return;
       }
 

--- a/apps/lfx-one/src/server/controllers/clas.controller.ts
+++ b/apps/lfx-one/src/server/controllers/clas.controller.ts
@@ -9,7 +9,7 @@
 
 import { CLA_GROUP_SEARCH_MIN_CHARS, CLA_MANAGER_MESSAGE_MAX_LENGTH, CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
 import type { ClaManagerRequestType } from '@lfx-one/shared/interfaces';
-import { codePointLength } from '@lfx-one/shared/utils';
+import { codePointLength, sanitizePlainText } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 
 import { AuthenticationError } from '../errors';
@@ -266,7 +266,9 @@ export class ClasController {
         return;
       }
 
-      const trimmedMessage = String(body?.message ?? '').trim();
+      // Sanitized, because the producer validates and stores the sanitized text: control
+      // characters other than newline and tab never reach it, so they must not count here.
+      const trimmedMessage = sanitizePlainText(String(body?.message ?? ''));
       // Code points, not UTF-16 units, to match the producer's go-swagger rune cap — see
       // CLA_MANAGER_MESSAGE_MAX_LENGTH.
       if (codePointLength(trimmedMessage) > CLA_MANAGER_MESSAGE_MAX_LENGTH) {

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -1339,6 +1339,22 @@ describe('ClaService.createClaManagerRequest', () => {
     ).rejects.toThrow('Upstream recorded no usable CLA manager request');
   });
 
+  it('refuses a receipt for a different request type than the one sent', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      requestID: 'r-4',
+      signatureID: MANAGER_SIG,
+      requestType: 'approval',
+      status: 'sent',
+      recipients: ['jdoe'],
+    });
+
+    // An approval receipt for a contact request would otherwise be forwarded as success, and the
+    // modal picks its copy from the mode it asked for, hiding the mismatch from the contributor.
+    await expect(
+      new ClaService().createClaManagerRequest(req, MANAGER_SIG, identity, { requestType: 'contact', recipients: ['jdoe'], message: 'hi' })
+    ).rejects.toThrow('Upstream recorded no usable CLA manager request');
+  });
+
   it('returns null on a 404', async () => {
     gatewayFetch.mockRejectedValueOnce(new MicroserviceError('not found', 404, 'NOT_FOUND', { service: 'cla_service' }));
 

--- a/apps/lfx-one/src/server/services/cla.service.spec.ts
+++ b/apps/lfx-one/src/server/services/cla.service.spec.ts
@@ -1298,6 +1298,47 @@ describe('ClaService.createClaManagerRequest', () => {
     expect(opts.body).toEqual({ requestType: 'approval', recipients: ['jdoe'] });
   });
 
+  it('posts contact with its message and returns the contact receipt', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      requestID: 'r-2',
+      signatureID: MANAGER_SIG,
+      requestType: 'contact',
+      status: 'sent',
+      recipients: ['jdoe'],
+    });
+
+    const result = await new ClaService().createClaManagerRequest(req, MANAGER_SIG, identity, {
+      requestType: 'contact',
+      recipients: ['jdoe'],
+      message: 'who owns our approved list?',
+    });
+
+    expect(result).toEqual({
+      requestId: 'r-2',
+      signatureId: MANAGER_SIG,
+      requestType: 'contact',
+      status: 'sent',
+      recipients: ['jdoe'],
+    });
+    const [, , opts] = gatewayFetch.mock.calls[0] as [unknown, string, { body?: Record<string, unknown>; bearerToken?: string }];
+    expect(opts.body).toEqual({ requestType: 'contact', recipients: ['jdoe'], message: 'who owns our approved list?' });
+    expect(opts.bearerToken).toBeUndefined();
+  });
+
+  it('refuses a receipt naming a request type outside the producer enum', async () => {
+    gatewayFetch.mockResolvedValueOnce({
+      requestID: 'r-3',
+      signatureID: MANAGER_SIG,
+      requestType: 'nudge',
+      status: 'sent',
+      recipients: ['jdoe'],
+    });
+
+    await expect(
+      new ClaService().createClaManagerRequest(req, MANAGER_SIG, identity, { requestType: 'contact', recipients: ['jdoe'], message: 'hi' })
+    ).rejects.toThrow('Upstream recorded no usable CLA manager request');
+  });
+
   it('returns null on a 404', async () => {
     gatewayFetch.mockRejectedValueOnce(new MicroserviceError('not found', 404, 'NOT_FOUND', { service: 'cla_service' }));
 

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -10,7 +10,6 @@
 // authenticated user before searching and reports unverifiable keys in
 // `skippedIdentities` — SS surfaces that as identity-gap telemetry.
 
-import { CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
 import {
   Auth0Identity,
   ClaGroupOption,
@@ -291,10 +290,6 @@ export function collectClaEmails(primaryEmail: string | null, emailData: EmailMa
 const KNOWN_CLA_STATUSES = new Set<string>(['valid', 'needs_attention', 'revoked', 'invalidated', 'unknown', 'superseded']);
 
 const KNOWN_CLA_SIGNED_VIA = new Set<string>(['github', 'gitlab', 'gerrit']);
-
-// `requestType` values the producer's receipt may echo. A receipt naming some other type is not
-// a receipt for the request that was sent, so it is refused rather than forwarded.
-const KNOWN_CLA_MANAGER_REQUEST_TYPES = new Set<string>(CLA_MANAGER_REQUEST_TYPES);
 
 /** Narrows the wire `status` to `ClaStatus`, or null when it is absent or out of contract. */
 function asClaStatus(status: string | undefined): ClaStatus | null {
@@ -814,7 +809,7 @@ export class ClaService {
     const requestId = result?.requestID?.trim();
     const requestType = result?.requestType;
     const status = result?.status;
-    if (!requestId || !requestType || !KNOWN_CLA_MANAGER_REQUEST_TYPES.has(requestType) || (status !== 'sent' && status !== 'recorded')) {
+    if (!requestId || requestType !== request.requestType || (status !== 'sent' && status !== 'recorded')) {
       throw new MicroserviceError('Upstream recorded no usable CLA manager request', 502, 'UPSTREAM_ERROR', { service: SERVICE });
     }
 

--- a/apps/lfx-one/src/server/services/cla.service.ts
+++ b/apps/lfx-one/src/server/services/cla.service.ts
@@ -10,6 +10,7 @@
 // authenticated user before searching and reports unverifiable keys in
 // `skippedIdentities` — SS surfaces that as identity-gap telemetry.
 
+import { CLA_MANAGER_REQUEST_TYPES } from '@lfx-one/shared/constants';
 import {
   Auth0Identity,
   ClaGroupOption,
@@ -290,6 +291,10 @@ export function collectClaEmails(primaryEmail: string | null, emailData: EmailMa
 const KNOWN_CLA_STATUSES = new Set<string>(['valid', 'needs_attention', 'revoked', 'invalidated', 'unknown', 'superseded']);
 
 const KNOWN_CLA_SIGNED_VIA = new Set<string>(['github', 'gitlab', 'gerrit']);
+
+// `requestType` values the producer's receipt may echo. A receipt naming some other type is not
+// a receipt for the request that was sent, so it is refused rather than forwarded.
+const KNOWN_CLA_MANAGER_REQUEST_TYPES = new Set<string>(CLA_MANAGER_REQUEST_TYPES);
 
 /** Narrows the wire `status` to `ClaStatus`, or null when it is absent or out of contract. */
 function asClaStatus(status: string | undefined): ClaStatus | null {
@@ -758,9 +763,13 @@ export class ClaService {
   }
 
   /**
-   * Records an approval or removal request and emails the selected CLA managers
+   * Records an approval, removal, or contact request and emails the selected CLA managers
    * (`POST /v4/my-clas/{id}/cla-manager-requests`). Does not change signature state.
    * 404 (unknown / not-owned / ICLA) becomes null, matching getClaManagers.
+   *
+   * The message is passed through as given. A contact request needs a non-blank one — the
+   * producer rejects an empty message for that type — and the controller enforces it, so a
+   * blank one is not quietly dropped here into a request the producer will refuse.
    *
    * No bearerToken override: this is a write, blocked at the route during impersonation,
    * so the default gateway token is the caller EasyCLA should attribute.
@@ -805,7 +814,7 @@ export class ClaService {
     const requestId = result?.requestID?.trim();
     const requestType = result?.requestType;
     const status = result?.status;
-    if (!requestId || (requestType !== 'approval' && requestType !== 'removal') || (status !== 'sent' && status !== 'recorded')) {
+    if (!requestId || !requestType || !KNOWN_CLA_MANAGER_REQUEST_TYPES.has(requestType) || (status !== 'sent' && status !== 'recorded')) {
       throw new MicroserviceError('Upstream recorded no usable CLA manager request', 502, 'UPSTREAM_ERROR', { service: SERVICE });
     }
 

--- a/apps/lfx-one/src/server/types/cla.types.ts
+++ b/apps/lfx-one/src/server/types/cla.types.ts
@@ -191,8 +191,9 @@ export interface EasyClaMyClaManagerList {
 
 /** Body for `POST /v4/my-clas/{signatureID}/cla-manager-requests` (`#/definitions/my-cla-manager-request`). */
 export interface EasyClaMyClaManagerRequest {
-  requestType: 'approval' | 'removal';
+  requestType: 'approval' | 'removal' | 'contact';
   recipients: string[];
+  /** Required and non-blank for `contact`; the producer rejects an empty one. */
   message?: string;
 }
 
@@ -200,7 +201,7 @@ export interface EasyClaMyClaManagerRequest {
 export interface EasyClaMyClaManagerRequestResult {
   requestID?: string;
   signatureID?: string;
-  requestType?: 'approval' | 'removal';
+  requestType?: 'approval' | 'removal' | 'contact';
   status?: 'sent' | 'recorded';
   recipients?: string[];
 }

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -49,23 +49,23 @@ export const CLA_MANAGER_MESSAGE_MAX_LENGTH = 4096;
 /** The `requestType` values the producer's enum accepts (`my-cla-manager-request.yaml`). */
 export const CLA_MANAGER_REQUEST_TYPES = ['approval', 'removal', 'contact'] as const;
 
+/** Approval and removal share one receipt; contact phrases it as a message. */
+const CLA_MANAGER_REQUEST_RECEIPT = {
+  sent: { summary: 'Request sent', detail: 'The CLA manager(s) you selected will be notified.' },
+  recorded: { summary: 'Request recorded', detail: 'The request was recorded, but no CLA manager email could be delivered.' },
+} as const;
+
 /** v17 `mgrCopy` — titles also used as DialogService headers by the kebab factory. */
 export const CLA_MANAGER_MODAL_COPY = {
   approval: {
     title: 'Request approval',
     hint: (project: string) => `Ask the CLA manager(s) below to re-approve your ECLA for ${project}.`,
-    receipt: {
-      sent: { summary: 'Request sent', detail: 'The CLA manager(s) you selected will be notified.' },
-      recorded: { summary: 'Request recorded', detail: 'The request was recorded, but no CLA manager email could be delivered.' },
-    },
+    receipt: CLA_MANAGER_REQUEST_RECEIPT,
   },
   removal: {
     title: 'Request Removal',
     hint: (project: string) => `Ask the CLA manager(s) below to remove your ECLA for ${project}. This starts the process to invalidate it on your behalf.`,
-    receipt: {
-      sent: { summary: 'Request sent', detail: 'The CLA manager(s) you selected will be notified.' },
-      recorded: { summary: 'Request recorded', detail: 'The request was recorded, but no CLA manager email could be delivered.' },
-    },
+    receipt: CLA_MANAGER_REQUEST_RECEIPT,
   },
   contact: {
     title: 'Contact CLA Manager',

--- a/packages/shared/src/constants/cla.constants.ts
+++ b/packages/shared/src/constants/cla.constants.ts
@@ -37,18 +37,42 @@ export const CLA_GROUP_ORG_SOURCE_ICONS = {
 /** Hover tooltips on a right-edge kebab open off-screen; keep the CCLA reason in the item. */
 export const ECLA_COVERED_DOWNLOAD_LABEL = 'Download PDF<br><span class="mt-0.5 block text-xs font-normal">Covered by Corporate CLA (CCLA)</span>';
 
+/**
+ * Mirrors the producer's `message` bound (`my-cla-manager-request.yaml`: maxLength 4096).
+ * Shared between the BFF validator, the modal's reactive-form validator and its counter so
+ * client and server enforce one contract. Counted in code points, not UTF-16 units: go-swagger
+ * validates `maxLength` with `utf8.RuneCountInString`, so counting units would reject an
+ * emoji-heavy message the producer would have accepted.
+ */
+export const CLA_MANAGER_MESSAGE_MAX_LENGTH = 4096;
+
+/** The `requestType` values the producer's enum accepts (`my-cla-manager-request.yaml`). */
+export const CLA_MANAGER_REQUEST_TYPES = ['approval', 'removal', 'contact'] as const;
+
 /** v17 `mgrCopy` — titles also used as DialogService headers by the kebab factory. */
 export const CLA_MANAGER_MODAL_COPY = {
   approval: {
     title: 'Request approval',
     hint: (project: string) => `Ask the CLA manager(s) below to re-approve your ECLA for ${project}.`,
+    receipt: {
+      sent: { summary: 'Request sent', detail: 'The CLA manager(s) you selected will be notified.' },
+      recorded: { summary: 'Request recorded', detail: 'The request was recorded, but no CLA manager email could be delivered.' },
+    },
   },
   removal: {
     title: 'Request Removal',
     hint: (project: string) => `Ask the CLA manager(s) below to remove your ECLA for ${project}. This starts the process to invalidate it on your behalf.`,
+    receipt: {
+      sent: { summary: 'Request sent', detail: 'The CLA manager(s) you selected will be notified.' },
+      recorded: { summary: 'Request recorded', detail: 'The request was recorded, but no CLA manager email could be delivered.' },
+    },
   },
   contact: {
     title: 'Contact CLA Manager',
     hint: (project: string) => `Send a message to the CLA manager(s) for ${project}.`,
+    receipt: {
+      sent: { summary: 'Message sent', detail: 'The CLA manager(s) you selected will be notified.' },
+      recorded: { summary: 'Message recorded', detail: 'The message was recorded, but no CLA manager email could be delivered.' },
+    },
   },
 } as const;

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import type { CLA_MANAGER_REQUEST_TYPES } from '../constants/cla.constants';
 import type { TagSeverity } from './components.interface';
 
 // UI-facing shapes for the read-only "CLAs" view (Me lens → Profile tab).
@@ -288,8 +289,13 @@ export interface PrepareSignResponse {
 /** Copy/API mode for the shared Contact CLA Manager modal (#1372 / #1574). */
 export type ClaManagerRequestMode = 'approval' | 'removal' | 'contact';
 
-/** Producer `requestType` — Contact is a UI mode only and is never sent. */
-export type ClaManagerRequestType = 'approval' | 'removal';
+/**
+ * Producer `requestType`, derived from `CLA_MANAGER_REQUEST_TYPES`. Kept separate from
+ * `ClaManagerRequestMode` even though the two currently coincide: one is the modal's copy
+ * set, the other is the wire contract, and a future copy mode must not silently become a
+ * request type the producer never promised to accept.
+ */
+export type ClaManagerRequestType = (typeof CLA_MANAGER_REQUEST_TYPES)[number];
 
 /** One CLA manager from the CCLA signature ACL covering an ECLA. */
 export interface ClaManager {
@@ -314,11 +320,15 @@ export interface ClaManagerRequest {
   requestType: ClaManagerRequestType;
   /** LF usernames of the checked managers. Must be non-empty. */
   recipients: string[];
-  /** Optional note included in the notification email (max 4096). */
+  /**
+   * Note included in the notification email, capped at `CLA_MANAGER_MESSAGE_MAX_LENGTH`.
+   * Optional for approval and removal; required and non-blank for contact, which asks for
+   * no change and so carries nothing else for the manager to read.
+   */
   message?: string;
 }
 
-/** Receipt for an approval/removal request. */
+/** Receipt for an approval, removal, or contact request. */
 export interface ClaManagerRequestResult {
   requestId: string;
   signatureId: string;

--- a/packages/shared/src/utils/cla-manager-actions.utils.spec.ts
+++ b/packages/shared/src/utils/cla-manager-actions.utils.spec.ts
@@ -48,10 +48,19 @@ describe('canRequestClaRemoval', () => {
 });
 
 describe('canContactClaManager', () => {
-  it('is true only for Needs-attention ECLA', () => {
+  it('is true for Valid and Needs-attention ECLA', () => {
+    expect(canContactClaManager(agreement({ status: 'valid' }))).toBe(true);
     expect(canContactClaManager(agreement({ status: 'needs_attention' }))).toBe(true);
-    expect(canContactClaManager(agreement({ status: 'valid' }))).toBe(false);
+  });
+
+  it('is false for every other ECLA status', () => {
     expect(canContactClaManager(agreement({ status: 'invalidated' }))).toBe(false);
+    expect(canContactClaManager(agreement({ status: 'revoked' }))).toBe(false);
+    expect(canContactClaManager(agreement({ status: 'unknown' }))).toBe(false);
+  });
+
+  it('is false for ICLA, which has no covering CCLA and so no managers', () => {
+    expect(canContactClaManager(agreement({ kind: 'ICLA', status: 'valid', pdfAvailable: true }))).toBe(false);
     expect(canContactClaManager(agreement({ kind: 'ICLA', status: 'needs_attention', pdfAvailable: true }))).toBe(false);
   });
 });

--- a/packages/shared/src/utils/cla-manager-actions.utils.ts
+++ b/packages/shared/src/utils/cla-manager-actions.utils.ts
@@ -18,11 +18,12 @@ export function canRequestClaRemoval(agreement: MyClaAgreement): boolean {
 }
 
 /**
- * Contact CLA Manager — Needs-attention ECLA only (v17). Send is a no-op; this gate
- * only decides whether the item is offered.
+ * Contact CLA Manager — Valid or Needs-attention ECLA. Never ICLA: both endpoints the modal
+ * needs (`GET`/`POST /my-clas/{id}/cla-manager[-request]s`) 404 on an ICLA signature id,
+ * because an ICLA has no covering CCLA and so no managers to resolve.
  */
 export function canContactClaManager(agreement: MyClaAgreement): boolean {
-  return agreement.kind === 'ECLA' && agreement.status === 'needs_attention';
+  return agreement.kind === 'ECLA' && (agreement.status === 'valid' || agreement.status === 'needs_attention');
 }
 
 /**

--- a/packages/shared/src/utils/string.utils.spec.ts
+++ b/packages/shared/src/utils/string.utils.spec.ts
@@ -3,7 +3,7 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { capCodePointEdit, codePointLength, slugify, splitIntoParagraphs } from './string.utils';
+import { capCodePointEdit, codePointLength, sanitizePlainText, slugify, splitIntoParagraphs } from './string.utils';
 
 describe('codePointLength', () => {
   it('counts ASCII the same as String.length', () => {
@@ -28,6 +28,35 @@ describe('codePointLength', () => {
   it('counts BMP characters (including surrogate-free CJK) as one each', () => {
     expect(codePointLength('café')).toBe(4);
     expect(codePointLength('日本語')).toBe(3);
+  });
+});
+
+// Cases mirror the CLA backend's own TestSanitizePlainText, so a producer change shows up as a
+// failure here rather than as an opaque upstream 400.
+describe('sanitizePlainText', () => {
+  it('returns an empty string for input that is only whitespace and control characters', () => {
+    expect(sanitizePlainText('')).toBe('');
+    expect(sanitizePlainText(' \r\n \x07\x1b \t ')).toBe('');
+  });
+
+  it('normalizes CR and CRLF to LF', () => {
+    expect(sanitizePlainText('one\r\ntwo\rthree')).toBe('one\ntwo\nthree');
+  });
+
+  it('keeps tabs and newlines', () => {
+    expect(sanitizePlainText('keep\ttabs\nand lines')).toBe('keep\ttabs\nand lines');
+  });
+
+  it('drops other control characters', () => {
+    expect(sanitizePlainText('bell\x07 stripped\x00')).toBe('bell stripped');
+  });
+
+  it('trims the result', () => {
+    expect(sanitizePlainText('  trimmed \n')).toBe('trimmed');
+  });
+
+  it('leaves an emoji intact, so the cap still counts it as one code point', () => {
+    expect(sanitizePlainText('hi 😀')).toBe('hi 😀');
   });
 });
 

--- a/packages/shared/src/utils/string.utils.ts
+++ b/packages/shared/src/utils/string.utils.ts
@@ -117,6 +117,26 @@ export function codePointLength(value: string): number {
 }
 
 /**
+ * Mirror of the CLA backend's `utils.SanitizePlainText` for free-text a user sends upstream:
+ * CR and CRLF become LF, other control characters are dropped, and the result is trimmed.
+ * Validate the sanitized value, because the producer validates what it stores, not what was
+ * typed — a control-character-only message is blank to it, and its length cap counts the
+ * sanitized runes, so measuring the raw input rejects text the producer would accept.
+ * @param value - The raw user-supplied text
+ * @returns The text as the producer will store it
+ */
+export function sanitizePlainText(value: string): string {
+  return (
+    value
+      .replace(/\r\n?/gu, '\n')
+      // \p{Cc} is the Unicode control category, which is exactly what Go's `unicode.IsControl`
+      // matches; newline and tab survive because the producer keeps them.
+      .replace(/\p{Cc}/gu, (control) => (control === '\n' || control === '\t' ? control : ''))
+      .trim()
+  );
+}
+
+/**
  * Clip `next` to `max` code points by trimming only the region that changed vs `previous`, so a
  * mid-string insertion into a full field drops the excess input rather than unrelated trailing text.
  * @param previous - The last within-cap value (must itself be <= max code points)

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -8,5 +8,6 @@ export * from './linux-alias.validator';
 export * from './mailing-list.validators';
 export * from './max-code-points.validator';
 export * from './meeting.validators';
+export * from './plain-text-message.validator';
 export * from './newsletter.validators';
 export * from './vote.validators';

--- a/packages/shared/src/validators/index.ts
+++ b/packages/shared/src/validators/index.ts
@@ -8,6 +8,6 @@ export * from './linux-alias.validator';
 export * from './mailing-list.validators';
 export * from './max-code-points.validator';
 export * from './meeting.validators';
-export * from './plain-text-message.validator';
 export * from './newsletter.validators';
+export * from './plain-text-message.validator';
 export * from './vote.validators';

--- a/packages/shared/src/validators/plain-text-message.validator.spec.ts
+++ b/packages/shared/src/validators/plain-text-message.validator.spec.ts
@@ -1,0 +1,55 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { AbstractControl } from '@angular/forms';
+import { describe, expect, it } from 'vitest';
+
+import { plainTextMessageValidator } from './plain-text-message.validator';
+
+// ValidatorFn only reads control.value, so a bare object stands in for an AbstractControl.
+function control(value: unknown): AbstractControl {
+  return { value } as AbstractControl;
+}
+
+describe('plainTextMessageValidator', () => {
+  function validate(value: unknown, options: { required: boolean; max: number }) {
+    return plainTextMessageValidator(options)(control(value));
+  }
+
+  const required = { required: true, max: 10 };
+  const optional = { required: false, max: 10 };
+
+  it('accepts text within the cap', () => {
+    expect(validate('hello', required)).toBeNull();
+  });
+
+  it('rejects a required value that sanitizes to empty, which the producer would refuse', () => {
+    expect(validate('\x07\x1b', required)).toEqual({ trimmedRequired: true });
+    expect(validate('   ', required)).toEqual({ trimmedRequired: true });
+  });
+
+  it('allows an empty optional value', () => {
+    expect(validate('', optional)).toBeNull();
+    expect(validate('\x07', optional)).toBeNull();
+  });
+
+  it('does not let control characters consume the cap', () => {
+    // Ten real characters plus stripped controls is within the cap, because the producer counts
+    // only what survives sanitization.
+    expect(validate(`0123456789${'\x07'.repeat(50)}`, required)).toBeNull();
+  });
+
+  it('rejects text whose sanitized length exceeds the cap', () => {
+    expect(validate('01234567890', required)).toEqual({ maxCodePoints: { requiredLength: 10, actualLength: 11 } });
+  });
+
+  it('measures the cap in code points, so an emoji counts once', () => {
+    expect(validate('😀'.repeat(10), required)).toBeNull();
+    expect(validate('😀'.repeat(11), required)).toEqual({ maxCodePoints: { requiredLength: 10, actualLength: 11 } });
+  });
+
+  it('ignores a non-string value', () => {
+    expect(validate(null, required)).toBeNull();
+    expect(validate(undefined, required)).toBeNull();
+  });
+});

--- a/packages/shared/src/validators/plain-text-message.validator.ts
+++ b/packages/shared/src/validators/plain-text-message.validator.ts
@@ -1,0 +1,26 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { AbstractControl, ValidationErrors, ValidatorFn } from '@angular/forms';
+
+import { codePointLength, sanitizePlainText } from '../utils/string.utils';
+
+/**
+ * Validates free text destined for a CLA backend endpoint that sanitizes before it validates.
+ * Both checks run on the sanitized value, so the control agrees with the producer: text that is
+ * only control characters is blank, and control characters do not consume the cap. Emits the same
+ * error shapes as `trimmedRequired` and `maxCodePointsValidator` so existing error mapping holds.
+ * @param options - `required` rejects a value that sanitizes to empty; `max` caps sanitized code points
+ */
+export function plainTextMessageValidator(options: { required: boolean; max: number }): ValidatorFn {
+  return (control: AbstractControl): ValidationErrors | null => {
+    const value = control.value;
+    if (typeof value !== 'string') return null;
+
+    const sanitized = sanitizePlainText(value);
+    const actualLength = codePointLength(sanitized);
+    if (actualLength > options.max) return { maxCodePoints: { requiredLength: options.max, actualLength } };
+    if (options.required && !sanitized) return { trimmedRequired: true };
+    return null;
+  };
+}


### PR DESCRIPTION
Closes #1861 (Contact CLA Manager: deliver the message, offer on Valid rows)

## Summary

`Contact CLA Manager` now sends. Contact mode POSTs `requestType: 'contact'` alongside approval and removal; its message is mandatory (approval and removal keep it optional) with an inline error, a code-point counter, and `aria-required`. The BFF accepts `contact`, rejects a blank contact message, and counts the 4096 cap in code points. The action is offered on **Valid** as well as Needs-attention ECLA rows. ICLA is excluded.

The producer added `contact` to `requestType` in [easycla#5156 (MyCLAs contact requests)](https://github.com/linuxfoundation/easycla/pull/5156) (`dev`) and [easycla#5157 (M2 prod BE)](https://github.com/linuxfoundation/easycla/pull/5157) (prod `main`). The M2 status matrix specifies the action on “ECLA showing Valid or Needs attention”.

`lfx-textarea` gained a backwards-compatible `required` input (defaults `false`) wired to `aria-required`.

## How to verify

Deploy preview: https://ui-pr-1869.dev.v2.cluster.linuxfound.info

- Set `localStorage` flags `my-clas-enabled` and `my-clas-m2-enabled`, open `/profile/clas`
- Kebab menu on a **Valid** ECLA row offers Contact CLA Manager
- Kebab menu on a **Needs-attention** ECLA row offers Contact CLA Manager
- ICLA rows do not offer the action
- Send is blocked while the message is blank, with an inline error
- A filled message reports `Message sent` or `Message recorded`

Locally: `yarn start` in `apps/lfx-one`, same steps.

## Notes

The 4096 cap is counted in **code points**, not UTF-16 units, because the producer’s go-swagger `maxLength` validates with `utf8.RuneCount` — counting units would reject emoji-heavy text the producer accepts. That is also why the textarea carries no native `[maxlength]`. Message validation runs on the sanitized value (`sanitizePlainText`), matching the producer’s `SanitizePlainText` before it validates. A non-string `message` is a 400, not coerced.

ICLA is excluded structurally: both manager endpoints return 404 for an ICLA signature id, since an ICLA has no covering CCLA and so no managers to resolve.

Contact stays visible while impersonating, as approval and removal already are; the write is blocked server-side by `blockDuringImpersonation`.

## Out of scope

Invalidated and Revoked dates remain unwired ([#1370 (revocation metadata)](https://github.com/linuxfoundation/lfx-self-serve/issues/1370), [#1732 (Record ICLA invalidation date)](https://github.com/linuxfoundation/lfx-self-serve/issues/1732)).
