### PR TITLE
perf(meetings): parallelize access-check on public meeting join

### DIFF
--- a/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.spec.ts
@@ -7,11 +7,16 @@ const MEETING_UID = 'a0000000-0000-0000-0000-000000000001';
 const COMMITTEE_UID = 'b0000000-0000-0000-0000-000000000002';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { meetingSvc } = vi.hoisted(() => ({
+const { meetingSvc, getEffectiveEmailMock, addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedByMock } = vi.hoisted(() => ({
   meetingSvc: {
     getMeetingRegistrants: vi.fn(),
     getAuthorizedRegistrantsForImport: vi.fn(),
+    getMeetingById: vi.fn(),
+    getMeetingHostKey: vi.fn(),
   },
+  getEffectiveEmailMock: vi.fn(),
+  addInvitedStatusToMeetingMock: vi.fn(),
+  enrichMeetingsWithCreatedByMock: vi.fn(),
 }));
 
 // The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config.
@@ -19,18 +24,24 @@ vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal())
 vi.mock('@lfx-one/shared/enums', async (importOriginal) => importOriginal());
 vi.mock('@lfx-one/shared/interfaces', async (importOriginal) => importOriginal());
 // The real module transitively needs @angular/compiler outside an Angular bootstrap (see
-// meeting.utils.spec.ts); validation.helper only needs resolvePeriodRange from it, so stub that.
-vi.mock('@lfx-one/shared/utils', () => ({ resolvePeriodRange: vi.fn() }));
+// meeting.utils.spec.ts); validation.helper only needs resolvePeriodRange from it, and
+// meeting.helper (kept real below, for isWithinHostKeyWindow/applyOrganizerAndHostKeyResult)
+// needs resolveMeetingOrganizer/resolveMeetingOwner — stub all three.
+vi.mock('@lfx-one/shared/utils', () => ({
+  resolvePeriodRange: vi.fn(),
+  resolveMeetingOrganizer: vi.fn(() => null),
+  resolveMeetingOwner: vi.fn(() => null),
+}));
 
-vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(), getUsernameFromAuth: vi.fn() }));
+vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: getEffectiveEmailMock, getUsernameFromAuth: vi.fn() }));
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
 vi.mock('../helpers/committee-v1-mapping.helper', () => ({ resolveCommitteeV2UidsToV1Ids: vi.fn() }));
-vi.mock('../helpers/meeting.helper', () => ({
-  addInvitedStatusToMeeting: vi.fn(),
-  applyHostKeyVisibility: vi.fn(),
-  enrichMeetingsWithCreatedBy: vi.fn(),
-  stripHostKey: vi.fn(),
-}));
+// Keep the real host-key gate (isWithinHostKeyWindow + applyOrganizerAndHostKeyResult); stub
+// only the registrant-lookup/enrichment helpers so the controller tests don't need M2M plumbing.
+vi.mock('../helpers/meeting.helper', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('../helpers/meeting.helper')>();
+  return { ...actual, addInvitedStatusToMeeting: addInvitedStatusToMeetingMock, enrichMeetingsWithCreatedBy: enrichMeetingsWithCreatedByMock };
+});
 vi.mock('../services/meeting.service', () => ({
   MeetingService: vi.fn(function () {
     return meetingSvc;
@@ -38,11 +49,6 @@ vi.mock('../services/meeting.service', () => ({
 }));
 vi.mock('../services/committee.service', () => ({
   CommitteeService: vi.fn(function () {
-    return {};
-  }),
-}));
-vi.mock('../services/access-check.service', () => ({
-  AccessCheckService: vi.fn(function () {
     return {};
   }),
 }));
@@ -134,5 +140,78 @@ describe('MeetingController.getMeetingRegistrants — delegation', () => {
 
     expect(next).toHaveBeenCalledWith(authError);
     expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
+function buildMeeting(overrides: Record<string, unknown> = {}): any {
+  return {
+    id: MEETING_UID,
+    project_uid: 'project-1',
+    // 1 min from now, 60-min duration — inside the 70-min pre-window so the "authorized"/
+    // "unauthorized" tests exercise the real fetch path rather than being skipped by the
+    // time gate. The "outside window" test overrides start_time explicitly.
+    start_time: new Date(Date.now() + 60_000).toISOString(),
+    duration: 60,
+    ...overrides,
+  };
+}
+
+// isWithinHostKeyWindow / applyOrganizerAndHostKeyResult are kept real (see the meeting.helper
+// mock above) so these tests exercise the actual host-key gate, not a stub standing in for it.
+describe('MeetingController.getMeetingById host-key gating', () => {
+  let controller: MeetingController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new MeetingController();
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
+    addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: any) => ({ ...meeting, invited: false }));
+    enrichMeetingsWithCreatedByMock.mockImplementation(async (_req: any, meetings: any[]) => meetings);
+  });
+
+  it('surfaces the host key for an authorized caller inside the host-key window', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: true }));
+    meetingSvc.getMeetingHostKey.mockResolvedValue('123456');
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingById(buildReq({}), res, next);
+
+    expect(meetingSvc.getMeetingHostKey).toHaveBeenCalledWith(expect.anything(), MEETING_UID);
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.host_key).toBe('123456');
+    expect(payload.can_view_host_key).toBe(true);
+    expect(payload.organizer).toBe(true);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('strips the host key when the fetch resolves null (unauthorized, or no credentials doc indexed yet)', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ organizer: false, host_key: 'stale-key' }));
+    meetingSvc.getMeetingHostKey.mockResolvedValue(null);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingById(buildReq({}), res, next);
+
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.host_key).toBeUndefined();
+    expect(payload.can_view_host_key).toBe(false);
+    expect(payload.organizer).toBe(false);
+  });
+
+  it('skips the host-key fetch entirely outside the host-key window', async () => {
+    meetingSvc.getMeetingById.mockResolvedValue(
+      buildMeeting({ organizer: false, start_time: new Date(Date.now() - 365 * 24 * 60 * 60_000).toISOString(), duration: 60 })
+    );
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getMeetingById(buildReq({}), res, next);
+
+    expect(meetingSvc.getMeetingHostKey).not.toHaveBeenCalled();
+    const payload = res.json.mock.calls[0][0];
+    expect(payload.host_key).toBeUndefined();
+    expect(payload.can_view_host_key).toBe(false);
   });
 });

--- a/apps/lfx-one/src/server/controllers/meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/meeting.controller.ts
@@ -22,9 +22,14 @@ import { NextFunction, Request, Response } from 'express';
 
 import { resolveCommitteeV2UidsToV1Ids } from '../helpers/committee-v1-mapping.helper';
 import { AuthorizationError, ServiceValidationError } from '../errors';
-import { addInvitedStatusToMeeting, applyHostKeyVisibility, enrichMeetingsWithCreatedBy, stripHostKey } from '../helpers/meeting.helper';
+import {
+  addInvitedStatusToMeeting,
+  applyOrganizerAndHostKeyResult,
+  enrichMeetingsWithCreatedBy,
+  isWithinHostKeyWindow,
+  stripHostKey,
+} from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
-import { AccessCheckService } from '../services/access-check.service';
 import { AiService } from '../services/ai.service';
 import { CommitteeService } from '../services/committee.service';
 import { logger } from '../services/logger.service';
@@ -43,7 +48,6 @@ export class MeetingController {
   private committeeService: CommitteeService = new CommitteeService();
   private natsService: NatsService = new NatsService();
   private userService: UserService = new UserService();
-  private accessCheckService: AccessCheckService = new AccessCheckService();
 
   /**
    * GET /meetings
@@ -146,8 +150,16 @@ export class MeetingController {
 
       const userEmail = getEffectiveEmail(req) || '';
 
-      // Run registrant counts and invited status check in parallel
-      const [registrants, meetingWithInvitedStatus] = await Promise.all([
+      // meeting.organizer is already set by getMeetingById(access: true) above, so no separate
+      // organizer FGA check is needed here. The query-service enforces the FGA `host` relation
+      // on v1_meeting_host_credentials directly, so an optimistic host-key fetch inside the
+      // time window is safe: unauthorized callers get an empty resources array (null returned).
+      // Skipping the fetch outside the window avoids a wasted round trip for anyone viewing a
+      // meeting far in the future or past — the key would be stripped anyway.
+      const withinHostKeyWindow = isWithinHostKeyWindow(meeting);
+
+      // Run registrant counts, invited status, and host-key fetch in parallel.
+      const [registrants, meetingWithInvitedStatus, hostKey] = await Promise.all([
         // TODO: Remove this once we have a way to get the registrants count
         this.meetingService.getMeetingRegistrants(req, meeting.id).catch((error) => {
           logger.warning(req, 'get_meeting_by_id', 'Failed to fetch registrants for meeting', {
@@ -157,6 +169,15 @@ export class MeetingController {
           return null;
         }),
         addInvitedStatusToMeeting(req, meeting, userEmail),
+        withinHostKeyWindow
+          ? this.meetingService.getMeetingHostKey(req, uid).catch((error) => {
+              logger.warning(req, 'get_meeting_by_id', 'Failed to fetch host key credentials, continuing without host key', {
+                meeting_id: uid,
+                err: error,
+              });
+              return null;
+            })
+          : Promise.resolve(null),
       ]);
 
       if (registrants) {
@@ -168,25 +189,17 @@ export class MeetingController {
         meetingWithInvitedStatus.committee_members_count = 0;
       }
 
-      // Gate the Zoom host key: expose it only to organizer / project writer / committee writer,
-      // stripped for everyone else. Runs on the authenticated user's token (active on this route).
-      await applyHostKeyVisibility(req, this.accessCheckService, meetingWithInvitedStatus);
-
-      // host_key is no longer on the v2 meeting API response — fetch it from the separately
-      // indexed v1_meeting_host_credentials object (FGA-gated by host relation on v1_meeting).
-      if (meetingWithInvitedStatus.can_view_host_key) {
-        try {
-          const hostKey = await this.meetingService.getMeetingHostKey(req, uid);
-          if (hostKey) {
-            meetingWithInvitedStatus.host_key = hostKey;
-          }
-        } catch (error) {
-          logger.warning(req, 'get_meeting_by_id', 'Failed to fetch host key credentials, continuing without host key', {
-            meeting_id: uid,
-            err: error,
-          });
-        }
-      }
+      // Gate the Zoom host key: the query-service enforces FGA `host` on v1_meeting_host_credentials
+      // (covering direct co-hosts AND organizer-derived writers/coordinators), so a null return
+      // means the caller isn't authorized OR no credentials doc is indexed yet — either way, no
+      // key is surfaced. can_view_host_key is derived from a truthy fetch result (LFXV2-2885).
+      // organizer is already resolved (getMeetingById(access: true) above), so only the
+      // host-key half of applyOrganizerAndHostKeyResult's result is meaningful here.
+      applyOrganizerAndHostKeyResult(meetingWithInvitedStatus, {
+        organizer: meetingWithInvitedStatus.organizer ?? false,
+        canViewHostKey: !!hostKey,
+        hostKey: hostKey ?? undefined,
+      });
 
       // The ITX detail payload omits created_by — join back to the live v1_meeting index so
       // the organizer name can be shown. Single meeting keyed on its own UID.

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.spec.ts
@@ -11,7 +11,7 @@ const PROJECT_UID = 'project-2222';
 // Hoisted, per-test-controllable mocks. The controller (and the real meeting.helper it delegates
 // to for the host-key gate) reach these through the module mocks registered below.
 const {
-  checkAccessMock,
+  checkSingleAccessMock,
   addAccessToResourceMock,
   generateM2MTokenMock,
   getEffectiveEmailMock,
@@ -22,7 +22,7 @@ const {
   projectSvc,
   addInvitedStatusToMeetingMock,
 } = vi.hoisted(() => ({
-  checkAccessMock: vi.fn(),
+  checkSingleAccessMock: vi.fn(),
   addAccessToResourceMock: vi.fn(),
   generateM2MTokenMock: vi.fn(),
   getEffectiveEmailMock: vi.fn(),
@@ -80,7 +80,7 @@ vi.mock('../services/committee.service', () => ({
 }));
 vi.mock('../services/access-check.service', () => ({
   AccessCheckService: vi.fn(function () {
-    return { checkAccess: checkAccessMock, addAccessToResource: addAccessToResourceMock };
+    return { checkSingleAccess: checkSingleAccessMock, addAccessToResource: addAccessToResourceMock };
   }),
 }));
 vi.mock('../services/logger.service', () => ({
@@ -101,8 +101,8 @@ vi.mock('../utils/auth-helper', () => ({
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
 vi.mock('../utils/security.util', () => ({ validatePassword: validatePasswordMock }));
 
-// Keep the real host-key gate (applyHostKeyVisibility + stripHostKey); stub only the
-// registrant-lookup helpers so we don't need M2M/registrant plumbing.
+// Keep the real host-key gate (resolveOrganizerAndHostKey + applyOrganizerAndHostKeyResult +
+// stripHostKey); stub only the registrant-lookup helpers so we don't need M2M/registrant plumbing.
 vi.mock('../helpers/meeting.helper', async (importOriginal) => {
   const actual = await importOriginal<typeof import('../helpers/meeting.helper')>();
   return { ...actual, addInvitedStatusToMeeting: addInvitedStatusToMeetingMock, checkPastMeetingAccess: vi.fn() };
@@ -170,11 +170,6 @@ function buildReqRes(authenticated: boolean, hasUserToken = true) {
   return { req, res, next };
 }
 
-// checkAccess now keys results as "id#access" (e.g. "meeting-1111#organizer").
-function accessMap(entries: [string, boolean][]): Map<string, boolean> {
-  return new Map(entries);
-}
-
 describe('PublicMeetingController.getMeetingById host_key gating', () => {
   let controller: PublicMeetingController;
 
@@ -186,20 +181,19 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
     getEffectiveUsernameMock.mockReturnValue('user');
     projectSvc.getProjectById.mockResolvedValue(buildProject());
     meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
-    // Default: host key fetch returns null (no access); authorized tests override this.
+    // Default: host key fetch returns null (unauthorized OR no doc yet — the query-service's
+    // FGA gate on v1_meeting_host_credentials returns an empty resources array in both cases).
+    // Authorized tests override this.
     meetingSvc.getMeetingHostKey.mockResolvedValue(null);
+    // Default: organizer FGA check returns false. Organizer tests override this.
+    checkSingleAccessMock.mockResolvedValue(false);
     // Default invited helper: not invited, host_key preserved on the returned object.
     addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: Meeting) => ({ ...meeting, invited: false }));
   });
 
   it('strips host_key for an authenticated non-organizer on a PUBLIC non-restricted meeting (the leak regression)', async () => {
+    // organizer=false + no host_key returned from the query-service (FGA denies) => can_view_host_key=false.
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
-    checkAccessMock.mockResolvedValue(
-      accessMap([
-        [`${MEETING_ID}#organizer`, false],
-        [`${MEETING_ID}#host`, false],
-      ])
-    );
     const { req, res, next } = buildReqRes(true);
 
     await controller.getMeetingById(req, res, next);
@@ -213,12 +207,7 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
   it('keeps host_key for a meeting organizer', async () => {
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.getMeetingHostKey.mockResolvedValue('123456');
-    checkAccessMock.mockResolvedValue(
-      accessMap([
-        [`${MEETING_ID}#organizer`, true],
-        [`${MEETING_ID}#host`, true],
-      ])
-    );
+    checkSingleAccessMock.mockResolvedValue(true);
     const { req, res, next } = buildReqRes(true);
 
     await controller.getMeetingById(req, res, next);
@@ -226,17 +215,15 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.host_key).toBe('123456');
     expect(payload.meeting.can_view_host_key).toBe(true);
+    expect(payload.meeting.organizer).toBe(true);
   });
 
-  it('keeps host_key for a project writer who is not the organizer (host=true via FGA derivation)', async () => {
+  it('keeps host_key for a direct co-host who is not the meeting organizer (query-service FGA authorizes the fetch)', async () => {
+    // organizer=false but the query-service returns a host_key because the FGA `host` relation
+    // on v1_meeting_host_credentials covers registrants with Host=true independently of the
+    // organizer chain. No local `host` access-check is needed.
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.getMeetingHostKey.mockResolvedValue('123456');
-    checkAccessMock.mockResolvedValue(
-      accessMap([
-        [`${MEETING_ID}#organizer`, false],
-        [`${MEETING_ID}#host`, true],
-      ])
-    );
     const { req, res, next } = buildReqRes(true);
 
     await controller.getMeetingById(req, res, next);
@@ -244,6 +231,7 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.host_key).toBe('123456');
     expect(payload.meeting.can_view_host_key).toBe(true);
+    expect(payload.meeting.organizer).toBe(false);
   });
 
   it('does not call getMeetingHostKey for an unauthenticated caller', async () => {
@@ -258,14 +246,11 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
   });
 
   it('responds without host_key when getMeetingHostKey throws a non-fatal error', async () => {
+    // Query-service blip: fail closed with can_view_host_key=false and no host_key, but do not
+    // 500 the meeting response. This is the exact NATS-degraded case that LFXV2-2885 targets.
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
     meetingSvc.getMeetingHostKey.mockRejectedValue(new Error('query service 503'));
-    checkAccessMock.mockResolvedValue(
-      accessMap([
-        [`${MEETING_ID}#organizer`, true],
-        [`${MEETING_ID}#host`, true],
-      ])
-    );
+    checkSingleAccessMock.mockResolvedValue(true);
     const { req, res, next } = buildReqRes(true);
 
     await controller.getMeetingById(req, res, next);
@@ -275,6 +260,9 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
     expect(res.json).toHaveBeenCalled();
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.host_key).toBeUndefined();
+    expect(payload.meeting.can_view_host_key).toBe(false);
+    // organizer=true is still resolved from the FGA check even though the host-key fetch failed.
+    expect(payload.meeting.organizer).toBe(true);
   });
 
   it('strips host_key for an unauthenticated caller and never runs an access check', async () => {
@@ -283,7 +271,8 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
 
     await controller.getMeetingById(req, res, next);
 
-    expect(checkAccessMock).not.toHaveBeenCalled();
+    expect(checkSingleAccessMock).not.toHaveBeenCalled();
+    expect(meetingSvc.getMeetingHostKey).not.toHaveBeenCalled();
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.host_key).toBeUndefined();
     expect(payload.meeting.can_view_host_key).toBe(false);
@@ -296,22 +285,33 @@ describe('PublicMeetingController.getMeetingById host_key gating', () => {
 
     await controller.getMeetingById(req, res, next);
 
-    // The access check must NOT run under the application (M2M) identity.
-    expect(checkAccessMock).not.toHaveBeenCalled();
+    // Neither the access check nor the host-key fetch may run under the M2M identity — the
+    // application identity could hold writer relations and leak the host key.
+    expect(checkSingleAccessMock).not.toHaveBeenCalled();
+    expect(meetingSvc.getMeetingHostKey).not.toHaveBeenCalled();
     const payload = res.json.mock.calls[0][0];
     expect(payload.meeting.host_key).toBeUndefined();
     expect(payload.meeting.can_view_host_key).toBe(false);
   });
 
+  it('passes the captured user token through to both parallel access-check and host-key calls', async () => {
+    // Parallel-safe fan-out: the user token is passed per-call so it doesn't race with M2M
+    // sibling calls in the same Promise.all that read req.bearerToken.
+    meetingSvc.getMeetingById.mockResolvedValue(buildMeeting());
+    meetingSvc.getMeetingHostKey.mockResolvedValue('123456');
+    checkSingleAccessMock.mockResolvedValue(true);
+    const { req, res, next } = buildReqRes(true);
+
+    await controller.getMeetingById(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(checkSingleAccessMock).toHaveBeenCalledWith(req, { resource: 'v1_meeting', id: MEETING_ID, access: 'organizer' }, { bearerToken: 'user-token' });
+    expect(meetingSvc.getMeetingHostKey).toHaveBeenCalledWith(req, MEETING_ID, { bearerToken: 'user-token' });
+  });
+
   it('strips host_key for an invited non-organizer on a private restricted meeting', async () => {
     meetingSvc.getMeetingById.mockResolvedValue(buildMeeting({ visibility: MeetingVisibility.PRIVATE, restricted: true }));
     addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: Meeting) => ({ ...meeting, invited: true }));
-    checkAccessMock.mockResolvedValue(
-      accessMap([
-        [`${MEETING_ID}#organizer`, false],
-        [`${MEETING_ID}#host`, false],
-      ])
-    );
     const { req, res, next } = buildReqRes(true);
 
     await controller.getMeetingById(req, res, next);
@@ -335,7 +335,7 @@ describe('PublicMeetingController.getMeetingById parent project resolution (LFXV
     meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
     meetingSvc.getMeetingHostKey.mockResolvedValue(null);
     addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: Meeting) => ({ ...meeting, invited: false }));
-    checkAccessMock.mockResolvedValue(accessMap([]));
+    checkSingleAccessMock.mockResolvedValue(false);
   });
 
   it('resolves and returns the foundation project', async () => {
@@ -400,7 +400,7 @@ describe('PublicMeetingController.getPublicPastMeetingById parent project resolu
     getEffectiveEmailMock.mockReturnValue('user@example.com');
     getEffectiveUsernameMock.mockReturnValue('user');
     meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting());
-    checkAccessMock.mockResolvedValue(accessMap([]));
+    checkSingleAccessMock.mockResolvedValue(false);
   });
 
   it('resolves and returns the foundation project', async () => {
@@ -472,7 +472,7 @@ describe('PublicMeetingController.getMeetingById organizer privacy (LFXV2-2802)'
     meetingSvc.getMeetingRegistrants.mockResolvedValue([]);
     meetingSvc.getMeetingHostKey.mockResolvedValue(null);
     addInvitedStatusToMeetingMock.mockImplementation(async (_req: any, meeting: Meeting) => ({ ...meeting, invited: false }));
-    checkAccessMock.mockResolvedValue(accessMap([]));
+    checkSingleAccessMock.mockResolvedValue(false);
   });
 
   it('strips created_by and owner for an anonymous caller without querying the index', async () => {
@@ -512,7 +512,7 @@ describe('PublicMeetingController.getPublicPastMeetingById organizer privacy (LF
     projectSvc.getProjectById.mockResolvedValue(buildProject({ parent_uid: '' }));
     meetingSvc.getPastMeetingById.mockResolvedValue(buildPastMeeting({ created_by: createdBy, owner } as Partial<PastMeeting>));
     addAccessToResourceMock.mockImplementation(async (_req: any, resource: any) => ({ ...resource, organizer: false }));
-    checkAccessMock.mockResolvedValue(accessMap([]));
+    checkSingleAccessMock.mockResolvedValue(false);
   });
 
   it('strips created_by and owner for an anonymous caller without querying the index', async () => {

--- a/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
+++ b/apps/lfx-one/src/server/controllers/public-meeting.controller.ts
@@ -18,9 +18,10 @@ import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { AuthenticationError, AuthorizationError } from '../errors/authentication.error';
 import {
   addInvitedStatusToMeeting,
-  applyHostKeyVisibility,
+  applyOrganizerAndHostKeyResult,
   checkPastMeetingAccess,
   enrichMeetingsWithCreatedBy,
+  resolveOrganizerAndHostKey,
   stripHostKey,
 } from '../helpers/meeting.helper';
 import { validateUidParameter } from '../helpers/validation.helper';
@@ -75,12 +76,27 @@ export class PublicMeetingController {
 
       const isAuthenticated = req.oidc?.isAuthenticated();
 
-      // Fetch project and invited status in parallel (both depend only on meeting data)
-      const [project, meetingWithInvited] = await Promise.all([
+      // Guard on originalToken, not just isAuthenticated: this is an optional-auth route, so a
+      // token-refresh failure can leave isAuthenticated() true with NO user token captured
+      // (originalToken === undefined) while req.bearerToken still holds the M2M token. Running the
+      // access check in that state would evaluate the application identity — which may hold writer
+      // relations — and leak the host key. Fail closed unless we hold the user's own token.
+      const canRunUserAccessCheck = isAuthenticated && originalToken !== undefined;
+
+      // Fetch project, invited status, and organizer/host-key resolution in parallel. Each call
+      // uses its own identity explicitly (M2M for project/invited-status; the captured user token
+      // for organizer FGA + host-key fetch) so they don't race on the shared req.bearerToken
+      // field. Folding the access-check into this Promise.all — instead of running it serially
+      // after — cuts one round trip off the critical path for every authenticated caller
+      // (LFXV2-2885), which materially reduces exposure to access-check NATS blips.
+      const [project, meetingWithInvited, organizerAndHostKey] = await Promise.all([
         this.projectService.getProjectById(req, meeting.project_uid, false),
         isAuthenticated
           ? addInvitedStatusToMeeting(req, meeting, getEffectiveEmail(req) || '', m2mToken)
           : Promise.resolve(Object.assign(meeting, { invited: false })),
+        canRunUserAccessCheck
+          ? resolveOrganizerAndHostKey(req, this.accessCheckService, this.meetingService, meeting, originalToken)
+          : Promise.resolve({ organizer: false, canViewHostKey: false } as const),
       ]);
       meeting = meetingWithInvited;
 
@@ -92,63 +108,16 @@ export class PublicMeetingController {
         });
       }
 
+      // Apply organizer + host-key resolution. meeting.organizer is used by the private-meeting
+      // access gate and the organizer-only registrant count below; meeting.host_key /
+      // can_view_host_key are the response-side host-key surface. When we couldn't run the user
+      // access check (anonymous or missing user token), fail closed: no organizer, no host key.
+      applyOrganizerAndHostKeyResult(meeting, organizerAndHostKey);
+
       // Resolves the foundation project server-side (LFXV2-3266) so anonymous visitors get
       // breadcrumb/attribution data without an authenticated /api/projects/:uid call from the
-      // client. m2mToken is still active here — the user-token swap below happens later and is
-      // restored before this response is sent.
+      // client. m2mToken is still active on req.bearerToken.
       const parent = await this.resolveParentProject(req, project);
-
-      // Resolve host-key visibility (organizer OR project writer OR committee writer). This sets
-      // meeting.organizer (used for the registrant counts below) and meeting.can_view_host_key,
-      // and strips host_key when the user isn't authorized — the single source of truth for the
-      // gate across every response branch.
-      //
-      // Guard on originalToken, not just isAuthenticated: this is an optional-auth route, so a
-      // token-refresh failure can leave isAuthenticated() true with NO user token captured
-      // (originalToken === undefined) while req.bearerToken still holds the M2M token. Running the
-      // access check in that state would evaluate the application identity — which may hold writer
-      // relations — and leak the host key. Fail closed unless we hold the user's own token.
-      if (isAuthenticated && originalToken !== undefined) {
-        // Temporarily restore user's original token for the access check
-        req.bearerToken = originalToken;
-
-        try {
-          await applyHostKeyVisibility(req, this.accessCheckService, meeting);
-
-          // host_key is no longer on the v2 meeting API response — fetch it from the
-          // separately indexed v1_meeting_host_credentials object (FGA-gated by host relation).
-          // Must run while the user's own token is active, before restoring M2M below.
-          if (meeting.can_view_host_key) {
-            try {
-              const hostKey = await this.meetingService.getMeetingHostKey(req, id);
-              if (hostKey) {
-                meeting.host_key = hostKey;
-              }
-            } catch (error) {
-              logger.warning(req, 'get_public_meeting_by_id', 'Failed to fetch host key credentials, continuing without host key', {
-                meeting_id: id,
-                err: error,
-              });
-            }
-          }
-        } catch (error) {
-          // If the access check fails, log but fail closed (no organizer, no host key)
-          logger.warning(req, 'get_public_meeting_by_id', 'Failed to check host key access, continuing with no access', {
-            err: error,
-            meeting_id: id,
-          });
-          meeting.organizer = false;
-          meeting.can_view_host_key = false;
-          stripHostKey(meeting);
-        }
-
-        // Restore M2M token for subsequent operations (e.g., fetching public join URL)
-        req.bearerToken = m2mToken;
-      } else {
-        meeting.organizer = false;
-        meeting.can_view_host_key = false;
-        stripHostKey(meeting);
-      }
 
       // Fetch registrant counts for organizers, otherwise default to 0
       if (meeting.organizer) {

--- a/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.spec.ts
@@ -52,7 +52,7 @@ vi.mock('../services/logger.service', () => ({
 vi.mock('../utils/auth-helper', () => ({ getEffectiveEmail: vi.fn(), getUsernameFromAuth: vi.fn() }));
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: vi.fn() }));
 
-import { applyHostKeyVisibility, enrichMeetingsWithCreatedBy, isWithinHostKeyWindow, stripHostKey } from './meeting.helper';
+import { applyOrganizerAndHostKeyResult, enrichMeetingsWithCreatedBy, isWithinHostKeyWindow, resolveOrganizerAndHostKey, stripHostKey } from './meeting.helper';
 
 const req = {} as unknown as Request;
 const human: MeetingUserInfo = { name: 'Ada Lovelace', username: 'alovelace', email: 'ada@example.com' };
@@ -197,96 +197,136 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Meeting {
   } as Meeting;
 }
 
-function mockAccessCheck(results: Map<string, boolean>): { service: AccessCheckService; checkAccess: ReturnType<typeof vi.fn> } {
-  const checkAccess = vi.fn().mockResolvedValue(results);
-  return { service: { checkAccess } as unknown as AccessCheckService, checkAccess };
+function mockAccessCheck(hasOrganizer: boolean): {
+  service: AccessCheckService;
+  checkSingleAccess: ReturnType<typeof vi.fn>;
+} {
+  const checkSingleAccess = vi.fn().mockResolvedValue(hasOrganizer);
+  return { service: { checkSingleAccess } as unknown as AccessCheckService, checkSingleAccess };
 }
 
-describe('applyHostKeyVisibility', () => {
-  // Helper: build the composite-keyed map that checkAccess now returns.
-  function accessMap(organizer: boolean, host: boolean): Map<string, boolean> {
-    return new Map([
-      [`${MEETING_ID}#organizer`, organizer],
-      [`${MEETING_ID}#host`, host],
-    ]);
-  }
+function mockMeetingSvc(hostKey: string | null | Error): {
+  service: { getMeetingHostKey: ReturnType<typeof vi.fn> };
+  getMeetingHostKey: ReturnType<typeof vi.fn>;
+} {
+  const getMeetingHostKey = hostKey instanceof Error ? vi.fn().mockRejectedValue(hostKey) : vi.fn().mockResolvedValue(hostKey);
+  return { service: { getMeetingHostKey }, getMeetingHostKey };
+}
 
+describe('resolveOrganizerAndHostKey', () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it('keeps host_key for a meeting organizer (has both organizer and host via FGA derivation)', async () => {
+  it('returns the host key and organizer=true for a meeting organizer inside the window', async () => {
     const meeting = buildMeeting();
-    const { service } = mockAccessCheck(accessMap(true, true));
+    const { service: access, checkSingleAccess } = mockAccessCheck(true);
+    const { service: meetingSvc, getMeetingHostKey } = mockMeetingSvc('123456');
 
-    await applyHostKeyVisibility(req, service, meeting);
+    const result = await resolveOrganizerAndHostKey(req, access, meetingSvc as any, meeting);
 
-    expect(meeting.organizer).toBe(true);
-    expect(meeting.can_view_host_key).toBe(true);
-    expect(meeting.host_key).toBe('123456');
+    expect(result).toEqual({ organizer: true, canViewHostKey: true, hostKey: '123456' });
+    // Organizer FGA + host-key fetch are fired concurrently, both with the same identity.
+    expect(checkSingleAccess).toHaveBeenCalledTimes(1);
+    expect(getMeetingHostKey).toHaveBeenCalledTimes(1);
   });
 
-  it('keeps host_key for a direct co-host who is not the meeting organizer', async () => {
-    // host=true but organizer=false: registrant with Host=true, not a project/committee writer.
+  it('returns organizer=false and no host key for a non-organizer whose host-key fetch returns null', async () => {
+    // Query-service enforces FGA `host` on v1_meeting_host_credentials, so an unauthorized
+    // caller sees an empty resources array (null hostKey) even without a local host access check.
     const meeting = buildMeeting();
-    const { service } = mockAccessCheck(accessMap(false, true));
+    const { service: access } = mockAccessCheck(false);
+    const { service: meetingSvc } = mockMeetingSvc(null);
 
-    await applyHostKeyVisibility(req, service, meeting);
+    const result = await resolveOrganizerAndHostKey(req, access, meetingSvc as any, meeting);
 
-    expect(meeting.organizer).toBe(false);
-    expect(meeting.can_view_host_key).toBe(true);
-    expect(meeting.host_key).toBe('123456');
+    expect(result).toEqual({ organizer: false, canViewHostKey: false });
   });
 
-  it('strips host_key when the user has neither organizer nor host relation (the leak regression)', async () => {
+  it('returns the host key for a direct co-host who is not the meeting organizer', async () => {
+    // organizer=false but query-service returns a key because the FGA host relation covers
+    // registrants with Host=true independently of the organizer/writer chain.
     const meeting = buildMeeting();
-    const { service } = mockAccessCheck(accessMap(false, false));
+    const { service: access } = mockAccessCheck(false);
+    const { service: meetingSvc } = mockMeetingSvc('654321');
 
-    await applyHostKeyVisibility(req, service, meeting);
+    const result = await resolveOrganizerAndHostKey(req, access, meetingSvc as any, meeting);
 
-    expect(meeting.organizer).toBe(false);
-    expect(meeting.can_view_host_key).toBe(false);
-    expect(meeting.host_key).toBeUndefined();
+    expect(result).toEqual({ organizer: false, canViewHostKey: true, hostKey: '654321' });
   });
 
-  it('batches organizer and host checks into a single access-check call', async () => {
+  it('runs organizer FGA and host-key fetch in parallel with no host tuple in the access check', async () => {
+    // The single access-check call must be an organizer-only check — we no longer send a
+    // `host` tuple locally because the query-service already enforces FGA on the credentials doc.
     const meeting = buildMeeting();
-    const { service, checkAccess } = mockAccessCheck(accessMap(false, false));
+    const { service: access, checkSingleAccess } = mockAccessCheck(true);
+    const { service: meetingSvc } = mockMeetingSvc('123456');
 
-    await applyHostKeyVisibility(req, service, meeting);
+    await resolveOrganizerAndHostKey(req, access, meetingSvc as any, meeting);
 
-    expect(checkAccess).toHaveBeenCalledTimes(1);
-    expect(checkAccess).toHaveBeenCalledWith(req, [
-      { resource: 'v1_meeting', id: MEETING_ID, access: 'organizer' },
-      { resource: 'v1_meeting', id: MEETING_ID, access: 'host' },
-    ]);
+    expect(checkSingleAccess).toHaveBeenCalledWith(req, { resource: 'v1_meeting', id: MEETING_ID, access: 'organizer' }, undefined);
   });
 
-  it('strips host_key and sets can_view_host_key=false outside the time window, but still resolves organizer via FGA', async () => {
-    // Starts in 3 days — well beyond the 70-min pre-window.
+  it('skips the host-key fetch entirely outside the time window but still resolves organizer', async () => {
+    // Starts in 3 days — beyond the 70-min pre-window; the key would be stripped anyway.
     const meeting = buildMeeting({ start_time: isoOffset(3 * 24 * 60 * MIN), duration: 60 });
-    const { service, checkAccess } = mockAccessCheck(accessMap(true, true));
+    const { service: access, checkSingleAccess } = mockAccessCheck(true);
+    const { service: meetingSvc, getMeetingHostKey } = mockMeetingSvc('123456');
 
-    await applyHostKeyVisibility(req, service, meeting);
+    const result = await resolveOrganizerAndHostKey(req, access, meetingSvc as any, meeting);
 
-    // FGA still runs so organizer is set correctly (gates private-meeting access and registrant counts).
-    expect(checkAccess).toHaveBeenCalledTimes(1);
-    expect(meeting.organizer).toBe(true);
-    // Time gate blocks host-key visibility regardless of role.
-    expect(meeting.can_view_host_key).toBe(false);
-    expect(meeting.host_key).toBeUndefined();
+    expect(checkSingleAccess).toHaveBeenCalledTimes(1);
+    expect(getMeetingHostKey).not.toHaveBeenCalled();
+    expect(result).toEqual({ organizer: true, canViewHostKey: false });
   });
 
-  it('keeps host_key when the host is inside the time window', async () => {
-    // Starts in 30 min — inside the 70-min pre-window.
-    const meeting = buildMeeting({ start_time: isoOffset(30 * MIN), duration: 60 });
-    const { service } = mockAccessCheck(accessMap(true, true));
+  it('degrades to canViewHostKey=false when the host-key fetch throws', async () => {
+    const meeting = buildMeeting();
+    const { service: access } = mockAccessCheck(true);
+    const { service: meetingSvc } = mockMeetingSvc(new Error('query service 503'));
 
-    await applyHostKeyVisibility(req, service, meeting);
+    const result = await resolveOrganizerAndHostKey(req, access, meetingSvc as any, meeting);
+
+    expect(result).toEqual({ organizer: true, canViewHostKey: false });
+  });
+
+  it('forwards the bearerToken override to both parallel calls when provided', async () => {
+    // Parallel-safe fan-out: callers pass the user token explicitly so the calls don't race on
+    // req.bearerToken (which may be holding an M2M token for sibling calls in the same
+    // Promise.all).
+    const meeting = buildMeeting();
+    const { service: access, checkSingleAccess } = mockAccessCheck(false);
+    const { service: meetingSvc, getMeetingHostKey } = mockMeetingSvc(null);
+
+    await resolveOrganizerAndHostKey(req, access, meetingSvc as any, meeting, 'user-token');
+
+    expect(checkSingleAccess).toHaveBeenCalledWith(req, { resource: 'v1_meeting', id: MEETING_ID, access: 'organizer' }, { bearerToken: 'user-token' });
+    expect(getMeetingHostKey).toHaveBeenCalledWith(req, MEETING_ID, { bearerToken: 'user-token' });
+  });
+});
+
+describe('applyOrganizerAndHostKeyResult', () => {
+  it('applies organizer, can_view_host_key, and host_key when authorized', () => {
+    const meeting = buildMeeting();
+    delete meeting.host_key;
+
+    applyOrganizerAndHostKeyResult(meeting, { organizer: true, canViewHostKey: true, hostKey: '999999' });
 
     expect(meeting.organizer).toBe(true);
     expect(meeting.can_view_host_key).toBe(true);
-    expect(meeting.host_key).toBe('123456');
+    expect(meeting.host_key).toBe('999999');
+  });
+
+  it('strips any existing host_key when canViewHostKey is false', () => {
+    // Defense in depth: the meeting builder pre-populates host_key. If the resolution says the
+    // caller can't view it, the field must be stripped regardless of what was on the meeting.
+    const meeting = buildMeeting();
+
+    applyOrganizerAndHostKeyResult(meeting, { organizer: false, canViewHostKey: false });
+
+    expect(meeting.organizer).toBe(false);
+    expect(meeting.can_view_host_key).toBe(false);
+    expect(meeting.host_key).toBeUndefined();
   });
 });
 

--- a/apps/lfx-one/src/server/helpers/meeting.helper.ts
+++ b/apps/lfx-one/src/server/helpers/meeting.helper.ts
@@ -140,7 +140,7 @@ export async function enrichMeetingsWithCreatedBy<T extends Meeting>(req: Reques
  * Removes the Zoom host key from a meeting response.
  *
  * The host key is a 6-digit credential that grants Zoom host privileges to whoever holds it,
- * so it must never reach a client that isn't authorized to see it (see {@link applyHostKeyVisibility}).
+ * so it must never reach a client that isn't authorized to see it (see {@link resolveOrganizerAndHostKey}).
  * Used directly on response paths where the host key is never surfaced (list views, past meetings,
  * anonymous callers, create echoes).
  *
@@ -177,42 +177,90 @@ export function isWithinHostKeyWindow(meeting: Pick<Meeting, 'start_time' | 'dur
 }
 
 /**
- * Resolves whether the current user may view a meeting's Zoom host key and mutates the meeting
- * accordingly. This is the single source of truth for host-key visibility on detail endpoints.
+ * Resolves whether the current user is a meeting organizer AND (if inside the host-key time
+ * window) attempts to fetch the meeting's Zoom host key. This is the single source of truth for
+ * host-key visibility on detail endpoints.
  *
- * `meeting.organizer` is always resolved via `v1_meeting#organizer` — it gates private-meeting
- * access and registrant-count fetches independently of host-key visibility.
+ * `organizer` is resolved via `v1_meeting#organizer` — it gates private-meeting access and
+ * registrant-count fetches independently of host-key visibility.
  *
- * `meeting.can_view_host_key` requires BOTH gates to pass:
- *   1. FGA `v1_meeting#host` — covers direct co-hosts (registrants with Host=true) AND anyone
- *      with the derived organizer relation (project writers, committee writers, meeting coordinators)
- *      via the FGA model: host = [user] or auditor, auditor = organizer or auditor from project
- *   2. Time window — current time is within [effective_start − 70 min, effective_start + duration + 40 min)
- *      where effective_start = next_occurrence_start_time ?? start_time  (mirrors PCC)
+ * `can_view_host_key` and `host_key` are derived from whether the host-key fetch returned a
+ * value. The query-service enforces the FGA `host` relation on `v1_meeting_host_credentials`
+ * (covering direct co-hosts AND anyone with the derived organizer relation — project writers,
+ * committee writers, meeting coordinators), so a separate local `host` access-check is
+ * redundant with the query-service's gate and is intentionally NOT performed here. This drops
+ * one round trip on every request that would otherwise fetch a host key.
  *
- * Both checks are batched into a single `/access-check` round-trip. The check is fail-closed:
- * on any upstream error the access-check service returns all-false, so the host key is stripped.
+ * Time-window check: current time must be within
+ * [effective_start − 70 min, effective_start + duration + 40 min), where
+ * effective_start = next_occurrence_start_time ?? start_time (mirrors PCC). Outside the window
+ * we skip the host-key fetch entirely — the key would be stripped anyway.
  *
- * MUST be called with the user's own bearer token active on `req` — NOT an M2M token — or the
- * access check evaluates against the application identity instead of the user.
+ * Runs the organizer check and the host-key fetch in parallel (both use the user's bearer
+ * token). The optional `bearerToken` parameter lets the caller fan this out alongside other
+ * calls that use a different identity (e.g. M2M) without racing on `req.bearerToken`. When
+ * omitted, the calls use `req.bearerToken`.
+ *
+ * Returns a plain result object — callers apply it to the meeting after other parallel work
+ * completes, avoiding races on shared object fields.
  *
  * @param req - Express request object with the user's auth context
  * @param accessCheckService - Access-check service instance
- * @param meeting - The meeting to gate (mutated in place)
+ * @param meetingService - Meeting service instance (used to fetch the host-key credentials doc)
+ * @param meeting - The meeting to gate (read-only here; not mutated)
+ * @param bearerToken - Optional per-call bearer token override (typically the user's token
+ *   captured before an M2M token swap on `req.bearerToken`)
  */
-export async function applyHostKeyVisibility(req: Request, accessCheckService: AccessCheckService, meeting: Meeting): Promise<void> {
-  const results = await accessCheckService.checkAccess(req, [
-    { resource: 'v1_meeting', id: meeting.id, access: 'organizer' },
-    { resource: 'v1_meeting', id: meeting.id, access: 'host' },
+export async function resolveOrganizerAndHostKey(
+  req: Request,
+  accessCheckService: AccessCheckService,
+  meetingService: MeetingService,
+  meeting: Pick<Meeting, 'id' | 'start_time' | 'duration' | 'next_occurrence_start_time'>,
+  bearerToken?: string
+): Promise<{ organizer: boolean; canViewHostKey: boolean; hostKey?: string }> {
+  const withinWindow = isWithinHostKeyWindow(meeting);
+  const callOptions = bearerToken ? { bearerToken } : undefined;
+
+  // Fire both the organizer FGA check and the host-key fetch in parallel. `checkSingleAccess`
+  // already degrades to `false` on upstream failure; the host-key fetch we wrap in Promise.allSettled
+  // so a query-service blip cannot fail the whole meeting response.
+  const [organizerResult, hostKeyResult] = await Promise.allSettled([
+    accessCheckService.checkSingleAccess(req, { resource: 'v1_meeting', id: meeting.id, access: 'organizer' }, callOptions),
+    withinWindow ? meetingService.getMeetingHostKey(req, meeting.id, callOptions) : Promise.resolve(null),
   ]);
 
-  // organizer gates private-meeting access and registrant counts independently of host-key.
-  meeting.organizer = results.get(`${meeting.id}#organizer`) ?? false;
+  if (organizerResult.status === 'rejected') {
+    // checkSingleAccess.degrades to false internally, so this branch is only for genuinely
+    // unexpected throws (e.g. code bug). Log and fail closed.
+    logger.warning(req, 'resolve_organizer_and_host_key', 'Organizer FGA check threw, failing closed', {
+      meeting_id: meeting.id,
+      err: organizerResult.reason,
+    });
+  }
+  if (hostKeyResult.status === 'rejected') {
+    logger.warning(req, 'resolve_organizer_and_host_key', 'Host key fetch failed, continuing without host key', {
+      meeting_id: meeting.id,
+      err: hostKeyResult.reason,
+    });
+  }
 
-  // can_view_host_key requires host relation AND time-window.
-  meeting.can_view_host_key = (results.get(`${meeting.id}#host`) ?? false) && isWithinHostKeyWindow(meeting);
+  const organizer = organizerResult.status === 'fulfilled' ? organizerResult.value : false;
+  const hostKey = hostKeyResult.status === 'fulfilled' ? hostKeyResult.value : null;
 
-  if (!meeting.can_view_host_key) {
+  return hostKey ? { organizer, canViewHostKey: true, hostKey } : { organizer, canViewHostKey: false };
+}
+
+/**
+ * Applies a {@link resolveOrganizerAndHostKey} result to a meeting object. Sets `organizer`,
+ * `can_view_host_key`, and either sets or strips `host_key` accordingly. Kept as a small helper
+ * so both consumer controllers apply the result the same way.
+ */
+export function applyOrganizerAndHostKeyResult(meeting: Meeting, result: { organizer: boolean; canViewHostKey: boolean; hostKey?: string }): void {
+  meeting.organizer = result.organizer;
+  meeting.can_view_host_key = result.canViewHostKey;
+  if (result.hostKey) {
+    meeting.host_key = result.hostKey;
+  } else {
     stripHostKey(meeting);
   }
 }

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -127,6 +127,18 @@ describe('AccessCheckService.checkAccess', () => {
 
     expect(result.get('a#writer')).toBe(false);
   });
+
+  it('threads options.bearerToken into the proxy call, distinct from req.bearerToken', async () => {
+    const reqWithToken = { bearerToken: 'req-token' } as unknown as Request;
+    proxyRequest.mockResolvedValueOnce({ results: ['project:a#writer@user:alice\ttrue'] });
+
+    await service.checkAccess(reqWithToken, [{ resource: 'project', id: 'a', access: 'writer' }], { bearerToken: 'override-token' });
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    // proxyRequest signature: (req, service, path, method, query, data, customHeaders, options)
+    const options = proxyRequest.mock.calls[0][7];
+    expect(options).toEqual({ bearerToken: 'override-token' });
+  });
 });
 
 describe('AccessCheckService.checkAccessStrict / checkSingleAccessStrict', () => {

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -1,7 +1,14 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { AccessCheckAccessType, AccessCheckApiRequest, AccessCheckApiResponse, AccessCheckRequest, AccessCheckResourceType } from '@lfx-one/shared/interfaces';
+import {
+  AccessCheckAccessType,
+  AccessCheckApiRequest,
+  AccessCheckApiResponse,
+  AccessCheckRequest,
+  AccessCheckResourceType,
+  ApiRequestOptions,
+} from '@lfx-one/shared/interfaces';
 import { Request } from 'express';
 
 import { logger } from '../services/logger.service';
@@ -21,9 +28,10 @@ export class AccessCheckService {
    * Check access permissions for multiple resources
    * @param req Express request object with auth context
    * @param resources Array of resources to check access for
+   * @param options Optional per-call overrides (e.g. explicit bearer token)
    * @returns Map keyed by "id#access" to their access status (e.g. "meeting-1#organizer")
    */
-  public async checkAccess(req: Request, resources: AccessCheckRequest[]): Promise<Map<string, boolean>> {
+  public async checkAccess(req: Request, resources: AccessCheckRequest[], options?: ApiRequestOptions): Promise<Map<string, boolean>> {
     if (resources.length === 0) {
       return new Map();
     }
@@ -31,7 +39,7 @@ export class AccessCheckService {
     const { operationName, startTime } = this.beginCheckOperation(req, resources);
 
     try {
-      return await this.performCheck(req, resources, operationName, startTime);
+      return await this.performCheck(req, resources, operationName, startTime, options);
     } catch (error) {
       logger.error(req, operationName, startTime, error, {
         request_count: resources.length,
@@ -53,16 +61,17 @@ export class AccessCheckService {
    * from "couldn't verify" (503) — `checkAccess`'s fallback collapses that distinction.
    * @param req Express request object with auth context
    * @param resources Array of resources to check access for
+   * @param options Optional per-call overrides (e.g. explicit bearer token)
    * @returns Map keyed by "id#access" to their access status
    */
-  public async checkAccessStrict(req: Request, resources: AccessCheckRequest[]): Promise<Map<string, boolean>> {
+  public async checkAccessStrict(req: Request, resources: AccessCheckRequest[], options?: ApiRequestOptions): Promise<Map<string, boolean>> {
     if (resources.length === 0) {
       return new Map();
     }
 
     const { operationName, startTime } = this.beginCheckOperation(req, resources);
     try {
-      return await this.performCheck(req, resources, operationName, startTime);
+      return await this.performCheck(req, resources, operationName, startTime, options);
     } catch (error) {
       // Unlike checkAccess, this rethrows rather than degrading — but still logs, so a failed
       // strict check leaves the same terminal error record as any other failed operation instead
@@ -76,10 +85,11 @@ export class AccessCheckService {
    * Check access for a single resource (convenience method)
    * @param req Express request object with auth context
    * @param resource Resource to check access for
+   * @param options Optional per-call overrides (e.g. explicit bearer token)
    * @returns Boolean indicating whether user has access
    */
-  public async checkSingleAccess(req: Request, resource: AccessCheckRequest): Promise<boolean> {
-    const results = await this.checkAccess(req, [resource]);
+  public async checkSingleAccess(req: Request, resource: AccessCheckRequest, options?: ApiRequestOptions): Promise<boolean> {
+    const results = await this.checkAccess(req, [resource], options);
     return results.get(`${resource.id}#${resource.access}`) || false;
   }
 
@@ -87,10 +97,11 @@ export class AccessCheckService {
    * Check access for a single resource, propagating upstream failures. See `checkAccessStrict`.
    * @param req Express request object with auth context
    * @param resource Resource to check access for
+   * @param options Optional per-call overrides (e.g. explicit bearer token)
    * @returns Boolean indicating whether user has access
    */
-  public async checkSingleAccessStrict(req: Request, resource: AccessCheckRequest): Promise<boolean> {
-    const results = await this.checkAccessStrict(req, [resource]);
+  public async checkSingleAccessStrict(req: Request, resource: AccessCheckRequest, options?: ApiRequestOptions): Promise<boolean> {
+    const results = await this.checkAccessStrict(req, [resource], options);
     return results.get(`${resource.id}#${resource.access}`) || false;
   }
 
@@ -100,13 +111,15 @@ export class AccessCheckService {
    * @param resources Array of resource objects with uid or id field
    * @param resourceType Type of resource (project, meeting, committee)
    * @param accessType Type of access to check (default: writer)
+   * @param options Optional per-call overrides (e.g. explicit bearer token)
    * @returns Array of resources with writer field added
    */
   public async addAccessToResources<T extends { uid: string } | { id: string }>(
     req: Request,
     resources: T[],
     resourceType: AccessCheckResourceType,
-    accessType: AccessCheckAccessType = 'writer'
+    accessType: AccessCheckAccessType = 'writer',
+    options?: ApiRequestOptions
   ): Promise<(T & { writer?: boolean })[]> {
     if (resources.length === 0) {
       return resources;
@@ -120,7 +133,7 @@ export class AccessCheckService {
     }));
 
     // Perform batch access check
-    const accessResults = await this.checkAccess(req, accessCheckRequests);
+    const accessResults = await this.checkAccess(req, accessCheckRequests, options);
 
     // Add access field to each resource
     return resources.map((resource) => ({
@@ -135,13 +148,15 @@ export class AccessCheckService {
    * @param resource Single resource object with uid or id field
    * @param resourceType Type of resource (project, meeting, committee)
    * @param accessType Type of access to check (default: writer)
+   * @param options Optional per-call overrides (e.g. explicit bearer token)
    * @returns Resource with writer field added
    */
   public async addAccessToResource<T extends { uid: string } | { id: string }>(
     req: Request,
     resource: T,
     resourceType: AccessCheckResourceType,
-    accessType: AccessCheckAccessType = 'writer'
+    accessType: AccessCheckAccessType = 'writer',
+    options?: ApiRequestOptions
   ): Promise<T & { writer?: boolean }> {
     const resourceId = this.getResourceId(resource);
     logger.debug(req, 'add_access_to_resource', 'Adding access to resource', {
@@ -150,11 +165,15 @@ export class AccessCheckService {
       access_type: accessType,
     });
 
-    const hasAccess = await this.checkSingleAccess(req, {
-      resource: resourceType,
-      id: resourceId,
-      access: accessType,
-    });
+    const hasAccess = await this.checkSingleAccess(
+      req,
+      {
+        resource: resourceType,
+        id: resourceId,
+        access: accessType,
+      },
+      options
+    );
 
     return {
       ...resource,
@@ -181,7 +200,13 @@ export class AccessCheckService {
    * Performs the access-check request/response round trip with no error handling — callers decide
    * whether to degrade (`checkAccess`) or propagate (`checkAccessStrict`).
    */
-  private async performCheck(req: Request, resources: AccessCheckRequest[], operationName: string, startTime: number): Promise<Map<string, boolean>> {
+  private async performCheck(
+    req: Request,
+    resources: AccessCheckRequest[],
+    operationName: string,
+    startTime: number,
+    options?: ApiRequestOptions
+  ): Promise<Map<string, boolean>> {
     // Transform requests to the expected API format
     const apiRequests = resources.map((resource) => `${resource.resource}:${resource.id}#${resource.access}`);
 
@@ -189,14 +214,17 @@ export class AccessCheckService {
       requests: apiRequests,
     };
 
-    // Make the API request
+    // Make the API request. options?.bearerToken (when set) opts the call out of req.bearerToken
+    // for parallel-safe fan-out — see ApiRequestOptions.
     const response = await this.microserviceProxy.proxyRequest<AccessCheckApiResponse>(
       req,
       'LFX_V2_SERVICE',
       '/access-check',
       'POST',
       undefined,
-      requestPayload
+      requestPayload,
+      undefined,
+      options
     );
 
     // Parse each result string into a lookup keyed by the "resource:id#access" tuple it

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -210,6 +210,18 @@ describe('MeetingService.getMeetingHostKey', () => {
 
     expect(result).toBeNull();
   });
+
+  it('threads options.bearerToken into the proxy call, distinct from req.bearerToken', async () => {
+    const reqWithToken = { bearerToken: 'req-token' } as unknown as Request;
+    proxyRequest.mockResolvedValueOnce({ resources: [] });
+
+    await service.getMeetingHostKey(reqWithToken, 'meeting-abc', { bearerToken: 'override-token' });
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    // proxyRequest signature: (req, service, path, method, query, data, customHeaders, options)
+    const options = proxyRequest.mock.calls[0][7];
+    expect(options).toEqual({ bearerToken: 'override-token' });
+  });
 });
 
 describe('MeetingService.getPastOccurrencesForMeeting', () => {

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -4,6 +4,7 @@
 import { IMPORT_REGISTRANTS_MAX } from '@lfx-one/shared/constants';
 import { QueryServiceMeetingType } from '@lfx-one/shared/enums';
 import {
+  ApiRequestOptions,
   ApiResponse,
   AttachmentDownloadUrlResponse,
   Committee,
@@ -265,12 +266,14 @@ export class MeetingService {
    * v1_meeting), so it only returns data when the caller holds the derived host relation —
    * covering direct Zoom co-hosts (registrants with Host=true) as well as anyone with an
    * organizer/writer/coordinator role (project writers, committee writers, meeting coordinators).
-   * Must be called with the user's bearer token active on req — NOT an M2M token.
+   * Must be called with the user's bearer token — NOT an M2M token. Pass `options.bearerToken`
+   * when running this in parallel with other calls that use a different identity (e.g. an M2M
+   * project fetch), so the call doesn't race on `req.bearerToken`.
    *
    * Returns the 6-digit host key string, or null when the user has no access or no credentials
    * document has been indexed yet.
    */
-  public async getMeetingHostKey(req: Request, meetingId: string): Promise<string | null> {
+  public async getMeetingHostKey(req: Request, meetingId: string, options?: ApiRequestOptions): Promise<string | null> {
     logger.debug(req, 'get_meeting_host_key', 'Fetching host key credentials', { meeting_id: meetingId });
 
     const { resources } = await this.microserviceProxy.proxyRequest<QueryServiceResponse<{ host_key: string }>>(
@@ -278,7 +281,10 @@ export class MeetingService {
       'LFX_V2_SERVICE',
       '/query/resources',
       'GET',
-      { type: 'v1_meeting_host_credentials', tags: `meeting_id:${meetingId}` }
+      { type: 'v1_meeting_host_credentials', tags: `meeting_id:${meetingId}` },
+      undefined,
+      undefined,
+      options
     );
 
     const hostKey = resources?.[0]?.data?.host_key;

--- a/apps/lfx-one/src/server/services/microservice-proxy.service.spec.ts
+++ b/apps/lfx-one/src/server/services/microservice-proxy.service.spec.ts
@@ -1,0 +1,60 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// Mirrors access-check.service.spec.ts / meeting.service.spec.ts: the `@lfx-one/shared/*` alias
+// isn't wired into this app's vitest config, so the real collaborator (ApiClientService) is
+// mocked to isolate the bearerToken-override precedence logic under test.
+const { request } = vi.hoisted(() => ({ request: vi.fn() }));
+
+vi.mock('./api-client.service', () => ({
+  ApiClientService: class {
+    public request = request;
+  },
+}));
+
+import type { Request } from 'express';
+
+import { MicroserviceProxyService } from './microservice-proxy.service';
+
+const req = { bearerToken: 'req-token' } as unknown as Request;
+
+describe('MicroserviceProxyService bearerToken override precedence', () => {
+  let service: MicroserviceProxyService;
+
+  beforeEach(() => {
+    request.mockReset();
+    request.mockResolvedValue({ data: {}, status: 200, statusText: 'OK', headers: {} });
+    service = new MicroserviceProxyService();
+  });
+
+  it('proxyRequest sends options.bearerToken instead of req.bearerToken when set', async () => {
+    await service.proxyRequest(req, 'LFX_V2_SERVICE', '/path', 'GET', undefined, undefined, undefined, { bearerToken: 'override-token' });
+
+    expect(request).toHaveBeenCalledTimes(1);
+    const [, , bearerToken] = request.mock.calls[0];
+    expect(bearerToken).toBe('override-token');
+  });
+
+  it('proxyRequest falls back to req.bearerToken when no override is given', async () => {
+    await service.proxyRequest(req, 'LFX_V2_SERVICE', '/path', 'GET');
+
+    const [, , bearerToken] = request.mock.calls[0];
+    expect(bearerToken).toBe('req-token');
+  });
+
+  it('proxyRequestWithResponse sends options.bearerToken instead of req.bearerToken when set', async () => {
+    await service.proxyRequestWithResponse(req, 'LFX_V2_SERVICE', '/path', 'GET', undefined, undefined, undefined, { bearerToken: 'override-token' });
+
+    const [, , bearerToken] = request.mock.calls[0];
+    expect(bearerToken).toBe('override-token');
+  });
+
+  it('proxyRequestWithResponse falls back to req.bearerToken when no override is given', async () => {
+    await service.proxyRequestWithResponse(req, 'LFX_V2_SERVICE', '/path', 'GET');
+
+    const [, , bearerToken] = request.mock.calls[0];
+    expect(bearerToken).toBe('req-token');
+  });
+});

--- a/apps/lfx-one/src/server/services/microservice-proxy.service.ts
+++ b/apps/lfx-one/src/server/services/microservice-proxy.service.ts
@@ -26,7 +26,10 @@ export class MicroserviceProxyService {
     try {
       const baseUrl = this.resolveBaseUrl(service);
       const endpoint = `${baseUrl}${path}`;
-      const token = req.bearerToken;
+      // options.bearerToken lets callers fan out parallel requests with different identities
+      // (e.g. user token for FGA checks alongside M2M for public data) without mutating the
+      // shared req.bearerToken field — which would race across the parallel calls.
+      const token = options?.bearerToken ?? req.bearerToken;
 
       // Merge query parameters with defaults taking precedence
       // This ensures that default params cannot be overridden by the caller
@@ -52,20 +55,22 @@ export class MicroserviceProxyService {
     method: 'GET' | 'POST' | 'PUT' | 'PATCH' | 'DELETE' = 'GET',
     query?: Record<string, any>,
     data?: any,
-    customHeaders?: Record<string, string>
+    customHeaders?: Record<string, string>,
+    options?: ApiRequestOptions
   ): Promise<ApiResponse<T>> {
     const operation = `${method.toLowerCase()}_${path.replace(/\//g, '_')}`;
 
     try {
       const baseUrl = this.resolveBaseUrl(service);
       const endpoint = `${baseUrl}${path}`;
-      const token = req.bearerToken;
+      // See proxyRequest above — options.bearerToken opts out of req.bearerToken for parallel-safe calls.
+      const token = options?.bearerToken ?? req.bearerToken;
 
       // Merge query parameters with defaults taking precedence
       // This ensures that default params cannot be overridden by the caller
       const mergedQuery = { ...query, ...DEFAULT_QUERY_PARAMS };
 
-      const response = await this.apiClient.request<T>(method, endpoint, token, mergedQuery, data, customHeaders);
+      const response = await this.apiClient.request<T>(method, endpoint, token, mergedQuery, data, customHeaders, options);
       return response;
     } catch (error: any) {
       // Transform HTTP errors from API client into MicroserviceError

--- a/packages/shared/src/interfaces/api.interface.ts
+++ b/packages/shared/src/interfaces/api.interface.ts
@@ -21,6 +21,14 @@ export interface ApiClientConfig {
 export interface ApiRequestOptions {
   /** Per-request timeout in milliseconds; falls back to the client's configured default (`ApiClientConfig.timeout`, default 30s) */
   timeoutMs?: number;
+  /**
+   * Per-request bearer token override. When set, this token is used for the Authorization header
+   * instead of `req.bearerToken`. Lets callers fan out parallel requests that need different
+   * identities (e.g. user token for FGA checks alongside M2M token for public data fetches)
+   * without mutating the shared `req.bearerToken` field — which would race across the parallel
+   * calls and silently attribute one call's identity to another.
+   */
+  bearerToken?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Reduces sequential upstream calls on the public meeting join page for organizers/admins — the path that returned 500 during the LFXV2-2885 NATS access-check disruption.
- Adds an optional `bearerToken` override to `ApiRequestOptions`, wired through `MicroserviceProxyService`, `AccessCheckService`, and `MeetingService.getMeetingHostKey`, so parallel calls can use distinct identities (user token vs M2M) without mutating the shared `req.bearerToken` field.
- `PublicMeetingController.getMeetingById` folds the organizer FGA check and host-key fetch into the same `Promise.all` as the initial project + invited-status fan-out.
- Drops the redundant local `host` FGA tuple check — query-service already enforces the `host` relation on `v1_meeting_host_credentials` directly. Replaces `applyHostKeyVisibility` with `resolveOrganizerAndHostKey` (one organizer FGA call in parallel with an optimistic host-key fetch).
- `MeetingController.getMeetingById` (authenticated route) gets the same treatment, dropping a redundant FGA round trip since `organizer` is already set by `getMeetingById(access: true)`.

Net effect: one fewer sequential access-check round trip, one fewer FGA tuple per access-check call, and one fewer FGA round trip on the authenticated meeting detail page.

## Note for reviewers

This touches `apps/lfx-one/src/server/services/microservice-proxy.service.ts` (flagged by the repo's protected-files guard as core infra) — expected here since it's where the `bearerToken` override is threaded through. Please give it a close look.

Issue: LFXV2-2885