### PR TITLE
feat(charts): enable the campaign-service jobs cutover flag

### DIFF
--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -199,11 +199,18 @@ changing a value here rather than by shipping a revert.
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN`    | Allows Demand Gen Google campaigns. Requires a campaign-service that understands `googleAdsConfig.channel` (LFXV2-3257) — see below | No       | off      |
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_STATUS_TOGGLE` | Serves campaign pause/resume from campaign-service, which is what makes Google Ads and LinkedIn pausable — see below                | No       | off      |
 
-`..._JOBS` now defaults to `"true"` (LFXV2-3325), the first step of the enable order below. It is
-safe on its own: campaign-service mints UUID job ids and the legacy path mints `job_...`, so with
-`..._CREATE` still off no UUID job exists and every poll is answered by the store that holds it.
-`..._BRIEFS` and `..._CREATE` stay off and must be enabled in later changes, only once every pod
-carries this one — see **Rollout ordering** below, which still governs.
+`..._JOBS` now defaults to `"true"` (LFXV2-3325), the first step of the enable order below.
+**While `..._CREATE` remains off** — the state this chart ships — no UUID job id can exist, so
+every poll is answered by the store that holds it and this flip is inert for job polling.
+**That inertness ends when `..._CREATE` is enabled.** From then on JOBS must be on every pod
+before CREATE, and must stay on until outstanding UUID jobs drain; a pod with JOBS off skips the
+id-shape check entirely and answers a terminal `not_found` for a campaign that is running and
+spending. `..._BRIEFS` and `..._CREATE` stay off and are enabled in later changes, each only once
+the previous has converged — see **Rollout ordering** below, which governs.
+
+One behaviour does change today: with JOBS on, a poll for a UUID job id requires `?project=` and
+is refused with a 400 without it. The LFX One client always sends it, so in-product polling is
+unaffected; a direct API caller or a saved script may not.
 
 Every cutover flag in the table above is ON for `true`, `1`, `yes`, or `on` — trimmed and matched
 case-insensitively, so `"True"` and `" on "` also enable it. Every other value is OFF, including

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -191,13 +191,19 @@ Campaign endpoints are being moved off this application's vendor-direct integrat
 lfx-v2-campaign-service one at a time (LFXV2-3070). Each move is gated so it can be reversed by
 changing a value here rather than by shipping a revert.
 
-| Parameter                                                | Description                                                                                                                         | Required | Default |
-| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | ------- |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS`          | Serves campaign job status from campaign-service; see the accepted values below                                                     | No       | off     |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS`        | Persists the generated brief in campaign-service instead of only in the browser tab                                                 | No       | off     |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE`        | Creates campaigns through campaign-service instead of the per-platform Express services                                             | No       | off     |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN`    | Allows Demand Gen Google campaigns. Requires a campaign-service that understands `googleAdsConfig.channel` (LFXV2-3257) — see below | No       | off     |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_STATUS_TOGGLE` | Serves campaign pause/resume from campaign-service, which is what makes Google Ads and LinkedIn pausable — see below                | No       | off     |
+| Parameter                                                | Description                                                                                                                         | Required | Default  |
+| -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS`          | Serves campaign job status from campaign-service; see the accepted values below                                                     | No       | `"true"` |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS`        | Persists the generated brief in campaign-service instead of only in the browser tab                                                 | No       | off      |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE`        | Creates campaigns through campaign-service instead of the per-platform Express services                                             | No       | off      |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN`    | Allows Demand Gen Google campaigns. Requires a campaign-service that understands `googleAdsConfig.channel` (LFXV2-3257) — see below | No       | off      |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_STATUS_TOGGLE` | Serves campaign pause/resume from campaign-service, which is what makes Google Ads and LinkedIn pausable — see below                | No       | off      |
+
+`..._JOBS` now defaults to `"true"` (LFXV2-3325), the first step of the enable order below. It is
+safe on its own: campaign-service mints UUID job ids and the legacy path mints `job_...`, so with
+`..._CREATE` still off no UUID job exists and every poll is answered by the store that holds it.
+`..._BRIEFS` and `..._CREATE` stay off and must be enabled in later changes, only once every pod
+carries this one — see **Rollout ordering** below, which still governs.
 
 Every cutover flag in the table above is ON for `true`, `1`, `yes`, or `on` — trimmed and matched
 case-insensitively, so `"True"` and `" on "` also enable it. Every other value is OFF, including

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -379,11 +379,19 @@ environment:
   # It is NOT a live switch. This is a container environment variable, so changing it edits the
   # pod template and takes effect only as pods are replaced; with the default replica count and
   # a RollingUpdate, flag-on and flag-off pods serve side by side for the length of the rollout.
-  # That is safe for THIS flag because the source is chosen by the job id's shape as well as by
-  # the flag: a `job_...` id is answered from the in-process map on every pod, flag or no flag,
-  # and a UUID job id cannot exist until campaign creation is cut over too. Do not copy the
+  # The source is chosen by the job id's shape as well as by the flag: a `job_...` id is answered
+  # from the in-process map on every pod, flag or no flag. That made an overlapping rollout safe
+  # for THIS flag while no UUID job id could exist — but that premise EXPIRED when campaign
+  # creation shipped, and holds now only because CREATE below is still off. Once CREATE is on, a
+  # pod with JOBS off skips the id-shape check entirely and answers a terminal `not_found` for a
+  # campaign that is running and SPENDING. Enable JOBS everywhere before CREATE, and keep it on
+  # until outstanding UUID jobs drain; see the CREATE block for the full order. Do not copy the
   # "rollback is one value" line onto a future flag whose two paths could both claim the same
   # request — that one needs a no-overlap rollout or a shared runtime configuration source.
+  #
+  # With this flag on, a poll for a UUID job id requires `?project=` and is refused with a 400
+  # without it (campaign.controller.ts). The LFX One client always sends it; a direct API caller
+  # may not.
   LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS:
     value: "true"
 

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -385,7 +385,7 @@ environment:
   # "rollback is one value" line onto a future flag whose two paths could both claim the same
   # request — that one needs a no-overlap rollout or a shared runtime configuration source.
   LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS:
-    value:
+    value: "true"
 
   # Persist the generated campaign brief to campaign-service instead of holding it only in the
   # browser tab. Same accepted values and same default-deny as the flag above.


### PR DESCRIPTION
## What

Sets `LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` to `"true"` in the chart. One value, plus the README rows that document it.

```diff
  LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS:
-    value:
+    value: "true"
```

`_BRIEFS` and `_CREATE` stay off.

## Why this is only one flag

This PR originally set all three creation flags at once. That is the specific hazard `values.yaml:436-442` warns about, and I verified the mechanism rather than taking the comment's word for it:

- `campaign.controller.ts:464` routes with `isServerFeatureEnabled(CampaignServiceJobs) && isCampaignServiceJobId(jobId)` — the id-shape check is **ANDed with the flag**, not applied independently.
- So a not-yet-updated pod hands a UUID poll to its in-process map, which returns `{ status: 'not_found', error: JOB_LOST_MESSAGE }` (`campaign-proxy.service.ts:1024`) — terminal, so the client stops polling.
- With `replicaCount: 3` and `maxSurge: "100%"`, both generations serve side by side for the entire rollout. That is the widest overlap the chart can produce, not the narrowest.

Net effect of the original diff: a Google Ads campaign that exists and is spending real budget, reported to the user as lost.

**`_JOBS` alone is safe**, and for a checkable reason: routing depends on the job id's shape as well as the flag, and with `_CREATE` still off no UUID job id can exist. Every poll is answered by the store that holds it regardless of which pod serves it.

## Enable order

```
JOBS  ->  confirm every pod has it  ->  BRIEFS  ->  CREATE
```

This PR is step one. `_BRIEFS` and `_CREATE` follow in separate changes, each after the previous has converged.

## Prerequisite for the later `_CREATE` change — not this one

campaign-service reads ad credentials from its own encrypted connection tables, never from this application's `GADS_*` / `LINKEDIN_*` env vars. Before `_CREATE` is enabled, a Google Ads connection must exist for the project, or the LF system row must be installed via `bootstrap-system-account`.

Worth stating precisely, because "fails closed" is not the whole story: if the LF system row *is* installed, a project with no connection of its own does **not** fail — it succeeds, spending on the LF ad account. Only a genuine absence falls back; an unusable or undecryptable row does fail. So the hazard for an unprovisioned project is silent LF spend, not an error.

That credential does not yet exist on dev. It does not block this PR.

## Testing

- `helm template` renders `LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS` as `value: "true"`; the other four remain valueless.
- `prettier --check` and `markdownlint-cli2` both clean (the README table needed re-padding after the Default column widened — caught locally, fixed).
- License headers pass; pre-commit hook ran clean.
- Commit is DCO-signed and GPG-signed; branch rebased on `origin/main`.

Refs LFXV2-3325

