### PR TITLE
feat(charts): persist campaign briefs through campaign-service

### DIFF
--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -194,7 +194,7 @@ changing a value here rather than by shipping a revert.
 | Parameter                                                | Description                                                                                                                         | Required | Default  |
 | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- | -------- | -------- |
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS`          | Serves campaign job status from campaign-service; see the accepted values below                                                     | No       | `"true"` |
-| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS`        | Persists the generated brief in campaign-service instead of only in the browser tab                                                 | No       | off      |
+| `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS`        | Persists the generated brief in campaign-service instead of only in the browser tab                                                 | No       | `"true"` |
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_CREATE`        | Creates campaigns through campaign-service instead of the per-platform Express services                                             | No       | off      |
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN`    | Allows Demand Gen Google campaigns. Requires a campaign-service that understands `googleAdsConfig.channel` (LFXV2-3257) — see below | No       | off      |
 | `environment.LFX_CUTOVER_CAMPAIGN_SERVICE_STATUS_TOGGLE` | Serves campaign pause/resume from campaign-service, which is what makes Google Ads and LinkedIn pausable — see below                | No       | off      |
@@ -205,8 +205,16 @@ every poll is answered by the store that holds it and this flip is inert for job
 **That inertness ends when `..._CREATE` is enabled.** From then on JOBS must be on every pod
 before CREATE, and must stay on until outstanding UUID jobs drain; a pod with JOBS off skips the
 id-shape check entirely and answers a terminal `not_found` for a campaign that is running and
-spending. `..._BRIEFS` and `..._CREATE` stay off and are enabled in later changes, each only once
-the previous has converged — see **Rollout ordering** below, which governs.
+spending. `..._CREATE` stays off and is enabled in a later change, only once `..._BRIEFS` has
+converged on every pod — see **Rollout ordering** below, which governs.
+
+`..._BRIEFS` now defaults to `"true"` as well (step two of three). It must converge **before**
+`..._CREATE` is enabled, and the reason is not symmetry: `createCampaigns` gates on all three
+flags together, so during a mixed rollout a brief save can land on a BRIEFS-off pod and answer
+`enabled: false` with no persisted brief id, while the create that follows lands on a pod where
+all three are on. That create is refused terminally — `createCampaigns` returns
+`enabled: true` with _"its brief has not been saved yet"_ rather than falling through to the
+legacy creator, so the user gets a dead end rather than a working campaign.
 
 One behaviour does change today: with JOBS on, a poll for a UUID job id requires `?project=` and
 is refused with a 400 without it. The LFX One client always sends it, so in-product polling is

--- a/charts/lfx-self-serve/README.md
+++ b/charts/lfx-self-serve/README.md
@@ -208,13 +208,21 @@ id-shape check entirely and answers a terminal `not_found` for a campaign that i
 spending. `..._CREATE` stays off and is enabled in a later change, only once `..._BRIEFS` has
 converged on every pod — see **Rollout ordering** below, which governs.
 
-`..._BRIEFS` now defaults to `"true"` as well (step two of three). It must converge **before**
-`..._CREATE` is enabled, and the reason is not symmetry: `createCampaigns` gates on all three
-flags together, so during a mixed rollout a brief save can land on a BRIEFS-off pod and answer
-`enabled: false` with no persisted brief id, while the create that follows lands on a pod where
-all three are on. That create is refused terminally — `createCampaigns` returns
-`enabled: true` with _"its brief has not been saved yet"_ rather than falling through to the
-legacy creator, so the user gets a dead end rather than a working campaign.
+`..._BRIEFS` now defaults to `"true"` as well. **`..._CREATE` is still off**, so campaign creation
+continues on the legacy path until a later change enables it — the cutover is three flags landed
+one at a time:
+
+```text
+JOBS  →  BRIEFS  →  CREATE
+ done     here      later
+```
+
+`..._BRIEFS` must converge **before** `..._CREATE` is enabled, and the reason is not symmetry:
+`createCampaigns` gates on all three flags together, so during a mixed rollout a brief save can
+land on a BRIEFS-off pod and answer `enabled: false` with no persisted brief id, while the create
+that follows lands on a pod where all three are on. That create is refused terminally —
+`createCampaigns` returns `enabled: true` with _"its brief has not been saved yet"_ rather than
+falling through to the legacy creator, so the user gets a dead end rather than a working campaign.
 
 One behaviour does change today: with JOBS on, a poll for a UUID job id requires `?project=` and
 is refused with a 400 without it. The LFX One client always sends it, so in-product polling is

--- a/charts/lfx-self-serve/values.yaml
+++ b/charts/lfx-self-serve/values.yaml
@@ -420,7 +420,7 @@ environment:
   #
   # Turning it off again leaves the saved briefs in place; they simply stop being offered.
   LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS:
-    value:
+    value: "true"
 
   # Route campaign CREATION to lfx-v2-campaign-service instead of the per-platform Express
   # services. Same accepted values and same default-deny as the two flags above.


### PR DESCRIPTION
> **Gate cleared.** `..._JOBS` (#1879) is merged and converged — verified on all three pods
> (ReplicaSet `f95c587dc`, `LFX_CUTOVER_CAMPAIGN_SERVICE_JOBS=true` on each, 2026-08-27 00:17 UTC).
> Ready to merge.

## What

Enables `LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS` — **step two of four**.

```diff
  LFX_CUTOVER_CAMPAIGN_SERVICE_BRIEFS:
-    value:
+    value: "true"
```

`_CREATE` stays off and follows in a separate change.

## Why this is BRIEFS only

This PR originally enabled `_BRIEFS` **and** `_CREATE` together. Copilot flagged that as unsafe and **it was right** — I verified the mechanism rather than taking the finding's word for it:

- `createCampaigns` gates on all three flags **together** (`campaign-service.service.ts:619-623`).
- During a mixed rollout, a brief save can land on a `_BRIEFS`-off pod, which answers `enabled: false` with **no persisted brief id** (`campaign.controller.ts`, the `CampaignServiceBriefs` guard).
- The create that follows can land on a pod where all three are on. With `briefId === ''`, `createCampaigns` returns `enabled: true` with *"This campaign could not be created because its brief has not been saved yet."*

That is a **terminal refusal**, not a fall-through to the legacy creator. The user gets a dead end rather than a working campaign.

Same class of hazard as the JOBS/CREATE overlap, and it means the cutover is **four steps, not three**:

```
JOBS  →  BRIEFS  →  CREATE
 #1879    this PR    a later change
```

Each lands only after the previous has converged on every pod.

## Prerequisite for the later `_CREATE` change — not this one

campaign-service reads ad credentials from its own **encrypted connection tables**, never from `GADS_*` / `LINKEDIN_*` env vars. Verified against the dev database on 26 Aug: the LF system row for Google Ads is healthy (`system:linuxfoundation`, `active`), but **`tlf` is soft-deleted** — and a disconnect *blocks* the fallback rather than permitting it, so a `tlf` campaign would fail closed. Reconnect before `_CREATE` ships.

## Testing

- `helm template` renders `_JOBS` and `_BRIEFS` as `"true"`; `_CREATE`, `_DEMAND_GEN`, `_STATUS_TOGGLE` remain unset.
- `prettier --check` and `markdownlint-cli2` clean.
- Commit DCO-signed and GPG-signed.

Refs LFXV2-3325

