### PR TITLE
feat(org-profile): ungate the Upload Logo affordance

### DIFF
--- a/apps/lfx-one/e2e/org-profile.spec.ts
+++ b/apps/lfx-one/e2e/org-profile.spec.ts
@@ -16,8 +16,6 @@
  * - `org-lens-enabled` LaunchDarkly flag toggled ON for the test user
  */
 
-// Deep-imported, not from the barrel — the barrel pulls in Angular-dependent modules that fail to
-// load outside the app (same trap as org-roi.helper.ts).
 import type { CascadingRoleGrant } from '@lfx-one/shared/interfaces';
 import { expect, Page, test } from '@playwright/test';
 

--- a/apps/lfx-one/e2e/org-profile.spec.ts
+++ b/apps/lfx-one/e2e/org-profile.spec.ts
@@ -18,7 +18,6 @@
 
 // Deep-imported, not from the barrel — the barrel pulls in Angular-dependent modules that fail to
 // load outside the app (same trap as org-roi.helper.ts).
-import { FEATURE_FLAG_OVERRIDE_STORAGE_KEY, ORG_LENS_PRIVATE_RELEASE_FLAG } from '@lfx-one/shared/constants/feature-flags.constants';
 import type { CascadingRoleGrant } from '@lfx-one/shared/interfaces';
 import { expect, Page, test } from '@playwright/test';
 
@@ -189,19 +188,6 @@ async function stubCanonicalAndAddresses(page: Page, canonicalStatus: number = 2
 async function gotoProfileWithStubs(page: Page, writers: string[]): Promise<void> {
   await stubOrgProfileContext(page, { writers });
   await stubCanonicalAndAddresses(page);
-
-  // LFXV2-3288 / PR #1583 — pin `org_lens_private_release` for the whole suite. The Company Logo
-  // Upload affordance (button + hidden file input, S7/S8's target) sits behind this flag via the
-  // `isOrgLensUploadLogoEnabled` wrapper; the SDK evaluates against an anonymous context first, so
-  // without a pin the input never mounts and `setInputFiles` times out. Mirrors the pattern in
-  // `helpers/org-roi.helper.ts:stubFeatureFlags` (same FEATURE_FLAG_OVERRIDE_STORAGE_KEY contract),
-  // inlined here to avoid pulling in the ROI helper file just for one call. Pinned at the shared
-  // helper because the flag governs an edit-view element every writer-scoped scenario touches — a
-  // per-S7/S8 opt-in would leave the flag off in S3 the moment we extend that test to click Upload.
-  await page.addInitScript(([key, value]) => window.localStorage.setItem(key as string, value as string), [
-    FEATURE_FLAG_OVERRIDE_STORAGE_KEY,
-    JSON.stringify({ [ORG_LENS_PRIVATE_RELEASE_FLAG]: true }),
-  ] as const);
 
   // Install stubs before reload so client-side persona + role-grant fetches are intercepted (mirrors org-selector S9).
   await suppressCookieBanner(page);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -35,10 +35,10 @@
         (drop)="onLogoDrop($event)"
         data-testid="org-profile-edit-logo-dropzone">
         @if (logoUrl()) {
-          <img [src]="logoUrl()" [alt]="record().name + ' logo'" class="h-20 w-20 rounded-md object-contain" data-testid="org-profile-edit-logo-image" />
+          <img [src]="logoUrl()" [alt]="record().name + ' logo'" class="h-full w-full rounded-md object-contain" data-testid="org-profile-edit-logo-image" />
         } @else {
           <div
-            class="flex h-20 w-20 items-center justify-center rounded-md bg-blue-600 text-xl font-semibold text-white"
+            class="flex h-full w-full items-center justify-center rounded-md bg-blue-600 text-xl font-semibold text-white"
             data-testid="org-profile-edit-logo-initials">
             {{ (record().name | initials) || 'OR' }}
           </div>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -67,7 +67,7 @@
           [loading]="logoUploading()"
           (onClick)="triggerLogoUpload()"
           data-testid="org-profile-edit-upload-logo-button" />
-        <p class="text-xs text-gray-500">PNG, JPEG, or SVG, not more than 2MB.</p>
+        <p class="text-xs text-gray-500">PNG, JPEG, or SVG, not more than 2MB. SVGs are sanitized, so scripts and embedded styles are removed.</p>
       </div>
     </header>
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -44,10 +44,16 @@
           </div>
         }
         @if (logoUploading()) {
-          <div class="absolute inset-0 flex items-center justify-center rounded-md bg-black/40" role="status" aria-live="polite">
-            <i class="fa-light fa-spinner fa-spin text-white" aria-hidden="true"></i>
-            <span class="sr-only">Uploading logo…</span>
+          <div class="absolute inset-0 flex items-center justify-center rounded-md bg-black/40" aria-hidden="true">
+            <i class="fa-light fa-spinner fa-spin text-white"></i>
           </div>
+        }
+      </div>
+      <!-- Outside the dropzone on purpose: an element with role="button" flattens its descendants
+           in the accessibility tree, so a live region nested inside it is not reliably announced. -->
+      <div role="status" aria-live="polite" class="sr-only">
+        @if (logoUploading()) {
+          Uploading logo…
         }
       </div>
       <input

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -67,7 +67,7 @@
           [loading]="logoUploading()"
           (onClick)="triggerLogoUpload()"
           data-testid="org-profile-edit-upload-logo-button" />
-        <p class="text-xs text-gray-500">PNG, JPEG, or SVG, not more than 2MB. SVGs are sanitized, so scripts and embedded styles are removed.</p>
+        <p class="text-xs text-gray-500">PNG, JPEG, or SVG, not more than 2MB. SVGs are sanitized; those using unsupported CSS may be rejected.</p>
       </div>
     </header>
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.html
@@ -17,25 +17,16 @@
   </nav>
 
   <div class="rounded-lg border border-gray-200 bg-white p-6">
-    <!-- Logo + Upload Logo button (LFXV2-3288). Drop zone doubles as the preview; click or drag-drop a file.
-         The Upload Logo affordance (button, instruction copy, hidden file input) and every interactive
-         class/handler on the dropzone are gated behind the per-feature `isOrgLensUploadLogoEnabled`
-         wrapper (PR #1583) — today it just reads `org_lens_private_release`, but the wrapper lets
-         logo upload flip independently of other Org Lens surfaces later. When the flag is off, this
-         collapses to a static preview: no cursor-pointer, no dashed border, no click/drag surface,
-         no file picker — matching the read-only view most Org Lens users get today. -->
+    <!-- Logo + Upload Logo button (LFXV2-3288). Drop zone doubles as the preview; click or drag-drop a file. -->
     <header class="flex items-center gap-4 border-b border-gray-100 pb-4">
       <div
-        class="relative flex h-20 w-20 shrink-0 items-center justify-center rounded-md"
-        [class.cursor-pointer]="isOrgLensUploadLogoEnabled()"
-        [class.border-2]="isOrgLensUploadLogoEnabled()"
-        [class.border-dashed]="isOrgLensUploadLogoEnabled()"
-        [class.border-blue-500]="isOrgLensUploadLogoEnabled() && logoDragActive()"
-        [class.border-transparent]="isOrgLensUploadLogoEnabled() && !logoDragActive()"
-        [attr.role]="isOrgLensUploadLogoEnabled() ? 'button' : null"
-        [attr.tabindex]="isOrgLensUploadLogoEnabled() ? 0 : null"
-        [attr.aria-label]="isOrgLensUploadLogoEnabled() ? 'Upload organization logo' : null"
-        [attr.aria-disabled]="isOrgLensUploadLogoEnabled() ? busy() : null"
+        class="relative flex h-20 w-20 shrink-0 cursor-pointer items-center justify-center rounded-md border-2 border-dashed"
+        [class.border-blue-500]="logoDragActive()"
+        [class.border-transparent]="!logoDragActive()"
+        role="button"
+        tabindex="0"
+        aria-label="Upload organization logo"
+        [attr.aria-disabled]="busy()"
         (click)="triggerLogoUpload()"
         (keydown.enter)="$event.preventDefault(); triggerLogoUpload()"
         (keydown.space)="$event.preventDefault(); triggerLogoUpload()"
@@ -59,27 +50,25 @@
           </div>
         }
       </div>
-      @if (isOrgLensUploadLogoEnabled()) {
-        <input
-          #logoInput
-          type="file"
-          [attr.accept]="allowedLogoAccept"
-          class="hidden"
+      <input
+        #logoInput
+        type="file"
+        [attr.accept]="allowedLogoAccept"
+        class="hidden"
+        [disabled]="busy()"
+        (change)="onLogoFileSelected($event)"
+        data-testid="org-profile-edit-logo-input" />
+      <div class="flex flex-col gap-1">
+        <p-button
+          [label]="logoUploading() ? 'Uploading…' : 'Upload Logo'"
+          severity="secondary"
+          [outlined]="true"
           [disabled]="busy()"
-          (change)="onLogoFileSelected($event)"
-          data-testid="org-profile-edit-logo-input" />
-        <div class="flex flex-col gap-1">
-          <p-button
-            [label]="logoUploading() ? 'Uploading…' : 'Upload Logo'"
-            severity="secondary"
-            [outlined]="true"
-            [disabled]="busy()"
-            [loading]="logoUploading()"
-            (onClick)="triggerLogoUpload()"
-            data-testid="org-profile-edit-upload-logo-button" />
-          <p class="text-xs text-gray-500">PNG, JPEG, or SVG, not more than 2MB.</p>
-        </div>
-      }
+          [loading]="logoUploading()"
+          (onClick)="triggerLogoUpload()"
+          data-testid="org-profile-edit-upload-logo-button" />
+        <p class="text-xs text-gray-500">PNG, JPEG, or SVG, not more than 2MB.</p>
+      </div>
     </header>
 
     <form [formGroup]="form" (ngSubmit)="onSave()" class="mt-6 flex flex-col gap-6" data-testid="org-profile-edit-form">

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
@@ -334,4 +334,53 @@ describe('OrgProfileEditComponent — logo upload', () => {
     fixture.componentInstance['triggerLogoUpload']();
     expect(clickSpy).toHaveBeenCalledTimes(1);
   });
+
+  it.each([
+    [413, 'Logo too large', 'Logo must be 2MB or smaller.'],
+    [403, 'Permission denied', 'You no longer have permission to edit this organization.'],
+  ])('maps status %i to non-retryable copy', async (status, summary, detail) => {
+    fixture.detectChanges();
+    fixture.componentInstance['onLogoFileSelected']({
+      target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
+    } as unknown as Event);
+    await fixture.whenStable();
+
+    uploadLogo$.error(new HttpErrorResponse({ status }));
+    await fixture.whenStable();
+
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary, detail }));
+  });
+
+  it('surfaces the upstream reason when the sanitizer rejects an SVG', async () => {
+    fixture.detectChanges();
+    fixture.componentInstance['onLogoFileSelected']({
+      target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
+    } as unknown as Event);
+    await fixture.whenStable();
+
+    // A permanently-rejected file must not be described as retryable — the same bytes fail forever.
+    uploadLogo$.error(new HttpErrorResponse({ status: 400, error: { message: 'SVG upload cannot be processed: unsupported CSS selector "rect"' } }));
+    await fixture.whenStable();
+
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({
+        summary: 'Logo rejected',
+        detail: 'SVG upload cannot be processed: unsupported CSS selector "rect"',
+      })
+    );
+    expect(toastAdd).not.toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining('Please try again') }));
+  });
+
+  it('still prompts a retry for a server-side failure', async () => {
+    fixture.detectChanges();
+    fixture.componentInstance['onLogoFileSelected']({
+      target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
+    } as unknown as Event);
+    await fixture.whenStable();
+
+    uploadLogo$.error(new HttpErrorResponse({ status: 502 }));
+    await fixture.whenStable();
+
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Upload failed', detail: 'Unable to upload logo. Please try again.' }));
+  });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
@@ -304,4 +304,34 @@ describe('OrgProfileEditComponent — logo upload', () => {
     fixture.componentInstance['onCancel']();
     expect(cancelled).toEqual([undefined]);
   });
+
+  it('renders the Upload Logo button, the hidden file input and the logo image', () => {
+    fixture.detectChanges();
+    const root: HTMLElement = fixture.nativeElement;
+
+    expect(root.querySelector('[data-testid="org-profile-edit-upload-logo-button"]')).not.toBeNull();
+    expect(root.querySelector('[data-testid="org-profile-edit-logo-input"]')).not.toBeNull();
+    expect(root.querySelector('[data-testid="org-profile-edit-logo-image"]')).not.toBeNull();
+  });
+
+  it('does not reopen the file picker while an upload is already in flight', async () => {
+    fixture.detectChanges();
+    const clickSpy = vi.spyOn(fixture.componentInstance['logoInput']()!.nativeElement, 'click');
+
+    fixture.componentInstance['onLogoFileSelected']({
+      target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
+    } as unknown as Event);
+    await fixture.whenStable();
+    clickSpy.mockClear();
+
+    // busy() is true while uploadLogo is pending, so the trigger must be inert.
+    fixture.componentInstance['triggerLogoUpload']();
+    expect(clickSpy).not.toHaveBeenCalled();
+
+    uploadLogo$.next({ ...record, logoUrl: 'https://cdn.example.com/logo.png?v=3' });
+    await fixture.whenStable();
+
+    fixture.componentInstance['triggerLogoUpload']();
+    expect(clickSpy).toHaveBeenCalledTimes(1);
+  });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
@@ -1,13 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
-import { ORG_LENS_PRIVATE_RELEASE_FLAG } from '@lfx-one/shared/constants';
 import type { OrgCanonicalRecord } from '@lfx-one/shared/interfaces';
-import { FeatureFlagService } from '@services/feature-flag.service';
 import { OrgProfileService } from '@services/org-profile.service';
 import { MessageService } from 'primeng/api';
 import { Observable, Subject, take } from 'rxjs';
@@ -59,18 +56,7 @@ describe('OrgProfileEditComponent — logo upload', () => {
 
     await TestBed.configureTestingModule({
       imports: [OrgProfileEditComponent],
-      providers: [
-        provideNoopAnimations(),
-        { provide: OrgProfileService, useValue: { uploadLogo: uploadLogoMock } },
-        // PR #1583 — gate the Upload Logo affordance on `org_lens_private_release`. Default the
-        // flag to `true` in this suite because every existing test exercises the upload path; the
-        // dedicated "flag disabled" describe below re-configures TestBed with the same mock
-        // returning `false` for the gating test.
-        {
-          provide: FeatureFlagService,
-          useValue: { getBooleanFlag: vi.fn((key: string) => signal(key === ORG_LENS_PRIVATE_RELEASE_FLAG ? true : false)) },
-        },
-      ],
+      providers: [provideNoopAnimations(), { provide: OrgProfileService, useValue: { uploadLogo: uploadLogoMock } }],
     }).compileComponents();
 
     fixture = TestBed.createComponent(OrgProfileEditComponent);
@@ -317,71 +303,5 @@ describe('OrgProfileEditComponent — logo upload', () => {
 
     fixture.componentInstance['onCancel']();
     expect(cancelled).toEqual([undefined]);
-  });
-
-  /**
-   * PR #1583 — Company Logo Upload is gated on the per-feature wrapper `isOrgLensUploadLogoEnabled`,
-   * which today reads `org_lens_private_release` but is expected to graduate to its own key later.
-   * Assertions target the wrapper (the API surface the template and handlers consume), not the raw
-   * private flag reader — that way this suite still passes when the underlying key gets swapped.
-   * When the wrapper is on the Upload Logo button and hidden file input render and the dropzone
-   * accepts drops; when it's off the whole affordance collapses to a static preview so a general
-   * Org Lens viewer only sees the logo, not the write path.
-   */
-  describe('isOrgLensUploadLogoEnabled wrapper gating', () => {
-    it('renders the Upload Logo button and hidden file input when the wrapper is enabled (default suite mock)', () => {
-      fixture.detectChanges();
-      const root: HTMLElement = fixture.nativeElement;
-
-      expect(fixture.componentInstance['isOrgLensUploadLogoEnabled']()).toBe(true);
-      expect(root.querySelector('[data-testid="org-profile-edit-upload-logo-button"]')).not.toBeNull();
-      expect(root.querySelector('[data-testid="org-profile-edit-logo-input"]')).not.toBeNull();
-    });
-
-    it('hides the Upload Logo button and file input and neutralizes drop-handling when the wrapper is disabled', async () => {
-      // Fresh TestBed with the SAME mock shape but returning `false` for the gating flag — mirrors
-      // the pattern in weekly-brief-card.component.spec.ts's flag-off block.
-      TestBed.resetTestingModule();
-      await TestBed.configureTestingModule({
-        imports: [OrgProfileEditComponent],
-        providers: [
-          provideNoopAnimations(),
-          { provide: OrgProfileService, useValue: { uploadLogo: uploadLogoMock } },
-          {
-            provide: FeatureFlagService,
-            useValue: { getBooleanFlag: vi.fn((key: string) => signal(key === ORG_LENS_PRIVATE_RELEASE_FLAG ? false : false)) },
-          },
-        ],
-      }).compileComponents();
-
-      const disabledFixture = TestBed.createComponent(OrgProfileEditComponent);
-      disabledFixture.componentRef.setInput('record', record);
-      await disabledFixture.whenStable();
-      disabledFixture.detectChanges();
-      const root: HTMLElement = disabledFixture.nativeElement;
-
-      expect(disabledFixture.componentInstance['isOrgLensUploadLogoEnabled']()).toBe(false);
-      expect(root.querySelector('[data-testid="org-profile-edit-upload-logo-button"]')).toBeNull();
-      expect(root.querySelector('[data-testid="org-profile-edit-logo-input"]')).toBeNull();
-
-      // The static-preview shell still renders the logo image itself so read-only viewers keep the
-      // context; only the write affordance is stripped.
-      expect(root.querySelector('[data-testid="org-profile-edit-logo-image"]')).not.toBeNull();
-
-      // Defense-in-depth: even if a synthetic drop / click / file-select reaches the handlers, the
-      // component-level gate must not call through to the service.
-      uploadLogoMock.mockClear();
-      const file = pngFile();
-      disabledFixture.componentInstance['onLogoDrop']({
-        preventDefault: vi.fn(),
-        dataTransfer: { files: [file] } as unknown as DataTransfer,
-      } as unknown as DragEvent);
-      disabledFixture.componentInstance['triggerLogoUpload']();
-      const input = { files: [file], value: 'logo.png' } as unknown as HTMLInputElement;
-      disabledFixture.componentInstance['onLogoFileSelected']({ target: input } as unknown as Event);
-      await disabledFixture.whenStable();
-
-      expect(uploadLogoMock).not.toHaveBeenCalled();
-    });
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
@@ -81,7 +81,11 @@ describe('OrgProfileEditComponent — logo upload', () => {
     await fixture.whenStable();
 
     expect(uploadLogoMock).not.toHaveBeenCalled();
-    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Please choose a PNG, JPEG, or SVG image.' }));
+    // Summary matches the server-side wording for the same condition (415 -> 'Logo rejected'), so
+    // the user sees one voice whichever side catches it.
+    expect(toastAdd).toHaveBeenCalledWith(
+      expect.objectContaining({ severity: 'error', summary: 'Logo rejected', detail: 'Please choose a PNG, JPEG, or SVG image.' })
+    );
   });
 
   it('accepts an SVG file and calls the service', async () => {
@@ -98,7 +102,8 @@ describe('OrgProfileEditComponent — logo upload', () => {
     await fixture.whenStable();
 
     expect(uploadLogoMock).not.toHaveBeenCalled();
-    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Logo must be 2MB or smaller.' }));
+    // Same wording as the server-side 413 branch for the identical condition.
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', summary: 'Logo too large', detail: 'Logo must be 2MB or smaller.' }));
   });
 
   it('clears the file input value so re-selecting the same file still fires change', () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
@@ -167,16 +167,21 @@ describe('OrgProfileEditComponent — logo upload', () => {
     expect(status).not.toBeNull();
     expect(status?.getAttribute('aria-live')).toBe('polite');
     expect(status?.textContent).toContain('Uploading logo');
+    // The live region must sit outside the dropzone: an element with role="button" flattens its
+    // descendants in the accessibility tree, so a nested region is not reliably announced.
+    expect(root.querySelector('[data-testid="org-profile-edit-logo-dropzone"] [role="status"]')).toBeNull();
     // The spinner glyph carries no meaning of its own — it must not be read out alongside the copy.
-    expect(status?.querySelector('i')?.getAttribute('aria-hidden')).toBe('true');
+    expect(root.querySelector('[data-testid="org-profile-edit-logo-dropzone"] i')?.closest('[aria-hidden="true"]')).not.toBeNull();
     expect(root.querySelector('[data-testid="org-profile-edit-upload-logo-button"]')?.textContent).toContain('Uploading');
 
     uploadLogo$.next({ ...record, logoUrl: 'https://cdn.example.com/logo.png?v=2' });
     await fixture.whenStable();
     fixture.detectChanges();
 
-    // Region is removed once settled, so the next upload re-inserts it and is announced afresh.
-    expect(root.querySelector('[role="status"]')).toBeNull();
+    // The region itself persists — a live region has to be in the DOM before its content changes to
+    // be announced reliably — so it is the text that clears, and the next upload refills it.
+    expect(root.querySelector('[role="status"]')).not.toBeNull();
+    expect(root.querySelector('[role="status"]')?.textContent?.trim()).toBe('');
     expect(root.querySelector('[data-testid="org-profile-edit-upload-logo-button"]')?.textContent).toContain('Upload Logo');
   });
 
@@ -381,17 +386,40 @@ describe('OrgProfileEditComponent — logo upload', () => {
     expect(toastAdd).not.toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining('Please try again') }));
   });
 
-  it('falls back to generic guidance when a rejection carries no usable reason', async () => {
+  it('falls back to actionable guidance when a rejection carries no usable reason', async () => {
     fixture.detectChanges();
     fixture.componentInstance['onLogoFileSelected']({
       target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
     } as unknown as Event);
     await fixture.whenStable();
 
+    // Angular synthesizes a non-empty `error.message` ("Http failure response for …"), which must
+    // not reach the toast — the user needs guidance, not an HTTP debugging string.
     uploadLogo$.error(new HttpErrorResponse({ status: 415 }));
     await fixture.whenStable();
 
-    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Logo rejected' }));
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Logo rejected', detail: 'This image could not be used. Try a different file.' }));
+    expect(toastAdd).not.toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining('Http failure response') }));
+  });
+
+  // The BFF gives these their own actionable copy, so routing them through the rejection branch
+  // would print a summary that contradicts the detail and send the user off to swap a file that
+  // was never at fault (org-identity.controller.ts).
+  it.each([
+    [409, 'This organization was updated elsewhere. Refresh the page and try again.'],
+    [404, 'Organization not found'],
+  ])('does not label status %i as a rejected logo', async (status, serverMessage) => {
+    fixture.detectChanges();
+    fixture.componentInstance['onLogoFileSelected']({
+      target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
+    } as unknown as Event);
+    await fixture.whenStable();
+
+    uploadLogo$.error(new HttpErrorResponse({ status, error: { error: serverMessage } }));
+    await fixture.whenStable();
+
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Upload failed', detail: serverMessage }));
+    expect(toastAdd).not.toHaveBeenCalledWith(expect.objectContaining({ summary: 'Logo rejected' }));
   });
 
   it.each([[408], [429], [0]])('keeps the retry prompt for transient status %i', async (status) => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.spec.ts
@@ -351,24 +351,62 @@ describe('OrgProfileEditComponent — logo upload', () => {
     expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary, detail }));
   });
 
-  it('surfaces the upstream reason when the sanitizer rejects an SVG', async () => {
+  // The BFF serialises errors as `{ error, code, ... }` (BaseApiError.toResponse) and
+  // ServiceValidationError adds `errors[]` — there is no top-level `message` key, so these
+  // fixtures mirror the real contract rather than a convenient one.
+  it.each([
+    ['top-level error string', { error: 'SVG upload cannot be processed: unsupported CSS selector "rect"', code: 'VALIDATION_ERROR' }],
+    [
+      'field-level validation detail',
+      {
+        error: 'Validation failed for body',
+        code: 'VALIDATION_ERROR',
+        errors: [{ field: 'body', message: 'SVG upload cannot be processed: unsupported CSS property "d"' }],
+      },
+    ],
+    ['plain string body', 'SVG upload cannot be processed: unterminated rule'],
+  ])('surfaces the upstream reason (%s) when the sanitizer rejects an SVG', async (_label, body) => {
     fixture.detectChanges();
     fixture.componentInstance['onLogoFileSelected']({
       target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
     } as unknown as Event);
     await fixture.whenStable();
 
-    // A permanently-rejected file must not be described as retryable — the same bytes fail forever.
-    uploadLogo$.error(new HttpErrorResponse({ status: 400, error: { message: 'SVG upload cannot be processed: unsupported CSS selector "rect"' } }));
+    uploadLogo$.error(new HttpErrorResponse({ status: 400, error: body }));
     await fixture.whenStable();
 
     expect(toastAdd).toHaveBeenCalledWith(
-      expect.objectContaining({
-        summary: 'Logo rejected',
-        detail: 'SVG upload cannot be processed: unsupported CSS selector "rect"',
-      })
+      expect.objectContaining({ summary: 'Logo rejected', detail: expect.stringContaining('SVG upload cannot be processed') })
     );
     expect(toastAdd).not.toHaveBeenCalledWith(expect.objectContaining({ detail: expect.stringContaining('Please try again') }));
+  });
+
+  it('falls back to generic guidance when a rejection carries no usable reason', async () => {
+    fixture.detectChanges();
+    fixture.componentInstance['onLogoFileSelected']({
+      target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
+    } as unknown as Event);
+    await fixture.whenStable();
+
+    uploadLogo$.error(new HttpErrorResponse({ status: 415 }));
+    await fixture.whenStable();
+
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Logo rejected' }));
+  });
+
+  it.each([[408], [429], [0]])('keeps the retry prompt for transient status %i', async (status) => {
+    fixture.detectChanges();
+    fixture.componentInstance['onLogoFileSelected']({
+      target: { files: [pngFile()], value: 'logo.png' } as unknown as HTMLInputElement,
+    } as unknown as Event);
+    await fixture.whenStable();
+
+    // 408 and 429 are 4xx but retryable — this server mints 408 for its own upstream abort, so
+    // labelling either "Logo rejected" would tell the user a fine file is permanently broken.
+    uploadLogo$.error(new HttpErrorResponse({ status }));
+    await fixture.whenStable();
+
+    expect(toastAdd).toHaveBeenCalledWith(expect.objectContaining({ summary: 'Upload failed', detail: 'Unable to upload logo. Please try again.' }));
   });
 
   it('still prompts a retry for a server-side failure', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -162,9 +162,9 @@ export class OrgProfileEditComponent implements OnInit {
 
   /** Open the OS file picker via the hidden input — keeps the trigger a real, keyboard-operable `<button>`. */
   protected triggerLogoUpload(): void {
-    // Defense-in-depth: template already hides the Upload Logo button and the hidden file input
-    // when the flag is off (PR #1583). Guarding here too closes the imperative call path — a
-    // synthetic click or `@ViewChild` grabbed from a leftover reference cannot bypass the gate.
+    // Re-entrancy guard, not an access gate: a change event queued from a picker opened before
+    // Save can otherwise start a second upload mid-flight. Authorization lives upstream — the edit
+    // view is only instantiated when OrgProfileComponent.canEdit() passes.
     if (this.busy()) return;
     this.logoInput()?.nativeElement.click();
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -8,6 +8,7 @@ import { FormBuilder, FormGroup, ReactiveFormsModule, Validators } from '@angula
 import {
   ALLOWED_ORG_LOGO_MIME_TYPES,
   INDUSTRY_OPTIONS,
+  LOGO_REJECTION_STATUSES,
   MAX_ORG_LOGO_DIMENSION_PX,
   MAX_ORG_LOGO_SIZE_BYTES,
   MIN_ORG_LOGO_DIMENSION_PX,
@@ -16,7 +17,7 @@ import {
 } from '@lfx-one/shared/constants';
 import type { OrgCanonicalRecord, OrgProfileEditableFields, OrgUpdateRequest } from '@lfx-one/shared/interfaces';
 import { httpsUrlValidator } from '@lfx-one/shared/validators';
-import { extractErrorMessage, isTransientHttpError } from '@shared/utils/http-error.utils';
+import { extractErrorMessage } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -313,14 +314,17 @@ export class OrgProfileEditComponent implements OnInit {
   }
 
   /**
-   * Error copy for the logo upload, split by whether retrying can plausibly help.
+   * Error copy for the logo upload, split by whether the file itself is the problem.
    *
-   * The sanitizer upstream rejects an SVG it cannot reproduce faithfully — an unsupported selector,
-   * an @media block, an unknown vendor prefix — and returns the reason on a 4xx. Telling the user to
-   * try again there is actively wrong: the same file fails every time. Those surface the upstream
-   * reason instead. Transient statuses are excluded first via `isTransientHttpError`, so a timeout
-   * (408, which this server mints for its own upstream abort) or a rate limit (429) still reads as
-   * retryable rather than as a permanently rejected file.
+   * Only the statuses that mean "this image cannot be used" get the rejection wording — the
+   * sanitizer upstream refuses an SVG it cannot reproduce faithfully and returns the reason on a
+   * 400, and 415/422 carry the same meaning. Telling the user to retry there is wrong, since the
+   * same bytes fail every time.
+   *
+   * Everything else keeps its own voice. The BFF maps an If-Match miss to 409 and a missing org to
+   * 404 with their own actionable copy, so routing those through the rejection branch would print
+   * "Logo rejected — This organization was updated elsewhere", where the summary contradicts the
+   * detail and sends the user off to swap a file that was never at fault.
    */
   private toastForLogoError(error: unknown): { severity: string; summary: string; detail: string; life: number } {
     const status = error instanceof HttpErrorResponse ? error.status : 0;
@@ -330,15 +334,44 @@ export class OrgProfileEditComponent implements OnInit {
     if (status === 413) {
       return { severity: 'error', summary: 'Logo too large', detail: 'Logo must be 2MB or smaller.', life: 5000 };
     }
-    if (!isTransientHttpError(error) && status >= 400 && status < 500) {
+    if (LOGO_REJECTION_STATUSES.includes(status)) {
       return {
         severity: 'error',
         summary: 'Logo rejected',
-        detail: extractErrorMessage(error, 'This image could not be used. Try a different file.'),
+        detail: this.logoErrorDetail(error, 'This image could not be used. Try a different file.'),
         life: 8000,
       };
     }
+    if (status === 404 || status === 409) {
+      return { severity: 'error', summary: 'Upload failed', detail: this.logoErrorDetail(error, 'Unable to upload logo. Please try again.'), life: 5000 };
+    }
     return { severity: 'error', summary: 'Upload failed', detail: 'Unable to upload logo. Please try again.', life: 5000 };
+  }
+
+  /**
+   * Server-authored reason for a failed upload, or the caller's fallback.
+   *
+   * `extractErrorMessage` ends with `error.message || fallback`, and Angular always synthesizes a
+   * non-empty `error.message` ("Http failure response for …"), so its fallback is unreachable for a
+   * body-less response. Checking for a server-authored body first keeps that HTTP debugging string
+   * out of the toast.
+   */
+  private logoErrorDetail(error: unknown, fallback: string): string {
+    return this.hasServerMessage(error) ? extractErrorMessage(error, fallback) : fallback;
+  }
+
+  /** Whether the response body carries a message the server wrote, in any shape the BFF emits. */
+  private hasServerMessage(error: unknown): boolean {
+    const body = error instanceof HttpErrorResponse ? error.error : null;
+    if (typeof body === 'string') return body.trim().length > 0;
+    if (!body || typeof body !== 'object') return false;
+
+    const { message, error: errorText, errors } = body as { message?: unknown; error?: unknown; errors?: unknown };
+    const hasTopLevel = [message, errorText].some((value) => typeof value === 'string' && value.trim().length > 0);
+    const hasFieldDetail =
+      Array.isArray(errors) &&
+      errors.some((entry) => typeof (entry as { message?: unknown })?.message === 'string' && (entry as { message: string }).message.trim().length > 0);
+    return hasTopLevel || hasFieldDetail;
   }
 
   private refreshFieldFlags(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -248,11 +248,11 @@ export class OrgProfileEditComponent implements OnInit {
 
   private handleLogoFile(file: File): void {
     if (!(ALLOWED_ORG_LOGO_MIME_TYPES as readonly string[]).includes(file.type)) {
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Please choose a PNG, JPEG, or SVG image.' });
+      this.messageService.add({ severity: 'error', summary: 'Logo rejected', detail: 'Please choose a PNG, JPEG, or SVG image.' });
       return;
     }
     if (file.size > MAX_ORG_LOGO_SIZE_BYTES) {
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: 'Logo must be 2MB or smaller.' });
+      this.messageService.add({ severity: 'error', summary: 'Logo too large', detail: 'Logo must be 2MB or smaller.' });
       return;
     }
 

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -12,7 +12,6 @@ import {
   MAX_ORG_LOGO_SIZE_BYTES,
   MIN_ORG_LOGO_DIMENSION_PX,
   ORG_DESCRIPTION_MAX_LENGTH,
-  ORG_LENS_PRIVATE_RELEASE_FLAG,
   SECTOR_OPTIONS,
 } from '@lfx-one/shared/constants';
 import type { OrgCanonicalRecord, OrgProfileEditableFields, OrgUpdateRequest } from '@lfx-one/shared/interfaces';
@@ -28,7 +27,6 @@ import { TooltipModule } from 'primeng/tooltip';
 import { finalize } from 'rxjs';
 
 import { InitialsPipe } from '@pipes/initials.pipe';
-import { FeatureFlagService } from '@services/feature-flag.service';
 import { OrgProfileService } from '@services/org-profile.service';
 import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 
@@ -65,7 +63,6 @@ export class OrgProfileEditComponent implements OnInit {
   private readonly orgProfileService = inject(OrgProfileService);
   private readonly messageService = inject(MessageService);
   private readonly destroyRef = inject(DestroyRef);
-  private readonly featureFlagService = inject(FeatureFlagService);
 
   /** Source record loaded on the read-only view; reused here to avoid re-fetching (research R4). */
   public readonly record = input.required<OrgCanonicalRecord>();
@@ -91,26 +88,6 @@ export class OrgProfileEditComponent implements OnInit {
   protected readonly logoDragActive = signal(false);
   /** Overrides `record().logoUrl` after a successful upload so the preview updates without waiting on the parent's own record refresh. */
   protected readonly logoUrl = signal<string | null>(null);
-
-  /**
-   * Raw read of the umbrella Org Lens private-release gate. Kept private on purpose: many Org Lens
-   * surfaces are rolling out under this same flag, but each one is expected to expose its own
-   * per-feature wrapper (below) so a later split — swapping the umbrella flag for a dedicated
-   * child flag, or ANDing on an additional entitlement — is a single-line change here instead of
-   * a template/handler sweep.
-   */
-  private readonly isOrgLensPrivateReleaseEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_PRIVATE_RELEASE_FLAG, false);
-
-  /**
-   * Per-feature gate for the Company Logo Upload affordance (PR #1583). Today it just wraps the
-   * umbrella `org_lens_private_release` flag; the wrapper exists so logo upload can be flipped
-   * independently later (e.g. graduating to its own LaunchDarkly key, or ANDing on a member-service
-   * writer entitlement) without touching every template binding or handler guard downstream. When
-   * false, the logo area renders as a static preview only — no Upload Logo button, no dropzone
-   * click / drag handling, no file input. Existing logos remain visible so read-only viewers still
-   * get context. Defaults false so a mis-provisioned SDK never leaks the upload path.
-   */
-  protected readonly isOrgLensUploadLogoEnabled = computed(() => this.isOrgLensPrivateReleaseEnabled());
 
   /** Per-field touched-and-invalid flags — keep `form.get(...)` out of the template (CLAUDE.md "No functions in HTML templates"). */
   protected readonly descriptionInvalid = signal(false);
@@ -188,7 +165,7 @@ export class OrgProfileEditComponent implements OnInit {
     // Defense-in-depth: template already hides the Upload Logo button and the hidden file input
     // when the flag is off (PR #1583). Guarding here too closes the imperative call path — a
     // synthetic click or `@ViewChild` grabbed from a leftover reference cannot bypass the gate.
-    if (this.busy() || !this.isOrgLensUploadLogoEnabled()) return;
+    if (this.busy()) return;
     this.logoInput()?.nativeElement.click();
   }
 
@@ -197,13 +174,13 @@ export class OrgProfileEditComponent implements OnInit {
     const file = input.files?.[0];
     // Clear the input so re-selecting the same file (e.g. after a rejected upload) still fires change.
     input.value = '';
-    if (this.busy() || !this.isOrgLensUploadLogoEnabled()) return;
+    if (this.busy()) return;
     if (file) this.handleLogoFile(file);
   }
 
   protected onLogoDragOver(event: DragEvent): void {
     event.preventDefault();
-    if (!this.busy() && this.isOrgLensUploadLogoEnabled()) this.logoDragActive.set(true);
+    if (!this.busy()) this.logoDragActive.set(true);
   }
 
   protected onLogoDragLeave(event: DragEvent): void {
@@ -214,7 +191,7 @@ export class OrgProfileEditComponent implements OnInit {
   protected onLogoDrop(event: DragEvent): void {
     event.preventDefault();
     this.logoDragActive.set(false);
-    if (this.busy() || !this.isOrgLensUploadLogoEnabled()) return;
+    if (this.busy()) return;
     const file = event.dataTransfer?.files?.[0];
     if (file) this.handleLogoFile(file);
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -312,12 +312,33 @@ export class OrgProfileEditComponent implements OnInit {
   }
 
   /** FR-010-equivalent for the logo upload — mirrors toastForError's status mapping with upload-specific copy. */
+  /**
+   * Error copy for the logo upload, split by whether retrying can plausibly help.
+   *
+   * The sanitizer upstream rejects an SVG it cannot reproduce faithfully — an unsupported selector,
+   * an @media block, an unknown vendor prefix — and returns the reason on a 4xx. Telling the user to
+   * try again there is actively wrong: the same file fails every time. Those surface the upstream
+   * reason instead, and only transport/server failures keep the retry prompt.
+   */
   private toastForLogoError(error: unknown): { severity: string; summary: string; detail: string; life: number } {
     const status = error instanceof HttpErrorResponse ? error.status : 0;
     if (status === 403) {
       return { severity: 'error', summary: 'Permission denied', detail: 'You no longer have permission to edit this organization.', life: 5000 };
     }
+    if (status === 413) {
+      return { severity: 'error', summary: 'Logo too large', detail: 'Logo must be 2MB or smaller.', life: 5000 };
+    }
+    if (status >= 400 && status < 500) {
+      return { severity: 'error', summary: 'Logo rejected', detail: this.logoRejectionDetail(error), life: 8000 };
+    }
     return { severity: 'error', summary: 'Upload failed', detail: 'Unable to upload logo. Please try again.', life: 5000 };
+  }
+
+  /** Upstream reason for a rejected logo, falling back to generic guidance when none is supplied. */
+  private logoRejectionDetail(error: unknown): string {
+    const body = error instanceof HttpErrorResponse ? error.error : null;
+    const message = typeof body === 'string' ? body : body?.message;
+    return typeof message === 'string' && message.trim() ? message : 'This image could not be used. Try a different file.';
   }
 
   private refreshFieldFlags(): void {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-profile/org-profile-edit.component.ts
@@ -16,6 +16,7 @@ import {
 } from '@lfx-one/shared/constants';
 import type { OrgCanonicalRecord, OrgProfileEditableFields, OrgUpdateRequest } from '@lfx-one/shared/interfaces';
 import { httpsUrlValidator } from '@lfx-one/shared/validators';
+import { extractErrorMessage, isTransientHttpError } from '@shared/utils/http-error.utils';
 import { MessageService } from 'primeng/api';
 import { ButtonModule } from 'primeng/button';
 import { InputNumberModule } from 'primeng/inputnumber';
@@ -311,14 +312,15 @@ export class OrgProfileEditComponent implements OnInit {
       });
   }
 
-  /** FR-010-equivalent for the logo upload — mirrors toastForError's status mapping with upload-specific copy. */
   /**
    * Error copy for the logo upload, split by whether retrying can plausibly help.
    *
    * The sanitizer upstream rejects an SVG it cannot reproduce faithfully — an unsupported selector,
    * an @media block, an unknown vendor prefix — and returns the reason on a 4xx. Telling the user to
    * try again there is actively wrong: the same file fails every time. Those surface the upstream
-   * reason instead, and only transport/server failures keep the retry prompt.
+   * reason instead. Transient statuses are excluded first via `isTransientHttpError`, so a timeout
+   * (408, which this server mints for its own upstream abort) or a rate limit (429) still reads as
+   * retryable rather than as a permanently rejected file.
    */
   private toastForLogoError(error: unknown): { severity: string; summary: string; detail: string; life: number } {
     const status = error instanceof HttpErrorResponse ? error.status : 0;
@@ -328,17 +330,15 @@ export class OrgProfileEditComponent implements OnInit {
     if (status === 413) {
       return { severity: 'error', summary: 'Logo too large', detail: 'Logo must be 2MB or smaller.', life: 5000 };
     }
-    if (status >= 400 && status < 500) {
-      return { severity: 'error', summary: 'Logo rejected', detail: this.logoRejectionDetail(error), life: 8000 };
+    if (!isTransientHttpError(error) && status >= 400 && status < 500) {
+      return {
+        severity: 'error',
+        summary: 'Logo rejected',
+        detail: extractErrorMessage(error, 'This image could not be used. Try a different file.'),
+        life: 8000,
+      };
     }
     return { severity: 'error', summary: 'Upload failed', detail: 'Unable to upload logo. Please try again.', life: 5000 };
-  }
-
-  /** Upstream reason for a rejected logo, falling back to generic guidance when none is supplied. */
-  private logoRejectionDetail(error: unknown): string {
-    const body = error instanceof HttpErrorResponse ? error.error : null;
-    const message = typeof body === 'string' ? body : body?.message;
-    return typeof message === 'string' && message.trim() ? message : 'This image could not be used. Try a different file.';
   }
 
   private refreshFieldFlags(): void {

--- a/packages/shared/src/constants/org-profile.constants.ts
+++ b/packages/shared/src/constants/org-profile.constants.ts
@@ -41,3 +41,13 @@ export const MIN_ORG_LOGO_DIMENSION_PX = 128;
 
 /** Above this width/height (px), member-service downscales the logo server-side, preserving aspect ratio (`MaxLogoDimensionPx` in `pkg/constants/logo.go`). Warned about client-side so the user knows it'll happen; non-blocking, and not checked for SVG (vector, never resized). */
 export const MAX_ORG_LOGO_DIMENSION_PX = 1024;
+
+/**
+ * Upload statuses that mean the file itself is unusable, so the user must supply a different one
+ * rather than retry. 400 carries member-service's sanitizer rejection (an SVG whose CSS it cannot
+ * reproduce faithfully); 415 and 422 mean the same thing for content type and shape.
+ *
+ * Deliberately narrow: the BFF also returns 404 for a missing org and 409 for an If-Match miss
+ * (`org-identity.controller.ts`), and neither is a problem with the image.
+ */
+export const LOGO_REJECTION_STATUSES: readonly number[] = [400, 415, 422];


### PR DESCRIPTION
Removes the feature-flag gate from the Company Logo Upload affordance, and hardens the failure path the gate was hiding.

The org logo upload backend is released and verified in production (member-service `v0.10.19`), so the gate comes off.

## What changes

**The gate.** The per-feature `isOrgLensUploadLogoEnabled` wrapper and its private `org_lens_private_release` read are gone, along with 9 template bindings, the flag half of 4 handler guards, and the e2e flag pin. The dropzone's interactive affordances — pointer cursor, dashed border, drag highlight, `role="button"`, `tabindex`, `aria-label` — are now unconditional, which is exactly what rendered when the flag was on.

The `busy()` half of each guard is kept. It is a separate concern: it prevents a second upload starting while one is in flight.

**The umbrella flag is untouched.** `ORG_LENS_PRIVATE_RELEASE_FLAG` still gates the person detail drawer, its service, and the org project detail view, and is still exported from shared constants. Only this one surface graduates.

## Why the error-copy commits are here

They are not unrelated scope. The flag was the only thing keeping users away from the SVG sanitizer's rejection path, and that sanitizer recently became much stricter — it now rejects files it previously accepted-and-silently-blackened. Ungating without fixing the failure copy would ship a worse experience than leaving the gate on.

Previously every non-403 failure read *"Unable to upload logo. Please try again."* For a permanently rejected file that is the wrong instruction — the same bytes fail forever. Now:

| Status | Copy |
|---|---|
| 403 | Permission denied (unchanged) |
| 413 | Logo must be 2MB or smaller |
| 4xx (non-transient) | **Logo rejected** + the upstream reason |
| 408 / 429 / 0 / 5xx | Please try again |

408 and 429 are 4xx but retryable — this server mints 408 for its own upstream abort — so both are excluded via the repo's existing `isTransientHttpError`.

## Two bugs the pre-PR review caught

Recording these because both were mine and both would have shipped silently:

1. **The rejection detail read a key the BFF never emits.** `error.error.message` — but `BaseApiError.toResponse()` serialises `{ error, code }`, and `ServiceValidationError` adds `errors[]`. Every real rejection fell through to the generic fallback, so the sanitizer's reason never reached the user. The feature was inert in production. Worse, the test fabricated a body shape the server cannot produce, certifying the broken path as working. Both now go through the repo's `extractErrorMessage` helper, and the tests use the three real contract shapes — reverting the extraction fails three of them.

2. **`border-2` became unconditional**, and with border-box sizing the `h-20 w-20` children overflowed the wrapper's 76px content box. Invisible while the border was flag-gated off; the only rendered state after ungating. Children are now `h-full w-full`.

## Verification

- `yarn format:check` · `yarn lint:check` · `yarn check-types` — all clean
- Component suite **29 tests passing** (17 before; the flag-gating block was replaced with flag-independent coverage plus the new error mapping)
- Mutation-checked: restoring the old error extraction fails 3 tests; removing the `busy()` guard fails 1

## Notes for reviewers

- **No new permission surface.** `org-profile-edit` is not a route — it is only instantiated behind `canEdit()` (org writer), which `enterEditMode()` re-checks. The flag was redundant with an already-correct authorization gate.
- Pre-existing a11y issues were found and deliberately **not** fixed here to keep the diff scoped: the upload live region sits inside `role="button"` (presentational children), the wrapper `aria-label` shadows the logo `<img alt>`, and there is no focus-visible ring. All predate this change and are identical to the flag-ON behaviour. Happy to file them.

Issue: LFXV2-2016