### PR TITLE
fix(intercom): replace jira support links with fin messenger

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
@@ -321,13 +321,7 @@
                         Renew
                       </a>
                     } @else {
-                      <a
-                        href="https://jira.linuxfoundation.org/servicedesk/customer/portal/4"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        class="text-sm text-gray-600 hover:text-gray-900 transition-colors">
-                        Contact Us
-                      </a>
+                      <button type="button" lfxOpenIntercom class="text-sm text-gray-600 hover:text-gray-900 transition-colors">Contact Us</button>
                     }
                   </td>
                 </tr>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
@@ -209,7 +209,7 @@
                   <td class="text-sm text-gray-700">{{ membership.boardMembers }}</td>
                   <td class="text-sm text-gray-700">{{ membership.committeeMembers }}</td>
                   <td>
-                    @if (membership.orgProjects > 0) {
+                    @if (membership.orgProjects &gt; 0) {
                       <span class="text-sm font-medium text-blue-600">{{ membership.orgProjects }}</span>
                     } @else {
                       <span class="text-sm text-gray-700">0</span>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
@@ -209,7 +209,7 @@
                   <td class="text-sm text-gray-700">{{ membership.boardMembers }}</td>
                   <td class="text-sm text-gray-700">{{ membership.committeeMembers }}</td>
                   <td>
-                    @if (membership.orgProjects &gt; 0) {
+                    @if (membership.orgProjects > 0) {
                       <span class="text-sm font-medium text-blue-600">{{ membership.orgProjects }}</span>
                     } @else {
                       <span class="text-sm text-gray-700">0</span>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html
@@ -321,7 +321,13 @@
                         Renew
                       </a>
                     } @else {
-                      <button type="button" lfxOpenIntercom class="text-sm text-gray-600 hover:text-gray-900 transition-colors">Contact Us</button>
+                      <button
+                        type="button"
+                        lfxOpenIntercom
+                        data-testid="org-memberships-expired-contact-us-button"
+                        class="text-sm text-gray-600 hover:text-gray-900 transition-colors">
+                        Contact Us
+                      </button>
                     }
                   </td>
                 </tr>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.ts
@@ -15,6 +15,7 @@ import { OrgLensMembershipsService } from '@services/org-lens-memberships.servic
 import { CardComponent } from '@components/card/card.component';
 import { TableComponent } from '@components/table/table.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import type {
   OrgActiveMembershipsResponse,
   OrgDiscoverOpportunitiesResponse,
@@ -32,7 +33,7 @@ import { environment } from '@environments/environment';
 @Component({
   selector: 'lfx-org-memberships',
   standalone: true,
-  imports: [FormsModule, RouterLink, TableComponent, TooltipModule, SelectModule, InputTextModule, CardComponent, EmptyStateComponent],
+  imports: [FormsModule, RouterLink, TableComponent, TooltipModule, SelectModule, InputTextModule, CardComponent, EmptyStateComponent, OpenIntercomDirective],
   templateUrl: './org-memberships.component.html',
 })
 export class OrgMembershipsComponent {

--- a/apps/lfx-one/src/app/shared/directives/open-intercom.directive.spec.ts
+++ b/apps/lfx-one/src/app/shared/directives/open-intercom.directive.spec.ts
@@ -1,0 +1,85 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, TransferState } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { DEFAULT_RUNTIME_CONFIG, RUNTIME_CONFIG_KEY } from '@app/shared/providers/runtime-config.provider';
+import { IntercomService } from '@services/intercom.service';
+import { MessageService } from 'primeng/api';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { OpenIntercomDirective } from './open-intercom.directive';
+
+@Component({
+  selector: 'lfx-open-intercom-test-host',
+  imports: [OpenIntercomDirective],
+  template: '<a lfxOpenIntercom href="#">Contact support</a>',
+})
+class TestHostComponent {}
+
+/**
+ * Covers the user-visible decisions GH-1857 put in the directive rather than the service: an
+ * empty intercomAppId fails visibly (toast) instead of delegating to boot()'s console.warn
+ * refusal — which is also what makes the service's openMessenger('') spec a backstop rather
+ * than a production path — and a widget script that fails to load after the click surfaces
+ * the same toast through the load-error callback wired into openMessenger().
+ */
+describe('OpenIntercomDirective', () => {
+  let fixture: ComponentFixture<TestHostComponent>;
+  let transferState: TransferState;
+  let add: ReturnType<typeof vi.fn>;
+  let openMessenger: ReturnType<typeof vi.fn>;
+
+  const supportLink = (): HTMLAnchorElement => {
+    const el = fixture.nativeElement.querySelector('[lfxOpenIntercom]');
+    if (!el) throw new Error('no support link rendered');
+    return el as HTMLAnchorElement;
+  };
+
+  beforeEach(async () => {
+    add = vi.fn();
+    openMessenger = vi.fn();
+
+    await TestBed.configureTestingModule({
+      imports: [TestHostComponent],
+      providers: [
+        { provide: MessageService, useValue: { add } },
+        { provide: IntercomService, useValue: { openMessenger } },
+      ],
+    }).compileComponents();
+
+    transferState = TestBed.inject(TransferState);
+    fixture = TestBed.createComponent(TestHostComponent);
+    await fixture.whenStable();
+  });
+
+  it('shows the unavailable toast and skips the messenger when no app id is configured', () => {
+    // RUNTIME_CONFIG_KEY unset: getRuntimeConfig falls back to DEFAULT_RUNTIME_CONFIG (empty id).
+    supportLink().click();
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', summary: 'Support Unavailable' }));
+    expect(openMessenger).not.toHaveBeenCalled();
+  });
+
+  it('opens the messenger with a load-error callback when an app id is configured', () => {
+    transferState.set(RUNTIME_CONFIG_KEY, { ...DEFAULT_RUNTIME_CONFIG, intercomAppId: 'test-app-id' });
+
+    supportLink().click();
+
+    expect(openMessenger).toHaveBeenCalledWith('test-app-id', expect.any(Function));
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('shows the unavailable toast when the widget script fails to load after the click', () => {
+    transferState.set(RUNTIME_CONFIG_KEY, { ...DEFAULT_RUNTIME_CONFIG, intercomAppId: 'test-app-id' });
+
+    supportLink().click();
+    const onLoadError: unknown = openMessenger.mock.calls[0]?.[1];
+    if (typeof onLoadError !== 'function') {
+      throw new Error('openMessenger was not given a load-error callback');
+    }
+    onLoadError();
+
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', summary: 'Support Unavailable' }));
+  });
+});

--- a/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
+++ b/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
@@ -7,9 +7,9 @@ import { getRuntimeConfig } from '@app/shared/providers/runtime-config.provider'
 import { IntercomService } from '@services/intercom.service';
 
 // Opens the Fin Intercom messenger on click, booting Intercom anonymously on demand when
-// startup boot was skipped (impersonation, public pages, missing JWT claim). With no app id
-// configured the click cannot open anything (boot() would refuse with only a console.warn),
-// so surface that to the user instead of failing silently.
+// startup boot was skipped (impersonation, public pages, missing JWT claim). The click fails
+// visibly (toast) rather than silently when no app id is configured (boot() would refuse with
+// only a console.warn) or when the on-demand boot's widget script fails to load.
 @Directive({
   selector: '[lfxOpenIntercom]',
 })
@@ -24,14 +24,18 @@ export class OpenIntercomDirective {
 
     const { intercomAppId } = getRuntimeConfig(this.transferState);
     if (!intercomAppId) {
-      this.messageService.add({
-        severity: 'error',
-        summary: 'Support Unavailable',
-        detail: 'Support chat is unavailable right now. Please try again later.',
-      });
+      this.showSupportUnavailableToast();
       return;
     }
 
-    this.intercomService.openMessenger(intercomAppId);
+    this.intercomService.openMessenger(intercomAppId, () => this.showSupportUnavailableToast());
+  }
+
+  private showSupportUnavailableToast(): void {
+    this.messageService.add({
+      severity: 'error',
+      summary: 'Support Unavailable',
+      detail: 'Support chat is unavailable right now. Please try again later.',
+    });
   }
 }

--- a/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
+++ b/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
@@ -1,25 +1,24 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Directive, HostListener, inject } from '@angular/core';
-import { environment } from '@environments/environment';
+import { Directive, HostListener, inject, TransferState } from '@angular/core';
+import { getRuntimeConfig } from '@app/shared/providers/runtime-config.provider';
 import { IntercomService } from '@services/intercom.service';
 
-// Falls back to the Jira support URL when Intercom is not booted.
+// Opens the Fin Intercom messenger on click, booting Intercom anonymously on demand when
+// startup boot was skipped (impersonation, public pages, missing JWT claim).
 @Directive({
   selector: '[lfxOpenIntercom]',
 })
 export class OpenIntercomDirective {
   private readonly intercomService = inject(IntercomService);
+  private readonly transferState = inject(TransferState);
 
   @HostListener('click', ['$event'])
   public onClick(event: MouseEvent): void {
     event.preventDefault();
 
-    if (this.intercomService.isBootRequested) {
-      this.intercomService.show();
-    } else if (typeof window !== 'undefined') {
-      window.open(environment.urls.support, '_blank', 'noopener,noreferrer');
-    }
+    const { intercomAppId } = getRuntimeConfig(this.transferState);
+    this.intercomService.openMessenger(intercomAppId);
   }
 }

--- a/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
+++ b/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
@@ -9,7 +9,7 @@ import { IntercomService } from '@services/intercom.service';
 // Opens the Fin Intercom messenger on click, booting Intercom anonymously on demand when
 // startup boot was skipped (impersonation, public pages, missing JWT claim). The click fails
 // visibly (toast) rather than silently when no app id is configured (boot() would refuse with
-// only a console.warn) or when the on-demand boot's widget script fails to load.
+// only a console.warn) or when the widget script fails to load after the click.
 @Directive({
   selector: '[lfxOpenIntercom]',
 })

--- a/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
+++ b/apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts
@@ -2,23 +2,36 @@
 // SPDX-License-Identifier: MIT
 
 import { Directive, HostListener, inject, TransferState } from '@angular/core';
+import { MessageService } from 'primeng/api';
 import { getRuntimeConfig } from '@app/shared/providers/runtime-config.provider';
 import { IntercomService } from '@services/intercom.service';
 
 // Opens the Fin Intercom messenger on click, booting Intercom anonymously on demand when
-// startup boot was skipped (impersonation, public pages, missing JWT claim).
+// startup boot was skipped (impersonation, public pages, missing JWT claim). With no app id
+// configured the click cannot open anything (boot() would refuse with only a console.warn),
+// so surface that to the user instead of failing silently.
 @Directive({
   selector: '[lfxOpenIntercom]',
 })
 export class OpenIntercomDirective {
   private readonly intercomService = inject(IntercomService);
   private readonly transferState = inject(TransferState);
+  private readonly messageService = inject(MessageService);
 
   @HostListener('click', ['$event'])
   public onClick(event: MouseEvent): void {
     event.preventDefault();
 
     const { intercomAppId } = getRuntimeConfig(this.transferState);
+    if (!intercomAppId) {
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Support Unavailable',
+        detail: 'Support chat is unavailable right now. Please try again later.',
+      });
+      return;
+    }
+
     this.intercomService.openMessenger(intercomAppId);
   }
 }

--- a/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
@@ -85,6 +85,8 @@ describe('IntercomService', () => {
 
     expect(service.isBootRequested).toBe(true);
     expect(document.querySelectorAll('script[src^="https://widget.intercom.io/"]')).toHaveLength(1);
+    // The failed attempt's stub queue is discarded, so the retry queues exactly one boot + show.
+    expect(queuedCommands()).toEqual([['boot', { app_id: 'test-app-id' }], ['show']]);
   });
 
   it('should clear the load-error callback once the widget script loads', () => {

--- a/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
@@ -11,8 +11,9 @@ import { IntercomService } from './intercom.service';
  * Covers openMessenger(), the support-CTA entry point added for GH-1857: when startup boot was
  * skipped (impersonation, public pages, missing JWT claim) the first click must boot Intercom
  * anonymously, and boot must queue before show on the pre-load stub so the widget replays them
- * in order once its script loads. A click-triggered boot whose script fails to load must invoke
- * the caller's error callback so the CTA can fail visibly, and a successful load must clear it.
+ * in order once its script loads. A click whose widget script fails to load must invoke the
+ * caller's error callback so the CTA can fail visibly — including a click landing while a
+ * startup boot is still in flight — and a successful load must clear the callback.
  */
 describe('IntercomService', () => {
   let service: IntercomService;
@@ -94,5 +95,15 @@ describe('IntercomService', () => {
     widgetScript()?.onerror?.call(widgetScript() as GlobalEventHandlers, new Event('error'));
 
     expect(onLoadError).not.toHaveBeenCalled();
+  });
+
+  it('should invoke the load-error callback for a click landing while a startup boot is still loading', () => {
+    service.boot({ app_id: 'test-app-id' });
+    const onLoadError = vi.fn();
+
+    service.openMessenger('test-app-id', onLoadError);
+    widgetScript()?.onerror?.call(widgetScript() as GlobalEventHandlers, new Event('error'));
+
+    expect(onLoadError).toHaveBeenCalledTimes(1);
   });
 });

--- a/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
@@ -1,0 +1,69 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { DataDogRumService } from './datadog-rum.service';
+import { IntercomService } from './intercom.service';
+
+/**
+ * Covers openMessenger(), the support-CTA entry point added for GH-1857: when startup boot was
+ * skipped (impersonation, public pages, missing JWT claim) the first click must boot Intercom
+ * anonymously, and boot must queue before show on the pre-load stub so the widget replays them
+ * in order once its script loads.
+ */
+describe('IntercomService', () => {
+  let service: IntercomService;
+
+  const queuedCommands = (): unknown[][] => window.Intercom?.q ?? [];
+
+  beforeEach(() => {
+    vi.spyOn(console, 'info').mockImplementation(() => undefined);
+
+    TestBed.configureTestingModule({
+      providers: [{ provide: DataDogRumService, useValue: { addError: vi.fn() } }],
+    });
+
+    service = TestBed.inject(IntercomService);
+  });
+
+  afterEach(() => {
+    document.querySelectorAll('script[src^="https://widget.intercom.io/"]').forEach((script) => script.remove());
+    delete window.Intercom;
+    delete window.intercomSettings;
+    vi.restoreAllMocks();
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  it('should boot anonymously and queue boot before show when startup boot was skipped', () => {
+    service.openMessenger('test-app-id');
+
+    expect(service.isBootRequested).toBe(true);
+    expect(window.intercomSettings?.app_id).toBe('test-app-id');
+    expect(queuedCommands()).toEqual([['boot', { app_id: 'test-app-id' }], ['show']]);
+  });
+
+  it('should not boot a second time when Intercom is already booted', () => {
+    const bootSpy = vi.spyOn(service, 'boot');
+
+    service.openMessenger('test-app-id');
+    service.openMessenger('test-app-id');
+
+    expect(bootSpy).toHaveBeenCalledTimes(1);
+    expect(queuedCommands()).toEqual([['boot', { app_id: 'test-app-id' }], ['show'], ['show']]);
+  });
+
+  it('should refuse to boot without an app id and leave the click a no-op', () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined);
+
+    service.openMessenger('');
+
+    expect(service.isBootRequested).toBe(false);
+    expect(window.Intercom).toBeUndefined();
+    expect(warnSpy).toHaveBeenCalledWith('Intercom: boot called without app_id');
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.spec.ts
@@ -11,15 +11,18 @@ import { IntercomService } from './intercom.service';
  * Covers openMessenger(), the support-CTA entry point added for GH-1857: when startup boot was
  * skipped (impersonation, public pages, missing JWT claim) the first click must boot Intercom
  * anonymously, and boot must queue before show on the pre-load stub so the widget replays them
- * in order once its script loads.
+ * in order once its script loads. A click-triggered boot whose script fails to load must invoke
+ * the caller's error callback so the CTA can fail visibly, and a successful load must clear it.
  */
 describe('IntercomService', () => {
   let service: IntercomService;
 
   const queuedCommands = (): unknown[][] => window.Intercom?.q ?? [];
+  const widgetScript = (): HTMLScriptElement | null => document.querySelector('script[src^="https://widget.intercom.io/"]');
 
   beforeEach(() => {
     vi.spyOn(console, 'info').mockImplementation(() => undefined);
+    vi.spyOn(console, 'error').mockImplementation(() => undefined);
 
     TestBed.configureTestingModule({
       providers: [{ provide: DataDogRumService, useValue: { addError: vi.fn() } }],
@@ -65,5 +68,31 @@ describe('IntercomService', () => {
     expect(service.isBootRequested).toBe(false);
     expect(window.Intercom).toBeUndefined();
     expect(warnSpy).toHaveBeenCalledWith('Intercom: boot called without app_id');
+  });
+
+  it('should invoke the load-error callback and allow a retry when the widget script fails to load', () => {
+    const onLoadError = vi.fn();
+
+    service.openMessenger('test-app-id', onLoadError);
+    widgetScript()?.onerror?.call(widgetScript() as GlobalEventHandlers, new Event('error'));
+
+    expect(onLoadError).toHaveBeenCalledTimes(1);
+    expect(service.isBootRequested).toBe(false);
+
+    // A later click re-attempts the boot with a fresh script element.
+    service.openMessenger('test-app-id', onLoadError);
+
+    expect(service.isBootRequested).toBe(true);
+    expect(document.querySelectorAll('script[src^="https://widget.intercom.io/"]')).toHaveLength(1);
+  });
+
+  it('should clear the load-error callback once the widget script loads', () => {
+    const onLoadError = vi.fn();
+
+    service.openMessenger('test-app-id', onLoadError);
+    widgetScript()?.onload?.call(widgetScript() as GlobalEventHandlers, new Event('load'));
+    widgetScript()?.onerror?.call(widgetScript() as GlobalEventHandlers, new Event('error'));
+
+    expect(onLoadError).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/app/shared/services/intercom.service.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.ts
@@ -11,7 +11,7 @@ import { DataDogRumService } from './datadog-rum.service';
   providedIn: 'root',
 })
 export class IntercomService {
-  // Read by OpenIntercomDirective to decide whether to open Intercom or fall back to JIRA.
+  // Read by openMessenger() to decide whether an on-demand anonymous boot is needed first.
   // Set synchronously when boot() is called; the stub queue absorbs commands until the script loads.
   public isBootRequested = false;
 
@@ -46,6 +46,16 @@ export class IntercomService {
       return;
     }
     window.Intercom('show');
+  }
+
+  // Entry point for support CTAs: boots Intercom anonymously on demand when startup boot was
+  // skipped (impersonation, public pages, missing JWT claim), then shows the messenger.
+  // Fire-and-forget — a fresh boot queues behind the stub and replays before show on script load.
+  public openMessenger(appId: string): void {
+    if (!this.isBootRequested) {
+      this.boot({ app_id: appId });
+    }
+    this.show();
   }
 
   // Call before re-booting with a different user (impersonation identity reset).
@@ -92,7 +102,7 @@ export class IntercomService {
       script.remove();
       this.scriptElement = null;
       console.error('Intercom: failed to load widget script', error);
-      // Surface to RUM so "users stuck in Jira fallback" is dashboardable.
+      // Surface to RUM so sessions where the Fin messenger cannot open are dashboardable.
       this.dataDogRumService.addError(new Error('Intercom script failed to load'), { context: 'intercom_load' });
     };
 

--- a/apps/lfx-one/src/app/shared/services/intercom.service.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.ts
@@ -112,6 +112,11 @@ export class IntercomService {
       this.isBootRequested = false;
       script.remove();
       this.scriptElement = null;
+      // Drop the stub and settings so a retry boots from a genuinely fresh queue — otherwise the
+      // failed attempt's boot/show commands replay alongside the retry's (the queue is unreachable
+      // anyway once the only script that would drain it has failed).
+      delete window.Intercom;
+      delete window.intercomSettings;
       console.error('Intercom: failed to load widget script', error);
       // Surface to RUM so sessions where the Fin messenger cannot open are dashboardable.
       this.dataDogRumService.addError(new Error('Intercom script failed to load'), { context: 'intercom_load' });

--- a/apps/lfx-one/src/app/shared/services/intercom.service.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.ts
@@ -21,6 +21,10 @@ export class IntercomService {
 
   private scriptElement: HTMLScriptElement | null = null;
 
+  // Invoked from the widget script's onerror when set by a click-triggered openMessenger() —
+  // lets support CTAs surface a toast on load failure while startup boot stays silent.
+  private onLoadError?: () => void;
+
   // Fire-and-forget: stub queue absorbs calls before the script loads and replays them on load.
   public boot(options: IntercomBootOptions): void {
     if (typeof window === 'undefined') {
@@ -51,8 +55,11 @@ export class IntercomService {
   // Entry point for support CTAs: boots Intercom anonymously on demand when startup boot was
   // skipped (impersonation, public pages, missing JWT claim), then shows the messenger.
   // Fire-and-forget — a fresh boot queues behind the stub and replays before show on script load.
-  public openMessenger(appId: string): void {
+  // onLoadError fires if that on-demand boot's widget script fails to load (e.g. ad-blockers);
+  // it is ignored when Intercom is already booted, and cleared once the script loads.
+  public openMessenger(appId: string, onLoadError?: () => void): void {
     if (!this.isBootRequested) {
+      this.onLoadError = onLoadError;
       this.boot({ app_id: appId });
     }
     this.show();
@@ -94,6 +101,7 @@ export class IntercomService {
 
     script.onload = () => {
       this.isLoaded = true;
+      this.onLoadError = undefined;
       console.info('Intercom: widget script loaded');
     };
 
@@ -104,6 +112,8 @@ export class IntercomService {
       console.error('Intercom: failed to load widget script', error);
       // Surface to RUM so sessions where the Fin messenger cannot open are dashboardable.
       this.dataDogRumService.addError(new Error('Intercom script failed to load'), { context: 'intercom_load' });
+      this.onLoadError?.();
+      this.onLoadError = undefined;
     };
 
     const firstScript = document.getElementsByTagName('script')[0];

--- a/apps/lfx-one/src/app/shared/services/intercom.service.ts
+++ b/apps/lfx-one/src/app/shared/services/intercom.service.ts
@@ -55,12 +55,15 @@ export class IntercomService {
   // Entry point for support CTAs: boots Intercom anonymously on demand when startup boot was
   // skipped (impersonation, public pages, missing JWT claim), then shows the messenger.
   // Fire-and-forget — a fresh boot queues behind the stub and replays before show on script load.
-  // onLoadError fires if that on-demand boot's widget script fails to load (e.g. ad-blockers);
-  // it is ignored when Intercom is already booted, and cleared once the script loads.
+  // onLoadError fires if the widget script fails to load (e.g. ad-blockers) — including a click
+  // landing while a startup boot is still in flight. It is never registered by page-load boots
+  // and is cleared once the script loads, so ad-blocked users are only toasted after a click.
   public openMessenger(appId: string, onLoadError?: () => void): void {
     if (!this.isBootRequested) {
-      this.onLoadError = onLoadError;
       this.boot({ app_id: appId });
+    }
+    if (!this.isLoaded) {
+      this.onLoadError = onLoadError;
     }
     this.show();
   }

--- a/apps/lfx-one/src/environments/environment.dev.ts
+++ b/apps/lfx-one/src/environments/environment.dev.ts
@@ -5,7 +5,6 @@ export const environment = {
   production: false,
   urls: {
     home: 'https://app.dev.lfx.dev',
-    support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://pcc.dev.platform.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
     mentorship: 'https://people.dev.platform.linuxfoundation.org/#projects_all',

--- a/apps/lfx-one/src/environments/environment.prod.ts
+++ b/apps/lfx-one/src/environments/environment.prod.ts
@@ -5,7 +5,6 @@ export const environment = {
   production: true,
   urls: {
     home: 'https://app.lfx.dev',
-    support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://projectadmin.lfx.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
     mentorship: 'https://mentorship.lfx.linuxfoundation.org/',

--- a/apps/lfx-one/src/environments/environment.staging.ts
+++ b/apps/lfx-one/src/environments/environment.staging.ts
@@ -5,7 +5,6 @@ export const environment = {
   production: true,
   urls: {
     home: 'https://app.staging.lfx.dev',
-    support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://pcc.staging.platform.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
     mentorship: 'https://mentorship.lfx.linuxfoundation.org/',

--- a/apps/lfx-one/src/environments/environment.ts
+++ b/apps/lfx-one/src/environments/environment.ts
@@ -5,7 +5,6 @@ export const environment = {
   production: false,
   urls: {
     home: 'http://localhost:4200',
-    support: 'https://jira.linuxfoundation.org/plugins/servlet/desk',
     pcc: 'https://pcc.dev.platform.linuxfoundation.org',
     changelog: 'https://changelog.lfx.dev/',
     mentorship: 'https://people.dev.platform.linuxfoundation.org/#projects_all',


### PR DESCRIPTION
## Summary

GH-1857 asked to remove every Jira support link from Self Serve — support was never handled via Jira — and open the Fin Intercom messenger instead. The hard-coded Jira anchors are gone, but the shared `lfxOpenIntercom` directive (used by ~10 surfaces, including the mailing-lists "contact support" CTA from the issue) still fell back to opening the Jira service-desk portal whenever Intercom wasn't already booted — exactly the impersonation scenario in the report. This PR removes that Jira fallback entirely: support CTAs now boot the Fin messenger anonymously on demand, the last hard-coded Jira link (expired memberships "Contact Us") becomes an `lfxOpenIntercom` button, and the unused Jira support URL is dropped from all environment configs.

Closes #1857

## Behavior changes

### Support links open the Fin messenger

| Before | After |
|---|---|
| The expired-memberships "Contact Us" link opened a Jira service-desk portal in a new tab, and every other support CTA (mailing lists, not-found pages, profile dialogs, lens switcher) did the same whenever the chat widget wasn't already running — e.g. while impersonating a user. | All support CTAs open the Fin support messenger in place, inside the app. No surface sends users to Jira anymore. |

### Support click failure handling

| Before | After |
|---|---|
| If the chat widget couldn't load (e.g. ad-blocker) or support chat wasn't configured, clicking a support CTA failed silently — nothing happened and the user got no feedback. | The click fails visibly: the user sees a "Support Unavailable" toast asking them to try again later. Page-load widget failures stay silent — only clicks surface a toast. |

## Technical changes

`apps/lfx-one/src/app/shared/directives/open-intercom.directive.ts` — OpenIntercomDirective rewrite

- Replaces the Jira fallback (`window.open(environment.urls.support)`) with `intercomService.openMessenger()`, reading the Intercom app id from the `TransferState`-backed runtime config instead of the static environment file
- Shows a "Support Unavailable" error toast via `MessageService` when no app id is configured, or when the widget script fails to load after the click

`apps/lfx-one/src/app/shared/services/intercom.service.ts` — IntercomService

- Adds `openMessenger(appId, onLoadError?)`: boots Intercom anonymously on demand when startup boot was skipped (impersonation, public pages, missing JWT claim), then shows the messenger — a fresh boot queues behind the stub and replays before `show` once the script loads
- Adds an optional `onLoadError` callback invoked from the widget script's `onerror`, including for a click landing while a startup boot is still in flight; it is cleared on successful load and never registered by page-load boots, so ad-blocked users are only toasted after a click
- Script failures still log to console and DataDog RUM; fire-and-forget semantics unchanged

`apps/lfx-one/src/app/modules/dashboards/org/org-memberships/org-memberships.component.html, .ts` — Org memberships

- Replaces the expired-memberships "Contact Us" Jira anchor with a `lfxOpenIntercom` button and imports `OpenIntercomDirective`
- Adds `data-testid="org-memberships-expired-contact-us-button"` for reliable test targeting

`apps/lfx-one/src/environments/environment.ts, environment.dev.ts, environment.staging.ts, environment.prod.ts` — Environment configs

- Removes the now-unused `urls.support` Jira service-desk URL from all four environments (verified no remaining consumers)

`apps/lfx-one/src/app/shared/services/intercom.service.spec.ts` — Tests

- New spec covering `openMessenger()`: anonymous boot with boot-before-show queue ordering, single boot across repeated clicks, empty-app-id refusal, script-failure callback with retry, callback clearing on successful load, and a click landing while a startup boot is still in flight (7 tests)
