### PR TITLE
fix(auth): anchor remaining permissive ssr auth patterns

### DIFF
--- a/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
@@ -226,6 +226,76 @@ describe('authMiddleware route classification', () => {
     expect(res.oidc.login).toHaveBeenCalledTimes(1);
   });
 
+  it('allows an anonymous GET to a public foundation group directory (/foundations/:slug/groups)', async () => {
+    const req = buildReq({ path: '/foundations/acme/groups' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a nested /foundations/:slug/groups/<sub> path as public (anchored regex, no fail-open)', async () => {
+    const req = buildReq({ path: '/foundations/acme/groups/extra' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    // No `/foundations/:slug/groups/<sub>` route exists in app.routes.ts — the anchor is now a single
+    // trailing segment, so this falls through to the catch-all `required` row and redirects to login.
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows an anonymous GET to a public project group directory (/projects/:slug/groups)', async () => {
+    const req = buildReq({ path: '/projects/acme/groups' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a nested /projects/:slug/groups/<sub> path as public (anchored regex, no fail-open)', async () => {
+    const req = buildReq({ path: '/projects/acme/groups/extra' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
+  it('allows an anonymous GET to the invite error page (/invite/error)', async () => {
+    const req = buildReq({ path: '/invite/error' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('does not treat /invite/error-extra as public (anchored regex, no fail-open)', async () => {
+    const req = buildReq({ path: '/invite/error-extra' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    // A bare-string pattern would `startsWith`-match this; the anchored regex requires an exact
+    // (optionally trailing-slash) path, so this falls through to the catch-all and redirects to login.
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
   it('still redirects an anonymous GET to a protected SSR route', async () => {
     const req = buildReq({ path: '/foundation/overview' });
     const res = buildRes();

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -50,10 +50,10 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // impersonation session never leaks here; anchored regex prevents `startsWith` fail-open onto `/u/...`.
   { pattern: /^\/u\/[^/]+\/?$/, type: 'ssr', auth: 'public' },
 
-  // Public foundation and project group directories — unauthenticated discovery (LFXV2-2010)
-  // Regex-anchored to /:identifier/groups so the prefix cannot fail-open on unrelated paths
-  { pattern: /^\/foundations\/[^/]+\/groups(?:\/.*)?$/, type: 'ssr', auth: 'optional' },
-  { pattern: /^\/projects\/[^/]+\/groups(?:\/.*)?$/, type: 'ssr', auth: 'optional' },
+  // Public foundation and project group directories — unauthenticated discovery (LFXV2-2010).
+  // Anchored to a single trailing segment (no deeper route exists) so a nested path fails closed to `required`.
+  { pattern: /^\/foundations\/[^/]+\/groups\/?$/, type: 'ssr', auth: 'optional' },
+  { pattern: /^\/projects\/[^/]+\/groups\/?$/, type: 'ssr', auth: 'optional' },
 
   // Flow C callback via /passwordless/callback — needs session auth but no bearer token
   { pattern: '/passwordless/callback', type: 'ssr', auth: 'required', tokenRequired: false },
@@ -77,8 +77,9 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   // shape so a malformed/undecodable API path fails closed the same way — keep the two in sync.
   { pattern: '/api', type: 'api', auth: 'required', tokenRequired: true },
 
-  // Invite error page — public so unauthenticated users see the error instead of being redirected to login
-  { pattern: '/invite/error', type: 'ssr', auth: 'public' },
+  // Invite error page — public so unauthenticated users see the error instead of a login redirect.
+  // Anchored regex (not a bare string) so `startsWith` can't fail-open on `/invite/error-extra`.
+  { pattern: /^\/invite\/error\/?$/, type: 'ssr', auth: 'public' },
 
   // Auth error page — public so a failed/cleared session doesn't bounce the visitor to /login
   // instead of showing the branded error (the whole point of the redirect in server.ts). Anchored


### PR DESCRIPTION
## Summary

- Anchor the `/foundations/:slug/groups` and `/projects/:slug/groups` patterns in `auth.middleware.ts` to a single trailing segment (no deeper route exists in `app.routes.ts` for either family), closing the `(?:\/.*)?` fail-open tail.
- Anchor `/invite/error` to an exact regex instead of a bare string, so `startsWith` semantics can't fail-open on paths like `/invite/error-extra`.
- The third pattern flagged in the issue — excluding `/meetings/create` via a lookahead — was already fixed in a prior commit (#1471); left untouched.
- Add regression cases to `auth.middleware.spec.ts` covering both the anchored public shape and the previously fail-open nested/suffixed shape for each pattern.

## Protected files

Both changed files (`auth.middleware.ts`, `auth.middleware.spec.ts`) are flagged by the repo's protected-file guard as core request-processing infrastructure. This is expected — the entire change is scoped to tightening these two auth-classification regexes — but calling it out for reviewer awareness per the guard's recommendation.

Fixes #1609