### PR TITLE
feat(intercom): wire contact-support CTAs to fin messenger (#1880)

### DIFF
--- a/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
+++ b/apps/lfx-one/e2e/org-meetings-dashboard.spec.ts
@@ -374,6 +374,7 @@ test.describe('Org Meetings insights (6a redesign)', () => {
     await gotoOrgMeetingsPage(page);
 
     await expect(page.getByTestId('org-meetings-no-access-state')).toBeVisible();
+    await expect(page.getByTestId('org-meetings-no-access-contact-support')).toBeVisible();
     await expect(page.getByTestId('org-meetings-kpi-cards')).toHaveCount(0);
     await expect(page.getByTestId('org-meetings-no-company-empty-state')).toHaveCount(0);
   });

--- a/apps/lfx-one/e2e/org-projects.spec.ts
+++ b/apps/lfx-one/e2e/org-projects.spec.ts
@@ -260,6 +260,7 @@ test.describe('Org Projects', () => {
     await gotoOrgProjectsPage(page, { hasAccess: false });
     await expect(page.getByTestId('org-projects-no-access-state')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
     await expect(page.getByTestId('org-projects-no-access-title')).toHaveText('Organization Lens is not available');
+    await expect(page.getByTestId('org-projects-no-access-contact-support')).toBeVisible();
 
     await page.unrouteAll({ behavior: 'ignoreErrors' });
     await gotoOrgProjectsPage(page, { workspacesStatus: 500 });

--- a/apps/lfx-one/e2e/org-roi-summary.spec.ts
+++ b/apps/lfx-one/e2e/org-roi-summary.spec.ts
@@ -385,6 +385,7 @@ test.describe('Org Lens ROI Metrics — portfolio summary', () => {
     await gotoOrgRoiPage(page);
 
     await expect(page.getByTestId('org-roi-no-access-state')).toBeVisible();
+    await expect(page.getByTestId('org-roi-no-access-contact-support')).toBeVisible();
     await expect(page.getByTestId('org-roi-kpi-cards')).toHaveCount(0);
     await expect(page.getByTestId('org-roi-no-company-empty-state')).toHaveCount(0);
   });

--- a/apps/lfx-one/e2e/org-selector.spec.ts
+++ b/apps/lfx-one/e2e/org-selector.spec.ts
@@ -407,6 +407,7 @@ test.describe('Org Selector — /org/overview no-access state (S15)', () => {
     expect(page.url()).toContain('/org/overview');
     await expect(page.getByTestId('org-overview-no-access-state')).toBeVisible();
     await expect(page.getByTestId('org-overview-no-access-title')).toHaveText('Organization Lens is not available');
+    await expect(page.getByTestId('org-overview-no-access-contact-support')).toBeVisible();
     // The skeleton and the no-org-selected empty state must NOT show in this branch.
     await expect(page.getByTestId('org-overview-loading')).toHaveCount(0);
     await expect(page.getByTestId('org-overview-empty-state')).toHaveCount(0);

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.html
@@ -22,7 +22,8 @@
       </div>
       <h2 class="text-base font-semibold text-gray-900" data-testid="org-groups-no-access-title">Organization Lens is not available</h2>
       <p class="max-w-md text-sm text-gray-600" data-testid="org-groups-no-access-description">
-        Organization Lens is only available for an organization's administrators. If you believe you should have access, please contact us.
+        Organization Lens is only available for an organization's administrators. If you believe you should have access, please
+        <button type="button" lfxOpenIntercom class="font-medium underline" data-testid="org-groups-no-access-contact-support">contact us</button>.
       </p>
     </section>
   } @else if (!loaded()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-groups/org-groups.component.ts
@@ -32,6 +32,7 @@ import { OrgLensGroupsService } from '@services/org-lens-groups.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 
 import { GroupSeatHoldersDrawerComponent } from './components/group-seat-holders-drawer/group-seat-holders-drawer.component';
 
@@ -43,6 +44,7 @@ import { GroupSeatHoldersDrawerComponent } from './components/group-seat-holders
     GroupSeatHoldersDrawerComponent,
     InputTextComponent,
     NgTemplateOutlet,
+    OpenIntercomDirective,
     PersonDetailDrawerComponent,
     RouterLink,
     SelectComponent,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.html
@@ -19,7 +19,8 @@
       </div>
       <h2 class="text-base font-semibold text-gray-900" data-testid="org-meetings-no-access-title">Organization Lens is not available</h2>
       <p class="max-w-md text-sm text-gray-600" data-testid="org-meetings-no-access-description">
-        Organization Lens is only available for an organization's administrators. If you believe you should have access, please contact us.
+        Organization Lens is only available for an organization's administrators. If you believe you should have access, please
+        <button type="button" lfxOpenIntercom class="font-medium underline" data-testid="org-meetings-no-access-contact-support">contact us</button>.
       </p>
     </section>
   } @else if (!loaded()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-meetings/org-meetings.component.ts
@@ -9,6 +9,7 @@ import { AccountContextService } from '@services/account-context.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
@@ -34,6 +35,7 @@ import { OrgMeetingsTimeRangeComponent } from './components/org-meetings-time-ra
     OrgMeetingsSpendBreakdownComponent,
     OrgMeetingsInfluenceComponent,
     EmptyStateComponent,
+    OpenIntercomDirective,
     SkeletonModule,
   ],
   templateUrl: './org-meetings.component.html',

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.html
@@ -25,7 +25,8 @@
       </div>
       <h2 class="text-base font-semibold text-gray-900" data-testid="org-overview-no-access-title">Organization Lens is not available</h2>
       <p class="max-w-md text-sm text-gray-600" data-testid="org-overview-no-access-description">
-        Organization Lens is only available for an organization's administrators. If you believe you should have access, please contact us.
+        Organization Lens is only available for an organization's administrators. If you believe you should have access, please
+        <button type="button" lfxOpenIntercom class="font-medium underline" data-testid="org-overview-no-access-contact-support">contact us</button>.
       </p>
     </section>
   } @else if (!loaded()) {
@@ -58,7 +59,8 @@
       } @else {
         <p class="max-w-md text-sm text-gray-600" data-testid="org-overview-empty-description">
           We couldn't find any organizations you have access to in this environment. If you expect to see one or more here, double-check your invite status with
-          your admin or contact support.
+          your admin or
+          <button type="button" lfxOpenIntercom class="font-medium underline" data-testid="org-overview-empty-contact-support">contact support</button>.
         </p>
       }
     </section>

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-overview/org-overview.component.ts
@@ -7,6 +7,7 @@ import { AccountContextService } from '@services/account-context.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import { OrgOverviewFoundationsAndProjectsComponent } from '../components/org-overview-foundations-and-projects/org-overview-foundations-and-projects.component';
@@ -14,7 +15,7 @@ import { OrgOverviewInvolvementComponent } from '../components/org-overview-invo
 
 @Component({
   selector: 'lfx-org-overview',
-  imports: [TagComponent, SkeletonModule, OrgOverviewInvolvementComponent, OrgOverviewFoundationsAndProjectsComponent],
+  imports: [TagComponent, SkeletonModule, OpenIntercomDirective, OrgOverviewInvolvementComponent, OrgOverviewFoundationsAndProjectsComponent],
   templateUrl: './org-overview.component.html',
 })
 export class OrgOverviewComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.html
@@ -25,7 +25,8 @@
       </div>
       <h2 class="text-base font-semibold text-gray-900" data-testid="org-projects-no-access-title">Organization Lens is not available</h2>
       <p class="max-w-md text-sm text-gray-600" data-testid="org-projects-no-access-description">
-        Organization Lens is only available for an organization's administrators. If you believe you should have access, please contact us.
+        Organization Lens is only available for an organization's administrators. If you believe you should have access, please
+        <button type="button" lfxOpenIntercom class="font-medium underline" data-testid="org-projects-no-access-contact-support">contact us</button>.
       </p>
     </section>
   } @else if (!orgContextLoaded()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-projects/org-projects.component.ts
@@ -65,6 +65,7 @@ import { MenuComponent } from '@components/menu/menu.component';
 import { MultiSelectComponent } from '@components/multi-select/multi-select.component';
 import { SelectComponent } from '@components/select/select.component';
 import { TableComponent } from '@components/table/table.component';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { AccountContextService } from '@shared/services/account-context.service';
 import { OrgNavigationService } from '@shared/services/org-navigation.service';
 import { OrgLensProjectsService } from '@shared/services/org-lens-projects.service';
@@ -83,6 +84,7 @@ import { PersonaService } from '@shared/services/persona.service';
     InputTextComponent,
     MenuComponent,
     MultiSelectComponent,
+    OpenIntercomDirective,
     PopoverModule,
     RouterLink,
     SelectComponent,

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.html
@@ -30,7 +30,9 @@
 
       <p class="text-sm text-gray-500">
         Activity recorded under a differently-named or related organization is counted there instead, so it won't roll up to this one. If you think that's
-        what's happened, contact us and we can look at how your organization's activity is attributed.
+        what's happened,
+        <button type="button" lfxOpenIntercom class="font-medium underline" data-testid="org-roi-empty-contact-support">contact us</button>
+        and we can look at how your organization's activity is attributed.
       </p>
     </div>
   }

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/components/org-roi-empty-state/org-roi-empty-state.component.ts
@@ -3,9 +3,11 @@
 
 import { Component, computed, input, Signal } from '@angular/core';
 import type { OrgLensRoiCoverageReason } from '@lfx-one/shared/interfaces';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 
 @Component({
   selector: 'lfx-org-roi-empty-state',
+  imports: [OpenIntercomDirective],
   templateUrl: './org-roi-empty-state.component.html',
 })
 export class OrgRoiEmptyStateComponent {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.html
@@ -35,7 +35,8 @@
       </div>
       <h2 class="text-base font-semibold text-gray-900" data-testid="org-roi-no-access-title">Organization Lens is not available</h2>
       <p class="max-w-md text-sm text-gray-600" data-testid="org-roi-no-access-description">
-        Organization Lens is only available for an organization's administrators. If you believe you should have access, please contact us.
+        Organization Lens is only available for an organization's administrators. If you believe you should have access, please
+        <button type="button" lfxOpenIntercom class="font-medium underline" data-testid="org-roi-no-access-contact-support">contact us</button>.
       </p>
     </section>
   } @else if (!loaded()) {

--- a/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/org/org-roi/org-roi.component.ts
@@ -11,6 +11,7 @@ import { OrgLensRoiService } from '@services/org-lens-roi.service';
 import { OrgNavigationService } from '@services/org-navigation.service';
 import { OrgRoleGrantsService } from '@services/org-role-grants.service';
 import { PersonaService } from '@services/persona.service';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, combineLatest, filter, map, of, switchMap, tap } from 'rxjs';
 
@@ -54,6 +55,7 @@ const EMPTY_COVERAGE: OrgLensRoiCoverage = { orgUid: '', hasData: false, coverag
     OrgRoiAssumptionsDrawerComponent,
     OrgRoiEmptyStateComponent,
     EmptyStateComponent,
+    OpenIntercomDirective,
     SkeletonModule,
   ],
   templateUrl: './org-roi.component.html',

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.html
@@ -1,6 +1,38 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 <div class="container mx-auto px-4 sm:px-6 lg:px-8" data-testid="my-events-dashboard">
+  <!-- Salesforce-ID error toast — keyed so the custom template carrying the Contact Support action renders only for this error. -->
+  <p-toast [key]="salesforceErrorToastKey" position="top-right">
+    <ng-template let-message pTemplate="message">
+      <div class="flex items-start gap-3 w-full">
+        @switch (message.severity) {
+          @case ('error') {
+            <i class="fa-light fa-circle-xmark text-red-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+          }
+          @case ('info') {
+            <i class="fa-light fa-circle-info text-blue-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+          }
+          @default {
+            <i class="fa-light fa-circle-check text-emerald-500 text-xl mt-0.5 shrink-0" aria-hidden="true"></i>
+          }
+        }
+        <div class="flex flex-col gap-1 min-w-0 flex-1">
+          <span class="text-sm font-semibold text-gray-900">{{ message.summary }}</span>
+          <span class="text-sm text-gray-600">{{ message.detail }}</span>
+          @if (message.data?.showSupport) {
+            <button
+              type="button"
+              lfxOpenIntercom
+              class="text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline inline-flex items-center gap-1 mt-1 self-start"
+              data-testid="my-events-salesforce-error-contact-support">
+              Contact Support
+            </button>
+          }
+        </div>
+      </div>
+    </ng-template>
+  </p-toast>
+
   <div class="flex flex-col gap-6">
     <!-- Page Header -->
     <div class="flex items-start justify-between mt-3">

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -141,6 +141,9 @@ export class MyEventsDashboardComponent {
             detail: 'Your account is missing the required Salesforce ID. Please contact support.',
             data: { showSupport: true },
             closable: true,
+            // Sticky: the Contact Support CTA is the only remediation path — a 3s auto-dismiss
+            // (PrimeNG default life) would remove it before most users finish reading.
+            sticky: true,
           });
           return false;
         }),

--- a/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/events/my-events-dashboard/my-events-dashboard.component.ts
@@ -8,7 +8,9 @@ import { CardComponent } from '@components/card/card.component';
 import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { MY_EVENT_STATUS_OPTIONS, VISA_REQUEST_STATUS_OPTIONS } from '@lfx-one/shared/constants';
 import { EventTabId, FilterOption, FilterPillOption } from '@lfx-one/shared/interfaces';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 import { MessageService } from 'primeng/api';
+import { ToastModule } from 'primeng/toast';
 import { Tooltip } from 'primeng/tooltip';
 import { catchError, defer, finalize, map, of } from 'rxjs';
 import { DiscoverEventsButtonComponent } from '../components/discover-events-button/discover-events-button.component';
@@ -16,9 +18,22 @@ import { EventsTopBarComponent } from '../components/events-top-bar/events-top-b
 import { EventsListComponent } from './components/events-list/events-list.component';
 import { UserService } from '@app/shared/services/user.service';
 
+/** Dedicated toast key so the custom support-CTA template renders only for this component's Salesforce-ID error toast. */
+const SALESFORCE_ERROR_TOAST_KEY = 'my-events-salesforce-error';
+
 @Component({
   selector: 'lfx-my-events-dashboard',
-  imports: [ButtonComponent, CardComponent, CardTabsBarComponent, DiscoverEventsButtonComponent, EventsTopBarComponent, EventsListComponent, Tooltip],
+  imports: [
+    ButtonComponent,
+    CardComponent,
+    CardTabsBarComponent,
+    DiscoverEventsButtonComponent,
+    EventsTopBarComponent,
+    EventsListComponent,
+    Tooltip,
+    ToastModule,
+    OpenIntercomDirective,
+  ],
   templateUrl: './my-events-dashboard.component.html',
 })
 export class MyEventsDashboardComponent {
@@ -63,6 +78,7 @@ export class MyEventsDashboardComponent {
   protected readonly upcomingCount = computed(() => this.eventsListRef()?.tabCounts().upcoming ?? 0);
 
   protected readonly isSalesforceIdLoading = signal(false);
+  protected readonly salesforceErrorToastKey = SALESFORCE_ERROR_TOAST_KEY;
   protected readonly isCreateEnabled: Signal<boolean> = this.initIsCreateEnabled();
 
   protected onFoundationChange(value: string | null): void {
@@ -119,9 +135,12 @@ export class MyEventsDashboardComponent {
           }
 
           this.messageService.add({
+            key: SALESFORCE_ERROR_TOAST_KEY,
             severity: 'error',
             summary: 'Error',
             detail: 'Your account is missing the required Salesforce ID. Please contact support.',
+            data: { showSupport: true },
+            closable: true,
           });
           return false;
         }),

--- a/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.html
+++ b/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.html
@@ -23,6 +23,10 @@
 
           <p class="text-gray-600 mb-8 max-w-lg mx-auto" data-testid="invite-error-description">
             {{ description }}
+            @if (isGenericError) {
+              <span>Need more help? </span
+              ><button type="button" lfxOpenIntercom class="font-medium underline" data-testid="invite-error-contact-support">Contact support</button>
+            }
           </p>
 
           <lfx-button routerLink="/" icon="fa-light fa-house" label="Go to Dashboard" size="small" data-testid="invite-error-home-button"> </lfx-button>

--- a/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.ts
@@ -23,30 +23,34 @@ export class InviteErrorComponent {
 
   public constructor() {
     this.reason = this.route.snapshot.queryParamMap.get('reason') ?? 'failed';
-    this.title = this.initTitle();
-    this.description = this.initDescription();
-    this.isGenericError = this.reason !== 'expired' && this.reason !== 'missing';
+    // One switch owns all three fields so a future specific `case` can't drift apart from the
+    // generic-error flag that gates the Contact support CTA.
+    const content = this.initContent();
+    this.title = content.title;
+    this.description = content.description;
+    this.isGenericError = content.isGenericError;
   }
 
-  private initTitle(): string {
+  private initContent(): { title: string; description: string; isGenericError: boolean } {
     switch (this.reason) {
       case 'expired':
-        return 'Invite Link Expired';
+        return {
+          title: 'Invite Link Expired',
+          description: 'This invitation link has expired. Please ask the sender to generate a new invite.',
+          isGenericError: false,
+        };
       case 'missing':
-        return 'Invalid Invite Link';
+        return {
+          title: 'Invalid Invite Link',
+          description: 'This invitation link is not valid. Please check the URL and try again.',
+          isGenericError: false,
+        };
       default:
-        return 'Could Not Accept Invite';
-    }
-  }
-
-  private initDescription(): string {
-    switch (this.reason) {
-      case 'expired':
-        return 'This invitation link has expired. Please ask the sender to generate a new invite.';
-      case 'missing':
-        return 'This invitation link is not valid. Please check the URL and try again.';
-      default:
-        return 'Something went wrong while accepting your invitation. Please try again.';
+        return {
+          title: 'Could Not Accept Invite',
+          description: 'Something went wrong while accepting your invitation. Please try again.',
+          isGenericError: true,
+        };
     }
   }
 }

--- a/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.ts
+++ b/apps/lfx-one/src/app/modules/invite/invite-error/invite-error.component.ts
@@ -6,10 +6,11 @@ import { ActivatedRoute, RouterLink } from '@angular/router';
 import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { HeaderComponent } from '@components/header/header.component';
+import { OpenIntercomDirective } from '@shared/directives/open-intercom.directive';
 
 @Component({
   selector: 'lfx-invite-error',
-  imports: [RouterLink, HeaderComponent, CardComponent, ButtonComponent],
+  imports: [RouterLink, HeaderComponent, CardComponent, ButtonComponent, OpenIntercomDirective],
   templateUrl: './invite-error.component.html',
 })
 export class InviteErrorComponent {
@@ -18,11 +19,13 @@ export class InviteErrorComponent {
   protected readonly reason: string;
   protected readonly title: string;
   protected readonly description: string;
+  protected readonly isGenericError: boolean;
 
   public constructor() {
     this.reason = this.route.snapshot.queryParamMap.get('reason') ?? 'failed';
     this.title = this.initTitle();
     this.description = this.initDescription();
+    this.isGenericError = this.reason !== 'expired' && this.reason !== 'missing';
   }
 
   private initTitle(): string {
@@ -43,7 +46,7 @@ export class InviteErrorComponent {
       case 'missing':
         return 'This invitation link is not valid. Please check the URL and try again.';
       default:
-        return 'Something went wrong while accepting your invitation. Please try again or contact support.';
+        return 'Something went wrong while accepting your invitation. Please try again.';
     }
   }
 }


### PR DESCRIPTION
## Summary

Every "contact us / contact support" phrase that previously sat as dead text in an error or empty state now opens the Intercom (Fin) messenger so users can actually reach support in one click. This covers the Organization Lens no-access and empty states (overview, groups, projects, meetings, ROI), a new conditional Contact support CTA on the invite-error page for generic failures, and the My Events missing-Salesforce-ID error, which moves from a plain auto-dismissing toast to a sticky keyed toast carrying a Contact Support action.

Resolves #1880

## Behavior changes

### Organization Lens no-access and empty states

| Before | After |
|---|---|
| The no-access and empty states on the overview, groups, projects, meetings, and ROI pages told users to "contact us" or "contact support", but the phrase was plain text with no way to act on it. | The same phrases are now buttons that open the support messenger directly, so a user who hits a wall can reach support without leaving the page or hunting for a contact channel. |

### Invite-error page

| Before | After |
|---|---|
| A failed invite acceptance told the user to "try again or contact support", with support being unlinked text; expired and invalid-link reasons had their own remediation copy. | Generic invite failures now show a Contact support button (opening the support messenger) next to the retry guidance, while expired and invalid-link cases keep their specific self-serve copy without the extra CTA. |

### My Events — missing Salesforce ID error

| Before | After |
|---|---|
| When a user's account lacked the required Salesforce ID, an error toast appeared and auto-dismissed after about 3 seconds, giving the user no actionable next step and barely enough time to read it. | The error now appears in a persistent toast that stays on screen until dismissed and includes a Contact Support button that opens the support messenger — the only remediation path for this error. |

## Technical changes

`apps/lfx-one/src/app/modules/dashboards/org/` — Org Lens no-access / empty states
- Wraps "contact us / contact support" phrases in `lfxOpenIntercom` buttons across `org-overview`, `org-groups`, `org-projects`, `org-meetings`, `org-roi`, and `org-roi-empty-state` templates (overview gets two: the no-access state and the no-organizations empty state)
- Adds `OpenIntercomDirective` to each host component's `imports`; each button carries a `*-contact-support` testid

`apps/lfx-one/src/app/modules/invite/invite-error/` — Invite-error CTA
- Adds a conditional "Need more help? Contact support" line gated on a new `isGenericError` flag, shown only for generic failures (`expired` / `missing` keep their specific remediation copy)
- Consolidates `initTitle()` / `initDescription()` into a single `initContent()` switch so a future specific `case` can't drift from the generic-error flag that gates the CTA

`apps/lfx-one/src/app/modules/events/my-events-dashboard/` — Salesforce-ID error toast
- Moves the missing-Salesforce-ID error to a keyed `p-toast` (`my-events-salesforce-error`) with a custom message template so the Contact Support action renders only for this error
- Sets `sticky: true` (repo precedent for actionable error toasts) so PrimeNG's default 3s life doesn't auto-dismiss the CTA; adds `closable: true` and `data: { showSupport: true }` to drive the template
- Adds `ToastModule` and `OpenIntercomDirective` to the component imports

`apps/lfx-one/e2e/` — E2E coverage
- Asserts the contact-support CTA is visible in the org-lens no-access tests: `org-selector.spec.ts` (overview), `org-projects.spec.ts`, `org-meetings-dashboard.spec.ts`, `org-roi-summary.spec.ts`
