### PR TITLE
fix(clas): disable sign cla and row actions while impersonating

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.spec.ts
@@ -30,16 +30,16 @@ describe('buildContactClaManagerMenuItems', () => {
   const dialog = { open: vi.fn() } as unknown as DialogService;
 
   it('returns nothing for ICLA and Revoked rows', () => {
-    expect(buildContactClaManagerMenuItems(agreement({ kind: 'ICLA', pdfAvailable: true }), dialog)).toEqual([]);
-    expect(buildContactClaManagerMenuItems(agreement({ status: 'revoked' }), dialog)).toEqual([]);
+    expect(buildContactClaManagerMenuItems(agreement({ kind: 'ICLA', pdfAvailable: true }), dialog, false)).toEqual([]);
+    expect(buildContactClaManagerMenuItems(agreement({ status: 'revoked' }), dialog, false)).toEqual([]);
   });
 
   it('offers Request Removal and Contact CLA Manager on a Valid ECLA', () => {
-    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'valid' }), dialog))).toEqual(['Request Removal', 'Contact CLA Manager']);
+    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'valid' }), dialog, false))).toEqual(['Request Removal', 'Contact CLA Manager']);
   });
 
   it('offers approval, removal, and contact on Needs-attention + not_on_approval_list', () => {
-    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'needs_attention', statusReason: 'not_on_approval_list' }), dialog))).toEqual([
+    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'needs_attention', statusReason: 'not_on_approval_list' }), dialog, false))).toEqual([
       'Request approval',
       'Request Removal',
       'Contact CLA Manager',
@@ -47,17 +47,35 @@ describe('buildContactClaManagerMenuItems', () => {
   });
 
   it('hides Request approval when the reason is not an approval-list miss', () => {
-    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'needs_attention', statusReason: 'unknown' }), dialog))).toEqual([
+    expect(labels(buildContactClaManagerMenuItems(agreement({ status: 'needs_attention', statusReason: 'unknown' }), dialog, false))).toEqual([
       'Request Removal',
       'Contact CLA Manager',
     ]);
   });
 
+  it('leaves every item enabled in a normal session', () => {
+    const items = buildContactClaManagerMenuItems(agreement({ status: 'needs_attention', statusReason: 'not_on_approval_list' }), dialog, false);
+
+    expect(items.map((item) => item.disabled)).toEqual([false, false, false]);
+  });
+
+  it('disables every item while impersonating, since all three are writes (#1894)', () => {
+    const items = buildContactClaManagerMenuItems(agreement({ status: 'needs_attention', statusReason: 'not_on_approval_list' }), dialog, true);
+
+    // Still offered — the administrator sees the action exists and that it is unavailable.
+    expect(labels(items)).toEqual(['Request approval', 'Request Removal', 'Contact CLA Manager']);
+    expect(items.every((item) => item.disabled)).toBe(true);
+  });
+
   it('opens the shared modal in the matching mode', () => {
     const open = vi.fn();
-    const items = buildContactClaManagerMenuItems(agreement({ status: 'needs_attention', statusReason: 'not_on_approval_list' }), {
-      open,
-    } as unknown as DialogService);
+    const items = buildContactClaManagerMenuItems(
+      agreement({ status: 'needs_attention', statusReason: 'not_on_approval_list' }),
+      {
+        open,
+      } as unknown as DialogService,
+      false
+    );
 
     items[0]?.command?.({} as never);
 

--- a/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.ts
@@ -14,8 +14,12 @@ import { ContactClaManagerComponent } from './contact-cla-manager.component';
  *
  * Returns `[]` for ICLA and Revoked, so it is safe to spread onto every row. Does not read
  * LaunchDarkly — invoke only when `my-clas-m2-enabled` is on. Does not edit profile-clas.
+ *
+ * All three are writes, so `impersonating` renders them disabled rather than withheld: the
+ * administrator sees the action exists and that it is unavailable, and the server refuses it
+ * anyway (`blockDuringImpersonation` on `POST /api/me/clas/:signatureId/cla-manager-requests`).
  */
-export function buildContactClaManagerMenuItems(agreement: MyClaAgreement, dialog: DialogService): MenuItem[] {
+export function buildContactClaManagerMenuItems(agreement: MyClaAgreement, dialog: DialogService, impersonating: boolean): MenuItem[] {
   const items: MenuItem[] = [];
   const projectName = agreement.projectName || agreement.claGroupName;
   const open = (mode: ContactClaManagerDialogData['mode']): void => {
@@ -34,6 +38,7 @@ export function buildContactClaManagerMenuItems(agreement: MyClaAgreement, dialo
     items.push({
       label: CLA_MANAGER_MODAL_COPY.approval.title,
       icon: 'fa-light fa-circle-check',
+      disabled: impersonating,
       command: () => open('approval'),
     });
   }
@@ -41,6 +46,7 @@ export function buildContactClaManagerMenuItems(agreement: MyClaAgreement, dialo
     items.push({
       label: CLA_MANAGER_MODAL_COPY.removal.title,
       icon: 'fa-light fa-user-slash',
+      disabled: impersonating,
       command: () => open('removal'),
     });
   }
@@ -48,6 +54,7 @@ export function buildContactClaManagerMenuItems(agreement: MyClaAgreement, dialo
     items.push({
       label: CLA_MANAGER_MODAL_COPY.contact.title,
       icon: 'fa-light fa-address-book',
+      disabled: impersonating,
       command: () => open('contact'),
     });
   }

--- a/apps/lfx-one/src/app/modules/profile/clas/manage-ccla-console-menu.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/manage-ccla-console-menu.ts
@@ -16,8 +16,13 @@ import { environment } from '@environments/environment';
  *
  * Opens via `command` rather than `url` + `target`: PrimeNG's menu renders no `rel`
  * attribute, so an anchor here could not carry `noopener noreferrer`.
+ *
+ * Disabled while impersonating even though the item is a read plus a navigation. The Console
+ * authenticates the browser's own user, so following it from an impersonation session lands the
+ * administrator in the Console as themselves on someone else's project — an offer that does not
+ * do what the row implies. Row actions grey out together (#1894); only Download PDF stays.
  */
-export function buildManageInCclaConsoleMenuItems(agreement: MyClaAgreement): MenuItem[] {
+export function buildManageInCclaConsoleMenuItems(agreement: MyClaAgreement, impersonating: boolean): MenuItem[] {
   if (!canManageInCclaConsole(agreement)) {
     return [];
   }
@@ -26,6 +31,7 @@ export function buildManageInCclaConsoleMenuItems(agreement: MyClaAgreement): Me
     {
       label: 'Manage in CCLA Console',
       icon: 'fa-light fa-arrow-up-right-from-square',
+      disabled: impersonating,
       command: () => {
         if (typeof window !== 'undefined') {
           window.open(url, '_blank', 'noopener,noreferrer');

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.html
@@ -10,13 +10,18 @@ SPDX-License-Identifier: MIT
   <div class="flex items-start justify-between gap-4">
     <h2 class="text-lg font-semibold text-slate-800">CLAs</h2>
 
-    <!-- Page-level, not per-row: signing a new CLA has no row to act on yet. -->
-    @if (canSign()) {
+    <!--
+    Page-level, not per-row: signing a new CLA has no row to act on yet. Rendered whenever the M2
+    overlay is on, then disabled while impersonating rather than withheld.
+    -->
+    @if (myClasM2Enabled()) {
       <lfx-button
         label="Sign CLA"
         icon="fa-light fa-file-signature"
         size="small"
         [loading]="starting()"
+        [disabled]="impersonating()"
+        [ariaLabel]="impersonating() ? 'This action is unavailable while impersonating another user' : undefined"
         data-testid="sign-cla-action"
         (onClick)="openSignDialog()" />
     }

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -51,7 +51,7 @@ describe('ProfileClasComponent', () => {
   /** The list's own manager flags come from the row, so this stays uncalled unless the dialog opens. */
   let getClaManagersSpy: ReturnType<typeof vi.fn>;
 
-  async function render(agreements: MyClaAgreement[], options: { m2Enabled?: boolean } = {}): Promise<void> {
+  async function render(agreements: MyClaAgreement[], options: { m2Enabled?: boolean; impersonating?: boolean } = {}): Promise<void> {
     const response: MyClasResponse = {
       agreements,
       identity: { matchedUserIds: agreements.length > 0 ? 1 : 0, unmatched: agreements.length === 0, githubLinked: true },
@@ -68,7 +68,7 @@ describe('ProfileClasComponent', () => {
         { provide: MyClasService, useValue: { getMyClas: () => of(response), getPdfUrl: vi.fn(), getClaManagers } },
         // Stubbed rather than real: the Sign CLA action reads impersonating(), and the real
         // service would drag HttpClient into a TestBed that has no reason to make requests.
-        { provide: UserService, useValue: { impersonating: signal(false) } },
+        { provide: UserService, useValue: { impersonating: signal(options.impersonating ?? false) } },
         // Existing tests document M2 overlay behaviour; pin the flag on unless a case opts out.
         {
           provide: FeatureFlagService,
@@ -277,6 +277,42 @@ describe('ProfileClasComponent', () => {
 
     await render([agreement({ id: 's-ecla', kind: 'ECLA', pdfAvailable: false, companyName: 'Acme', claGroupId: 'g-anuket-005', claManager: false })]);
     expect(menuItems('s-ecla').map((item) => item.label)).toEqual([eclaDownloadLabel, 'Request Removal', 'Contact CLA Manager']);
+  });
+
+  it('disables every row action except Download PDF while impersonating (#1894)', async () => {
+    const attnEcla = agreement({
+      id: 's-attn',
+      kind: 'ECLA',
+      pdfAvailable: false,
+      status: 'needs_attention',
+      statusReason: 'not_on_approval_list',
+      companyName: 'Acme',
+      claGroupId: 'g-anuket-005',
+      claManager: true,
+      foundationSfid: 'a09P000000DsCE5IAN',
+    });
+
+    await render([attnEcla], { impersonating: true });
+
+    // Nothing is withheld — the same items a normal session gets, greyed out, so the
+    // administrator can see the action exists and that it is unavailable.
+    expect(menuItems('s-attn').map((item) => item.label)).toEqual([
+      eclaDownloadLabel,
+      'Request approval',
+      'Request Removal',
+      'Contact CLA Manager',
+      'Manage in CCLA Console',
+    ]);
+    expect(menuItems('s-attn').every((item) => item.disabled)).toBe(true);
+    expect(actionsTrigger('s-attn')).not.toBeNull();
+  });
+
+  it('keeps Download PDF enabled while impersonating — retrieving the document is a read (#1894)', async () => {
+    await render([agreement({ id: 's-icla', kind: 'ICLA', pdfAvailable: true })], { impersonating: true });
+
+    const items = menuItems('s-icla');
+    expect(items.map((item) => item.label)).toEqual(['Download PDF']);
+    expect(items[0].disabled).toBeFalsy();
   });
 
   it('reads manager status off the row rather than spending a managers GET per ECLA', async () => {
@@ -591,6 +627,11 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     return fixture.nativeElement.querySelector(`[data-testid="${testId}"]`);
   }
 
+  /** The real `<button>` inside `<lfx-button>` — where `disabled` and `aria-label` land. */
+  function signButton(fixture: ComponentFixture<ProfileClasComponent>): HTMLButtonElement | null {
+    return query(fixture, 'sign-cla-action')?.querySelector<HTMLButtonElement>('button') ?? null;
+  }
+
   /** Runs the whole flow from the entry point, as a click would. */
   async function sign(fixture: ComponentFixture<ProfileClasComponent>): Promise<void> {
     (fixture.componentInstance as any).openSignDialog();
@@ -624,12 +665,33 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     const fixture = await setup();
 
     expect(query(fixture, 'sign-cla-action')).not.toBeNull();
+    expect(signButton(fixture)?.disabled).toBe(false);
+    expect(signButton(fixture)?.getAttribute('aria-label')).toBeNull();
   });
 
-  it('withholds the action while impersonating, since the server refuses the write', async () => {
+  it('renders Sign CLA disabled, not hidden, while impersonating (#1894)', async () => {
     const fixture = await setup({ impersonating: true });
 
-    expect(query(fixture, 'sign-cla-action')).toBeNull();
+    // Visible and greyed rather than absent, so the administrator can see the action exists and
+    // read why it is unavailable — the same treatment as every other impersonation-blocked
+    // control on the profile. The server is still the guard.
+    expect(query(fixture, 'sign-cla-action')).not.toBeNull();
+    expect(signButton(fixture)?.disabled).toBe(true);
+    expect(signButton(fixture)?.getAttribute('aria-label')).toBe('This action is unavailable while impersonating another user');
+  });
+
+  it('opens no picker when Sign CLA is reached while impersonating', async () => {
+    const fixture = await setup({ impersonating: true });
+
+    signButton(fixture)?.click();
+    await fixture.whenStable();
+    expect(opened).toEqual([]);
+
+    // Guarded in the method too, not only on the button: now that the button is rendered, a
+    // keyboard or programmatic activation can reach `openSignDialog` directly.
+    await sign(fixture);
+    expect(opened).toEqual([]);
+    expect(prepareSign).not.toHaveBeenCalled();
   });
 
   it('withholds Sign CLA when my-clas-m2-enabled is off', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -72,6 +72,20 @@ export class ProfileClasComponent {
   /** Dark-launch for the M2 overlay. Default off — LaunchDarkly targeting is the rollout switch. */
   protected readonly myClasM2Enabled = this.featureFlagService.getBooleanFlag(MY_CLAS_M2_ENABLED_FLAG, false);
 
+  /**
+   * Read-only when impersonating — a signature and a CLA-manager request are binding acts that
+   * would be recorded against the target rather than the administrator, so the server refuses
+   * them (`blockDuringImpersonation` on `POST /api/me/clas/prepare-sign` and
+   * `POST /api/me/clas/:signatureId/cla-manager-requests`).
+   *
+   * Sign CLA and the row's write actions are therefore disabled rather than withheld, so an
+   * administrator can see the action exists and read why it is unavailable — the treatment every
+   * other impersonation-blocked control on the profile gets. Download PDF stays enabled: it is a
+   * read, and retrieving the signed document is the one thing an administrator legitimately
+   * needs on someone else's row.
+   */
+  protected readonly impersonating = this.userService.impersonating;
+
   // signatureID currently resolving a PDF URL (drives the row's spinner + guards double-clicks).
   protected readonly downloadingId = signal<string | null>(null);
 
@@ -93,22 +107,13 @@ export class ProfileClasComponent {
   protected readonly isEmpty = computed(() => isMyClasEmpty(this.state().loaded, this.state().error, this.agreements().length));
 
   /**
-   * The table's only binding source. Recomputes when the agreement list changes and not
-   * otherwise, which is also what keeps each row's `MenuItem[]` referentially stable —
-   * a fresh model per change-detection pass makes the PrimeNG popup miss the first click.
+   * The table's only binding source. Recomputes when the agreement list or the two session flags
+   * it reads change, and not otherwise, which is what keeps each row's `MenuItem[]` referentially
+   * stable — a fresh model per change-detection pass makes the PrimeNG popup miss the first click.
    */
   protected readonly rows: Signal<ClaRow[]> = this.initRows();
 
   // --- Sign CLA hand-off (#1251) -------------------------------------------
-
-  /**
-   * Offered only when M2 is on and the session is not impersonating. Impersonation is
-   * read-only by platform rule, and a signature is a binding act that would be recorded against
-   * the target rather than the administrator who performed it. Hiding it here avoids offering
-   * an action that cannot succeed; the server, not this flag, is the impersonation guard.
-   * `my-clas-m2-enabled` is the product gate — off, this page is the M1 list.
-   */
-  protected readonly canSign = computed(() => this.myClasM2Enabled() && !this.userService.impersonating());
 
   protected retry(): void {
     this.refresh$.next();
@@ -134,7 +139,10 @@ export class ProfileClasComponent {
    * dialog rule and the sibling profile tabs.
    */
   protected openSignDialog(): void {
-    if (!this.myClasM2Enabled() || this.starting() || this.signDialogOpen()) return;
+    // `impersonating()` is re-checked here and not only on the button: the button is now rendered
+    // rather than withheld, so a keyboard or programmatic activation can reach this method, and
+    // opening the picker would walk the administrator to a prepare the server refuses.
+    if (!this.myClasM2Enabled() || this.impersonating() || this.starting() || this.signDialogOpen()) return;
     this.signDialogOpen.set(true);
 
     const dialogRef = this.dialogService.open(ClaGroupSelectComponent, {
@@ -408,8 +416,11 @@ export class ProfileClasComponent {
    * An invalidated ICLA also has no ⋮, matching the v17-after-legal HTML (FDC3): empty
    * `actionscell` even when a PDF exists. Invalidated ECLA is not drawn there and still
    * keeps Request Removal.
+   *
+   * `impersonating` greys out the write actions the two factories emit; Download PDF is built
+   * without it, so the one action an administrator needs on someone else's row survives.
    */
-  private buildRowMenuItems(agreement: MyClaAgreement): MenuItem[] {
+  private buildRowMenuItems(agreement: MyClaAgreement, impersonating: boolean): MenuItem[] {
     if (agreement.status === 'revoked' || (agreement.kind === 'ICLA' && agreement.status === 'invalidated')) {
       return [];
     }
@@ -430,8 +441,8 @@ export class ProfileClasComponent {
           icon: 'fa-light fa-download',
           disabled: true,
         },
-        ...buildContactClaManagerMenuItems(agreement, this.dialogService),
-        ...buildManageInCclaConsoleMenuItems(agreement),
+        ...buildContactClaManagerMenuItems(agreement, this.dialogService, impersonating),
+        ...buildManageInCclaConsoleMenuItems(agreement, impersonating),
       ];
     }
     return [];
@@ -461,8 +472,9 @@ export class ProfileClasComponent {
   private initRows(): Signal<ClaRow[]> {
     return computed(() => {
       const m2 = this.myClasM2Enabled();
+      const impersonating = this.impersonating();
       return this.agreements().map((agreement) => {
-        const menuItems = m2 ? this.buildRowMenuItems(agreement) : [];
+        const menuItems = m2 ? this.buildRowMenuItems(agreement, impersonating) : [];
         return {
           id: agreement.id,
           agreement,


### PR DESCRIPTION
## Summary

While impersonating, the My CLAs screen hid the **Sign CLA** button entirely and left the per-row **⋮** menu fully enabled — so it withheld one action and offered three that the server then refused. Both diverge from the application's established impersonation treatment, which keeps the control visible and disabled so an administrator can see the action exists and read why it is unavailable (`docs/architecture/backend/impersonation.md`: "the frontend renders the corresponding edit affordances **visible but disabled**").

This PR brings My CLAs into line with that pattern. It is presentation only: the `blockDuringImpersonation` guards on `POST /api/me/clas/prepare-sign` and `POST /api/me/clas/:signatureId/cla-manager-requests` are untouched and remain the enforcement point.

Closes #1894

## Behavior changes

### Sign CLA

| Before | After |
|---|---|
| Omitted from the header during impersonation — `canSign` folded impersonation into the render gate, so an administrator saw no sign of the action at all. | Rendered whenever the M2 overlay is on, disabled and greyed while impersonating, announcing "This action is unavailable while impersonating another user". `my-clas-m2-enabled` remains the render gate; impersonation is now a disabled state. |

### Row actions (⋮)

| Before | After |
|---|---|
| Not gated on impersonation at all. Request approval, Request Removal, Contact CLA Manager, and Manage in CCLA Console were offered and then failed at the server. | Each renders disabled during impersonation. **Download PDF stays enabled** — it is a read, and retrieving the signed document is the one thing an administrator legitimately needs on someone else's row. |

A normal session is unchanged in both cases.

## Technical changes

`apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts` / `.html`

- Removes the `canSign` computed, which had collapsed to `myClasM2Enabled()` once impersonation stopped being a render gate; the template now gates on `myClasM2Enabled()` directly, matching the five sibling M2 gates in the same file
- Adds `impersonating`, forwarding `UserService.impersonating`, and applies `[disabled]` plus the conditional `[ariaLabel]` to the Sign CLA button — the same idiom used by all 19 `lfx-button` impersonation call sites in the app (Identities, profile email, work experience, affiliations, account settings)
- `openSignDialog()` re-checks `impersonating()`: now that the button is rendered rather than withheld, a keyboard or programmatic activation can reach the method, and opening the picker would walk the administrator to a prepare the server refuses
- `buildRowMenuItems()` and `initRows()` thread the flag to the two item factories; Download PDF is built without it, so it stays enabled by construction rather than by matching on its label

`apps/lfx-one/src/app/modules/profile/clas/contact-cla-manager-menu.ts`

- `buildContactClaManagerMenuItems` takes `impersonating: boolean` (required, not defaulted — one production caller, and a default would let a future caller silently omit it) and sets `disabled` on all three items

`apps/lfx-one/src/app/modules/profile/clas/manage-ccla-console-menu.ts`

- `buildManageInCclaConsoleMenuItems` takes the same flag and disables the item. Disabled despite being a read plus a navigation: the Console authenticates the browser's own user, so following it from an impersonation session lands the administrator in the Console as themselves on someone else's project — an offer that does not do what the row implies

`apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts`, `contact-cla-manager-menu.spec.ts` — Tests

- Replaces the spec asserting `sign-cla-action` is absent under impersonation with one asserting present, disabled, and correctly announced; extends the normal-session test to pin enabled-and-unannounced
- Adds a guard test that neither clicking the disabled button nor calling `openSignDialog()` directly opens a picker or reaches `prepareSign`
- Adds row-action coverage: an impersonated Needs-attention ECLA still offers all five items with every one disabled and its kebab trigger present; an ICLA with a document keeps Download PDF enabled
- Adds factory coverage for all three contact items disabled under impersonation and enabled without it
- The two specs asserting absence when `my-clas-m2-enabled` is **off** are unchanged — the flag still hides, impersonation disables