### PR TITLE
fix(campaigns): load the demand-gen capability on the create path

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1221,6 +1221,85 @@ describe('CampaignsComponent brief persistence', () => {
         ).toBeNull();
       });
 
+      /**
+       * The capability read must survive an Optimize visit landing on top of it.
+       *
+       * It originally shared `briefCampaignsGeneration` with `loadBriefCampaigns`, which looked
+       * right — same endpoint, same staleness question — but that counter is INCREMENTED by
+       * `loadBriefCampaigns` itself. So entering Optimize while the capability request was in
+       * flight bumped it and the response was dropped as stale, leaving the capability `null`
+       * and the control hidden: exactly the defect this method exists to fix. Guarding on the
+       * foundation instead is what makes an unrelated read harmless.
+       */
+      it('keeps a capability response that an Optimize load raced', async () => {
+        const capability = new Subject<CampaignListResult>();
+        const list = vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(capability.asObservable());
+
+        await withSavedBrief();
+
+        // Optimize entry lands on top of the still-open capability request.
+        list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: false }));
+        load();
+        await fixture.whenStable();
+
+        // ...and only now does the capability answer arrive.
+        capability.next({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true });
+        capability.complete();
+        await fixture.whenStable();
+
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBe(true);
+      });
+
+      /**
+       * The RESTORE path, which knows its brief id and still missed the capability.
+       *
+       * `onProceedToImplementation` originally asked for the capability before the
+       * `alreadyPersisted` branch wrote the restored id onto `briefPersistence`, so the read saw
+       * the PREVIOUS id and guarded itself out. Unlike a first create there is no persist to
+       * follow, so nothing retried and the capability stayed unknown for the whole session.
+       */
+      it('loads the capability for a brief restored from campaign-service', async () => {
+        vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(
+          of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true })
+        );
+
+        restore(brief, 'brief-9', true);
+        await fixture.whenStable();
+
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBe(true);
+      });
+
+      /**
+       * A read that starts failing must not leave the previous answer standing.
+       *
+       * The error arm wrote nothing at first, which reads as "left null" only on the FIRST read.
+       * Once a successful read had set `true`, a later failure kept offering the control on the
+       * strength of a read that no longer succeeds. Asserts the value, not merely that the arm ran.
+       */
+      it('clears a previously known capability when a later read fails', async () => {
+        const list = vi
+          .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')
+          .mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
+
+        await withSavedBrief();
+        await fixture.whenStable();
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBe(true);
+
+        list.mockReturnValue(throwError(() => new Error('query service down')));
+        (fixture.componentInstance as unknown as { loadCreateCapabilities(): void }).loadCreateCapabilities();
+        await fixture.whenStable();
+
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBeNull();
+      });
+
       it('clears the previous brief campaigns when the foundation changes', async () => {
         const list = vi
           .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1278,9 +1278,9 @@ describe('CampaignsComponent brief persistence', () => {
        * on every entry — so an ordinary Optimize click discarded an in-flight capability response
        * and left the control hidden.
        *
-       * Both readers hit the same endpoint, so they cannot disagree about the deployment; the
-       * mock answers `true` on both. What is asserted is that the answer SURVIVES the overlap,
-       * whichever of the two happens to deliver it.
+       * Both mocked responses return `true`. What is asserted is that the answer SURVIVES the
+       * overlap — whichever of the two requests delivers it first, a `true` lands on the signal
+       * rather than being overwritten to `null` by the later arrival.
        */
       it('keeps a capability answer when an Optimize load races it', async () => {
         const capability = new Subject<CampaignListResult>();
@@ -1403,8 +1403,8 @@ describe('CampaignsComponent brief persistence', () => {
        * A foundation switch clears the capability but dispatches no capability read of its own,
        * so it never bumps `createCapabilitiesGeneration`. An in-flight read from the previous
        * foundation therefore still looks current BY GENERATION, and only the slug check stops it
-       * writing foundation A's answer onto foundation B — a capability claim about a deployment
-       * the user is no longer looking at.
+       * writing foundation A's answer onto foundation B — a stale answer for a slug the user
+       * is no longer viewing.
        */
       it('drops a capability answer that arrives after the foundation changed', async () => {
         const pending = new Subject<CampaignListResult>();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1230,8 +1230,9 @@ describe('CampaignsComponent brief persistence', () => {
       });
 
       /**
-       * because the tab's draft restore clears a saved Demand Gen selection on an explicit `false`
-       * and a failed read has established nothing.
+       * A failed read leaves the capability `null`, never `false` — because the tab's draft restore
+       * clears a saved Demand Gen selection on an explicit `false`, and a failed read has
+       * established nothing.
        */
       it('leaves the capability unknown when the capability read fails', async () => {
         vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(throwError(() => new Error('query service down')));

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1243,29 +1243,56 @@ describe('CampaignsComponent brief persistence', () => {
       });
 
       /**
-       * The capability read must survive an Optimize visit landing on top of it.
+       * An Optimize visit landing on top of a capability read must not lose the answer.
        *
-       * It originally shared `briefCampaignsGeneration` with `loadBriefCampaigns`, which looked
-       * right — same endpoint, same staleness question — but that counter is INCREMENTED by
-       * `loadBriefCampaigns` itself. So entering Optimize while the capability request was in
-       * flight bumped it and the response was dropped as stale, leaving the capability `null`
-       * and the control hidden: exactly the defect this method exists to fix. Guarding on the
-       * foundation instead is what makes an unrelated read harmless.
+       * The guard shared Optimize's list counter at first, which `loadBriefCampaigns` increments
+       * on every entry — so an ordinary Optimize click discarded an in-flight capability response
+       * and left the control hidden.
+       *
+       * Both readers hit the same endpoint, so they cannot disagree about the deployment; the
+       * mock answers `true` on both. What is asserted is that the answer SURVIVES the overlap,
+       * whichever of the two happens to deliver it.
        */
-      it('keeps a capability response that an Optimize load raced', async () => {
+      it('keeps a capability answer when an Optimize load races it', async () => {
         const capability = new Subject<CampaignListResult>();
         const list = vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(capability.asObservable());
 
         await withSavedBrief();
 
         // Optimize entry lands on top of the still-open capability request.
-        list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: false }));
+        list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
         load();
         await fixture.whenStable();
 
-        // ...and only now does the capability answer arrive.
+        // ...and the original request answers only now.
         capability.next({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true });
         capability.complete();
+        await fixture.whenStable();
+
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
+      });
+
+      /**
+       * The reverse race, and the one a single-reader token cannot close: `loadBriefCampaigns`
+       * writes this signal too. An older list read failing AFTER a newer capability read
+       * succeeded must not reset a live answer to `null` — a failure has established nothing.
+       */
+      it('does not let an older failing list read wipe a newer capability answer', async () => {
+        const staleList = new Subject<CampaignListResult>();
+        const list = vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(staleList.asObservable());
+
+        await withSavedBrief();
+        load();
+        await fixture.whenStable();
+
+        // A newer capability read answers while that list request is still open.
+        list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
+        (fixture.componentInstance as unknown as { loadCreateCapabilities(): void }).loadCreateCapabilities();
+        await fixture.whenStable();
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
+
+        // The superseded list read now fails. It must not touch the newer answer.
+        staleList.error(new Error('query service down'));
         await fixture.whenStable();
 
         expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1300,6 +1300,38 @@ describe('CampaignsComponent brief persistence', () => {
         ).toBeNull();
       });
 
+      /**
+       * Out-of-order completion WITHIN one foundation — the case a foundation-only guard misses.
+       *
+       * The first version of this guard shared Optimize's counter and dropped valid responses.
+       * The second guarded on the foundation alone, which drops nothing valid but imposes no
+       * ORDER: two Implementation entries in the same foundation can complete in either order,
+       * and an older request failing after a newer one succeeded would wipe a live `true` back
+       * to `null`, hiding Demand Gen on a deployment that had just confirmed it.
+       */
+      it('ignores an older capability read that fails after a newer one succeeded', async () => {
+        const older = new Subject<CampaignListResult>();
+        const list = vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(older.asObservable());
+
+        await withSavedBrief();
+
+        // A second Implementation entry supersedes the first, and answers first.
+        list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
+        (fixture.componentInstance as unknown as { loadCreateCapabilities(): void }).loadCreateCapabilities();
+        await fixture.whenStable();
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBe(true);
+
+        // The superseded request now fails. It must not touch the newer answer.
+        older.error(new Error('query service down'));
+        await fixture.whenStable();
+
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBe(true);
+      });
+
       it('clears the previous brief campaigns when the foundation changes', async () => {
         const list = vi
           .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1252,9 +1252,7 @@ describe('CampaignsComponent brief persistence', () => {
        * persist-success path still fires its own read — but this case stays broken.
        */
       it('retries the capability read when the user re-enters Implementation via the tab bar', async () => {
-        const list = vi
-          .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')
-          .mockReturnValue(throwError(() => new Error('query service down')));
+        const list = vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(throwError(() => new Error('query service down')));
 
         // First create: persist succeeds, capability read fails.
         await withSavedBrief();
@@ -1264,7 +1262,10 @@ describe('CampaignsComponent brief persistence', () => {
         // User navigates away and comes back via the tab bar.
         list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
         (fixture.componentInstance as unknown as { selectTab(t: CampaignTab, owner: CampaignDeliveryType): void }).selectTab('planning', 'paid-marketing');
-        (fixture.componentInstance as unknown as { selectTab(t: CampaignTab, owner: CampaignDeliveryType): void }).selectTab('implementation', 'paid-marketing');
+        (fixture.componentInstance as unknown as { selectTab(t: CampaignTab, owner: CampaignDeliveryType): void }).selectTab(
+          'implementation',
+          'paid-marketing'
+        );
         await fixture.whenStable();
 
         expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1394,6 +1394,38 @@ describe('CampaignsComponent brief persistence', () => {
         expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBeNull();
       });
 
+      /**
+       * A failure must not take the success ordering with it.
+       *
+       * Stamping the shared token on the ERROR arm looked symmetrical and was wrong: two reads
+       * dispatched together, the first failing, would advance the token and make the second's
+       * valid answer fail its own write check — a failure suppressing a success, which is the one
+       * thing the ordering exists to prevent.
+       */
+      it('lets a success land after an earlier read has already failed', async () => {
+        const first = new Subject<CampaignListResult>();
+        const second = new Subject<CampaignListResult>();
+        const list = vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(first.asObservable());
+
+        await withSavedBrief();
+
+        // A second read dispatches while the first is still open.
+        list.mockReturnValue(second.asObservable());
+        (fixture.componentInstance as unknown as { loadCreateCapabilities(): void }).loadCreateCapabilities();
+        await fixture.whenStable();
+
+        // The FIRST fails...
+        first.error(new Error('query service down'));
+        await fixture.whenStable();
+
+        // ...and the second still succeeds. Its answer must land.
+        second.next({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true });
+        second.complete();
+        await fixture.whenStable();
+
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
+      });
+
       it('clears the previous brief campaigns when the foundation changes', async () => {
         const list = vi
           .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1180,6 +1180,47 @@ describe('CampaignsComponent brief persistence', () => {
         await fixture.whenStable();
       }
 
+      /**
+       * The first-create path, which is the one that was broken.
+       *
+       * `onProceedToImplementation` sets the tab DIRECTLY rather than through `selectTab`, so the
+       * Optimize-entry load never ran and the capability stayed `null` — the Implementation tab
+       * then withheld Demand Gen on every deployment, including ones that support it.
+       *
+       * Asserted through the PARENT rather than by setting the tab's input, because the input
+       * always worked; nothing populated it. A test that sets `demandGenEnabled` by hand passes
+       * against exactly the bug this covers.
+       */
+      it('loads the demand-gen capability on a first-create Planning to Implementation flow', async () => {
+        vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(
+          of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true })
+        );
+
+        await withSavedBrief();
+        await fixture.whenStable();
+
+        // The real value, not `null`: the tab renders the control only on an explicit `true`.
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBe(true);
+      });
+
+      /**
+       * The read is best-effort: a failure must leave the capability UNKNOWN rather than `false`,
+       * because the tab's draft restore clears a saved Demand Gen selection on an explicit `false`
+       * and a failed read has established nothing.
+       */
+      it('leaves the capability unknown when the capability read fails', async () => {
+        vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(throwError(() => new Error('query service down')));
+
+        await withSavedBrief();
+        await fixture.whenStable();
+
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBeNull();
+      });
+
       it('clears the previous brief campaigns when the foundation changes', async () => {
         const list = vi
           .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1200,32 +1200,33 @@ describe('CampaignsComponent brief persistence', () => {
         await fixture.whenStable();
 
         // The real value, not `null`: the tab renders the control only on an explicit `true`.
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBe(true);
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
       });
 
       /**
-       * When brief persistence is disabled (`enabled: false`), `result.briefId` is '' and the
-       * old `!briefId` guard would exit before dispatching. But `canCreateDemandGen()` returns
-       * `true` on the legacy path, and the server returns that capability even on an empty-id
-       * read — the client must not skip the request just because no brief row exists yet.
+       * The disabled-persist path deliberately does NOT dispatch a capability read.
        *
-       * Asserted through the parent for the same reason as the first-create test above: an input
-       * set by hand passes against exactly this bug.
+       * It is tempting to send one: `result.briefId` is `''` there, and the service really does
+       * return `demandGenEnabled` for a blank brief id. But the HTTP path never reaches that
+       * branch — `campaign.controller.ts` 400s on a blank `brief_id` first, which
+       * `campaign.controller.spec.ts` pins. Dispatching would spend a request per Implementation
+       * entry to receive an error, land in the error arm, and set the capability to `null`; the
+       * control stays hidden either way, with a spurious 400 added.
+       *
+       * So the assertion is that NOTHING was sent, and the capability stays unknown. Fixing this
+       * properly needs a capability read that does not require a brief id at all.
        */
-      it('loads the demand-gen capability when brief persistence is disabled', async () => {
-        vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(
-          of({ campaigns: [], possiblyStale: true, statusToggleEnabled: false, demandGenEnabled: true })
-        );
+      it('sends no capability request when brief persistence is disabled', async () => {
+        const list = vi
+          .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')
+          .mockReturnValue(of({ campaigns: [], possiblyStale: true, statusToggleEnabled: false, demandGenEnabled: true }));
 
         persistBrief.mockReturnValue(of({ enabled: false, briefId: '', etag: null, created: false, approved: false }));
         proceed();
         await fixture.whenStable();
 
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBe(true);
+        expect(list).not.toHaveBeenCalled();
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBeNull();
       });
 
       /**
@@ -1238,9 +1239,7 @@ describe('CampaignsComponent brief persistence', () => {
         await withSavedBrief();
         await fixture.whenStable();
 
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBeNull();
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBeNull();
       });
 
       /**
@@ -1269,9 +1268,7 @@ describe('CampaignsComponent brief persistence', () => {
         capability.complete();
         await fixture.whenStable();
 
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBe(true);
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
       });
 
       /**
@@ -1290,9 +1287,7 @@ describe('CampaignsComponent brief persistence', () => {
         restore(brief, 'brief-9', true);
         await fixture.whenStable();
 
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBe(true);
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
       });
 
       /**
@@ -1309,17 +1304,13 @@ describe('CampaignsComponent brief persistence', () => {
 
         await withSavedBrief();
         await fixture.whenStable();
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBe(true);
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
 
         list.mockReturnValue(throwError(() => new Error('query service down')));
         (fixture.componentInstance as unknown as { loadCreateCapabilities(): void }).loadCreateCapabilities();
         await fixture.whenStable();
 
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBeNull();
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBeNull();
       });
 
       /**
@@ -1341,17 +1332,13 @@ describe('CampaignsComponent brief persistence', () => {
         list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
         (fixture.componentInstance as unknown as { loadCreateCapabilities(): void }).loadCreateCapabilities();
         await fixture.whenStable();
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBe(true);
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
 
         // The superseded request now fails. It must not touch the newer answer.
         older.error(new Error('query service down'));
         await fixture.whenStable();
 
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBe(true);
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
       });
 
       /**
@@ -1377,9 +1364,7 @@ describe('CampaignsComponent brief persistence', () => {
         pending.complete();
         await fixture.whenStable();
 
-        expect(
-          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
-        ).toBeNull();
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBeNull();
       });
 
       it('clears the previous brief campaigns when the foundation changes', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1206,7 +1206,29 @@ describe('CampaignsComponent brief persistence', () => {
       });
 
       /**
-       * The read is best-effort: a failure must leave the capability UNKNOWN rather than `false`,
+       * When brief persistence is disabled (`enabled: false`), `result.briefId` is '' and the
+       * old `!briefId` guard would exit before dispatching. But `canCreateDemandGen()` returns
+       * `true` on the legacy path, and the server returns that capability even on an empty-id
+       * read — the client must not skip the request just because no brief row exists yet.
+       *
+       * Asserted through the parent for the same reason as the first-create test above: an input
+       * set by hand passes against exactly this bug.
+       */
+      it('loads the demand-gen capability when brief persistence is disabled', async () => {
+        vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(
+          of({ campaigns: [], possiblyStale: true, statusToggleEnabled: false, demandGenEnabled: true })
+        );
+
+        persistBrief.mockReturnValue(of({ enabled: false, briefId: '', etag: null, created: false, approved: false }));
+        proceed();
+        await fixture.whenStable();
+
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBe(true);
+      });
+
+      /**
        * because the tab's draft restore clears a saved Demand Gen selection on an explicit `false`
        * and a failed read has established nothing.
        */

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1460,6 +1460,31 @@ describe('CampaignsComponent brief persistence', () => {
         expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
       });
 
+      /**
+       * The capability is a DEPLOYMENT fact, so re-entering Implementation must not re-read it.
+       *
+       * Without the `null` guard this spent a full `listBriefCampaigns` round trip per tab entry
+       * to learn the same boolean. Asserted as a CALL COUNT rather than a value, because the
+       * value is identical either way — only the number of requests distinguishes them.
+       */
+      it('does not refetch the capability once it is known', async () => {
+        const list = vi
+          .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')
+          .mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
+
+        await withSavedBrief();
+        await fixture.whenStable();
+        const afterFirst = list.mock.calls.length;
+
+        // Leave and re-enter Implementation: the answer is already known.
+        (fixture.componentInstance as unknown as { selectTab(t: string, o: string): void }).selectTab('planning', 'paid-marketing');
+        (fixture.componentInstance as unknown as { selectTab(t: string, o: string): void }).selectTab('implementation', 'paid-marketing');
+        await fixture.whenStable();
+
+        expect(list.mock.calls.length).toBe(afterFirst);
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
+      });
+
       it('clears the previous brief campaigns when the foundation changes', async () => {
         const list = vi
           .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1332,6 +1332,34 @@ describe('CampaignsComponent brief persistence', () => {
         ).toBe(true);
       });
 
+      /**
+       * The half the generation counter cannot cover.
+       *
+       * A foundation switch clears the capability but dispatches no capability read of its own,
+       * so it never bumps `createCapabilitiesGeneration`. An in-flight read from the previous
+       * foundation therefore still looks current BY GENERATION, and only the slug check stops it
+       * writing foundation A's answer onto foundation B — a capability claim about a deployment
+       * the user is no longer looking at.
+       */
+      it('drops a capability answer that arrives after the foundation changed', async () => {
+        const pending = new Subject<CampaignListResult>();
+        vi.spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns').mockReturnValue(pending.asObservable());
+
+        await withSavedBrief();
+
+        selectFoundation('cncf');
+        await fixture.whenStable();
+
+        // The previous foundation's read answers only now.
+        pending.next({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true });
+        pending.complete();
+        await fixture.whenStable();
+
+        expect(
+          (fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()
+        ).toBeNull();
+      });
+
       it('clears the previous brief campaigns when the foundation changes', async () => {
         const list = vi
           .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1278,9 +1278,10 @@ describe('CampaignsComponent brief persistence', () => {
        * on every entry — so an ordinary Optimize click discarded an in-flight capability response
        * and left the control hidden.
        *
-       * Both readers hit the same endpoint, so they cannot disagree about the deployment; the
-       * mock answers `true` on both. What is asserted is that the answer SURVIVES the overlap,
-       * whichever of the two happens to deliver it.
+       * Both mocked responses answer `true`, and the assertion is only that the answer SURVIVES
+       * the overlap — not that the two reads must agree. They can disagree: during a rolling
+       * deployment identical `/list` calls land on pods with different flag values, which is the
+       * pod-local hazard recorded on #1885. Ordering, not agreement, is what this pins.
        */
       it('keeps a capability answer when an Optimize load races it', async () => {
         const capability = new Subject<CampaignListResult>();
@@ -1401,7 +1402,7 @@ describe('CampaignsComponent brief persistence', () => {
        * The half the generation counter cannot cover.
        *
        * A foundation switch clears the capability but dispatches no capability read of its own,
-       * so it never bumps `createCapabilitiesGeneration`. An in-flight read from the previous
+       * so it never bumps `capabilityGeneration`. An in-flight read from the previous
        * foundation therefore still looks current BY GENERATION, and only the slug check stops it
        * writing foundation A's answer onto foundation B — a capability claim about a deployment
        * the user is no longer looking at.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -1243,6 +1243,34 @@ describe('CampaignsComponent brief persistence', () => {
       });
 
       /**
+       * The return-entry trigger — the second of the two triggers at lines 947-949.
+       *
+       * A first-create persist calls `loadCreateCapabilitiesFor` on success, but if that read
+       * fails the user has no way to retry except by leaving and re-entering the tab. That
+       * re-entry goes through `selectTab`, which is the path under test here. Removing the
+       * `tab === 'implementation'` branch from `selectTab` leaves the tests above green — the
+       * persist-success path still fires its own read — but this case stays broken.
+       */
+      it('retries the capability read when the user re-enters Implementation via the tab bar', async () => {
+        const list = vi
+          .spyOn(TestBed.inject(CampaignService), 'listBriefCampaigns')
+          .mockReturnValue(throwError(() => new Error('query service down')));
+
+        // First create: persist succeeds, capability read fails.
+        await withSavedBrief();
+        await fixture.whenStable();
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBeNull();
+
+        // User navigates away and comes back via the tab bar.
+        list.mockReturnValue(of({ campaigns: [], possiblyStale: false, statusToggleEnabled: false, demandGenEnabled: true }));
+        (fixture.componentInstance as unknown as { selectTab(t: CampaignTab, owner: CampaignDeliveryType): void }).selectTab('planning', 'paid-marketing');
+        (fixture.componentInstance as unknown as { selectTab(t: CampaignTab, owner: CampaignDeliveryType): void }).selectTab('implementation', 'paid-marketing');
+        await fixture.whenStable();
+
+        expect((fixture.componentInstance as unknown as { briefCampaignsDemandGenEnabled(): boolean | null }).briefCampaignsDemandGenEnabled()).toBe(true);
+      });
+
+      /**
        * An Optimize visit landing on top of a capability read must not lose the answer.
        *
        * The guard shared Optimize's list counter at first, which `loadBriefCampaigns` increments

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -1299,15 +1299,16 @@ export class CampaignsComponent {
    * opened before `persistBrief` resolves, so reading `briefPersistence()` at entry finds `null`
    * and the entry-time call guards itself out. The persist success arm passes its own id here.
    *
-   * Called with an EMPTY brief id when brief persistence is disabled (`enabled: false`). The
-   * server's `listBriefCampaigns` handles an empty brief id and still returns
-   * `demandGenEnabled: canCreateDemandGen()`, so the client learns the capability without a
-   * stored brief. `null` is guarded because a `null` id means "no id was supplied at all" and
-   * should not make the request; an empty string is a deliberate signal from the disabled path.
+   * An EMPTY id is refused here along with `null`, and that is not an oversight. The service
+   * does return `demandGenEnabled` for a blank brief id — but the HTTP path never reaches that
+   * branch: `campaign.controller.ts` 400s on a blank `brief_id` before calling the service, and
+   * `campaign.controller.spec.ts` pins it. Sending one would spend a request per Implementation
+   * entry to receive an error, land in the arm below, and set the capability to `null` — the
+   * control stays hidden either way, with a spurious 400 added.
    */
   private loadCreateCapabilitiesFor(briefId: string | null): void {
     const projectSlug = this.activeFoundationSlug();
-    if (projectSlug === '' || briefId === null) return;
+    if (projectSlug === '' || !briefId) return;
 
     // Ordered by this reader's OWN generation, and checked against the foundation too — see
     // `createCapabilitiesGeneration`. The counter gives ordering among repeated Implementation
@@ -1621,14 +1622,6 @@ export class CampaignsComponent {
           }
 
           if (generation !== this.briefPersistenceGeneration) return;
-          // Load capabilities here for BOTH paths — enabled and disabled. When disabled
-          // (`enabled: false`), `result.briefId` is '' and `loadCreateCapabilitiesFor` sends
-          // the request without a brief id; the server returns `demandGenEnabled: canCreateDemandGen()`
-          // even on that empty-id read, so the legacy creator gets the correct answer.
-          // When enabled, this also covers the first-create path where the Implementation tab
-          // opened before the persist resolved — the entry-time call guarded out because no id
-          // was known yet, and this is where the id first arrives.
-          this.loadCreateCapabilitiesFor(result.briefId);
           if (!result.enabled) {
             this.briefPersistence.set(this.idlePersistence);
             return;
@@ -1704,6 +1697,12 @@ export class CampaignsComponent {
           // as a `message` on the SAVED state rather than a new status or an `error`: describing a
           // durable write as failed would be its own lie, and the banner already renders a message
           // in this state.
+          //
+          // The capability read needs a brief id, and THIS is where a first create gets one: the
+          // Implementation tab opened before the persist resolved, so the entry-time attempt
+          // guarded itself out. Without this the create path never learns the capability.
+          this.loadCreateCapabilitiesFor(result.briefId);
+
           this.briefPersistence.set({
             status: 'saved',
             briefId: result.briefId,

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -525,9 +525,11 @@ export class CampaignsComponent {
    * if another answer has landed since it dispatched.
    *
    * It does NOT cover a foundation switch: that clears the capability but dispatches nothing, so
-   * it never bumps this. The separate slug comparison in each reader is what rejects a response
-   * from the previous foundation — two mechanisms, stated apart so neither is removed on the
-   * strength of the other.
+   * it never bumps this. The two readers reject the previous foundation's response by different
+   * means, and both are load-bearing: `loadCreateCapabilitiesFor` compares the slug it dispatched
+   * against the active one, while `loadBriefCampaigns` relies on the switch handler incrementing
+   * `briefCampaignsGeneration`, which its own `isCurrent` checks. Stated apart from the ordering
+   * above so neither is removed on the strength of the other.
    */
   private capabilityGeneration = 0;
 
@@ -1345,9 +1347,11 @@ export class CampaignsComponent {
         // Cleared to `null`, not left alone and not set `false`. `false` would clear a restored
         // draft's selection on evidence a failed read does not have; leaving the previous value
         // keeps offering the control on the strength of a read that has since started failing.
+        // Clears WITHOUT stamping. A failure establishes no capability value, so it must not
+        // take the success ordering with it: two reads dispatched together, the first failing,
+        // would otherwise advance the token and make the second's valid answer fail `mayWrite`.
         error: () => {
           if (!mayWrite()) return;
-          this.capabilityGeneration++;
           this.briefCampaignsDemandGenEnabled.set(null);
         },
       });
@@ -1441,8 +1445,9 @@ export class CampaignsComponent {
           this.briefCampaignsStale.set(false);
           this.briefCampaignsUnavailable.set(true);
           this.briefCampaignsToggleEnabled.set(false);
+          // Cleared WITHOUT stamping, for the reason the sibling reader's error arm gives: a
+          // failure has established nothing and must not suppress an in-flight success.
           if (mayWriteCapability()) {
-            this.capabilityGeneration++;
             this.briefCampaignsDemandGenEnabled.set(null);
           }
         },

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -910,6 +910,55 @@ export class CampaignsComponent {
       // since the last look — must not render with a stale status the user then acts on.
       this.loadBriefCampaigns();
     }
+    if (tab === 'implementation') {
+      this.loadCreateCapabilities();
+    }
+  }
+
+  /**
+   * Read the create-time capabilities the Implementation tab gates controls on.
+   *
+   * Separate from `loadBriefCampaigns` deliberately, even though both read the same response
+   * today. That one is an Optimize concern: it needs a persisted `briefId`, it re-fetches on
+   * every entry because a status can go stale, and it clears its rows first. None of that is
+   * true here — the capability is a deployment fact, it is needed BEFORE a campaign exists, and
+   * on the first-create path there may be no brief id at all.
+   *
+   * So this asks only when it can, and stays silent otherwise: the tab treats an unanswered
+   * capability as `null` and withholds the control without touching the user's draft. That is
+   * the correct reading of "not known", and it is why this is safe to skip.
+   */
+  private loadCreateCapabilities(): void {
+    this.loadCreateCapabilitiesFor(this.briefPersistence().briefId);
+  }
+
+  /**
+   * The same read against an explicitly supplied brief id.
+   *
+   * Needed because the first-create path has no id on the signal yet: the Implementation tab is
+   * opened before `persistBrief` resolves, so reading `briefPersistence()` at entry finds `null`
+   * and the entry-time call guards itself out. The persist success arm passes its own id here.
+   */
+  private loadCreateCapabilitiesFor(briefId: string | null): void {
+    const projectSlug = this.activeFoundationSlug();
+    if (projectSlug === '' || !briefId) return;
+
+    const generation = this.briefCampaignsGeneration;
+    this.campaignService
+      .listBriefCampaigns(projectSlug, briefId)
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        // ONLY the capability. This must not touch `briefCampaigns` or the staleness flag —
+        // those belong to Optimize's own read, and writing them from here would render a list
+        // the operator did not ask for and cannot see.
+        next: (result) => {
+          if (generation !== this.briefCampaignsGeneration) return;
+          this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
+        },
+        // Left `null` rather than set `false`: a failed read has not established that the
+        // capability is off, and `false` would clear a restored draft's selection.
+        error: () => undefined,
+      });
   }
 
   /**
@@ -973,6 +1022,9 @@ export class CampaignsComponent {
     this.implementationDraft.set(null);
     this.briefOutput.set(brief);
     this.selectedTab.set('implementation');
+    // Also here, because this path sets the tab DIRECTLY rather than through `selectTab` — which
+    // is exactly why the capability never loaded on a first create.
+    this.loadCreateCapabilities();
     if (alreadyPersisted) {
       // Bump the generation even though nothing is being saved. `persistBrief` normally does
       // this as its first act, and skipping the save must not also skip the INVALIDATION: a
@@ -1607,6 +1659,10 @@ export class CampaignsComponent {
           // as a `message` on the SAVED state rather than a new status or an `error`: describing a
           // durable write as failed would be its own lie, and the banner already renders a message
           // in this state.
+          // The capability read needs a brief id, and THIS is where a first create gets one — the
+          // Implementation tab opened before the persist resolved, so the entry-time attempt was
+          // guarded out. Without this the first-create path never learns the capability at all.
+          this.loadCreateCapabilitiesFor(result.briefId);
           this.briefPersistence.set({
             status: 'saved',
             briefId: result.briefId,

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -934,61 +934,6 @@ export class CampaignsComponent {
   }
 
   /**
-   * Read the create-time capabilities the Implementation tab gates controls on.
-   *
-   * Separate from `loadBriefCampaigns` deliberately, even though both read the same response
-   * today. That one is an Optimize concern: it needs a persisted `briefId`, it re-fetches on
-   * every entry because a status can go stale, and it clears its rows first. None of that is
-   * true here — the capability is a deployment fact, it is needed BEFORE a campaign exists, and
-   * on the first-create path there may be no brief id at all.
-   *
-   * So this asks only when it can, and stays silent otherwise: the tab treats an unanswered
-   * capability as `null` and withholds the control without touching the user's draft. That is
-   * the correct reading of "not known", and it is why this is safe to skip.
-   */
-  private loadCreateCapabilities(): void {
-    this.loadCreateCapabilitiesFor(this.briefPersistence().briefId);
-  }
-
-  /**
-   * The same read against an explicitly supplied brief id.
-   *
-   * Needed because the first-create path has no id on the signal yet: the Implementation tab is
-   * opened before `persistBrief` resolves, so reading `briefPersistence()` at entry finds `null`
-   * and the entry-time call guards itself out. The persist success arm passes its own id here.
-   */
-  private loadCreateCapabilitiesFor(briefId: string | null): void {
-    const projectSlug = this.activeFoundationSlug();
-    if (projectSlug === '' || !briefId) return;
-
-    // Ordered by this reader's OWN generation, and checked against the foundation too — see
-    // `createCapabilitiesGeneration`. The counter gives ordering among repeated Implementation
-    // entries; the slug is what makes a response from the previous foundation inapplicable
-    // rather than merely old.
-    const generation = ++this.createCapabilitiesGeneration;
-    const isCurrent = (): boolean => generation === this.createCapabilitiesGeneration && projectSlug === this.activeFoundationSlug();
-    this.campaignService
-      .listBriefCampaigns(projectSlug, briefId)
-      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
-      .subscribe({
-        // ONLY the capability. This must not touch `briefCampaigns` or the staleness flag —
-        // those belong to Optimize's own read, and writing them from here would render a list
-        // the operator did not ask for and cannot see.
-        next: (result) => {
-          if (!isCurrent()) return;
-          this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
-        },
-        // Cleared to `null`, not left alone and not set `false`. `false` would clear a restored
-        // draft's selection on evidence a failed read does not have; leaving the previous value
-        // keeps offering the control on the strength of a read that has since started failing.
-        error: () => {
-          if (!isCurrent()) return;
-          this.briefCampaignsDemandGenEnabled.set(null);
-        },
-      });
-  }
-
-  /**
    * Roving-tabindex keyboard navigation over one tablist.
    *
    * The owner is passed in for the same reason `selectTab` takes it, plus one specific to this
@@ -1328,6 +1273,61 @@ export class CampaignsComponent {
       this.knownBriefIds.set(key, { id: briefId, etag: validator, ...(validator === null ? { absence: 'overwrite' as const } : {}) });
     }
     this.onProceedToImplementation(brief, true, approved);
+  }
+
+  /**
+   * Read the create-time capabilities the Implementation tab gates controls on.
+   *
+   * Separate from `loadBriefCampaigns` deliberately, even though both read the same response
+   * today. That one is an Optimize concern: it needs a persisted `briefId`, it re-fetches on
+   * every entry because a status can go stale, and it clears its rows first. None of that is
+   * true here — the capability is a deployment fact, it is needed BEFORE a campaign exists, and
+   * on the first-create path there may be no brief id at all.
+   *
+   * So this asks only when it can, and stays silent otherwise: the tab treats an unanswered
+   * capability as `null` and withholds the control without touching the user's draft. That is
+   * the correct reading of "not known", and it is why this is safe to skip.
+   */
+  private loadCreateCapabilities(): void {
+    this.loadCreateCapabilitiesFor(this.briefPersistence().briefId);
+  }
+
+  /**
+   * The same read against an explicitly supplied brief id.
+   *
+   * Needed because the first-create path has no id on the signal yet: the Implementation tab is
+   * opened before `persistBrief` resolves, so reading `briefPersistence()` at entry finds `null`
+   * and the entry-time call guards itself out. The persist success arm passes its own id here.
+   */
+  private loadCreateCapabilitiesFor(briefId: string | null): void {
+    const projectSlug = this.activeFoundationSlug();
+    if (projectSlug === '' || !briefId) return;
+
+    // Ordered by this reader's OWN generation, and checked against the foundation too — see
+    // `createCapabilitiesGeneration`. The counter gives ordering among repeated Implementation
+    // entries; the slug is what makes a response from the previous foundation inapplicable
+    // rather than merely old.
+    const generation = ++this.createCapabilitiesGeneration;
+    const isCurrent = (): boolean => generation === this.createCapabilitiesGeneration && projectSlug === this.activeFoundationSlug();
+    this.campaignService
+      .listBriefCampaigns(projectSlug, briefId)
+      .pipe(take(1), takeUntilDestroyed(this.destroyRef))
+      .subscribe({
+        // ONLY the capability. This must not touch `briefCampaigns` or the staleness flag —
+        // those belong to Optimize's own read, and writing them from here would render a list
+        // the operator did not ask for and cannot see.
+        next: (result) => {
+          if (!isCurrent()) return;
+          this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
+        },
+        // Cleared to `null`, not left alone and not set `false`. `false` would clear a restored
+        // draft's selection on evidence a failed read does not have; leaving the previous value
+        // keeps offering the control on the strength of a read that has since started failing.
+        error: () => {
+          if (!isCurrent()) return;
+          this.briefCampaignsDemandGenEnabled.set(null);
+        },
+      });
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -479,9 +479,11 @@ export class CampaignsComponent {
    * Implementation tab's draft restore, where a false negative REWRITES the user's saved
    * selection — so the arms that mean "no answer" must say `null`, not "off".
    *
-   * It also stays `null` on the whole Planning → Implementation path, because the only writer is
-   * `loadBriefCampaigns` and that runs on Optimize entry. The tab treats `null` as "withhold the
-   * control but preserve the draft", which is the correct behaviour for an unanswered question;
+   * Two readers write it: `loadBriefCampaigns` on Optimize entry, and `loadCreateCapabilities`
+   * on the Implementation entry paths — the create path needs the answer BEFORE any campaign
+   * exists, so it cannot wait for the first. `null` therefore means "unanswered or failed", not
+   * "never asked". The tab treats it as "withhold the control but preserve the draft", which is
+   * the correct behaviour for an unanswered question;
    * the server-side predicate reports `true` whenever the legacy creator still owns creation, so
    * the common case is not a silently missing control.
    */
@@ -943,7 +945,14 @@ export class CampaignsComponent {
     const projectSlug = this.activeFoundationSlug();
     if (projectSlug === '' || !briefId) return;
 
-    const generation = this.briefCampaignsGeneration;
+    // Guarded on the FOUNDATION, not on `briefCampaignsGeneration`. Sharing that counter looked
+    // right — it is the staleness guard for the same endpoint — but it is incremented by
+    // `loadBriefCampaigns` on every Optimize entry as well as by the foundation-switch effect.
+    // So a user who opens Implementation and then clicks Optimize bumps it while this read is
+    // still in flight, and the response would be discarded as stale though nothing about it is:
+    // the capability would stay `null` and the control stay hidden, which is the defect this
+    // method exists to fix. The foundation is what actually invalidates the answer.
+    const requestedSlug = projectSlug;
     this.campaignService
       .listBriefCampaigns(projectSlug, briefId)
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
@@ -952,12 +961,16 @@ export class CampaignsComponent {
         // those belong to Optimize's own read, and writing them from here would render a list
         // the operator did not ask for and cannot see.
         next: (result) => {
-          if (generation !== this.briefCampaignsGeneration) return;
+          if (requestedSlug !== this.activeFoundationSlug()) return;
           this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
         },
-        // Left `null` rather than set `false`: a failed read has not established that the
-        // capability is off, and `false` would clear a restored draft's selection.
-        error: () => undefined,
+        // Cleared to `null`, not left alone and not set `false`. `false` would clear a restored
+        // draft's selection on evidence a failed read does not have; leaving the previous value
+        // keeps offering the control on the strength of a read that has since started failing.
+        error: () => {
+          if (requestedSlug !== this.activeFoundationSlug()) return;
+          this.briefCampaignsDemandGenEnabled.set(null);
+        },
       });
   }
 
@@ -1022,9 +1035,6 @@ export class CampaignsComponent {
     this.implementationDraft.set(null);
     this.briefOutput.set(brief);
     this.selectedTab.set('implementation');
-    // Also here, because this path sets the tab DIRECTLY rather than through `selectTab` — which
-    // is exactly why the capability never loaded on a first create.
-    this.loadCreateCapabilities();
     if (alreadyPersisted) {
       // Bump the generation even though nothing is being saved. `persistBrief` normally does
       // this as its first act, and skipping the save must not also skip the INVALIDATION: a
@@ -1049,8 +1059,15 @@ export class CampaignsComponent {
         // of false never reaches a genuinely-approved one.
         approved: restoredApproved,
       });
+      // AFTER the branch, not before it. This path sets the tab directly, bypassing `selectTab`,
+      // so the capability must be asked for here — but the restored brief's id is written by the
+      // branch above, and asking first read the PREVIOUS id and guarded out. A restored brief
+      // then reached Implementation with the capability permanently unknown.
+      this.loadCreateCapabilities();
       return;
     }
+    // The create path has no id yet — `persistBrief` mints one — so the read is triggered from
+    // its success arm rather than here. See `loadCreateCapabilitiesFor`.
     this.persistBrief(brief);
   }
 
@@ -1662,7 +1679,11 @@ export class CampaignsComponent {
           // The capability read needs a brief id, and THIS is where a first create gets one — the
           // Implementation tab opened before the persist resolved, so the entry-time attempt was
           // guarded out. Without this the first-create path never learns the capability at all.
+          // The capability read needs a brief id, and THIS is where a first create gets one: the
+          // Implementation tab opened before the persist resolved, so the entry-time attempt
+          // guarded itself out. Without this the create path never learns the capability.
           this.loadCreateCapabilitiesFor(result.briefId);
+
           this.briefPersistence.set({
             status: 'saved',
             briefId: result.briefId,

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -1298,10 +1298,16 @@ export class CampaignsComponent {
    * Needed because the first-create path has no id on the signal yet: the Implementation tab is
    * opened before `persistBrief` resolves, so reading `briefPersistence()` at entry finds `null`
    * and the entry-time call guards itself out. The persist success arm passes its own id here.
+   *
+   * Called with an EMPTY brief id when brief persistence is disabled (`enabled: false`). The
+   * server's `listBriefCampaigns` handles an empty brief id and still returns
+   * `demandGenEnabled: canCreateDemandGen()`, so the client learns the capability without a
+   * stored brief. `null` is guarded because a `null` id means "no id was supplied at all" and
+   * should not make the request; an empty string is a deliberate signal from the disabled path.
    */
   private loadCreateCapabilitiesFor(briefId: string | null): void {
     const projectSlug = this.activeFoundationSlug();
-    if (projectSlug === '' || !briefId) return;
+    if (projectSlug === '' || briefId === null) return;
 
     // Ordered by this reader's OWN generation, and checked against the foundation too — see
     // `createCapabilitiesGeneration`. The counter gives ordering among repeated Implementation
@@ -1615,6 +1621,14 @@ export class CampaignsComponent {
           }
 
           if (generation !== this.briefPersistenceGeneration) return;
+          // Load capabilities here for BOTH paths — enabled and disabled. When disabled
+          // (`enabled: false`), `result.briefId` is '' and `loadCreateCapabilitiesFor` sends
+          // the request without a brief id; the server returns `demandGenEnabled: canCreateDemandGen()`
+          // even on that empty-id read, so the legacy creator gets the correct answer.
+          // When enabled, this also covers the first-create path where the Implementation tab
+          // opened before the persist resolved — the entry-time call guarded out because no id
+          // was known yet, and this is where the id first arrives.
+          this.loadCreateCapabilitiesFor(result.briefId);
           if (!result.enabled) {
             this.briefPersistence.set(this.idlePersistence);
             return;
@@ -1690,11 +1704,6 @@ export class CampaignsComponent {
           // as a `message` on the SAVED state rather than a new status or an `error`: describing a
           // durable write as failed would be its own lie, and the banner already renders a message
           // in this state.
-          // The capability read needs a brief id, and THIS is where a first create gets one: the
-          // Implementation tab opened before the persist resolved, so the entry-time attempt
-          // guarded itself out. Without this the create path never learns the capability.
-          this.loadCreateCapabilitiesFor(result.briefId);
-
           this.briefPersistence.set({
             status: 'saved',
             briefId: result.briefId,

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -511,11 +511,25 @@ export class CampaignsComponent {
    * entries within one foundation can land out of order and an older failure can wipe a newer
    * success back to `null`.
    *
-   * A counter owned by this reader answers both — bumped on every dispatch here, untouched by
-   * Optimize, and made stale by the foundation-switch effect for free because that dispatches
-   * nothing here. Only the newest capability read may write.
+   * Ordered by ANSWER, not by dispatch, and shared by every writer of the capability.
+   *
+   * Dispatch order is the obvious rule and it is wrong here, because the two readers race in both
+   * directions. `loadCreateCapabilitiesFor` can answer while an Optimize list is still open, and
+   * `loadBriefCampaigns` can answer while a capability read is still open — "last dispatched
+   * wins" drops a good answer in whichever direction happens to lose, which is how the first two
+   * versions of this guard each broke one case while fixing the other.
+   *
+   * What both cases actually want is the same invariant: a SUCCESS is authoritative from the
+   * moment it lands, and nothing older may overwrite it — least of all a failure, which has
+   * established nothing. So this is stamped when an answer is WRITTEN, and a writer defers to it
+   * if another answer has landed since it dispatched.
+   *
+   * It does NOT cover a foundation switch: that clears the capability but dispatches nothing, so
+   * it never bumps this. The separate slug comparison in each reader is what rejects a response
+   * from the previous foundation — two mechanisms, stated apart so neither is removed on the
+   * strength of the other.
    */
-  private createCapabilitiesGeneration = 0;
+  private capabilityGeneration = 0;
 
   /**
    * Whether the server has told us the brief-persistence cutover is on.
@@ -1310,12 +1324,12 @@ export class CampaignsComponent {
     const projectSlug = this.activeFoundationSlug();
     if (projectSlug === '' || !briefId) return;
 
-    // Ordered by this reader's OWN generation, and checked against the foundation too — see
-    // `createCapabilitiesGeneration`. The counter gives ordering among repeated Implementation
-    // entries; the slug is what makes a response from the previous foundation inapplicable
-    // rather than merely old.
-    const generation = ++this.createCapabilitiesGeneration;
-    const isCurrent = (): boolean => generation === this.createCapabilitiesGeneration && projectSlug === this.activeFoundationSlug();
+    // Ordered by the SHARED capability generation — see `capabilityGeneration` — and checked
+    // against the foundation too. The counter orders this against every other capability writer,
+    // `loadBriefCampaigns` included; the slug is what makes a response from the previous
+    // foundation inapplicable rather than merely old.
+    const dispatchedAt = this.capabilityGeneration;
+    const mayWrite = (): boolean => dispatchedAt === this.capabilityGeneration && projectSlug === this.activeFoundationSlug();
     this.campaignService
       .listBriefCampaigns(projectSlug, briefId)
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
@@ -1324,14 +1338,16 @@ export class CampaignsComponent {
         // those belong to Optimize's own read, and writing them from here would render a list
         // the operator did not ask for and cannot see.
         next: (result) => {
-          if (!isCurrent()) return;
+          if (!mayWrite()) return;
+          this.capabilityGeneration++;
           this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
         },
         // Cleared to `null`, not left alone and not set `false`. `false` would clear a restored
         // draft's selection on evidence a failed read does not have; leaving the previous value
         // keeps offering the control on the strength of a read that has since started failing.
         error: () => {
-          if (!isCurrent()) return;
+          if (!mayWrite()) return;
+          this.capabilityGeneration++;
           this.briefCampaignsDemandGenEnabled.set(null);
         },
       });
@@ -1362,6 +1378,12 @@ export class CampaignsComponent {
     // a request dispatched under the previous brief land afterwards and still pass `isCurrent()`.
     const generation = ++this.briefCampaignsGeneration;
     const isCurrent = (): boolean => generation === this.briefCampaignsGeneration;
+    // The capability is written from here too, under the SHARED answer ordering — see
+    // `capabilityGeneration`. Without it an older list read failing after a newer capability read
+    // succeeded would still pass `isCurrent` above (its own list generation is untouched by that
+    // reader) and reset a live answer to `null`.
+    const capabilityDispatchedAt = this.capabilityGeneration;
+    const mayWriteCapability = (): boolean => capabilityDispatchedAt === this.capabilityGeneration;
 
     // Cleared on EVERY entry, before dispatch — not only on the early return below.
     //
@@ -1404,7 +1426,10 @@ export class CampaignsComponent {
           this.briefCampaignsStale.set(result.possiblyStale);
           this.briefCampaignsUnavailable.set(false);
           this.briefCampaignsToggleEnabled.set(result.statusToggleEnabled);
-          this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
+          if (mayWriteCapability()) {
+            this.capabilityGeneration++;
+            this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
+          }
         },
         error: () => {
           if (!isCurrent()) {
@@ -1416,7 +1441,10 @@ export class CampaignsComponent {
           this.briefCampaignsStale.set(false);
           this.briefCampaignsUnavailable.set(true);
           this.briefCampaignsToggleEnabled.set(false);
-          this.briefCampaignsDemandGenEnabled.set(null);
+          if (mayWriteCapability()) {
+            this.capabilityGeneration++;
+            this.briefCampaignsDemandGenEnabled.set(null);
+          }
         },
       });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -945,7 +945,17 @@ export class CampaignsComponent {
       this.loadBriefCampaigns();
     }
     if (tab === 'implementation') {
-      this.loadCreateCapabilities();
+      // Guarded on "never answered", mirroring `loadEmailTemplatesIfNeverAnswered` on the email
+      // path. The capability is a DEPLOYMENT fact, not per-visit state, so re-reading it on every
+      // tab entry spends a query-service round trip to learn the same boolean.
+      //
+      // `null` is exactly the right predicate and needs no extra flag: the foundation-switch
+      // effect and `loadBriefCampaigns`' own pre-request clear both reset it to `null`, and a
+      // failed read leaves it `null` — so the read still re-fires on every occasion where the
+      // answer is genuinely unknown, including a retry after failure.
+      if (this.briefCampaignsDemandGenEnabled() === null) {
+        this.loadCreateCapabilities();
+      }
     }
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -502,6 +502,22 @@ export class CampaignsComponent {
   private briefCampaignsGeneration = 0;
 
   /**
+   * Generation counter for the create-time capability read — its OWN, deliberately.
+   *
+   * Two wrong versions preceded this one, and both were reachable. Sharing
+   * `briefCampaignsGeneration` fails because `loadBriefCampaigns` increments it, so an ordinary
+   * Optimize visit discarded an in-flight capability response. Guarding on the foundation alone
+   * fails the other way: it drops no valid response but imposes no ORDER, so two Implementation
+   * entries within one foundation can land out of order and an older failure can wipe a newer
+   * success back to `null`.
+   *
+   * A counter owned by this reader answers both — bumped on every dispatch here, untouched by
+   * Optimize, and made stale by the foundation-switch effect for free because that dispatches
+   * nothing here. Only the newest capability read may write.
+   */
+  private createCapabilitiesGeneration = 0;
+
+  /**
    * Whether the server has told us the brief-persistence cutover is on.
    *
    * Starts false meaning UNKNOWN, not off, and only a response can change it: the flag is an
@@ -945,14 +961,12 @@ export class CampaignsComponent {
     const projectSlug = this.activeFoundationSlug();
     if (projectSlug === '' || !briefId) return;
 
-    // Guarded on the FOUNDATION, not on `briefCampaignsGeneration`. Sharing that counter looked
-    // right — it is the staleness guard for the same endpoint — but it is incremented by
-    // `loadBriefCampaigns` on every Optimize entry as well as by the foundation-switch effect.
-    // So a user who opens Implementation and then clicks Optimize bumps it while this read is
-    // still in flight, and the response would be discarded as stale though nothing about it is:
-    // the capability would stay `null` and the control stay hidden, which is the defect this
-    // method exists to fix. The foundation is what actually invalidates the answer.
-    const requestedSlug = projectSlug;
+    // Ordered by this reader's OWN generation, and checked against the foundation too — see
+    // `createCapabilitiesGeneration`. The counter gives ordering among repeated Implementation
+    // entries; the slug is what makes a response from the previous foundation inapplicable
+    // rather than merely old.
+    const generation = ++this.createCapabilitiesGeneration;
+    const isCurrent = (): boolean => generation === this.createCapabilitiesGeneration && projectSlug === this.activeFoundationSlug();
     this.campaignService
       .listBriefCampaigns(projectSlug, briefId)
       .pipe(take(1), takeUntilDestroyed(this.destroyRef))
@@ -961,14 +975,14 @@ export class CampaignsComponent {
         // those belong to Optimize's own read, and writing them from here would render a list
         // the operator did not ask for and cannot see.
         next: (result) => {
-          if (requestedSlug !== this.activeFoundationSlug()) return;
+          if (!isCurrent()) return;
           this.briefCampaignsDemandGenEnabled.set(result.demandGenEnabled);
         },
         // Cleared to `null`, not left alone and not set `false`. `false` would clear a restored
         // draft's selection on evidence a failed read does not have; leaving the previous value
         // keeps offering the control on the strength of a read that has since started failing.
         error: () => {
-          if (requestedSlug !== this.activeFoundationSlug()) return;
+          if (!isCurrent()) return;
           this.briefCampaignsDemandGenEnabled.set(null);
         },
       });
@@ -1676,9 +1690,6 @@ export class CampaignsComponent {
           // as a `message` on the SAVED state rather than a new status or an `error`: describing a
           // durable write as failed would be its own lie, and the banner already renders a message
           // in this state.
-          // The capability read needs a brief id, and THIS is where a first create gets one — the
-          // Implementation tab opened before the persist resolved, so the entry-time attempt was
-          // guarded out. Without this the first-create path never learns the capability at all.
           // The capability read needs a brief id, and THIS is where a first create gets one: the
           // Implementation tab opened before the persist resolved, so the entry-time attempt
           // guarded itself out. Without this the create path never learns the capability.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -3251,6 +3251,30 @@ describe('ImplementationTabComponent demand gen capability gate', () => {
     expect(c['canSubmit']()).toBe(false);
   });
 
+  /**
+   * The generated campaign name must describe the request that will actually be sent.
+   *
+   * The preview reads the same form value the builder does, so a hidden `includeDemandGen: true`
+   * would render `Multi` while the request carries only `search` — naming a campaign that will
+   * not be created, in a name operators use to find it in the ad platform later.
+   */
+  it('previews a Search-only name when a hidden Demand Gen selection cannot be created', () => {
+    fixture.componentRef.setInput('demandGenEnabled', false);
+    fixture.componentRef.setInput('briefData', {
+      eventDetails: { name: 'KubeCon EU 2026', slug: 'kubecon-eu-2026', registrationUrl: 'https://example.com', countryCode: 'US' },
+      selectedPlatforms: ['google-ads'],
+    } as unknown as CampaignBriefOutput);
+    fixture.detectChanges();
+
+    const c = fixture.componentInstance as unknown as Record<string, any>;
+    c['campaignForm'].patchValue({ includeSearch: true, includeDemandGen: true });
+    fixture.detectChanges();
+
+    // `Multi` is what the raw form value would produce; `Search` is what will be created.
+    expect(c['campaignName']()).toContain('| Search |');
+    expect(c['campaignName']()).not.toContain('| Multi |');
+  });
+
   it('hides the Demand Gen control when the deployment cannot create it', () => {
     fixture.componentRef.setInput('demandGenEnabled', false);
     fixture.detectChanges();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -3220,12 +3220,11 @@ describe('ImplementationTabComponent demand gen capability gate', () => {
    * a fully valid Google form (headlines, descriptions, budget) and that scaffolding would test
    * the validators rather than this gate.
    *
-   * The matching guard in the request builder (`campaignTypes.push('demand-gen')` in `submit`) is
-   * NOT independently pinned by this test, and deleting it alone leaves the suite green — this
-   * assertion catches it only because `canSubmit` returns false first. That is weaker evidence
-   * than a direct test, and it is recorded rather than glossed: the builder guard is defence in
-   * depth for a path `canSubmit` already closes, kept because `submit` reads the FORM while the
-   * control reads the INPUT, and those can disagree.
+   * The matching guard in the request builder is pinned separately, by `sends only search when a
+   * hidden Demand Gen selection accompanies Search` below — which reaches `submit()` with
+   * `canSubmit()` true and asserts the payload. That distinction matters: `canSubmit` only
+   * rejects Google with NEITHER type selected, so it does not cover Search plus a stale hidden
+   * Demand Gen, and the builder guard is the only thing keeping that off the wire.
    */
   it('does not treat a hidden Demand Gen selection as a submittable Google campaign', () => {
     fixture.componentRef.setInput('demandGenEnabled', false);

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -3318,7 +3318,10 @@ describe('ImplementationTabComponent demand gen capability gate', () => {
   it('sends only search when a hidden Demand Gen selection accompanies Search', async () => {
     const createCampaign = vi.spyOn(TestBed.inject(CampaignService), 'createCampaign').mockReturnValue(of({ jobId: 'j-1' }));
 
-    fixture.componentRef.setInput('demandGenEnabled', false);
+    // `null` AT MOUNT, so `applyDraft` PRESERVES the draft's `true` — the clear at :1636 fires
+    // only on an explicit `false`. This is the one sequence that puts a hidden `true` on the
+    // form, and therefore the only one the wire guard can be reached through.
+    fixture.componentRef.setInput('demandGenEnabled', null);
     fixture.componentRef.setInput('draft', {
       eventSlug: 'kubecon-eu-2026',
       eventName: 'KubeCon EU 2026',
@@ -3337,10 +3340,16 @@ describe('ImplementationTabComponent demand gen capability gate', () => {
     } as unknown as CampaignBriefOutput);
     fixture.detectChanges();
 
+    // The capability now resolves OFF. The control disappears; the form value does not change.
+    fixture.componentRef.setInput('demandGenEnabled', false);
+    fixture.detectChanges();
+
     const c = fixture.componentInstance as unknown as Record<string, any>;
     // The form really is submittable — otherwise this would pass without reaching the builder.
     expect(c['canSubmit']()).toBe(true);
-    expect(c['campaignForm'].controls['includeDemandGen'].value).toBe(false);
+    // The hidden `true` the wire guard exists for. If this were already false the guard would
+    // have nothing to guard and the test would pass against its deletion.
+    expect(c['campaignForm'].controls['includeDemandGen'].value).toBe(true);
 
     c['submit']();
     await fixture.whenStable();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -3206,6 +3206,51 @@ describe('ImplementationTabComponent demand gen capability gate', () => {
    * the control at all, and one that only read `demandGenEnabled()` would pass against a template
    * that ignores it entirely.
    */
+  /**
+   * The gate that actually keeps `demand-gen` off the wire.
+   *
+   * Hiding the checkbox is not sufficient on its own: `applyDraft` runs once at mount under
+   * `untracked`, so a tab that mounts while the capability is still `null` restores
+   * `includeDemandGen: true` onto the form. When the capability later resolves `false` the
+   * control disappears, but the FORM value remains true — and `submit` builds `campaignTypes`
+   * from the form, not from the input. Without this gate a create carrying `demand-gen` reaches
+   * a server that refuses it, and the user gets an error for a control they cannot see.
+   *
+   * Asserted on `canSubmit` rather than by driving `submit`, because reaching the builder needs
+   * a fully valid Google form (headlines, descriptions, budget) and that scaffolding would test
+   * the validators rather than this gate.
+   *
+   * The matching guard in the request builder (`campaignTypes.push('demand-gen')` in `submit`) is
+   * NOT independently pinned by this test, and deleting it alone leaves the suite green — this
+   * assertion catches it only because `canSubmit` returns false first. That is weaker evidence
+   * than a direct test, and it is recorded rather than glossed: the builder guard is defence in
+   * depth for a path `canSubmit` already closes, kept because `submit` reads the FORM while the
+   * control reads the INPUT, and those can disagree.
+   */
+  it('does not treat a hidden Demand Gen selection as a submittable Google campaign', () => {
+    fixture.componentRef.setInput('demandGenEnabled', false);
+    fixture.componentRef.setInput('briefData', {
+      eventDetails: { name: 'KubeCon EU 2026', slug: 'kubecon-eu-2026', registrationUrl: 'https://example.com' },
+      selectedPlatforms: ['google-ads'],
+    } as unknown as CampaignBriefOutput);
+    fixture.detectChanges();
+
+    const c = fixture.componentInstance as unknown as Record<string, any>;
+    // Exactly the state a draft restore leaves behind: Demand Gen ticked, Search not, and the
+    // control hidden. Search alone would be submittable; a hidden Demand Gen alone must not be.
+    c['campaignForm'].patchValue({
+      eventName: 'KubeCon EU 2026',
+      registrationUrl: 'https://example.com',
+      startDate: '2026-09-01',
+      endDate: '2026-09-30',
+      includeSearch: false,
+      includeDemandGen: true,
+    });
+    fixture.detectChanges();
+
+    expect(c['canSubmit']()).toBe(false);
+  });
+
   it('hides the Demand Gen control when the deployment cannot create it', () => {
     fixture.componentRef.setInput('demandGenEnabled', false);
     fixture.detectChanges();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -199,6 +199,41 @@ describe('ImplementationTabComponent submit gate', () => {
 
     expect(canSubmit()).toBe(true);
   });
+
+  /**
+   * `applyDraft` runs under `untracked` during mount, so it reads `demandGenEnabled` once.
+   * If the tab mounts while the request is pending (`null`), it preserves the draft's
+   * `includeDemandGen: true`. A later `false` hides the checkbox but `applyDraft` does not
+   * re-run — so without this guard a hidden `true` would still satisfy the "Google needs at
+   * least one sub-type" check and let the user submit with `demand-gen` silently appended.
+   */
+  it('blocks submit when Google is selected with only a hidden DemandGen checked', async () => {
+    const c = fixture.componentInstance as unknown as {
+      selectedPlatforms: { set(v: string[]): void };
+      campaignForm: {
+        controls: Record<string, { setValue(v: unknown): void }>;
+        get(name: string): { controls: { setValue(v: unknown): void }[] } | null;
+      };
+    };
+    c.selectedPlatforms.set(['google-ads']);
+    c.campaignForm.controls['eventName'].setValue('KubeCon EU 2026');
+    c.campaignForm.controls['registrationUrl'].setValue('https://events.example.com/kubecon-eu-2026');
+    c.campaignForm.controls['startDate'].setValue('2026-09-01');
+    c.campaignForm.controls['endDate'].setValue('2026-09-30');
+    c.campaignForm.controls['includeSearch'].setValue(false);
+    // DemandGen is checked in the form (draft restored before capability arrived)
+    c.campaignForm.controls['includeDemandGen'].setValue(true);
+    c.campaignForm.get('headlines')?.controls.forEach((ctrl) => ctrl.setValue('Attend KubeCon'));
+    c.campaignForm.get('descriptions')?.controls.forEach((ctrl) => ctrl.setValue('Join us in September'));
+    fixture.detectChanges();
+
+    // Capability now resolves to false — the checkbox is hidden.
+    fixture.componentRef.setInput('demandGenEnabled', false);
+    fixture.detectChanges();
+
+    // A hidden DemandGen must not satisfy the "at least one Google sub-type" requirement.
+    expect(canSubmit()).toBe(false);
+  });
 });
 
 /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -3275,6 +3275,35 @@ describe('ImplementationTabComponent demand gen capability gate', () => {
     expect(c['campaignName']()).not.toContain('| Multi |');
   });
 
+  /**
+   * The preview must follow the capability, not just the form.
+   *
+   * `campaignName` is `toSignal` over `valueChanges`, so a signal read inside its `map` is NOT a
+   * reactive dependency — it re-evaluates only when the form changes. Gating the preview on the
+   * capability therefore froze it at whatever the capability was AT MOUNT: a tab that mounts with
+   * the capability still `null` previews Search, and a later `true` leaves the name saying Search
+   * while submit sends `demand-gen`.
+   */
+  it('updates the previewed name when the capability arrives after mount', () => {
+    fixture.componentRef.setInput('demandGenEnabled', null);
+    fixture.componentRef.setInput('briefData', {
+      eventDetails: { name: 'KubeCon EU 2026', slug: 'kubecon-eu-2026', registrationUrl: 'https://example.com', countryCode: 'US' },
+      selectedPlatforms: ['google-ads'],
+    } as unknown as CampaignBriefOutput);
+    fixture.detectChanges();
+
+    const c = fixture.componentInstance as unknown as Record<string, any>;
+    c['campaignForm'].patchValue({ includeSearch: true, includeDemandGen: true });
+    fixture.detectChanges();
+    expect(c['campaignName']()).toContain('| Search |');
+
+    // The capability resolves AFTER mount, with no further form edit.
+    fixture.componentRef.setInput('demandGenEnabled', true);
+    fixture.detectChanges();
+
+    expect(c['campaignName']()).toContain('| Multi |');
+  });
+
   it('hides the Demand Gen control when the deployment cannot create it', () => {
     fixture.componentRef.setInput('demandGenEnabled', false);
     fixture.detectChanges();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.spec.ts
@@ -3304,6 +3304,51 @@ describe('ImplementationTabComponent demand gen capability gate', () => {
     expect(c['campaignName']()).toContain('| Multi |');
   });
 
+  /**
+   * The WIRE guard, reached with `canSubmit` passing — the case I previously and wrongly said
+   * `canSubmit` covered.
+   *
+   * It does not. `canSubmit` only rejects Google with NEITHER type selected; with Search also
+   * ticked it passes, and `campaignTypes.push('demand-gen')` at the builder is then the only
+   * thing keeping the hidden selection off the request. Deleting that line left the suite green.
+   *
+   * Search + a stale hidden Demand Gen is the ordinary shape of this bug: a draft saved when the
+   * capability was on, restored on a deployment where it is off.
+   */
+  it('sends only search when a hidden Demand Gen selection accompanies Search', async () => {
+    const createCampaign = vi.spyOn(TestBed.inject(CampaignService), 'createCampaign').mockReturnValue(of({ jobId: 'j-1' }));
+
+    fixture.componentRef.setInput('demandGenEnabled', false);
+    fixture.componentRef.setInput('draft', {
+      eventSlug: 'kubecon-eu-2026',
+      eventName: 'KubeCon EU 2026',
+      registrationUrl: 'https://example.com',
+      includeSearch: true,
+      includeDemandGen: true,
+      budgetUsd: 500,
+      startDate: '2026-09-01',
+      endDate: '2026-09-30',
+      headlines: ['Join us at KubeCon'],
+      descriptions: ['Register today for KubeCon EU 2026.'],
+    } as unknown as CampaignImplementationDraft);
+    fixture.componentRef.setInput('briefData', {
+      eventDetails: { name: 'KubeCon EU 2026', slug: 'kubecon-eu-2026', registrationUrl: 'https://example.com', countryCode: 'US' },
+      selectedPlatforms: ['google-ads'],
+    } as unknown as CampaignBriefOutput);
+    fixture.detectChanges();
+
+    const c = fixture.componentInstance as unknown as Record<string, any>;
+    // The form really is submittable — otherwise this would pass without reaching the builder.
+    expect(c['canSubmit']()).toBe(true);
+    expect(c['campaignForm'].controls['includeDemandGen'].value).toBe(false);
+
+    c['submit']();
+    await fixture.whenStable();
+
+    expect(createCampaign).toHaveBeenCalled();
+    expect(createCampaign.mock.calls[0][0].campaignTypes).toEqual(['search']);
+  });
+
   it('hides the Demand Gen control when the deployment cannot create it', () => {
     fixture.componentRef.setInput('demandGenEnabled', false);
     fixture.detectChanges();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -779,7 +779,7 @@ export class ImplementationTabComponent implements OnInit {
     const sharedFieldsValid = !!form.eventName.value?.trim() && !!form.registrationUrl.value?.trim() && !!form.startDate.value && !!form.endDate.value;
     if (!sharedFieldsValid) return false;
 
-    if (googleSelected && !this.campaignForm.controls.includeSearch.value && !this.campaignForm.controls.includeDemandGen.value) return false;
+    if (googleSelected && !this.campaignForm.controls.includeSearch.value && !(this.demandGenAvailable() && this.campaignForm.controls.includeDemandGen.value)) return false;
     if (googleSelected && this.campaignForm.invalid) return false;
     if (linkedInSelected && this.linkedInBudgetUsd() < 1) return false;
     if (linkedInSelected && this.linkedInGeoTargets().length === 0) return false;
@@ -1343,7 +1343,7 @@ export class ImplementationTabComponent implements OnInit {
     const form = this.campaignForm.getRawValue();
     const campaignTypes: CampaignType[] = [];
     if (form.includeSearch) campaignTypes.push('search');
-    if (form.includeDemandGen) campaignTypes.push('demand-gen');
+    if (this.demandGenAvailable() && form.includeDemandGen) campaignTypes.push('demand-gen');
     const slug = form.eventSlug || form.eventName.toLowerCase().replace(/\s+/g, '-');
 
     const request = {

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -2039,27 +2039,33 @@ export class ImplementationTabComponent implements OnInit {
   }
 
   private initCampaignName(): Signal<string> {
-    return toSignal(
-      this.campaignForm.valueChanges.pipe(
-        startWith(this.campaignForm.getRawValue()),
-        map((form) => {
-          const name = form.eventName;
-          const region = form.countryCode || 'NA';
-          const startDate = form.startDate || '';
-          const includeSearch = form.includeSearch;
-          // Capability-gated exactly as the request builder is. The form can carry a hidden
-          // `includeDemandGen: true` — a draft restored before the capability resolved — and
-          // reading it raw would preview `Multi` or `DG Display` for a request that sends only
-          // `search`, naming a campaign that will not be created.
-          const includeDemandGen = this.demandGenAvailable() && form.includeDemandGen;
-          let channel = 'Search';
-          if (includeSearch && includeDemandGen) channel = 'Multi';
-          else if (includeDemandGen) channel = 'DG Display';
-          return name ? `Events | ${name} | ${region} | Conversions | Prospecting | ${channel} | Linux Foundation | BoFU | ${startDate}` : '';
-        })
-      ),
-      { initialValue: '' }
-    );
+    // A `computed` over the form stream, not a `map` inside it, because the name depends on the
+    // CAPABILITY as well as the form. A signal read inside that `map` is not a reactive
+    // dependency — `toSignal` re-emits only when `valueChanges` fires — so gating the preview on
+    // `demandGenAvailable()` there froze it at whatever the capability was at mount: a tab that
+    // mounts before the capability resolves would preview Search for ever while submit sent
+    // `demand-gen`. Reading it in the outer `computed` makes it a real dependency, so the name
+    // recomputes when either the form or the capability changes.
+    const formValue = toSignal(this.campaignForm.valueChanges.pipe(startWith(this.campaignForm.getRawValue())), {
+      initialValue: this.campaignForm.getRawValue(),
+    });
+    return computed(() => {
+      const demandGenAvailable = this.demandGenAvailable();
+      const form = formValue();
+      const name = form.eventName;
+      const region = form.countryCode || 'NA';
+      const startDate = form.startDate || '';
+      const includeSearch = form.includeSearch;
+      // Capability-gated exactly as the request builder is. The form can carry a hidden
+      // `includeDemandGen: true` — a draft restored before the capability resolved — and reading
+      // it raw would preview `Multi` or `DG Display` for a request that sends only `search`,
+      // naming a campaign that will not be created.
+      const includeDemandGen = demandGenAvailable && form.includeDemandGen;
+      let channel = 'Search';
+      if (includeSearch && includeDemandGen) channel = 'Multi';
+      else if (includeDemandGen) channel = 'DG Display';
+      return name ? `Events | ${name} | ${region} | Conversions | Prospecting | ${channel} | Linux Foundation | BoFU | ${startDate}` : '';
+    });
   }
   /**
    * Shape only: two uppercase letters, the form campaign-service requires before it consults its

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -2047,7 +2047,11 @@ export class ImplementationTabComponent implements OnInit {
           const region = form.countryCode || 'NA';
           const startDate = form.startDate || '';
           const includeSearch = form.includeSearch;
-          const includeDemandGen = form.includeDemandGen;
+          // Capability-gated exactly as the request builder is. The form can carry a hidden
+          // `includeDemandGen: true` — a draft restored before the capability resolved — and
+          // reading it raw would preview `Multi` or `DG Display` for a request that sends only
+          // `search`, naming a campaign that will not be created.
+          const includeDemandGen = this.demandGenAvailable() && form.includeDemandGen;
           let channel = 'Search';
           if (includeSearch && includeDemandGen) channel = 'Multi';
           else if (includeDemandGen) channel = 'DG Display';

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/components/implementation-tab/implementation-tab.component.ts
@@ -779,7 +779,8 @@ export class ImplementationTabComponent implements OnInit {
     const sharedFieldsValid = !!form.eventName.value?.trim() && !!form.registrationUrl.value?.trim() && !!form.startDate.value && !!form.endDate.value;
     if (!sharedFieldsValid) return false;
 
-    if (googleSelected && !this.campaignForm.controls.includeSearch.value && !(this.demandGenAvailable() && this.campaignForm.controls.includeDemandGen.value)) return false;
+    if (googleSelected && !this.campaignForm.controls.includeSearch.value && !(this.demandGenAvailable() && this.campaignForm.controls.includeDemandGen.value))
+      return false;
     if (googleSelected && this.campaignForm.invalid) return false;
     if (linkedInSelected && this.linkedInBudgetUsd() < 1) return false;
     if (linkedInSelected && this.linkedInGeoTargets().length === 0) return false;

--- a/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/campaign.controller.spec.ts
@@ -1700,6 +1700,11 @@ describe('CampaignController.listBriefCampaigns', () => {
     ['brief_id', { project: 'tlf' }],
     ['a blank project', { project: '   ', brief_id: 'b-1' }],
     ['a blank brief_id', { project: 'tlf', brief_id: '   ' }],
+    // The EMPTY string specifically, not just whitespace. The disabled-persist path reports
+    // `briefId: ''`, and a client that forwarded it here to read a deployment capability would
+    // get a 400 rather than an answer — the request never reaches the service branch that
+    // returns `demandGenEnabled` for a blank id.
+    ['an empty brief_id', { project: 'tlf', brief_id: '' }],
   ])('refuses a request with no %s', async (_label, query) => {
     await controller.listBriefCampaigns(listReq(query), res, next);
 

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1713,10 +1713,18 @@ export interface CampaignListResult {
   /**
    * Whether THIS deployment can actually create a Demand Gen Google campaign.
    *
-   * Same reasoning as `statusToggleEnabled`, for a different capability: the create route refuses
-   * `demand-gen` unless `LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN` is on, and the chart leaves that
-   * flag unset. Nothing in the create request tells the client that in advance, so without this
-   * field the Implementation tab offers a Demand Gen checkbox whose every submission is refused.
+   * Same reasoning as `statusToggleEnabled`, for a different capability. Nothing in the create
+   * request tells the client in advance, so without this field the Implementation tab offers a
+   * Demand Gen checkbox whose every submission is refused.
+   *
+   * NOT the `LFX_CUTOVER_CAMPAIGN_SERVICE_DEMAND_GEN` flag, and the difference matters. That flag
+   * gates the campaign-service create path only; while the CREATE/BRIEFS/JOBS cutover is dark the
+   * legacy creator owns creation and makes Demand Gen campaigns regardless of it. So this is
+   * `true` across the whole staged CREATE-off rollout, and `false` only in the narrow window
+   * where campaign-service owns creation and has not been told it understands
+   * `googleAdsConfig.channel`. See `canCreateDemandGen` in `campaign-service.service.ts`, which
+   * is the authoritative computation — simplifying this back to the raw flag would hide a
+   * working legacy option for the entire rollout.
    *
    * Worse than a plain dead end, because the two refusals disagree: selecting Search AND Demand
    * Gen is refused with "deselect one and create it", and following that advice lands on the

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -1731,8 +1731,13 @@ export interface CampaignListResult {
    * capability refusal saying Demand Gen is not available at all. The first message walks the
    * user into the second.
    *
-   * Defaults to `false` on every error and pre-load path. Withholding a control for one request
-   * is cheap; offering one that cannot succeed is not.
+   * Always present on a successful read, and never a fallback: an error produces no
+   * `CampaignListResult` at all, so there is no arm of this type that means "we could not tell".
+   * The client models that separately — it holds the capability as `boolean | null` and uses
+   * `null` for unanswered or failed, because a false negative there would clear a user's saved
+   * Demand Gen selection rather than merely withhold a control. Do not read this field's type as
+   * licence to treat `false` as a safe default for "unknown"; `false` is a server statement that
+   * the capability is off.
    */
   demandGenEnabled: boolean;
 }


### PR DESCRIPTION
Follows up the two non-blocking findings @dealako left on #1885, which merged before they were addressed. Both are **latent on `main` today** — with `_DEMAND_GEN` off and `_CREATE` on, `canCreateDemandGen` is `false` everywhere, so the control is correctly hidden either way. They bite when `_DEMAND_GEN` is enabled.

## The capability never reached the create path

`briefCampaignsDemandGenEnabled` is written only by `loadBriefCampaigns`, whose callers are all Optimize entry, retry, or a foundation switch *while already on Optimize*. `onProceedToImplementation` sets the tab **directly** rather than through `selectTab`, so the signal stayed `null` and the Implementation tab withheld Demand Gen even on a deployment that supports it.

**Two triggers, because one is not enough.** Tab entry covers a return visit, but on a genuine first create there is no brief id yet — `persistBrief` has not resolved — so the entry-time read guards itself out. The persist success arm passes its own id, which is the moment the read becomes possible at all.

Kept separate from `loadBriefCampaigns` rather than reusing it: that one is an Optimize concern that clears rows and re-fetches for staleness, and writing its state from the Implementation tab would render a list nobody asked for.

A failed read leaves the capability `null`, never `false` — the draft restore clears a saved selection on an explicit `false`, and a failure has established nothing.

## The interface doc contradicted the implementation

The field doc described `demandGenEnabled` as mirroring the raw `_DEMAND_GEN` flag. It is actually produced by `canCreateDemandGen`, which returns `true` across the whole staged CREATE-off rollout because the legacy creator makes Demand Gen regardless. A maintainer reading only that doc could "simplify" the predicate back to the raw flag and hide the working legacy option for the entire rollout — the exact regression the function doc warns against.

## Testing

Tested **through the parent**, not by setting the tab's input. That distinction is the point: the input always worked, nothing populated it, and a hand-set input passes against exactly this bug — which is how the original version shipped broken past 5 tests and 3 mutations.

- Mutation-verified: removing the persist-arm trigger fails 1 test; setting `false` on a failed read fails 2.
- 1290 app + 2095 server tests pass.

## Still open from #1885

@copilot raised that `canCreateDemandGen` is **pod-local, not deployment-wide**: during a CREATE rollout an old pod can answer `/list` with `demandGenEnabled: true` while `/create` lands on a new pod that refuses it. That is real and I have not addressed it here — no pod can know the cluster's state, and the conservative answer (`false`) reintroduces the regression above by hiding the working legacy option. It needs a shared source of rollout state rather than a per-pod inference, which is a larger change than this fix.
