### PR TITLE
fix(clas): label gerrit-signed rows in the signed as line

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -372,7 +372,7 @@ describe('ProfileClasComponent', () => {
     return fixture.nativeElement.querySelector(`[data-testid="agreement-signed-as-${id}"]`);
   }
 
-  it('renders Signed as {identity} (GitHub) / (GitLab) / no suffix under the date', async () => {
+  it('renders Signed as {identity} (GitHub) / (GitLab) / (Gerrit) under the date', async () => {
     await render([
       agreement({ id: 's-gh', signedVia: 'github', signedAs: 'jellis' }),
       agreement({ id: 's-gl', signedVia: 'gitlab', signedAs: 'jellis' }),
@@ -381,7 +381,7 @@ describe('ProfileClasComponent', () => {
 
     expect(signedAs('s-gh')?.textContent?.trim()).toBe('Signed as jellis (GitHub)');
     expect(signedAs('s-gl')?.textContent?.trim()).toBe('Signed as jellis (GitLab)');
-    expect(signedAs('s-email')?.textContent?.trim()).toBe('Signed as jellis@acme-motors.example');
+    expect(signedAs('s-email')?.textContent?.trim()).toBe('Signed as jellis@acme-motors.example (Gerrit)');
     expect(headers()).toEqual(['Project', 'Type', 'Status', 'Signed', 'Actions']);
   });
 

--- a/packages/shared/src/utils/cla-view.utils.spec.ts
+++ b/packages/shared/src/utils/cla-view.utils.spec.ts
@@ -4,7 +4,7 @@
 import { describe, expect, it } from 'vitest';
 
 import { PROFILE_TABS } from '../constants/profile.constants';
-import { ClaStatus, MyClaAgreement, MyClasIdentitySummary } from '../interfaces/cla.interface';
+import { ClaSignedVia, ClaStatus, MyClaAgreement, MyClasIdentitySummary } from '../interfaces/cla.interface';
 import {
   buildProfileTabs,
   claGroupPrimaryName,
@@ -146,10 +146,10 @@ describe('claStatusSeverity', () => {
 });
 
 describe('signedAsLine', () => {
-  it('adds a platform suffix for GitHub and GitLab, and none for Gerrit/email', () => {
+  it('adds a platform suffix for GitHub, GitLab, and Gerrit', () => {
     expect(signedAsLine('github', 'jellis')).toBe('Signed as jellis (GitHub)');
     expect(signedAsLine('gitlab', 'jellis')).toBe('Signed as jellis (GitLab)');
-    expect(signedAsLine('gerrit', 'jellis@acme-motors.example')).toBe('Signed as jellis@acme-motors.example');
+    expect(signedAsLine('gerrit', 'jellis@acme-motors.example')).toBe('Signed as jellis@acme-motors.example (Gerrit)');
   });
 
   it('omits the line when the identity is missing, empty, or whitespace', () => {
@@ -161,6 +161,12 @@ describe('signedAsLine', () => {
 
   it('prints the identity with no suffix when the platform is missing', () => {
     expect(signedAsLine(undefined, 'jellis')).toBe('Signed as jellis');
+  });
+
+  it('does not lend the Gerrit label to a token it does not recognise', () => {
+    // The BFF mapper narrows unknown wire tokens to undefined, so this branch is only
+    // reachable by cast. Pinned so a future token cannot inherit the Gerrit label.
+    expect(signedAsLine('bitbucket' as ClaSignedVia, 'jellis')).toBe('Signed as jellis');
   });
 });
 

--- a/packages/shared/src/utils/cla-view.utils.ts
+++ b/packages/shared/src/utils/cla-view.utils.ts
@@ -99,9 +99,14 @@ export function claStatusSeverity(status: ClaStatus): TagSeverity {
 /**
  * Second line under the signed date (#1573). Undefined ⇒ the Signed cell is date-only.
  *
- * GitHub and GitLab take a platform suffix; Gerrit / LF SSO / email do not — that is the
- * committed prototype, not a missing label. A blank identity omits the line even when a
- * platform is present: `Signed as  (GitHub)` is worse than a date-only cell.
+ * Every platform the producer names takes a suffix. `gerrit` reads wider than the Gerrit
+ * tool — it is also the LF SSO / email-identified case and the last resort in the producer's
+ * `github > gitlab > gerrit` precedence — and `(Gerrit)` is still the agreed label, because
+ * a narrower one cannot be derived from that token alone.
+ *
+ * An absent or unrecognised platform prints the bare line rather than borrowing a label, and
+ * a blank identity omits the line even when a platform is present: `Signed as  (GitHub)` is
+ * worse than a date-only cell.
  */
 export function signedAsLine(signedVia: ClaSignedVia | undefined, signedAs: string | undefined): string | undefined {
   const identity = signedAs?.trim();
@@ -112,6 +117,7 @@ export function signedAsLine(signedVia: ClaSignedVia | undefined, signedAs: stri
     case 'gitlab':
       return `Signed as ${identity} (GitLab)`;
     case 'gerrit':
+      return `Signed as ${identity} (Gerrit)`;
     default:
       return `Signed as ${identity}`;
   }


### PR DESCRIPTION
## Summary

Rows whose signer identity came from Gerrit rendered with no platform label, so the Signed cell read `Signed as contributor@example.org` with nothing saying where that identity came from — while GitHub and GitLab rows carried `(GitHub)` / `(GitLab)`. Raised in M2 QA.

`signedAsLine` gave `gerrit` no branch of its own: it shared `default` and returned the bare line. This gives it one.

Closes #1893

## Behavior

| `signedVia` | Before | After |
|---|---|---|
| `github` | `Signed as jellis (GitHub)` | unchanged |
| `gitlab` | `Signed as jellis (GitLab)` | unchanged |
| `gerrit` | `Signed as jellis@example.org` | `Signed as jellis@example.org (Gerrit)` |
| absent or unrecognised | `Signed as jellis` | unchanged — the bare line, not the Gerrit label |
| any, with a blank identity | line omitted | unchanged |

Applies to ICLA and ECLA rows in every status; the existing spec already covers those combinations.

## Technical changes

`packages/shared/src/utils/cla-view.utils.ts`

- Splits `case 'gerrit'` off the `default` branch. Keeping `default` bare is the point of the split rather than a side effect: the BFF mapper narrows unrecognised wire tokens to `undefined`, and a future producer token must not silently inherit the Gerrit label
- Rewrites the function's doc comment, which previously argued *for* the absence of a Gerrit suffix and would otherwise have read as an instruction not to make this change

`packages/shared/src/utils/cla-view.utils.spec.ts`, `apps/lfx-one/.../profile-clas.component.spec.ts` — Tests

- Flips the Gerrit assertions and renames the two test titles that asserted the absence of the label
- Adds a case pinning that an unrecognised token still prints the bare line, reached by cast since the mapper makes it unreachable on the wire

## Note for reviewers

`signedVia: "gerrit"` reads wider than the Gerrit tool. The producer's contract (`cla-backend-go/swagger/common/my-cla.yaml`) states that *"gerrit also covers LF SSO signings identified by email"*, and the same token is the last resort in its `github > gitlab > gerrit` precedence — so `(Gerrit)` will also appear on rows that did not go through a Gerrit flow. A label true of Gerrit alone cannot be derived from this wire value; that would need a distinct producer token. `(Gerrit)` is the agreed label given that constraint.

This also changes the display specified in #1573, whose acceptance criteria show email rows with no platform suffix. `specs/008-signed-under-identity/` is deliberately left untouched — it is the point-in-time record of what #1573 shipped, and rewriting it would falsify that record.