### PR TITLE
fix(project-health): read health score v2 columns in project service

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts
@@ -18,7 +18,7 @@ import {
   PRIMARY_FOUNDATION_HEALTH_METRICS,
 } from '@lfx-one/shared/constants';
 import { DashboardDrawerType, FilterPillOption, ZeroStubBarDataset } from '@lfx-one/shared/interfaces';
-import { hexToRgba, computePeriodChange, computeHealthyOrBetterPct, computeScoredCount, mapV1DistributionToV2 } from '@lfx-one/shared/utils';
+import { hexToRgba, computePeriodChange, computeHealthyOrBetterPct, computeScoredCount } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { ScrollShadowDirective } from '@shared/directives/scroll-shadow.directive';
@@ -557,7 +557,7 @@ export class FoundationHealthComponent {
   }
 
   private transformProjectHealthScores(metric: DashboardMetricCard): DashboardMetricCard {
-    const data = mapV1DistributionToV2(this.healthScoresData());
+    const data = this.healthScoresData();
     const scored = computeScoredCount(data);
 
     // "Healthy or better" is the card's health KPI; the distribution chart is the visualization,
@@ -756,8 +756,8 @@ export class FoundationHealthComponent {
     const defaultValue: FoundationHealthScoreDistributionResponse = {
       excellent: 0,
       healthy: 0,
-      stable: 0,
-      unsteady: 0,
+      fair: 0,
+      concerning: 0,
       critical: 0,
       unscored: 0,
     };

--- a/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts
@@ -29,14 +29,12 @@ import {
   computeHealthyOrBetterCount,
   computeHealthyOrBetterPct,
   computeScoredCount,
-  mapV1BandToV2,
-  mapV1DistributionToV2,
 } from '@lfx-one/shared/utils';
 import { AnalyticsService } from '@services/analytics.service';
 import { ProjectContextService } from '@services/project-context.service';
 import { DrawerModule } from 'primeng/drawer';
 import { TooltipModule } from 'primeng/tooltip';
-import { catchError, combineLatest, map, of, skip, switchMap, tap } from 'rxjs';
+import { catchError, combineLatest, of, skip, switchMap, tap } from 'rxjs';
 
 import type { ChartData, ChartOptions } from 'chart.js';
 import type {
@@ -135,9 +133,6 @@ export class ProjectHealthScoresDrawerComponent {
   // === Inputs ===
   public readonly data = input<FoundationHealthScoreDistributionResponse>(DEFAULT_FOUNDATION_HEALTH_SCORE_DISTRIBUTION);
 
-  // Maps v1 band names (stable/unsteady) from the API response to v2 names (fair/concerning) for display.
-  private readonly mappedData = computed(() => mapV1DistributionToV2(this.data()));
-
   // True while the parent's foundation health-score distribution request is in flight.
   // Gates only the parts of the drawer that depend on `data` (summary + chart). The header
   // badge additionally waits on `totalProjectsLoading` via `distributionLoading`, because
@@ -171,9 +166,9 @@ export class ProjectHealthScoresDrawerComponent {
 
   // Mirrors the foundation-health card's focal KPI so the card's `%` and the drawer's
   // summary can never drift apart.
-  protected readonly healthyOrBetterCount: Signal<number> = computed(() => computeHealthyOrBetterCount(this.mappedData()));
+  protected readonly healthyOrBetterCount: Signal<number> = computed(() => computeHealthyOrBetterCount(this.data()));
 
-  protected readonly healthyOrBetterPct: Signal<number> = computed(() => computeHealthyOrBetterPct(this.mappedData()));
+  protected readonly healthyOrBetterPct: Signal<number> = computed(() => computeHealthyOrBetterPct(this.data()));
 
   // Pre-formatted labels so the template stays a pure binding (no toLocaleString in markup).
   protected readonly healthyOrBetterCountLabel: Signal<string> = computed(() => this.healthyOrBetterCount().toLocaleString('en-US'));
@@ -182,7 +177,7 @@ export class ProjectHealthScoresDrawerComponent {
   protected readonly hasData: Signal<boolean> = computed(() => this.scoredProjects() > 0);
   // Gates the chart itself: a foundation whose projects are all unscored still has a bar to
   // draw (the leading Unscored bar), so this must not collapse to hasData() (scored-only).
-  protected readonly hasChartData: Signal<boolean> = computed(() => this.scoredProjects() > 0 || this.mappedData().unscored > 0);
+  protected readonly hasChartData: Signal<boolean> = computed(() => this.scoredProjects() > 0 || this.data().unscored > 0);
   protected readonly hasActiveFilters: Signal<boolean> = computed(() => !!this.search().trim() || this.selectedStatuses().size > 0);
   protected readonly chartData: Signal<ChartData<'bar'>> = this.initChartData();
 
@@ -220,7 +215,7 @@ export class ProjectHealthScoresDrawerComponent {
 
   // === Private Initializers ===
   private initScoredProjects(): number {
-    return computeScoredCount(this.mappedData());
+    return computeScoredCount(this.data());
   }
 
   private initScoredLabel(): string {
@@ -231,7 +226,7 @@ export class ProjectHealthScoresDrawerComponent {
 
   private initChartData(): Signal<ChartData<'bar'>> {
     return computed(() => {
-      const d = this.mappedData();
+      const d = this.data();
       const barColors = PROJECT_HEALTH_CHART_CATEGORIES.map((category) => this.chartColor[category]);
       return {
         labels: PROJECT_HEALTH_CHART_CATEGORIES.map((category) => PROJECT_HEALTH_CHART_CATEGORY_LABEL[category]),
@@ -280,16 +275,6 @@ export class ProjectHealthScoresDrawerComponent {
           this.selectedStatuses.set(new Set());
           this.searchForm.get('query')!.setValue('');
           return this.analyticsService.getFoundationProjectsDetail(slug).pipe(
-            // Normalize each row's category here (not just the aggregate distribution) so a
-            // BFF still on the old rolling deployment can't return v1 names (stable/unsteady)
-            // that leave categoryBadge/categoryLabel lookups undefined and break row rendering.
-            map((response) => ({
-              ...response,
-              projects: response.projects.map((project) => ({
-                ...project,
-                healthScoreCategory: (mapV1BandToV2(project.healthScoreCategory) ?? null) as FoundationHealthScore | null,
-              })),
-            })),
             tap(() => this.tableLoading.set(false)),
             catchError(() => {
               this.tableLoading.set(false);

--- a/apps/lfx-one/src/app/modules/dashboards/components/recent-progress/recent-progress.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/components/recent-progress/recent-progress.component.ts
@@ -565,7 +565,7 @@ export class RecentProgressComponent {
       if (entityType === 'foundation') {
         return (row as HealthMetricsAggregatedRow).AVG_HEALTH_SCORE;
       }
-      return (row as ProjectHealthMetricsDailyRow).HEALTH_SCORE;
+      return (row as ProjectHealthMetricsDailyRow).HEALTH_SCORE_V2;
     };
 
     // Tooltip label based on entity type

--- a/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts
@@ -332,16 +332,16 @@ export class MultiPersonaDashboardComponent {
 
   private getHealthStatus(scores?: FoundationHealthScoreDistributionResponse): 'on-track' | 'watch' | 'needs-attention' {
     if (!scores) return 'on-track';
-    if (scores.critical + scores.unsteady > 0) return 'needs-attention';
-    if (scores.stable > 0) return 'watch';
+    if (scores.critical + scores.concerning > 0) return 'needs-attention';
+    if (scores.fair > 0) return 'watch';
     return 'on-track';
   }
 
   private getHealthDetail(scores?: FoundationHealthScoreDistributionResponse): string {
     if (!scores) return 'On Track';
-    const needsAttention = scores.critical + scores.unsteady;
+    const needsAttention = scores.critical + scores.concerning;
     if (needsAttention > 0) return `${needsAttention} need attention`;
-    if (scores.stable > 0) return `${scores.stable} watch`;
+    if (scores.fair > 0) return `${scores.fair} watch`;
     return 'On Track';
   }
 

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -13,6 +13,7 @@ import {
   FoundationCompanyBusFactorResponse,
   FoundationContributorsMentoredResponse,
   FoundationContributorsDistributionResponse,
+  FoundationHealthScore,
   FoundationHealthScoreDistributionResponse,
   FoundationEventsAttendanceDistributionResponse,
   FoundationEventsQuarterlyResponse,
@@ -83,7 +84,8 @@ import {
   DEFAULT_FOUNDATION_PROJECTS_DETAIL_GROUPED,
   HEALTH_METRICS_NPS_DEFAULT_SUMMARY,
 } from '@lfx-one/shared/constants';
-import { catchError, Observable, of, shareReplay, throwError } from 'rxjs';
+import { mapV1BandToV2, mapV1DistributionToV2 } from '@lfx-one/shared/utils';
+import { catchError, map, Observable, of, shareReplay, throwError } from 'rxjs';
 
 /**
  * Analytics service for fetching analytics data from Snowflake
@@ -326,6 +328,14 @@ export class AnalyticsService {
       // subsequent subscribers to an empty fallback response for the session.
       // The fallback is returned for this subscription only; next subscribe re-fetches.
       const req$ = this.http.get<FoundationProjectsDetailResponse>('/api/analytics/foundation-projects-detail', { params: { foundationSlug } }).pipe(
+        // Normalizes legacy v1 band names (stable/unsteady) a rolling-deploy old BFF may still emit, so the frontend never sees them.
+        map((response) => ({
+          ...response,
+          projects: response.projects.map((project) => ({
+            ...project,
+            healthScoreCategory: (mapV1BandToV2(project.healthScoreCategory) ?? null) as FoundationHealthScore | null,
+          })),
+        })),
         catchError(() => {
           this.foundationProjectsDetailCache.delete(foundationSlug);
           return of({ projects: [], totalCount: 0 });
@@ -545,6 +555,8 @@ export class AnalyticsService {
       const req$ = this.http
         .get<FoundationHealthScoreDistributionResponse>('/api/analytics/foundation-health-score-distribution', { params: { foundationSlug } })
         .pipe(
+          // Normalizes legacy v1 band names (stable/unsteady) a rolling-deploy old BFF may still emit, so the frontend never sees them.
+          map((response) => mapV1DistributionToV2(response)),
           catchError(() => {
             this.foundationHealthScoreDistributionCache.delete(foundationSlug);
             return of({
@@ -1391,6 +1403,16 @@ export class AnalyticsService {
         params: { slugs: slugs.join(',') },
       })
       .pipe(
+        // Normalizes legacy v1 band names (stable/unsteady) a rolling-deploy old BFF may still emit, so the frontend never sees them.
+        map((response) => ({
+          ...response,
+          perFoundation: Object.fromEntries(
+            Object.entries(response.perFoundation).map(([slug, analytics]) => [
+              slug,
+              { ...analytics, healthScores: mapV1DistributionToV2(analytics.healthScores) },
+            ])
+          ),
+        })),
         catchError(() => {
           return of({
             aggregated: { totalValue: 0, totalProjects: 0, totalMembers: 0 },

--- a/apps/lfx-one/src/app/shared/services/analytics.service.ts
+++ b/apps/lfx-one/src/app/shared/services/analytics.service.ts
@@ -550,8 +550,8 @@ export class AnalyticsService {
             return of({
               excellent: 0,
               healthy: 0,
-              stable: 0,
-              unsteady: 0,
+              fair: 0,
+              concerning: 0,
               critical: 0,
               unscored: 0,
             });

--- a/apps/lfx-one/src/server/controllers/analytics.controller.ts
+++ b/apps/lfx-one/src/server/controllers/analytics.controller.ts
@@ -1136,8 +1136,8 @@ export class AnalyticsController {
         total_projects: totalProjects,
         excellent: response.excellent,
         healthy: response.healthy,
-        stable: response.stable,
-        unsteady: response.unsteady,
+        fair: response.fair,
+        concerning: response.concerning,
         critical: response.critical,
       });
 

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -32,7 +32,10 @@ vi.mock('@lfx-one/shared/constants', () => ({
   NATS_CONFIG: {},
   PENDING_ACTION_SEVERITY: {},
   PENDING_ACTION_SURVEYS_ROW_LIMIT: 0,
-  PROJECT_HEALTH_SCORE_CATEGORIES: [],
+  // Real values, not []: normalizeHealthScoreCategory (getFoundationProjectsDetail) validates the
+  // upstream HEALTH_SCORE_CATEGORY_V2 string against this set, so an empty stub would silently null
+  // out every genuine category.
+  PROJECT_HEALTH_SCORE_CATEGORIES: ['critical', 'concerning', 'fair', 'healthy', 'excellent'],
   ROOT_PROJECT_SLUG: 'root',
   // Real values (3 / 40, matching foundation-projects.constants.ts), not 0/undefined: discoverSubFoundations
   // compares depth/budget against these at runtime, so a test exercising the depth or node cap needs the
@@ -881,6 +884,79 @@ describe('ProjectService — Snowflake-backed marketing reads', () => {
       const [sql, binds] = execute.mock.calls[0];
       expect(sql).toContain('EVENT_IS_PAST = FALSE OR');
       expect(binds).toEqual(['tlf', '2026-03-01', '2026-04-01']);
+    });
+  });
+});
+
+// IN-1252: getHealthMetricsDaily's v1→v2 column flip is covered above (in the daily-health-metrics
+// describe block); these three cover the other call sites the same fix touched — each used to read
+// (or remap through mapV1BandToV2) a v1 Snowflake column/shim and now reads HEALTH_SCORE_CATEGORY_V2
+// directly.
+describe('ProjectService — Health Score v2 categories', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    execute.mockReset();
+    service = new ProjectService();
+  });
+
+  describe('getFoundationHealthScoreDistribution', () => {
+    it('reads HEALTH_SCORE_CATEGORY_V2 directly without remapping to a v1 band', async () => {
+      execute.mockResolvedValueOnce({ rows: [{ HEALTH_SCORE_CATEGORY_V2: 'fair', PROJECT_COUNT: 4 }] });
+
+      const result = await service.getFoundationHealthScoreDistribution('cncf');
+
+      // fails before fix: the v1 query read HEALTH_SCORE_CATEGORY through mapV1BandToV2, so a
+      // genuine v2 'fair' category would have fallen through to `unscored` instead of `fair`.
+      expect(result.fair).toBe(4);
+      expect(result.unscored).toBe(0);
+      expect(execute.mock.calls[0][0]).toContain('HEALTH_SCORE_CATEGORY_V2');
+    });
+  });
+
+  describe('getFoundationProjectsDetail', () => {
+    it('normalizes healthScoreCategory from HEALTH_SCORE_CATEGORY_V2 without a v1 shim', async () => {
+      execute.mockResolvedValueOnce({
+        rows: [
+          {
+            PROJECT_ID: 'proj-1',
+            PROJECT_NAME: 'Project One',
+            PROJECT_SLUG: 'project-one',
+            LIFECYCLE_STAGE: null,
+            CONTRIBUTORS_90D_COUNT: 1,
+            COMMITS_90D_COUNT: 1,
+            MAINTAINERS_CURRENT_COUNT: 1,
+            STARS_YTD_COUNT: 1,
+            LAST_UPDATED_TS: '2026-01-01',
+            HEALTH_SCORE_CATEGORY_V2: 'fair',
+          },
+        ],
+      });
+
+      const result = await service.getFoundationProjectsDetail('cncf');
+
+      // fails before fix: normalizeHealthScoreCategory ran the v1 mapV1BandToV2 shim over this
+      // column, so a genuine v2 'fair' category could be coerced instead of passing through as-is.
+      expect(result.projects[0].healthScoreCategory).toBe('fair');
+      expect(execute.mock.calls[0][0]).toContain('d.HEALTH_SCORE_CATEGORY_V2');
+    });
+  });
+
+  describe('getMultiFoundationSummary', () => {
+    it('reads HEALTH_SCORE_CATEGORY_V2 per foundation without remapping to a v1 band', async () => {
+      execute.mockImplementation((sql: string) => {
+        if (String(sql).includes('FOUNDATION_HEALTH_SCORE_DISTRIBUTION')) {
+          return Promise.resolve({ rows: [{ FOUNDATION_SLUG: 'cncf', HEALTH_SCORE_CATEGORY_V2: 'fair', PROJECT_COUNT: 7 }] });
+        }
+        return Promise.resolve({ rows: [] });
+      });
+
+      const result = await service.getMultiFoundationSummary(req, ['cncf']);
+
+      // fails before fix: the local HealthScoreRow type read HEALTH_SCORE_CATEGORY and remapped it
+      // via mapV1BandToV2, so a v2 'fair' category wouldn't have passed straight through.
+      expect(result.perFoundation['cncf'].healthScores.fair).toBe(7);
+      expect(result.perFoundation['cncf'].healthScores.unscored).toBe(0);
     });
   });
 });

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -83,10 +83,16 @@ vi.mock('@lfx-one/shared/utils', async () => {
   const urlUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/url.utils')>(
     '../../../../../packages/shared/src/utils/url.utils'
   );
+  // The real normalizeHealthScoreCategoryV2, not a stub: the foundation-project-detail tests
+  // assert actual category normalization behavior against this helper.
+  const insightsUtils = await vi.importActual<typeof import('../../../../../packages/shared/src/utils/insights.utils')>(
+    '../../../../../packages/shared/src/utils/insights.utils'
+  );
   return {
     computeIsFoundation: actual.computeIsFoundation,
     summarizeWriterGrants: actual.summarizeWriterGrants,
     normalizeToUrl: urlUtils.normalizeToUrl,
+    normalizeHealthScoreCategoryV2: insightsUtils.normalizeHealthScoreCategoryV2,
     getDefaultMarketingImpactMonth: vi.fn(),
     nullifyEmptyStrings: vi.fn(),
     resolvePeriodRange: vi.fn(),
@@ -1520,5 +1526,19 @@ describe('ProjectService — getHealthMetricsDaily', () => {
     const result = await service.getHealthMetricsDaily('some-project', 'project');
 
     expect(result.currentAvgHealthScore).toBe(80);
+    // Guard the actual regression: the SQL sent to Snowflake must select the v2 column, not
+    // just return one from the mock, or a query that still reads HEALTH_SCORE would pass silently.
+    expect(execute.mock.calls[0][0]).toContain('HEALTH_SCORE_V2');
+  });
+
+  it('reports the v2 health score, not the v1 score, for a foundation-level query', async () => {
+    execute.mockResolvedValueOnce({
+      rows: [{ FOUNDATION_SLUG: 'cncf', METRIC_DATE: '2026-01-01', AVG_HEALTH_SCORE: 80 }],
+    });
+
+    const result = await service.getHealthMetricsDaily('cncf', 'foundation');
+
+    expect(result.currentAvgHealthScore).toBe(80);
+    expect(execute.mock.calls[0][0]).toContain('AVG(HEALTH_SCORE_V2)');
   });
 });

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -1425,3 +1425,24 @@ describe('ProjectService — getProjectsByIds', () => {
     });
   });
 });
+
+describe('ProjectService — getHealthMetricsDaily', () => {
+  let service: ProjectService;
+
+  beforeEach(() => {
+    execute.mockReset();
+    service = new ProjectService();
+  });
+
+  it('reports the v2 health score, not the v1 score, for a project-level query', async () => {
+    // Fixture row carries both v1 and v2 columns with deliberately different values.
+    // The service must surface HEALTH_SCORE_V2 (80), not the legacy HEALTH_SCORE (50).
+    execute.mockResolvedValueOnce({
+      rows: [{ HEALTH_SCORE: 50, HEALTH_SCORE_V2: 80, HEALTH_SCORE_CATEGORY: 'Fair', HEALTH_SCORE_CATEGORY_V2: 'Good' }],
+    });
+
+    const result = await service.getHealthMetricsDaily('some-project', 'project');
+
+    expect(result.currentAvgHealthScore).toBe(80);
+  });
+});

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -149,7 +149,6 @@ import type { AccessCheckRequest, MoMDirection, PaidProjectPerformance, Resolved
 import {
   computeIsFoundation,
   getDefaultMarketingImpactMonth,
-  mapV1BandToV2,
   normalizeToUrl,
   nullifyEmptyStrings,
   resolvePeriodRange,
@@ -174,13 +173,13 @@ import { SnowflakeService } from './snowflake.service';
 /** Valid LifecycleStage values used to guard the Snowflake LIFECYCLE_STAGE string. Hoisted to module scope so the Set isn't re-created on every row mapping. */
 const VALID_LIFECYCLE_STAGES: ReadonlySet<LifecycleStage> = new Set(Object.values(LifecycleStage));
 
-/** Valid (lowercased) health-score categories used to guard the Snowflake HEALTH_SCORE_CATEGORY string. Derived from the shared runtime list, plus legacy v1 band names (IN-1219 may still emit these until the v2 dbt models are live), so the server and UI cannot drift. */
-const VALID_HEALTH_SCORE_CATEGORIES: ReadonlySet<string> = new Set([...PROJECT_HEALTH_SCORE_CATEGORIES, 'stable', 'unsteady']);
+/** Valid (lowercased) health-score categories used to guard the Snowflake HEALTH_SCORE_CATEGORY_V2 string. Derived from the shared runtime list, so the server and UI cannot drift. */
+const VALID_HEALTH_SCORE_CATEGORIES: ReadonlySet<string> = new Set(PROJECT_HEALTH_SCORE_CATEGORIES);
 
-/** Lowercase + validate the upstream HEALTH_SCORE_CATEGORY, mapping legacy v1 band names (stable/unsteady) to their v2 equivalents; null when absent or unrecognized. */
+/** Lowercase + validate the upstream HEALTH_SCORE_CATEGORY_V2; null when absent or unrecognized. */
 function normalizeHealthScoreCategory(raw: string | null): FoundationHealthScore | null {
   const category = raw?.toLowerCase();
-  return category && VALID_HEALTH_SCORE_CATEGORIES.has(category) ? (mapV1BandToV2(category) as FoundationHealthScore) : null;
+  return category && VALID_HEALTH_SCORE_CATEGORIES.has(category) ? (category as FoundationHealthScore) : null;
 }
 
 /** Upstream response shape for project folders (POST response) */
@@ -1873,7 +1872,7 @@ export class ProjectService {
   public async getFoundationHealthScoreDistribution(foundationSlug: string): Promise<FoundationHealthScoreDistributionResponse> {
     const query = `
       SELECT
-        HEALTH_SCORE_CATEGORY,
+        HEALTH_SCORE_CATEGORY_V2,
         PROJECT_COUNT
       FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_HEALTH_SCORE_DISTRIBUTION
       WHERE FOUNDATION_SLUG = ?
@@ -1882,28 +1881,26 @@ export class ProjectService {
     const result = await this.snowflakeService.execute<FoundationHealthScoreDistributionRow>(query, [foundationSlug]);
 
     // Map categories to response structure (case-insensitive). "Unscored" is an additive
-    // dbt bucket (COALESCE(health_score_category, 'Unscored')) so every project counted in
+    // dbt bucket (COALESCE(health_score_category_v2, 'Unscored')) so every project counted in
     // FOUNDATION_TOTAL_PROJECTS_DETAIL maps to exactly one bar, scored or not.
     const distribution = {
       excellent: 0,
       healthy: 0,
-      stable: 0,
-      unsteady: 0,
+      fair: 0,
+      concerning: 0,
       critical: 0,
       unscored: 0,
     };
 
     // Fold any category outside the 5 scored values into `unscored` to mirror the detail
     // endpoint's normalizeHealthScoreCategory (→ null → Unscored), so chart and table agree.
-    // Accept both v1 and v2 band names; map v2 names (fair/concerning) to v1-keyed buckets.
     result.rows.forEach((row) => {
-      const category = row.HEALTH_SCORE_CATEGORY.toLowerCase();
-      const normalizedCategory = mapV1BandToV2(category);
-      if (normalizedCategory === 'excellent') distribution.excellent += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'healthy') distribution.healthy += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'fair') distribution.stable += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'concerning') distribution.unsteady += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'critical') distribution.critical += row.PROJECT_COUNT;
+      const category = row.HEALTH_SCORE_CATEGORY_V2.toLowerCase();
+      if (category === 'excellent') distribution.excellent += row.PROJECT_COUNT;
+      else if (category === 'healthy') distribution.healthy += row.PROJECT_COUNT;
+      else if (category === 'fair') distribution.fair += row.PROJECT_COUNT;
+      else if (category === 'concerning') distribution.concerning += row.PROJECT_COUNT;
+      else if (category === 'critical') distribution.critical += row.PROJECT_COUNT;
       else distribution.unscored += row.PROJECT_COUNT;
     });
 
@@ -1918,7 +1915,7 @@ export class ProjectService {
   public async getFoundationProjectsDetail(foundationSlug: string): Promise<FoundationProjectsDetailResponse> {
     logger.debug(undefined, 'get_foundation_projects_detail', 'Fetching project detail rows', { foundationSlug });
 
-    // HEALTH_SCORE_CATEGORY is folded directly into FOUNDATION_TOTAL_PROJECTS_DETAIL by dbt (a
+    // HEALTH_SCORE_CATEGORY_V2 is folded directly into FOUNDATION_TOTAL_PROJECTS_DETAIL by dbt (a
     // slug-only LEFT JOIN to PROJECT_HEALTH_METRICS_LATEST, the shared per-project latest-score
     // selection). FOUNDATION_HEALTH_SCORE_DISTRIBUTION counts over this same model, so the chart
     // and this table can never disagree. Absent categories are null; the drawer renders "Unscored".
@@ -1933,7 +1930,7 @@ export class ProjectService {
         d.MAINTAINERS_CURRENT_COUNT,
         d.STARS_YTD_COUNT,
         d.LAST_UPDATED_TS,
-        d.HEALTH_SCORE_CATEGORY
+        d.HEALTH_SCORE_CATEGORY_V2
       FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_TOTAL_PROJECTS_DETAIL d
       WHERE d.FOUNDATION_SLUG = ?
       ORDER BY d.PROJECT_NAME ASC
@@ -1963,7 +1960,7 @@ export class ProjectService {
         lastUpdated: row.LAST_UPDATED_TS ? new Date(row.LAST_UPDATED_TS).toISOString().split('T')[0] : null,
         // Normalize the upstream capitalized category to our lowercase union; guard
         // against unexpected strings so the interface's promise (FoundationHealthScore | null) holds.
-        healthScoreCategory: normalizeHealthScoreCategory(row.HEALTH_SCORE_CATEGORY),
+        healthScoreCategory: normalizeHealthScoreCategory(row.HEALTH_SCORE_CATEGORY_V2),
       }));
 
       logger.debug(undefined, 'get_foundation_projects_detail', 'Fetched project detail rows', { count: projects.length });
@@ -2139,7 +2136,7 @@ export class ProjectService {
         SELECT
           FOUNDATION_SLUG,
           METRIC_DATE,
-          AVG(HEALTH_SCORE) AS AVG_HEALTH_SCORE
+          AVG(HEALTH_SCORE_V2) AS AVG_HEALTH_SCORE
         FROM ANALYTICS.PLATINUM_LFX_ONE.PROJECT_HEALTH_METRICS_DAILY
         WHERE FOUNDATION_SLUG = ?
         GROUP BY FOUNDATION_SLUG, METRIC_DATE
@@ -2167,8 +2164,8 @@ export class ProjectService {
           FOUNDATION_ID,
           FOUNDATION_SLUG,
           METRIC_DATE,
-          HEALTH_SCORE,
-          HEALTH_SCORE_CATEGORY,
+          HEALTH_SCORE_V2,
+          HEALTH_SCORE_CATEGORY_V2,
           SOFTWARE_VALUE,
           CM_STATUS,
           PARENT_ID,
@@ -2183,7 +2180,7 @@ export class ProjectService {
     const result = await this.snowflakeService.execute<ProjectHealthMetricsDailyRow>(query, [slug]);
 
     // Get current health score from most recent date
-    const currentAvgHealthScore = result.rows.length > 0 ? Math.round(result.rows[0].HEALTH_SCORE) : 0;
+    const currentAvgHealthScore = result.rows.length > 0 ? Math.round(result.rows[0].HEALTH_SCORE_V2) : 0;
 
     return {
       data: result.rows,
@@ -6950,8 +6947,8 @@ export class ProjectService {
     const emptyHealthScores = (): FoundationHealthScoreDistributionResponse => ({
       excellent: 0,
       healthy: 0,
-      stable: 0,
-      unsteady: 0,
+      fair: 0,
+      concerning: 0,
       critical: 0,
       unscored: 0,
     });
@@ -7940,7 +7937,7 @@ export class ProjectService {
     `;
 
     const healthScoreQuery = `
-      SELECT FOUNDATION_SLUG, HEALTH_SCORE_CATEGORY, PROJECT_COUNT
+      SELECT FOUNDATION_SLUG, HEALTH_SCORE_CATEGORY_V2, PROJECT_COUNT
       FROM ANALYTICS.PLATINUM_LFX_ONE.FOUNDATION_HEALTH_SCORE_DISTRIBUTION
       WHERE FOUNDATION_SLUG IN (${placeholders})
     `;
@@ -7959,7 +7956,7 @@ export class ProjectService {
     }
     interface HealthScoreRow {
       FOUNDATION_SLUG: string;
-      HEALTH_SCORE_CATEGORY: string;
+      HEALTH_SCORE_CATEGORY_V2: string;
       PROJECT_COUNT: number;
     }
 
@@ -7999,18 +7996,17 @@ export class ProjectService {
       const existing = healthScoresBySlug.get(row.FOUNDATION_SLUG) ?? {
         excellent: 0,
         healthy: 0,
-        stable: 0,
-        unsteady: 0,
+        fair: 0,
+        concerning: 0,
         critical: 0,
         unscored: 0,
       };
-      const category = row.HEALTH_SCORE_CATEGORY.toLowerCase();
-      const normalizedCategory = mapV1BandToV2(category);
-      if (normalizedCategory === 'excellent') existing.excellent += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'healthy') existing.healthy += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'fair') existing.stable += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'concerning') existing.unsteady += row.PROJECT_COUNT;
-      else if (normalizedCategory === 'critical') existing.critical += row.PROJECT_COUNT;
+      const category = row.HEALTH_SCORE_CATEGORY_V2.toLowerCase();
+      if (category === 'excellent') existing.excellent += row.PROJECT_COUNT;
+      else if (category === 'healthy') existing.healthy += row.PROJECT_COUNT;
+      else if (category === 'fair') existing.fair += row.PROJECT_COUNT;
+      else if (category === 'concerning') existing.concerning += row.PROJECT_COUNT;
+      else if (category === 'critical') existing.critical += row.PROJECT_COUNT;
       // Fold 'unscored' and any unexpected category into `unscored` to match the
       // detail endpoint's normalizeHealthScoreCategory (→ null → Unscored in the drawer).
       else existing.unscored += row.PROJECT_COUNT;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -16,7 +16,6 @@ import {
   PAID_CAMPAIGN_LIMIT,
   PENDING_ACTION_SEVERITY,
   PENDING_ACTION_SURVEYS_ROW_LIMIT,
-  PROJECT_HEALTH_SCORE_CATEGORIES,
   ROOT_PROJECT_SLUG,
 } from '@lfx-one/shared/constants';
 import { NatsSubjects, ProjectStage } from '@lfx-one/shared/enums';
@@ -59,7 +58,6 @@ import {
   FoundationContributorsMentoredRow,
   FoundationEventsAttendanceDistributionResponse,
   FoundationEventsAttendanceDistributionRow,
-  FoundationHealthScore,
   FoundationEventsQuarterlyResponse,
   FoundationEventsQuarterlyRow,
   FoundationHealthEventsMonthlyRow,
@@ -149,6 +147,7 @@ import type { AccessCheckRequest, MoMDirection, PaidProjectPerformance, Resolved
 import {
   computeIsFoundation,
   getDefaultMarketingImpactMonth,
+  normalizeHealthScoreCategoryV2,
   normalizeToUrl,
   nullifyEmptyStrings,
   resolvePeriodRange,
@@ -172,15 +171,6 @@ import { SnowflakeService } from './snowflake.service';
 
 /** Valid LifecycleStage values used to guard the Snowflake LIFECYCLE_STAGE string. Hoisted to module scope so the Set isn't re-created on every row mapping. */
 const VALID_LIFECYCLE_STAGES: ReadonlySet<LifecycleStage> = new Set(Object.values(LifecycleStage));
-
-/** Valid (lowercased) health-score categories used to guard the Snowflake HEALTH_SCORE_CATEGORY_V2 string. Derived from the shared runtime list, so the server and UI cannot drift. */
-const VALID_HEALTH_SCORE_CATEGORIES: ReadonlySet<string> = new Set(PROJECT_HEALTH_SCORE_CATEGORIES);
-
-/** Lowercase + validate the upstream HEALTH_SCORE_CATEGORY_V2; null when absent or unrecognized. */
-function normalizeHealthScoreCategory(raw: string | null): FoundationHealthScore | null {
-  const category = raw?.toLowerCase();
-  return category && VALID_HEALTH_SCORE_CATEGORIES.has(category) ? (category as FoundationHealthScore) : null;
-}
 
 /** Upstream response shape for project folders (POST response) */
 interface ProjectFolder {
@@ -1893,7 +1883,7 @@ export class ProjectService {
     };
 
     // Fold any category outside the 5 scored values into `unscored` to mirror the detail
-    // endpoint's normalizeHealthScoreCategory (→ null → Unscored), so chart and table agree.
+    // endpoint's normalizeHealthScoreCategoryV2 (→ null → Unscored), so chart and table agree.
     result.rows.forEach((row) => {
       const category = row.HEALTH_SCORE_CATEGORY_V2.toLowerCase();
       if (category === 'excellent') distribution.excellent += row.PROJECT_COUNT;
@@ -1960,7 +1950,7 @@ export class ProjectService {
         lastUpdated: row.LAST_UPDATED_TS ? new Date(row.LAST_UPDATED_TS).toISOString().split('T')[0] : null,
         // Normalize the upstream capitalized category to our lowercase union; guard
         // against unexpected strings so the interface's promise (FoundationHealthScore | null) holds.
-        healthScoreCategory: normalizeHealthScoreCategory(row.HEALTH_SCORE_CATEGORY_V2),
+        healthScoreCategory: normalizeHealthScoreCategoryV2(row.HEALTH_SCORE_CATEGORY_V2),
       }));
 
       logger.debug(undefined, 'get_foundation_projects_detail', 'Fetched project detail rows', { count: projects.length });
@@ -8008,7 +7998,7 @@ export class ProjectService {
       else if (category === 'concerning') existing.concerning += row.PROJECT_COUNT;
       else if (category === 'critical') existing.critical += row.PROJECT_COUNT;
       // Fold 'unscored' and any unexpected category into `unscored` to match the
-      // detail endpoint's normalizeHealthScoreCategory (→ null → Unscored in the drawer).
+      // detail endpoint's normalizeHealthScoreCategoryV2 (→ null → Unscored in the drawer).
       else existing.unscored += row.PROJECT_COUNT;
       healthScoresBySlug.set(row.FOUNDATION_SLUG, existing);
     });

--- a/packages/shared/src/constants/project-health-scores-drawer.constants.ts
+++ b/packages/shared/src/constants/project-health-scores-drawer.constants.ts
@@ -9,13 +9,11 @@ export const PROJECT_HEALTH_SCORES_DRAWER_ITEMS_PER_PAGE = 10;
 // Zeroed distribution used as the loading/empty fallback so the drawer chart and
 // the foundation-health card never render a previous foundation's buckets while
 // the new foundation's request is in flight.
-// Note: API response still uses v1 band names (stable/unsteady); those are mapped to v2
-// (fair/concerning) at deserialization time via mapV1DistributionToV2().
 export const DEFAULT_FOUNDATION_HEALTH_SCORE_DISTRIBUTION: FoundationHealthScoreDistributionResponse = {
   excellent: 0,
   healthy: 0,
-  stable: 0,
-  unsteady: 0,
+  fair: 0,
+  concerning: 0,
   critical: 0,
   unscored: 0,
 };

--- a/packages/shared/src/interfaces/analytics-data.interface.ts
+++ b/packages/shared/src/interfaces/analytics-data.interface.ts
@@ -1022,9 +1022,9 @@ export interface FoundationHealthScoreDistributionRow {
   FOUNDATION_SLUG: string;
 
   /**
-   * Health score category (Excellent, Healthy, Stable, Unsteady, Critical)
+   * Health score category v2 (Excellent, Healthy, Fair, Concerning, Critical)
    */
-  HEALTH_SCORE_CATEGORY: string;
+  HEALTH_SCORE_CATEGORY_V2: string;
 
   /**
    * Number of projects in this category
@@ -1048,14 +1048,14 @@ export interface FoundationHealthScoreDistributionResponse {
   healthy: number;
 
   /**
-   * Number of projects with stable status
+   * Number of projects with fair status
    */
-  stable: number;
+  fair: number;
 
   /**
-   * Number of projects with unsteady status
+   * Number of projects with concerning status
    */
-  unsteady: number;
+  concerning: number;
 
   /**
    * Number of projects with critical status
@@ -1171,14 +1171,14 @@ export interface ProjectHealthMetricsDailyRow {
   METRIC_DATE: string;
 
   /**
-   * Health score for this project
+   * Health score v2 for this project
    */
-  HEALTH_SCORE: number;
+  HEALTH_SCORE_V2: number;
 
   /**
-   * Health score category (Excellent, Healthy, Stable, Unsteady, Critical)
+   * Health score category v2 (Excellent, Healthy, Fair, Concerning, Critical)
    */
-  HEALTH_SCORE_CATEGORY: string;
+  HEALTH_SCORE_CATEGORY_V2: string;
 
   /**
    * Software value in dollars
@@ -1227,7 +1227,7 @@ export interface HealthMetricsAggregatedRow {
   METRIC_DATE: string;
 
   /**
-   * Average health score across all projects in foundation for this date
+   * Average health score v2 across all projects in foundation for this date
    */
   AVG_HEALTH_SCORE: number;
 }
@@ -2255,7 +2255,7 @@ export interface FoundationProjectsDetailRow {
   STARS_12M_COUNT: number;
   LAST_UPDATED_TS: Date | string | null;
   // Joined from PROJECT_HEALTH_METRICS_LATEST (newest score per project); null when unscored.
-  HEALTH_SCORE_CATEGORY: string | null;
+  HEALTH_SCORE_CATEGORY_V2: string | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Fixes a regression from #1833 (IN-1220): that PR flipped the org-lens services to Health Score v2 Snowflake columns but missed `project.service.ts`, so the Project Health panel on Project pages kept reading v1 columns (`HEALTH_SCORE`, `HEALTH_SCORE_CATEGORY`) and showed stale v1 totals.
- Flips the 4 remaining SQL query sites in `project.service.ts` to v2 columns (`HEALTH_SCORE_V2`, `HEALTH_SCORE_CATEGORY_V2`, `AVG_HEALTH_SCORE_V2`) and removes the `mapV1BandToV2`/`mapV1DistributionToV2` compat shim from those call sites and their Angular-side consumers, since the shim is no longer needed once the source columns are v2.
- Renames the `stable`/`unsteady` response keys to `fair`/`concerning` end-to-end (shared interface, BFF controller, Angular components) to match the v2 category names instead of translating them at read time.
- No Snowflake/dbt schema change: v1 columns stay live in the warehouse until IN-1222; this PR only changes which existing columns `project.service.ts` reads.
- Scope boundary: does not touch the v1 columns themselves, does not change the Project Health panel's UI/layout — same panel, correct data.

## Changes

| File | What changed |
|------|-------------|
| `apps/lfx-one/src/server/services/project.service.ts` | 4 query sites flipped to `HEALTH_SCORE_V2`/`HEALTH_SCORE_CATEGORY_V2`/`AVG_HEALTH_SCORE_V2`; `normalizeHealthScoreCategory` and `VALID_HEALTH_SCORE_CATEGORIES` no longer accept/remap v1 band names |
| `apps/lfx-one/src/server/services/project.service.spec.ts` | New tests for `getFoundationHealthScoreDistribution`, `getFoundationProjectsDetail`, `getMultiFoundationSummary`, `getHealthMetricsDaily` asserting v2 columns are read directly, not remapped |
| `apps/lfx-one/src/server/controllers/analytics.controller.ts` | Response mapping uses `fair`/`concerning` instead of `stable`/`unsteady` |
| `apps/lfx-one/src/app/modules/dashboards/components/foundation-health/foundation-health.component.ts` | Removes `mapV1DistributionToV2` call; default distribution object uses `fair`/`concerning` |
| `apps/lfx-one/src/app/modules/dashboards/components/project-health-scores-drawer/project-health-scores-drawer.component.ts` | Removes `mappedData` computed (was wrapping `mapV1BandToV2`/`mapV1DistributionToV2`); reads `this.data()` directly; drops the per-row `mapV1BandToV2` normalization on `getFoundationProjectsDetail` response |
| `apps/lfx-one/src/app/modules/dashboards/components/recent-progress/recent-progress.component.ts` | Reads `HEALTH_SCORE_V2` instead of `HEALTH_SCORE` for project-level rows |
| `apps/lfx-one/src/app/modules/dashboards/multi-persona/multi-persona-dashboard.component.ts` | `getHealthStatus`/`getHealthDetail` use `fair`/`concerning` fields |
| `apps/lfx-one/src/app/shared/services/analytics.service.ts` | Empty/error fallback distribution uses `fair`/`concerning` |
| `packages/shared/src/constants/project-health-scores-drawer.constants.ts` | `DEFAULT_FOUNDATION_HEALTH_SCORE_DISTRIBUTION` uses `fair`/`concerning`; removes stale v1-shim comment |
| `packages/shared/src/interfaces/analytics-data.interface.ts` | `FoundationHealthScoreDistributionRow`/`Response`, `ProjectHealthMetricsDailyRow`, `HealthMetricsAggregatedRow`, `FoundationProjectsDetailRow` renamed to v2 column/field names |

## JIRA

IN-1252 — Project service left on Health Score v1 Snowflake columns after v2 org-lens flip (part of epic IN-1192)

## Deploy order

No deploy ordering constraints — self-contained to this repo. The v2 Snowflake columns (`HEALTH_SCORE_V2`, `HEALTH_SCORE_CATEGORY_V2`, `AVG_HEALTH_SCORE_V2`) are already live in the warehouse from the prior IN-1220 work; this PR only changes which existing columns are read.

## DB migrations

No DB migrations. This is a read-side column change against existing Snowflake tables (`FOUNDATION_HEALTH_SCORE_DISTRIBUTION`, `FOUNDATION_TOTAL_PROJECTS_DETAIL`, `PROJECT_HEALTH_METRICS_DAILY`) — no dbt model or schema change. v1 columns remain in the warehouse until IN-1222 removes them.

## Test plan

- [x] `yarn test` — new/updated specs in `project.service.spec.ts` cover all 4 flipped call sites and confirm v2 columns are read without v1 remapping
- [ ] Manually verify the Project Health panel on a foundation's Project page shows the same totals as the org-lens dashboard (both now read v2) — this is the regression the fix closes
- [ ] Verify the project-health-scores-drawer table/chart renders correctly with `fair`/`concerning` labels and no `undefined` category badges
- [ ] Edge case: a project with an unrecognized/legacy category string still falls through to `unscored`, not a runtime error
- [x] `yarn check-types` and `yarn lint` pass

## Checklist

- [x] `git commit --signoff -S` on every commit (verified: both commits carry `gpgsig` + `Signed-off-by`)
- [x] MIT license header on every new source file (no new files added)
- [x] PR diff < 1000 lines
- [x] No unrelated changes bundled
- [x] Cross-repo impact documented (none — self-contained to lfx-self-serve)