### PR TITLE
feat(meetings): add public project calendar page

### DIFF
--- a/apps/lfx-one/src/app/app.routes.ts
+++ b/apps/lfx-one/src/app/app.routes.ts
@@ -507,6 +507,12 @@ export const routes: Routes = [
     path: 'projects/:projectSlug/groups',
     loadComponent: () => import('./modules/groups/public-project-groups/public-project-groups.component').then((m) => m.PublicProjectGroupsComponent),
   },
+  // Public project calendar — month/week calendar of a project's public meetings, optionally scoped
+  // to a single committee via ?committee=<uid> (no auth required).
+  {
+    path: 'projects/:projectSlug/calendar',
+    loadComponent: () => import('./modules/meetings/public-project-calendar/public-project-calendar.component').then((m) => m.PublicProjectCalendarComponent),
+  },
   // Invite acceptance — authGuard preserves ?token= through the Auth0 login redirect.
   {
     path: 'invite',

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
@@ -1,0 +1,48 @@
+<!-- Copyright The Linux Foundation and each contributor to LFX. -->
+<!-- SPDX-License-Identifier: MIT -->
+
+<div class="min-h-screen bg-gray-50">
+  <lfx-header />
+
+  <main class="container mx-auto flex flex-col gap-6 px-4 py-8 sm:px-6 lg:px-8" data-testid="public-project-calendar-page">
+    <!-- Page header -->
+    <header class="flex flex-col gap-1" data-testid="public-project-calendar-header">
+      @if (loading()) {
+        <p-skeleton width="12rem" height="2rem" />
+        <p-skeleton width="20rem" height="1rem" class="mt-1" />
+      } @else {
+        <h1 class="font-display font-light text-2xl text-gray-900" data-testid="public-project-calendar-title">
+          @if (projectName()) {
+            {{ projectName() }} — Calendar
+          } @else {
+            Calendar
+          }
+        </h1>
+        <p class="text-sm text-gray-500" data-testid="public-project-calendar-subtitle">{{ total() }} {{ total() === 1 ? 'meeting' : 'meetings' }}</p>
+      }
+    </header>
+
+    <!-- Error state -->
+    @if (fetchError()) {
+      <lfx-empty-state
+        icon="fa-light fa-circle-exclamation"
+        title="Unable to load calendar"
+        subtitle="Something went wrong while fetching meeting data. Please try refreshing the page."
+        data-testid="public-project-calendar-error" />
+    } @else if (loading()) {
+      <!-- Loading skeleton -->
+      <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="public-project-calendar-skeleton">
+        <p-skeleton width="100%" height="24rem" />
+      </div>
+    } @else {
+      <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="public-project-calendar-container">
+        <lfx-fullcalendar
+          [events]="calendarEvents()"
+          [initialView]="initialView()"
+          height="auto"
+          (eventClick)="onCalendarEventClick($event)"
+          data-testid="public-project-calendar-fullcalendar" />
+      </div>
+    }
+  </main>
+</div>

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
@@ -1,0 +1,132 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { provideHttpClient } from '@angular/common/http';
+import { provideHttpClientTesting } from '@angular/common/http/testing';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute, provideRouter } from '@angular/router';
+import { MeetingService } from '@services/meeting.service';
+import { headerTestProviders, installMatchMediaShim } from '@shared/testing/header-test-providers';
+import { BehaviorSubject, of, throwError } from 'rxjs';
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+import type { PublicCalendarMeeting, PublicProjectMeetingsResponse } from '@lfx-one/shared/interfaces';
+
+import { PublicProjectCalendarComponent } from './public-project-calendar.component';
+
+beforeAll(installMatchMediaShim);
+
+function meeting(over: Partial<PublicCalendarMeeting> = {}): PublicCalendarMeeting {
+  return {
+    id: 'meeting-1',
+    title: 'Technical Steering Committee',
+    start_time: '2026-09-01T15:00:00Z',
+    duration: 60,
+    timezone: 'America/New_York',
+    ...over,
+  };
+}
+
+function response(over: Partial<PublicProjectMeetingsResponse> = {}): PublicProjectMeetingsResponse {
+  return {
+    meetings: [meeting()],
+    total: 1,
+    project: { uid: 'p1', name: 'Kubernetes' },
+    ...over,
+  };
+}
+
+describe('PublicProjectCalendarComponent', () => {
+  let fixture: ComponentFixture<PublicProjectCalendarComponent>;
+  let getPublicProjectMeetings: ReturnType<typeof vi.fn>;
+  let queryParamMap: BehaviorSubject<Map<string, string>>;
+
+  async function render(
+    options: {
+      response?: PublicProjectMeetingsResponse;
+      fail?: boolean;
+      slug?: string;
+      query?: Map<string, string>;
+    } = {}
+  ): Promise<void> {
+    const { fail = false, slug = 'kubernetes' } = options;
+    queryParamMap = new BehaviorSubject(options.query ?? new Map<string, string>());
+    getPublicProjectMeetings = vi.fn(() => (fail ? throwError(() => new Error('upstream 503')) : of(options.response ?? response())));
+
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      imports: [PublicProjectCalendarComponent],
+      providers: [
+        ...headerTestProviders(),
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: MeetingService, useValue: { getPublicProjectMeetings } },
+        // After provideRouter, which also provides ActivatedRoute — the last provider wins, and the
+        // router's own empty paramMap would otherwise silently swallow the slug/committee assertions.
+        {
+          provide: ActivatedRoute,
+          useValue: { paramMap: of(new Map([['projectSlug', slug]])), queryParamMap: queryParamMap.asObservable() },
+        },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(PublicProjectCalendarComponent);
+    await fixture.whenStable();
+  }
+
+  it('renders the project name and meeting count once the feed resolves', async () => {
+    await render();
+
+    const title = fixture.nativeElement.querySelector('[data-testid="public-project-calendar-title"]');
+    const subtitle = fixture.nativeElement.querySelector('[data-testid="public-project-calendar-subtitle"]');
+    expect(title?.textContent?.trim()).toBe('Kubernetes — Calendar');
+    expect(subtitle?.textContent?.trim()).toBe('1 meeting');
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-container"]')).not.toBeNull();
+  });
+
+  it('shows the error state and no calendar when the feed fails', async () => {
+    await render({ fail: true });
+
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-error"]')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-container"]')).toBeNull();
+  });
+
+  it('scopes the request to a committee when ?committee= is present', async () => {
+    await render({ query: new Map([['committee', 'committee-uid-1234']]) });
+
+    expect(getPublicProjectMeetings).toHaveBeenCalledWith('kubernetes', 'committee-uid-1234');
+  });
+
+  it('opens on the week view when ?view=week, and the month view otherwise', async () => {
+    await render({ query: new Map([['view', 'week']]) });
+    expect((fixture.componentInstance as unknown as { initialView: () => string }).initialView()).toBe('timeGridWeek');
+
+    await render();
+    expect((fixture.componentInstance as unknown as { initialView: () => string }).initialView()).toBe('dayGridMonth');
+  });
+
+  it('does not refetch when only ?view changes', async () => {
+    // Regression lock: the fetch pipeline reads queryParamMap for `committee`, so without
+    // distinctUntilChanged on {slug, committeeUid} a pure month/week toggle would re-enter
+    // switchMap, re-hit the upstream feed, and flash the loading skeleton.
+    await render();
+    expect(getPublicProjectMeetings).toHaveBeenCalledTimes(1);
+
+    queryParamMap.next(new Map([['view', 'week']]));
+    await fixture.whenStable();
+
+    expect(getPublicProjectMeetings).toHaveBeenCalledTimes(1);
+  });
+
+  it('refetches when the committee filter changes', async () => {
+    await render();
+    expect(getPublicProjectMeetings).toHaveBeenCalledTimes(1);
+
+    queryParamMap.next(new Map([['committee', 'committee-uid-1234']]));
+    await fixture.whenStable();
+
+    expect(getPublicProjectMeetings).toHaveBeenCalledTimes(2);
+    expect(getPublicProjectMeetings).toHaveBeenLastCalledWith('kubernetes', 'committee-uid-1234');
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -29,10 +29,6 @@ export class PublicProjectCalendarComponent {
 
   private readonly calendarData: Signal<PublicProjectMeetingsResponse | null> = this.initCalendarData();
 
-  protected readonly committeeUid: Signal<string | undefined> = toSignal(this.route.queryParamMap.pipe(map((params) => params.get('committee') ?? undefined)), {
-    initialValue: undefined,
-  });
-
   protected readonly initialView: Signal<string> = toSignal(
     this.route.queryParamMap.pipe(map((params) => (params.get('view') === 'week' ? 'timeGridWeek' : 'dayGridMonth'))),
     { initialValue: 'dayGridMonth' }

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -1,0 +1,82 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { Component, computed, inject, signal, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { ActivatedRoute, Router } from '@angular/router';
+import { FullCalendarComponent } from '@components/fullcalendar/fullcalendar.component';
+import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
+import { HeaderComponent } from '@components/header/header.component';
+import { EventClickArg, EventInput } from '@fullcalendar/core';
+import { MeetingCalendarClickProps, PublicProjectMeetingsResponse } from '@lfx-one/shared/interfaces';
+import { meetingToCalendarEvents, resolveMeetingCalendarClickRoute } from '@lfx-one/shared/utils';
+import { MeetingService } from '@services/meeting.service';
+import { SkeletonModule } from 'primeng/skeleton';
+import { catchError, combineLatest, map, of, switchMap } from 'rxjs';
+
+@Component({
+  selector: 'lfx-public-project-calendar',
+  imports: [FullCalendarComponent, EmptyStateComponent, HeaderComponent, SkeletonModule],
+  templateUrl: './public-project-calendar.component.html',
+})
+export class PublicProjectCalendarComponent {
+  private readonly route = inject(ActivatedRoute);
+  private readonly router = inject(Router);
+  private readonly meetingService = inject(MeetingService);
+
+  protected readonly loading = signal(true);
+  protected readonly fetchError = signal(false);
+
+  private readonly calendarData: Signal<PublicProjectMeetingsResponse | null> = this.initCalendarData();
+
+  protected readonly committeeUid: Signal<string | undefined> = toSignal(this.route.queryParamMap.pipe(map((params) => params.get('committee') ?? undefined)), {
+    initialValue: undefined,
+  });
+
+  protected readonly initialView: Signal<string> = toSignal(
+    this.route.queryParamMap.pipe(map((params) => (params.get('view') === 'week' ? 'timeGridWeek' : 'dayGridMonth'))),
+    { initialValue: 'dayGridMonth' }
+  );
+
+  protected readonly projectName: Signal<string> = computed(() => this.calendarData()?.project?.name ?? '');
+  protected readonly total: Signal<number> = computed(() => this.calendarData()?.total ?? 0);
+
+  protected readonly calendarEvents: Signal<EventInput[]> = computed(() =>
+    (this.calendarData()?.meetings ?? []).flatMap((m) => meetingToCalendarEvents(m) as EventInput[])
+  );
+
+  /** Handles FullCalendar event click — navigates to the public meeting join page. Cancelled occurrences are inert. */
+  protected onCalendarEventClick(arg: EventClickArg): void {
+    const route = resolveMeetingCalendarClickRoute(arg.event.extendedProps as MeetingCalendarClickProps, arg.event.start);
+    if (!route) {
+      return;
+    }
+    void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : undefined);
+  }
+
+  // Private initializer functions
+
+  private initCalendarData(): Signal<PublicProjectMeetingsResponse | null> {
+    return toSignal(
+      combineLatest([this.route.paramMap, this.route.queryParamMap]).pipe(
+        map(([params, queryParams]) => ({ slug: params.get('projectSlug') ?? '', committeeUid: queryParams.get('committee') ?? undefined })),
+        switchMap(({ slug, committeeUid }) => {
+          this.loading.set(true);
+          this.fetchError.set(false);
+          return this.meetingService.getPublicProjectMeetings(slug, committeeUid).pipe(
+            map((response) => {
+              this.loading.set(false);
+              return response;
+            }),
+            catchError(() => {
+              this.loading.set(false);
+              this.fetchError.set(true);
+              return of(null);
+            })
+          );
+        })
+      ),
+      { initialValue: null }
+    );
+  }
+}

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -4,15 +4,15 @@
 import { Component, computed, inject, signal, Signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import { FullCalendarComponent } from '@components/fullcalendar/fullcalendar.component';
+import { FullCalendarComponent } from '@app/shared/components/fullcalendar/fullcalendar.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { HeaderComponent } from '@components/header/header.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
 import { MeetingCalendarClickProps, PublicProjectMeetingsResponse } from '@lfx-one/shared/interfaces';
-import { meetingToCalendarEvents, resolveMeetingCalendarClickRoute } from '@lfx-one/shared/utils';
+import { publicMeetingToCalendarEvents, resolveMeetingCalendarClickRoute } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { SkeletonModule } from 'primeng/skeleton';
-import { catchError, combineLatest, map, of, switchMap } from 'rxjs';
+import { catchError, combineLatest, distinctUntilChanged, map, of, switchMap } from 'rxjs';
 
 @Component({
   selector: 'lfx-public-project-calendar',
@@ -29,16 +29,15 @@ export class PublicProjectCalendarComponent {
 
   private readonly calendarData: Signal<PublicProjectMeetingsResponse | null> = this.initCalendarData();
 
-  protected readonly initialView: Signal<string> = toSignal(
-    this.route.queryParamMap.pipe(map((params) => (params.get('view') === 'week' ? 'timeGridWeek' : 'dayGridMonth'))),
-    { initialValue: 'dayGridMonth' }
-  );
+  protected readonly initialView: Signal<string> = this.initInitialView();
 
   protected readonly projectName: Signal<string> = computed(() => this.calendarData()?.project?.name ?? '');
   protected readonly total: Signal<number> = computed(() => this.calendarData()?.total ?? 0);
 
+  // publicMeetingToCalendarEvents (not meetingToCalendarEvents) — the public mapper never places a
+  // meeting password in extendedProps, so a click can't forward one into the join URL, history, or referrer.
   protected readonly calendarEvents: Signal<EventInput[]> = computed(() =>
-    (this.calendarData()?.meetings ?? []).flatMap((m) => meetingToCalendarEvents(m) as EventInput[])
+    (this.calendarData()?.meetings ?? []).flatMap((m) => publicMeetingToCalendarEvents(m) as EventInput[])
   );
 
   /** Handles FullCalendar event click — navigates to the public meeting join page. Cancelled occurrences are inert. */
@@ -52,10 +51,19 @@ export class PublicProjectCalendarComponent {
 
   // Private initializer functions
 
+  private initInitialView(): Signal<string> {
+    return toSignal(this.route.queryParamMap.pipe(map((params) => (params.get('view') === 'week' ? 'timeGridWeek' : 'dayGridMonth'))), {
+      initialValue: 'dayGridMonth',
+    });
+  }
+
   private initCalendarData(): Signal<PublicProjectMeetingsResponse | null> {
     return toSignal(
       combineLatest([this.route.paramMap, this.route.queryParamMap]).pipe(
         map(([params, queryParams]) => ({ slug: params.get('projectSlug') ?? '', committeeUid: queryParams.get('committee') ?? undefined })),
+        // Only slug and committee affect the request — without this, switching ?view=month|week would
+        // re-enter switchMap, refetching the feed and flashing the skeleton on a pure view toggle.
+        distinctUntilChanged((a, b) => a.slug === b.slug && a.committeeUid === b.committeeUid),
         switchMap(({ slug, committeeUid }) => {
           this.loading.set(true);
           this.fetchError.set(false);

--- a/apps/lfx-one/src/app/shared/services/meeting.service.ts
+++ b/apps/lfx-one/src/app/shared/services/meeting.service.ts
@@ -40,6 +40,7 @@ import {
   PublicMeetingOccurrencesResponse,
   PublicMeetingProject,
   PublicPastMeetingResponse,
+  PublicProjectMeetingsResponse,
   QueryServiceCountResponse,
   UpdateMeetingAttachmentRequest,
   UpdateMeetingRegistrantRequest,
@@ -258,6 +259,21 @@ export class MeetingService {
     return this.http
       .get<PublicMeetingOccurrencesResponse>(`/public/api/meetings/${id}/occurrences`, { headers })
       .pipe(catchError(() => of({ past: [], future: [] } as PublicMeetingOccurrencesResponse)));
+  }
+
+  /** Public project calendar page — meetings for a project (by UID or slug), optionally scoped to a single committee. */
+  public getPublicProjectMeetings(identifier: string, committeeUid?: string): Observable<PublicProjectMeetingsResponse> {
+    let params = new HttpParams();
+    if (committeeUid) {
+      params = params.set('committee', committeeUid);
+    }
+
+    return this.http.get<PublicProjectMeetingsResponse>(`/public/api/projects/${encodeURIComponent(identifier)}/meetings`, { params }).pipe(
+      catchError((error) => {
+        console.error(`Failed to load public meetings for project ${identifier}:`, error);
+        return throwError(() => error);
+      })
+    );
   }
 
   public getPublicMeetingJoinUrl(

--- a/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
@@ -63,13 +63,15 @@ vi.mock('../helpers/ics.helper', () => ({
 vi.mock('../helpers/validation.helper', () => ({ getStringQueryParam: vi.fn() }));
 
 import { CommitteeController } from './committee.controller';
+import { buildVCalendar, fetchAllMeetingPages, meetingsToVEvents } from '../helpers/ics.helper';
+import { generateM2MToken } from '../utils/m2m-token.util';
 
 function buildReq(body: Record<string, unknown> = {}): any {
   return { params: { id: COMMITTEE_ID, inviteId: INVITE_ID }, body, path: '/test', log: {} };
 }
 
 function buildRes(): any {
-  return { status: vi.fn().mockReturnThis(), send: vi.fn() };
+  return { status: vi.fn().mockReturnThis(), send: vi.fn(), setHeader: vi.fn() };
 }
 
 describe('CommitteeController.acceptCommitteeInvite — from_lfid_invite flag', () => {
@@ -169,5 +171,48 @@ describe('CommitteeController.acceptCommitteeInvite — from_lfid_invite flag', 
       );
       expect(committeeSvc.acceptCommitteeInvite).not.toHaveBeenCalled();
     });
+  });
+});
+
+describe('CommitteeController.getCommitteeCalendar', () => {
+  let controller: CommitteeController;
+
+  function buildCalendarReq(id: string = COMMITTEE_ID): any {
+    return { params: { id }, headers: {}, bearerToken: undefined, path: `/public/api/committees/${id}/calendar.ics` };
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new CommitteeController();
+    (generateM2MToken as any).mockResolvedValue('m2m-token');
+    (fetchAllMeetingPages as any).mockResolvedValue([]);
+    (meetingsToVEvents as any).mockReturnValue([]);
+    (buildVCalendar as any).mockReturnValue('BEGIN:VCALENDAR\r\nEND:VCALENDAR');
+  });
+
+  it('passes the resolved committee name through to buildVCalendar as calname', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_ID, name: 'Technical Steering Committee' });
+    const req = buildCalendarReq();
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getCommitteeCalendar(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(buildVCalendar).toHaveBeenCalledWith(expect.anything(), expect.any(String), 'Technical Steering Committee');
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it('falls back to an undefined calname (still 200) when the committee name lookup fails', async () => {
+    committeeSvc.getCommitteeById.mockRejectedValue(new Error('upstream 503'));
+    const req = buildCalendarReq();
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getCommitteeCalendar(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(buildVCalendar).toHaveBeenCalledWith(expect.anything(), expect.any(String), undefined);
+    expect(res.send).toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -1516,16 +1516,23 @@ export class CommitteeController {
 
       // Paginate both upcoming and past meetings — first page only would silently
       // drop meetings once a committee exceeds the default page size.
-      const [upcoming, past] = await Promise.all([
+      const [upcoming, past, calname] = await Promise.all([
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_meeting', false)),
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
+        this.committeeService
+          .getCommitteeById(req, id)
+          .then((committee) => committee.name)
+          .catch((error) => {
+            logger.warning(req, 'get_committee_calendar', 'Failed to resolve committee name for X-WR-CALNAME', { committee_id: id, err: error });
+            return undefined;
+          }),
       ]);
 
       // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
       // still listed so their existence is discoverable; join authorization is enforced separately at join time.
       const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
       const events = meetingsToVEvents(allMeetings);
-      const ics = buildVCalendar(events, '-//LFX//Committee Calendar//EN');
+      const ics = buildVCalendar(events, '-//LFX//Committee Calendar//EN', calname);
 
       logger.success(req, 'get_committee_calendar', startTime, {
         committee_id: id,

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -120,6 +120,12 @@ function buildMeeting(overrides: Partial<Meeting> = {}): Meeting {
     description: '',
     created_by: { name: 'Organizer', email: 'organizer@example.com' },
     owner: { name: 'Owner', email: 'owner@example.com' },
+    // Seeded so the public-feed tests assert these never reach an anonymous caller.
+    organizers: ['organizer-lfid'],
+    password: 'super-secret',
+    passcode: '123456',
+    host_key: '654321',
+    zoom_config: { meeting_id: '99152950841', passcode: '123456' },
     ...overrides,
   } as Meeting;
 }
@@ -313,7 +319,7 @@ describe('ProjectController.getProjectMeetings', () => {
     meetingSvc.getMeetings.mockResolvedValue({ data: [], page_token: undefined });
   });
 
-  it('strips created_by/owner PII from public meetings and returns the project envelope', async () => {
+  it('returns only allowlisted calendar fields and the project envelope', async () => {
     meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
       Promise.resolve({ data: resourceType === 'v1_meeting' ? [buildMeeting()] : [], page_token: undefined })
     );
@@ -325,10 +331,80 @@ describe('ProjectController.getProjectMeetings', () => {
     expect(res.json).toHaveBeenCalledTimes(1);
     const response = res.json.mock.calls[0][0];
     expect(response.meetings).toHaveLength(1);
-    expect(response.meetings[0]).not.toHaveProperty('created_by');
-    expect(response.meetings[0]).not.toHaveProperty('owner');
+    // Exact key set, not a list of absent keys — a delete-based strip would pass an "is X absent"
+    // check for every field named here while still shipping the next sensitive field added upstream.
+    expect(Object.keys(response.meetings[0]).sort()).toEqual(
+      ['cancelled_occurrences', 'duration', 'id', 'meeting_and_occurrence_id', 'occurrences', 'scheduled_start_time', 'start_time', 'timezone', 'title'].sort()
+    );
     expect(response.total).toBe(1);
     expect(response.project).toEqual({ uid: PROJECT_UID, name: 'CNCF' });
+  });
+
+  it('never serializes credentials or organizer PII to anonymous callers', async () => {
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({ data: resourceType === 'v1_meeting' ? [buildMeeting()] : [], page_token: undefined })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    // Serialized, not just key-checked — `password` on a nested object (e.g. zoom_config) would
+    // still be on the wire while every top-level property assertion passed.
+    const serialized = JSON.stringify(res.json.mock.calls[0][0]);
+    for (const secret of ['super-secret', '123456', '654321', 'organizer@example.com', 'owner@example.com', 'organizer-lfid']) {
+      expect(serialized).not.toContain(secret);
+    }
+    for (const key of ['password', 'passcode', 'host_key', 'zoom_config', 'organizers', 'created_by', 'owner']) {
+      expect(serialized).not.toContain(key);
+    }
+  });
+
+  it('projects occurrences down to timestamps and status, dropping per-occurrence titles', async () => {
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({
+        data:
+          resourceType === 'v1_meeting'
+            ? [
+                buildMeeting({
+                  occurrences: [
+                    { occurrence_id: '1630560600', start_time: '2026-09-01T15:00:00Z', duration: 30, status: 'available', title: 'Internal agenda' } as any,
+                  ],
+                }),
+              ]
+            : [],
+        page_token: undefined,
+      })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    const [occurrence] = res.json.mock.calls[0][0].meetings[0].occurrences;
+    expect(occurrence).toEqual({ occurrence_id: '1630560600', start_time: '2026-09-01T15:00:00Z', duration: 30, status: 'available' });
+    expect(JSON.stringify(res.json.mock.calls[0][0])).not.toContain('Internal agenda');
+  });
+
+  it('sets a public Cache-Control on the JSON feed', async () => {
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'public, max-age=300');
+  });
+
+  it('still returns meetings with an empty project name when project metadata lookup fails', async () => {
+    projectSvc.getProjectById.mockRejectedValue(new Error('upstream 503'));
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({ data: resourceType === 'v1_meeting' ? [buildMeeting()] : [], page_token: undefined })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const response = res.json.mock.calls[0][0];
+    expect(response.meetings).toHaveLength(1);
+    expect(response.project).toEqual({ uid: PROJECT_UID, name: '' });
   });
 
   it('filters out PRIVATE meetings from the public feed', async () => {

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -260,6 +260,47 @@ describe('ProjectController.getLensRedirect', () => {
   });
 });
 
+describe('ProjectController.getProjectCalendar', () => {
+  let controller: ProjectController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new ProjectController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+    meetingSvc.getMeetings.mockResolvedValue({ data: [], page_token: undefined });
+  });
+
+  function buildCalendarReqRes(id: string = PROJECT_UID) {
+    const req = { params: { id }, headers: {}, bearerToken: undefined, path: `/public/api/projects/${id}/calendar.ics` } as any;
+    const res = { send: vi.fn(), setHeader: vi.fn() } as any;
+    const next = vi.fn();
+    return { req, res, next };
+  }
+
+  it('includes X-WR-CALNAME when the project name resolves', async () => {
+    projectSvc.getProjectById.mockResolvedValue(buildProject({ name: 'CNCF' }));
+    const { req, res, next } = buildCalendarReqRes();
+
+    await controller.getProjectCalendar(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const ics = res.send.mock.calls[0][0] as string;
+    expect(ics).toContain('X-WR-CALNAME:CNCF');
+  });
+
+  it('falls back to an unnamed calendar (200, no X-WR-CALNAME) when the project name lookup fails', async () => {
+    projectSvc.getProjectById.mockRejectedValue(new Error('upstream 503'));
+    const { req, res, next } = buildCalendarReqRes();
+
+    await controller.getProjectCalendar(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const ics = res.send.mock.calls[0][0] as string;
+    expect(ics).not.toContain('X-WR-CALNAME');
+    expect(ics).toContain('BEGIN:VCALENDAR');
+  });
+});
+
 describe('ProjectController.getProjectMeetings', () => {
   let controller: ProjectController;
 

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -384,6 +384,25 @@ describe('ProjectController.getProjectMeetings', () => {
     expect(JSON.stringify(res.json.mock.calls[0][0])).not.toContain('Internal agenda');
   });
 
+  it('resolves an occurrence with no duration override to the series duration', async () => {
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({
+        data:
+          resourceType === 'v1_meeting'
+            ? [buildMeeting({ duration: 90, occurrences: [{ occurrence_id: '1630560600', start_time: '2026-09-01T15:00:00Z' } as any] })]
+            : [],
+        page_token: undefined,
+      })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    // MeetingOccurrenceSummary types duration as required — an undefined on the wire would make the
+    // client mapper compute a NaN past-state and a silent 60-minute end time.
+    expect(res.json.mock.calls[0][0].meetings[0].occurrences[0].duration).toBe(90);
+  });
+
   it('sets a public Cache-Control on the JSON feed', async () => {
     const { req, res, next } = buildMeetingsReqRes();
 

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { Project } from '@lfx-one/shared/interfaces';
+import type { Meeting, Project } from '@lfx-one/shared/interfaces';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 const SLUG = 'cncf';
@@ -11,9 +11,13 @@ const PROJECT_UID = 'project-2222';
 // into vitest (see vitest.config.ts), so the shared barrels the controller imports at
 // module load are stubbed here. `computeIsFoundation` is mocked so each test can drive
 // the foundation-vs-project branch without constructing a full Project graph.
-const { computeIsFoundationMock, generateM2MTokenMock, projectSvc } = vi.hoisted(() => ({
+const { computeIsFoundationMock, generateM2MTokenMock, isUuidMock, meetingSvc, projectSvc } = vi.hoisted(() => ({
   computeIsFoundationMock: vi.fn(),
   generateM2MTokenMock: vi.fn(),
+  isUuidMock: vi.fn(),
+  meetingSvc: {
+    getMeetings: vi.fn(),
+  },
   projectSvc: {
     getProjectIdBySlug: vi.fn(),
     getProjectById: vi.fn(),
@@ -23,7 +27,7 @@ const { computeIsFoundationMock, generateM2MTokenMock, projectSvc } = vi.hoisted
 vi.mock('@lfx-one/shared/utils', () => ({
   computeIsFoundation: computeIsFoundationMock,
   isFileTypeAllowed: vi.fn(),
-  isUuid: vi.fn(),
+  isUuid: isUuidMock,
 }));
 vi.mock('@lfx-one/shared/constants', async () => {
   // Deep-import the real allowlist so the drift guard below asserts the production
@@ -41,7 +45,10 @@ vi.mock('@lfx-one/shared/constants', async () => {
 vi.mock('@lfx-one/shared/enums', () => ({ MeetingVisibility: { PUBLIC: 'public', PRIVATE: 'private' } }));
 // validation.helper pulls in a heavy shared/constants + shared/enums graph; stub it
 // wholesale so only the controller's getLensRedirect path loads.
-vi.mock('../helpers/validation.helper', () => ({ getStringQueryParam: vi.fn(), validateUidParameter: vi.fn(() => true) }));
+vi.mock('../helpers/validation.helper', () => ({
+  getStringQueryParam: vi.fn((req: any, key: string) => (typeof req.query?.[key] === 'string' ? req.query[key] : undefined)),
+  validateUidParameter: vi.fn(() => true),
+}));
 
 vi.mock('../services/project.service', () => ({
   ProjectService: vi.fn(function () {
@@ -50,7 +57,7 @@ vi.mock('../services/project.service', () => ({
 }));
 vi.mock('../services/meeting.service', () => ({
   MeetingService: vi.fn(function () {
-    return {};
+    return meetingSvc;
   }),
 }));
 vi.mock('../services/logger.service', () => ({
@@ -97,6 +104,37 @@ function buildProject(overrides: Partial<Project> = {}): Project {
     mailing_list_count: 0,
     ...overrides,
   } as Project;
+}
+
+function buildMeeting(overrides: Partial<Meeting> = {}): Meeting {
+  return {
+    id: 'meeting-1',
+    project_uid: PROJECT_UID,
+    visibility: 'public',
+    restricted: false,
+    committees: [],
+    start_time: new Date().toISOString(),
+    duration: 60,
+    timezone: 'America/New_York',
+    title: 'Meeting',
+    description: '',
+    created_by: { name: 'Organizer', email: 'organizer@example.com' },
+    owner: { name: 'Owner', email: 'owner@example.com' },
+    ...overrides,
+  } as Meeting;
+}
+
+function buildMeetingsReqRes(id: string = PROJECT_UID, query: Record<string, string> = {}) {
+  const req = {
+    params: { id },
+    query,
+    headers: {},
+    bearerToken: undefined,
+    path: `/public/api/projects/${id}/meetings`,
+  } as any;
+  const res = { json: vi.fn(), setHeader: vi.fn() } as any;
+  const next = vi.fn();
+  return { req, res, next };
 }
 
 function buildReqRes(slug: string = SLUG, resource: string = 'votes') {
@@ -219,6 +257,103 @@ describe('ProjectController.getLensRedirect', () => {
     await controller.getLensRedirect(req, res, next);
 
     expect(res.redirect).toHaveBeenCalledWith(302, '/project/votes?project=my-project_1');
+  });
+});
+
+describe('ProjectController.getProjectMeetings', () => {
+  let controller: ProjectController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    controller = new ProjectController();
+    generateM2MTokenMock.mockResolvedValue('m2m-token');
+    isUuidMock.mockImplementation((value: string) => value === PROJECT_UID || value === 'committee-uid-1234');
+    projectSvc.getProjectById.mockResolvedValue(buildProject());
+    meetingSvc.getMeetings.mockResolvedValue({ data: [], page_token: undefined });
+  });
+
+  it('strips created_by/owner PII from public meetings and returns the project envelope', async () => {
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({ data: resourceType === 'v1_meeting' ? [buildMeeting()] : [], page_token: undefined })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledTimes(1);
+    const response = res.json.mock.calls[0][0];
+    expect(response.meetings).toHaveLength(1);
+    expect(response.meetings[0]).not.toHaveProperty('created_by');
+    expect(response.meetings[0]).not.toHaveProperty('owner');
+    expect(response.total).toBe(1);
+    expect(response.project).toEqual({ uid: PROJECT_UID, name: 'CNCF' });
+  });
+
+  it('filters out PRIVATE meetings from the public feed', async () => {
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({ data: resourceType === 'v1_meeting' ? [buildMeeting({ id: 'private-1', visibility: 'private' as any })] : [], page_token: undefined })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    const response = res.json.mock.calls[0][0];
+    expect(response.meetings).toHaveLength(0);
+  });
+
+  it('resolves a slug identifier to a UID before querying meetings', async () => {
+    isUuidMock.mockReturnValue(false);
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: PROJECT_UID, slug: SLUG, exists: true });
+    const { req, res, next } = buildMeetingsReqRes(SLUG);
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(projectSvc.getProjectIdBySlug).toHaveBeenCalledWith(req, SLUG);
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json).toHaveBeenCalledTimes(1);
+  });
+
+  it('passes next() a not-found error when the slug is unresolvable', async () => {
+    isUuidMock.mockReturnValue(false);
+    projectSvc.getProjectIdBySlug.mockResolvedValue({ uid: '', slug: SLUG, exists: false });
+    const { req, res, next } = buildMeetingsReqRes(SLUG);
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+  });
+
+  it('uses tags_all with both project and committee tags when committee query param is a valid UUID', async () => {
+    const { req, res, next } = buildMeetingsReqRes(PROJECT_UID, { committee: 'committee-uid-1234' });
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const [, query] = meetingSvc.getMeetings.mock.calls[0];
+    expect(query).toEqual({ tags_all: [`project_uid:${PROJECT_UID}`, 'committee_uid:committee-uid-1234'] });
+  });
+
+  it('rejects an invalid committee query param via next() without calling meeting service', async () => {
+    const { req, res, next } = buildMeetingsReqRes(PROJECT_UID, { committee: 'not-a-uuid' });
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(meetingSvc.getMeetings).not.toHaveBeenCalled();
+    expect(res.json).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(ServiceValidationError);
+  });
+
+  it('rejects an invalid project id via next() without an M2M call', async () => {
+    const { req, res, next } = buildMeetingsReqRes('bad id!');
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(generateM2MTokenMock).not.toHaveBeenCalled();
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next.mock.calls[0][0]).toBeInstanceOf(ServiceValidationError);
   });
 });
 

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -7,6 +7,8 @@ import {
   AddUserToProjectRequest,
   CreateProjectDocumentRequest,
   Meeting,
+  PastMeeting,
+  PublicCalendarMeeting,
   PublicProjectMeetingsResponse,
   UpdateUserRoleRequest,
   UploadProjectDocumentRequest,
@@ -991,22 +993,30 @@ export class ProjectController {
       const [upcoming, past, project] = await Promise.all([
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_meeting', false)),
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
-        this.projectService.getProjectById(req, projectUid, false),
+        // Project metadata only feeds the page header — degrade gracefully rather than failing the whole
+        // feed on a transient project-service error, matching the X-WR-CALNAME fallback in getProjectCalendar.
+        this.projectService.getProjectById(req, projectUid, false).catch((error) => {
+          logger.warning(req, 'get_project_meetings', 'Failed to resolve project metadata for the calendar header', {
+            project_id: projectUid,
+            err: error,
+          });
+          return undefined;
+        }),
       ]);
 
       // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
       // still listed so their existence is discoverable; join authorization is enforced separately at join time.
-      // created_by/owner carry organizer PII (name/email) — authenticated-visible only, per the same
-      // strip applied to anonymous callers in PublicMeetingController.getMeetingById (LFXV2-2802).
-      const meetings = [...upcoming, ...past]
+      // The projection is an allowlist, not a strip: this is an unauthenticated bulk-export endpoint, so
+      // credentials (password/passcode/host_key/zoom_config) and organizer PII (created_by/owner/organizers)
+      // must stay out of the payload even as new Meeting fields land upstream (LFXV2-2802).
+      const meetings: PublicCalendarMeeting[] = [...upcoming, ...past]
         .filter((m) => m.visibility === MeetingVisibility.PUBLIC)
-        .map((m) => {
-          const meeting = { ...m };
-          delete (meeting as Partial<Meeting>).created_by;
-          delete (meeting as Partial<Meeting>).owner;
-          return meeting;
-        });
-      const response: PublicProjectMeetingsResponse = { meetings, total: meetings.length, project: { uid: project.uid, name: project.name } };
+        .map((m) => this.toPublicCalendarMeeting(m));
+      const response: PublicProjectMeetingsResponse = {
+        meetings,
+        total: meetings.length,
+        project: { uid: projectUid, name: project?.name ?? '' },
+      };
 
       logger.success(req, 'get_project_meetings', startTime, {
         project_id: id,
@@ -1014,6 +1024,9 @@ export class ProjectController {
         meeting_count: meetings.length,
       });
 
+      // Shorter than calendar.ics's 15 minutes: calendar clients poll the ICS feed on their own schedule,
+      // while this feed backs an interactive page where a newly scheduled meeting should surface quickly.
+      res.setHeader('Cache-Control', 'public, max-age=300');
       res.json(response);
     } catch (error) {
       next(error);
@@ -1092,5 +1105,30 @@ export class ProjectController {
       });
     }
     return result.uid;
+  }
+
+  /**
+   * Projects an indexed `v1_meeting` / `v1_past_meeting` record onto the credential-free shape served
+   * by `GET /public/api/projects/:id/meetings`. Field-by-field allowlist, deliberately not a spread with
+   * deletes — anything not named here can never reach an anonymous caller.
+   */
+  private toPublicCalendarMeeting(meeting: Meeting | PastMeeting): PublicCalendarMeeting {
+    const pastRow = meeting as Partial<PastMeeting>;
+    return {
+      id: meeting.id,
+      title: meeting.title,
+      start_time: meeting.start_time,
+      duration: meeting.duration,
+      timezone: meeting.timezone,
+      occurrences: (meeting.occurrences ?? []).map((occurrence) => ({
+        occurrence_id: occurrence.occurrence_id,
+        start_time: occurrence.start_time,
+        duration: occurrence.duration,
+        status: occurrence.status,
+      })),
+      cancelled_occurrences: meeting.cancelled_occurrences,
+      scheduled_start_time: pastRow.scheduled_start_time,
+      meeting_and_occurrence_id: pastRow.meeting_and_occurrence_id,
+    };
   }
 }

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -3,14 +3,20 @@
 
 import { ALLOWED_FILE_TYPES, LENS_REDIRECT_RESOURCES } from '@lfx-one/shared/constants';
 import { MeetingVisibility } from '@lfx-one/shared/enums';
-import { AddUserToProjectRequest, CreateProjectDocumentRequest, UpdateUserRoleRequest, UploadProjectDocumentRequest } from '@lfx-one/shared/interfaces';
+import {
+  AddUserToProjectRequest,
+  CreateProjectDocumentRequest,
+  PublicProjectMeetingsResponse,
+  UpdateUserRoleRequest,
+  UploadProjectDocumentRequest,
+} from '@lfx-one/shared/interfaces';
 import { computeIsFoundation, isFileTypeAllowed, isUuid } from '@lfx-one/shared/utils';
 import { NextFunction, Request, Response } from 'express';
 import { Readable } from 'node:stream';
 import { pipeline } from 'node:stream/promises';
 import { ReadableStream as NodeReadableStream } from 'node:stream/web';
 
-import { ServiceValidationError } from '../errors';
+import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { contentDispositionAttachment } from '../helpers/content-disposition.helper';
 import { buildVCalendar, fetchAllMeetingPages, meetingsToVEvents } from '../helpers/ics.helper';
 import { getStringQueryParam, validateUidParameter } from '../helpers/validation.helper';
@@ -920,16 +926,23 @@ export class ProjectController {
       const query = { tags: `project_uid:${id}` };
 
       // Fetch all pages — first-page-only would silently drop meetings beyond the default page size.
-      const [upcoming, past] = await Promise.all([
+      const [upcoming, past, calname] = await Promise.all([
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_meeting', false)),
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
+        this.projectService
+          .getProjectById(req, id, false)
+          .then((project) => project.name)
+          .catch((error) => {
+            logger.warning(req, 'get_project_calendar', 'Failed to resolve project name for X-WR-CALNAME', { project_id: id, err: error });
+            return undefined;
+          }),
       ]);
 
       // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
       // still listed so their existence is discoverable; join authorization is enforced separately at join time.
       const allMeetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
       const events = meetingsToVEvents(allMeetings);
-      const ics = buildVCalendar(events, '-//LFX//Project Calendar//EN');
+      const ics = buildVCalendar(events, '-//LFX//Project Calendar//EN', calname);
 
       logger.success(req, 'get_project_calendar', startTime, {
         project_id: id,
@@ -941,6 +954,51 @@ export class ProjectController {
       res.setHeader('Content-Disposition', `attachment; filename="project-${id}.ics"`);
       res.setHeader('Cache-Control', 'public, max-age=900'); // 15 minutes — reduces load from calendar clients polling every 15-60 minutes
       res.send(ics);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
+   * GET /public/api/projects/:id/meetings — PUBLIC meetings for the project calendar page (by UID or slug).
+   * Optional `committee` query param scopes the feed to a single committee within the project.
+   */
+  public async getProjectMeetings(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const { id } = req.params;
+    const committeeUid = getStringQueryParam(req, 'committee');
+    const startTime = logger.startOperation(req, 'get_project_meetings', { project_id: id, committee_uid: committeeUid });
+
+    if (!id || !/^[A-Za-z0-9_-]+$/.test(id)) {
+      next(ServiceValidationError.forField('id', 'Invalid project ID', { operation: 'get_project_meetings' }));
+      return;
+    }
+
+    try {
+      if (!req.bearerToken) {
+        req.bearerToken = await generateM2MToken(req);
+      }
+
+      const projectUid = await this.resolveProjectIdentifier(req, id);
+      const query = committeeUid ? { tags_all: [`project_uid:${projectUid}`, `committee_uid:${committeeUid}`] } : { tags: `project_uid:${projectUid}` };
+
+      const [upcoming, past, project] = await Promise.all([
+        fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_meeting', false)),
+        fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
+        this.projectService.getProjectById(req, projectUid, false),
+      ]);
+
+      // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
+      // still listed so their existence is discoverable; join authorization is enforced separately at join time.
+      const meetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
+      const response: PublicProjectMeetingsResponse = { meetings, total: meetings.length, project: { uid: project.uid, name: project.name } };
+
+      logger.success(req, 'get_project_meetings', startTime, {
+        project_id: id,
+        committee_uid: committeeUid,
+        meeting_count: meetings.length,
+      });
+
+      res.json(response);
     } catch (error) {
       next(error);
     }
@@ -1002,5 +1060,21 @@ export class ProjectController {
       res.setHeader('Cache-Control', 'no-store');
       res.redirect(302, `/${resource}?project=${encodeURIComponent(slug)}`);
     }
+  }
+
+  /** Resolves a project route param that may be a UID or a slug down to a UID. */
+  private async resolveProjectIdentifier(req: Request, identifier: string): Promise<string> {
+    if (isUuid(identifier)) {
+      return identifier;
+    }
+    const result = await this.projectService.getProjectIdBySlug(req, identifier);
+    if (!result.exists || !result.uid) {
+      throw new ResourceNotFoundError('Project', identifier, {
+        operation: 'resolve_project_identifier',
+        service: 'project_controller',
+        path: `/projects/${identifier}`,
+      });
+    }
+    return result.uid;
   }
 }

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -6,6 +6,7 @@ import { MeetingVisibility } from '@lfx-one/shared/enums';
 import {
   AddUserToProjectRequest,
   CreateProjectDocumentRequest,
+  Meeting,
   PublicProjectMeetingsResponse,
   UpdateUserRoleRequest,
   UploadProjectDocumentRequest,
@@ -973,7 +974,13 @@ export class ProjectController {
       return;
     }
 
+    if (committeeUid && !isUuid(committeeUid)) {
+      next(ServiceValidationError.forField('committee', 'Invalid committee ID', { operation: 'get_project_meetings' }));
+      return;
+    }
+
     try {
+      // Public route has no session — obtain M2M token so meeting/project service calls succeed.
       if (!req.bearerToken) {
         req.bearerToken = await generateM2MToken(req);
       }
@@ -989,7 +996,16 @@ export class ProjectController {
 
       // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
       // still listed so their existence is discoverable; join authorization is enforced separately at join time.
-      const meetings = [...upcoming, ...past].filter((m) => m.visibility === MeetingVisibility.PUBLIC);
+      // created_by/owner carry organizer PII (name/email) — authenticated-visible only, per the same
+      // strip applied to anonymous callers in PublicMeetingController.getMeetingById (LFXV2-2802).
+      const meetings = [...upcoming, ...past]
+        .filter((m) => m.visibility === MeetingVisibility.PUBLIC)
+        .map((m) => {
+          const meeting = { ...m };
+          delete (meeting as Partial<Meeting>).created_by;
+          delete (meeting as Partial<Meeting>).owner;
+          return meeting;
+        });
       const response: PublicProjectMeetingsResponse = { meetings, total: meetings.length, project: { uid: project.uid, name: project.name } };
 
       logger.success(req, 'get_project_meetings', startTime, {

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -1123,7 +1123,9 @@ export class ProjectController {
       occurrences: (meeting.occurrences ?? []).map((occurrence) => ({
         occurrence_id: occurrence.occurrence_id,
         start_time: occurrence.start_time,
-        duration: occurrence.duration,
+        // Indexed occurrences omit duration when there is no per-occurrence override; resolve it here
+        // so the wire payload honors MeetingOccurrenceSummary's required `duration` for every consumer.
+        duration: occurrence.duration ?? meeting.duration,
         status: occurrence.status,
       })),
       cancelled_occurrences: meeting.cancelled_occurrences,

--- a/apps/lfx-one/src/server/helpers/ics.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/ics.helper.spec.ts
@@ -1,0 +1,43 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('../services/logger.service', () => ({
+  logger: { warning: vi.fn() },
+}));
+// The `@lfx-one/shared/*` path alias isn't wired into the server-side vitest config, and the
+// real barrel pulls in Angular-dependent code that fails to JIT-compile outside the browser build.
+vi.mock('@lfx-one/shared/utils', () => ({ addMinutesToDate: vi.fn((iso: string) => iso) }));
+
+import { buildVCalendar } from './ics.helper';
+
+describe('buildVCalendar', () => {
+  it('omits X-WR-CALNAME when no calname is provided', () => {
+    const ics = buildVCalendar(['BEGIN:VEVENT\r\nEND:VEVENT'], '-//LFX//Calendar//EN');
+
+    expect(ics).not.toContain('X-WR-CALNAME');
+    expect(ics.split('\r\n')[0]).toBe('BEGIN:VCALENDAR');
+  });
+
+  it('emits an escaped X-WR-CALNAME line right after PRODID/CALSCALE/METHOD when calname is provided', () => {
+    const ics = buildVCalendar(['BEGIN:VEVENT\r\nEND:VEVENT'], '-//LFX//Project Calendar//EN', 'CNCF, Inc.');
+
+    const lines = ics.split('\r\n');
+    expect(lines).toContain('X-WR-CALNAME:CNCF\\, Inc.');
+    // Comes after the fixed header block and before the events.
+    expect(lines.indexOf('X-WR-CALNAME:CNCF\\, Inc.')).toBeGreaterThan(lines.indexOf('METHOD:PUBLISH'));
+    expect(lines.indexOf('X-WR-CALNAME:CNCF\\, Inc.')).toBeLessThan(lines.indexOf('BEGIN:VEVENT'));
+  });
+
+  it('folds a long calendar name per RFC 5545 line-length limits', () => {
+    const longName = 'A'.repeat(100);
+    const ics = buildVCalendar([], '-//LFX//Calendar//EN', longName);
+
+    const rawLines = ics.split('\r\n');
+    const calnameStart = rawLines.findIndex((line) => line.startsWith('X-WR-CALNAME:'));
+    expect(calnameStart).toBeGreaterThanOrEqual(0);
+    // Folded continuation lines are prefixed with a single space.
+    expect(rawLines[calnameStart + 1].startsWith(' ')).toBe(true);
+  });
+});

--- a/apps/lfx-one/src/server/helpers/ics.helper.ts
+++ b/apps/lfx-one/src/server/helpers/ics.helper.ts
@@ -104,9 +104,17 @@ export function meetingsToVEvents(meetings: Meeting[]): string[] {
 
 /**
  * Wraps VEVENT strings in a VCALENDAR envelope and returns the complete ICS string.
+ * X-WR-CALNAME is a de facto standard (not in RFC 5545) that Google Calendar and Apple
+ * Calendar read for the subscribed calendar's display name; omitting it shows an unnamed feed.
  */
-export function buildVCalendar(events: string[], prodId = '-//LFX//Calendar//EN'): string {
-  return [`BEGIN:VCALENDAR`, `VERSION:2.0`, `PRODID:${prodId}`, `CALSCALE:GREGORIAN`, `METHOD:PUBLISH`, ...events, `END:VCALENDAR`].join('\r\n');
+export function buildVCalendar(events: string[], prodId = '-//LFX//Calendar//EN', calname?: string): string {
+  const lines = [`BEGIN:VCALENDAR`, `VERSION:2.0`, `PRODID:${prodId}`, `CALSCALE:GREGORIAN`, `METHOD:PUBLISH`];
+
+  if (calname) {
+    lines.push(foldLine(`X-WR-CALNAME:${escapeICSText(calname)}`));
+  }
+
+  return [...lines, ...events, `END:VCALENDAR`].join('\r\n');
 }
 
 const MAX_PAGES = 50;

--- a/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.spec.ts
@@ -272,6 +272,28 @@ describe('authMiddleware route classification', () => {
     expect(res.oidc.login).toHaveBeenCalledTimes(1);
   });
 
+  it('allows an anonymous GET to the public project calendar (/projects/:slug/calendar)', async () => {
+    const req = buildReq({ path: '/projects/acme/calendar' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(next).toHaveBeenCalledTimes(1);
+    expect(next).toHaveBeenCalledWith();
+    expect(res.oidc.login).not.toHaveBeenCalled();
+  });
+
+  it('does not treat a nested /projects/:slug/calendar/<sub> path as public (anchored regex, no fail-open)', async () => {
+    const req = buildReq({ path: '/projects/acme/calendar/extra' });
+    const res = buildRes();
+    const next = vi.fn() as unknown as NextFunction;
+
+    await middleware(req, res, next);
+
+    expect(res.oidc.login).toHaveBeenCalledTimes(1);
+  });
+
   it('allows an anonymous GET to the invite error page (/invite/error)', async () => {
     const req = buildReq({ path: '/invite/error' });
     const res = buildRes();

--- a/apps/lfx-one/src/server/middleware/auth.middleware.ts
+++ b/apps/lfx-one/src/server/middleware/auth.middleware.ts
@@ -55,6 +55,11 @@ const DEFAULT_ROUTE_CONFIG: RouteAuthConfig[] = [
   { pattern: /^\/foundations\/[^/]+\/groups\/?$/, type: 'ssr', auth: 'optional' },
   { pattern: /^\/projects\/[^/]+\/groups\/?$/, type: 'ssr', auth: 'optional' },
 
+  // Public project calendar (LFXV2-3340) — month/week view of a project's public meetings, optionally
+  // scoped to one committee via `?committee=`. Same single-segment anchoring as the group directories
+  // above (no deeper route exists) so a nested path fails closed to `required`.
+  { pattern: /^\/projects\/[^/]+\/calendar\/?$/, type: 'ssr', auth: 'optional' },
+
   // Flow C callback via /passwordless/callback — needs session auth but no bearer token
   { pattern: '/passwordless/callback', type: 'ssr', auth: 'required', tokenRequired: false },
 

--- a/apps/lfx-one/src/server/routes/public-projects.route.ts
+++ b/apps/lfx-one/src/server/routes/public-projects.route.ts
@@ -16,6 +16,12 @@ const publicGroupsController = new PublicGroupsController();
 // (Google Calendar, Outlook, Apple Calendar) can subscribe by URL.
 router.get('/:id/calendar.ics', (req, res, next) => projectController.getProjectCalendar(req, res, next));
 
+// GET /public/api/projects/:id/meetings
+// Returns public meetings for a project (by UID or slug) as JSON, for the public calendar page.
+// Optional `committee` query param scopes the feed to a single committee within the project.
+// Public access — no authentication required; M2M token used for upstream calls.
+router.get('/:id/meetings', (req, res, next) => projectController.getProjectMeetings(req, res, next));
+
 // GET /public/api/projects/:slug/lens-redirect/:resource
 // 302-redirects to the lens-prefixed resource page for email deep links (votes, meetings, …).
 // The lens is derived from the project's own attributes (computeIsFoundation), not the

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1442,3 +1442,10 @@ export interface MeLensMeetingFilters {
   /** Viewer username/LFID used by the `organizerOnly` predicate; null disables matching. */
   viewerUsername: string | null;
 }
+
+/** Response envelope returned by `GET /public/api/projects/:id/meetings` — the public calendar page's meeting list. */
+export interface PublicProjectMeetingsResponse {
+  meetings: Meeting[];
+  total: number;
+  project: { uid: string; name: string };
+}

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1443,9 +1443,45 @@ export interface MeLensMeetingFilters {
   viewerUsername: string | null;
 }
 
-/** Response envelope returned by `GET /public/api/projects/:id/meetings` — the public calendar page's meeting list. */
+/**
+ * Public-safe meeting projection for the anonymous project calendar feed
+ * @description Allowlisted rendering and navigation fields only. `GET /public/api/projects/:id/meetings`
+ * builds this shape field-by-field rather than deleting known-sensitive keys off a full `Meeting`, so
+ * credentials (`password`, `passcode`, `host_key`, `zoom_config`) and organizer PII (`created_by`,
+ * `owner`, `organizers`) stay out of the anonymous payload even as new `Meeting` fields land upstream
+ * (LFXV2-2802). Mirrors the minimal-projection contract of `PublicMeetingOccurrencesResponse`.
+ */
+export interface PublicCalendarMeeting {
+  /** Meeting UID of the live series, or of the originating series for a past-meeting row */
+  id: string;
+  /** Series title — also used for every occurrence, since per-occurrence titles are not published */
+  title: string;
+  /** Series start time in RFC3339 format */
+  start_time: string;
+  /** Duration in minutes */
+  duration: number;
+  /** IANA timezone (e.g. "America/New_York") */
+  timezone: string;
+  /** Occurrence timestamps and status only — no titles, descriptions, or registrant counts */
+  occurrences?: MeetingOccurrenceSummary[];
+  /** Cancelled occurrence IDs from the live series (10-digit Unix-second keys) */
+  cancelled_occurrences?: string[];
+  /** Scheduled start of a past occurrence; present only on `v1_past_meeting` rows */
+  scheduled_start_time?: string;
+  /** Composite past-meeting id (e.g. "99152950841-1630560600000"); present only on `v1_past_meeting` rows */
+  meeting_and_occurrence_id?: string;
+}
+
+/**
+ * Response envelope returned by `GET /public/api/projects/:id/meetings`
+ * @description The public calendar page's meeting list — PUBLIC-visibility meetings only, upcoming
+ * and past combined, optionally scoped to one committee via the `committee` query param
+ */
 export interface PublicProjectMeetingsResponse {
-  meetings: Meeting[];
+  /** Credential- and PII-free meeting projections; see {@link PublicCalendarMeeting} */
+  meetings: PublicCalendarMeeting[];
+  /** Number of entries in `meetings` */
   total: number;
+  /** Slim project envelope for the page header; `name` is empty when project lookup fails */
   project: { uid: string; name: string };
 }

--- a/packages/shared/src/utils/meeting-calendar.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.spec.ts
@@ -5,7 +5,9 @@ import '@angular/compiler';
 
 import { describe, expect, it } from 'vitest';
 
-import { meetingToCalendarEvents } from './meeting-calendar.utils';
+import { meetingToCalendarEvents, publicMeetingToCalendarEvents, resolveMeetingCalendarClickRoute } from './meeting-calendar.utils';
+
+import type { PublicCalendarMeeting } from '../interfaces';
 
 describe('meetingToCalendarEvents', () => {
   it('does not style in-progress v1_past_meeting rows as past', () => {
@@ -28,5 +30,59 @@ describe('meetingToCalendarEvents', () => {
     } as never);
 
     expect(events[0].classNames).toContain('meeting-event-past');
+  });
+});
+
+describe('publicMeetingToCalendarEvents', () => {
+  function publicMeeting(over: Partial<PublicCalendarMeeting> = {}): PublicCalendarMeeting {
+    return {
+      id: 'meeting-1',
+      title: 'Technical Steering Committee',
+      start_time: new Date(Date.now() + 60 * 60_000).toISOString(),
+      duration: 60,
+      timezone: 'America/New_York',
+      ...over,
+    };
+  }
+
+  it('never emits a password into extendedProps, so a click cannot forward one into the join URL', () => {
+    // The public projection has no `password` field at all, but a future refactor pointing this
+    // mapper back at a full Meeting would silently reintroduce the leak — so the click route the
+    // event actually produces is asserted, not just the absence of the key.
+    const [event] = publicMeetingToCalendarEvents({ ...publicMeeting(), password: 'super-secret' } as PublicCalendarMeeting);
+
+    expect(event.extendedProps).not.toHaveProperty('password');
+    const route = resolveMeetingCalendarClickRoute(event.extendedProps!);
+    expect(route?.queryParams ?? {}).not.toHaveProperty('password');
+  });
+
+  it('expands occurrences using the series title and marks cancelled ones inert', () => {
+    const events = publicMeetingToCalendarEvents(
+      publicMeeting({
+        cancelled_occurrences: ['1630560600'],
+        occurrences: [
+          { occurrence_id: '1630560600', start_time: new Date(Date.now() + 60 * 60_000).toISOString(), duration: 30 },
+          { occurrence_id: '1630647000', start_time: new Date(Date.now() + 120 * 60_000).toISOString(), duration: 30 },
+        ],
+      })
+    );
+
+    expect(events).toHaveLength(2);
+    expect(events.every((e) => e.title === 'Technical Steering Committee')).toBe(true);
+    expect(events[0].classNames).toContain('cursor-default');
+    expect(resolveMeetingCalendarClickRoute(events[0].extendedProps!)).toBeNull();
+    expect(events[1].classNames).not.toContain('cursor-default');
+  });
+
+  it('links a past-meeting row through its composite resource id', () => {
+    const [event] = publicMeetingToCalendarEvents(
+      publicMeeting({
+        meeting_and_occurrence_id: '99152950841-1630560600000',
+        scheduled_start_time: new Date(Date.now() - 2 * 60 * 60_000).toISOString(),
+      })
+    );
+
+    expect(event.classNames).toContain('meeting-event-past');
+    expect(resolveMeetingCalendarClickRoute(event.extendedProps!)?.path).toEqual(['/meetings', '99152950841-1630560600000']);
   });
 });

--- a/packages/shared/src/utils/meeting-calendar.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.spec.ts
@@ -74,6 +74,18 @@ describe('publicMeetingToCalendarEvents', () => {
     expect(events[1].classNames).not.toContain('cursor-default');
   });
 
+  it('falls back to the series duration for an occurrence with no per-occurrence override', () => {
+    // Without the fallback, isOccurrencePast computes NaN (so an ended occurrence never styles as
+    // past) and addMinutesToDate silently substitutes 60 minutes — wrong end time for any meeting
+    // whose series duration isn't 60, and no durationMinutes for the click route to build from.
+    const start = new Date(Date.now() - 3 * 60 * 60_000).toISOString();
+    const [event] = publicMeetingToCalendarEvents(publicMeeting({ duration: 90, occurrences: [{ occurrence_id: '1630560600', start_time: start } as never] }));
+
+    expect(event.extendedProps?.durationMinutes).toBe(90);
+    expect(new Date(event.end!).getTime() - new Date(start).getTime()).toBe(90 * 60_000);
+    expect(event.classNames).toContain('meeting-event-past');
+  });
+
   it('links a past-meeting row through its composite resource id', () => {
     const [event] = publicMeetingToCalendarEvents(
       publicMeeting({

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -102,8 +102,12 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): Meeting
 export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): MeetingCalendarEventInput[] {
   if (meeting.occurrences && meeting.occurrences.length > 0) {
     return meeting.occurrences.map((occ) => {
+      // `duration` is typed required, but indexed occurrences omit it when there is no per-occurrence
+      // override — same fallback the sibling mapper applies. Without it `isOccurrencePast` computes
+      // NaN (never past) and `addMinutesToDate` quietly substitutes 60 minutes.
+      const occurrenceDuration = occ.duration ?? meeting.duration;
       const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
-      const isPast = !isCancelled && isOccurrencePast(occ.start_time, occ.duration);
+      const isPast = !isCancelled && isOccurrencePast(occ.start_time, occurrenceDuration);
       const colors = resolveMeetingCalendarColors(isCancelled, isPast);
       const classNames = ['meeting-event'];
       if (isCancelled) {
@@ -115,7 +119,7 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): M
         id: `${meeting.id}-${occ.occurrence_id}`,
         title: meeting.title,
         start: occ.start_time,
-        end: addMinutesToDate(occ.start_time, occ.duration).toISOString(),
+        end: addMinutesToDate(occ.start_time, occurrenceDuration).toISOString(),
         backgroundColor: colors.bg,
         borderColor: colors.border,
         textColor: colors.text,
@@ -126,7 +130,7 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): M
           meetingId: meeting.id,
           cancelled: isCancelled,
           startTime: occ.start_time,
-          durationMinutes: occ.duration,
+          durationMinutes: occurrenceDuration,
         },
       };
     });

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { Meeting, MeetingOccurrenceRoute, PastMeeting } from '../interfaces';
+import { Meeting, MeetingOccurrenceRoute, PastMeeting, PublicCalendarMeeting } from '../interfaces';
 import type { MeetingCalendarClickProps, MeetingCalendarEventInput } from '../interfaces/calendar.interface';
 import { Vote } from '../interfaces/poll.interface';
 import { Survey } from '../interfaces/survey.interface';
@@ -86,6 +86,76 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): Meeting
         meetingId: pastResourceId ?? meeting.id,
         pastMeetingResourceId: pastResourceId,
         password: meeting.password ?? undefined,
+        startTime,
+        durationMinutes: meeting.duration,
+      },
+    },
+  ];
+}
+
+/**
+ * Builds FullCalendar event inputs for anonymous/public calendar surfaces.
+ * Takes the credential-free `PublicCalendarMeeting` projection rather than a full `Meeting`, so no
+ * meeting password can reach client event state, click-through URLs, browser history, or referrers —
+ * defense in depth behind the server-side allowlist on `GET /public/api/projects/:id/meetings`.
+ */
+export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): MeetingCalendarEventInput[] {
+  if (meeting.occurrences && meeting.occurrences.length > 0) {
+    return meeting.occurrences.map((occ) => {
+      const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
+      const isPast = !isCancelled && isOccurrencePast(occ.start_time, occ.duration);
+      const colors = resolveMeetingCalendarColors(isCancelled, isPast);
+      const classNames = ['meeting-event'];
+      if (isCancelled) {
+        classNames.push('cursor-default');
+      } else if (isPast) {
+        classNames.push('meeting-event-past');
+      }
+      return {
+        id: `${meeting.id}-${occ.occurrence_id}`,
+        title: meeting.title,
+        start: occ.start_time,
+        end: addMinutesToDate(occ.start_time, occ.duration).toISOString(),
+        backgroundColor: colors.bg,
+        borderColor: colors.border,
+        textColor: colors.text,
+        display: 'block',
+        classNames,
+        extendedProps: {
+          type: 'meeting',
+          meetingId: meeting.id,
+          cancelled: isCancelled,
+          startTime: occ.start_time,
+          durationMinutes: occ.duration,
+        },
+      };
+    });
+  }
+
+  const startTime = meeting.scheduled_start_time ?? meeting.start_time;
+  const isPast = isOccurrencePast(startTime, meeting.duration);
+  const colors = resolveMeetingCalendarColors(false, isPast);
+  const resourceId = meeting.meeting_and_occurrence_id ?? meeting.id;
+  const classNames = ['meeting-event'];
+  if (isPast) {
+    classNames.push('meeting-event-past');
+  }
+
+  return [
+    {
+      id: resourceId,
+      title: meeting.title,
+      start: startTime,
+      end: addMinutesToDate(startTime, meeting.duration).toISOString(),
+      backgroundColor: colors.bg,
+      borderColor: colors.border,
+      textColor: colors.text,
+      display: 'block',
+      classNames,
+      extendedProps: {
+        type: 'meeting',
+        meetingId: resourceId,
+        pastMeetingResourceId: meeting.meeting_and_occurrence_id,
         startTime,
         durationMinutes: meeting.duration,
       },


### PR DESCRIPTION
## Summary
- Adds an unauthenticated, project-scoped public calendar page at `/projects/:projectSlug/calendar`, mirroring lfx-pcc's Public Calendar page (`?committee=<uid>` sub-filter, `?view=month|week`), reusing the existing `lfx-fullcalendar` wrapper.
- Adds a new public JSON endpoint `GET /public/api/projects/:id/meetings` (slug or UID, optional `committee` query param via `tags_all`), stripping PII (`created_by`/`owner`) per the existing public-endpoint pattern (LFXV2-2802).
- Fixes an independent bug: `buildVCalendar()` in `ics.helper.ts` never emitted `X-WR-CALNAME`, so subscribed project/committee calendars showed up unnamed in Google Calendar/Apple Calendar. Threaded the resolved project/committee name through both `getProjectCalendar` and `getCommitteeCalendar`, with a graceful fallback (still 200, no calname) if name resolution fails.

## Test plan
- [x] `yarn format:check`, `yarn lint:check`, `yarn build` all pass
- [x] `yarn vitest run` — new/updated specs for `ics.helper.ts`, `project.controller.ts`, `committee.controller.ts` all pass
- [x] Post-commit reviewer trio (general + standards) run on every commit, findings addressed
- [x] Full-branch sweep (general-code-reviewer against origin/main) clean — 0 Critical, 0 Important
- [ ] Manual verification: visit `/projects/:projectSlug/calendar` (and with `?committee=` / `?view=week`) once deployed

LFXV2-3340