### PR TITLE
feat(ci): notify argocd after tagged Docker Build

### DIFF
--- a/.github/workflows/docker-build-tag.yml
+++ b/.github/workflows/docker-build-tag.yml
@@ -145,3 +145,28 @@ jobs:
       registry-username: ${{ github.actor }}
     secrets:
       registry-password: ${{ secrets.GITHUB_TOKEN }}
+
+  notify-argocd-version-bump:
+    name: Notify ArgoCD version-bump job
+    needs:
+      - build-and-push
+      - release-helm-chart
+      - create-ghcr-helm-provenance
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Dispatch create-version-bump-pr.yml
+        env:
+          GH_TOKEN: ${{ secrets.LFX_ARGOCD_WORKFLOW_DISPATCH_TOKEN }}
+          APP_VERSION: ${{ needs.build-and-push.outputs.app_version }}
+        run: |
+          set -euo pipefail
+          gh workflow run create-version-bump-pr.yml \
+            --repo linuxfoundation/lfx-v2-argocd \
+            --ref main \
+            -f service=lfx-self-serve \
+            -f version="${APP_VERSION}" \
+            -f source_repo="${GITHUB_REPOSITORY}" \
+            -f source_run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+            -f release_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/releases/tag/${GITHUB_REF_NAME}"

--- a/.github/workflows/docker-build-tag.yml
+++ b/.github/workflows/docker-build-tag.yml
@@ -155,10 +155,33 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
     steps:
+      - name: Configure AWS Credentials
+        uses: aws-actions/configure-aws-credentials@8df5847569e6427dd6c4fb1cf565c83acfa8afa7 # v6.0.0
+        with:
+          role-to-assume: arn:aws:iam::788942260905:role/github-actions-deploy
+          aws-region: us-east-2
+
+      - name: Get version-bump GitHub App from AWS Secrets Manager
+        uses: aws-actions/aws-secretsmanager-get-secrets@3a411b6ec5cace3d626412dd917e7bfeac242cfa # v3.0.0
+        with:
+          secret-ids: |
+            OPENER, /cloudops/managed-secrets/cloud/github/linuxfoundation/lfx-version-bump-opener
+          parse-json-secrets: true
+
+      - name: Mint GitHub App installation token
+        id: app-token
+        uses: actions/create-github-app-token@bcd2ba49218906704ab6c1aa796996da409d3eb1 # v3.2.0
+        with:
+          app-id: ${{ env.OPENER_APP_ID }}
+          private-key: ${{ env.OPENER_PRIVATE_KEY }}
+          owner: linuxfoundation
+          repositories: lfx-v2-argocd
+
       - name: Dispatch create-version-bump-pr.yml
         env:
-          GH_TOKEN: ${{ secrets.LFX_ARGOCD_WORKFLOW_DISPATCH_TOKEN }}
+          GH_TOKEN: ${{ steps.app-token.outputs.token }}
           APP_VERSION: ${{ needs.build-and-push.outputs.app_version }}
         run: |
           set -euo pipefail


### PR DESCRIPTION
## Summary
- After image, chart, and provenance succeed, Docker Build - Release dispatches `create-version-bump-pr.yml` in `lfx-v2-argocd`.
- This repo does not edit GitOps files. It only sends the completion signal.
- The dispatch token is a short-lived GitHub App installation token, minted from AWS Secrets Manager. There is no repo PAT.

Companion PR: https://github.com/linuxfoundation/lfx-v2-argocd/pull/1420
Ops issue: https://github.com/linuxfoundation/lfx-self-serve-ops/issues/2

## CloudOps
Put the version-bump GitHub App in
`/cloudops/managed-secrets/cloud/github/linuxfoundation/lfx-version-bump-opener`
as JSON `APP_ID` + `PRIVATE_KEY` (1Password to SM). Install the app on `lfx-v2-argocd` with `actions: write` so it can dispatch `create-version-bump-pr.yml`.

## Test plan
- [ ] Workflow YAML parses
- [ ] After the ArgoCD companion PR is merged and the SM app credentials exist, a tagged release starts a `Bump lfx-self-serve to v…` run in `lfx-v2-argocd`
- [ ] A failed dispatch fails Docker Build - Release