### PR TITLE
fix(cla): always show the GitHub account picker

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.html
@@ -5,8 +5,7 @@ SPDX-License-Identifier: MIT
 
 <div class="flex flex-col" data-testid="github-account-select-dialog">
   <p class="mb-4 text-sm text-slate-600">
-    Choose the GitHub account to sign with. Your signature will be recorded against the account you pick, and contributions from your other accounts won't be
-    covered by it.
+    This CLA group is linked to GitHub repositories. Choose the GitHub account you'll sign with — you'll be redirected to EasyCLA to complete it.
   </p>
 
   <div role="listbox" aria-label="Linked GitHub accounts" class="flex flex-col gap-2">

--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
@@ -12,7 +12,7 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
 
 /**
  * "Which GitHub account are you signing as?" step, shown between the CLA-group picker and the
- * Console hand-off (#1252) when the contributor has linked more than one GitHub account.
+ * Console hand-off (#1252) whenever the contributor has at least one linked GitHub account.
  *
  * It exists because the account a CLA is recorded against used to be decided by whichever
  * record an identity search returned first, which is not a decision the contributor got to

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -754,7 +754,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     expect(opened.filter((component) => component === ClaGroupSelectComponent)).toHaveLength(1);
   });
 
-  // --- Cardinality (FR-002) -------------------------------------------------
+  // --- Cardinality ----------------------------------------------------------
 
   it('asks which account to sign as when several are linked', async () => {
     const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS) });
@@ -787,16 +787,29 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     expect(location.href).toBe(HOME);
   });
 
-  it('skips the choice but still prepares when exactly one account is linked', async () => {
+  it('asks which account to sign as when exactly one is linked', async () => {
     const fixture = await setup({ accounts: () => of(ONE_ACCOUNT) });
 
     await sign(fixture);
 
-    // "No picker" must not become "no prepare" — dropping the call here would leave the
-    // single-account contributor with no signing session and no verified identity.
-    expect(opened).not.toContain(GithubAccountSelectComponent);
+    // A list of one still names the identity the signature will be recorded against, which is
+    // what the step is for — so it is served the account rather than the account being assumed.
+    expect(opened).toContain(GithubAccountSelectComponent);
+    expect(open.mock.calls.at(-1)?.[1]).toMatchObject({ data: { accounts: ONE_ACCOUNT.accounts } });
     expect(prepareSign).toHaveBeenCalledWith({ githubId: '12345', claGroupId: 'cg-1' });
     expect(location.href).toBe(SIGN_URL);
+  });
+
+  it('prepares nothing when the sole linked account is not confirmed', async () => {
+    const fixture = await setup({ accounts: () => of(ONE_ACCOUNT), accountClosesWith: null });
+
+    await sign(fixture);
+
+    // Showing the step and ignoring its outcome would satisfy "a picker appears" while still
+    // signing as an account nobody confirmed. The confirmation, not the render, is the gate.
+    expect(prepareSign).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
+    expect(isStarting(fixture)).toBe(false);
   });
 
   it('routes to account linking rather than showing an empty picker when none are linked', async () => {

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -238,21 +238,16 @@ export class ProfileClasComponent {
   }
 
   /**
-   * Routes on how many accounts are linked.
+   * Routes on whether any account is linked at all: none goes to linking, any number is asked.
    *
-   * One account skips the dialog but still prepares — the screen is what is unnecessary when
-   * there is nothing to choose between, not the identity step. Dropping the prepare too would
-   * leave exactly the contributors this feature was built for on the old unpredictable path.
+   * A single account is asked for too. What the screen carries is which identity the signature
+   * will be recorded against, and a list of one says that as plainly as a list of two — so there
+   * is something to show even where there is nothing to choose between.
    */
   private chooseAccountThenSign(option: ClaGroupOption, accounts: GithubAccountOption[]): void {
     if (accounts.length === 0) {
       this.starting.set(false);
       this.sendToAccountLinking();
-      return;
-    }
-
-    if (accounts.length === 1) {
-      this.prepareThenHandOff(option, accounts[0]);
       return;
     }
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -255,7 +255,7 @@ export class ProfileClasComponent {
     this.signDialogOpen.set(true);
 
     const dialogRef = this.dialogService.open(GithubAccountSelectComponent, {
-      header: 'Choose a GitHub account',
+      header: 'Select a GitHub account',
       width: '32rem',
       modal: true,
       closable: true,


### PR DESCRIPTION
## What

The GitHub account step on My CLAs was skipped when a contributor had exactly one linked GitHub account. The account was chosen for them and they went straight to the Contributor Console, never seeing which identity their signature would be recorded against.

Every non-empty account list now opens the picker. A single account is presented like any other, unselected, with the continue action unavailable until it is chosen. The step's header and body text read as the v17 prototype writes them.

## Why

The step's purpose is not to disambiguate between candidates — it is to tell the contributor which identity is about to be recorded. A list of one carries that as plainly as a list of two.

#1249 states this directly: *"show the account-picker modal so the contributor chooses which account to sign with — no silent auto-pick, even when only one account is linked"*. #1252's own criterion is looser, asking only for a multi-account picker, and the picker was built against it — which is how the single-account case shipped as an automatic choice.

## Copy

The header reads **Select a GitHub account**, and the body reads *"This CLA group is linked to GitHub repositories. Choose the GitHub account you'll sign with — you'll be redirected to EasyCLA to complete it."*

The prototype's text leads with why the step is there and says where confirming leads. It makes no claim about accounts other than the one being signed with, so the sentence about other accounts not being covered does not carry over.

The option labels stay the bare handle. The prototype annotates each account with the scope it belongs to, but nothing in the linked-account data distinguishes a personal account from a work one.

## Not changed

- **The zero-account path.** Still routes to Identities with the same message. Nothing here touches it.
- **The picker's options, actions, and layout.** The option list, the Cancel and Continue actions, and the layout are as they were, and already matched the prototype. A one-item list rendered correctly before this change, so the always-show requirement needed no structural change to the component.
- **Everything after confirmation.** The numeric-id match against the server-served list, the no-first-account-fallback rule, the echoed-identity guard, the prepare request, and the hand-off address are all as they were.

## Testing

The test asserting the old skip is inverted rather than deleted, so the behaviour it guarded stays guarded in its new form. A second test asserts that backing out of a single-account picker prepares nothing — that one fails on `main`, because the old code prepared before any dialog existed to back out of.

Full suite green: 1304 tests, plus licence headers, prettier, eslint, and tsc.

Refs #1249