### PR TITLE
feat(social-listening): redesign feed and analytics experience (#1821)

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
@@ -224,6 +224,7 @@
                         class="flex items-center gap-1 whitespace-nowrap text-[11px] font-medium"
                         [class]="(trend.inverted ? invertedDeltaTextClass : deltaTextClass)[trend.direction]"
                         [attr.data-testid]="'social-listening-analytics-sentiment-trend-' + row.sentiment">
+                        <span class="sr-only">{{ deltaDirectionSrLabel[trend.direction] }}</span>
                         <i [class]="deltaIcon[trend.direction]" aria-hidden="true"></i>
                         {{ trend.label }}
                       </span>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
@@ -1,187 +1,244 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div #analyticsContent class="flex flex-col gap-4" data-testid="social-listening-analytics">
-  <!-- Row 1: KPI stat cards (error degrades the row to a message instead of zeroed cards) -->
+<div #analyticsContent class="flex flex-col gap-5" [class.analytics--exporting]="isExporting()" data-testid="social-listening-analytics">
+  <!-- KPI band (error degrades the row to a message instead of zeroed cards) -->
   @if (overviewError(); as overviewErrorMessage) {
     <lfx-message severity="error" [text]="overviewErrorMessage" data-testid="social-listening-analytics-overview-error" />
   } @else {
     <lfx-stat-card-grid [cards]="statCards()" [loading]="overviewLoading()" [columns]="3" data-testid="social-listening-analytics-stats" />
   }
 
-  <!-- Row 2: Mentions Over Time + Mentions by Platform -->
-  <div class="grid grid-cols-1 gap-4 lg:grid-cols-[13fr_7fr]">
-    <lfx-card styleClass="[&_.p-card-body]:p-5">
-      <div class="analytics-panel" data-testid="social-listening-analytics-over-time">
-        <h3 class="panel-title">Mentions Over Time</h3>
-        @if (overTimeLoading()) {
-          <p-skeleton height="400px" />
-        } @else if (overTimeError(); as overTimeErrorMessage) {
-          <lfx-message severity="error" [text]="overTimeErrorMessage" data-testid="social-listening-analytics-over-time-error" />
-        } @else if (overTimeData(); as overTimeChartData) {
-          <div class="h-[400px] w-full" data-chart-tooltip-host role="img" aria-label="Mentions over time chart. The following table lists the same values.">
-            <lfx-chart type="line" [data]="overTimeChartData" [options]="overTimeOptions" height="100%" />
-            <div
-              data-lfx-tip
-              class="pointer-events-none fixed z-50 hidden max-h-[calc(100vh-1rem)] overflow-hidden rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-lg"></div>
-          </div>
-          <!-- Screen-reader equivalent: the canvas exposes its values only via a pointer tooltip -->
-          @if (overTimeTable(); as overTimeTableData) {
-            <table class="sr-only" data-testid="social-listening-analytics-over-time-table">
-              <caption>
-                Mentions over time by project
-              </caption>
-              <thead>
-                <tr>
-                  <th scope="col">Period</th>
-                  @for (series of overTimeTableData.series; track series.label) {
-                    <th scope="col">{{ series.label }}</th>
-                  }
-                </tr>
-              </thead>
-              <tbody>
-                @for (period of overTimeTableData.periods; track period; let i = $index) {
+  <div class="grid grid-cols-1 items-start gap-5 lg:grid-cols-[minmax(0,2fr)_minmax(0,1fr)]">
+    <!-- Left column: the wide chart panels -->
+    <div class="flex flex-col gap-5">
+      <lfx-card styleClass="[&_.p-card-body]:p-5">
+        <div class="analytics-panel" data-testid="social-listening-analytics-over-time">
+          <h3 class="panel-title">Mentions Over Time</h3>
+          @if (overTimeLoading()) {
+            <p-skeleton height="400px" />
+          } @else if (overTimeError(); as overTimeErrorMessage) {
+            <lfx-message severity="error" [text]="overTimeErrorMessage" data-testid="social-listening-analytics-over-time-error" />
+          } @else if (overTimeData(); as overTimeChartData) {
+            <div class="h-[400px] w-full" data-chart-tooltip-host role="img" aria-label="Mentions over time chart. The following table lists the same values.">
+              <lfx-chart type="line" [data]="overTimeChartData" [options]="overTimeOptions" height="100%" />
+              <div
+                data-lfx-tip
+                class="pointer-events-none fixed z-50 hidden max-h-[calc(100vh-1rem)] overflow-hidden rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-lg"></div>
+            </div>
+            <!-- Screen-reader equivalent: the canvas exposes its values only via a pointer tooltip -->
+            @if (overTimeTable(); as overTimeTableData) {
+              <table class="sr-only" data-testid="social-listening-analytics-over-time-table">
+                <caption>
+                  Mentions over time by project
+                </caption>
+                <thead>
                   <tr>
-                    <th scope="row">{{ period }}</th>
+                    <th scope="col">Period</th>
                     @for (series of overTimeTableData.series; track series.label) {
-                      <td>{{ series.values[i] }}</td>
+                      <th scope="col">{{ series.label }}</th>
                     }
                   </tr>
-                }
-              </tbody>
-            </table>
-          }
-        } @else {
-          <lfx-empty-state
-            icon="fa-light fa-chart-line-up"
-            title="No mentions in this period"
-            subtitle="Try a different period or broaden the project or platform scope."
-            [withCard]="false"
-            data-testid="social-listening-analytics-over-time-empty" />
-        }
-      </div>
-    </lfx-card>
-
-    <lfx-card styleClass="[&_.p-card-body]:p-5">
-      <div class="analytics-panel" data-testid="social-listening-analytics-platform">
-        <h3 class="panel-title">Mentions by Platform</h3>
-        @if (platformLoading()) {
-          <div class="flex flex-col gap-4">
-            @for (row of [1, 2, 3, 4, 5]; track row) {
-              <p-skeleton height="2.5rem" />
-            }
-          </div>
-        } @else if (platformError(); as platformErrorMessage) {
-          <lfx-message severity="error" [text]="platformErrorMessage" data-testid="social-listening-analytics-platform-error" />
-        } @else if (platformRows().length > 0) {
-          <div class="flex flex-col gap-4">
-            @for (row of platformRows(); track row.config.label) {
-              <div class="flex flex-col gap-2">
-                <div class="flex items-center justify-between">
-                  <div class="flex items-center gap-1.5">
-                    <i [class]="row.config.icon + ' ' + row.config.colorClass" aria-hidden="true"></i>
-                    <span class="text-sm font-medium text-gray-900">{{ row.config.label }}</span>
-                  </div>
-                  @if (showPlatformPercents()) {
-                    <span class="text-sm font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
+                </thead>
+                <tbody>
+                  @for (period of overTimeTableData.periods; track period; let i = $index) {
+                    <tr>
+                      <th scope="row">{{ period }}</th>
+                      @for (series of overTimeTableData.series; track series.label) {
+                        <td>{{ series.values[i] }}</td>
+                      }
+                    </tr>
                   }
-                </div>
-                <div class="flex items-center gap-3">
-                  <div class="h-2.5 flex-1 overflow-hidden rounded-full bg-gray-200">
-                    <div class="h-full rounded-full" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal"></div>
-                  </div>
-                  <span class="min-w-12 flex-shrink-0 text-right text-sm font-medium text-gray-400">{{ row.mentionsCount | number }}</span>
-                </div>
-              </div>
+                </tbody>
+              </table>
             }
-          </div>
-        } @else {
-          <lfx-empty-state
-            icon="fa-light fa-chart-pie"
-            title="No platform data"
-            subtitle="No mentions matched the current scope in this period."
-            [withCard]="false"
-            data-testid="social-listening-analytics-platform-empty" />
-        }
-      </div>
-    </lfx-card>
-  </div>
-
-  <!-- Row 3: Mentions by Tag + right column (Sentiment Distribution, Top Projects) -->
-  <div class="grid grid-cols-1 gap-4 lg:grid-cols-[13fr_7fr]">
-    <lfx-card styleClass="[&_.p-card-body]:p-5">
-      <div class="analytics-panel" data-testid="social-listening-analytics-tags">
-        <h3 class="panel-title">Mentions by Tag</h3>
-        @if (tagsLoading()) {
-          <p-skeleton height="350px" />
-        } @else if (tagsError(); as tagsErrorMessage) {
-          <lfx-message severity="error" [text]="tagsErrorMessage" data-testid="social-listening-analytics-tags-error" />
-        } @else if (tagsData(); as tagsChartData) {
-          <div class="h-[350px] w-full" data-chart-tooltip-host role="img" aria-label="Mentions by tag chart. The following table lists the same values.">
-            <lfx-chart type="bar" [data]="tagsChartData" [options]="tagsChartOptions" height="100%" />
-            <div
-              data-lfx-tip
-              class="pointer-events-none fixed z-50 hidden max-h-[calc(100vh-1rem)] overflow-hidden rounded-lg border border-gray-200 bg-white px-3 py-2 shadow-lg"></div>
-          </div>
-          <!-- Screen-reader equivalent: the canvas exposes its values only via a pointer tooltip -->
-          @if (tagsTable(); as tagsTableRows) {
-            <table class="sr-only" data-testid="social-listening-analytics-tags-table">
-              <caption>
-                Mentions by tag
-              </caption>
-              <thead>
-                <tr>
-                  <th scope="col">Tag</th>
-                  <th scope="col">Mentions</th>
-                </tr>
-              </thead>
-              <tbody>
-                @for (row of tagsTableRows; track row.label) {
-                  <tr>
-                    <th scope="row">{{ row.label }}</th>
-                    <td>{{ row.count }}</td>
-                  </tr>
-                }
-              </tbody>
-            </table>
+          } @else {
+            <lfx-empty-state
+              icon="fa-light fa-chart-line-up"
+              title="No mentions in this period"
+              subtitle="Try a different period or broaden the project or platform scope."
+              [withCard]="false"
+              data-testid="social-listening-analytics-over-time-empty" />
           }
-        } @else {
-          <lfx-empty-state
-            icon="fa-light fa-tags"
-            title="No tags in this period"
-            subtitle="Tagged mentions appear here once they are ingested for the current scope."
-            [withCard]="false"
-            data-testid="social-listening-analytics-tags-empty" />
-        }
-      </div>
-    </lfx-card>
+        </div>
+      </lfx-card>
 
-    <div class="flex flex-col gap-4">
-      <lfx-card styleClass="h-full [&_.p-card-body]:p-5">
+      <lfx-card styleClass="[&_.p-card-body]:p-5">
+        <div class="analytics-panel" data-testid="social-listening-analytics-platform">
+          <h3 class="panel-title">Mentions by Platform</h3>
+          @if (platformLoading()) {
+            <div class="flex flex-col gap-4">
+              @for (row of [1, 2, 3, 4, 5]; track row) {
+                <p-skeleton height="2.5rem" />
+              }
+            </div>
+          } @else if (platformError(); as platformErrorMessage) {
+            <lfx-message severity="error" [text]="platformErrorMessage" data-testid="social-listening-analytics-platform-error" />
+          } @else if (platformRows().length > 0) {
+            <div class="flex flex-col gap-1">
+              @for (row of platformRows(); track row.platform) {
+                <button
+                  type="button"
+                  class="platform-row"
+                  [attr.aria-label]="'Show ' + row.config.label + ' mentions in the feed'"
+                  (click)="onPlatformRowClick(row)"
+                  [attr.data-testid]="'social-listening-analytics-platform-row-' + row.platform">
+                  <div class="flex w-full items-center justify-between gap-3">
+                    <div class="flex min-w-0 items-center gap-2">
+                      <i [class]="row.config.icon + ' ' + row.config.colorClass" class="text-sm" aria-hidden="true"></i>
+                      <span class="truncate text-[13px] font-medium text-gray-900">{{ row.config.label }}</span>
+                    </div>
+                    @if (showPlatformPercents()) {
+                      <span class="text-[13px] font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
+                    }
+                  </div>
+                  <div class="flex w-full items-center gap-3">
+                    <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
+                      <div class="h-full rounded-full" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal"></div>
+                    </div>
+                    <span class="min-w-12 shrink-0 text-right text-xs font-medium text-gray-400">{{ row.mentionsCount | number }}</span>
+                  </div>
+                </button>
+              }
+            </div>
+          } @else {
+            <lfx-empty-state
+              icon="fa-light fa-chart-pie"
+              title="No platform data"
+              subtitle="No mentions matched the current scope in this period."
+              [withCard]="false"
+              data-testid="social-listening-analytics-platform-empty" />
+          }
+        </div>
+      </lfx-card>
+
+      <lfx-card styleClass="[&_.p-card-body]:p-5">
+        <div class="analytics-panel" data-testid="social-listening-analytics-tags">
+          <h3 class="panel-title">Mentions by Tag</h3>
+          @if (tagsLoading()) {
+            <div class="flex flex-col gap-3">
+              @for (row of [1, 2, 3, 4, 5]; track row) {
+                <p-skeleton height="1.5rem" />
+              }
+            </div>
+          } @else if (tagsError(); as tagsErrorMessage) {
+            <lfx-message severity="error" [text]="tagsErrorMessage" data-testid="social-listening-analytics-tags-error" />
+          } @else if (tagRows().length > 0) {
+            <ol class="flex flex-col gap-3" data-testid="social-listening-analytics-tags-list">
+              @for (row of tagRows(); track row.label) {
+                <li class="flex items-center gap-3">
+                  <span class="min-w-0 flex-1 truncate text-xs text-gray-600">{{ row.label }}</span>
+                  <span class="tag-track">
+                    <span class="tag-fill" [style.width.%]="row.percentOfMax"></span>
+                  </span>
+                  <span class="min-w-10 shrink-0 text-right text-xs font-medium text-gray-900">{{ row.count | number }}</span>
+                </li>
+              }
+            </ol>
+          } @else {
+            <lfx-empty-state
+              icon="fa-light fa-tags"
+              title="No tags in this period"
+              subtitle="Tagged mentions appear here once they are ingested for the current scope."
+              [withCard]="false"
+              data-testid="social-listening-analytics-tags-empty" />
+          }
+        </div>
+      </lfx-card>
+    </div>
+
+    <!-- Right rail: the summary panels, pinned while the left column scrolls -->
+    <div class="analytics-rail flex flex-col gap-5">
+      <lfx-card styleClass="[&_.p-card-body]:p-5">
+        <div class="analytics-panel" data-testid="social-listening-analytics-top-projects">
+          <h3 class="panel-title">Mentions by Project</h3>
+          @if (topProjectsLoading()) {
+            <div class="flex flex-col gap-3">
+              @for (row of [1, 2, 3, 4, 5]; track row) {
+                <p-skeleton height="2.25rem" />
+              }
+            </div>
+          } @else if (topProjectsError(); as topProjectsErrorMessage) {
+            <lfx-message severity="error" [text]="topProjectsErrorMessage" data-testid="social-listening-analytics-top-projects-error" />
+          } @else if (topProjects().length > 0) {
+            <ol class="flex flex-col gap-3">
+              @for (project of topProjects(); track project.SOURCE_PROJECT_NAME; let idx = $index) {
+                <li class="flex items-center gap-3">
+                  <span class="project-rank" aria-hidden="true">{{ idx + 1 }}</span>
+                  <span class="flex min-w-0 flex-1 flex-col">
+                    <span class="truncate text-[13px] font-semibold text-gray-900">{{ project.SOURCE_PROJECT_NAME }}</span>
+                    <span class="text-[11px] text-gray-500">{{ project.TOTAL_MENTIONS | number }} mentions</span>
+                  </span>
+                </li>
+              }
+            </ol>
+          } @else {
+            <lfx-empty-state
+              icon="fa-light fa-diagram-project"
+              title="No project data"
+              subtitle="Project mention rankings appear here when mentions exist for the current scope."
+              [withCard]="false"
+              data-testid="social-listening-analytics-top-projects-empty" />
+          }
+        </div>
+      </lfx-card>
+
+      <lfx-card styleClass="[&_.p-card-body]:p-5">
         <div class="analytics-panel" data-testid="social-listening-analytics-sentiment">
           <h3 class="panel-title">Sentiment Distribution</h3>
           @if (sentimentLoading()) {
             <div class="flex flex-col gap-3">
-              <p-skeleton height="0.75rem" />
+              <p-skeleton height="1.125rem" />
               <p-skeleton height="2rem" />
               <p-skeleton height="2rem" />
             </div>
           } @else if (sentimentError(); as sentimentErrorMessage) {
             <lfx-message severity="error" [text]="sentimentErrorMessage" data-testid="social-listening-analytics-sentiment-error" />
           } @else if (sentimentRows().length > 0) {
-            <div class="flex h-3 w-full overflow-hidden rounded-full bg-gray-100" role="img" aria-label="Sentiment distribution bar">
+            <div class="flex h-[18px] w-full overflow-hidden rounded-full bg-gray-100" role="img" aria-label="Sentiment distribution bar">
               @for (row of sentimentRows(); track row.sentiment) {
-                <div class="h-full" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal"></div>
+                <div class="flex h-full items-center justify-center overflow-hidden" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal">
+                  @if (row.percentOfTotal >= 12) {
+                    <span class="text-[10px] font-semibold text-white">{{ row.mentionCount | number }}</span>
+                  }
+                </div>
               }
             </div>
             <div class="flex flex-col gap-3">
               @for (row of sentimentRows(); track row.sentiment) {
-                <div class="flex items-center justify-between">
-                  <div class="flex items-center gap-2.5">
-                    <span class="h-3 w-3 flex-shrink-0 rounded-full" [class]="row.config.barClass" aria-hidden="true"></span>
-                    <span class="text-sm font-medium text-gray-900">{{ row.config.label }}</span>
+                <div class="flex items-center justify-between gap-3">
+                  <div class="flex min-w-0 items-center gap-2.5">
+                    <span class="h-3 w-3 shrink-0 rounded-full" [class]="row.config.barClass" aria-hidden="true"></span>
+                    <span class="truncate text-[13px] font-medium text-gray-900">{{ row.config.label }}</span>
                   </div>
-                  <span class="text-sm font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
+                  <div class="flex shrink-0 items-center gap-2">
+                    <span class="text-[13px] text-gray-500">{{ row.mentionCount | number }}</span>
+                    <span class="text-[13px] font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
+                    @switch (row.sentiment) {
+                      @case ('positive') {
+                        @if (sentimentTrends().positive; as trend) {
+                          <span
+                            class="flex items-center gap-1 whitespace-nowrap text-[11px] font-medium"
+                            [class]="deltaTextClass[trend.direction]"
+                            data-testid="social-listening-analytics-sentiment-trend-positive">
+                            <i [class]="deltaIcon[trend.direction]" aria-hidden="true"></i>
+                            {{ trend.label }}
+                          </span>
+                        }
+                      }
+                      @case ('negative') {
+                        @if (sentimentTrends().negative; as trend) {
+                          <span
+                            class="flex items-center gap-1 whitespace-nowrap text-[11px] font-medium"
+                            [class]="invertedDeltaTextClass[trend.direction]"
+                            data-testid="social-listening-analytics-sentiment-trend-negative">
+                            <i [class]="deltaIcon[trend.direction]" aria-hidden="true"></i>
+                            {{ trend.label }}
+                          </span>
+                        }
+                      }
+                    }
+                  </div>
                 </div>
               }
             </div>
@@ -192,40 +249,6 @@
               subtitle="Sentiment breakdown appears here when mentions exist for the current scope."
               [withCard]="false"
               data-testid="social-listening-analytics-sentiment-empty" />
-          }
-        </div>
-      </lfx-card>
-
-      <lfx-card styleClass="h-full [&_.p-card-body]:p-5">
-        <div class="analytics-panel" data-testid="social-listening-analytics-top-projects">
-          <h3 class="panel-title">Top Projects</h3>
-          @if (topProjectsLoading()) {
-            <div class="flex flex-col gap-3">
-              @for (row of [1, 2, 3, 4, 5]; track row) {
-                <p-skeleton height="3.5rem" />
-              }
-            </div>
-          } @else if (topProjectsError(); as topProjectsErrorMessage) {
-            <lfx-message severity="error" [text]="topProjectsErrorMessage" data-testid="social-listening-analytics-top-projects-error" />
-          } @else if (topProjects().length > 0) {
-            <div class="flex flex-col gap-3">
-              @for (project of topProjects(); track project.SOURCE_PROJECT_NAME; let idx = $index) {
-                <div class="top-project-row">
-                  <div class="project-rank">{{ idx + 1 }}</div>
-                  <div class="flex flex-1 flex-col">
-                    <div class="text-sm font-semibold text-gray-900">{{ project.SOURCE_PROJECT_NAME }}</div>
-                    <div class="text-xs text-gray-500">{{ project.TOTAL_MENTIONS | number }} mentions</div>
-                  </div>
-                </div>
-              }
-            </div>
-          } @else {
-            <lfx-empty-state
-              icon="fa-light fa-diagram-project"
-              title="No project data"
-              subtitle="Project mention rankings appear here when mentions exist for the current scope."
-              [withCard]="false"
-              data-testid="social-listening-analytics-top-projects-empty" />
           }
         </div>
       </lfx-card>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
@@ -77,29 +77,32 @@
           } @else if (platformRows().length > 0) {
             <div class="flex flex-col gap-1">
               @for (row of platformRows(); track row.platform) {
-                <button
-                  type="button"
-                  class="platform-row"
-                  [disabled]="row.sourcePlatforms.length !== 1"
-                  [attr.aria-label]="row.sourcePlatforms.length === 1 ? 'Show ' + row.config.label + ' mentions in the feed' : null"
-                  (click)="onPlatformRowClick(row)"
-                  [attr.data-testid]="'social-listening-analytics-platform-row-' + row.platform">
-                  <div class="flex w-full items-center justify-between gap-3">
-                    <div class="flex min-w-0 items-center gap-2">
-                      <i [class]="row.config.icon + ' ' + row.config.colorClass" class="text-sm" aria-hidden="true"></i>
-                      <span class="truncate text-[13px] font-medium text-gray-900">{{ row.config.label }}</span>
+                <!-- Tooltip sits on the wrapper: disabled buttons swallow pointer events, so the reason would never show -->
+                <div [pTooltip]="row.actionLabel" [tooltipDisabled]="row.drillable" tooltipPosition="top">
+                  <button
+                    type="button"
+                    class="flex w-full cursor-pointer flex-col gap-2 rounded-lg border-0 bg-transparent p-2 text-left transition-colors hover:bg-gray-50 disabled:cursor-default disabled:hover:bg-transparent"
+                    [disabled]="!row.drillable"
+                    [attr.aria-label]="row.actionLabel"
+                    (click)="onPlatformRowClick(row)"
+                    [attr.data-testid]="'social-listening-analytics-platform-row-' + row.platform">
+                    <div class="flex w-full items-center justify-between gap-3">
+                      <div class="flex min-w-0 items-center gap-2">
+                        <i [class]="row.config.icon + ' ' + row.config.colorClass" class="text-sm" aria-hidden="true"></i>
+                        <span class="truncate text-[13px] font-medium text-gray-900">{{ row.config.label }}</span>
+                      </div>
+                      @if (showPlatformPercents()) {
+                        <span class="text-[13px] font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
+                      }
                     </div>
-                    @if (showPlatformPercents()) {
-                      <span class="text-[13px] font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
-                    }
-                  </div>
-                  <div class="flex w-full items-center gap-3">
-                    <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
-                      <div class="h-full rounded-full" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal"></div>
+                    <div class="flex w-full items-center gap-3">
+                      <div class="h-1.5 flex-1 overflow-hidden rounded-full bg-gray-100">
+                        <div class="h-full rounded-full" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal"></div>
+                      </div>
+                      <span class="min-w-12 shrink-0 text-right text-xs font-medium text-gray-400">{{ row.mentionsCount | number }}</span>
                     </div>
-                    <span class="min-w-12 shrink-0 text-right text-xs font-medium text-gray-400">{{ row.mentionsCount | number }}</span>
-                  </div>
-                </button>
+                  </button>
+                </div>
               }
             </div>
           } @else {
@@ -129,8 +132,9 @@
               @for (row of tagRows(); track row.label) {
                 <li class="flex items-center gap-3">
                   <span class="min-w-0 flex-1 truncate text-xs text-gray-600">{{ row.label }}</span>
-                  <span class="tag-track">
-                    <span class="tag-fill" [style.width.%]="row.percentOfMax"></span>
+                  <!-- Fixed-width track so every row's count column lands at the same x -->
+                  <span class="h-2.5 w-20 shrink-0 overflow-hidden rounded-full bg-gray-100 sm:w-40">
+                    <span class="block h-full rounded-full bg-blue-500" [style.width.%]="row.percentOfMax"></span>
                   </span>
                   <span class="min-w-10 shrink-0 text-right text-xs font-medium text-gray-900">{{ row.count | number }}</span>
                 </li>
@@ -199,7 +203,7 @@
             <div class="flex h-[18px] w-full overflow-hidden rounded-full bg-gray-100" role="img" aria-label="Sentiment distribution bar">
               @for (row of sentimentRows(); track row.sentiment) {
                 <div class="flex h-full items-center justify-center overflow-hidden" [class]="row.config.barClass" [style.width.%]="row.percentOfTotal">
-                  @if (row.percentOfTotal >= 12) {
+                  @if (row.percentOfTotal >= sentimentBarLabelMinPercent) {
                     <span class="text-[10px] font-semibold text-white">{{ row.mentionCount | number }}</span>
                   }
                 </div>
@@ -215,29 +219,14 @@
                   <div class="flex shrink-0 items-center gap-2">
                     <span class="text-[13px] text-gray-500">{{ row.mentionCount | number }}</span>
                     <span class="text-[13px] font-semibold text-gray-900">{{ row.percentOfTotal }}%</span>
-                    @switch (row.sentiment) {
-                      @case ('positive') {
-                        @if (sentimentTrends().positive; as trend) {
-                          <span
-                            class="flex items-center gap-1 whitespace-nowrap text-[11px] font-medium"
-                            [class]="deltaTextClass[trend.direction]"
-                            data-testid="social-listening-analytics-sentiment-trend-positive">
-                            <i [class]="deltaIcon[trend.direction]" aria-hidden="true"></i>
-                            {{ trend.label }}
-                          </span>
-                        }
-                      }
-                      @case ('negative') {
-                        @if (sentimentTrends().negative; as trend) {
-                          <span
-                            class="flex items-center gap-1 whitespace-nowrap text-[11px] font-medium"
-                            [class]="invertedDeltaTextClass[trend.direction]"
-                            data-testid="social-listening-analytics-sentiment-trend-negative">
-                            <i [class]="deltaIcon[trend.direction]" aria-hidden="true"></i>
-                            {{ trend.label }}
-                          </span>
-                        }
-                      }
+                    @if (row.trend; as trend) {
+                      <span
+                        class="flex items-center gap-1 whitespace-nowrap text-[11px] font-medium"
+                        [class]="(trend.inverted ? invertedDeltaTextClass : deltaTextClass)[trend.direction]"
+                        [attr.data-testid]="'social-listening-analytics-sentiment-trend-' + row.sentiment">
+                        <i [class]="deltaIcon[trend.direction]" aria-hidden="true"></i>
+                        {{ trend.label }}
+                      </span>
                     }
                   </div>
                 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.html
@@ -80,7 +80,8 @@
                 <button
                   type="button"
                   class="platform-row"
-                  [attr.aria-label]="'Show ' + row.config.label + ' mentions in the feed'"
+                  [disabled]="row.sourcePlatforms.length !== 1"
+                  [attr.aria-label]="row.sourcePlatforms.length === 1 ? 'Show ' + row.config.label + ' mentions in the feed' : null"
                   (click)="onPlatformRowClick(row)"
                   [attr.data-testid]="'social-listening-analytics-platform-row-' + row.platform">
                   <div class="flex w-full items-center justify-between gap-3">

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
@@ -20,33 +20,6 @@
   @apply static;
 }
 
-// The whole platform row is the feed drill-down target — reset the button chrome, keep the two-line layout.
-.platform-row {
-  @apply flex w-full cursor-pointer flex-col gap-2 rounded-lg border-0 bg-transparent p-2 text-left transition-colors;
-
-  &:hover {
-    @apply bg-gray-50;
-  }
-
-  // Merged groups (e.g. `other`) can't drill down — no pointer affordance.
-  &:disabled {
-    @apply cursor-default;
-
-    &:hover {
-      @apply bg-transparent;
-    }
-  }
-}
-
-// Fixed-width track so every tag row's count column lands at the same x.
-.tag-track {
-  @apply h-2.5 w-20 shrink-0 overflow-hidden rounded-full bg-gray-100 sm:w-40;
-}
-
-.tag-fill {
-  @apply bg-blue-500 block h-full rounded-full;
-}
-
 // Mentions by Project rank badges.
 .project-rank {
   @apply bg-blue-500 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold text-white;

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
@@ -10,11 +10,35 @@
   @apply m-0 text-xs font-bold tracking-wider text-gray-500 uppercase;
 }
 
-// Top Projects ranked rows.
-.top-project-row {
-  @apply flex items-center gap-4 rounded-lg bg-gray-50 p-3 transition-colors hover:bg-gray-100;
+// Summary rail pins beside the scrolling chart column; the offset clears the page header plus the filter row.
+.analytics-rail {
+  @apply lg:sticky lg:top-[150px];
 }
 
+// html-to-image rasterizes at the current scroll offset, so a pinned rail would land mid-column in the PNG.
+.analytics--exporting .analytics-rail {
+  @apply static;
+}
+
+// The whole platform row is the feed drill-down target — reset the button chrome, keep the two-line layout.
+.platform-row {
+  @apply flex w-full cursor-pointer flex-col gap-2 rounded-lg border-0 bg-transparent p-2 text-left transition-colors;
+
+  &:hover {
+    @apply bg-gray-50;
+  }
+}
+
+// Fixed-width track so every tag row's count column lands at the same x.
+.tag-track {
+  @apply h-2.5 w-20 shrink-0 overflow-hidden rounded-full bg-gray-100 sm:w-40;
+}
+
+.tag-fill {
+  @apply bg-blue-500 block h-full rounded-full;
+}
+
+// Mentions by Project rank badges.
 .project-rank {
-  @apply bg-blue-500 flex h-8 w-8 flex-shrink-0 items-center justify-center rounded-full text-sm font-bold text-white;
+  @apply bg-blue-500 flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[11px] font-bold text-white;
 }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.scss
@@ -27,6 +27,15 @@
   &:hover {
     @apply bg-gray-50;
   }
+
+  // Merged groups (e.g. `other`) can't drill down — no pointer affordance.
+  &:disabled {
+    @apply cursor-default;
+
+    &:hover {
+      @apply bg-transparent;
+    }
+  }
 }
 
 // Fixed-width track so every tag row's count column lands at the same x.

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.spec.ts
@@ -167,6 +167,90 @@ describe('SocialListeningAnalyticsComponent', () => {
     expect(cards[1].value).toBe('0%');
   });
 
+  it('ranks the tag rows, drops blank tags, and sizes each bar against the top row', async () => {
+    getMentionsTags.mockReturnValue(
+      of([
+        { TAG: 'cloud_native', TOTAL_COUNT: 5 },
+        { TAG: '', TOTAL_COUNT: 99 },
+        { TAG: 'ai_agents', TOTAL_COUNT: 10 },
+      ])
+    );
+    create();
+    await settle();
+
+    expect(fixture.componentInstance.tagRows()).toEqual([
+      { label: 'AI Agents', count: 10, percentOfMax: 100 },
+      { label: 'Cloud Native', count: 5, percentOfMax: 50 },
+    ]);
+    const labels = [...fixture.nativeElement.querySelectorAll('[data-testid="social-listening-analytics-tags-list"] li')].map((li: Element) =>
+      (li.textContent || '').trim()
+    );
+    expect(labels).toHaveLength(2);
+    expect(labels[0]).toContain('AI Agents');
+    expect(labels[0]).toContain('10');
+  });
+
+  it('emits the normalized platform key when a platform row is clicked', async () => {
+    getAnalyticsPlatformDistribution.mockReturnValue(
+      of([
+        { SOURCE_PLATFORM: 'reddit', SOCIAL_NETWORK: 'Reddit', MENTIONS_COUNT: 40, PERCENT_OF_TOTAL: 80 },
+        { SOURCE_PLATFORM: 'X', SOCIAL_NETWORK: 'X', MENTIONS_COUNT: 10, PERCENT_OF_TOTAL: 20 },
+      ])
+    );
+    create();
+    await settle();
+
+    const emitted: string[] = [];
+    fixture.componentInstance.platformSelected.subscribe((platform) => emitted.push(platform));
+
+    // `X` normalizes to the `twitter` config key, which is what the row carries and emits.
+    const row = fixture.nativeElement.querySelector('[data-testid="social-listening-analytics-platform-row-twitter"]') as HTMLButtonElement;
+    expect(row).toBeTruthy();
+    row.click();
+
+    expect(emitted).toEqual(['twitter']);
+  });
+
+  it('keeps the sentiment counts and percentages when the overview errors, omitting only the trend chips', async () => {
+    getAnalyticsOverview.mockImplementation(() => throwError(() => new Error('boom')));
+    getAnalyticsSentimentDistribution.mockReturnValue(
+      of([
+        { SENTIMENT: 'positive', MENTION_COUNT: 90, PERCENT_OF_TOTAL: 45 },
+        { SENTIMENT: 'negative', MENTION_COUNT: 40, PERCENT_OF_TOTAL: 20 },
+      ])
+    );
+    create();
+    await settle();
+
+    expect(fixture.componentInstance.overviewError()).toBe('Failed to load this panel');
+    expect(fixture.componentInstance.sentimentTrends()).toEqual({ positive: null, negative: null });
+
+    const panel = fixture.nativeElement.querySelector('[data-testid="social-listening-analytics-sentiment"]');
+    expect(panel.textContent).toContain('45%');
+    expect(panel.textContent).toContain('90');
+    expect(panel.querySelector('[data-testid="social-listening-analytics-sentiment-trend-positive"]')).toBeNull();
+    expect(panel.querySelector('[data-testid="social-listening-analytics-sentiment-trend-negative"]')).toBeNull();
+  });
+
+  it('renders the sentiment trend chips from the overview panel', async () => {
+    getAnalyticsSentimentDistribution.mockReturnValue(
+      of([
+        { SENTIMENT: 'positive', MENTION_COUNT: 90, PERCENT_OF_TOTAL: 45 },
+        { SENTIMENT: 'negative', MENTION_COUNT: 40, PERCENT_OF_TOTAL: 20 },
+      ])
+    );
+    create();
+    await settle();
+
+    // A null POSITIVE_SENTIMENT_CHANGE_PCT (thin previous window) hides that chip; the negative one inverts.
+    expect(fixture.componentInstance.sentimentTrends().positive).toBeNull();
+    expect(fixture.componentInstance.sentimentTrends().negative).toEqual({ label: '4.2% vs last period', direction: 'down', inverted: true });
+
+    const panel = fixture.nativeElement.querySelector('[data-testid="social-listening-analytics-sentiment"]');
+    expect(panel.querySelector('[data-testid="social-listening-analytics-sentiment-trend-positive"]')).toBeNull();
+    expect(panel.querySelector('[data-testid="social-listening-analytics-sentiment-trend-negative"]').className).toContain('text-emerald-700');
+  });
+
   it('reports panelsLoading while any panel is in flight and clears it once all settle', async () => {
     const overview$ = new Subject<SocialListeningAnalyticsOverview>();
     getAnalyticsOverview.mockReturnValue(overview$.asObservable());

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.spec.ts
@@ -275,6 +275,8 @@ describe('SocialListeningAnalyticsComponent', () => {
     const panel = fixture.nativeElement.querySelector('[data-testid="social-listening-analytics-sentiment"]');
     expect(panel.querySelector('[data-testid="social-listening-analytics-sentiment-trend-positive"]')).toBeNull();
     expect(panel.querySelector('[data-testid="social-listening-analytics-sentiment-trend-negative"]').className).toContain('text-emerald-700');
+    // The arrow is aria-hidden — the sr-only direction word carries the sign for screen readers.
+    expect(panel.querySelector('[data-testid="social-listening-analytics-sentiment-trend-negative"]').textContent).toContain('Decreased');
   });
 
   it('reports panelsLoading while any panel is in flight and clears it once all settle', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.spec.ts
@@ -190,7 +190,7 @@ describe('SocialListeningAnalyticsComponent', () => {
     expect(labels[0]).toContain('10');
   });
 
-  it('emits the normalized platform key when a platform row is clicked', async () => {
+  it('emits the raw platform value when a single-source platform row is clicked', async () => {
     getAnalyticsPlatformDistribution.mockReturnValue(
       of([
         { SOURCE_PLATFORM: 'reddit', SOCIAL_NETWORK: 'Reddit', MENTIONS_COUNT: 40, PERCENT_OF_TOTAL: 80 },
@@ -203,12 +203,38 @@ describe('SocialListeningAnalyticsComponent', () => {
     const emitted: string[] = [];
     fixture.componentInstance.platformSelected.subscribe((platform) => emitted.push(platform));
 
-    // `X` normalizes to the `twitter` config key, which is what the row carries and emits.
+    // The feed filter matches raw SOURCE_PLATFORM values, so the row emits raw `X` (not the normalized `twitter` key it tracks by).
     const row = fixture.nativeElement.querySelector('[data-testid="social-listening-analytics-platform-row-twitter"]') as HTMLButtonElement;
     expect(row).toBeTruthy();
     row.click();
 
-    expect(emitted).toEqual(['twitter']);
+    expect(emitted).toEqual(['X']);
+  });
+
+  it('keeps merged platform groups display-only (no drill-down emission)', async () => {
+    getAnalyticsPlatformDistribution.mockReturnValue(
+      of([
+        { SOURCE_PLATFORM: 'X', SOCIAL_NETWORK: 'X', MENTIONS_COUNT: 10, PERCENT_OF_TOTAL: 15 },
+        { SOURCE_PLATFORM: 'twitter', SOCIAL_NETWORK: 'Twitter', MENTIONS_COUNT: 5, PERCENT_OF_TOTAL: 5 },
+        { SOURCE_PLATFORM: 'forums', SOCIAL_NETWORK: 'Forums', MENTIONS_COUNT: 6, PERCENT_OF_TOTAL: 8 },
+        { SOURCE_PLATFORM: 'mastodon', SOCIAL_NETWORK: 'Mastodon', MENTIONS_COUNT: 4, PERCENT_OF_TOTAL: 7 },
+      ])
+    );
+    create();
+    await settle();
+
+    const emitted: string[] = [];
+    fixture.componentInstance.platformSelected.subscribe((platform) => emitted.push(platform));
+
+    // X+twitter fold into one `twitter` row and forums+mastodon into `other` — merged groups can't drill down.
+    const merged = fixture.nativeElement.querySelector('[data-testid="social-listening-analytics-platform-row-twitter"]') as HTMLButtonElement;
+    const other = fixture.nativeElement.querySelector('[data-testid="social-listening-analytics-platform-row-other"]') as HTMLButtonElement;
+    expect(merged.disabled).toBe(true);
+    expect(other.disabled).toBe(true);
+    merged.click();
+    other.click();
+
+    expect(emitted).toEqual([]);
   });
 
   it('keeps the sentiment counts and percentages when the overview errors, omitting only the trend chips', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
@@ -184,8 +184,10 @@ export class SocialListeningAnalyticsComponent {
     effect(() => this.panelsLoading.set(this.anyPanelLoading()));
   }
 
+  /** The feed filter matches raw `SOURCE_PLATFORM` values, so only single-source groups drill down (merged groups like `other` stay display-only). */
   public onPlatformRowClick(row: SocialListeningPlatformRow): void {
-    this.platformSelected.emit(row.platform);
+    if (row.sourcePlatforms.length !== 1) return;
+    this.platformSelected.emit(row.sourcePlatforms[0]);
   }
 
   private async exportAnalytics(): Promise<void> {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
@@ -12,6 +12,7 @@ import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid
 import {
   ANALYTICS_TOP_PROJECTS_LIMIT,
   DELTA_DIRECTION_ICON,
+  DELTA_DIRECTION_SR_LABEL,
   DELTA_DIRECTION_TEXT_CLASS,
   INVERTED_DELTA_DIRECTION_TEXT_CLASS,
   lfxColors,
@@ -179,6 +180,7 @@ export class SocialListeningAnalyticsComponent {
   };
 
   protected readonly deltaIcon = DELTA_DIRECTION_ICON;
+  protected readonly deltaDirectionSrLabel = DELTA_DIRECTION_SR_LABEL;
   protected readonly deltaTextClass = DELTA_DIRECTION_TEXT_CLASS;
   /** Negative-sentiment trends invert: an increase is bad, so up renders red and down emerald. */
   protected readonly invertedDeltaTextClass = INVERTED_DELTA_DIRECTION_TEXT_CLASS;

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
@@ -15,12 +15,14 @@ import {
   DELTA_DIRECTION_TEXT_CLASS,
   INVERTED_DELTA_DIRECTION_TEXT_CLASS,
   lfxColors,
+  SENTIMENT_BAR_LABEL_MIN_PERCENT,
 } from '@lfx-one/shared/constants';
 import { buildAnalyticsDelta, buildOverTimeChartData, mapPlatformDistributionRows, mapSentimentRows, mapTagRows } from '@lfx-one/shared/utils';
 import { SocialListeningService } from '@services/social-listening.service';
 import { downloadCardAsImage } from '@shared/utils/download-card.util';
 import { MessageService } from 'primeng/api';
 import { SkeletonModule } from 'primeng/skeleton';
+import { TooltipModule } from 'primeng/tooltip';
 import { catchError, debounceTime, map, Observable, of, startWith, switchMap } from 'rxjs';
 
 import type { Chart, ChartData, ChartOptions, TooltipModel } from 'chart.js';
@@ -44,7 +46,7 @@ import type {
  */
 @Component({
   selector: 'lfx-social-listening-analytics',
-  imports: [DecimalPipe, CardComponent, ChartComponent, EmptyStateComponent, MessageComponent, StatCardGridComponent, SkeletonModule],
+  imports: [DecimalPipe, CardComponent, ChartComponent, EmptyStateComponent, MessageComponent, StatCardGridComponent, SkeletonModule, TooltipModule],
   templateUrl: './social-listening-analytics.component.html',
   styleUrl: './social-listening-analytics.component.scss',
 })
@@ -112,7 +114,17 @@ export class SocialListeningAnalyticsComponent {
   /** Screen-reader equivalent of the canvas line chart — the chart's values are otherwise tooltip-only. */
   public readonly overTimeTable: Signal<{ periods: string[]; series: { label: string; values: (number | null)[] }[] } | null> = this.initOverTimeTable();
 
-  public readonly platformRows = computed(() => this.platformState().data);
+  /** Rows with drill-down precomputed — merged groups (multi-source) are disabled, and their label/tooltip carries the reason why. */
+  public readonly platformRows = computed(() =>
+    this.platformState().data.map((row) => ({
+      ...row,
+      drillable: row.sourcePlatforms.length === 1,
+      actionLabel:
+        row.sourcePlatforms.length === 1
+          ? `Show ${row.config.label} mentions in the feed`
+          : `${row.config.label} groups several platforms and can't be filtered in the feed`,
+    }))
+  );
   public readonly platformLoading = computed(() => this.platformState().loading);
   public readonly platformError = computed(() => this.platformState().error);
   /** PCC behavior: the per-platform % label is only meaningful on the unfiltered (all-platforms) view. */
@@ -122,7 +134,11 @@ export class SocialListeningAnalyticsComponent {
   public readonly tagsLoading = computed(() => this.tagsState().loading);
   public readonly tagsError = computed(() => this.tagsState().error);
 
-  public readonly sentimentRows = computed(() => this.sentimentState().data);
+  /** Rows with the trend chip pre-attached — neutral carries no trend, and the delta's own `inverted` flag picks the class map. */
+  public readonly sentimentRows = computed(() => {
+    const trends = this.sentimentTrends();
+    return this.sentimentState().data.map((row) => ({ ...row, trend: row.sentiment === 'neutral' ? null : trends[row.sentiment] }));
+  });
   public readonly sentimentLoading = computed(() => this.sentimentState().loading);
   public readonly sentimentError = computed(() => this.sentimentState().error);
 
@@ -166,6 +182,7 @@ export class SocialListeningAnalyticsComponent {
   protected readonly deltaTextClass = DELTA_DIRECTION_TEXT_CLASS;
   /** Negative-sentiment trends invert: an increase is bad, so up renders red and down emerald. */
   protected readonly invertedDeltaTextClass = INVERTED_DELTA_DIRECTION_TEXT_CLASS;
+  protected readonly sentimentBarLabelMinPercent = SENTIMENT_BAR_LABEL_MIN_PERCENT;
 
   private destroyed = false;
 

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/analytics/social-listening-analytics.component.ts
@@ -2,15 +2,21 @@
 // SPDX-License-Identifier: MIT
 
 import { DecimalPipe, isPlatformBrowser } from '@angular/common';
-import { Component, computed, DestroyRef, effect, ElementRef, inject, input, model, PLATFORM_ID, Signal, untracked, viewChild } from '@angular/core';
+import { Component, computed, DestroyRef, effect, ElementRef, inject, input, model, output, PLATFORM_ID, Signal, untracked, viewChild } from '@angular/core';
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { CardComponent } from '@components/card/card.component';
 import { ChartComponent } from '@components/chart/chart.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { MessageComponent } from '@components/message/message.component';
 import { StatCardGridComponent } from '@components/stat-card-grid/stat-card-grid.component';
-import { ANALYTICS_TOP_PROJECTS_LIMIT, lfxColors } from '@lfx-one/shared/constants';
-import { buildAnalyticsDelta, buildOverTimeChartData, buildTagsChartData, mapPlatformDistributionRows, mapSentimentRows } from '@lfx-one/shared/utils';
+import {
+  ANALYTICS_TOP_PROJECTS_LIMIT,
+  DELTA_DIRECTION_ICON,
+  DELTA_DIRECTION_TEXT_CLASS,
+  INVERTED_DELTA_DIRECTION_TEXT_CLASS,
+  lfxColors,
+} from '@lfx-one/shared/constants';
+import { buildAnalyticsDelta, buildOverTimeChartData, mapPlatformDistributionRows, mapSentimentRows, mapTagRows } from '@lfx-one/shared/utils';
 import { SocialListeningService } from '@services/social-listening.service';
 import { downloadCardAsImage } from '@shared/utils/download-card.util';
 import { MessageService } from 'primeng/api';
@@ -26,6 +32,8 @@ import type {
   SocialListeningAnalyticsRequest,
   SocialListeningPlatformRow,
   SocialListeningSentimentRow,
+  SocialListeningSentimentTrends,
+  SocialListeningTagRow,
   SocialListeningTopProject,
   StatCardItem,
 } from '@lfx-one/shared/interfaces';
@@ -60,6 +68,9 @@ export class SocialListeningAnalyticsComponent {
   /** True while any panel is still fetching — the page disables the export trigger so the PNG can't capture skeletons. */
   public readonly panelsLoading = model(false);
 
+  /** Platform drill-down: the page scopes the feed to this platform and switches tabs. */
+  public readonly platformSelected = output<string>();
+
   private readonly analyticsContent = viewChild<ElementRef<HTMLElement>>('analyticsContent');
 
   private readonly analyticsRequest: Signal<SocialListeningAnalyticsRequest | null> = this.initAnalyticsRequest();
@@ -77,9 +88,9 @@ export class SocialListeningAnalyticsComponent {
     (req) => this.socialListeningService.getAnalyticsPlatformDistribution(req).pipe(map((rows) => mapPlatformDistributionRows(rows))),
     []
   );
-  private readonly tagsState: Signal<LoadableState<ChartData<'bar'> | null>> = this.initAnalyticsState(
-    (req) => this.socialListeningService.getMentionsTags(req).pipe(map(buildTagsChartData)),
-    null
+  private readonly tagsState: Signal<LoadableState<SocialListeningTagRow[]>> = this.initAnalyticsState(
+    (req) => this.socialListeningService.getMentionsTags(req).pipe(map(mapTagRows)),
+    []
   );
   private readonly sentimentState: Signal<LoadableState<SocialListeningSentimentRow[]>> = this.initAnalyticsState(
     (req) => this.socialListeningService.getAnalyticsSentimentDistribution(req).pipe(map(mapSentimentRows)),
@@ -107,11 +118,9 @@ export class SocialListeningAnalyticsComponent {
   /** PCC behavior: the per-platform % label is only meaningful on the unfiltered (all-platforms) view. */
   public readonly showPlatformPercents = computed(() => this.platform() === 'all');
 
-  public readonly tagsData = computed(() => this.tagsState().data);
+  public readonly tagRows = computed(() => this.tagsState().data);
   public readonly tagsLoading = computed(() => this.tagsState().loading);
   public readonly tagsError = computed(() => this.tagsState().error);
-  /** Screen-reader equivalent of the canvas bar chart — the chart's values are otherwise tooltip-only. */
-  public readonly tagsTable: Signal<{ label: string; count: number | null }[] | null> = this.initTagsTable();
 
   public readonly sentimentRows = computed(() => this.sentimentState().data);
   public readonly sentimentLoading = computed(() => this.sentimentState().loading);
@@ -120,6 +129,9 @@ export class SocialListeningAnalyticsComponent {
   public readonly topProjects = computed(() => this.topProjectsState().data);
   public readonly topProjectsLoading = computed(() => this.topProjectsState().loading);
   public readonly topProjectsError = computed(() => this.topProjectsState().error);
+
+  /** Sentiment trends live on the overview endpoint, so the sentiment card keeps its own counts when that panel errors. */
+  public readonly sentimentTrends: Signal<SocialListeningSentimentTrends> = this.initSentimentTrends();
 
   private readonly anyPanelLoading = computed(
     () =>
@@ -150,19 +162,10 @@ export class SocialListeningAnalyticsComponent {
     },
   };
 
-  protected readonly tagsChartOptions: ChartOptions<'bar'> = {
-    responsive: true,
-    maintainAspectRatio: false,
-    plugins: {
-      legend: { display: false },
-      // White DOM tooltip shared with the over-time chart — the canvas default renders a dark box.
-      tooltip: { enabled: false, external: this.buildChartExternalTooltip() },
-    },
-    scales: {
-      x: { grid: { display: false }, ticks: { color: lfxColors.gray[500], font: { size: 11 } } },
-      y: { display: true, beginAtZero: true, grid: { color: lfxColors.gray[200] }, ticks: { color: lfxColors.gray[500] } },
-    },
-  };
+  protected readonly deltaIcon = DELTA_DIRECTION_ICON;
+  protected readonly deltaTextClass = DELTA_DIRECTION_TEXT_CLASS;
+  /** Negative-sentiment trends invert: an increase is bad, so up renders red and down emerald. */
+  protected readonly invertedDeltaTextClass = INVERTED_DELTA_DIRECTION_TEXT_CLASS;
 
   private destroyed = false;
 
@@ -179,6 +182,10 @@ export class SocialListeningAnalyticsComponent {
 
     // Report panel loading to the page so the export trigger stays disabled while skeletons are visible.
     effect(() => this.panelsLoading.set(this.anyPanelLoading()));
+  }
+
+  public onPlatformRowClick(row: SocialListeningPlatformRow): void {
+    this.platformSelected.emit(row.platform);
   }
 
   private async exportAnalytics(): Promise<void> {
@@ -219,7 +226,7 @@ export class SocialListeningAnalyticsComponent {
    * External DOM tooltip shared by the analytics charts — white card instead of the dark canvas
    * default (and no canvas clipping); flips left near the viewport edge and clamps vertically.
    */
-  private buildChartExternalTooltip(): (args: { chart: Chart; tooltip: TooltipModel<'line'> | TooltipModel<'bar'> }) => void {
+  private buildChartExternalTooltip(): (args: { chart: Chart; tooltip: TooltipModel<'line'> }) => void {
     return ({ chart, tooltip }) => {
       const tip = chart.canvas.closest('[data-chart-tooltip-host]')?.querySelector<HTMLElement>('[data-lfx-tip]');
       if (!tip) return;
@@ -242,7 +249,7 @@ export class SocialListeningAnalyticsComponent {
 
         const dot = document.createElement('span');
         dot.className = 'h-2 w-2 shrink-0 rounded-full';
-        // Line datasets carry one borderColor; the tag bars carry a per-index backgroundColor array.
+        // Line datasets carry a single borderColor; fall back for datasets that only declare a fill.
         const dotColor = point.dataset.borderColor ?? point.dataset.backgroundColor;
         dot.style.backgroundColor = String(Array.isArray(dotColor) ? dotColor[point.dataIndex] : dotColor);
         row.appendChild(dot);
@@ -296,16 +303,14 @@ export class SocialListeningAnalyticsComponent {
     );
   }
 
-  /** Screen-reader table mirror of the tags chart data; null while the panel shows its empty state. */
-  private initTagsTable(): Signal<{ label: string; count: number | null }[] | null> {
+  /** Trend chips for the sentiment card; an overview error drops the chips without touching the card's own counts. */
+  private initSentimentTrends(): Signal<SocialListeningSentimentTrends> {
     return computed(() => {
-      const data = this.tagsData();
-      if (!data) return null;
-      const counts = data.datasets[0]?.data ?? [];
-      return (data.labels ?? []).map((label, i) => {
-        const value = counts[i];
-        return { label: String(label), count: typeof value === 'number' ? value : null };
-      });
+      const overview = this.overviewState().error ? null : this.overviewState().data;
+      return {
+        positive: buildAnalyticsDelta(overview?.POSITIVE_SENTIMENT_CHANGE_PCT ?? null) ?? null,
+        negative: buildAnalyticsDelta(overview?.NEGATIVE_SENTIMENT_CHANGE_PCT ?? null, true) ?? null,
+      };
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
@@ -72,10 +72,14 @@
           [outlined]="true"
           styleClass="feed-header__view-trigger w-44"
           [ariaExpanded]="viewsVisible()"
+          [pTooltip]="viewsLabel()"
+          [tooltipDisabled]="!showViewTooltip()"
+          tooltipPosition="top"
+          tooltipEvent="both"
           (onClick)="toggleViews()"
           data-testid="social-listening-views-button">
           <i class="fa-light fa-bookmark text-sm text-gray-400" aria-hidden="true"></i>
-          <span class="min-w-0 truncate" [pTooltip]="viewsLabel()" [tooltipDisabled]="!showViewTooltip()" tooltipPosition="top">{{ viewsLabel() }}</span>
+          <span class="min-w-0 truncate">{{ viewsLabel() }}</span>
           <i
             class="fa-light ml-auto text-xs text-gray-400"
             [class.fa-chevron-up]="viewsVisible()"

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="feed-header flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 py-4" data-testid="social-listening-feed-header">
-  <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+  <div class="flex min-w-0 flex-1 basis-full flex-wrap items-center gap-2 sm:basis-0">
     <!-- Search (feed tab only; debounce + min-chars enforced by the page pipeline) — query leads, scope filters follow -->
     @if (!isAnalyticsTab()) {
       <div class="min-w-56 flex-1">
@@ -75,7 +75,7 @@
           (onClick)="toggleViews()"
           data-testid="social-listening-views-button">
           <i class="fa-light fa-bookmark text-sm text-gray-400" aria-hidden="true"></i>
-          <span class="min-w-0 truncate">{{ viewsLabel() }}</span>
+          <span class="min-w-0 truncate" [pTooltip]="viewsLabel()" [tooltipDisabled]="!showViewTooltip()" tooltipPosition="top">{{ viewsLabel() }}</span>
           <i
             class="fa-light ml-auto text-xs text-gray-400"
             [class.fa-chevron-up]="viewsVisible()"

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
@@ -2,7 +2,21 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="feed-header flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 py-4" data-testid="social-listening-feed-header">
-  <div class="flex flex-wrap items-center gap-2">
+  <div class="flex min-w-0 flex-1 flex-wrap items-center gap-2">
+    <!-- Search (feed tab only; debounce + min-chars enforced by the page pipeline) — query leads, scope filters follow -->
+    @if (!isAnalyticsTab()) {
+      <div class="min-w-56 flex-1">
+        <lfx-input-text
+          [form]="headerForm"
+          control="search"
+          type="text"
+          icon="fa-light fa-search"
+          placeholder="Search mentions..."
+          styleClass="w-full"
+          data-testid="feed-header-search" />
+      </div>
+    }
+
     <!-- Sub-project selector (static badge when the foundation has exactly one) -->
     @if (hasSingleProject()) {
       <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700" data-testid="feed-header-single-project">{{
@@ -46,37 +60,31 @@
       ariaLabel="Select reporting period"
       styleClass="w-44"
       data-testid="feed-header-period-select" />
-
-    <!-- Search (feed tab only; debounce + min-chars enforced by the page pipeline) -->
-    @if (!isAnalyticsTab()) {
-      <lfx-input-text
-        [form]="headerForm"
-        control="search"
-        type="text"
-        icon="fa-light fa-search"
-        placeholder="Search mentions..."
-        styleClass="w-56"
-        data-testid="feed-header-search" />
-    }
   </div>
 
   <div class="flex items-center gap-2">
     <!-- Views trigger (feed tab only) — the label is the active saved view or "No Preset View" -->
     @if (!isAnalyticsTab()) {
-      <lfx-button
-        #viewsTrigger
-        severity="secondary"
-        [outlined]="true"
-        [rounded]="true"
-        size="small"
-        styleClass="feed-header__pill w-36"
-        [ariaExpanded]="viewsVisible()"
-        (onClick)="toggleViews()"
-        data-testid="social-listening-views-button">
-        <i class="fa-light fa-bookmark text-xs" aria-hidden="true"></i>
-        <span class="min-w-0 truncate text-xs">{{ viewsLabel() }}</span>
-        <i class="fa-light text-[10px]" [class.fa-chevron-up]="viewsVisible()" [class.fa-chevron-down]="!viewsVisible()" aria-hidden="true"></i>
-      </lfx-button>
+      <div class="relative">
+        <lfx-button
+          #viewsTrigger
+          severity="secondary"
+          [outlined]="true"
+          styleClass="feed-header__view-trigger w-44"
+          [ariaExpanded]="viewsVisible()"
+          (onClick)="toggleViews()"
+          data-testid="social-listening-views-button">
+          <i class="fa-light fa-bookmark text-sm text-gray-400" aria-hidden="true"></i>
+          <span class="min-w-0 truncate">{{ viewsLabel() }}</span>
+          <i
+            class="fa-light ml-auto text-xs text-gray-400"
+            [class.fa-chevron-up]="viewsVisible()"
+            [class.fa-chevron-down]="!viewsVisible()"
+            aria-hidden="true"></i>
+        </lfx-button>
+        <!-- The page projects the views dropdown here so the panel anchors under the trigger -->
+        <ng-content select="[data-views-dropdown]"></ng-content>
+      </div>
     }
 
     <!-- Filters trigger (feed tab only) — hover/focus arms the page's lazy option fetches -->

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
@@ -1,111 +1,114 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<lfx-card-tabs-bar [options]="tabOptions" [selectedFilter]="activeTab()" (filterChange)="onTabChange($event)" data-testid="social-listening-tabs">
-  <div class="flex flex-wrap items-center gap-3">
-    <!-- Sub-project selector (static badge when the foundation has exactly one) -->
-    @if (hasSingleProject()) {
-      <span class="inline-flex items-center rounded-md bg-gray-100 px-3 py-1.5 text-sm font-medium text-gray-700" data-testid="feed-header-single-project">{{
-        singleProjectName()
-      }}</span>
-    } @else {
-      <lfx-select
-        [form]="headerForm"
-        control="sourceProject"
-        [options]="projectOptions()"
-        optionLabel="label"
-        optionValue="value"
-        placeholder="All Projects"
-        ariaLabel="Filter by project"
-        [loading]="optionsLoading()"
-        styleClass="w-44"
-        data-testid="feed-header-project-select" />
-    }
-
-    <!-- Platform selector -->
+<div class="feed-header flex flex-wrap items-center gap-2 border-b border-gray-200 px-5 py-4" data-testid="social-listening-feed-header">
+  <!-- Sub-project selector (static badge when the foundation has exactly one) -->
+  @if (hasSingleProject()) {
+    <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700" data-testid="feed-header-single-project">{{
+      singleProjectName()
+    }}</span>
+  } @else {
     <lfx-select
       [form]="headerForm"
-      control="platform"
-      [options]="platformOptions()"
+      control="sourceProject"
+      [options]="projectOptions()"
       optionLabel="label"
       optionValue="value"
-      placeholder="All Platforms"
-      ariaLabel="Filter by platform"
+      placeholder="All Projects"
+      ariaLabel="Filter by project"
       [loading]="optionsLoading()"
       styleClass="w-44"
-      data-testid="feed-header-platform-select" />
+      data-testid="feed-header-project-select" />
+  }
 
-    <!-- Period selector -->
-    <lfx-select
+  <!-- Platform selector -->
+  <lfx-select
+    [form]="headerForm"
+    control="platform"
+    [options]="platformOptions()"
+    optionLabel="label"
+    optionValue="value"
+    placeholder="All Platforms"
+    ariaLabel="Filter by platform"
+    [loading]="optionsLoading()"
+    styleClass="w-44"
+    data-testid="feed-header-platform-select" />
+
+  <!-- Period selector -->
+  <lfx-select
+    [form]="headerForm"
+    control="period"
+    [options]="periodOptions"
+    optionLabel="label"
+    optionValue="value"
+    placeholder="Select period"
+    ariaLabel="Select reporting period"
+    styleClass="w-44"
+    data-testid="feed-header-period-select" />
+
+  <!-- Search (feed tab only; debounce + min-chars enforced by the page pipeline) -->
+  @if (!isAnalyticsTab()) {
+    <lfx-input-text
       [form]="headerForm"
-      control="period"
-      [options]="periodOptions"
-      optionLabel="label"
-      optionValue="value"
-      placeholder="Select period"
-      ariaLabel="Select reporting period"
-      styleClass="w-44"
-      data-testid="feed-header-period-select" />
+      control="search"
+      type="text"
+      icon="fa-light fa-search"
+      placeholder="Search mentions..."
+      styleClass="w-56"
+      data-testid="feed-header-search" />
+  }
 
-    <!-- Search (feed tab only; debounce + min-chars enforced by the page pipeline) -->
-    @if (!isAnalyticsTab()) {
-      <lfx-input-text
-        [form]="headerForm"
-        control="search"
-        type="text"
-        icon="fa-light fa-search"
-        placeholder="Search mentions..."
-        styleClass="w-56"
-        data-testid="feed-header-search" />
-    }
+  <!-- Views trigger (feed tab only) — the label is the active saved view or "No Preset View" -->
+  @if (!isAnalyticsTab()) {
+    <lfx-button
+      #viewsTrigger
+      severity="secondary"
+      [outlined]="true"
+      [rounded]="true"
+      size="small"
+      styleClass="feed-header__pill w-36"
+      [ariaExpanded]="viewsVisible()"
+      (onClick)="toggleViews()"
+      data-testid="social-listening-views-button">
+      <i class="fa-light fa-bookmark text-xs" aria-hidden="true"></i>
+      <span class="min-w-0 truncate text-xs">{{ viewsLabel() }}</span>
+      <i class="fa-light text-[10px]" [class.fa-chevron-up]="viewsVisible()" [class.fa-chevron-down]="!viewsVisible()" aria-hidden="true"></i>
+    </lfx-button>
+  }
 
-    <!-- Views trigger (feed tab only) — the label is the active saved view or "No Preset View" -->
-    @if (!isAnalyticsTab()) {
-      <lfx-button
-        #viewsTrigger
-        severity="secondary"
-        [outlined]="true"
-        size="small"
-        styleClass="w-36"
-        [ariaExpanded]="viewsVisible()"
-        (onClick)="toggleViews()"
-        data-testid="social-listening-views-button">
-        <i class="fa-light fa-bookmark" aria-hidden="true"></i>
-        <span class="min-w-0 truncate">{{ viewsLabel() }}</span>
-        <i class="fa-light text-xs" [class.fa-chevron-up]="viewsVisible()" [class.fa-chevron-down]="!viewsVisible()" aria-hidden="true"></i>
-      </lfx-button>
-    }
+  <!-- Filters trigger (feed tab only) — hover/focus arms the page's lazy option fetches -->
+  @if (!isAnalyticsTab()) {
+    <lfx-button
+      #filtersTrigger
+      icon="fa-light fa-sliders"
+      severity="secondary"
+      [outlined]="true"
+      [rounded]="true"
+      size="small"
+      styleClass="feed-header__pill"
+      ariaLabel="Filters"
+      [ariaPressed]="filtersVisible()"
+      [badge]="activeFilterCount() > 0 ? activeFilterCount().toString() : undefined"
+      badgeSeverity="info"
+      (onClick)="toggleFilters()"
+      (focusin)="filtersPrefetch.emit()"
+      (mouseenter)="filtersPrefetch.emit()"
+      data-testid="social-listening-filters-button" />
+  }
 
-    <!-- Filters trigger (feed tab only) — hover/focus arms the page's lazy option fetches -->
-    @if (!isAnalyticsTab()) {
-      <lfx-button
-        #filtersTrigger
-        icon="fa-light fa-sliders"
-        severity="secondary"
-        [outlined]="true"
-        size="small"
-        ariaLabel="Filters"
-        [ariaPressed]="filtersVisible()"
-        [badge]="activeFilterCount() > 0 ? activeFilterCount().toString() : undefined"
-        badgeSeverity="info"
-        (onClick)="toggleFilters()"
-        (focusin)="filtersPrefetch.emit()"
-        (mouseenter)="filtersPrefetch.emit()"
-        data-testid="social-listening-filters-button" />
-    }
-
-    <!-- Export trigger (analytics tab only) — the page increments the analytics component's exportNonce -->
-    @if (isAnalyticsTab()) {
-      <lfx-button
-        icon="fa-light fa-arrow-down-to-bracket"
-        severity="secondary"
-        [outlined]="true"
-        size="small"
-        ariaLabel="Export analytics as PNG"
-        [loading]="exporting()"
-        [disabled]="exporting() || exportDisabled()"
-        (onClick)="exportAnalytics.emit()"
-        data-testid="social-listening-analytics-export" />
-    }
-  </div>
-</lfx-card-tabs-bar>
+  <!-- Export trigger (analytics tab only) — the page increments the analytics component's exportNonce -->
+  @if (isAnalyticsTab()) {
+    <lfx-button
+      icon="fa-light fa-arrow-down-to-bracket"
+      severity="secondary"
+      [outlined]="true"
+      [rounded]="true"
+      size="small"
+      styleClass="feed-header__pill"
+      ariaLabel="Export analytics as PNG"
+      [loading]="exporting()"
+      [disabled]="exporting() || exportDisabled()"
+      (onClick)="exportAnalytics.emit()"
+      data-testid="social-listening-analytics-export" />
+  }
+</div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.html
@@ -1,114 +1,118 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div class="feed-header flex flex-wrap items-center gap-2 border-b border-gray-200 px-5 py-4" data-testid="social-listening-feed-header">
-  <!-- Sub-project selector (static badge when the foundation has exactly one) -->
-  @if (hasSingleProject()) {
-    <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700" data-testid="feed-header-single-project">{{
-      singleProjectName()
-    }}</span>
-  } @else {
+<div class="feed-header flex flex-wrap items-center justify-between gap-2 border-b border-gray-200 py-4" data-testid="social-listening-feed-header">
+  <div class="flex flex-wrap items-center gap-2">
+    <!-- Sub-project selector (static badge when the foundation has exactly one) -->
+    @if (hasSingleProject()) {
+      <span class="inline-flex items-center rounded-full bg-gray-100 px-3 py-1.5 text-xs font-medium text-gray-700" data-testid="feed-header-single-project">{{
+        singleProjectName()
+      }}</span>
+    } @else {
+      <lfx-select
+        [form]="headerForm"
+        control="sourceProject"
+        [options]="projectOptions()"
+        optionLabel="label"
+        optionValue="value"
+        placeholder="All Projects"
+        ariaLabel="Filter by project"
+        [loading]="optionsLoading()"
+        styleClass="w-44"
+        data-testid="feed-header-project-select" />
+    }
+
+    <!-- Platform selector -->
     <lfx-select
       [form]="headerForm"
-      control="sourceProject"
-      [options]="projectOptions()"
+      control="platform"
+      [options]="platformOptions()"
       optionLabel="label"
       optionValue="value"
-      placeholder="All Projects"
-      ariaLabel="Filter by project"
+      placeholder="All Platforms"
+      ariaLabel="Filter by platform"
       [loading]="optionsLoading()"
       styleClass="w-44"
-      data-testid="feed-header-project-select" />
-  }
+      data-testid="feed-header-platform-select" />
 
-  <!-- Platform selector -->
-  <lfx-select
-    [form]="headerForm"
-    control="platform"
-    [options]="platformOptions()"
-    optionLabel="label"
-    optionValue="value"
-    placeholder="All Platforms"
-    ariaLabel="Filter by platform"
-    [loading]="optionsLoading()"
-    styleClass="w-44"
-    data-testid="feed-header-platform-select" />
-
-  <!-- Period selector -->
-  <lfx-select
-    [form]="headerForm"
-    control="period"
-    [options]="periodOptions"
-    optionLabel="label"
-    optionValue="value"
-    placeholder="Select period"
-    ariaLabel="Select reporting period"
-    styleClass="w-44"
-    data-testid="feed-header-period-select" />
-
-  <!-- Search (feed tab only; debounce + min-chars enforced by the page pipeline) -->
-  @if (!isAnalyticsTab()) {
-    <lfx-input-text
+    <!-- Period selector -->
+    <lfx-select
       [form]="headerForm"
-      control="search"
-      type="text"
-      icon="fa-light fa-search"
-      placeholder="Search mentions..."
-      styleClass="w-56"
-      data-testid="feed-header-search" />
-  }
+      control="period"
+      [options]="periodOptions"
+      optionLabel="label"
+      optionValue="value"
+      placeholder="Select period"
+      ariaLabel="Select reporting period"
+      styleClass="w-44"
+      data-testid="feed-header-period-select" />
 
-  <!-- Views trigger (feed tab only) — the label is the active saved view or "No Preset View" -->
-  @if (!isAnalyticsTab()) {
-    <lfx-button
-      #viewsTrigger
-      severity="secondary"
-      [outlined]="true"
-      [rounded]="true"
-      size="small"
-      styleClass="feed-header__pill w-36"
-      [ariaExpanded]="viewsVisible()"
-      (onClick)="toggleViews()"
-      data-testid="social-listening-views-button">
-      <i class="fa-light fa-bookmark text-xs" aria-hidden="true"></i>
-      <span class="min-w-0 truncate text-xs">{{ viewsLabel() }}</span>
-      <i class="fa-light text-[10px]" [class.fa-chevron-up]="viewsVisible()" [class.fa-chevron-down]="!viewsVisible()" aria-hidden="true"></i>
-    </lfx-button>
-  }
+    <!-- Search (feed tab only; debounce + min-chars enforced by the page pipeline) -->
+    @if (!isAnalyticsTab()) {
+      <lfx-input-text
+        [form]="headerForm"
+        control="search"
+        type="text"
+        icon="fa-light fa-search"
+        placeholder="Search mentions..."
+        styleClass="w-56"
+        data-testid="feed-header-search" />
+    }
+  </div>
 
-  <!-- Filters trigger (feed tab only) — hover/focus arms the page's lazy option fetches -->
-  @if (!isAnalyticsTab()) {
-    <lfx-button
-      #filtersTrigger
-      icon="fa-light fa-sliders"
-      severity="secondary"
-      [outlined]="true"
-      [rounded]="true"
-      size="small"
-      styleClass="feed-header__pill"
-      ariaLabel="Filters"
-      [ariaPressed]="filtersVisible()"
-      [badge]="activeFilterCount() > 0 ? activeFilterCount().toString() : undefined"
-      badgeSeverity="info"
-      (onClick)="toggleFilters()"
-      (focusin)="filtersPrefetch.emit()"
-      (mouseenter)="filtersPrefetch.emit()"
-      data-testid="social-listening-filters-button" />
-  }
+  <div class="flex items-center gap-2">
+    <!-- Views trigger (feed tab only) — the label is the active saved view or "No Preset View" -->
+    @if (!isAnalyticsTab()) {
+      <lfx-button
+        #viewsTrigger
+        severity="secondary"
+        [outlined]="true"
+        [rounded]="true"
+        size="small"
+        styleClass="feed-header__pill w-36"
+        [ariaExpanded]="viewsVisible()"
+        (onClick)="toggleViews()"
+        data-testid="social-listening-views-button">
+        <i class="fa-light fa-bookmark text-xs" aria-hidden="true"></i>
+        <span class="min-w-0 truncate text-xs">{{ viewsLabel() }}</span>
+        <i class="fa-light text-[10px]" [class.fa-chevron-up]="viewsVisible()" [class.fa-chevron-down]="!viewsVisible()" aria-hidden="true"></i>
+      </lfx-button>
+    }
 
-  <!-- Export trigger (analytics tab only) — the page increments the analytics component's exportNonce -->
-  @if (isAnalyticsTab()) {
-    <lfx-button
-      icon="fa-light fa-arrow-down-to-bracket"
-      severity="secondary"
-      [outlined]="true"
-      [rounded]="true"
-      size="small"
-      styleClass="feed-header__pill"
-      ariaLabel="Export analytics as PNG"
-      [loading]="exporting()"
-      [disabled]="exporting() || exportDisabled()"
-      (onClick)="exportAnalytics.emit()"
-      data-testid="social-listening-analytics-export" />
-  }
+    <!-- Filters trigger (feed tab only) — hover/focus arms the page's lazy option fetches -->
+    @if (!isAnalyticsTab()) {
+      <lfx-button
+        #filtersTrigger
+        icon="fa-light fa-sliders"
+        severity="secondary"
+        [outlined]="true"
+        [rounded]="true"
+        size="small"
+        styleClass="feed-header__pill"
+        ariaLabel="Filters"
+        [ariaPressed]="filtersVisible()"
+        [badge]="activeFilterCount() > 0 ? activeFilterCount().toString() : undefined"
+        badgeSeverity="info"
+        (onClick)="toggleFilters()"
+        (focusin)="filtersPrefetch.emit()"
+        (mouseenter)="filtersPrefetch.emit()"
+        data-testid="social-listening-filters-button" />
+    }
+
+    <!-- Export trigger (analytics tab only) — the page increments the analytics component's exportNonce -->
+    @if (isAnalyticsTab()) {
+      <lfx-button
+        icon="fa-light fa-arrow-down-to-bracket"
+        severity="secondary"
+        [outlined]="true"
+        [rounded]="true"
+        size="small"
+        styleClass="feed-header__pill"
+        ariaLabel="Export analytics as PNG"
+        [loading]="exporting()"
+        [disabled]="exporting() || exportDisabled()"
+        (onClick)="exportAnalytics.emit()"
+        data-testid="social-listening-analytics-export" />
+    }
+  </div>
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.scss
@@ -4,3 +4,12 @@
 :host {
   @apply block;
 }
+
+// Ghost-pill treatment for the views/filters/export triggers: 12px label, tight height, no fill at rest.
+:host ::ng-deep .feed-header__pill {
+  @apply h-8 gap-1.5 whitespace-nowrap border-gray-200 px-3 text-xs text-gray-600;
+
+  &:not(:disabled):hover {
+    @apply border-gray-300 bg-gray-50 text-gray-900;
+  }
+}

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.scss
@@ -5,11 +5,29 @@
   @apply block;
 }
 
-// Ghost-pill treatment for the views/filters/export triggers: 12px label, tight height, no fill at rest.
+// Ghost-pill treatment for the filters/export triggers: 12px label, tight height, no fill at rest.
 :host ::ng-deep .feed-header__pill {
   @apply h-8 gap-1.5 whitespace-nowrap border-gray-200 px-3 text-xs text-gray-600;
 
   &:not(:disabled):hover {
     @apply border-gray-300 bg-gray-50 text-gray-900;
+  }
+}
+
+// Views trigger consumes the same small form-field tokens as the selects so it matches their chrome by construction.
+:host ::ng-deep .feed-header__view-trigger {
+  @apply inline-flex items-center justify-start gap-2 whitespace-nowrap font-normal;
+  padding: var(--p-form-field-sm-padding-y) var(--p-form-field-sm-padding-x);
+  font-size: var(--p-form-field-sm-font-size);
+  line-height: 1.25rem;
+  color: var(--p-form-field-color);
+  background: var(--p-form-field-background);
+  border: 1px solid var(--p-form-field-border-color);
+  border-radius: var(--p-form-field-border-radius);
+
+  &:not(:disabled):hover {
+    color: var(--p-form-field-color);
+    background: var(--p-form-field-background);
+    border-color: var(--p-form-field-hover-border-color);
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
@@ -8,6 +8,8 @@ import { ButtonComponent } from '@components/button/button.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { buildMarketingImpactPeriodOptions } from '@lfx-one/shared/utils';
+import { VIEWS_DROPDOWN_NAME_TOOLTIP_THRESHOLD } from '@lfx-one/shared/constants';
+import { TooltipModule } from 'primeng/tooltip';
 
 import type { MarketingImpactPeriodOption, SocialListeningOption, SocialListeningTab } from '@lfx-one/shared/interfaces';
 
@@ -17,7 +19,7 @@ import type { MarketingImpactPeriodOption, SocialListeningOption, SocialListenin
  */
 @Component({
   selector: 'lfx-feed-header',
-  imports: [ReactiveFormsModule, ButtonComponent, SelectComponent, InputTextComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, SelectComponent, InputTextComponent, TooltipModule],
   templateUrl: './feed-header.component.html',
   styleUrl: './feed-header.component.scss',
 })
@@ -45,6 +47,7 @@ export class FeedHeaderComponent {
   public readonly activeViewName = input<string | null>(null);
 
   protected readonly viewsLabel = computed(() => this.activeViewName() ?? 'No Preset View');
+  protected readonly showViewTooltip = computed(() => this.viewsLabel().length > VIEWS_DROPDOWN_NAME_TOOLTIP_THRESHOLD);
 
   // === Analytics export (LFXV2-3018) — button renders on the Analytics tab only ===
   public readonly exporting = input(false);

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/feed-header/feed-header.component.ts
@@ -5,26 +5,19 @@ import { Component, computed, DestroyRef, effect, ElementRef, inject, input, mod
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormBuilder, FormControl, ReactiveFormsModule } from '@angular/forms';
 import { ButtonComponent } from '@components/button/button.component';
-import { CardTabsBarComponent } from '@components/card-tabs-bar/card-tabs-bar.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { SelectComponent } from '@components/select/select.component';
 import { buildMarketingImpactPeriodOptions } from '@lfx-one/shared/utils';
 
-import type { FilterPillOption, MarketingImpactPeriodOption, SocialListeningOption, SocialListeningTab } from '@lfx-one/shared/interfaces';
-
-/** Feed/Analytics tab pills for the header's `lfx-card-tabs-bar`. */
-const SOCIAL_LISTENING_TAB_OPTIONS: FilterPillOption[] = [
-  { id: 'feed', label: 'Feed' },
-  { id: 'analytics', label: 'Analytics' },
-];
+import type { MarketingImpactPeriodOption, SocialListeningOption, SocialListeningTab } from '@lfx-one/shared/interfaces';
 
 /**
- * Social Listening feed header (LFXV2-3016/17/18): tabs, scope selects, search, Filters button, and
+ * Social Listening feed header (LFXV2-3016/17/18): scope selects, search, Filters button, and
  * the analytics export trigger. State lives in the page; `headerForm` bridges the form-bound wrappers.
  */
 @Component({
   selector: 'lfx-feed-header',
-  imports: [ReactiveFormsModule, ButtonComponent, CardTabsBarComponent, SelectComponent, InputTextComponent],
+  imports: [ReactiveFormsModule, ButtonComponent, SelectComponent, InputTextComponent],
   templateUrl: './feed-header.component.html',
   styleUrl: './feed-header.component.scss',
 })
@@ -32,7 +25,7 @@ export class FeedHeaderComponent {
   private readonly fb = inject(FormBuilder);
   private readonly destroyRef = inject(DestroyRef);
 
-  public readonly activeTab = model.required<SocialListeningTab>();
+  public readonly activeTab = input.required<SocialListeningTab>();
   public readonly selectedPeriod = model.required<string>();
   public readonly selectedProject = model.required<string>();
   public readonly selectedPlatform = model.required<string>();
@@ -68,7 +61,6 @@ export class FeedHeaderComponent {
     search: [''],
   });
 
-  protected readonly tabOptions = SOCIAL_LISTENING_TAB_OPTIONS;
   /** Resolved per component instance (matches marketing-impact): the month list depends on "now". */
   protected readonly periodOptions: MarketingImpactPeriodOption[] = buildMarketingImpactPeriodOptions();
 
@@ -100,12 +92,6 @@ export class FeedHeaderComponent {
 
     this.restoreFocusOnFiltersClose();
     this.restoreFocusOnViewsClose();
-  }
-
-  protected onTabChange(tabId: string): void {
-    if (tabId === 'feed' || tabId === 'analytics') {
-      this.activeTab.set(tabId);
-    }
   }
 
   // One panel at a time (PCC's activePanel union): opening one closes the other.

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
@@ -99,8 +99,8 @@
         </div>
       </div>
 
-      <!-- Body beside the link preview; the preview column collapses entirely when there is no image -->
-      <div class="flex gap-4">
+      <!-- Body beside the link preview from sm up, stacked on phones (the fixed-width preview would starve the body); no image = no preview column -->
+      <div class="flex flex-col gap-4 sm:flex-row">
         <div class="flex min-w-0 flex-1 flex-col gap-1">
           @if (hasTitle()) {
             <h3 class="text-base font-bold text-gray-900">{{ mention.title }}</h3>
@@ -142,7 +142,7 @@
               [alt]="mention.title || 'Mention image'"
               loading="lazy"
               (error)="onImageError(imageUrl)"
-              class="h-28 w-[200px] shrink-0 rounded-xl object-cover"
+              class="h-28 w-full shrink-0 rounded-xl object-cover sm:w-[200px]"
               data-testid="mention-card-image" />
           }
         }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
@@ -15,11 +15,8 @@
         (click)="onCardClick()"></a>
     }
 
-    <!-- Sentiment rail: the color runs the height of the card, replacing the old sentiment chip -->
-    <div
-      class="mention-rail flex shrink-0 flex-col items-center gap-2"
-      [attr.aria-label]="sentimentConfig().label + ' sentiment'"
-      data-testid="mention-card-sentiment-rail">
+    <!-- Sentiment rail: the color runs the height of the card, replacing the old sentiment chip. w-5 keeps every card's text column aligned regardless of glyph width; the sr-only span carries the label (aria-label isn't exposed on a roleless div) -->
+    <div class="flex w-5 shrink-0 flex-col items-center gap-2" data-testid="mention-card-sentiment-rail">
       <i [class]="sentimentConfig().icon + ' ' + sentimentConfig().textClass" class="text-base leading-none" aria-hidden="true"></i>
       <span class="w-0.5 flex-1 rounded-full" [class]="sentimentConfig().railClass" aria-hidden="true"></span>
       <span class="sr-only">{{ sentimentConfig().label }} sentiment</span>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
@@ -2,7 +2,7 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 @if (mention(); as mention) {
-  <div class="mention-card flex gap-5 p-5" [class.mention-card--read]="isRead()" data-testid="mention-card" (click)="onCardContainerClick($event)">
+  <div class="mention-card flex gap-3 p-5" [class.mention-card--read]="isRead()" data-testid="mention-card" (click)="onCardContainerClick($event)">
     <!-- Stretched link: covers the whole card, sits below the interactive elements -->
     @if (mention.originalUrl | validExternalUrl; as url) {
       <a
@@ -15,130 +15,152 @@
         (click)="onCardClick()"></a>
     }
 
-    <!-- Left: text content -->
-    <div class="flex min-w-0 flex-1 flex-col">
-      <!-- Header -->
-      <div class="mb-2 flex flex-wrap items-center gap-1.5 text-sm text-gray-900">
-        <i [class]="platformConfig().icon + ' ' + platformConfig().colorClass" class="text-base" aria-hidden="true"></i>
-        <span>Mention of</span>
-        <span class="font-semibold text-amber-600">{{ displayKeyword() }}</span>
-        <span class="text-gray-300">&middot;</span>
-        <span>{{ platformConfig().label }}</span>
-        <span class="text-gray-300">&middot;</span>
-        <span class="text-gray-400">{{ timeAgo() }}</span>
-        <span class="text-gray-300">&middot;</span>
-        @if (mention.authorProfileLink | validExternalUrl; as profileUrl) {
-          <a [href]="profileUrl" target="_blank" rel="noopener noreferrer" class="card-interactive font-medium text-gray-900 hover:underline">{{
-            mention.authorName
-          }}</a>
-        } @else {
-          <span class="font-medium text-gray-900">{{ mention.authorName }}</span>
-        }
-        @if (isReddit() && mention.subreddit) {
-          @if (subredditUrl() | validExternalUrl; as subredditUrl) {
-            <span>in</span>
-            <a [href]="subredditUrl" target="_blank" rel="noopener noreferrer" class="card-interactive text-gray-500 hover:underline"
-              >r/{{ mention.subreddit }}</a
-            >
+    <!-- Sentiment rail: the color runs the height of the card, replacing the old sentiment chip -->
+    <div
+      class="mention-rail flex shrink-0 flex-col items-center gap-2"
+      [attr.aria-label]="sentimentConfig().label + ' sentiment'"
+      data-testid="mention-card-sentiment-rail">
+      <i [class]="sentimentConfig().icon + ' ' + sentimentConfig().textClass" class="text-base leading-none" aria-hidden="true"></i>
+      <span class="w-0.5 flex-1 rounded-full" [class]="sentimentConfig().railClass" aria-hidden="true"></span>
+      <span class="sr-only">{{ sentimentConfig().label }} sentiment</span>
+    </div>
+
+    <div class="flex min-w-0 flex-1 flex-col gap-2">
+      <!-- Header: provenance line on the left, action cluster on the right -->
+      <div class="flex items-start justify-between gap-3">
+        <div class="flex min-w-0 flex-wrap items-center gap-1.5 text-xs text-gray-500">
+          <i [class]="platformConfig().icon + ' ' + platformConfig().colorClass" class="text-sm" aria-hidden="true"></i>
+          <span>Mention of</span>
+          <span class="rounded-full bg-blue-100 px-1.5 py-0.5 font-semibold text-blue-500" data-testid="mention-card-project">{{ displayProject() }}</span>
+          <span>in</span>
+          <span class="font-medium text-gray-700">{{ platformConfig().label }}</span>
+          @if (isReddit() && mention.subreddit) {
+            @if (subredditUrl() | validExternalUrl; as subredditUrl) {
+              <a [href]="subredditUrl" target="_blank" rel="noopener noreferrer" class="card-interactive text-gray-500 hover:underline"
+                >r/{{ mention.subreddit }}</a
+              >
+            }
+          }
+          <span class="text-gray-300">&middot;</span>
+          <span>by</span>
+          @if (mention.authorProfileLink | validExternalUrl; as profileUrl) {
+            <a [href]="profileUrl" target="_blank" rel="noopener noreferrer" class="card-interactive font-medium text-gray-900 hover:underline">{{
+              mention.authorName
+            }}</a>
+          } @else {
+            <span class="font-medium text-gray-900">{{ mention.authorName }}</span>
+          }
+          <span class="text-gray-300">&middot;</span>
+          <span class="text-gray-400">{{ timeAgo() }}</span>
+        </div>
+
+        <div class="action-icons flex shrink-0 items-center gap-1">
+          <a
+            [href]="forwardEmailHref()"
+            class="card-interactive icon-btn"
+            pTooltip="Forward by email"
+            tooltipPosition="top"
+            aria-label="Forward mention by email"
+            data-testid="mention-card-forward-email">
+            <i class="fa-light fa-share text-base"></i>
+          </a>
+          <button
+            type="button"
+            class="card-interactive icon-btn"
+            [pTooltip]="copied() ? 'Copied!' : 'Copy Link'"
+            tooltipPosition="top"
+            [attr.aria-label]="copied() ? 'Link copied' : 'Copy link to mention'"
+            (click)="onCopyLink()"
+            data-testid="mention-card-copy-link">
+            <i [class]="copied() ? 'fa-light fa-check text-base text-emerald-600' : 'fa-light fa-link text-base'"></i>
+          </button>
+          <button
+            type="button"
+            class="card-interactive icon-btn"
+            [pTooltip]="isRead() ? 'Mark as Unread' : 'Mark as Read'"
+            tooltipPosition="top"
+            [attr.aria-label]="isRead() ? 'Mark mention as unread' : 'Mark mention as read'"
+            [attr.aria-pressed]="isRead()"
+            (click)="onToggleRead()"
+            data-testid="mention-card-read-toggle">
+            <i [class]="isRead() ? 'fa-solid fa-eye-slash text-base text-gray-400' : 'fa-light fa-eye text-base'"></i>
+          </button>
+          <button
+            type="button"
+            class="card-interactive icon-btn"
+            [pTooltip]="isBookmarked() ? 'Remove Bookmark' : 'Bookmark'"
+            tooltipPosition="top"
+            [attr.aria-label]="isBookmarked() ? 'Remove bookmark' : 'Bookmark mention'"
+            [attr.aria-pressed]="isBookmarked()"
+            (click)="onToggleBookmark()"
+            data-testid="mention-card-bookmark">
+            <i [class]="isBookmarked() ? 'fa-solid fa-bookmark text-base text-blue-600' : 'fa-light fa-bookmark text-base'"></i>
+          </button>
+        </div>
+      </div>
+
+      <!-- Body beside the link preview; the preview column collapses entirely when there is no image -->
+      <div class="flex gap-4">
+        <div class="flex min-w-0 flex-1 flex-col gap-1">
+          @if (hasTitle()) {
+            <h3 class="text-base font-bold text-gray-900">{{ mention.title }}</h3>
+          }
+
+          <!-- Body content (restricted markdown: no images or raw HTML, links gated by the external-URL policy) -->
+          @if (mention.content) {
+            <div #bodyEl class="mention-body break-words" [class.line-clamp-4]="!bodyExpanded()" [class.mention-body--truncated]="truncated()">
+              <lfx-markdown-renderer [content]="mention.content" [breaks]="true" [restricted]="true" data-testid="mention-card-body" />
+            </div>
+          }
+
+          @if (bodyExpandable()) {
+            <div class="flex flex-wrap items-center gap-3">
+              <button
+                type="button"
+                class="card-interactive cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-blue-600 hover:underline"
+                [attr.aria-expanded]="bodyExpanded()"
+                (click)="onToggleBody()"
+                data-testid="mention-card-body-toggle">
+                {{ bodyExpanded() ? 'See less' : 'Show more' }}
+              </button>
+
+              <!-- Decorative: the stretched link handles the click and stays the sole tab stop to the original URL. -->
+              @if (hasOriginalUrl()) {
+                <span class="text-xs font-medium text-blue-600" data-testid="mention-card-read-more">
+                  Read full post on {{ platformConfig().label }}
+                  <i class="fa-light fa-arrow-up-right-from-square ml-1 text-[10px]" aria-hidden="true"></i>
+                </span>
+              }
+            </div>
+          }
+        </div>
+
+        @if (mention.imageUrl | validExternalUrl; as imageUrl) {
+          @if (failedImageUrl() !== imageUrl) {
+            <img
+              [src]="imageUrl"
+              [alt]="mention.title || 'Mention image'"
+              loading="lazy"
+              (error)="onImageError(imageUrl)"
+              class="h-28 w-[200px] shrink-0 rounded-xl object-cover"
+              data-testid="mention-card-image" />
           }
         }
       </div>
 
-      <!-- Title -->
-      @if (hasTitle()) {
-        <h3 class="mb-1 text-base font-bold text-gray-900">{{ mention.title }}</h3>
-      }
-
-      <!-- Body content (restricted markdown: no images or raw HTML, links gated by the external-URL policy) -->
-      @if (mention.content) {
-        <div #bodyEl class="mention-body line-clamp-3 mb-3 break-words" [class.mention-body--truncated]="truncated()">
-          <lfx-markdown-renderer [content]="mention.content" [breaks]="true" [restricted]="true" data-testid="mention-card-body" />
-        </div>
-      }
-
-      <!-- Decorative: the stretched link handles the click and stays the sole tab stop to the original URL. -->
-      @if (truncated() && hasOriginalUrl()) {
-        <span class="-mt-2 mb-3 text-sm font-medium text-blue-600" data-testid="mention-card-read-more">
-          Read full post on {{ platformConfig().label }}
-          <i class="fa-light fa-arrow-up-right-from-square ml-1 text-xs" aria-hidden="true"></i>
-        </span>
-      }
+      <!-- Chips row (mt-auto keeps it flush with the card bottom) -->
+      <div class="mt-auto flex flex-wrap items-center gap-2">
+        <lfx-tag [value]="relevanceConfig().label + ' Relevance'" [severity]="relevanceConfig().severity" [rounded]="true" />
+        @for (tag of mention.tags; track tag) {
+          <lfx-tag [value]="tag | formatTag" icon="fa-light fa-tag" severity="secondary" [rounded]="true" [outlined]="true" />
+        }
+      </div>
 
       <!-- Analysis (Octolens enrichment — not on the original post, so it needs its own expand path) -->
       @if (mention.analysis) {
-        <div class="mb-3">
-          <lfx-expandable-text [maxHeight]="analysisMaxHeight">
-            <p class="text-xs text-gray-700">{{ mention.analysis }}</p>
-          </lfx-expandable-text>
-        </div>
-      }
-
-      <!-- Pills row (mt-auto keeps it flush with the card bottom) -->
-      <div class="mt-auto flex flex-wrap items-center gap-2">
-        <lfx-tag [value]="sentimentConfig().label" [icon]="sentimentConfig().icon" [severity]="sentimentConfig().severity" [rounded]="true" />
-        <lfx-tag [value]="relevanceConfig().label + ' Relevance'" [severity]="relevanceConfig().severity" [rounded]="true" />
-        @for (tag of mention.tags; track tag) {
-          <lfx-tag [value]="tag | formatTag" severity="secondary" [rounded]="true" [outlined]="true" />
-        }
-      </div>
-    </div>
-
-    <!-- Right: actions + image -->
-    <div class="flex shrink-0 flex-col items-end gap-3">
-      <div class="action-icons flex items-center gap-2">
-        <button
-          type="button"
-          class="card-interactive icon-btn"
-          [pTooltip]="isBookmarked() ? 'Remove Bookmark' : 'Bookmark'"
-          tooltipPosition="top"
-          [attr.aria-label]="isBookmarked() ? 'Remove bookmark' : 'Bookmark mention'"
-          [attr.aria-pressed]="isBookmarked()"
-          (click)="onToggleBookmark()"
-          data-testid="mention-card-bookmark">
-          <i [class]="isBookmarked() ? 'fa-solid fa-bookmark text-base text-blue-600' : 'fa-light fa-bookmark text-base'"></i>
-        </button>
-        <button
-          type="button"
-          class="card-interactive icon-btn"
-          [pTooltip]="copied() ? 'Copied!' : 'Copy Link'"
-          tooltipPosition="top"
-          [attr.aria-label]="copied() ? 'Link copied' : 'Copy link to mention'"
-          (click)="onCopyLink()"
-          data-testid="mention-card-copy-link">
-          <i [class]="copied() ? 'fa-light fa-check text-base text-emerald-600' : 'fa-light fa-link text-base'"></i>
-        </button>
-        <button
-          type="button"
-          class="card-interactive icon-btn"
-          [pTooltip]="isRead() ? 'Mark as Unread' : 'Mark as Read'"
-          tooltipPosition="top"
-          [attr.aria-label]="isRead() ? 'Mark mention as unread' : 'Mark mention as read'"
-          [attr.aria-pressed]="isRead()"
-          (click)="onToggleRead()"
-          data-testid="mention-card-read-toggle">
-          <i [class]="isRead() ? 'fa-solid fa-eye-slash text-base text-gray-400' : 'fa-light fa-eye text-base'"></i>
-        </button>
-        <a
-          [href]="forwardEmailHref()"
-          class="card-interactive icon-btn"
-          pTooltip="Forward by email"
-          tooltipPosition="top"
-          aria-label="Forward mention by email"
-          data-testid="mention-card-forward-email">
-          <i class="fa-light fa-envelope text-base text-gray-400"></i>
-        </a>
-      </div>
-
-      @if (mention.imageUrl | validExternalUrl; as imageUrl) {
-        @if (failedImageUrl() !== imageUrl) {
-          <img
-            [src]="imageUrl"
-            [alt]="mention.title || 'Mention image'"
-            loading="lazy"
-            (error)="onImageError(imageUrl)"
-            class="max-h-36 w-48 rounded-lg object-cover"
-            data-testid="mention-card-image" />
-        }
+        <lfx-expandable-text [maxHeight]="analysisMaxHeight">
+          <p class="text-xs text-gray-400">{{ mention.analysis }}</p>
+        </lfx-expandable-text>
       }
     </div>
   </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.html
@@ -105,29 +105,18 @@
 
           <!-- Body content (restricted markdown: no images or raw HTML, links gated by the external-URL policy) -->
           @if (mention.content) {
-            <div #bodyEl class="mention-body break-words" [class.line-clamp-4]="!bodyExpanded()" [class.mention-body--truncated]="truncated()">
+            <div #bodyEl class="mention-body break-words line-clamp-4" [class.mention-body--truncated]="truncated()">
               <lfx-markdown-renderer [content]="mention.content" [breaks]="true" [restricted]="true" data-testid="mention-card-body" />
             </div>
           }
 
-          @if (bodyExpandable()) {
-            <div class="flex flex-wrap items-center gap-3">
-              <button
-                type="button"
-                class="card-interactive cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-blue-600 hover:underline"
-                [attr.aria-expanded]="bodyExpanded()"
-                (click)="onToggleBody()"
-                data-testid="mention-card-body-toggle">
-                {{ bodyExpanded() ? 'See less' : 'Show more' }}
-              </button>
-
-              <!-- Decorative: the stretched link handles the click and stays the sole tab stop to the original URL. -->
-              @if (hasOriginalUrl()) {
-                <span class="text-xs font-medium text-blue-600" data-testid="mention-card-read-more">
-                  Read full post on {{ platformConfig().label }}
-                  <i class="fa-light fa-arrow-up-right-from-square ml-1 text-[10px]" aria-hidden="true"></i>
-                </span>
-              }
+          <!-- Decorative: the stretched link handles the click and stays the sole tab stop to the original URL. -->
+          @if (truncated() && hasOriginalUrl()) {
+            <div>
+              <span class="text-xs font-medium text-blue-600" data-testid="mention-card-read-more">
+                Read full post on {{ platformConfig().label }}
+                <i class="fa-light fa-arrow-up-right-from-square ml-1 text-[10px]" aria-hidden="true"></i>
+              </span>
             </div>
           }
         </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.scss
@@ -19,9 +19,6 @@
 }
 
 // Fixed-width gutter so every card's text column starts at the same x regardless of the sentiment icon's glyph width.
-.mention-rail {
-  @apply w-5;
-}
 
 // Stretched link: an invisible anchor covering the entire card, giving native link/keyboard
 // behavior without nesting interactive elements inside it.

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.scss
@@ -6,16 +6,21 @@
 }
 
 .mention-card {
-  @apply relative rounded-lg border border-gray-200 bg-white shadow-sm transition-all;
+  @apply relative rounded-2xl border border-gray-200 bg-white shadow-sm transition-all;
 
   &:hover {
-    @apply border-gray-400 shadow-md;
+    @apply border-gray-300 shadow-lg;
   }
 
   &--read {
     // Full opacity keeps text contrast legal (WCAG) — the muted background carries the read/unread distinction instead.
     @apply bg-gray-50;
   }
+}
+
+// Fixed-width gutter so every card's text column starts at the same x regardless of the sentiment icon's glyph width.
+.mention-rail {
+  @apply w-5;
 }
 
 // Stretched link: an invisible anchor covering the entire card, giving native link/keyboard
@@ -65,7 +70,7 @@
 }
 
 .icon-btn {
-  @apply flex h-6 w-6 cursor-pointer items-center justify-center rounded text-sm text-gray-400 transition-all;
+  @apply flex h-9 w-9 cursor-pointer items-center justify-center rounded-full border-0 bg-transparent text-gray-400 transition-all;
 
   &:hover {
     @apply bg-gray-100 text-gray-600;

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.spec.ts
@@ -16,6 +16,7 @@ describe('MentionCardComponent', () => {
       id: 'm1',
       platform: 'reddit',
       keyword: 'kubernetes',
+      sourceProjectName: 'Kubernetes',
       timestamp: '2026-08-01T00:00:00Z',
       authorName: 'Jane Doe',
       authorProfileLink: 'https://reddit.com/u/jane',
@@ -255,6 +256,62 @@ describe('MentionCardComponent', () => {
     expect(querySelector('[data-testid="mention-card"]')?.className).toContain('mention-card--read');
     // Read cards no longer mark on click — the stretched link's label must not promise it.
     expect(querySelector('.card-link')?.getAttribute('aria-label')).toBe('Open original post on Reddit');
+  });
+
+  it('announces sentiment through the rail instead of a chip, coloring both the icon and the bar', async () => {
+    setMention(baseMention({ sentiment: 'negative' }));
+    await fixture.whenStable();
+
+    const rail = querySelector('[data-testid="mention-card-sentiment-rail"]') as HTMLElement;
+    expect(rail).not.toBeNull();
+    expect(rail.querySelector('.sr-only')?.textContent?.trim()).toBe('Negative sentiment');
+    expect(rail.querySelector('i')?.className).toContain('text-red-500');
+    expect(rail.querySelector('span[aria-hidden="true"]')?.className).toContain('bg-red-500');
+  });
+
+  it('names the sub-project in the pill, falling back to the capitalized keyword when the column is blank', async () => {
+    setMention(baseMention({ sourceProjectName: 'CNCF Kubernetes' }));
+    await fixture.whenStable();
+
+    expect(querySelector('[data-testid="mention-card-project"]')?.textContent?.trim()).toBe('CNCF Kubernetes');
+
+    setMention(baseMention({ sourceProjectName: '' }));
+    await fixture.whenStable();
+
+    expect(querySelector('[data-testid="mention-card-project"]')?.textContent?.trim()).toBe('Kubernetes');
+  });
+
+  it('expands the clamped body and keeps the toggle reachable so it can be collapsed again', async () => {
+    setMention(baseMention());
+    await fixture.whenStable();
+
+    expect(querySelector('[data-testid="mention-card-body-toggle"]')).toBeNull();
+
+    // jsdom reports zero heights — stub the layout boxes so the clamp measure sees overflow.
+    const body = querySelector('.mention-body') as HTMLElement;
+    Object.defineProperty(body, 'scrollHeight', { value: 200 });
+    Object.defineProperty(body, 'clientHeight', { value: 72 });
+    fixture.componentRef.setInput('timeTick', 1);
+    await fixture.whenStable();
+
+    const toggle = querySelector('[data-testid="mention-card-body-toggle"]') as HTMLButtonElement;
+    expect(toggle.textContent?.trim()).toBe('Show more');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(querySelector('.mention-body')?.className).toContain('line-clamp-4');
+
+    toggle.click();
+    await fixture.whenStable();
+
+    // Expanding drops the clamp, which makes the measurement report "not truncated" — the toggle must survive it.
+    const expandedToggle = querySelector('[data-testid="mention-card-body-toggle"]') as HTMLButtonElement;
+    expect(expandedToggle.textContent?.trim()).toBe('See less');
+    expect(expandedToggle.getAttribute('aria-expanded')).toBe('true');
+    expect(querySelector('.mention-body')?.className).not.toContain('line-clamp-4');
+
+    expandedToggle.click();
+    await fixture.whenStable();
+
+    expect(querySelector('.mention-body')?.className).toContain('line-clamp-4');
   });
 
   it('exposes the stretched link as the sole keyboard tab stop to the original URL', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.spec.ts
@@ -281,11 +281,9 @@ describe('MentionCardComponent', () => {
     expect(querySelector('[data-testid="mention-card-project"]')?.textContent?.trim()).toBe('Kubernetes');
   });
 
-  it('expands the clamped body and keeps the toggle reachable so it can be collapsed again', async () => {
+  it('keeps the body clamped and points to the original post once truncated', async () => {
     setMention(baseMention());
     await fixture.whenStable();
-
-    expect(querySelector('[data-testid="mention-card-body-toggle"]')).toBeNull();
 
     // jsdom reports zero heights — stub the layout boxes so the clamp measure sees overflow.
     const body = querySelector('.mention-body') as HTMLElement;
@@ -294,24 +292,8 @@ describe('MentionCardComponent', () => {
     fixture.componentRef.setInput('timeTick', 1);
     await fixture.whenStable();
 
-    const toggle = querySelector('[data-testid="mention-card-body-toggle"]') as HTMLButtonElement;
-    expect(toggle.textContent?.trim()).toBe('Show more');
-    expect(toggle.getAttribute('aria-expanded')).toBe('false');
     expect(querySelector('.mention-body')?.className).toContain('line-clamp-4');
-
-    toggle.click();
-    await fixture.whenStable();
-
-    // Expanding drops the clamp, which makes the measurement report "not truncated" — the toggle must survive it.
-    const expandedToggle = querySelector('[data-testid="mention-card-body-toggle"]') as HTMLButtonElement;
-    expect(expandedToggle.textContent?.trim()).toBe('See less');
-    expect(expandedToggle.getAttribute('aria-expanded')).toBe('true');
-    expect(querySelector('.mention-body')?.className).not.toContain('line-clamp-4');
-
-    expandedToggle.click();
-    await fixture.whenStable();
-
-    expect(querySelector('.mention-body')?.className).toContain('line-clamp-4');
+    expect(querySelector('[data-testid="mention-card-read-more"]')?.textContent).toContain('Read full post on Reddit');
   });
 
   it('exposes the stretched link as the sole keyboard tab stop to the original URL', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.ts
@@ -54,6 +54,7 @@ export class MentionCardComponent {
   public readonly failedImageUrl = signal<string | null>(null);
   /** Drives the fade + "Read full post" affordance; measured against the clamped body after each render. */
   public readonly truncated = signal(false);
+  public readonly bodyExpanded = signal(false);
   private copyTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private readonly bodyEl = viewChild<ElementRef<HTMLElement>>('bodyEl');
 
@@ -69,6 +70,10 @@ export class MentionCardComponent {
     () => MENTION_RELEVANCE_CONFIG[this.mention().relevance] ?? MENTION_RELEVANCE_CONFIG.low
   );
   public readonly displayKeyword = computed(() => capitalizeFirst(this.mention().keyword));
+  /** Blank `SOURCE_PROJECT_NAME` rows still get a pill — the keyword is the closest thing the feed matched on. */
+  public readonly displayProject = computed(() => this.mention().sourceProjectName || this.displayKeyword());
+  /** Expanding removes the clamp, so `truncated` reads false — latch on `bodyExpanded` to keep the toggle and full-post link in place. */
+  public readonly bodyExpandable = computed(() => this.truncated() || this.bodyExpanded());
   public readonly isReddit = computed(() => this.mention().platform === 'reddit');
   /** Subreddit directory link — distinct from the stretched card link, which opens the mention itself. */
   public readonly subredditUrl = computed(() => {
@@ -105,6 +110,10 @@ export class MentionCardComponent {
   /** Re-emits the toggle intent — the page decides whether the write proceeds (cap/loading gates live in the service). */
   public onToggleBookmark(): void {
     this.bookmarkToggled.emit(this.mention());
+  }
+
+  public onToggleBody(): void {
+    this.bodyExpanded.update((expanded) => !expanded);
   }
 
   /** Re-emits the toggle intent — the loading gate lives in the service. */

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.ts
@@ -54,7 +54,9 @@ export class MentionCardComponent {
   public readonly failedImageUrl = signal<string | null>(null);
   /** Drives the fade + "Read full post" affordance; measured against the clamped body after each render. */
   public readonly truncated = signal(false);
-  public readonly bodyExpanded = signal(false);
+  /** Keyed by mention id (same reuse hazard as failedImageUrl) — a recycled row never renders the next mention expanded. */
+  private readonly expandedMentionId = signal<string | null>(null);
+  public readonly bodyExpanded = computed(() => this.expandedMentionId() === this.mention().id);
   private copyTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private readonly bodyEl = viewChild<ElementRef<HTMLElement>>('bodyEl');
 
@@ -113,7 +115,7 @@ export class MentionCardComponent {
   }
 
   public onToggleBody(): void {
-    this.bodyExpanded.update((expanded) => !expanded);
+    this.expandedMentionId.update((id) => (id === this.mention().id ? null : this.mention().id));
   }
 
   /** Re-emits the toggle intent — the loading gate lives in the service. */

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mention-card/mention-card.component.ts
@@ -54,9 +54,6 @@ export class MentionCardComponent {
   public readonly failedImageUrl = signal<string | null>(null);
   /** Drives the fade + "Read full post" affordance; measured against the clamped body after each render. */
   public readonly truncated = signal(false);
-  /** Keyed by mention id (same reuse hazard as failedImageUrl) — a recycled row never renders the next mention expanded. */
-  private readonly expandedMentionId = signal<string | null>(null);
-  public readonly bodyExpanded = computed(() => this.expandedMentionId() === this.mention().id);
   private copyTimeoutId: ReturnType<typeof setTimeout> | null = null;
   private readonly bodyEl = viewChild<ElementRef<HTMLElement>>('bodyEl');
 
@@ -74,8 +71,6 @@ export class MentionCardComponent {
   public readonly displayKeyword = computed(() => capitalizeFirst(this.mention().keyword));
   /** Blank `SOURCE_PROJECT_NAME` rows still get a pill — the keyword is the closest thing the feed matched on. */
   public readonly displayProject = computed(() => this.mention().sourceProjectName || this.displayKeyword());
-  /** Expanding removes the clamp, so `truncated` reads false — latch on `bodyExpanded` to keep the toggle and full-post link in place. */
-  public readonly bodyExpandable = computed(() => this.truncated() || this.bodyExpanded());
   public readonly isReddit = computed(() => this.mention().platform === 'reddit');
   /** Subreddit directory link — distinct from the stretched card link, which opens the mention itself. */
   public readonly subredditUrl = computed(() => {
@@ -114,10 +109,6 @@ export class MentionCardComponent {
     this.bookmarkToggled.emit(this.mention());
   }
 
-  public onToggleBody(): void {
-    this.expandedMentionId.update((id) => (id === this.mention().id ? null : this.mention().id));
-  }
-
   /** Re-emits the toggle intent — the loading gate lives in the service. */
   public onToggleRead(): void {
     this.readToggled.emit(this.mention());
@@ -139,6 +130,8 @@ export class MentionCardComponent {
     const url = normalizeToUrl(this.mention().originalUrl);
     if (!url) return;
 
+    // Safe: normalizeToUrl only returns http(s) URLs or https-upgraded valid domains, else null (handled above).
+    // pi-lens-ignore: ast-grep:no-open-redirect
     window.open(url, '_blank', 'noopener,noreferrer');
     this.onCardClick();
   }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
@@ -112,6 +112,9 @@
               icon="fa-light fa-circle-check"
               title="You're all caught up"
               subtitle="No unread mentions match the current filters."
+              ctaLabel="Clear filters"
+              ctaIcon="fa-light fa-filter-slash"
+              (ctaClick)="clearFilters.emit()"
               data-testid="mentions-list-all-read-state" />
           } @else {
             <lfx-empty-state

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
@@ -1,60 +1,51 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-<div #listContainer class="flex flex-col gap-4">
-  <!-- Header row -->
-  <div class="flex items-center justify-between">
-    <div class="flex items-center gap-3">
-      <h2 class="text-xs font-bold tracking-wide text-gray-500">LATEST MENTIONS</h2>
-      @if (!loading() && totalMentions() > 0 && mentions().length > 0) {
-        <span class="text-xs text-gray-400" data-testid="mentions-list-count"
-          >{{ first() + 1 }}–{{ first() + mentions().length }} of {{ totalMentions() }}</span
-        >
-      }
-    </div>
-    <div class="flex items-center gap-2">
-      @if (!loading() && totalMentions() > 0) {
-        <lfx-button
-          label="Mark all as read"
-          icon="fa-light fa-check-double"
-          [text]="true"
-          styleClass="mark-all-btn"
-          (onClick)="markAllRead.emit()"
-          data-testid="mentions-list-mark-all-read" />
-        <lfx-button
-          label="Mark all as unread"
-          icon="fa-light fa-eye-slash"
-          [text]="true"
-          styleClass="mark-all-btn"
-          (onClick)="markAllUnread.emit()"
-          data-testid="mentions-list-mark-all-unread" />
-        <span class="text-xs text-gray-300">&middot;</span>
-      }
-      @if (dataComputedAt(); as computedAt) {
-        <span class="text-xs text-gray-400" data-testid="mentions-list-computed-at">Data as of {{ computedAt | date: 'short' }}</span>
-      }
+<div class="flex flex-col gap-4">
+  <!-- Count row: 12px label + count, hairline rule, mark-all actions and the freshness watermark -->
+  <div class="flex flex-col gap-2 border-b border-gray-100 pb-3">
+    <div class="flex flex-wrap items-center justify-between gap-2">
+      <div class="flex items-center gap-3">
+        <h2 class="text-xs font-bold tracking-wide text-gray-500">LATEST MENTIONS</h2>
+        @if (!loading() && totalMentions() > 0 && mentions().length > 0) {
+          <span class="text-xs text-gray-400" data-testid="mentions-list-count">{{ loadedCount() }} of {{ totalMentions() }}</span>
+        }
+      </div>
+      <div class="flex items-center gap-2">
+        @if (!loading() && totalMentions() > 0) {
+          <lfx-button
+            label="Mark all as read"
+            icon="fa-light fa-check-double"
+            [text]="true"
+            styleClass="mark-all-btn"
+            (onClick)="markAllRead.emit()"
+            data-testid="mentions-list-mark-all-read" />
+          <lfx-button
+            label="Mark all as unread"
+            icon="fa-light fa-eye-slash"
+            [text]="true"
+            styleClass="mark-all-btn"
+            (onClick)="markAllUnread.emit()"
+            data-testid="mentions-list-mark-all-unread" />
+          <span class="text-xs text-gray-300">&middot;</span>
+        }
+        @if (dataComputedAt(); as computedAt) {
+          <span class="text-xs text-gray-400" data-testid="mentions-list-computed-at">Data as of {{ computedAt | date: 'short' }}</span>
+        }
+      </div>
     </div>
   </div>
 
-  <!-- Cards + paginator (lfx-table is the confirmed paginator wrapper; one card per single-cell row) -->
-  <!-- The page report interpolates the capped paginatorTotalRecords — suppress it above the cap so the header's true total stays authoritative. -->
+  <!-- Cards only — lfx-table is retained for its skeleton-row and empty-message machinery, not its paginator -->
   <lfx-table
     [value]="mentions()"
     [loading]="loading()"
     [lazy]="true"
     [lazyLoadOnInit]="false"
-    [paginator]="true"
-    [rows]="rows()"
-    [first]="first()"
-    [totalRecords]="paginatorTotalRecords()"
-    [rowsPerPageOptions]="rowsPerPageOptions()"
-    [showCurrentPageReport]="paginatorTotalRecords() >= totalMentions()"
-    currentPageReportTemplate="Showing {first} to {last} of {totalRecords} mentions"
-    [alwaysShowPaginator]="totalMentions() > 0 || countError()"
+    [paginator]="false"
     [skeletonColumns]="1"
     [skeletonRows]="3"
     styleClass="mentions-table"
-    (onPage)="onTablePage($event)"
     data-testid="mentions-list-table">
     <ng-template #body let-mention>
       <tr>
@@ -109,8 +100,8 @@
           @if (phase2Failed()) {
             <lfx-empty-state
               icon="fa-light fa-triangle-exclamation"
-              title="Couldn't load this page"
-              subtitle="This page of mentions failed to load. Try again."
+              title="Couldn't load these mentions"
+              subtitle="This batch of mentions failed to load. Try again."
               ctaLabel="Retry"
               ctaIcon="fa-light fa-arrow-rotate-left"
               (ctaClick)="retry.emit()"
@@ -126,10 +117,40 @@
               icon="fa-light fa-ear-listen"
               title="No mentions found"
               subtitle="No mentions match the current scope and filters. Try widening the period or clearing the search."
+              ctaLabel="Clear filters"
+              ctaIcon="fa-light fa-filter-slash"
+              (ctaClick)="clearFilters.emit()"
               data-testid="mentions-list-empty-state" />
           }
         </td>
       </tr>
     </ng-template>
   </lfx-table>
+
+  <!-- Load More footer: running count plus the advance control, both gone once the feed is exhausted -->
+  @if (hasMore()) {
+    <div class="flex flex-col items-center gap-2" data-testid="mentions-list-load-more-footer">
+      <p class="text-xs text-gray-400" data-testid="mentions-list-showing">
+        @if (countError()) {
+          Showing {{ loadedCount() }} mentions
+        } @else {
+          Showing {{ loadedCount() }} of {{ servableTotal() }} mentions
+        }
+      </p>
+      <button
+        type="button"
+        class="inline-flex cursor-pointer items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-default disabled:opacity-60"
+        [disabled]="loadingMore()"
+        data-testid="mentions-list-load-more"
+        (click)="loadMore.emit()">
+        @if (loadingMore()) {
+          <i class="fa-light fa-spinner-third fa-spin" aria-hidden="true"></i>
+          Loading…
+        } @else {
+          <i class="fa-light fa-arrow-down" aria-hidden="true"></i>
+          Load more mentions
+        }
+      </button>
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
@@ -141,8 +141,9 @@
       data-testid="mentions-list-inline-error" />
   }
 
-  <!-- Load More footer: running count plus the advance control — hidden once the feed is exhausted or a window needs retry -->
-  @if (hasMore() && !phase2Failed() && !loadError()) {
+  <!-- Load More footer: running count plus the advance control — hidden until the first row lands (an advance before
+       then cancels the window-0 fetch and strands the feed), once the feed is exhausted, or while a window needs retry -->
+  @if (showLoadMore()) {
     <div class="flex flex-col items-center gap-2" data-testid="mentions-list-load-more-footer">
       <p class="text-xs text-gray-400" data-testid="mentions-list-showing">
         @if (countError()) {
@@ -166,5 +167,10 @@
         }
       </button>
     </div>
+  } @else if (renderCapped()) {
+    <!-- Render limit reached with more servable: bound the DOM and point the user at narrowing instead of scanning -->
+    <p class="text-center text-xs text-gray-400" data-testid="mentions-list-render-cap">
+      Showing the first {{ loadedCount() }} mentions. Narrow the filters or shorten the period to see more.
+    </p>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
@@ -49,7 +49,7 @@
     data-testid="mentions-list-table">
     <ng-template #body let-mention>
       <tr>
-        <td class="border-0 p-0 pb-3">
+        <td class="border-0 p-0 pb-6">
           <lfx-mention-card
             [mention]="mention"
             [timeTick]="timeTick()"
@@ -63,8 +63,8 @@
 
     <ng-template #loadingbody let-rowData>
       <tr class="lfx-skeleton-row" [style.animation-delay]="rowData.delay">
-        <td class="border-0 p-0 pb-3">
-          <div class="flex gap-5 rounded-lg border border-gray-200 bg-white p-5">
+        <td class="border-0 p-0 pb-6">
+          <div class="flex gap-5 rounded-2xl border border-gray-200 bg-white p-5">
             <div class="min-w-0 flex-1">
               <div class="mb-2 flex items-center gap-1.5">
                 <p-skeleton width="1rem" height="1rem" shape="circle" />

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
@@ -36,10 +36,11 @@
     </div>
   </div>
 
-  <!-- Cards only — lfx-table is retained for its skeleton-row and empty-message machinery, not its paginator -->
+  <!-- Cards only — lfx-table is retained for its skeleton-row and empty-message machinery, not its paginator.
+       Skeletons paint only when nothing is on screen — a Load More fetch keeps the cards and spins the footer. -->
   <lfx-table
     [value]="mentions()"
-    [loading]="loading()"
+    [loading]="loading() && mentions().length === 0"
     [lazy]="true"
     [lazyLoadOnInit]="false"
     [paginator]="false"
@@ -127,8 +128,21 @@
     </ng-template>
   </lfx-table>
 
-  <!-- Load More footer: running count plus the advance control, both gone once the feed is exhausted -->
-  @if (hasMore()) {
+  <!-- Window failure with rows on screen (a phase-2 hole or a failed Load More fetch): the table's empty state
+       can't render over content, so the retry lives here and Load More hides behind it -->
+  @if (mentions().length > 0 && (phase2Failed() || loadError())) {
+    <lfx-empty-state
+      icon="fa-light fa-triangle-exclamation"
+      title="Couldn't load more mentions"
+      subtitle="This batch of mentions failed to load. Try again."
+      ctaLabel="Retry"
+      ctaIcon="fa-light fa-arrow-rotate-left"
+      (ctaClick)="retry.emit()"
+      data-testid="mentions-list-inline-error" />
+  }
+
+  <!-- Load More footer: running count plus the advance control — hidden once the feed is exhausted or a window needs retry -->
+  @if (hasMore() && !phase2Failed() && !loadError()) {
     <div class="flex flex-col items-center gap-2" data-testid="mentions-list-load-more-footer">
       <p class="text-xs text-gray-400" data-testid="mentions-list-showing">
         @if (countError()) {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.html
@@ -141,17 +141,11 @@
       data-testid="mentions-list-inline-error" />
   }
 
-  <!-- Load More footer: running count plus the advance control — hidden until the first row lands (an advance before
-       then cancels the window-0 fetch and strands the feed), once the feed is exhausted, or while a window needs retry -->
+  <!-- Footers: Load More (hidden until the first row lands — an early advance cancels the window-0 fetch — and while a window
+       needs retry), a render-cap note, and a count-only end state — the running count persists below the exhausted feed per #1821. -->
   @if (showLoadMore()) {
     <div class="flex flex-col items-center gap-2" data-testid="mentions-list-load-more-footer">
-      <p class="text-xs text-gray-400" data-testid="mentions-list-showing">
-        @if (countError()) {
-          Showing {{ loadedCount() }} mentions
-        } @else {
-          Showing {{ loadedCount() }} of {{ servableTotal() }} mentions
-        }
-      </p>
+      <p class="text-xs text-gray-400" data-testid="mentions-list-showing">{{ showingLabel() }}</p>
       <button
         type="button"
         class="inline-flex cursor-pointer items-center gap-2 rounded-full border border-gray-200 bg-white px-4 py-2 text-xs font-medium text-gray-700 hover:bg-gray-50 disabled:cursor-default disabled:opacity-60"
@@ -172,5 +166,7 @@
     <p class="text-center text-xs text-gray-400" data-testid="mentions-list-render-cap">
       Showing the first {{ loadedCount() }} mentions. Narrow the filters or shorten the period to see more.
     </p>
+  } @else if (showExhaustedCount()) {
+    <p class="text-center text-xs text-gray-400" data-testid="mentions-list-showing">{{ showingLabel() }}</p>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.scss
@@ -29,7 +29,7 @@
 
     > td {
       border: 0;
-      padding: 0 0 var(--spacing-3, 0.75rem);
+      padding: 0 0 var(--spacing-6, 1.5rem);
       background: transparent;
     }
   }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.scss
@@ -17,7 +17,7 @@
 }
 
 // The mentions feed renders cards, not a data grid — strip the table chrome (borders, cell
-// padding, header row) so the wrapper reads as a stacked card list with a paginator.
+// padding, header row) so the wrapper reads as a stacked card list.
 :host ::ng-deep .mentions-table {
   .p-datatable-thead,
   .p-datatable-tfoot {
@@ -32,12 +32,5 @@
       padding: 0 0 var(--spacing-3, 0.75rem);
       background: transparent;
     }
-  }
-
-  // The paginator is the only visible table chrome; align it with the card list.
-  .p-paginator {
-    border: 0;
-    background: transparent;
-    padding-inline: 0;
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.spec.ts
@@ -4,7 +4,6 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { provideRouter } from '@angular/router';
-import { TableComponent } from '@components/table/table.component';
 import { beforeEach, describe, expect, it } from 'vitest';
 
 import type { Mention } from '@lfx-one/shared/interfaces';
@@ -20,6 +19,7 @@ describe('MentionsListComponent', () => {
       id,
       platform: 'reddit',
       keyword: 'kubernetes',
+      sourceProjectName: 'Kubernetes',
       timestamp: '2026-08-01T00:00:00Z',
       authorName: 'Jane Doe',
       authorProfileLink: 'https://reddit.com/u/jane',
@@ -48,8 +48,9 @@ describe('MentionsListComponent', () => {
   function setMentions(mentions: Mention[]): void {
     fixture.componentRef.setInput('mentions', mentions);
     fixture.componentRef.setInput('totalMentions', mentions.length);
-    // Mirror the parent: the paginator total tracks the true total until the server offset cap kicks in.
-    fixture.componentRef.setInput('paginatorTotalRecords', mentions.length);
+    // Mirror the parent: everything handed down is loaded, and the reachable total tracks it until the offset cap bites.
+    fixture.componentRef.setInput('loadedCount', mentions.length);
+    fixture.componentRef.setInput('servableTotal', mentions.length);
   }
 
   function cards(): MentionCardComponent[] {
@@ -138,7 +139,7 @@ describe('MentionsListComponent', () => {
     expect(fixture.nativeElement.querySelector('[data-testid="mentions-list-mark-all-unread"]')).toBeNull();
   });
 
-  it('keeps the range count and the paginator report visible in unread view — the server total is exact', async () => {
+  it('keeps the range count visible in unread view — the server total is exact', async () => {
     setMentions([baseMention('m1')]);
     await fixture.whenStable();
     expect(fixture.nativeElement.querySelector('[data-testid="mentions-list-count"]')).not.toBeNull();
@@ -147,14 +148,54 @@ describe('MentionsListComponent', () => {
     await fixture.whenStable();
 
     expect(fixture.nativeElement.querySelector('[data-testid="mentions-list-count"]')).not.toBeNull();
-    const table = fixture.debugElement.query(By.directive(TableComponent)).componentInstance as TableComponent;
-    expect(table.showCurrentPageReport()).toBe(true);
+  });
 
-    // Above the server offset cap the report would echo the capped paginator total — it suppresses so the header's true total stays authoritative.
-    fixture.componentRef.setInput('totalMentions', 150000);
-    fixture.componentRef.setInput('paginatorTotalRecords', 100100);
+  it('hides the Load More control once the feed is exhausted', async () => {
+    setMentions([baseMention('m1')]);
     await fixture.whenStable();
-    expect(table.showCurrentPageReport()).toBe(false);
+    expect(fixture.nativeElement.querySelector('[data-testid="mentions-list-load-more"]')).toBeNull();
+
+    fixture.componentRef.setInput('hasMore', true);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelector('[data-testid="mentions-list-load-more"]')).not.toBeNull();
+  });
+
+  it('emits loadMore when the advance control is clicked', async () => {
+    setMentions([baseMention('m1')]);
+    fixture.componentRef.setInput('hasMore', true);
+    await fixture.whenStable();
+
+    let emitted = 0;
+    fixture.componentInstance.loadMore.subscribe(() => (emitted += 1));
+    (fixture.nativeElement.querySelector('[data-testid="mentions-list-load-more"]') as HTMLButtonElement).click();
+
+    expect(emitted).toBe(1);
+  });
+
+  it('spins and locks the advance control while a Load More fetch is in flight', async () => {
+    setMentions([baseMention('m1')]);
+    fixture.componentRef.setInput('hasMore', true);
+    fixture.componentRef.setInput('loadingMore', true);
+    await fixture.whenStable();
+
+    const button = fixture.nativeElement.querySelector('[data-testid="mentions-list-load-more"]') as HTMLButtonElement;
+    expect(button.disabled).toBe(true);
+    expect(button.querySelector('.fa-spinner-third')).not.toBeNull();
+  });
+
+  it('drops the reachable total from the running count when the count request failed', async () => {
+    setMentions([baseMention('m1')]);
+    fixture.componentRef.setInput('hasMore', true);
+    fixture.componentRef.setInput('servableTotal', 500);
+    await fixture.whenStable();
+    expect(fixture.nativeElement.querySelector('[data-testid="mentions-list-showing"]').textContent).toContain('1 of 500');
+
+    fixture.componentRef.setInput('countError', true);
+    await fixture.whenStable();
+
+    const showing = fixture.nativeElement.querySelector('[data-testid="mentions-list-showing"]').textContent;
+    expect(showing).toContain('Showing 1 mentions');
+    expect(showing).not.toContain('500');
   });
 
   it('swaps the empty state for all-caught-up copy in unread view', async () => {
@@ -170,5 +211,16 @@ describe('MentionsListComponent', () => {
     const allRead = fixture.nativeElement.querySelector('[data-testid="mentions-list-all-read-state"]');
     expect(allRead).not.toBeNull();
     expect(allRead.textContent).toContain('No unread mentions match the current filters.');
+  });
+
+  it('offers a one-click filter reset from the empty state', async () => {
+    setMentions([]);
+    await fixture.whenStable();
+
+    let emitted = 0;
+    fixture.componentInstance.clearFilters.subscribe(() => (emitted += 1));
+    (fixture.nativeElement.querySelector('[data-testid="mentions-list-empty-state"] button') as HTMLButtonElement).click();
+
+    expect(emitted).toBe(1);
   });
 });

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.spec.ts
@@ -194,8 +194,20 @@ describe('MentionsListComponent', () => {
     await fixture.whenStable();
 
     const showing = fixture.nativeElement.querySelector('[data-testid="mentions-list-showing"]').textContent;
-    expect(showing).toContain('Showing 1 mentions');
+    expect(showing).toContain('Showing 1 mention');
     expect(showing).not.toContain('500');
+  });
+
+  it('drops the reachable total from the running count while the count request is in flight', async () => {
+    setMentions([baseMention('m1')]);
+    fixture.componentRef.setInput('hasMore', true);
+    fixture.componentRef.setInput('servableTotal', 0);
+    fixture.componentRef.setInput('countLoading', true);
+    await fixture.whenStable();
+
+    const showing = fixture.nativeElement.querySelector('[data-testid="mentions-list-showing"]').textContent;
+    expect(showing).toContain('Showing 1 mention');
+    expect(showing).not.toContain(' of ');
   });
 
   it('swaps the empty state for all-caught-up copy in unread view', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.spec.ts
@@ -223,6 +223,12 @@ describe('MentionsListComponent', () => {
     const allRead = fixture.nativeElement.querySelector('[data-testid="mentions-list-all-read-state"]');
     expect(allRead).not.toBeNull();
     expect(allRead.textContent).toContain('No unread mentions match the current filters.');
+
+    // The unread branch carries the same one-click filter reset as the generic empty state (#1821).
+    let emitted = 0;
+    fixture.componentInstance.clearFilters.subscribe(() => (emitted += 1));
+    (allRead.querySelector('button') as HTMLButtonElement).click();
+    expect(emitted).toBe(1);
   });
 
   it('offers a one-click filter reset from the empty state', async () => {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
@@ -33,6 +33,8 @@ export class MentionsListComponent {
   public readonly hasMore = input(false);
   /** A Load More fetch is in flight — the footer spins while the loaded rows stay on screen. */
   public readonly loadingMore = input(false);
+  /** Rendered rows hit MENTION_FEED_RENDER_LIMIT with more still servable — the footer swaps the button for a refine note. */
+  public readonly renderCapped = input(false);
   /** "Data as of" watermark — the feed response's `computedAt`, converted to a Date by the page. */
   public readonly dataComputedAt = input<Date | null>(null);
   /** Shared relative-time heartbeat from the page, passed through to each card. */
@@ -51,7 +53,7 @@ export class MentionsListComponent {
   public readonly unreadView = input(false);
 
   public readonly loadMore = output<void>();
-  /** Empty-state escape hatch — the page owns the reset via clearAllFilters(). */
+  /** Empty-state escape hatch — the page owns the reset via resetToDefaultViewState() (scope + filters). */
   public readonly clearFilters = output<void>();
   /** Manual retry of a phase-2-failed window. */
   public readonly retry = output<void>();
@@ -65,6 +67,8 @@ export class MentionsListComponent {
 
   public readonly isBookmarkedFn: Signal<(id: string) => boolean> = this.initIsBookmarkedFn();
   public readonly isReadFn: Signal<(id: string) => boolean> = this.initIsReadFn();
+  /** Load More footer visibility — gated on a landed row so an early advance can't cancel the in-flight window-0 fetch. */
+  public readonly showLoadMore = computed(() => this.hasMore() && this.loadedCount() > 0 && !this.phase2Failed() && !this.loadError());
 
   /** Per-card bookmark lookup (PCC port): one computed over the input set, not a per-row method call. */
   private initIsBookmarkedFn(): Signal<(id: string) => boolean> {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
@@ -39,6 +39,8 @@ export class MentionsListComponent {
   public readonly timeTick = input(0);
   /** Current window's background fill failed past its auto-retry — the empty state swaps to a retry row. */
   public readonly phase2Failed = input(false);
+  /** A Load More window fetch failed with rows on screen — the list stays mounted and offers an inline retry. */
+  public readonly loadError = input(false);
   /** Count endpoint failed while the feed has rows — keeps the Load More footer visible so the user isn't stranded. */
   public readonly countError = input(false);
   /** Bookmarked mention IDs for the current foundation (LFXV2-3002 Block 1) — decorates each card's bookmark toggle. */

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
@@ -1,12 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { DatePipe, isPlatformBrowser } from '@angular/common';
-import { Component, computed, ElementRef, inject, input, output, PLATFORM_ID, Signal, viewChild } from '@angular/core';
+import { DatePipe } from '@angular/common';
+import { Component, computed, input, output, Signal } from '@angular/core';
 import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { TableComponent } from '@components/table/table.component';
-import { DEFAULT_MENTION_PAGE_SIZE, MENTION_PAGE_SIZE_OPTIONS } from '@lfx-one/shared/constants';
 import { SkeletonModule } from 'primeng/skeleton';
 
 import type { Mention } from '@lfx-one/shared/interfaces';
@@ -14,8 +13,8 @@ import type { Mention } from '@lfx-one/shared/interfaces';
 import { MentionCardComponent } from '../mention-card/mention-card.component';
 
 /**
- * The Social Listening feed list (LFXV2-3016): one `lfx-mention-card` per row inside a lazy
- * `lfx-table`; the page feeds the current window slice, `totalRecords` comes from the count endpoint.
+ * The Social Listening feed list (LFXV2-3016): one `lfx-mention-card` per row inside a paginator-less
+ * `lfx-table`; the page feeds the cumulative loaded rows and a Load More footer advances the feed.
  */
 @Component({
   selector: 'lfx-mentions-list',
@@ -24,23 +23,23 @@ import { MentionCardComponent } from '../mention-card/mention-card.component';
   styleUrl: './mentions-list.component.scss',
 })
 export class MentionsListComponent {
-  private readonly platformId = inject(PLATFORM_ID);
-
   public readonly mentions = input<Mention[]>([]);
   public readonly loading = input(false);
   public readonly totalMentions = input(0);
-  /** Paginator-navigable total — the page caps this at the server's deepest servable offset; `totalMentions` keeps the true count. */
-  public readonly paginatorTotalRecords = input(0);
-  public readonly first = input(0);
-  public readonly rows = input(DEFAULT_MENTION_PAGE_SIZE);
-  public readonly rowsPerPageOptions = input<number[]>(MENTION_PAGE_SIZE_OPTIONS);
+  /** Rows rendered so far — the Load More footer reports it against `servableTotal`. */
+  public readonly loadedCount = input(0);
+  /** Reachable total — the page caps this at the server's deepest servable offset; `totalMentions` keeps the true count. */
+  public readonly servableTotal = input(0);
+  public readonly hasMore = input(false);
+  /** A Load More fetch is in flight — the footer spins while the loaded rows stay on screen. */
+  public readonly loadingMore = input(false);
   /** "Data as of" watermark — the feed response's `computedAt`, converted to a Date by the page. */
   public readonly dataComputedAt = input<Date | null>(null);
   /** Shared relative-time heartbeat from the page, passed through to each card. */
   public readonly timeTick = input(0);
   /** Current window's background fill failed past its auto-retry — the empty state swaps to a retry row. */
   public readonly phase2Failed = input(false);
-  /** Count endpoint failed while the feed has rows — keeps the paginator visible so the user isn't stranded. */
+  /** Count endpoint failed while the feed has rows — keeps the Load More footer visible so the user isn't stranded. */
   public readonly countError = input(false);
   /** Bookmarked mention IDs for the current foundation (LFXV2-3002 Block 1) — decorates each card's bookmark toggle. */
   public readonly bookmarkedIds = input<Set<string>>(new Set());
@@ -49,7 +48,9 @@ export class MentionsListComponent {
   /** Unread view — selects the "all caught up" empty state variant. Totals stay visible: the server returns the exact unread count. */
   public readonly unreadView = input(false);
 
-  public readonly pageChange = output<{ page: number; rows: number }>();
+  public readonly loadMore = output<void>();
+  /** Empty-state escape hatch — the page owns the reset via clearAllFilters(). */
+  public readonly clearFilters = output<void>();
   /** Manual retry of a phase-2-failed window. */
   public readonly retry = output<void>();
   /** Re-emitted card toggle — the page owns the write via MentionBookmarkService. */
@@ -62,13 +63,6 @@ export class MentionsListComponent {
 
   public readonly isBookmarkedFn: Signal<(id: string) => boolean> = this.initIsBookmarkedFn();
   public readonly isReadFn: Signal<(id: string) => boolean> = this.initIsReadFn();
-
-  private readonly listContainer = viewChild<ElementRef<HTMLElement>>('listContainer');
-
-  protected onTablePage(event: { first: number; rows: number }): void {
-    this.pageChange.emit({ page: event.rows > 0 ? Math.floor(event.first / event.rows) : 0, rows: event.rows });
-    this.scrollListIntoView();
-  }
 
   /** Per-card bookmark lookup (PCC port): one computed over the input set, not a per-row method call. */
   private initIsBookmarkedFn(): Signal<(id: string) => boolean> {
@@ -84,16 +78,5 @@ export class MentionsListComponent {
       const ids = this.readMentionIds();
       return (id: string) => ids.has(id);
     });
-  }
-
-  // Scrolls the list, not the window — paging shouldn't yank the user past the page header.
-  private scrollListIntoView(): void {
-    if (!isPlatformBrowser(this.platformId)) {
-      return;
-    }
-
-    const container = this.listContainer()?.nativeElement;
-    const reduceMotion = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    container?.scrollIntoView({ block: 'start', behavior: reduceMotion ? 'auto' : 'smooth' });
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
@@ -45,6 +45,8 @@ export class MentionsListComponent {
   public readonly loadError = input(false);
   /** Count endpoint failed while the feed has rows — keeps the Load More footer visible so the user isn't stranded. */
   public readonly countError = input(false);
+  /** Count request still in flight — the footer label reports only the rendered rows until the total lands. */
+  public readonly countLoading = input(false);
   /** Bookmarked mention IDs for the current foundation (LFXV2-3002 Block 1) — decorates each card's bookmark toggle. */
   public readonly bookmarkedIds = input<Set<string>>(new Set());
   /** Read mention IDs for the current foundation (LFXV2-3002 Block 2) — decorates each card's read toggle. */
@@ -73,10 +75,12 @@ export class MentionsListComponent {
   public readonly showExhaustedCount = computed(
     () => !this.showLoadMore() && !this.renderCapped() && this.loadedCount() > 0 && this.servableTotal() > 0 && !this.phase2Failed() && !this.loadError()
   );
-  /** Running-count label shared by the Load More and exhausted footers — a failed count drops the total rather than inventing one. */
-  public readonly showingLabel = computed(() =>
-    this.countError() ? `Showing ${this.loadedCount()} mentions` : `Showing ${this.loadedCount()} of ${this.servableTotal()} mentions`
-  );
+  /** Running-count label shared by the Load More and exhausted footers — a failed or in-flight count drops the total rather than inventing one. */
+  public readonly showingLabel = computed(() => {
+    const count = this.loadedCount();
+    const noun = count === 1 ? 'mention' : 'mentions';
+    return this.countError() || this.countLoading() ? `Showing ${count} ${noun}` : `Showing ${count} of ${this.servableTotal()} ${noun}`;
+  });
 
   /** Per-card bookmark lookup (PCC port): one computed over the input set, not a per-row method call. */
   private initIsBookmarkedFn(): Signal<(id: string) => boolean> {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
@@ -69,9 +69,9 @@ export class MentionsListComponent {
   public readonly isReadFn: Signal<(id: string) => boolean> = this.initIsReadFn();
   /** Load More footer visibility — gated on a landed row so an early advance can't cancel the in-flight window-0 fetch. */
   public readonly showLoadMore = computed(() => this.hasMore() && this.loadedCount() > 0 && !this.phase2Failed() && !this.loadError());
-  /** Exhausted feed with rows on screen — the count persists below the feed while the advance control hides. */
+  /** Exhausted feed with rows on screen — the count persists below the feed; the servable-total gate keeps an in-flight count from flashing a bogus "of 0" total. */
   public readonly showExhaustedCount = computed(
-    () => !this.showLoadMore() && !this.renderCapped() && this.loadedCount() > 0 && !this.phase2Failed() && !this.loadError()
+    () => !this.showLoadMore() && !this.renderCapped() && this.loadedCount() > 0 && this.servableTotal() > 0 && !this.phase2Failed() && !this.loadError()
   );
   /** Running-count label shared by the Load More and exhausted footers — a failed count drops the total rather than inventing one. */
   public readonly showingLabel = computed(() =>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/components/mentions-list/mentions-list.component.ts
@@ -69,6 +69,14 @@ export class MentionsListComponent {
   public readonly isReadFn: Signal<(id: string) => boolean> = this.initIsReadFn();
   /** Load More footer visibility — gated on a landed row so an early advance can't cancel the in-flight window-0 fetch. */
   public readonly showLoadMore = computed(() => this.hasMore() && this.loadedCount() > 0 && !this.phase2Failed() && !this.loadError());
+  /** Exhausted feed with rows on screen — the count persists below the feed while the advance control hides. */
+  public readonly showExhaustedCount = computed(
+    () => !this.showLoadMore() && !this.renderCapped() && this.loadedCount() > 0 && !this.phase2Failed() && !this.loadError()
+  );
+  /** Running-count label shared by the Load More and exhausted footers — a failed count drops the total rather than inventing one. */
+  public readonly showingLabel = computed(() =>
+    this.countError() ? `Showing ${this.loadedCount()} mentions` : `Showing ${this.loadedCount()} of ${this.servableTotal()} mentions`
+  );
 
   /** Per-card bookmark lookup (PCC port): one computed over the input set, not a per-row method call. */
   private initIsBookmarkedFn(): Signal<(id: string) => boolean> {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -2,9 +2,30 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto flex w-full flex-col gap-4 px-4 sm:px-6 lg:px-8" data-testid="social-listening-page">
-  <div class="flex flex-col gap-1">
-    <h1 class="text-2xl font-semibold text-gray-900" data-testid="social-listening-title">Social Listening</h1>
-    <p class="text-sm text-gray-500" data-testid="social-listening-subtitle">Mentions and sentiment across your foundation's projects.</p>
+  <!-- z-10 keeps the pinned header above the scrolling card but below the filters panel's `relative z-20` wrapper. -->
+  <div class="social-listening-header sticky top-0 z-10 flex flex-wrap items-center justify-between gap-3" data-testid="social-listening-header">
+    <div class="flex flex-col gap-1">
+      <h1 class="text-2xl font-semibold text-gray-900" data-testid="social-listening-title">Social Listening</h1>
+      <p class="text-sm text-gray-500" data-testid="social-listening-subtitle">Brand mentions and sentiment across social, forums, and podcasts.</p>
+    </div>
+
+    <div
+      class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 p-1"
+      role="group"
+      aria-label="Social listening view"
+      data-testid="social-listening-tabs">
+      @for (tab of tabOptions; track tab.id) {
+        <button
+          type="button"
+          class="cursor-pointer rounded-full border-0 px-4 py-1.5 text-xs font-medium transition-colors"
+          [class]="activeTab() === tab.id ? 'bg-white text-gray-900 shadow-sm' : 'bg-transparent text-gray-500 hover:text-gray-700'"
+          [attr.aria-pressed]="activeTab() === tab.id"
+          [attr.data-testid]="'social-listening-tab-' + tab.id"
+          (click)="onTabSelected(tab.id)">
+          {{ tab.label }}
+        </button>
+      }
+    </div>
   </div>
 
   @if (!hasFoundation()) {
@@ -15,10 +36,10 @@
       data-testid="social-listening-no-foundation" />
   } @else {
     <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="social-listening-card">
-      <!-- Positioning context for the filters panel dropdown (ports PCC's relative wrapper) -->
-      <div class="relative z-20">
+      <!-- Positioning context for the filters panel dropdown, and the filter row's own sticky anchor beneath the page header -->
+      <div class="social-listening-filter-row z-20 bg-white">
         <lfx-feed-header
-          [(activeTab)]="activeTab"
+          [activeTab]="activeTab()"
           [(selectedPeriod)]="selectedPeriod"
           [(selectedProject)]="selectedProject"
           [(selectedPlatform)]="selectedPlatform"
@@ -168,15 +189,16 @@
               (markAllRead)="onMarkAllAsRead()"
               (markAllUnread)="onMarkAllAsUnread()"
               [totalMentions]="totalRecords()"
-              [paginatorTotalRecords]="paginatorTotalRecords()"
-              [first]="first()"
-              [rows]="pageSize()"
-              [rowsPerPageOptions]="rowsPerPageOptions"
+              [loadedCount]="loadedCount()"
+              [servableTotal]="servableTotal()"
+              [hasMore]="hasMore()"
+              [loadingMore]="loadingMore()"
               [dataComputedAt]="dataComputedAt()"
               [timeTick]="timeTick()"
               [phase2Failed]="phase2Failed()"
               [countError]="countError() !== null"
-              (pageChange)="onPageChange($event)"
+              (loadMore)="onLoadMore()"
+              (clearFilters)="clearAllFilters()"
               (retry)="retryWindow()" />
           }
 
@@ -193,7 +215,8 @@
             [filters]="analyticsFilters()"
             [exportNonce]="exportNonce()"
             [(isExporting)]="exporting"
-            [(panelsLoading)]="analyticsPanelsLoading" />
+            [(panelsLoading)]="analyticsPanelsLoading"
+            (platformSelected)="onAnalyticsPlatformSelected($event)" />
         }
       </div>
     </lfx-card>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -2,30 +2,109 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto flex w-full flex-col gap-4 px-4 sm:px-6 lg:px-8" data-testid="social-listening-page">
-  <!-- z-20 lifts the pinned header above the mention cards' stretched-link content (z-10); the filter row's later DOM order wins the z-20 tie. -->
-  <div class="social-listening-header sticky top-0 z-20 flex flex-wrap items-center justify-between gap-3" data-testid="social-listening-header">
-    <div class="flex flex-col gap-1">
-      <h1 class="text-2xl font-semibold text-gray-900" data-testid="social-listening-title">Social Listening</h1>
-      <p class="text-sm text-gray-500" data-testid="social-listening-subtitle">Brand mentions and sentiment across social, forums, and podcasts.</p>
+  <!-- One sticky stack for both pinned rows: separate stickies need a fixed offset that breaks when the header wraps on narrow screens. z-20 lifts the stack above the cards' stretched-link content (z-10). -->
+  <div class="sticky top-0 z-20 flex flex-col">
+    <div class="social-listening-header flex flex-wrap items-center justify-between gap-3" data-testid="social-listening-header">
+      <div class="flex flex-col gap-1">
+        <h1 class="text-2xl font-semibold text-gray-900" data-testid="social-listening-title">Social Listening</h1>
+        <p class="text-sm text-gray-500" data-testid="social-listening-subtitle">Brand mentions and sentiment across social, forums, and podcasts.</p>
+      </div>
+
+      <div
+        class="inline-flex items-center gap-1 rounded-full bg-gray-100 p-1"
+        role="group"
+        aria-label="Social listening view"
+        data-testid="social-listening-tabs">
+        @for (tab of tabOptions; track tab.id) {
+          <button
+            type="button"
+            class="cursor-pointer rounded-full border-0 px-4 py-1.5 text-xs font-medium transition-colors"
+            [class]="activeTab() === tab.id ? 'bg-white text-gray-900 shadow-sm' : 'bg-transparent text-gray-500 hover:text-gray-700'"
+            [attr.aria-pressed]="activeTab() === tab.id"
+            [attr.data-testid]="'social-listening-tab-' + tab.id"
+            (click)="onTabSelected(tab.id)">
+            {{ tab.label }}
+          </button>
+        }
+      </div>
     </div>
 
-    <div
-      class="inline-flex items-center gap-1 rounded-full bg-gray-100 p-1"
-      role="group"
-      aria-label="Social listening view"
-      data-testid="social-listening-tabs">
-      @for (tab of tabOptions; track tab.id) {
-        <button
-          type="button"
-          class="cursor-pointer rounded-full border-0 px-4 py-1.5 text-xs font-medium transition-colors"
-          [class]="activeTab() === tab.id ? 'bg-white text-gray-900 shadow-sm' : 'bg-transparent text-gray-500 hover:text-gray-700'"
-          [attr.aria-pressed]="activeTab() === tab.id"
-          [attr.data-testid]="'social-listening-tab-' + tab.id"
-          (click)="onTabSelected(tab.id)">
-          {{ tab.label }}
-        </button>
-      }
-    </div>
+    @if (hasFoundation()) {
+      <!-- Positioning context for the filters panel dropdown -->
+      <div class="social-listening-filter-row">
+        <lfx-feed-header
+          [activeTab]="activeTab()"
+          [(selectedPeriod)]="selectedPeriod"
+          [(selectedProject)]="selectedProject"
+          [(selectedPlatform)]="selectedPlatform"
+          [(searchInput)]="searchInput"
+          [(filtersVisible)]="filtersOpen"
+          [(viewsVisible)]="viewsOpen"
+          [activeViewName]="activeViewName()"
+          [activeFilterCount]="activeFilterCount()"
+          [projectOptions]="subProjectOptions()"
+          [platformOptions]="platformOptions()"
+          [optionsLoading]="optionsLoading()"
+          [exporting]="exporting()"
+          [exportDisabled]="analyticsPanelsLoading()"
+          (filtersPrefetch)="prefetchFilterOptions()"
+          (exportAnalytics)="onExportAnalytics()">
+          <!-- Views dropdown (feed tab only) — backdrop closes; the panel's own Escape/rows handle keyboard -->
+          @if (viewsOpen() && activeTab() === 'feed') {
+            <ng-container data-views-dropdown>
+              <div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-views-backdrop" (click)="viewsOpen.set(false)"></div>
+              <lfx-views-dropdown
+                class="absolute right-0 top-full z-20 mt-1 max-sm:right-auto max-sm:left-0"
+                [savedViews]="savedFilters()"
+                [activeViewId]="activeViewId()"
+                [canSaveCurrentView]="canSaveCurrentView()"
+                [atSavedViewLimit]="atSavedViewLimit()"
+                [savedViewLimit]="savedViewLimit"
+                [readOnly]="savedViewsReadOnly()"
+                [isLoading]="savedFiltersLoading()"
+                [deletingViewIds]="deletingViewIds()"
+                (viewSelected)="onViewSelected($event)"
+                (defaultViewSelected)="onDefaultViewSelected()"
+                (viewDeleted)="onSavedViewDeleted($event.id)"
+                (saveCurrentViewRequested)="openSaveDialog()"
+                (close)="viewsOpen.set(false)" />
+            </ng-container>
+          }
+        </lfx-feed-header>
+
+        @if (filtersOpen() && activeTab() === 'feed') {
+          <lfx-filters-panel
+            [(visible)]="filtersOpen"
+            [(selectedSentiment)]="selectedSentiment"
+            [(selectedRelevance)]="selectedRelevance"
+            [(selectedLanguage)]="selectedLanguage"
+            [(selectedHasTitle)]="selectedHasTitle"
+            [(selectedBookmarkFilter)]="selectedBookmarkFilter"
+            [(selectedReadFilter)]="selectedReadFilter"
+            [(selectedKeywords)]="selectedKeywords"
+            [(selectedTags)]="selectedTags"
+            [(selectedAuthors)]="selectedAuthors"
+            [languageOptions]="languageOptions()"
+            [languagesLoading]="languagesLoading()"
+            [languagesError]="languagesError()"
+            [availableKeywords]="availableKeywords()"
+            [keywordsLoading]="keywordsLoading()"
+            [keywordsError]="keywordsError()"
+            [availableTags]="availableTags()"
+            [tagsLoading]="tagsLoading()"
+            [tagsError]="tagsError()"
+            [availableAuthors]="availableAuthors()"
+            [authorsLoading]="authorsLoading()"
+            [authorsError]="authorsError()"
+            [activeFilterCount]="activeFilterCount()"
+            [canSaveCurrentView]="canSaveCurrentView()"
+            [atSavedViewLimit]="atSavedViewLimit()"
+            [savedViewLimit]="savedViewLimit"
+            (filtersCleared)="clearAllFilters()"
+            (saveViewRequested)="openSaveDialog()" />
+        }
+      </div>
+    }
   </div>
 
   @if (!hasFoundation()) {
@@ -35,81 +114,6 @@
       subtitle="Choose a foundation from the sidebar context picker to see its social listening feed."
       data-testid="social-listening-no-foundation" />
   } @else {
-    <!-- Positioning context for the filters panel dropdown, and the filter row's own sticky anchor beneath the page header -->
-    <div class="social-listening-filter-row z-20">
-      <lfx-feed-header
-        [activeTab]="activeTab()"
-        [(selectedPeriod)]="selectedPeriod"
-        [(selectedProject)]="selectedProject"
-        [(selectedPlatform)]="selectedPlatform"
-        [(searchInput)]="searchInput"
-        [(filtersVisible)]="filtersOpen"
-        [(viewsVisible)]="viewsOpen"
-        [activeViewName]="activeViewName()"
-        [activeFilterCount]="activeFilterCount()"
-        [projectOptions]="subProjectOptions()"
-        [platformOptions]="platformOptions()"
-        [optionsLoading]="optionsLoading()"
-        [exporting]="exporting()"
-        [exportDisabled]="analyticsPanelsLoading()"
-        (filtersPrefetch)="prefetchFilterOptions()"
-        (exportAnalytics)="onExportAnalytics()">
-        <!-- Views dropdown (feed tab only) — backdrop closes; the panel's own Escape/rows handle keyboard -->
-        @if (viewsOpen() && activeTab() === 'feed') {
-          <ng-container data-views-dropdown>
-            <div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-views-backdrop" (click)="viewsOpen.set(false)"></div>
-            <lfx-views-dropdown
-              class="absolute right-0 top-full z-20 mt-1 max-sm:right-auto max-sm:left-0"
-              [savedViews]="savedFilters()"
-              [activeViewId]="activeViewId()"
-              [canSaveCurrentView]="canSaveCurrentView()"
-              [atSavedViewLimit]="atSavedViewLimit()"
-              [savedViewLimit]="savedViewLimit"
-              [readOnly]="savedViewsReadOnly()"
-              [isLoading]="savedFiltersLoading()"
-              [deletingViewIds]="deletingViewIds()"
-              (viewSelected)="onViewSelected($event)"
-              (defaultViewSelected)="onDefaultViewSelected()"
-              (viewDeleted)="onSavedViewDeleted($event.id)"
-              (saveCurrentViewRequested)="openSaveDialog()"
-              (close)="viewsOpen.set(false)" />
-          </ng-container>
-        }
-      </lfx-feed-header>
-
-      @if (filtersOpen() && activeTab() === 'feed') {
-        <lfx-filters-panel
-          [(visible)]="filtersOpen"
-          [(selectedSentiment)]="selectedSentiment"
-          [(selectedRelevance)]="selectedRelevance"
-          [(selectedLanguage)]="selectedLanguage"
-          [(selectedHasTitle)]="selectedHasTitle"
-          [(selectedBookmarkFilter)]="selectedBookmarkFilter"
-          [(selectedReadFilter)]="selectedReadFilter"
-          [(selectedKeywords)]="selectedKeywords"
-          [(selectedTags)]="selectedTags"
-          [(selectedAuthors)]="selectedAuthors"
-          [languageOptions]="languageOptions()"
-          [languagesLoading]="languagesLoading()"
-          [languagesError]="languagesError()"
-          [availableKeywords]="availableKeywords()"
-          [keywordsLoading]="keywordsLoading()"
-          [keywordsError]="keywordsError()"
-          [availableTags]="availableTags()"
-          [tagsLoading]="tagsLoading()"
-          [tagsError]="tagsError()"
-          [availableAuthors]="availableAuthors()"
-          [authorsLoading]="authorsLoading()"
-          [authorsError]="authorsError()"
-          [activeFilterCount]="activeFilterCount()"
-          [canSaveCurrentView]="canSaveCurrentView()"
-          [atSavedViewLimit]="atSavedViewLimit()"
-          [savedViewLimit]="savedViewLimit"
-          (filtersCleared)="clearAllFilters()"
-          (saveViewRequested)="openSaveDialog()" />
-      }
-    </div>
-
     <div class="flex flex-col gap-4">
       <!-- Active-filter summary on BOTH tabs: analytics applies the feed predicate too (M1), so the pills are the only on-tab indication. Click a pill to remove that filter -->
       @if (activeFilterPills().length) {
@@ -155,8 +159,11 @@
           </div>
         }
 
-        @if (error(); as errorMessage) {
-          <lfx-message severity="error" [text]="errorMessage" data-testid="social-listening-error" />
+        <!-- A failure past the initial load keeps the loaded feed mounted — the list renders an inline retry instead -->
+        @if (loadedCount() === 0) {
+          @if (error(); as errorMessage) {
+            <lfx-message severity="error" [text]="errorMessage" data-testid="social-listening-error" />
+          }
         }
 
         @if (countError(); as countErrorMessage) {
@@ -177,8 +184,8 @@
             data-testid="social-listening-bookmark-state-error" />
         }
 
-        <!-- The list (and its empty state) stays hidden behind an error banner so the two never contradict -->
-        @if (!error() && !readStateError() && !bookmarkStateError()) {
+        <!-- The list stays hidden behind a blocking error/state banner so the two never contradict; a Load More failure is non-blocking (rows stay mounted) -->
+        @if ((!error() || loadedCount() > 0) && !readStateError() && !bookmarkStateError()) {
           <lfx-mentions-list
             [mentions]="mentions()"
             [loading]="loading()"
@@ -197,6 +204,7 @@
             [dataComputedAt]="dataComputedAt()"
             [timeTick]="timeTick()"
             [phase2Failed]="phase2Failed()"
+            [loadError]="!!error() && loadedCount() > 0"
             [countError]="countError() !== null"
             (loadMore)="onLoadMore()"
             (clearFilters)="clearAllFilters()"

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -10,23 +10,26 @@
         <p class="text-sm text-gray-500" data-testid="social-listening-subtitle">Brand mentions and sentiment across social, forums, and podcasts.</p>
       </div>
 
-      <div
-        class="inline-flex items-center gap-1 rounded-full bg-gray-100 p-1"
-        role="group"
-        aria-label="Social listening view"
-        data-testid="social-listening-tabs">
-        @for (tab of tabOptions; track tab.id) {
-          <button
-            type="button"
-            class="cursor-pointer rounded-full border-0 px-4 py-1.5 text-xs font-medium transition-colors"
-            [class]="activeTab() === tab.id ? 'bg-white text-gray-900 shadow-sm' : 'bg-transparent text-gray-500 hover:text-gray-700'"
-            [attr.aria-pressed]="activeTab() === tab.id"
-            [attr.data-testid]="'social-listening-tab-' + tab.id"
-            (click)="onTabSelected(tab.id)">
-            {{ tab.label }}
-          </button>
-        }
-      </div>
+      <!-- Tabs are meaningless without a foundation — the body renders the empty state either way -->
+      @if (hasFoundation()) {
+        <div
+          class="inline-flex items-center gap-1 rounded-full bg-gray-100 p-1"
+          role="group"
+          aria-label="Social listening view"
+          data-testid="social-listening-tabs">
+          @for (tab of tabOptions; track tab.id) {
+            <button
+              type="button"
+              class="cursor-pointer rounded-full border-0 px-4 py-1.5 text-xs font-medium transition-colors"
+              [class]="activeTab() === tab.id ? 'bg-white text-gray-900 shadow-sm' : 'bg-transparent text-gray-500 hover:text-gray-700'"
+              [attr.aria-pressed]="activeTab() === tab.id"
+              [attr.data-testid]="'social-listening-tab-' + tab.id"
+              (click)="onTabSelected(tab.id)">
+              {{ tab.label }}
+            </button>
+          }
+        </div>
+      }
     </div>
 
     @if (hasFoundation()) {
@@ -207,6 +210,7 @@
             [phase2Failed]="phase2Failed()"
             [loadError]="!!error() && loadedCount() > 0"
             [countError]="countError() !== null"
+            [countLoading]="countLoading()"
             (loadMore)="onLoadMore()"
             (clearFilters)="resetToDefaultViewState()"
             (retry)="retryWindow()" />

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -2,15 +2,15 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 <div class="container mx-auto flex w-full flex-col gap-4 px-4 sm:px-6 lg:px-8" data-testid="social-listening-page">
-  <!-- z-10 keeps the pinned header above the scrolling card but below the filters panel's `relative z-20` wrapper. -->
-  <div class="social-listening-header sticky top-0 z-10 flex flex-wrap items-center justify-between gap-3" data-testid="social-listening-header">
+  <!-- z-20 lifts the pinned header above the mention cards' stretched-link content (z-10); the filter row's later DOM order wins the z-20 tie. -->
+  <div class="social-listening-header sticky top-0 z-20 flex flex-wrap items-center justify-between gap-3" data-testid="social-listening-header">
     <div class="flex flex-col gap-1">
       <h1 class="text-2xl font-semibold text-gray-900" data-testid="social-listening-title">Social Listening</h1>
       <p class="text-sm text-gray-500" data-testid="social-listening-subtitle">Brand mentions and sentiment across social, forums, and podcasts.</p>
     </div>
 
     <div
-      class="inline-flex items-center gap-1 rounded-full border border-gray-200 bg-gray-50 p-1"
+      class="inline-flex items-center gap-1 rounded-full bg-gray-100 p-1"
       role="group"
       aria-label="Social listening view"
       data-testid="social-listening-tabs">
@@ -35,190 +35,188 @@
       subtitle="Choose a foundation from the sidebar context picker to see its social listening feed."
       data-testid="social-listening-no-foundation" />
   } @else {
-    <lfx-card styleClass="[&_.p-card-body]:p-0 [&_.p-card-content]:p-0" data-testid="social-listening-card">
-      <!-- Positioning context for the filters panel dropdown, and the filter row's own sticky anchor beneath the page header -->
-      <div class="social-listening-filter-row z-20 bg-white">
-        <lfx-feed-header
-          [activeTab]="activeTab()"
-          [(selectedPeriod)]="selectedPeriod"
-          [(selectedProject)]="selectedProject"
-          [(selectedPlatform)]="selectedPlatform"
-          [(searchInput)]="searchInput"
-          [(filtersVisible)]="filtersOpen"
-          [(viewsVisible)]="viewsOpen"
-          [activeViewName]="activeViewName()"
+    <!-- Positioning context for the filters panel dropdown, and the filter row's own sticky anchor beneath the page header -->
+    <div class="social-listening-filter-row z-20">
+      <lfx-feed-header
+        [activeTab]="activeTab()"
+        [(selectedPeriod)]="selectedPeriod"
+        [(selectedProject)]="selectedProject"
+        [(selectedPlatform)]="selectedPlatform"
+        [(searchInput)]="searchInput"
+        [(filtersVisible)]="filtersOpen"
+        [(viewsVisible)]="viewsOpen"
+        [activeViewName]="activeViewName()"
+        [activeFilterCount]="activeFilterCount()"
+        [projectOptions]="subProjectOptions()"
+        [platformOptions]="platformOptions()"
+        [optionsLoading]="optionsLoading()"
+        [exporting]="exporting()"
+        [exportDisabled]="analyticsPanelsLoading()"
+        (filtersPrefetch)="prefetchFilterOptions()"
+        (exportAnalytics)="onExportAnalytics()" />
+
+      @if (filtersOpen() && activeTab() === 'feed') {
+        <lfx-filters-panel
+          [(visible)]="filtersOpen"
+          [(selectedSentiment)]="selectedSentiment"
+          [(selectedRelevance)]="selectedRelevance"
+          [(selectedLanguage)]="selectedLanguage"
+          [(selectedHasTitle)]="selectedHasTitle"
+          [(selectedBookmarkFilter)]="selectedBookmarkFilter"
+          [(selectedReadFilter)]="selectedReadFilter"
+          [(selectedKeywords)]="selectedKeywords"
+          [(selectedTags)]="selectedTags"
+          [(selectedAuthors)]="selectedAuthors"
+          [languageOptions]="languageOptions()"
+          [languagesLoading]="languagesLoading()"
+          [languagesError]="languagesError()"
+          [availableKeywords]="availableKeywords()"
+          [keywordsLoading]="keywordsLoading()"
+          [keywordsError]="keywordsError()"
+          [availableTags]="availableTags()"
+          [tagsLoading]="tagsLoading()"
+          [tagsError]="tagsError()"
+          [availableAuthors]="availableAuthors()"
+          [authorsLoading]="authorsLoading()"
+          [authorsError]="authorsError()"
           [activeFilterCount]="activeFilterCount()"
-          [projectOptions]="subProjectOptions()"
-          [platformOptions]="platformOptions()"
-          [optionsLoading]="optionsLoading()"
-          [exporting]="exporting()"
-          [exportDisabled]="analyticsPanelsLoading()"
-          (filtersPrefetch)="prefetchFilterOptions()"
-          (exportAnalytics)="onExportAnalytics()" />
+          [canSaveCurrentView]="canSaveCurrentView()"
+          [atSavedViewLimit]="atSavedViewLimit()"
+          [savedViewLimit]="savedViewLimit"
+          (filtersCleared)="clearAllFilters()"
+          (saveViewRequested)="openSaveDialog()" />
+      }
 
-        @if (filtersOpen() && activeTab() === 'feed') {
-          <lfx-filters-panel
-            [(visible)]="filtersOpen"
-            [(selectedSentiment)]="selectedSentiment"
-            [(selectedRelevance)]="selectedRelevance"
-            [(selectedLanguage)]="selectedLanguage"
-            [(selectedHasTitle)]="selectedHasTitle"
-            [(selectedBookmarkFilter)]="selectedBookmarkFilter"
-            [(selectedReadFilter)]="selectedReadFilter"
-            [(selectedKeywords)]="selectedKeywords"
-            [(selectedTags)]="selectedTags"
-            [(selectedAuthors)]="selectedAuthors"
-            [languageOptions]="languageOptions()"
-            [languagesLoading]="languagesLoading()"
-            [languagesError]="languagesError()"
-            [availableKeywords]="availableKeywords()"
-            [keywordsLoading]="keywordsLoading()"
-            [keywordsError]="keywordsError()"
-            [availableTags]="availableTags()"
-            [tagsLoading]="tagsLoading()"
-            [tagsError]="tagsError()"
-            [availableAuthors]="availableAuthors()"
-            [authorsLoading]="authorsLoading()"
-            [authorsError]="authorsError()"
-            [activeFilterCount]="activeFilterCount()"
-            [canSaveCurrentView]="canSaveCurrentView()"
-            [atSavedViewLimit]="atSavedViewLimit()"
-            [savedViewLimit]="savedViewLimit"
-            (filtersCleared)="clearAllFilters()"
-            (saveViewRequested)="openSaveDialog()" />
-        }
+      <!-- Views dropdown (feed tab only) — backdrop closes; the panel's own Escape/rows handle keyboard -->
+      @if (viewsOpen() && activeTab() === 'feed') {
+        <div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-views-backdrop" (click)="viewsOpen.set(false)"></div>
+        <lfx-views-dropdown
+          class="absolute right-0 top-full z-20 mt-1"
+          [savedViews]="savedFilters()"
+          [activeViewId]="activeViewId()"
+          [canSaveCurrentView]="canSaveCurrentView()"
+          [atSavedViewLimit]="atSavedViewLimit()"
+          [savedViewLimit]="savedViewLimit"
+          [readOnly]="savedViewsReadOnly()"
+          [isLoading]="savedFiltersLoading()"
+          [deletingViewIds]="deletingViewIds()"
+          (viewSelected)="onViewSelected($event)"
+          (defaultViewSelected)="onDefaultViewSelected()"
+          (viewDeleted)="onSavedViewDeleted($event.id)"
+          (saveCurrentViewRequested)="openSaveDialog()"
+          (close)="viewsOpen.set(false)" />
+      }
+    </div>
 
-        <!-- Views dropdown (feed tab only) — backdrop closes; the panel's own Escape/rows handle keyboard -->
-        @if (viewsOpen() && activeTab() === 'feed') {
-          <div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-views-backdrop" (click)="viewsOpen.set(false)"></div>
-          <lfx-views-dropdown
-            class="absolute right-0 top-full z-20 mt-1"
-            [savedViews]="savedFilters()"
-            [activeViewId]="activeViewId()"
-            [canSaveCurrentView]="canSaveCurrentView()"
-            [atSavedViewLimit]="atSavedViewLimit()"
-            [savedViewLimit]="savedViewLimit"
-            [readOnly]="savedViewsReadOnly()"
-            [isLoading]="savedFiltersLoading()"
-            [deletingViewIds]="deletingViewIds()"
-            (viewSelected)="onViewSelected($event)"
-            (defaultViewSelected)="onDefaultViewSelected()"
-            (viewDeleted)="onSavedViewDeleted($event.id)"
-            (saveCurrentViewRequested)="openSaveDialog()"
-            (close)="viewsOpen.set(false)" />
-        }
-      </div>
+    <div class="flex flex-col gap-4">
+      <!-- Active-filter summary on BOTH tabs: analytics applies the feed predicate too (M1), so the pills are the only on-tab indication. Click a pill to remove that filter -->
+      @if (activeFilterPills().length > 0) {
+        <div class="flex flex-wrap items-center gap-2" aria-label="Active filters" data-testid="social-listening-filter-pills">
+          <lfx-filter-pills [options]="activeFilterPills()" selectedFilter="" (filterChange)="removeFilterPill($event)" />
+          <button
+            type="button"
+            class="cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
+            data-testid="social-listening-filter-pills-clear-all"
+            (click)="clearAllFilters()">
+            Clear all
+          </button>
+        </div>
+      }
 
-      <div class="flex flex-col gap-4 px-5 py-5">
-        <!-- Active-filter summary on BOTH tabs: analytics applies the feed predicate too (M1), so the pills are the only on-tab indication. Click a pill to remove that filter -->
-        @if (activeFilterPills().length > 0) {
-          <div class="flex flex-wrap items-center gap-2" aria-label="Active filters" data-testid="social-listening-filter-pills">
-            <lfx-filter-pills [options]="activeFilterPills()" selectedFilter="" (filterChange)="removeFilterPill($event)" />
+      @if (activeTab() === 'feed') {
+        <p-confirmDialog data-testid="social-listening-confirm-dialog" />
+
+        @if (foreignViewBannerVisible()) {
+          <div
+            class="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800"
+            data-testid="social-listening-foreign-view-banner">
+            <i class="fa-light fa-circle-info flex-shrink-0 text-blue-500"></i>
+            <span class="flex-1">These filters were shared as a preset view — they were saved by the person who shared this link.</span>
+            @if (canSaveCurrentView() && !atSavedViewLimit()) {
+              <button
+                type="button"
+                class="whitespace-nowrap font-medium text-blue-600 underline"
+                data-testid="social-listening-foreign-view-save"
+                (click)="onSaveFromForeignBanner()">
+                Save as my view
+              </button>
+            }
             <button
               type="button"
-              class="cursor-pointer border-0 bg-transparent p-0 text-xs font-medium text-blue-600 hover:text-blue-700 hover:underline"
-              data-testid="social-listening-filter-pills-clear-all"
-              (click)="clearAllFilters()">
-              Clear all
+              class="ml-1 flex-shrink-0 text-blue-400 hover:text-blue-600"
+              title="Dismiss"
+              aria-label="Dismiss"
+              data-testid="social-listening-foreign-view-dismiss"
+              (click)="dismissForeignViewBanner()">
+              <i class="fa-light fa-xmark"></i>
             </button>
           </div>
         }
 
-        @if (activeTab() === 'feed') {
-          <p-confirmDialog data-testid="social-listening-confirm-dialog" />
-
-          @if (foreignViewBannerVisible()) {
-            <div
-              class="flex items-center gap-3 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800"
-              data-testid="social-listening-foreign-view-banner">
-              <i class="fa-light fa-circle-info flex-shrink-0 text-blue-500"></i>
-              <span class="flex-1">These filters were shared as a preset view — they were saved by the person who shared this link.</span>
-              @if (canSaveCurrentView() && !atSavedViewLimit()) {
-                <button
-                  type="button"
-                  class="whitespace-nowrap font-medium text-blue-600 underline"
-                  data-testid="social-listening-foreign-view-save"
-                  (click)="onSaveFromForeignBanner()">
-                  Save as my view
-                </button>
-              }
-              <button
-                type="button"
-                class="ml-1 flex-shrink-0 text-blue-400 hover:text-blue-600"
-                title="Dismiss"
-                aria-label="Dismiss"
-                data-testid="social-listening-foreign-view-dismiss"
-                (click)="dismissForeignViewBanner()">
-                <i class="fa-light fa-xmark"></i>
-              </button>
-            </div>
-          }
-
-          @if (error(); as errorMessage) {
-            <lfx-message severity="error" [text]="errorMessage" data-testid="social-listening-error" />
-          }
-
-          @if (countError(); as countErrorMessage) {
-            <lfx-message severity="error" [text]="countErrorMessage" data-testid="social-listening-count-error" />
-          }
-
-          @if (readStateError()) {
-            <lfx-message
-              severity="error"
-              text="Your read state could not be loaded, so the unread view is unavailable. Refresh the page and try again."
-              data-testid="social-listening-read-state-error" />
-          }
-
-          @if (bookmarkStateError()) {
-            <lfx-message
-              severity="error"
-              text="Your bookmarks could not be loaded, so the bookmarked view is unavailable. Refresh the page and try again."
-              data-testid="social-listening-bookmark-state-error" />
-          }
-
-          <!-- The list (and its empty state) stays hidden behind an error banner so the two never contradict -->
-          @if (!error() && !readStateError() && !bookmarkStateError()) {
-            <lfx-mentions-list
-              [mentions]="mentions()"
-              [loading]="loading()"
-              [bookmarkedIds]="bookmarkedIds()"
-              [readMentionIds]="readMentionIds()"
-              [unreadView]="selectedReadFilter() === 'unread'"
-              (bookmarkToggled)="onBookmarkToggled($event)"
-              (readToggled)="onReadToggled($event)"
-              (markAllRead)="onMarkAllAsRead()"
-              (markAllUnread)="onMarkAllAsUnread()"
-              [totalMentions]="totalRecords()"
-              [loadedCount]="loadedCount()"
-              [servableTotal]="servableTotal()"
-              [hasMore]="hasMore()"
-              [loadingMore]="loadingMore()"
-              [dataComputedAt]="dataComputedAt()"
-              [timeTick]="timeTick()"
-              [phase2Failed]="phase2Failed()"
-              [countError]="countError() !== null"
-              (loadMore)="onLoadMore()"
-              (clearFilters)="clearAllFilters()"
-              (retry)="retryWindow()" />
-          }
-
-          <!-- Octolens data attribution (legal requirement — ported verbatim from PCC) -->
-          <p class="text-center text-xs text-gray-400" data-testid="social-listening-attribution">
-            The social listening data displayed here is provided by Octolens and consists exclusively of publicly available content sourced from third-party
-            platforms across the web. The Linux Foundation does not independently collect, enrich, or modify this data.
-          </p>
-        } @else {
-          <lfx-social-listening-analytics
-            [foundationSlug]="foundationSlug()"
-            [period]="selectedPeriod()"
-            [platform]="selectedPlatform()"
-            [filters]="analyticsFilters()"
-            [exportNonce]="exportNonce()"
-            [(isExporting)]="exporting"
-            [(panelsLoading)]="analyticsPanelsLoading"
-            (platformSelected)="onAnalyticsPlatformSelected($event)" />
+        @if (error(); as errorMessage) {
+          <lfx-message severity="error" [text]="errorMessage" data-testid="social-listening-error" />
         }
-      </div>
-    </lfx-card>
+
+        @if (countError(); as countErrorMessage) {
+          <lfx-message severity="error" [text]="countErrorMessage" data-testid="social-listening-count-error" />
+        }
+
+        @if (readStateError()) {
+          <lfx-message
+            severity="error"
+            text="Your read state could not be loaded, so the unread view is unavailable. Refresh the page and try again."
+            data-testid="social-listening-read-state-error" />
+        }
+
+        @if (bookmarkStateError()) {
+          <lfx-message
+            severity="error"
+            text="Your bookmarks could not be loaded, so the bookmarked view is unavailable. Refresh the page and try again."
+            data-testid="social-listening-bookmark-state-error" />
+        }
+
+        <!-- The list (and its empty state) stays hidden behind an error banner so the two never contradict -->
+        @if (!error() && !readStateError() && !bookmarkStateError()) {
+          <lfx-mentions-list
+            [mentions]="mentions()"
+            [loading]="loading()"
+            [bookmarkedIds]="bookmarkedIds()"
+            [readMentionIds]="readMentionIds()"
+            [unreadView]="selectedReadFilter() === 'unread'"
+            (bookmarkToggled)="onBookmarkToggled($event)"
+            (readToggled)="onReadToggled($event)"
+            (markAllRead)="onMarkAllAsRead()"
+            (markAllUnread)="onMarkAllAsUnread()"
+            [totalMentions]="totalRecords()"
+            [loadedCount]="loadedCount()"
+            [servableTotal]="servableTotal()"
+            [hasMore]="hasMore()"
+            [loadingMore]="loadingMore()"
+            [dataComputedAt]="dataComputedAt()"
+            [timeTick]="timeTick()"
+            [phase2Failed]="phase2Failed()"
+            [countError]="countError() !== null"
+            (loadMore)="onLoadMore()"
+            (clearFilters)="clearAllFilters()"
+            (retry)="retryWindow()" />
+        }
+
+        <!-- Octolens data attribution (legal requirement — ported verbatim from PCC) -->
+        <p class="text-center text-xs text-gray-400" data-testid="social-listening-attribution">
+          The social listening data displayed here is provided by Octolens and consists exclusively of publicly available content sourced from third-party
+          platforms across the web. The Linux Foundation does not independently collect, enrich, or modify this data.
+        </p>
+      } @else {
+        <lfx-social-listening-analytics
+          [foundationSlug]="foundationSlug()"
+          [period]="selectedPeriod()"
+          [platform]="selectedPlatform()"
+          [filters]="analyticsFilters()"
+          [exportNonce]="exportNonce()"
+          [(isExporting)]="exporting"
+          [(panelsLoading)]="analyticsPanelsLoading"
+          (platformSelected)="onAnalyticsPlatformSelected($event)" />
+      }
+    </div>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -53,7 +53,29 @@
         [exporting]="exporting()"
         [exportDisabled]="analyticsPanelsLoading()"
         (filtersPrefetch)="prefetchFilterOptions()"
-        (exportAnalytics)="onExportAnalytics()" />
+        (exportAnalytics)="onExportAnalytics()">
+        <!-- Views dropdown (feed tab only) — backdrop closes; the panel's own Escape/rows handle keyboard -->
+        @if (viewsOpen() && activeTab() === 'feed') {
+          <ng-container data-views-dropdown>
+            <div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-views-backdrop" (click)="viewsOpen.set(false)"></div>
+            <lfx-views-dropdown
+              class="absolute right-0 top-full z-20 mt-1"
+              [savedViews]="savedFilters()"
+              [activeViewId]="activeViewId()"
+              [canSaveCurrentView]="canSaveCurrentView()"
+              [atSavedViewLimit]="atSavedViewLimit()"
+              [savedViewLimit]="savedViewLimit"
+              [readOnly]="savedViewsReadOnly()"
+              [isLoading]="savedFiltersLoading()"
+              [deletingViewIds]="deletingViewIds()"
+              (viewSelected)="onViewSelected($event)"
+              (defaultViewSelected)="onDefaultViewSelected()"
+              (viewDeleted)="onSavedViewDeleted($event.id)"
+              (saveCurrentViewRequested)="openSaveDialog()"
+              (close)="viewsOpen.set(false)" />
+          </ng-container>
+        }
+      </lfx-feed-header>
 
       @if (filtersOpen() && activeTab() === 'feed') {
         <lfx-filters-panel
@@ -86,26 +108,6 @@
           (filtersCleared)="clearAllFilters()"
           (saveViewRequested)="openSaveDialog()" />
       }
-
-      <!-- Views dropdown (feed tab only) — backdrop closes; the panel's own Escape/rows handle keyboard -->
-      @if (viewsOpen() && activeTab() === 'feed') {
-        <div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-views-backdrop" (click)="viewsOpen.set(false)"></div>
-        <lfx-views-dropdown
-          class="absolute right-0 top-full z-20 mt-1"
-          [savedViews]="savedFilters()"
-          [activeViewId]="activeViewId()"
-          [canSaveCurrentView]="canSaveCurrentView()"
-          [atSavedViewLimit]="atSavedViewLimit()"
-          [savedViewLimit]="savedViewLimit"
-          [readOnly]="savedViewsReadOnly()"
-          [isLoading]="savedFiltersLoading()"
-          [deletingViewIds]="deletingViewIds()"
-          (viewSelected)="onViewSelected($event)"
-          (defaultViewSelected)="onDefaultViewSelected()"
-          (viewDeleted)="onSavedViewDeleted($event.id)"
-          (saveCurrentViewRequested)="openSaveDialog()"
-          (close)="viewsOpen.set(false)" />
-      }
     </div>
 
     <div class="flex flex-col gap-4">
@@ -124,7 +126,7 @@
       }
 
       @if (activeTab() === 'feed') {
-        <p-confirmDialog data-testid="social-listening-confirm-dialog" />
+        <p-confirmdialog data-testid="social-listening-confirm-dialog" />
 
         @if (foreignViewBannerVisible()) {
           <div

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -200,6 +200,7 @@
             [loadedCount]="loadedCount()"
             [servableTotal]="servableTotal()"
             [hasMore]="hasMore()"
+            [renderCapped]="renderCapped()"
             [loadingMore]="loadingMore()"
             [dataComputedAt]="dataComputedAt()"
             [timeTick]="timeTick()"
@@ -207,7 +208,7 @@
             [loadError]="!!error() && loadedCount() > 0"
             [countError]="countError() !== null"
             (loadMore)="onLoadMore()"
-            (clearFilters)="clearAllFilters()"
+            (clearFilters)="resetToDefaultViewState()"
             (retry)="retryWindow()" />
         }
 

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.html
@@ -59,7 +59,7 @@
           <ng-container data-views-dropdown>
             <div class="fixed inset-0 z-10" aria-hidden="true" data-testid="social-listening-views-backdrop" (click)="viewsOpen.set(false)"></div>
             <lfx-views-dropdown
-              class="absolute right-0 top-full z-20 mt-1"
+              class="absolute right-0 top-full z-20 mt-1 max-sm:right-auto max-sm:left-0"
               [savedViews]="savedFilters()"
               [activeViewId]="activeViewId()"
               [canSaveCurrentView]="canSaveCurrentView()"
@@ -112,7 +112,7 @@
 
     <div class="flex flex-col gap-4">
       <!-- Active-filter summary on BOTH tabs: analytics applies the feed predicate too (M1), so the pills are the only on-tab indication. Click a pill to remove that filter -->
-      @if (activeFilterPills().length > 0) {
+      @if (activeFilterPills().length) {
         <div class="flex flex-wrap items-center gap-2" aria-label="Active filters" data-testid="social-listening-filter-pills">
           <lfx-filter-pills [options]="activeFilterPills()" selectedFilter="" (filterChange)="removeFilterPill($event)" />
           <button

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
@@ -3,14 +3,12 @@
 
 :host {
   @apply block;
-  // Rendered height of the sticky page header (pt-4 + 32px title + gap-1 + 20px subtitle + pb-4).
-  --sl-header-offset: 5.5rem;
 }
 
 // The pinned header floats on the page canvas: an opaque backdrop in the canvas color plus a fade
 // so cards scrolling under it dissolve instead of colliding with the title row.
 .social-listening-header {
-  @apply -mx-4 bg-gray-50 px-4 pb-4 pt-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8;
+  @apply relative -mx-4 bg-gray-50 px-4 pb-4 pt-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8;
 
   &::after {
     content: '';
@@ -18,12 +16,10 @@
   }
 }
 
-// Sticky at the header's height so the scope selects, search, and Filters trigger stay reachable while
-// the feed scrolls. `position: sticky` also anchors the absolutely positioned filters panel.
-// The fade sits at the bottom of the pinned stack so the feed dissolves as it scrolls underneath.
+// One sticky container holds both pinned rows (see the template) — a fixed per-row offset broke when the
+// header wrapped. `relative` anchors the filters panel; pt-4 keeps the unpinned rhythm. Fade: bottom of the stack.
 .social-listening-filter-row {
-  @apply sticky bg-gray-50;
-  top: var(--sl-header-offset);
+  @apply relative bg-gray-50 pt-4;
 
   &::after {
     content: '';

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
@@ -19,7 +19,7 @@
 }
 
 // Sticky at the header's height so the scope selects, search, and Filters trigger stay reachable while
-// the feed scrolls. `position: sticky` also anchors the absolutely positioned filters/views panels.
+// the feed scrolls. `position: sticky` also anchors the absolutely positioned filters panel.
 // The fade sits at the bottom of the pinned stack so the feed dissolves as it scrolls underneath.
 .social-listening-filter-row {
   @apply sticky bg-gray-50;

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
@@ -7,20 +7,26 @@
   --sl-header-offset: 5.5rem;
 }
 
-// The pinned header needs an opaque backdrop plus a fade so cards scrolling under it dissolve
-// instead of colliding with the title row.
+// The pinned header floats on the page canvas: an opaque backdrop in the canvas color plus a fade
+// so cards scrolling under it dissolve instead of colliding with the title row.
 .social-listening-header {
-  @apply -mx-4 bg-white px-4 pb-4 pt-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8;
+  @apply -mx-4 bg-gray-50 px-4 pb-4 pt-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8;
 
   &::after {
     content: '';
-    @apply pointer-events-none absolute inset-x-0 top-full h-4 bg-gradient-to-b from-white to-transparent;
+    @apply pointer-events-none absolute inset-x-0 top-full h-4 bg-gradient-to-b from-gray-50 to-transparent;
   }
 }
 
 // Sticky at the header's height so the scope selects, search, and Filters trigger stay reachable while
 // the feed scrolls. `position: sticky` also anchors the absolutely positioned filters/views panels.
+// The fade sits at the bottom of the pinned stack so the feed dissolves as it scrolls underneath.
 .social-listening-filter-row {
-  @apply sticky;
+  @apply sticky bg-gray-50;
   top: var(--sl-header-offset);
+
+  &::after {
+    content: '';
+    @apply pointer-events-none absolute inset-x-0 top-full h-4 bg-gradient-to-b from-gray-50 to-transparent;
+  }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.scss
@@ -3,4 +3,24 @@
 
 :host {
   @apply block;
+  // Rendered height of the sticky page header (pt-4 + 32px title + gap-1 + 20px subtitle + pb-4).
+  --sl-header-offset: 5.5rem;
+}
+
+// The pinned header needs an opaque backdrop plus a fade so cards scrolling under it dissolve
+// instead of colliding with the title row.
+.social-listening-header {
+  @apply -mx-4 bg-white px-4 pb-4 pt-4 sm:-mx-6 sm:px-6 lg:-mx-8 lg:px-8;
+
+  &::after {
+    content: '';
+    @apply pointer-events-none absolute inset-x-0 top-full h-4 bg-gradient-to-b from-white to-transparent;
+  }
+}
+
+// Sticky at the header's height so the scope selects, search, and Filters trigger stay reachable while
+// the feed scrolls. `position: sticky` also anchors the absolutely positioned filters/views panels.
+.social-listening-filter-row {
+  @apply sticky;
+  top: var(--sl-header-offset);
 }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.spec.ts
@@ -36,7 +36,6 @@ import { SocialListeningComponent } from './social-listening.component';
 
 /**
  * Container-level coverage for the two things the child specs cannot see: the windowed pagination
-
  * arithmetic (windowIndex/serverOffset/localOffset, cumulative window rendering) and the bidirectional
  * query-param sync. The template is blanked out — nothing here needs the rendered tree.
  */

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.spec.ts
@@ -36,7 +36,8 @@ import { SocialListeningComponent } from './social-listening.component';
 
 /**
  * Container-level coverage for the two things the child specs cannot see: the windowed pagination
- * arithmetic (windowIndex/serverOffset/localOffset, ±2-window cache eviction) and the bidirectional
+
+ * arithmetic (windowIndex/serverOffset/localOffset, cumulative window rendering) and the bidirectional
  * query-param sync. The template is blanked out — nothing here needs the rendered tree.
  */
 describe('SocialListeningComponent', () => {
@@ -124,6 +125,14 @@ describe('SocialListeningComponent', () => {
 
   function mentionIds(): string[] {
     return fixture.componentInstance.mentions().map((mention: Mention) => mention.id);
+  }
+
+  /** Load More advances one batch at a time — there is no arbitrary page jump to emulate. */
+  async function loadMore(times = 1): Promise<void> {
+    for (let i = 0; i < times; i++) {
+      fixture.componentInstance.onLoadMore();
+      await settle();
+    }
   }
 
   beforeEach(async () => {
@@ -225,55 +234,50 @@ describe('SocialListeningComponent', () => {
     await settle();
   });
 
-  describe('windowed pagination', () => {
-    it('fetches window 0 in two phases, then pages within it without a refetch', async () => {
-      // Phase 1 paints the visible page; phase 2 fills the rest of the 100-row window.
+  describe('windowed load more', () => {
+    it('fetches window 0 in two phases, then appends within it without a refetch', async () => {
+      // Phase 1 paints the first batch; phase 2 fills the rest of the 100-row window.
       expect(feedCalls()).toEqual([expect.objectContaining({ limit: 20, offset: 0 }), expect.objectContaining({ limit: 80, offset: 20 })]);
       expect(cachedWindows()).toEqual([0]);
       expect(mentionIds()).toHaveLength(20);
 
-      // Page 4 (rows 80–99) still lives in window 0 — no new fetch.
-      fixture.componentInstance.onPageChange({ page: 4, rows: 20 });
-      await settle();
+      // Batches 2–5 (rows 20–99) still live in window 0 — no new fetch.
+      await loadMore(4);
 
       expect(getMentionsFeed).toHaveBeenCalledTimes(2);
-      expect(mentionIds()[0]).toBe('m80');
+      expect(mentionIds()).toHaveLength(100);
+      expect(mentionIds()[0]).toBe('m0');
+      expect(mentionIds().at(-1)).toBe('m99');
     });
 
-    it('fetches the next window when the page crosses the window edge', async () => {
-      fixture.componentInstance.onPageChange({ page: 5, rows: 20 });
-      await settle();
+    it('appends the next batch below the rows already rendered', async () => {
+      await loadMore();
+
+      expect(mentionIds()).toHaveLength(40);
+      expect(mentionIds().slice(0, 20)).toEqual(Array.from({ length: 20 }, (_, i) => `m${i}`));
+      expect(mentionIds().slice(20)).toEqual(Array.from({ length: 20 }, (_, i) => `m${20 + i}`));
+    });
+
+    it('renders cumulatively across a window boundary', async () => {
+      await loadMore(5);
 
       expect(feedCalls().at(-2)).toEqual(expect.objectContaining({ limit: 20, offset: 100 }));
       expect(cachedWindows()).toEqual([0, 1]);
-      expect(mentionIds()[0]).toBe('m100');
+      // Window 0 stays on screen — the boundary batch is appended, not swapped in.
+      expect(mentionIds()).toHaveLength(120);
+      expect(mentionIds()[0]).toBe('m0');
+      expect(mentionIds().at(-1)).toBe('m119');
     });
 
-    it('a page-size change mid-window slices the cached window instead of refetching', async () => {
-      fixture.componentInstance.onPageChange({ page: 1, rows: 50 });
-      await settle();
+    it('retains every window it has walked into, so a loaded batch is never refetched', async () => {
+      await loadMore(20);
 
-      // Offset 50 sits inside window 0 (rows 0–99) — the cache serves it.
-      expect(getMentionsFeed).toHaveBeenCalledTimes(2);
-      expect(mentionIds()).toHaveLength(50);
-      expect(mentionIds()[0]).toBe('m50');
-
-      // Offset 150 lands past the window edge — a new window fetch is required.
-      fixture.componentInstance.onPageChange({ page: 3, rows: 50 });
-      await settle();
-
-      expect(feedCalls().at(-1)).toEqual(expect.objectContaining({ offset: 100 }));
-      expect(mentionIds()[0]).toBe('m150');
-    });
-
-    it('evicts windows farther than ±2 from the current window', async () => {
-      for (const page of [5, 10, 15, 20]) {
-        fixture.componentInstance.onPageChange({ page, rows: 20 });
-        await settle();
-      }
-
-      // Window 4 is current (page 20 at rows 20); windows 0 and 1 fell out of the ±2 band.
-      expect(cachedWindows()).toEqual([2, 3, 4]);
+      expect(cachedWindows()).toEqual([0, 1, 2, 3, 4]);
+      // Two calls per window (20 + 80) and not one repeat: nothing was evicted and re-fetched.
+      expect(feedCalls()).toHaveLength(10);
+      expect(new Set(feedCalls().map((req) => req.offset)).size).toBe(10);
+      expect(mentionIds()).toHaveLength(420);
+      expect(mentionIds().at(-1)).toBe('m419');
     });
 
     it('auto-refetches a window once when its phase-2 fill fails, then serves it complete', async () => {
@@ -287,20 +291,18 @@ describe('SocialListeningComponent', () => {
         return of(feedResponse(req));
       });
 
-      fixture.componentInstance.onPageChange({ page: 5, rows: 20 });
-      await settle();
+      await loadMore(5);
 
       // Failed fill (120) + forced refetch of the window (100 + 120 again).
       expect(feedCalls().filter((req) => req.offset === 120)).toHaveLength(2);
       expect(cachedWindows()).toEqual([0, 1]);
-      expect(mentionIds()[0]).toBe('m100');
+      expect(mentionIds()).toHaveLength(120);
 
-      // The recovered window is complete — in-window paging serves it without another fetch.
+      // The recovered window is complete — the next batch is served without another fetch.
       const calls = getMentionsFeed.mock.calls.length;
-      fixture.componentInstance.onPageChange({ page: 6, rows: 20 });
-      await settle();
+      await loadMore();
       expect(getMentionsFeed).toHaveBeenCalledTimes(calls);
-      expect(mentionIds()[0]).toBe('m120');
+      expect(mentionIds().at(-1)).toBe('m139');
     });
 
     it('flags the window for manual retry when the phase-2 fill keeps failing, and retry recovers it', async () => {
@@ -308,8 +310,7 @@ describe('SocialListeningComponent', () => {
         req.offset === 120 ? throwError(() => new Error('phase 2 failed')) : of(feedResponse(req))
       );
 
-      fixture.componentInstance.onPageChange({ page: 5, rows: 20 });
-      await settle();
+      await loadMore(5);
 
       // One failed fill + one failed refetch — then the partial window stays cached, flagged for manual retry.
       expect(feedCalls().filter((req) => req.offset === 120)).toHaveLength(2);
@@ -323,7 +324,8 @@ describe('SocialListeningComponent', () => {
 
       expect(feedCalls().filter((req) => req.offset === 120)).toHaveLength(3);
       expect(fixture.componentInstance.phase2Failed()).toBe(false);
-      expect(mentionIds()[0]).toBe('m100');
+      expect(mentionIds()).toHaveLength(120);
+      expect(mentionIds().at(-1)).toBe('m119');
     });
   });
 
@@ -337,7 +339,7 @@ describe('SocialListeningComponent', () => {
 
       expect(fixture.componentInstance.countError()).toBe('Failed to load the mention count');
       // No zero-total masquerade: the provisional total (serverOffset 0 + 100 loaded rows + one pageSize)
-      // keeps Next enabled past the loaded window until the count recovers.
+      // keeps Load More reachable past the loaded window until the count recovers.
       expect(fixture.componentInstance.totalRecords()).toBe(120);
     });
   });
@@ -608,9 +610,8 @@ describe('SocialListeningComponent', () => {
     it('re-queries unread from page 1 when mark-all-as-read refreshes the snapshot', async () => {
       fixture.componentInstance.selectedReadFilter.set('unread');
       await settle();
-      fixture.componentInstance.onPageChange({ page: 4, rows: 20 });
-      await settle();
-      expect(fixture.componentInstance.currentPage()).toBe(4);
+      await loadMore(4);
+      expect(fixture.componentInstance.lastLoadedPage()).toBe(4);
 
       // Unread mode narrows the feed, so mark-all first resolves the foundation-global newest via a limit-1 fetch.
       // Mirror the production ordering inside the mock: the store's optimistic commit lands
@@ -623,7 +624,7 @@ describe('SocialListeningComponent', () => {
 
       expect(markAllAsRead).toHaveBeenCalledWith('2026-08-01T00:00:00Z');
       // Then the refreshed snapshot re-queries with the new cutoff, restarting at page 1.
-      expect(fixture.componentInstance.currentPage()).toBe(0);
+      expect(fixture.componentInstance.lastLoadedPage()).toBe(0);
       expect(feedCalls().at(-1)).toMatchObject({ unreadOnly: true, readBeforeTs: '2026-08-01T00:00:00Z' });
     });
 
@@ -725,8 +726,7 @@ describe('SocialListeningComponent', () => {
       await settle();
 
       // pageSize 20 × page 5 = offset 100 → window 1 (serverWindowSize is 100).
-      fixture.componentInstance.onPageChange({ page: 5, rows: 20 });
-      await settle();
+      await loadMore(5);
       expect(cachedWindows()).toEqual([0, 1]);
 
       fixture.componentInstance.onMarkAllAsRead();
@@ -734,8 +734,8 @@ describe('SocialListeningComponent', () => {
       expect(markAllAsRead).toHaveBeenCalledWith('2026-08-01T00:00:00Z');
     });
 
-    it('retains the global-newest mark-all cutoff after window 0 is pruned from the cache', async () => {
-      // Window 0 rows stamp newer than every deeper window — the retained cutoff must survive window 0's eviction.
+    it('retains the global-newest mark-all cutoff after loading deep into the feed', async () => {
+      // Window 0 rows stamp newer than every deeper window — the retained cutoff must stay pinned to them.
       getMentionsFeed.mockImplementation((req: SocialListeningFeedRequest) => {
         const response = feedResponse(req);
         const ts = (req.offset ?? 0) === 0 ? '2026-08-01T00:00:00Z' : '2026-07-01T00:00:00Z';
@@ -746,12 +746,9 @@ describe('SocialListeningComponent', () => {
       fixture.detectChanges();
       await settle();
 
-      // Page into window 4 — windows 0 and 1 fall out of the ±2 band.
-      for (const page of [5, 10, 15, 20]) {
-        fixture.componentInstance.onPageChange({ page, rows: 20 });
-        await settle();
-      }
-      expect(cachedWindows()).toEqual([2, 3, 4]);
+      // Load through to window 4 — every window walked into stays cached.
+      await loadMore(20);
+      expect(cachedWindows()).toEqual([0, 1, 2, 3, 4]);
 
       fixture.componentInstance.onMarkAllAsRead();
 
@@ -760,16 +757,15 @@ describe('SocialListeningComponent', () => {
 
     it('resets the page and re-queries with the snapshot params on read-filter change', async () => {
       readState.set(readStateWith({ readIds: ['m7'] }));
-      fixture.componentInstance.onPageChange({ page: 4, rows: 20 });
-      await settle();
-      expect(fixture.componentInstance.currentPage()).toBe(4);
+      await loadMore(4);
+      expect(fixture.componentInstance.lastLoadedPage()).toBe(4);
       expect(cachedWindows()).toEqual([0]);
       const feedCallCount = getMentionsFeed.mock.calls.length;
 
       fixture.componentInstance.selectedReadFilter.set('unread');
       await settle();
 
-      expect(fixture.componentInstance.currentPage()).toBe(0);
+      expect(fixture.componentInstance.lastLoadedPage()).toBe(0);
       // The window cache went cold and refilled — the server now filters, so cached unfiltered windows no longer apply.
       expect(cachedWindows()).toEqual([0]);
       expect(getMentionsFeed.mock.calls.length).toBeGreaterThan(feedCallCount);

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -13,6 +13,7 @@ import {
   DEFAULT_MENTION_PREDICATE,
   DEFAULT_MENTION_VIEW_SCOPE,
   MAX_SAVED_FILTERS_PER_PROJECT,
+  MENTION_FEED_RENDER_LIMIT,
   MENTION_FILTER_MAX_VALUES,
   MENTION_MAX_FEED_OFFSET,
   MENTION_SEARCH_DEBOUNCE_MS,
@@ -316,7 +317,9 @@ export class SocialListeningComponent {
   public readonly phase2Failed = computed(() => this.windowCache().get(this.windowIndex())?.phase2Failed === true);
   public readonly mentions: Signal<Mention[]> = this.initMentions();
   public readonly loadedCount = computed(() => this.mentions().length);
-  public readonly hasMore = computed(() => this.loadedCount() < this.servableTotal());
+  /** Past MENTION_FEED_RENDER_LIMIT the footer stops advancing — the rendered DOM, not the window cache, is what's bounded. */
+  public readonly renderCapped = computed(() => this.loadedCount() >= MENTION_FEED_RENDER_LIMIT && this.loadedCount() < this.servableTotal());
+  public readonly hasMore = computed(() => this.loadedCount() < Math.min(this.servableTotal(), MENTION_FEED_RENDER_LIMIT));
   /** Distinguishes a Load More fetch from the initial load, so the footer spins while the list keeps its rows. */
   public readonly loadingMore = computed(() => this.loading() && this.loadedCount() > 0);
   public readonly readMentionIds: Signal<Set<string>> = this.initReadMentionIds();
@@ -562,6 +565,8 @@ export class SocialListeningComponent {
   }
 
   public onLoadMore(): void {
+    // The footer stays hidden until the first row lands — advancing mid-fetch would cancel the in-flight window request.
+    if (this.loading()) return;
     this.lastLoadedPage.update((page) => page + 1);
   }
 
@@ -706,6 +711,14 @@ export class SocialListeningComponent {
     resetters[id as keyof FilterPredicate]?.();
   }
 
+  /** Resets predicate + scope to the defaults and drops the active view — the "No Preset View", active-view-deleted, and empty-state CTA path. */
+  public resetToDefaultViewState(): void {
+    applyPredicateToSignals({ ...DEFAULT_MENTION_PREDICATE, keywords: [], tags: [], authors: [] }, this.signals);
+    applyViewScopeToSignals({ ...DEFAULT_MENTION_VIEW_SCOPE, period: this.defaultPeriod }, this.scopeSignals);
+    this.activeViewId.set(null);
+    this.commitScopeKey();
+  }
+
   /** Any active feed predicate or a non-default period means the loaded windows (and their newest) are a subset of the foundation feed. */
   private feedNarrowed(): boolean {
     return Object.keys(this.currentFilters()).length > 0 || this.selectedPeriod() !== this.defaultPeriod;
@@ -761,14 +774,6 @@ export class SocialListeningComponent {
     const scopeKey = this.computeScopeKey();
     if (!scopeKey) return;
     this.previousScopeKey = scopeKey;
-  }
-
-  /** Resets predicate + scope to the defaults and drops the active view — the "No Preset View" / active-view-deleted path. */
-  private resetToDefaultViewState(): void {
-    applyPredicateToSignals({ ...DEFAULT_MENTION_PREDICATE, keywords: [], tags: [], authors: [] }, this.signals);
-    applyViewScopeToSignals({ ...DEFAULT_MENTION_VIEW_SCOPE, period: this.defaultPeriod }, this.scopeSignals);
-    this.activeViewId.set(null);
-    this.commitScopeKey();
   }
 
   private initSearchQuery(): Signal<string> {

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -319,7 +319,7 @@ export class SocialListeningComponent {
   public readonly loadedCount = computed(() => this.mentions().length);
   /** Past MENTION_FEED_RENDER_LIMIT the footer stops advancing — the rendered DOM, not the window cache, is what's bounded. */
   public readonly renderCapped = computed(() => this.loadedCount() >= MENTION_FEED_RENDER_LIMIT && this.loadedCount() < this.servableTotal());
-  public readonly hasMore = computed(() => this.loadedCount() < Math.min(this.servableTotal(), MENTION_FEED_RENDER_LIMIT));
+  public readonly hasMore: Signal<boolean> = this.initHasMore();
   /** Distinguishes a Load More fetch from the initial load, so the footer spins while the list keeps its rows. */
   public readonly loadingMore = computed(() => this.loading() && this.loadedCount() > 0);
   public readonly readMentionIds: Signal<Set<string>> = this.initReadMentionIds();
@@ -1107,6 +1107,19 @@ export class SocialListeningComponent {
         if (this.mentionReadStateService.isRead(m.id, m.timestamp)) ids.add(m.id);
       }
       return ids;
+    });
+  }
+
+  private initHasMore(): Signal<boolean> {
+    return computed(() => {
+      if (this.loadedCount() >= Math.min(this.servableTotal(), MENTION_FEED_RENDER_LIMIT)) return false;
+      // A complete short window is the feed's real end — stop there even when the count is stale or failed; the terminal
+      // window's prefetched pages stay revealable, since revealing them advances no further fetch.
+      const windowData = this.windowCache().get(this.windowIndex());
+      if (windowData?.complete && windowData.mentions.length < this.serverWindowSize) {
+        return this.loadedCount() < this.serverOffset() + windowData.mentions.length;
+      }
+      return true;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -5,7 +5,6 @@ import { isPlatformBrowser } from '@angular/common';
 import { Component, computed, DestroyRef, effect, inject, PLATFORM_ID, Signal, signal, untracked } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router } from '@angular/router';
-import { CardComponent } from '@components/card/card.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { FilterPillsComponent } from '@components/filter-pills/filter-pills.component';
 import { MessageComponent } from '@components/message/message.component';
@@ -118,7 +117,6 @@ const EMPTY_FEED_RESPONSE: SocialListeningFeedResponse = { mentions: [], compute
 @Component({
   selector: 'lfx-social-listening',
   imports: [
-    CardComponent,
     EmptyStateComponent,
     FilterPillsComponent,
     MessageComponent,

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -175,8 +175,11 @@ export class SocialListeningComponent {
 
   // === Pagination state ===
   public readonly lastLoadedPage = signal(0);
-  public readonly pageSize = signal(DEFAULT_MENTION_PAGE_SIZE);
+  private readonly pageSize = DEFAULT_MENTION_PAGE_SIZE;
   private readonly windowCache = signal<Map<number, SocialListeningWindowCacheEntry>>(new Map());
+  // Memo table for mapCachedWindow — keyed by entry identity, so a Load More click re-slices without
+  // re-mapping every loaded row (at the render cap that was 500 card re-renders for 20 new rows).
+  private readonly mentionViewCache = new WeakMap<SocialListeningWindowCacheEntry, Mention[]>();
   // Global-newest MENTION_TS, captured whenever window 0 loads — held outside the cache so a mark-all from a deep page still stamps the true cutoff.
   private newestMentionTs: string | null = null;
   /** Guards the mark-all cutoff fetch against double-clicks during a slow round-trip. */
@@ -220,10 +223,10 @@ export class SocialListeningComponent {
   /** Read-state snapshot behind the unread feed filter — refreshed only on mode entry, load completion, and the two mark-all actions, so single toggles restyle in place and pagination stays stable. */
   private readonly unreadSnapshot = signal<ReadStateData | null>(null);
 
-  private readonly windowIndex = computed(() => Math.floor((this.lastLoadedPage() * this.pageSize()) / this.serverWindowSize));
+  private readonly windowIndex = computed(() => Math.floor((this.lastLoadedPage() * this.pageSize) / this.serverWindowSize));
   // Load More is capped at the last servable window, so serverOffset stays within MENTION_MAX_FEED_OFFSET (100,000).
   private readonly serverOffset = computed(() => this.windowIndex() * this.serverWindowSize);
-  private readonly localOffset = computed(() => this.lastLoadedPage() * this.pageSize() - this.serverOffset());
+  private readonly localOffset = computed(() => this.lastLoadedPage() * this.pageSize - this.serverOffset());
 
   // === Request pipelines ===
   private readonly searchQuery: Signal<string> = this.initSearchQuery();
@@ -240,6 +243,7 @@ export class SocialListeningComponent {
   // The server clamps offset at MENTION_MAX_FEED_OFFSET — never advertise more than the last servable window holds.
   public readonly servableTotal = computed(() => Math.min(this.totalRecords(), MENTION_MAX_FEED_OFFSET + this.serverWindowSize));
   public readonly countError = computed(() => this.countState().error);
+  public readonly countLoading = computed(() => this.countState().loading);
   private readonly subProjectsState: Signal<LoadableState<SocialListeningSubProject[]>> = this.initSubProjectsState();
   private readonly platformsState: Signal<LoadableState<SocialListeningPlatform[]>> = this.initPlatformsState();
 
@@ -304,7 +308,7 @@ export class SocialListeningComponent {
     if (!windowData) return this.feedRequest() !== null && !this.feedState().error;
     if (windowData.complete) return false;
     // Partial window: the visible page extends past what phase 2 has filled so far.
-    const neededEnd = this.localOffset() + this.pageSize();
+    const neededEnd = this.localOffset() + this.pageSize;
     if (neededEnd <= windowData.mentions.length) return false;
     return this.backgroundLoading() || this.feedState().loading;
   });
@@ -886,8 +890,8 @@ export class SocialListeningComponent {
           }
 
           // Phase 2 re-requests from offset + initialLimit — past MENTION_MAX_FEED_OFFSET that offset clamps, duplicating rows.
-          const canSplitWindow = (req.offset ?? 0) + this.pageSize() <= MENTION_MAX_FEED_OFFSET;
-          const initialLimit = this.localOffset() === 0 && canSplitWindow ? this.pageSize() : this.serverWindowSize;
+          const canSplitWindow = (req.offset ?? 0) + this.pageSize <= MENTION_MAX_FEED_OFFSET;
+          const initialLimit = this.localOffset() === 0 && canSplitWindow ? this.pageSize : this.serverWindowSize;
           const initialReq = { ...req, limit: initialLimit };
 
           return this.socialListeningService.getMentionsFeed(initialReq).pipe(
@@ -1088,14 +1092,24 @@ export class SocialListeningComponent {
       // Load More renders cumulatively: every window the user has walked into is concatenated in order,
       // then trimmed to the batches actually requested so a prefetched window tail never paints early.
       const cache = this.windowCache();
-      const rows: SocialListeningMention[] = [];
+      const rows: Mention[] = [];
       for (let w = 0; w <= this.windowIndex(); w++) {
         const entry = cache.get(w);
         if (!entry) break;
-        rows.push(...entry.mentions);
+        rows.push(...this.mapCachedWindow(entry));
       }
-      return rows.slice(0, (this.lastLoadedPage() + 1) * this.pageSize()).map(mapRawToMention);
+      return rows.slice(0, (this.lastLoadedPage() + 1) * this.pageSize);
     });
+  }
+
+  /** View-model mapping memoized per cache-entry identity, so advancing the feed re-maps only windows that actually changed. */
+  private mapCachedWindow(entry: SocialListeningWindowCacheEntry): Mention[] {
+    let mapped = this.mentionViewCache.get(entry);
+    if (!mapped) {
+      mapped = entry.mentions.map(mapRawToMention);
+      this.mentionViewCache.set(entry, mapped);
+    }
+    return mapped;
   }
 
   private initReadMentionIds(): Signal<Set<string>> {
@@ -1112,7 +1126,10 @@ export class SocialListeningComponent {
 
   private initHasMore(): Signal<boolean> {
     return computed(() => {
-      if (this.loadedCount() >= Math.min(this.servableTotal(), MENTION_FEED_RENDER_LIMIT)) return false;
+      if (this.loadedCount() >= MENTION_FEED_RENDER_LIMIT) return false;
+      // A landed count is authoritative; an in-flight one reads as servableTotal 0 — unknown, not an exhausted feed.
+      const total = this.servableTotal();
+      if (total > 0 && this.loadedCount() >= total) return false;
       // A complete short window is the feed's real end — stop there even when the count is stale or failed; the terminal
       // window's prefetched pages stay revealable, since revealing them advances no further fetch.
       const windowData = this.windowCache().get(this.windowIndex());
@@ -1126,9 +1143,9 @@ export class SocialListeningComponent {
   private initTotalRecords(): Signal<number> {
     return computed(() => {
       const count = this.countState();
-      // Count failed: a zero total would disable Next and strand the user on page 1 despite loaded rows.
-      // Derive a provisional total from the loaded window; the extra pageSize keeps Next enabled past it.
-      if (count.error) return this.serverOffset() + this.currentWindowData().mentions.length + this.pageSize();
+      // Count failed: a zero total would hide Load More and strand the user on the first window despite loaded rows.
+      // Derive a provisional total from the loaded window; the extra pageSize keeps Load More available past it.
+      if (count.error) return this.serverOffset() + this.currentWindowData().mentions.length + this.pageSize;
       return count.data ?? 0;
     });
   }

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -570,7 +570,8 @@ export class SocialListeningComponent {
 
   public onLoadMore(): void {
     // The footer stays hidden until the first row lands — advancing mid-fetch would cancel the in-flight window request.
-    if (this.loading()) return;
+    // A queued second click can outrun the footer's unmount, so re-check hasMore() instead of trusting the button's visibility.
+    if (this.loading() || !this.hasMore()) return;
     this.lastLoadedPage.update((page) => page + 1);
   }
 

--- a/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts
@@ -15,13 +15,12 @@ import {
   DEFAULT_MENTION_VIEW_SCOPE,
   MAX_SAVED_FILTERS_PER_PROJECT,
   MENTION_FILTER_MAX_VALUES,
-  MENTION_MAX_CACHED_WINDOWS,
   MENTION_MAX_FEED_OFFSET,
-  MENTION_PAGE_SIZE_OPTIONS,
   MENTION_SEARCH_DEBOUNCE_MS,
   MENTION_SEARCH_MIN_CHARS,
   MENTION_SERVER_WINDOW_SIZE,
   MENTION_TIME_TICK_INTERVAL_MS,
+  SOCIAL_LISTENING_TAB_OPTIONS,
 } from '@lfx-one/shared/constants';
 import {
   applyPredicateToSignals,
@@ -155,6 +154,8 @@ export class SocialListeningComponent {
   /** Deep-linked search, decoded once — seeds the input and the debounced query so the first fetch is already filtered. */
   private readonly initialSearch = decodePredicateFromQueryParams(this.route.snapshot.queryParams, this.defaultPeriod).predicate.search;
 
+  public readonly tabOptions = SOCIAL_LISTENING_TAB_OPTIONS;
+
   // === Model signals (two-way bound by the feed header) ===
   public readonly activeTab = signal<SocialListeningTab>('feed');
   public readonly selectedPeriod = signal(this.defaultPeriod);
@@ -174,11 +175,10 @@ export class SocialListeningComponent {
   public readonly selectedAuthors = signal<string[]>([]);
 
   // === Pagination state ===
-  public readonly currentPage = signal(0);
+  public readonly lastLoadedPage = signal(0);
   public readonly pageSize = signal(DEFAULT_MENTION_PAGE_SIZE);
-  public readonly rowsPerPageOptions = MENTION_PAGE_SIZE_OPTIONS;
   private readonly windowCache = signal<Map<number, SocialListeningWindowCacheEntry>>(new Map());
-  // Global-newest MENTION_TS, captured whenever window 0 loads — survives cache pruning so a mark-all from a deep page still stamps the true cutoff.
+  // Global-newest MENTION_TS, captured whenever window 0 loads — held outside the cache so a mark-all from a deep page still stamps the true cutoff.
   private newestMentionTs: string | null = null;
   /** Guards the mark-all cutoff fetch against double-clicks during a slow round-trip. */
   private markAllPending = false;
@@ -221,10 +221,10 @@ export class SocialListeningComponent {
   /** Read-state snapshot behind the unread feed filter — refreshed only on mode entry, load completion, and the two mark-all actions, so single toggles restyle in place and pagination stays stable. */
   private readonly unreadSnapshot = signal<ReadStateData | null>(null);
 
-  private readonly windowIndex = computed(() => Math.floor((this.currentPage() * this.pageSize()) / this.serverWindowSize));
-  // The paginator is capped at the last servable window, so serverOffset stays within MENTION_MAX_FEED_OFFSET (100,000).
+  private readonly windowIndex = computed(() => Math.floor((this.lastLoadedPage() * this.pageSize()) / this.serverWindowSize));
+  // Load More is capped at the last servable window, so serverOffset stays within MENTION_MAX_FEED_OFFSET (100,000).
   private readonly serverOffset = computed(() => this.windowIndex() * this.serverWindowSize);
-  private readonly localOffset = computed(() => this.currentPage() * this.pageSize() - this.serverOffset());
+  private readonly localOffset = computed(() => this.lastLoadedPage() * this.pageSize() - this.serverOffset());
 
   // === Request pipelines ===
   private readonly searchQuery: Signal<string> = this.initSearchQuery();
@@ -238,8 +238,8 @@ export class SocialListeningComponent {
   private readonly feedState: Signal<LoadableState<SocialListeningFeedResponse>> = this.initFeedState();
   private readonly countState: Signal<LoadableState<number>> = this.initCountState();
   public readonly totalRecords: Signal<number> = this.initTotalRecords();
-  // The server clamps offset at MENTION_MAX_FEED_OFFSET — never advertise pages past the last servable window.
-  public readonly paginatorTotalRecords = computed(() => Math.min(this.totalRecords(), MENTION_MAX_FEED_OFFSET + this.serverWindowSize));
+  // The server clamps offset at MENTION_MAX_FEED_OFFSET — never advertise more than the last servable window holds.
+  public readonly servableTotal = computed(() => Math.min(this.totalRecords(), MENTION_MAX_FEED_OFFSET + this.serverWindowSize));
   public readonly countError = computed(() => this.countState().error);
   private readonly subProjectsState: Signal<LoadableState<SocialListeningSubProject[]>> = this.initSubProjectsState();
   private readonly platformsState: Signal<LoadableState<SocialListeningPlatform[]>> = this.initPlatformsState();
@@ -316,8 +316,11 @@ export class SocialListeningComponent {
   public readonly bookmarkStateError = computed(() => this.selectedBookmarkFilter() === 'bookmarked' && this.mentionBookmarkService.state().error !== null);
   /** Current window's background fill failed past its automatic retry — the list swaps the empty state for a retry row. */
   public readonly phase2Failed = computed(() => this.windowCache().get(this.windowIndex())?.phase2Failed === true);
-  public readonly first = computed(() => this.currentPage() * this.pageSize());
   public readonly mentions: Signal<Mention[]> = this.initMentions();
+  public readonly loadedCount = computed(() => this.mentions().length);
+  public readonly hasMore = computed(() => this.loadedCount() < this.servableTotal());
+  /** Distinguishes a Load More fetch from the initial load, so the footer spins while the list keeps its rows. */
+  public readonly loadingMore = computed(() => this.loading() && this.loadedCount() > 0);
   public readonly readMentionIds: Signal<Set<string>> = this.initReadMentionIds();
   public readonly dataComputedAt: Signal<Date | null> = this.initDataComputedAt();
 
@@ -453,7 +456,7 @@ export class SocialListeningComponent {
       if (this.selectedBookmarkFilter() !== 'bookmarked') this.selectedPeriod();
       this.currentFilters();
       untracked(() => {
-        this.currentPage.set(0);
+        this.lastLoadedPage.set(0);
         this.windowCache.set(new Map());
         this.retriedWindows.clear();
         this.newestMentionTs = null;
@@ -554,9 +557,20 @@ export class SocialListeningComponent {
       .subscribe(() => this.filtersOpenedOnce.set(true));
   }
 
-  public onPageChange(event: { page: number; rows: number }): void {
-    this.currentPage.set(event.page);
-    this.pageSize.set(event.rows);
+  public onTabSelected(tabId: string): void {
+    if (tabId === 'feed' || tabId === 'analytics') {
+      this.activeTab.set(tabId);
+    }
+  }
+
+  public onLoadMore(): void {
+    this.lastLoadedPage.update((page) => page + 1);
+  }
+
+  /** Analytics platform row → scope the feed to that platform and switch tabs, so the drill-down lands on matching mentions. */
+  public onAnalyticsPlatformSelected(platform: string): void {
+    this.selectedPlatform.set(platform);
+    this.activeTab.set('feed');
   }
 
   /** Card toggle → the bookmark service owns the cap/loading gates, the optimistic write, and the toasts. */
@@ -1068,10 +1082,16 @@ export class SocialListeningComponent {
 
   private initMentions(): Signal<Mention[]> {
     return computed(() => {
-      const start = this.localOffset();
-      return this.currentWindowData()
-        .mentions.slice(start, start + this.pageSize())
-        .map(mapRawToMention);
+      // Load More renders cumulatively: every window the user has walked into is concatenated in order,
+      // then trimmed to the batches actually requested so a prefetched window tail never paints early.
+      const cache = this.windowCache();
+      const rows: SocialListeningMention[] = [];
+      for (let w = 0; w <= this.windowIndex(); w++) {
+        const entry = cache.get(w);
+        if (!entry) break;
+        rows.push(...entry.mentions);
+      }
+      return rows.slice(0, (this.lastLoadedPage() + 1) * this.pageSize()).map(mapRawToMention);
     });
   }
 
@@ -1126,22 +1146,16 @@ export class SocialListeningComponent {
     });
   }
 
-  /** Caches a fetched window and prunes entries farther than ±MENTION_MAX_CACHED_WINDOWS from it. */
+  /** Caches a fetched window; entries are retained for the whole range the session has loaded, so Load More never refetches. */
   private updateWindowCache(windowIdx: number, cacheKey: string, data: SocialListeningWindowCacheEntry): void {
     // An in-flight response from before a scope/filter reset can land after the cache was cleared
     // (pipeline cancellation lags one macrotask) — drop it instead of serving stale rows.
     if (cacheKey !== untracked(this.feedCacheKey)) return;
-    // Window 0 holds the global newest (feed sorts newest-first) — retain its cutoff outside the prunable cache.
+    // Window 0 holds the global newest (feed sorts newest-first) — keep its cutoff on the instance, not in the cache.
     if (windowIdx === 0) {
       this.newestMentionTs = this.newestTsOf(data.mentions);
     }
-    this.windowCache.update((cache) => {
-      const updated = new Map(cache).set(windowIdx, data);
-      for (const key of Array.from(updated.keys())) {
-        if (Math.abs(key - windowIdx) > MENTION_MAX_CACHED_WINDOWS) updated.delete(key);
-      }
-      return updated;
-    });
+    this.windowCache.update((cache) => new Map(cache).set(windowIdx, data));
   }
 
   /** Newest parseable MENTION_TS in a window — epoch-ms compare since Snowflake's space-separated timestamps don't lexicographically sort against ISO "T"; NaN never wins a `>` compare, so unparseable values are skipped. */

--- a/apps/lfx-one/tailwind.config.js
+++ b/apps/lfx-one/tailwind.config.js
@@ -36,6 +36,8 @@ export default {
     // Social Listening analytics distribution bars (barClass on MENTION_PLATFORM_CONFIG / MENTION_SENTIMENT_CONFIG)
     ...Object.values(MENTION_PLATFORM_CONFIG).map((c) => c.barClass),
     ...Object.values(MENTION_SENTIMENT_CONFIG).map((c) => c.barClass),
+    // Social Listening mention-card sentiment rail (railClass / textClass on MENTION_SENTIMENT_CONFIG, not scanned here)
+    ...Object.values(MENTION_SENTIMENT_CONFIG).flatMap((c) => [c.railClass, c.textClass]),
     // Stat card grid columns/dividers: `GRID_COLS_CLASS`/`GRID_DIVIDER_CLASS` are defined in
     // @lfx-one/shared (outside `content`), and their responsive/arbitrary utilities need to be
     // scanned directly since they never appear as literal strings inside `content`.

--- a/packages/shared/src/constants/delta-direction.constants.ts
+++ b/packages/shared/src/constants/delta-direction.constants.ts
@@ -23,3 +23,10 @@ export const INVERTED_DELTA_DIRECTION_TEXT_CLASS: Record<StatCardDeltaDirection,
   down: DELTA_DIRECTION_TEXT_CLASS.up,
   flat: DELTA_DIRECTION_TEXT_CLASS.flat,
 };
+
+/** Screen-reader word per delta direction — the arrow icon is aria-hidden, so the direction needs a text alternative. */
+export const DELTA_DIRECTION_SR_LABEL: Record<StatCardDeltaDirection, string> = {
+  up: 'Increased',
+  down: 'Decreased',
+  flat: 'No change',
+};

--- a/packages/shared/src/constants/social-listening.constants.ts
+++ b/packages/shared/src/constants/social-listening.constants.ts
@@ -3,6 +3,7 @@
 
 /** Social Listening runtime constants — option lists double as server-side validation whitelists (3015). No hex colors (styling rule): Tailwind `colorClass` + `TagSeverity`. */
 
+import type { FilterPillOption } from '../interfaces/dashboard-metric.interface';
 import type {
   FilterPredicate,
   MentionPlatform,
@@ -37,9 +38,30 @@ export const MENTION_PLATFORM_CONFIG: Record<MentionPlatform, MentionPlatformCon
 };
 
 export const MENTION_SENTIMENT_CONFIG: Record<MentionSentiment, MentionSentimentConfigEntry> = {
-  positive: { icon: 'fa-light fa-face-smile', label: 'Positive', severity: 'success', barClass: 'bg-emerald-500' },
-  neutral: { icon: 'fa-light fa-face-meh', label: 'Neutral', severity: 'secondary', barClass: 'bg-amber-400' },
-  negative: { icon: 'fa-light fa-thumbs-down', label: 'Negative', severity: 'danger', barClass: 'bg-red-500' },
+  positive: {
+    icon: 'fa-light fa-face-smile',
+    label: 'Positive',
+    severity: 'success',
+    barClass: 'bg-emerald-500',
+    railClass: 'bg-emerald-500',
+    textClass: 'text-emerald-500',
+  },
+  neutral: {
+    icon: 'fa-light fa-face-meh',
+    label: 'Neutral',
+    severity: 'secondary',
+    barClass: 'bg-amber-400',
+    railClass: 'bg-amber-400',
+    textClass: 'text-amber-400',
+  },
+  negative: {
+    icon: 'fa-light fa-thumbs-down',
+    label: 'Negative',
+    severity: 'danger',
+    barClass: 'bg-red-500',
+    railClass: 'bg-red-500',
+    textClass: 'text-red-500',
+  },
 };
 
 export const MENTION_RELEVANCE_CONFIG: Record<MentionRelevance, MentionRelevanceConfigEntry> = {
@@ -80,19 +102,24 @@ export const MENTION_READ_FILTER_OPTIONS: SocialListeningOption[] = [
   { label: 'Unread', value: 'unread' },
 ];
 
+/** Feed/Analytics view-switcher pills — owned by the page header since the redesign dropped `lfx-card-tabs-bar`. */
+export const SOCIAL_LISTENING_TAB_OPTIONS: FilterPillOption[] = [
+  { id: 'feed', label: 'Feed' },
+  { id: 'analytics', label: 'Analytics' },
+];
+
 // ---------------------------------------------------------------------------
 // Pagination + limits
 // ---------------------------------------------------------------------------
 
-export const MENTION_PAGE_SIZE_OPTIONS: number[] = [10, 20, 50, 100];
+/** Load More batch size — fixed, since the feed has no rows-per-page selector. */
 export const DEFAULT_MENTION_PAGE_SIZE = 20;
 
-/** Server fetch window: the client caches ±2 windows of this size around the visible page. */
+/** Server fetch window: windows are retained for the range the user has loaded, so Load More never refetches. */
 export const MENTION_SERVER_WINDOW_SIZE = 100;
 
 /** Deepest feed offset the server honors — past ~1000 windows a paginated request is a scan, not navigation. */
 export const MENTION_MAX_FEED_OFFSET = 100_000;
-export const MENTION_MAX_CACHED_WINDOWS = 2;
 
 /** Cap for array-valued filters (keywords / tags / authors) — enforced at the HTTP boundary and in the SQL builder. */
 export const MENTION_FILTER_MAX_VALUES = 200;

--- a/packages/shared/src/constants/social-listening.constants.ts
+++ b/packages/shared/src/constants/social-listening.constants.ts
@@ -170,6 +170,9 @@ export const ANALYTICS_TOP_PLATFORMS_LIMIT = 5;
 /** Row cap requested for the analytics top-projects panel (mirrors the server's `TOP_PROJECTS_LIMIT` default). */
 export const ANALYTICS_TOP_PROJECTS_LIMIT = 5;
 
+/** Minimum segment share before the sentiment bar renders its in-segment count — below this the label can't fit. */
+export const SENTIMENT_BAR_LABEL_MIN_PERCENT = 12;
+
 /**
  * Series colors for the analytics charts (LFXV2-3018) — `lfxColors` scales only (styling rule).
  * Index 0 is the "Total" line; other series cycle from index 1 (500s first, then 300s).

--- a/packages/shared/src/constants/social-listening.constants.ts
+++ b/packages/shared/src/constants/social-listening.constants.ts
@@ -121,6 +121,9 @@ export const MENTION_SERVER_WINDOW_SIZE = 100;
 /** Deepest feed offset the server honors — past ~1000 windows a paginated request is a scan, not navigation. */
 export const MENTION_MAX_FEED_OFFSET = 100_000;
 
+/** Rendered-row cap for the cumulative feed — bounds DOM size and per-card render hooks; the loaded window cache is unaffected. */
+export const MENTION_FEED_RENDER_LIMIT = 500;
+
 /** Cap for array-valued filters (keywords / tags / authors) — enforced at the HTTP boundary and in the SQL builder. */
 export const MENTION_FILTER_MAX_VALUES = 200;
 

--- a/packages/shared/src/interfaces/social-listening.interface.ts
+++ b/packages/shared/src/interfaces/social-listening.interface.ts
@@ -359,8 +359,10 @@ export interface AuthorOption extends SocialListeningMentionAuthor {
 
 /** Analytics platform-distribution row with display config pre-resolved (built by `mapPlatformDistributionRows`). */
 export interface SocialListeningPlatformRow {
-  /** Normalized grouping key — also the value the analytics tab emits when a row is clicked to scope the feed. */
+  /** Normalized grouping key — drives the display config and the row's track key. */
   platform: MentionPlatform;
+  /** Distinct raw `SOURCE_PLATFORM` values folded into the group — drill-down emits from this list (the feed filter matches raw values), so merged groups can't drill down. */
+  sourcePlatforms: string[];
   config: MentionPlatformConfigEntry;
   mentionsCount: number;
   /** 0–100 share of in-scope mentions, one decimal (server-rounded). */

--- a/packages/shared/src/interfaces/social-listening.interface.ts
+++ b/packages/shared/src/interfaces/social-listening.interface.ts
@@ -5,6 +5,7 @@
 
 import type { SOCIAL_LISTENING_PREFERENCE_NAME_PREFIXES } from '../constants/social-listening.constants';
 import type { TagSeverity } from './components.interface';
+import type { StatCardDelta } from './stat-card.interface';
 
 // ---------------------------------------------------------------------------
 // Value unions
@@ -295,6 +296,8 @@ export interface Mention {
   id: string;
   platform: MentionPlatform;
   keyword: string;
+  /** Sub-project the mention was matched against — the card's project pill falls back to `keyword` when blank. */
+  sourceProjectName: string;
   timestamp: string;
   authorName: string;
   authorProfileLink: string;
@@ -335,6 +338,10 @@ export interface MentionSentimentConfigEntry {
   severity: TagSeverity;
   /** Tailwind bg-color class for the analytics sentiment-distribution bar segment (no hex — repo styling rule). */
   barClass: string;
+  /** Tailwind bg-color class for the mention card's left sentiment rail (no hex — repo styling rule). */
+  railClass: string;
+  /** Tailwind text-color class for the rail's sentiment icon (no hex — repo styling rule). */
+  textClass: string;
 }
 
 /** Display config for a relevance value (see `MENTION_RELEVANCE_CONFIG`). */
@@ -352,6 +359,8 @@ export interface AuthorOption extends SocialListeningMentionAuthor {
 
 /** Analytics platform-distribution row with display config pre-resolved (built by `mapPlatformDistributionRows`). */
 export interface SocialListeningPlatformRow {
+  /** Normalized grouping key — also the value the analytics tab emits when a row is clicked to scope the feed. */
+  platform: MentionPlatform;
   config: MentionPlatformConfigEntry;
   mentionsCount: number;
   /** 0–100 share of in-scope mentions, one decimal (server-rounded). */
@@ -365,6 +374,20 @@ export interface SocialListeningSentimentRow {
   mentionCount: number;
   /** 0–100 share of in-scope mentions, one decimal (server-rounded). */
   percentOfTotal: number;
+}
+
+/** Ranked tag row for the analytics tag list; `percentOfMax` sizes the bar against the top row so the longest always fills. */
+export interface SocialListeningTagRow {
+  label: string;
+  count: number;
+  /** 0–100 share of the top row's count. */
+  percentOfMax: number;
+}
+
+/** Sentiment trend chips, sourced from the overview panel (the distribution endpoint carries no change percentages); null when that panel has no data or errored. */
+export interface SocialListeningSentimentTrends {
+  positive: StatCardDelta | null;
+  negative: StatCardDelta | null;
 }
 
 /** Declarative fetch state for the toSignal pipelines. */

--- a/packages/shared/src/utils/social-listening.utils.spec.ts
+++ b/packages/shared/src/utils/social-listening.utils.spec.ts
@@ -38,6 +38,7 @@ function rawMention(overrides: Partial<SocialListeningMention> = {}): SocialList
     SOURCE_PLATFORM: 'reddit',
     SOCIAL_NETWORK: 'Reddit',
     KEYWORD: 'Kubernetes',
+    SOURCE_PROJECT_NAME: 'CNCF Kubernetes',
     MENTION_TS: '2026-02-01T12:00:00Z',
     AUTHOR: '@alice',
     AUTHOR_PROFILE_LINK: 'https://example.test/alice',
@@ -103,6 +104,7 @@ describe('mapRawToMention', () => {
       id: 'key-1',
       platform: 'reddit',
       keyword: 'kubernetes',
+      sourceProjectName: 'CNCF Kubernetes',
       authorName: '@alice',
       sentiment: 'positive',
       relevance: 'high',
@@ -145,6 +147,7 @@ describe('mapRawToMention', () => {
 
     expect(mention).toMatchObject({
       keyword: '',
+      sourceProjectName: '',
       timestamp: '',
       authorName: 'Unknown',
       title: '',

--- a/packages/shared/src/utils/social-listening.utils.ts
+++ b/packages/shared/src/utils/social-listening.utils.ts
@@ -285,21 +285,25 @@ export function mapTagRows(tags: SocialListeningTagCount[]): SocialListeningTagR
   }));
 }
 
-/** Top-N platform rows (default `ANALYTICS_TOP_PLATFORMS_LIMIT`) grouped by normalized key — raw duplicates (`X`/`twitter`, unsupported → other) would duplicate the template's `track row.config.label` keys. */
+/** Top-N platform rows (default `ANALYTICS_TOP_PLATFORMS_LIMIT`) grouped by normalized key — raw duplicates (`X`/`twitter`, unsupported → other) would duplicate the template's `track row.config.label` keys.
+ * `sourcePlatforms` keeps the group's raw values so drill-down can emit a feed-filter value the server actually matches. */
 export function mapPlatformDistributionRows(
   rows: SocialListeningPlatformDistribution[],
   limit: number = ANALYTICS_TOP_PLATFORMS_LIMIT
 ): SocialListeningPlatformRow[] {
   const byKey = new Map<MentionPlatform, SocialListeningPlatformRow>();
   for (const row of rows) {
-    const key = normalizePlatformKey(row.SOURCE_PLATFORM || row.SOCIAL_NETWORK);
+    const raw = row.SOURCE_PLATFORM || row.SOCIAL_NETWORK;
+    const key = normalizePlatformKey(raw);
     const existing = byKey.get(key);
     if (existing) {
       existing.mentionsCount += row.MENTIONS_COUNT;
       existing.percentOfTotal += row.PERCENT_OF_TOTAL || 0;
+      if (raw && !existing.sourcePlatforms.includes(raw)) existing.sourcePlatforms.push(raw);
     } else {
       byKey.set(key, {
         platform: key,
+        sourcePlatforms: raw ? [raw] : [],
         config: MENTION_PLATFORM_CONFIG[key],
         mentionsCount: row.MENTIONS_COUNT,
         percentOfTotal: row.PERCENT_OF_TOTAL || 0,

--- a/packages/shared/src/utils/social-listening.utils.ts
+++ b/packages/shared/src/utils/social-listening.utils.ts
@@ -43,6 +43,7 @@ import type {
   SocialListeningSentimentRow,
   SocialListeningSubProject,
   SocialListeningTagCount,
+  SocialListeningTagRow,
 } from '../interfaces/social-listening.interface';
 import type { StatCardDelta, StatCardDeltaDirection } from '../interfaces/stat-card.interface';
 import { normalizeSnowflakeTimestamp } from './date-time.utils';
@@ -78,6 +79,7 @@ export function mapRawToMention(raw: SocialListeningMention): Mention {
     id: raw.MENTION_ID,
     platform,
     keyword: (raw.KEYWORD || '').toLowerCase(),
+    sourceProjectName: raw.SOURCE_PROJECT_NAME || '',
     // Zone-less Snowflake timestamp → explicit UTC so `timeAgo` and read-state compares don't parse it as browser-local.
     timestamp: normalizeSnowflakeTimestamp(raw.MENTION_TS || ''),
     authorName: raw.AUTHOR || 'Unknown',
@@ -272,22 +274,15 @@ export function buildOverTimeChartData(points: SocialListeningOverTimePoint[]): 
   return { labels, datasets };
 }
 
-/** Mentions by Tag bar chart: rows arrive pre-sorted/capped (`MENTION_TOP_TAGS_LIMIT`); labels title-cased via `formatTag`. Null when empty. */
-export function buildTagsChartData(tags: SocialListeningTagCount[]): ChartData<'bar'> | null {
-  const rows = tags.filter((tag) => !!tag.TAG);
-  if (rows.length === 0) return null;
-
-  return {
-    labels: rows.map((tag) => formatTag(tag.TAG)),
-    datasets: [
-      {
-        data: rows.map((tag) => tag.TOTAL_COUNT),
-        backgroundColor: rows.map((_, i) => seriesColor(i)),
-        borderRadius: 4,
-        borderSkipped: false,
-      },
-    ],
-  };
+/** Ranked Mentions by Tag rows; upstream pre-sorts and caps (`MENTION_TOP_TAGS_LIMIT`) but the sort is re-applied so the bar widths stay monotonic. */
+export function mapTagRows(tags: SocialListeningTagCount[]): SocialListeningTagRow[] {
+  const rows = tags.filter((tag) => !!tag.TAG).sort((a, b) => b.TOTAL_COUNT - a.TOTAL_COUNT);
+  const max = rows[0]?.TOTAL_COUNT ?? 0;
+  return rows.map((tag) => ({
+    label: formatTag(tag.TAG),
+    count: tag.TOTAL_COUNT,
+    percentOfMax: max > 0 ? (tag.TOTAL_COUNT / max) * 100 : 0,
+  }));
 }
 
 /** Top-N platform rows (default `ANALYTICS_TOP_PLATFORMS_LIMIT`) grouped by normalized key — raw duplicates (`X`/`twitter`, unsupported → other) would duplicate the template's `track row.config.label` keys. */
@@ -304,6 +299,7 @@ export function mapPlatformDistributionRows(
       existing.percentOfTotal += row.PERCENT_OF_TOTAL || 0;
     } else {
       byKey.set(key, {
+        platform: key,
         config: MENTION_PLATFORM_CONFIG[key],
         mentionsCount: row.MENTIONS_COUNT,
         percentOfTotal: row.PERCENT_OF_TOTAL || 0,


### PR DESCRIPTION
## Summary

Redesigns the Social Listening page end to end: the feed moves from a white card shell with a PrimeNG paginator to mentions floating on the gray page canvas with a Load More flow, the mention card and analytics tab get full visual redesigns, and the feed header is reordered around search. The motivation is to bring the page in line with the new design spec and make long-feed reading and analytics scanning less cramped.

Resolves #1821

## Behavior changes

### Feed navigation

| Before | After |
|---|---|
| The feed paged through mentions with a rows-per-page paginator that replaced the current page of results and offered page-size choices of 10–100. | Mentions accumulate as you scroll: a Load More button appends the next batch below what's already loaded, with a running "n of total" count, and previously loaded batches never refetch. |

### Page layout and view switching

| Before | After |
|---|---|
| The whole feed lived inside one large white card, with a card-tabs bar for switching between Feed and Analytics, and the header scrolled away with the content. | Mention cards and analytics panels float directly on the gray page background; the page title and the filter row stay pinned at the top while scrolling; a segmented pill switcher in the header swaps between Feed and Analytics. |

### Feed header controls

| Before | After |
|---|---|
| Search sat after the scope dropdowns, the preset-views trigger looked unlike the other fields, and on phones the control row could overflow the screen; long saved-view names truncated with no way to read them. | Search leads the header and grows to fill available space, with project, platform, and period filters grouped after it; the views trigger matches the other form fields, sits at the right edge, shows the full view name in a tooltip on hover or keyboard focus when truncated, and the controls wrap cleanly on mobile. |

### Mention cards

| Before | After |
|---|---|
| Mentions rendered as flat rows with sentiment shown as a small tag, the matched keyword as the only label, and a fixed-height excerpt; read mentions were dimmed. | Each mention is a card with a colored left rail signaling sentiment, a project pill showing the matched sub-project, circular icon actions with tooltips, a four-line excerpt that expands in place, and a side-by-side link preview; read mentions keep full contrast and are distinguished only by background. |

### Analytics

| Before | After |
|---|---|
| Analytics panels stacked in a single column, tags appeared as a bar chart, and platform rows were display-only. | Analytics uses a two-column layout with a sticky summary rail (Mentions by Project and Sentiment Distribution stay in view), tags render as a ranked list with proportional bars, positive/negative sentiment show period-over-period trend chips, and clicking a platform row jumps to the feed filtered to that platform. |

## Technical changes

`apps/lfx-one/src/app/modules/dashboards/social-listening/social-listening.component.ts, .html, .scss` — Page shell and feed state
- Removes the white `lfx-card` shell; the pinned page header and filter row go sticky at `z-20` (above the cards' stretched links), re-skinned gray-50, with the scroll fade moved to the filter row
- Replaces the `lfx-card-tabs-bar` with an in-page segmented Feed/Analytics pill switcher (`aria-pressed`, options from the new shared `SOCIAL_LISTENING_TAB_OPTIONS`)
- Replaces `currentPage` with `lastLoadedPage`: `initMentions()` now concatenates every loaded window in order and trims to the requested batches, so Load More appends cumulatively and never refetches; the window cache drops its ±2-window pruning (`MENTION_MAX_CACHED_WINDOWS` removed) and the global-newest mention cutoff lives outside the cache
- Adds `loadedCount`, `hasMore`, `loadingMore`, and `servableTotal` signals (the last still capped at `MENTION_MAX_FEED_OFFSET`) and the `onLoadMore` / `onTabSelected` handlers
- Adds `onAnalyticsPlatformSelected` — scopes the feed's platform filter and switches to the feed tab for analytics drill-down
- Anchors the views dropdown under its trigger, right-aligned on desktop and left-aligned on mobile so the wrapped header can't push it off-screen

`.../components/feed-header/feed-header.component.ts, .html, .scss` — Feed header
- Moves search to the front of the header, growing to fill slack (matches the meetings top-bar pattern); project/platform/period selects stay grouped after it as scope filters
- Restyles the preset-views trigger with form-field chrome matching the selects and moves it to the right edge with the filters gear
- Shows a tooltip with the full preset-view name when the trigger label truncates, gated by a computed on `VIEWS_DROPDOWN_NAME_TOOLTIP_THRESHOLD`; the tooltip binding sits on the focusable `lfx-button` host with `tooltipEvent="both"` so keyboard focus reveals it (the wrapper's own tooltip input would suppress `ariaExpanded` forwarding — both consume PrimeNG's `pt` binding)
- Makes the control group grow desktop-only (`basis-full sm:basis-0`) so the trigger group wraps to its own row on phones
- `activeTab` becomes a one-way `input` (tab state is owned by the page's pill switcher) and the `CardTabsBarComponent` import is dropped

`.../components/mentions-list/mentions-list.component.ts, .html, .scss` — Feed list
- Removes the PrimeNG paginator and the page-size/`first`/`rowsPerPageOptions` inputs in favor of `loadedCount` / `servableTotal` / `hasMore` / `loadingMore`, with a Load More footer that spins while loaded rows stay on screen
- Replaces the `pageChange` output with `loadMore` and `clearFilters` outputs, and drops the scroll-into-view-on-page-change behavior

`.../components/mention-card/mention-card.component.ts, .html, .scss` — Mention card
- Adds the left sentiment rail (driven by the new `railClass`/`textClass` config) with a screen-reader-only sentiment label
- Adds the project pill via a `displayProject` computed — `sourceProjectName` with a fallback to the matched keyword
- Converts the actions to circular icon buttons with tooltips, adds the 4-line body clamp with an in-place expand toggle (`bodyExpanded` / `bodyExpandable` latch so the toggle survives un-clamping), and lays the link preview out side by side
- Keeps read mentions at full contrast, distinguishing them by background only

`.../components/analytics/social-listening-analytics.component.ts, .html, .scss` — Analytics
- Reworks the layout into two columns (`2fr / 1fr`) with a sticky summary rail holding Mentions by Project and Sentiment Distribution; the rail is forced static during PNG export so `html-to-image` captures the full laid-out view
- Replaces the tags bar chart with a ranked list fed by the new `mapTagRows` util (`percentOfMax` sizes each bar against the top row); the screen-reader mirror table goes away since the list is natively readable
- Adds positive/negative sentiment trend chips via `initSentimentTrends`, sourced from the overview panel's change percentages (the distribution endpoint carries none); an overview error drops the chips without touching the card's own counts, and negative sentiment inverts the delta colors (up renders red)
- Makes platform rows clickable buttons emitting the new `platformSelected` output (each row carries its normalized `platform` key) for feed drill-down
- Narrows the shared external chart tooltip typing to line charts now that the bar chart is gone

`packages/shared/src/constants/social-listening.constants.ts, interfaces/social-listening.interface.ts, utils/social-listening.utils.ts` — Shared package
- Adds `Mention.sourceProjectName`, mapped from `SOURCE_PROJECT_NAME` in `mapRawToMention` (falls back to `keyword` when blank)
- Adds the `SocialListeningTagRow` and `SocialListeningSentimentTrends` interfaces, a normalized `platform` key on `SocialListeningPlatformRow`, and `railClass` / `textClass` on `MentionSentimentConfigEntry` (Tailwind classes, no hex — repo styling rule)
- Replaces `buildTagsChartData` with `mapTagRows` (re-sorts upstream rows so bar widths stay monotonic); removes `MENTION_PAGE_SIZE_OPTIONS` and `MENTION_MAX_CACHED_WINDOWS` (no remaining consumers); Load More batch is fixed at `DEFAULT_MENTION_PAGE_SIZE` (20)
- Moves `SOCIAL_LISTENING_TAB_OPTIONS` into shared constants now that the page header owns the view switcher

`.../social-listening/*.spec.ts, packages/shared/src/utils/social-listening.utils.spec.ts` — Tests
- Updates the page, list, card, and analytics specs for the Load More flow, pill switcher, platform drill-down, and expand/collapse body; adds `mapTagRows` coverage
