### PR TITLE
fix(cla): show the account picker's empty state when none are linked

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.html
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.html
@@ -8,25 +8,35 @@ SPDX-License-Identifier: MIT
     This CLA group is linked to GitHub repositories. Choose the GitHub account you'll sign with — you'll be redirected to EasyCLA to complete it.
   </p>
 
-  <div role="listbox" aria-label="Linked GitHub accounts" class="flex flex-col gap-2">
-    @for (account of accounts(); track account.githubId) {
-      <lfx-selectable-card
-        [form]="selectForm"
-        control="githubId"
-        [value]="account.githubId"
-        [label]="account.label"
-        [testId]="'github-account-select-' + account.githubId" />
-    }
-  </div>
+  @if (hasAccounts()) {
+    <div role="listbox" aria-label="Linked GitHub accounts" class="flex flex-col gap-2">
+      @for (account of accounts(); track account.githubId) {
+        <lfx-selectable-card
+          [form]="selectForm"
+          control="githubId"
+          [value]="account.githubId"
+          [label]="account.label"
+          [testId]="'github-account-select-' + account.githubId" />
+      }
+    </div>
 
-  <div class="mt-4 flex justify-end gap-2.5">
-    <lfx-button label="Cancel" [text]="true" (onClick)="onCancel()" data-testid="github-account-select-cancel" />
-    <lfx-button
-      label="Continue to sign"
-      icon="fa-light fa-arrow-right"
-      iconPos="right"
-      [disabled]="!selectedId()"
-      (onClick)="onContinue()"
-      data-testid="github-account-select-continue" />
-  </div>
+    <div class="mt-4 flex justify-end gap-2.5">
+      <lfx-button label="Cancel" [text]="true" (onClick)="onCancel()" data-testid="github-account-select-cancel" />
+      <lfx-button
+        label="Continue to sign"
+        icon="fa-light fa-arrow-right"
+        iconPos="right"
+        [disabled]="!selectedId()"
+        (onClick)="onContinue()"
+        data-testid="github-account-select-continue" />
+    </div>
+  } @else {
+    <div class="px-2 py-6 text-center" data-testid="github-account-select-empty">
+      <i class="fa-light fa-circle-question mb-2.5 block text-2xl text-slate-400" aria-hidden="true"></i>
+      <p class="mb-4 text-sm leading-relaxed text-slate-600">
+        No GitHub accounts are connected to your profile yet. Link one from Identities, then come back to sign.
+      </p>
+      <lfx-button label="Go to Identities" [outlined]="true" (onClick)="onLinkAccounts()" data-testid="github-account-select-link-accounts" />
+    </div>
+  }
 </div>

--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.spec.ts
@@ -17,6 +17,10 @@ import { GithubAccountSelectComponent } from './github-account-select.component'
  * token — so what these tests protect is the contributor's *choice*: that every linked account
  * is offered, that nothing is chosen on their behalf, and that the dialog closes with exactly
  * what they picked. Those three are what the parent depends on.
+ *
+ * With no linked account there is no choice to protect, and the tests turn to the block instead
+ * (#1917): that the list and its actions are gone rather than merely disabled, and that asking
+ * to link an account is distinguishable from walking away.
  */
 describe('GithubAccountSelectComponent', () => {
   const OCTOCAT: GithubAccountOption = { githubId: '12345', githubUsername: 'octocat' };
@@ -96,7 +100,7 @@ describe('GithubAccountSelectComponent', () => {
 
     // The number, not the handle: handles get renamed and reclaimed by other people, so a
     // hand-off keyed on one could land on a different account than the one shown here.
-    expect(close).toHaveBeenCalledWith(HUBOT.githubId);
+    expect(close).toHaveBeenCalledWith({ githubId: HUBOT.githubId });
   });
 
   it('closes with the later choice when the contributor changes their mind', async () => {
@@ -104,7 +108,7 @@ describe('GithubAccountSelectComponent', () => {
     await choose(HUBOT.githubId);
     (fixture.componentInstance as any).onContinue();
 
-    expect(close).toHaveBeenCalledWith(HUBOT.githubId);
+    expect(close).toHaveBeenCalledWith({ githubId: HUBOT.githubId });
   });
 
   it('closes with nothing when the contributor backs out', async () => {
@@ -116,9 +120,47 @@ describe('GithubAccountSelectComponent', () => {
     expect(close).toHaveBeenCalledWith(null);
   });
 
-  it('renders without a choice when opened with no accounts', async () => {
-    // Should not happen — the caller routes an empty list into account linking — but an empty
-    // picker must not offer a Continue that could submit nothing.
+  // --- Empty state (#1917) --------------------------------------------------
+
+  it('blocks with an empty state instead of an empty list when nothing is linked', async () => {
+    await setup([]);
+
+    // The list and both footer actions give way to the empty state, so there is no Continue to
+    // press and nothing to press it against — the block is structural, not a disabled button.
+    expect(query('github-account-select-empty')).not.toBeNull();
+    expect(fixture.nativeElement.querySelector('[role="listbox"]')).toBeNull();
+    expect(query('github-account-select-continue')).toBeNull();
+    expect(query('github-account-select-cancel')).toBeNull();
+  });
+
+  it('says which accounts are missing and where to link one', async () => {
+    await setup([]);
+
+    expect(query('github-account-select-empty')?.textContent).toContain('No GitHub accounts are connected to your profile yet');
+    expect(query('github-account-select-link-accounts')?.textContent).toContain('Go to Identities');
+  });
+
+  it('keeps the group explanation above the empty state, as the design leaves it', async () => {
+    await setup([]);
+
+    // The design shows this paragraph at every account count, and its first sentence is the only
+    // place the flow says why a GitHub account in particular is being asked for. Dropping it
+    // because the second sentence reads oddly with nothing to choose from would be a rewrite of
+    // copy that is taken verbatim, so it stays and this holds it there.
+    expect(query('github-account-select-dialog')?.textContent).toContain('This CLA group is linked to GitHub repositories');
+  });
+
+  it('asks the caller to open Identities rather than navigating itself', async () => {
+    await setup([]);
+
+    query('github-account-select-link-accounts')?.querySelector('button')?.click();
+
+    // Distinguishable from the dismissal below, which is the whole reason it is not just a
+    // close: only one of the two should move the contributor off the page they started from.
+    expect(close).toHaveBeenCalledWith({ linkAccounts: true });
+  });
+
+  it('cannot submit an account from the empty state', async () => {
     await setup([]);
 
     (fixture.componentInstance as any).onContinue();

--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
@@ -12,7 +12,8 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
 
 /**
  * "Which GitHub account are you signing as?" step, shown between the CLA-group picker and the
- * Console hand-off (#1252) whenever the contributor has at least one linked GitHub account.
+ * Console hand-off (#1252). It is shown for every account list the server returns, an empty
+ * one included.
  *
  * It exists because the account a CLA is recorded against used to be decided by whichever
  * record an identity search returned first, which is not a decision the contributor got to

--- a/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/github-account-select.component.ts
@@ -1,10 +1,10 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { ChangeDetectionStrategy, Component, inject, signal } from '@angular/core';
+import { ChangeDetectionStrategy, Component, computed, inject, signal } from '@angular/core';
 import { takeUntilDestroyed } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
-import type { GithubAccountChoice, GithubAccountOption } from '@lfx-one/shared/interfaces';
+import type { GithubAccountChoice, GithubAccountOption, GithubAccountSelectResult } from '@lfx-one/shared/interfaces';
 import { DynamicDialogConfig, DynamicDialogRef } from 'primeng/dynamicdialog';
 
 import { ButtonComponent } from '@components/button/button.component';
@@ -24,9 +24,21 @@ import { SelectableCardComponent } from '@components/selectable-card/selectable-
  * component must present what it is given and nothing else — it must never accept an account
  * from the URL, from user input, or from anywhere but `config.data`.
  *
- * Closes with the chosen account's `githubId`, or `null` if the contributor backs out. The id
- * alone, because the parent already holds the list and resolves the rest from it rather than
- * taking a handle from here.
+ * With no linked account it becomes a blocking empty state rather than an empty list: the
+ * contributor is told why they cannot continue at the point they tried to, instead of being
+ * moved elsewhere and left to work out that the CLA group they picked was dropped (#1917).
+ *
+ * That block is written out here rather than delegated to `lfx-empty-state` because that
+ * component takes `title` as a required input and the design has no title — an icon, one
+ * sentence, one action. Reusing it would mean inventing a heading, and the wording here is
+ * required to be the design's. Its page-level proportions — a card, `p-8 md:p-16`, an 80px icon
+ * badge — are the second reason; every other use of it in the app is a page or a table, not a
+ * 32rem dialog. The action still takes that component's own outlined treatment, so the two
+ * agree on everything but size.
+ *
+ * Closes with the chosen account's `githubId`, with `linkAccounts` if they asked to link one,
+ * or `null` if they backed out. The id alone, because the parent already holds the list and
+ * resolves the rest from it rather than taking a handle from here.
  */
 @Component({
   selector: 'lfx-github-account-select',
@@ -60,6 +72,7 @@ export class GithubAccountSelectComponent {
     }))
   );
   protected readonly selectedId = signal<string | null>(null);
+  protected readonly hasAccounts = computed(() => this.accounts().length > 0);
 
   public constructor() {
     this.selectForm.controls.githubId.valueChanges.pipe(takeUntilDestroyed()).subscribe((value) => this.selectedId.set(value));
@@ -68,10 +81,18 @@ export class GithubAccountSelectComponent {
   protected onContinue(): void {
     const githubId = this.selectedId();
     if (!githubId) return;
-    this.ref.close(githubId);
+    this.ref.close({ githubId } satisfies GithubAccountSelectResult);
   }
 
   protected onCancel(): void {
     this.ref.close(null);
+  }
+
+  /**
+   * Asks the caller to take the contributor to Identities. Navigating from here instead would
+   * put routing in a dialog, which nothing else in this flow does.
+   */
+  protected onLinkAccounts(): void {
+    this.ref.close({ linkAccounts: true } satisfies GithubAccountSelectResult);
   }
 }

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -17,6 +17,7 @@ import type {
   ClaGroupSearchResponse,
   ClaManagerList,
   GithubAccountOptions,
+  GithubAccountSelectResult,
   MyClaAgreement,
   MyClasResponse,
   PrepareSignResponse,
@@ -505,11 +506,11 @@ describe('ProfileClasComponent', () => {
  * inside it (#1252).
  *
  * Each picker is a dynamic dialog with its own spec; what matters here is the orchestration —
- * that the action is offered only when it can succeed, that the number of linked accounts
- * decides whether a choice is even presented, that the address navigated to is the one the CLA
- * backend returned rather than one assembled here, and that a refusal ends the flow rather than
- * quietly picking another account. The template is rendered rather than overridden, because
- * whether the action is offered at all is a template condition.
+ * that the action is offered only when it can succeed, that every account list reaches the
+ * picker whatever its length, that the address navigated to is the one the CLA backend returned
+ * rather than one assembled here, and that a refusal ends the flow rather than quietly picking
+ * another account. The template is rendered rather than overridden, because whether the action
+ * is offered at all is a template condition.
  */
 describe('ProfileClasComponent — Sign CLA hand-off and account selection (#1251, #1252)', () => {
   const CLA_GROUP: ClaGroupOption = { claGroupId: 'cg-1', projectName: 'Venus test', matchTypes: ['project'], organizations: [] };
@@ -548,7 +549,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
       accounts?: () => Observable<GithubAccountOptions>;
       prepare?: () => Observable<PrepareSignResponse>;
       closesWith?: ClaGroupOption | null;
-      accountClosesWith?: string | null;
+      accountClosesWith?: GithubAccountSelectResult | null;
       dismissGroup?: 'close' | 'destroy' | 'hold';
       dismissAccount?: 'close' | 'destroy' | 'hold';
     } = {}
@@ -565,7 +566,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     open = vi.fn((component: unknown) => {
       opened.push(component);
       if (component === GithubAccountSelectComponent) {
-        return dialogEvents('accountClosesWith' in options ? options.accountClosesWith : '12345', options.dismissAccount ?? 'close');
+        return dialogEvents('accountClosesWith' in options ? options.accountClosesWith : { githubId: '12345' }, options.dismissAccount ?? 'close');
       }
       return dialogEvents('closesWith' in options ? options.closesWith : CLA_GROUP, options.dismissGroup ?? 'close');
     });
@@ -769,7 +770,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
   });
 
   it('submits the account chosen, not the first one listed', async () => {
-    const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS), accountClosesWith: '67890' });
+    const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS), accountClosesWith: { githubId: '67890' } });
 
     await sign(fixture);
 
@@ -777,7 +778,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
   });
 
   it('does not submit an account that is not in the served list', async () => {
-    const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS), accountClosesWith: '99999' });
+    const fixture = await setup({ accounts: () => of(TWO_ACCOUNTS), accountClosesWith: { githubId: '99999' } });
 
     await sign(fixture);
 
@@ -812,14 +813,40 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     expect(isStarting(fixture)).toBe(false);
   });
 
-  it('routes to account linking rather than showing an empty picker when none are linked', async () => {
-    const fixture = await setup({ accounts: () => of({ accounts: [] }) });
+  it('opens the picker on its empty state when no account is linked (#1917)', async () => {
+    const fixture = await setup({ accounts: () => of({ accounts: [] }), accountClosesWith: null });
 
     await sign(fixture);
 
-    expect(opened).not.toContain(GithubAccountSelectComponent);
+    // The picker is opened and served the empty list rather than being skipped for a redirect.
+    // Stopping the contributor where they are is what keeps the CLA group they already chose.
+    expect(opened).toContain(GithubAccountSelectComponent);
+    expect(open.mock.calls.at(-1)?.[1]).toMatchObject({ data: { accounts: [] } });
     expect(prepareSign).not.toHaveBeenCalled();
+    expect(location.href).toBe(HOME);
+    expect(isStarting(fixture)).toBe(false);
+  });
+
+  it('goes to Identities when the empty state asks for it', async () => {
+    const fixture = await setup({ accounts: () => of({ accounts: [] }), accountClosesWith: { linkAccounts: true } });
+
+    await sign(fixture);
+
     expect(navigate).toHaveBeenCalledWith(['/profile/identities']);
+    expect(prepareSign).not.toHaveBeenCalled();
+    // No toast on the way out: the empty state they acted on already said this, and repeating it
+    // on arrival reads as an error report for something that went right.
+    expect(messageAdd).not.toHaveBeenCalled();
+  });
+
+  it('stays put when the empty state is dismissed rather than acted on', async () => {
+    const fixture = await setup({ accounts: () => of({ accounts: [] }), accountClosesWith: null });
+
+    await sign(fixture);
+
+    // Dismissing and asking to link both leave the picker with no account chosen. Navigating on
+    // either would move a contributor who only wanted to close the dialog.
+    expect(navigate).not.toHaveBeenCalled();
     expect(location.href).toBe(HOME);
   });
 
@@ -907,7 +934,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     // nothing below this layer can notice. Only comparing what came back against what went in
     // catches a signature about to be attributed to an account nobody chose.
     const fixture = await setup({
-      accountClosesWith: '12345',
+      accountClosesWith: { githubId: '12345' },
       prepare: () => of({ ...PREPARED, githubId: '67890', githubUsername: 'hubot' }),
     });
 
@@ -918,7 +945,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
   });
 
   it('proceeds when the verified account matches, so the check is not merely blocking everything', async () => {
-    const fixture = await setup({ accountClosesWith: '67890', prepare: () => of({ ...PREPARED, githubId: '67890', githubUsername: 'hubot' }) });
+    const fixture = await setup({ accountClosesWith: { githubId: '67890' }, prepare: () => of({ ...PREPARED, githubId: '67890', githubUsername: 'hubot' }) });
 
     await sign(fixture);
 
@@ -930,7 +957,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
     // The server refuses this too; the second guard is here because this is the only layer that
     // saw the picker.
     const fixture = await setup({
-      accountClosesWith: '12345',
+      accountClosesWith: { githubId: '12345' },
       prepare: () => of({ ...PREPARED, githubId: '67890', githubUsername: 'hubot', skippedIdentities: ['github-id:12345'] }),
     });
 
@@ -941,7 +968,7 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
   });
 
   it('reports a mismatch as a mismatch, not as a failure to open the page', async () => {
-    const fixture = await setup({ accountClosesWith: '12345', prepare: () => of({ ...PREPARED, githubId: '67890' }) });
+    const fixture = await setup({ accountClosesWith: { githubId: '12345' }, prepare: () => of({ ...PREPARED, githubId: '67890' }) });
 
     await sign(fixture);
 

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.spec.ts
@@ -855,8 +855,9 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
 
     await sign(fixture);
 
-    // Routing this into account linking would tell a contributor who has a linked account to
-    // go connect one — sending them to fix something that is not broken.
+    // Treating this as zero accounts would put the contributor in front of the empty state,
+    // telling someone who does have a linked account to go connect one — asking them to fix
+    // something that is not broken.
     expect(navigate).not.toHaveBeenCalled();
     expect(messageAdd).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error' }));
     expect(location.href).toBe(HOME);
@@ -1039,9 +1040,10 @@ describe('ProfileClasComponent — Sign CLA hand-off and account selection (#125
   });
 
   it('does not route a refusal into account linking', async () => {
-    // Account linking is reached only from an empty account list, which is a fact about this
-    // session rather than an upstream answer. Routing a refusal there would send someone who
-    // does have a linked account to fix something that is not broken.
+    // Account linking is reached only when the contributor asks for it from the picker's empty
+    // state, which is a fact about this session rather than an upstream answer. Routing a
+    // refusal there would send someone who does have a linked account to fix something that is
+    // not broken.
     const fixture = await setup({ prepare: refusedWith(403, OWNERSHIP_REFUSAL) });
 
     await sign(fixture);

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -217,8 +217,8 @@ export class ProfileClasComponent {
         error: () => {
           this.starting.set(false);
           // Explicitly not treated as "no accounts linked". The two are indistinguishable in
-          // the payload but not in consequence: sending someone who already linked an account
-          // into account-linking asks them to fix something that is not broken.
+          // the payload but not in consequence: showing the picker's empty state to someone
+          // who already linked an account asks them to fix something that is not broken.
           this.messageService.add({
             severity: 'error',
             summary: 'Could not start signing',

--- a/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/clas/profile-clas.component.ts
@@ -6,7 +6,16 @@ import { ChangeDetectionStrategy, Component, computed, DestroyRef, inject, PLATF
 import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { Router, RouterLink } from '@angular/router';
 import { ECLA_COVERED_DOWNLOAD_LABEL, MY_CLAS_M2_ENABLED_FLAG } from '@lfx-one/shared/constants';
-import type { ClaGroupOption, ClaRow, ClaStatus, GithubAccountOption, MyClaAgreement, MyClasState, PrepareSignResponse } from '@lfx-one/shared/interfaces';
+import type {
+  ClaGroupOption,
+  ClaRow,
+  ClaStatus,
+  GithubAccountOption,
+  GithubAccountSelectResult,
+  MyClaAgreement,
+  MyClasState,
+  PrepareSignResponse,
+} from '@lfx-one/shared/interfaces';
 import { claStatusLabel, claStatusSeverity, downloadFromUrl, isMyClasEmpty, signedAsLine } from '@lfx-one/shared/utils';
 import { MenuItem, MessageService } from 'primeng/api';
 import { DialogService, DynamicDialogRef } from 'primeng/dynamicdialog';
@@ -238,19 +247,16 @@ export class ProfileClasComponent {
   }
 
   /**
-   * Routes on whether any account is linked at all: none goes to linking, any number is asked.
+   * Asks which account the signature will be recorded against. Every account list reaches the
+   * picker, whatever its length.
    *
-   * A single account is asked for too. What the screen carries is which identity the signature
-   * will be recorded against, and a list of one says that as plainly as a list of two — so there
-   * is something to show even where there is nothing to choose between.
+   * A single account is asked for too, because what the screen carries is the identity rather
+   * than the choice, and a list of one says that as plainly as a list of two. An empty one is
+   * shown as well, as the picker's own blocking empty state (#1917) — the contributor is stopped
+   * where they are instead of being moved off the page, which would drop the CLA group they had
+   * already chosen. Either way nothing reaches the Console without an account.
    */
   private chooseAccountThenSign(option: ClaGroupOption, accounts: GithubAccountOption[]): void {
-    if (accounts.length === 0) {
-      this.starting.set(false);
-      this.sendToAccountLinking();
-      return;
-    }
-
     this.starting.set(false);
     this.signDialogOpen.set(true);
 
@@ -263,10 +269,14 @@ export class ProfileClasComponent {
       data: { accounts },
     }) as DynamicDialogRef;
 
-    this.whenDialogSettles<string>(dialogRef, (githubId) => {
+    this.whenDialogSettles<GithubAccountSelectResult>(dialogRef, (result) => {
       this.signDialogOpen.set(false);
-      if (!githubId) {
-        this.starting.set(false);
+      this.starting.set(false);
+
+      if (!result) return;
+
+      if ('linkAccounts' in result) {
+        this.sendToAccountLinking();
         return;
       }
 
@@ -274,9 +284,8 @@ export class ProfileClasComponent {
       // account submitted is always one of the accounts linked to this session. Ownership
       // verification upstream passes for every account the contributor holds, which is what
       // makes where this value came from matter.
-      const chosen = accounts.find((account) => account.githubId === githubId);
+      const chosen = accounts.find((account) => account.githubId === result.githubId);
       if (!chosen) {
-        this.starting.set(false);
         this.reportRecordedMismatch();
         return;
       }
@@ -376,12 +385,13 @@ export class ProfileClasComponent {
     });
   }
 
+  /**
+   * Takes the contributor to Identities, having asked for it from the picker's empty state.
+   *
+   * No accompanying message: the empty state they just acted on says the same thing, and a toast
+   * repeating it on arrival reads as though something went wrong.
+   */
   private sendToAccountLinking(): void {
-    this.messageService.add({
-      severity: 'info',
-      summary: 'Link a GitHub account',
-      detail: 'Connect the GitHub account you contribute with, then start signing again.',
-    });
     void this.router.navigate(['/profile/identities']);
   }
 

--- a/packages/shared/src/interfaces/cla.interface.ts
+++ b/packages/shared/src/interfaces/cla.interface.ts
@@ -241,6 +241,15 @@ export interface GithubAccountChoice extends GithubAccountOption {
   label: string;
 }
 
+/**
+ * What the GitHub account step closes with, beyond `null` for a dismissal (#1917).
+ *
+ * The two outcomes are kept apart because dismissing the empty state and asking to link an
+ * account both leave the picker with no account chosen, and only one of them should move the
+ * contributor off the page they started from.
+ */
+export type GithubAccountSelectResult = { githubId: string } | { linkAccounts: true };
+
 /** Response for `GET /api/me/clas/github-accounts`. */
 export interface GithubAccountOptions {
   accounts: GithubAccountOption[];


### PR DESCRIPTION
## Problem

Starting **Sign CLA** on a GitHub-backed CLA group with no linked GitHub
account never opened the account step. Self Serve reported "Link a GitHub
account" and navigated to `/profile/identities`.

That discards the CLA group the contributor had just selected, so linking an
account returns them to the beginning of the flow rather than to where they
were.

## What changes

#1249 asks for the opposite shape — the picker opens and blocks inside itself:

> the picker shows an empty state that **blocks continuing** — "No GitHub
> accounts are connected to your profile yet" — with a link to Identities to
> link one. It MUST NOT fall through to the Console.

Both shapes stop the hand-off, so nothing reaches the Contributor Console
without a linked account either way. What changes is where the contributor is
told, and whether they keep their place.

- The last count test leaves `chooseAccountThenSign`. Every list length now
  reaches the dialog, and the dialog decides what to render — no count in the
  caller can bypass the step.
- With an empty list the step renders a blocking empty state: no account list,
  and no continue action at all rather than a disabled one.
- Its close payload widens to `{ githubId } | { linkAccounts: true }`.
  Dismissing the step and asking to link an account both leave it with no
  account chosen, and only one of them may navigate.
- The informational toast is dropped. The empty state says the same thing at
  the point the contributor tried to act; repeating it after a navigation they
  asked for reads as a report that something went wrong.

Copy follows the v17 prototype verbatim, including the explanatory paragraph
above the step, which the prototype leaves visible at every account count.

Unchanged: the presentation for one or more linked accounts (#1915), the
numeric-id match against the server-served list, the echoed-identity guard,
and the prepare call.

## Testing

- Licence headers, prettier, eslint, `check-types` — all clean.
- 2,207 server tests and 1,310 app tests pass (1,304 before this change).
- Eight new tests cover the step: that the empty state replaces the account
  list and both footer actions rather than disabling them, that its wording is
  the prototype's, and that asking to link an account is distinguishable from
  dismissing the dialog.

## Notes for review

The dialog closes with a payload instead of navigating itself, because nothing
under `modules/profile/clas/` injects `Router` except the page component.

Refs #1249, #1917
