### PR TITLE
fix(events): scope combined cte dedup to the full union

### DIFF
--- a/apps/lfx-one/src/server/services/events.service.spec.ts
+++ b/apps/lfx-one/src/server/services/events.service.spec.ts
@@ -174,11 +174,11 @@ describe('EventsService.getMyEvents past-event SQL', () => {
     const sql = await sqlFor({ isPast: false, affiliatedProjectSlugs: ['example'] });
     const combined = sql.slice(sql.indexOf('combined AS ('));
     const wrapperOpen = combined.indexOf('SELECT * FROM (');
-    // Each branch landmark pins its priority literal to its source, so swapping them fails here;
-    // the QUALIFY landmark closes at ")", so an ORDER BY flipped to DESC stops matching too.
+    // Each branch landmark pins its priority literal to its source; the QUALIFY landmark spans the
+    // ORDER BY through "= 1", so a DESC flip or a changed row-number predicate stops matching too.
     const firstBranch = combined.indexOf('SELECT *, 1 AS SOURCE_PRIORITY FROM registered_events');
     const lastBranch = combined.indexOf('SELECT *, 2 AS SOURCE_PRIORITY FROM affiliated_upcoming');
-    const qualify = combined.indexOf('QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY SOURCE_PRIORITY)');
+    const qualify = combined.indexOf('QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY SOURCE_PRIORITY) = 1');
 
     // Ordering alone passes on a missing landmark (indexOf returns -1), so require each to exist.
     for (const landmark of [wrapperOpen, firstBranch, lastBranch, qualify]) {

--- a/apps/lfx-one/src/server/services/events.service.spec.ts
+++ b/apps/lfx-one/src/server/services/events.service.spec.ts
@@ -168,6 +168,17 @@ describe('EventsService.getMyEvents past-event SQL', () => {
     expect(sql).toContain('e.EVENT_SOURCE,');
   });
 
+  it('scopes the combined-CTE dedup to the whole union, not just the last branch', async () => {
+    // QUALIFY binds to a single SELECT block, so the union has to be wrapped: written directly
+    // after UNION ALL it only dedups affiliated_upcoming and duplicates cross-branch events.
+    const sql = await sqlFor({ isPast: false, affiliatedProjectSlugs: ['example'] });
+    const combined = sql.slice(sql.indexOf('combined AS ('));
+    const qualify = combined.indexOf('QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY source_priority)');
+
+    expect(combined.indexOf('SELECT * FROM (')).toBeLessThan(combined.indexOf('SELECT *, 1 AS source_priority'));
+    expect(combined.slice(combined.indexOf('FROM affiliated_upcoming'), qualify)).toContain(')');
+  });
+
   it('selects EVENT_SOURCE in the past branch', async () => {
     const sql = await sqlFor({ isPast: true });
 

--- a/apps/lfx-one/src/server/services/events.service.spec.ts
+++ b/apps/lfx-one/src/server/services/events.service.spec.ts
@@ -174,9 +174,11 @@ describe('EventsService.getMyEvents past-event SQL', () => {
     const sql = await sqlFor({ isPast: false, affiliatedProjectSlugs: ['example'] });
     const combined = sql.slice(sql.indexOf('combined AS ('));
     const wrapperOpen = combined.indexOf('SELECT * FROM (');
-    const firstBranch = combined.indexOf('SELECT *, 1 AS source_priority');
-    const lastBranch = combined.indexOf('FROM affiliated_upcoming');
-    const qualify = combined.indexOf('QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY source_priority)');
+    // Each branch landmark pins its priority literal to its source, so swapping them fails here;
+    // the QUALIFY landmark closes at ")", so an ORDER BY flipped to DESC stops matching too.
+    const firstBranch = combined.indexOf('SELECT *, 1 AS SOURCE_PRIORITY FROM registered_events');
+    const lastBranch = combined.indexOf('SELECT *, 2 AS SOURCE_PRIORITY FROM affiliated_upcoming');
+    const qualify = combined.indexOf('QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY SOURCE_PRIORITY)');
 
     // Ordering alone passes on a missing landmark (indexOf returns -1), so require each to exist.
     for (const landmark of [wrapperOpen, firstBranch, lastBranch, qualify]) {

--- a/apps/lfx-one/src/server/services/events.service.spec.ts
+++ b/apps/lfx-one/src/server/services/events.service.spec.ts
@@ -173,10 +173,17 @@ describe('EventsService.getMyEvents past-event SQL', () => {
     // after UNION ALL it only dedups affiliated_upcoming and duplicates cross-branch events.
     const sql = await sqlFor({ isPast: false, affiliatedProjectSlugs: ['example'] });
     const combined = sql.slice(sql.indexOf('combined AS ('));
+    const wrapperOpen = combined.indexOf('SELECT * FROM (');
+    const firstBranch = combined.indexOf('SELECT *, 1 AS source_priority');
+    const lastBranch = combined.indexOf('FROM affiliated_upcoming');
     const qualify = combined.indexOf('QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY source_priority)');
 
-    expect(combined.indexOf('SELECT * FROM (')).toBeLessThan(combined.indexOf('SELECT *, 1 AS source_priority'));
-    expect(combined.slice(combined.indexOf('FROM affiliated_upcoming'), qualify)).toContain(')');
+    // Ordering alone passes on a missing landmark (indexOf returns -1), so require each to exist.
+    for (const landmark of [wrapperOpen, firstBranch, lastBranch, qualify]) {
+      expect(landmark).toBeGreaterThanOrEqual(0);
+    }
+    expect(wrapperOpen).toBeLessThan(firstBranch);
+    expect(combined.slice(lastBranch, qualify)).toContain(')');
   });
 
   it('selects EVENT_SOURCE in the past branch', async () => {

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -190,11 +190,11 @@ export class EventsService {
           -- The subquery is load-bearing: QUALIFY written directly after UNION ALL binds to
           -- the last SELECT block only, so the cross-branch dedup would never run (#1926).
           SELECT * FROM (
-            SELECT *, 1 AS source_priority FROM registered_events
+            SELECT *, 1 AS SOURCE_PRIORITY FROM registered_events
             UNION ALL
-            SELECT *, 2 AS source_priority FROM affiliated_upcoming
+            SELECT *, 2 AS SOURCE_PRIORITY FROM affiliated_upcoming
           )
-          QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY source_priority) = 1
+          QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY SOURCE_PRIORITY) = 1
         )
         SELECT
           e.EVENT_ID,

--- a/apps/lfx-one/src/server/services/events.service.ts
+++ b/apps/lfx-one/src/server/services/events.service.ts
@@ -187,9 +187,13 @@ export class EventsService {
             AND REGISTRATION_STATUS = 'Accepted'
         ),
         combined AS (
-          SELECT *, 1 AS source_priority FROM registered_events
-          UNION ALL
-          SELECT *, 2 AS source_priority FROM affiliated_upcoming
+          -- The subquery is load-bearing: QUALIFY written directly after UNION ALL binds to
+          -- the last SELECT block only, so the cross-branch dedup would never run (#1926).
+          SELECT * FROM (
+            SELECT *, 1 AS source_priority FROM registered_events
+            UNION ALL
+            SELECT *, 2 AS source_priority FROM affiliated_upcoming
+          )
           QUALIFY ROW_NUMBER() OVER (PARTITION BY EVENT_ID ORDER BY source_priority) = 1
         )
         SELECT


### PR DESCRIPTION
## Summary

- Fixes duplicate event cards in step 1 ("Choose an Event") of the Travel Funding Application flow
- `QUALIFY` placed directly after `UNION ALL` in the `combined` CTE (`events.service.ts`) binds to the last `SELECT` block only, so the cross-branch dedup that CTE exists to perform never ran — an event matching both the registered and affiliated branches was returned twice
- Wraps the union in a derived table so `QUALIFY` applies to the combined result
- `COUNT(*) OVER()` is computed after the join, so inflated paging totals are corrected by the same fix
- Adds a regression test asserting the dedup is scoped to the whole union, not a single branch

`events.service.ts` was the only place in the server where a `QUALIFY` trailed a `UNION ALL`.

Fixes #1926
