### PR TITLE
perf(projects): reduce access-check demand on affiliations page

### DIFF
--- a/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.spec.ts
@@ -1,0 +1,104 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { Router } from '@angular/router';
+import { CdpProjectAffiliation, ProjectGroup } from '@lfx-one/shared/interfaces';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it } from 'vitest';
+
+import { ProjectService } from '../../../shared/services/project.service';
+import { UserService } from '../../../shared/services/user.service';
+import { ProfileAffiliationsComponent } from './profile-affiliations.component';
+
+/** Minimal CDP affiliation fixture — only the fields transformToProjectGroups reads. */
+function makeCdpAffiliation(slug: string): CdpProjectAffiliation {
+  return {
+    id: slug,
+    projectSlug: slug,
+    projectLogo: '',
+    projectName: `Project ${slug}`,
+    contributionCount: 1,
+    roles: [{ id: 'r1', role: 'Contributor', startDate: '', endDate: '', repoUrl: '', repoFileUrl: '' }],
+    affiliations: [],
+  };
+}
+
+type TransformFn = (affiliations: CdpProjectAffiliation[], lfxSlugs: Set<string> | null) => ProjectGroup[];
+
+/**
+ * Guards the null-slug (filter-skip) and empty-set (filter-all) branches of
+ * transformToProjectGroups added in #1901. The null-vs-empty distinction is the
+ * core behavioral contract: null means "slug fetch unavailable, skip LFX filter";
+ * an empty Set means "fetch succeeded, no LFX projects, filter all out."
+ */
+describe('ProfileAffiliationsComponent — transformToProjectGroups', () => {
+  let fixture: ComponentFixture<ProfileAffiliationsComponent>;
+  let comp: ProfileAffiliationsComponent;
+
+  beforeEach(async () => {
+    TestBed.resetTestingModule();
+
+    TestBed.configureTestingModule({
+      imports: [ProfileAffiliationsComponent],
+      providers: [
+        {
+          provide: UserService,
+          useValue: {
+            user: signal(null),
+            impersonating: signal(false),
+            getCdpProjectAffiliations: () => of([]),
+            getWorkExperiences: () => of([]),
+            getIdentities: () => of([]),
+          },
+        },
+        {
+          provide: ProjectService,
+          useValue: { getProjectSlugs: () => of(null) },
+        },
+        { provide: MessageService, useValue: { add: () => {} } },
+        { provide: Router, useValue: { navigate: () => Promise.resolve(true) } },
+        { provide: DialogService, useValue: { open: () => ({ onClose: of(null) }) } },
+      ],
+    });
+    // Empty template: exercise class logic without rendering PrimeNG children.
+    // Clear component-level providers so the module-level stubs above are used.
+    TestBed.overrideComponent(ProfileAffiliationsComponent, { set: { template: '', imports: [], providers: [] } });
+
+    fixture = TestBed.createComponent(ProfileAffiliationsComponent);
+    comp = fixture.componentInstance;
+    fixture.detectChanges();
+    await fixture.whenStable();
+  });
+
+  function transform(affiliations: CdpProjectAffiliation[], lfxSlugs: Set<string> | null): ProjectGroup[] {
+    return (comp as unknown as { transformToProjectGroups: TransformFn }).transformToProjectGroups(affiliations, lfxSlugs);
+  }
+
+  it('passes all affiliations through when lfxSlugs is null (slug fetch unavailable)', () => {
+    const affiliations = [makeCdpAffiliation('slug-a'), makeCdpAffiliation('slug-b'), makeCdpAffiliation('slug-c')];
+
+    const result = transform(affiliations, null);
+
+    expect(result.map((g) => g.id)).toEqual(['slug-a', 'slug-b', 'slug-c']);
+  });
+
+  it('filters to only matching slugs when lfxSlugs is a non-empty Set', () => {
+    const affiliations = [makeCdpAffiliation('slug-a'), makeCdpAffiliation('slug-b'), makeCdpAffiliation('slug-c')];
+
+    const result = transform(affiliations, new Set(['slug-a', 'slug-c']));
+
+    expect(result.map((g) => g.id)).toEqual(['slug-a', 'slug-c']);
+  });
+
+  it('filters all affiliations out when lfxSlugs is an empty Set (fetch succeeded, no LFX projects)', () => {
+    const affiliations = [makeCdpAffiliation('slug-a'), makeCdpAffiliation('slug-b')];
+
+    const result = transform(affiliations, new Set());
+
+    expect(result).toHaveLength(0);
+  });
+});

--- a/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.ts
@@ -67,7 +67,7 @@ export class ProfileAffiliationsComponent {
   public readonly addWorkExperience = output();
 
   private readonly cdpAffiliations = signal<CdpProjectAffiliation[]>([]);
-  private readonly lfxSlugs = signal<Set<string>>(new Set());
+  private readonly lfxSlugs = signal<Set<string> | null>(new Set());
   private readonly connectedIdentities = signal<EnrichedIdentity[]>([]);
   private readonly identitiesLoadFailed = signal(false);
 
@@ -429,7 +429,9 @@ export class ProfileAffiliationsComponent {
         ),
       ]).pipe(
         map(([cdpAffiliations, slugs, workExperiences, identities]) => {
-          const lfxSlugs = new Set(slugs);
+          // null means the slug fetch failed — use null to skip LFX filtering so affiliations
+          // are not silently hidden when the slug endpoint is temporarily unavailable.
+          const lfxSlugs = slugs !== null ? new Set(slugs) : null;
           this.cdpAffiliations.set(cdpAffiliations);
           this.lfxSlugs.set(lfxSlugs);
           this.workExperience.set(workExperiences);
@@ -448,7 +450,7 @@ export class ProfileAffiliationsComponent {
     );
   }
 
-  private transformToProjectGroups(cdpAffiliations: CdpProjectAffiliation[], lfxSlugs: Set<string>): ProjectGroup[] {
+  private transformToProjectGroups(cdpAffiliations: CdpProjectAffiliation[], lfxSlugs: Set<string> | null): ProjectGroup[] {
     const lfid = this.userService.user()?.username || this.userService.user()?.['https://sso.linuxfoundation.org/claims/username'] || '';
 
     const verifiedOrgIds = new Set(
@@ -458,7 +460,7 @@ export class ProfileAffiliationsComponent {
     );
 
     return cdpAffiliations
-      .filter((project) => project.projectSlug && lfxSlugs.has(project.projectSlug))
+      .filter((project) => project.projectSlug && (!lfxSlugs || lfxSlugs.has(project.projectSlug)))
       .map((project) => {
         const firstRole = project.roles.length > 0 ? project.roles[0] : undefined;
         const role: 'Maintainer' | 'Contributor' = firstRole?.role === 'Maintainer' ? 'Maintainer' : 'Contributor';

--- a/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.ts
@@ -419,7 +419,7 @@ export class ProfileAffiliationsComponent {
     return toSignal(
       forkJoin([
         this.userService.getCdpProjectAffiliations(),
-        this.projectService.getProjects(),
+        this.projectService.getProjectSlugs(),
         this.userService.getWorkExperiences(),
         this.userService.getIdentities().pipe(
           catchError(() => {
@@ -428,8 +428,8 @@ export class ProfileAffiliationsComponent {
           })
         ),
       ]).pipe(
-        map(([cdpAffiliations, lfxProjects, workExperiences, identities]) => {
-          const lfxSlugs = new Set(lfxProjects.map((p) => p.slug));
+        map(([cdpAffiliations, slugs, workExperiences, identities]) => {
+          const lfxSlugs = new Set(slugs);
           this.cdpAffiliations.set(cdpAffiliations);
           this.lfxSlugs.set(lfxSlugs);
           this.workExperience.set(workExperiences);

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -48,10 +48,12 @@ describe('ProjectService.getProjectSlugs', () => {
     // Use a plain Error (not HttpErrorResponse) so retryTransientHttpError passes it through
     // immediately — only status-0/408/429/5xx HttpErrorResponse values are retried.
     httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
-    service.getProjectSlugs().subscribe();
+    let fallback: string[] = ['sentinel'];
+    service.getProjectSlugs().subscribe((v) => (fallback = v));
 
     // tap({ error }) fires synchronously (throwError is synchronous), so the cache is already
     // null by the time we assert. The next call must issue a new request.
+    expect(fallback).toEqual([]);
     expect((service as unknown as { slugsCache$: unknown }).slugsCache$).toBeNull();
 
     httpGet.mockReturnValueOnce(of(['slug-c']));

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -15,9 +15,18 @@ describe('ProjectService.getProjectSlugs', () => {
   beforeEach(() => {
     httpGet = vi.fn().mockReturnValue(of(['slug-a', 'slug-b']));
     TestBed.configureTestingModule({
-      providers: [{ provide: HttpClient, useValue: { get: httpGet, post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() } }],
+      providers: [
+        {
+          provide: HttpClient,
+          useValue: { get: httpGet, post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+        },
+      ],
     });
     service = TestBed.inject(ProjectService);
+  });
+
+  afterEach(() => {
+    TestBed.resetTestingModule();
   });
 
   it('issues GET /api/projects/slugs and returns the slug array', () => {

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -37,9 +37,11 @@ describe('ProjectService.getProjectSlugs', () => {
   });
 
   it('reuses the cached observable on a second call without issuing another request', () => {
-    service.getProjectSlugs().subscribe();
-    service.getProjectSlugs().subscribe();
+    const results: string[][] = [];
+    service.getProjectSlugs().subscribe((v) => results.push(v));
+    service.getProjectSlugs().subscribe((v) => results.push(v));
     expect(httpGet).toHaveBeenCalledTimes(1);
+    expect(results).toEqual([['slug-a', 'slug-b'], ['slug-a', 'slug-b']]);
   });
 
   it('evicts slugsCache$ on error so the next caller gets a fresh HTTP attempt', () => {

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -1,0 +1,57 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { HttpClient } from '@angular/common/http';
+import { TestBed } from '@angular/core/testing';
+import { of, throwError } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProjectService } from './project.service';
+
+describe('ProjectService.getProjectSlugs', () => {
+  let service: ProjectService;
+  let httpGet: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    httpGet = vi.fn().mockReturnValue(of(['slug-a', 'slug-b']));
+    TestBed.configureTestingModule({
+      providers: [{ provide: HttpClient, useValue: { get: httpGet, post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() } }],
+    });
+    service = TestBed.inject(ProjectService);
+  });
+
+  it('issues GET /api/projects/slugs and returns the slug array', () => {
+    let result: string[] = [];
+    service.getProjectSlugs().subscribe((slugs) => (result = slugs));
+    expect(httpGet).toHaveBeenCalledWith('/api/projects/slugs');
+    expect(result).toEqual(['slug-a', 'slug-b']);
+  });
+
+  it('reuses the cached observable on a second call without issuing another request', () => {
+    service.getProjectSlugs().subscribe();
+    service.getProjectSlugs().subscribe();
+    expect(httpGet).toHaveBeenCalledTimes(1);
+  });
+
+  it('evicts slugsCache$ on error so the next caller gets a fresh HTTP attempt', () => {
+    // Use a plain Error (not HttpErrorResponse) so retryTransientHttpError passes it through
+    // immediately — only status-0/408/429/5xx HttpErrorResponse values are retried.
+    httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
+    service.getProjectSlugs().subscribe();
+
+    // tap({ error }) fires synchronously (throwError is synchronous), so the cache is already
+    // null by the time we assert. The next call must issue a new request.
+    expect((service as unknown as { slugsCache$: unknown }).slugsCache$).toBeNull();
+
+    httpGet.mockReturnValueOnce(of(['slug-c']));
+    service.getProjectSlugs().subscribe();
+    expect(httpGet).toHaveBeenCalledTimes(2);
+  });
+
+  it('falls back to [] on error so callers never receive an error notification', () => {
+    httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
+    let result: string[] = ['sentinel'];
+    service.getProjectSlugs().subscribe((slugs) => (result = slugs));
+    expect(result).toEqual([]);
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -4,7 +4,7 @@
 import { HttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { of, throwError } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProjectService } from './project.service';
 

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -30,14 +30,14 @@ describe('ProjectService.getProjectSlugs', () => {
   });
 
   it('issues GET /api/projects/slugs and returns the slug array', () => {
-    let result: string[] = [];
+    let result: string[] | null = null;
     service.getProjectSlugs().subscribe((slugs) => (result = slugs));
     expect(httpGet).toHaveBeenCalledWith('/api/projects/slugs');
     expect(result).toEqual(['slug-a', 'slug-b']);
   });
 
   it('reuses the cached observable on a second call without issuing another request', () => {
-    const results: string[][] = [];
+    const results: (string[] | null)[] = [];
     service.getProjectSlugs().subscribe((v) => results.push(v));
     service.getProjectSlugs().subscribe((v) => results.push(v));
     expect(httpGet).toHaveBeenCalledTimes(1);
@@ -51,12 +51,14 @@ describe('ProjectService.getProjectSlugs', () => {
     // Use a plain Error (not HttpErrorResponse) so retryTransientHttpError passes it through
     // immediately — only status-0/408/429/5xx HttpErrorResponse values are retried.
     httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
-    let fallback: string[] = ['sentinel'];
+    let fallback: string[] | null = ['sentinel'];
     service.getProjectSlugs().subscribe((v) => (fallback = v));
 
     // tap({ error }) fires synchronously (throwError is synchronous), so the cache is already
     // null by the time we assert. The next call must issue a new request.
-    expect(fallback).toEqual([]);
+    // Returns null (not []) so callers can distinguish "fetch failed, skip LFX filter"
+    // from "fetch succeeded, no LFX projects".
+    expect(fallback).toBeNull();
     expect((service as unknown as { slugsCache$: unknown }).slugsCache$).toBeNull();
 
     httpGet.mockReturnValueOnce(of(['slug-c']));
@@ -64,10 +66,10 @@ describe('ProjectService.getProjectSlugs', () => {
     expect(httpGet).toHaveBeenCalledTimes(2);
   });
 
-  it('falls back to [] on error so callers never receive an error notification', () => {
+  it('falls back to null on error so callers can skip the LFX filter rather than filtering all affiliations out', () => {
     httpGet.mockReturnValueOnce(throwError(() => new Error('network-error')));
-    let result: string[] = ['sentinel'];
+    let result: string[] | null = ['sentinel'];
     service.getProjectSlugs().subscribe((slugs) => (result = slugs));
-    expect(result).toEqual([]);
+    expect(result).toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/shared/services/project.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.spec.ts
@@ -41,7 +41,10 @@ describe('ProjectService.getProjectSlugs', () => {
     service.getProjectSlugs().subscribe((v) => results.push(v));
     service.getProjectSlugs().subscribe((v) => results.push(v));
     expect(httpGet).toHaveBeenCalledTimes(1);
-    expect(results).toEqual([['slug-a', 'slug-b'], ['slug-a', 'slug-b']]);
+    expect(results).toEqual([
+      ['slug-a', 'slug-b'],
+      ['slug-a', 'slug-b'],
+    ]);
   });
 
   it('evicts slugsCache$ on error so the next caller gets a fresh HTTP attempt', () => {

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -19,6 +19,7 @@ export class ProjectService {
   private readonly http = inject(HttpClient);
   private readonly projectCache = new Map<string, Observable<Project | null>>();
   private readonly projectsCache = new Map<string, Observable<Project[]>>();
+  private slugsCache$: Observable<string[]> | null = null;
 
   public getProjects(params?: HttpParams): Observable<Project[]> {
     const cacheKey = params?.toString() || '';
@@ -45,9 +46,21 @@ export class ProjectService {
   /**
    * Fetches project slugs without access-check overhead. Use when only slugs are needed
    * (e.g. membership checks) — skips the OpenFGA POST that getProjects() incurs.
+   * Cached for the session lifetime; evicted on error so a failed fetch is retryable.
    */
   public getProjectSlugs(): Observable<string[]> {
-    return this.http.get<string[]>('/api/projects/slugs').pipe(retryTransientHttpError(), shareReplay(1));
+    if (!this.slugsCache$) {
+      this.slugsCache$ = this.http.get<string[]>('/api/projects/slugs').pipe(
+        retryTransientHttpError(),
+        catchError((error) => {
+          console.error('Failed to fetch project slugs:', error);
+          this.slugsCache$ = null;
+          return of([]);
+        }),
+        shareReplay(1)
+      );
+    }
+    return this.slugsCache$;
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -19,7 +19,7 @@ export class ProjectService {
   private readonly http = inject(HttpClient);
   private readonly projectCache = new Map<string, Observable<Project | null>>();
   private readonly projectsCache = new Map<string, Observable<Project[]>>();
-  private slugsCache$: Observable<string[]> | null = null;
+  private slugsCache$: Observable<string[] | null> | null = null;
 
   public getProjects(params?: HttpParams): Observable<Project[]> {
     const cacheKey = params?.toString() || '';
@@ -48,16 +48,19 @@ export class ProjectService {
    * (e.g. membership checks) — skips the OpenFGA POST that getProjects() incurs.
    * Cached for the session lifetime; evicted on error so a failed fetch is retryable.
    */
-  public getProjectSlugs(): Observable<string[]> {
+  public getProjectSlugs(): Observable<string[] | null> {
     if (!this.slugsCache$) {
       this.slugsCache$ = this.http.get<string[]>('/api/projects/slugs').pipe(
         retryTransientHttpError(),
-        // Evict the cache entry before catchError converts the error to of([]), so a
-        // future caller gets a fresh HTTP attempt instead of the pinned empty result.
+        // Evict the cache entry before catchError converts the error to of(null), so a
+        // future caller gets a fresh HTTP attempt instead of the pinned null result.
         tap({ error: () => (this.slugsCache$ = null) }),
         catchError((error) => {
           console.error('Failed to fetch project slugs:', error);
-          return of([]);
+          // Return null rather than [] so callers can distinguish "fetch failed, skip
+          // LFX filter" from "fetch succeeded, no LFX projects" — an empty array would
+          // make the component filter out all CDP affiliations as non-LFX contributions.
+          return of(null);
         }),
         shareReplay(1)
       );

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -52,9 +52,11 @@ export class ProjectService {
     if (!this.slugsCache$) {
       this.slugsCache$ = this.http.get<string[]>('/api/projects/slugs').pipe(
         retryTransientHttpError(),
+        // Evict the cache entry before catchError converts the error to of([]), so a
+        // future caller gets a fresh HTTP attempt instead of the pinned empty result.
+        tap({ error: () => (this.slugsCache$ = null) }),
         catchError((error) => {
           console.error('Failed to fetch project slugs:', error);
-          this.slugsCache$ = null;
           return of([]);
         }),
         shareReplay(1)

--- a/apps/lfx-one/src/app/shared/services/project.service.ts
+++ b/apps/lfx-one/src/app/shared/services/project.service.ts
@@ -43,6 +43,14 @@ export class ProjectService {
   }
 
   /**
+   * Fetches project slugs without access-check overhead. Use when only slugs are needed
+   * (e.g. membership checks) — skips the OpenFGA POST that getProjects() incurs.
+   */
+  public getProjectSlugs(): Observable<string[]> {
+    return this.http.get<string[]>('/api/projects/slugs').pipe(retryTransientHttpError(), shareReplay(1));
+  }
+
+  /**
    * Fail-closed on error, mirroring getProjects. One retry, transient errors only — this is the
    * bootstrap-critical fast path (LFXV2-2857), so a bare blip shouldn't leave the caller's lens
    * set narrowed until the (much slower) deferred sweep eventually resolves it instead.

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -21,6 +21,7 @@ const { computeIsFoundationMock, generateM2MTokenMock, isUuidMock, meetingSvc, p
   projectSvc: {
     getProjectIdBySlug: vi.fn(),
     getProjectById: vi.fn(),
+    getProjectSlugs: vi.fn(),
   },
 }));
 
@@ -78,6 +79,7 @@ import { readFileSync } from 'node:fs';
 import { LENS_REDIRECT_RESOURCES } from '@lfx-one/shared/constants';
 import { ProjectController } from './project.controller';
 import { ServiceValidationError } from '../errors';
+import { logger } from '../services/logger.service';
 
 function buildProject(overrides: Partial<Project> = {}): Project {
   return {
@@ -271,13 +273,12 @@ describe('ProjectController.getProjectSlugs', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
-    (projectSvc as any).getProjectSlugs = vi.fn();
     controller = new ProjectController();
   });
 
-  it('responds with the slug array and does not call next()', async () => {
+  it('responds with the slug array, logs success, and does not call next()', async () => {
     const slugs = ['cncf', 'kubernetes', 'linux'];
-    (projectSvc as any).getProjectSlugs.mockResolvedValue(slugs);
+    projectSvc.getProjectSlugs.mockResolvedValue(slugs);
     const req = { headers: {}, bearerToken: undefined, method: 'GET' } as any;
     const res = { json: vi.fn() } as any;
     const next = vi.fn();
@@ -285,12 +286,14 @@ describe('ProjectController.getProjectSlugs', () => {
     await controller.getProjectSlugs(req, res, next);
 
     expect(res.json).toHaveBeenCalledWith(slugs);
+    expect(logger.startOperation).toHaveBeenCalledWith(req, 'get_project_slugs');
+    expect(logger.success).toHaveBeenCalledWith(req, 'get_project_slugs', 0, { slug_count: 3 });
     expect(next).not.toHaveBeenCalled();
   });
 
   it('forwards errors to next() without calling res.json', async () => {
     const boom = new Error('upstream-down');
-    (projectSvc as any).getProjectSlugs.mockRejectedValue(boom);
+    projectSvc.getProjectSlugs.mockRejectedValue(boom);
     const req = { headers: {}, bearerToken: undefined, method: 'GET' } as any;
     const res = { json: vi.fn() } as any;
     const next = vi.fn();

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -266,6 +266,42 @@ describe('ProjectController.getLensRedirect', () => {
   });
 });
 
+describe('ProjectController.getProjectSlugs', () => {
+  let controller: ProjectController;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (projectSvc as any).getProjectSlugs = vi.fn();
+    controller = new ProjectController();
+  });
+
+  it('responds with the slug array and does not call next()', async () => {
+    const slugs = ['cncf', 'kubernetes', 'linux'];
+    (projectSvc as any).getProjectSlugs.mockResolvedValue(slugs);
+    const req = { headers: {}, bearerToken: undefined, method: 'GET' } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    await controller.getProjectSlugs(req, res, next);
+
+    expect(res.json).toHaveBeenCalledWith(slugs);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('forwards errors to next() without calling res.json', async () => {
+    const boom = new Error('upstream-down');
+    (projectSvc as any).getProjectSlugs.mockRejectedValue(boom);
+    const req = { headers: {}, bearerToken: undefined, method: 'GET' } as any;
+    const res = { json: vi.fn() } as any;
+    const next = vi.fn();
+
+    await controller.getProjectSlugs(req, res, next);
+
+    expect(next).toHaveBeenCalledWith(boom);
+    expect(res.json).not.toHaveBeenCalled();
+  });
+});
+
 describe('ProjectController.getProjectCalendar', () => {
   let controller: ProjectController;
 

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -61,6 +61,25 @@ export class ProjectController {
   }
 
   /**
+   * GET /projects/slugs
+   */
+  public async getProjectSlugs(req: Request, res: Response, next: NextFunction): Promise<void> {
+    const startTime = logger.startOperation(req, 'get_project_slugs');
+
+    try {
+      const slugs = await this.projectService.getProjectSlugs(req);
+
+      logger.success(req, 'get_project_slugs', startTime, {
+        slug_count: slugs.length,
+      });
+
+      res.json(slugs);
+    } catch (error) {
+      next(error);
+    }
+  }
+
+  /**
    * GET /projects/writer-summary
    */
   public async getWriterSummary(req: Request, res: Response, next: NextFunction): Promise<void> {

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -61,7 +61,7 @@ export class ProjectController {
   }
 
   /**
-   * GET /projects/slugs
+   * GET /api/projects/slugs
    */
   public async getProjectSlugs(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_project_slugs');

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -61,7 +61,7 @@ export class ProjectController {
   }
 
   /**
-   * GET /api/projects/slugs
+   * GET /projects/slugs
    */
   public async getProjectSlugs(req: Request, res: Response, next: NextFunction): Promise<void> {
     const startTime = logger.startOperation(req, 'get_project_slugs');

--- a/apps/lfx-one/src/server/routes/projects.route.ts
+++ b/apps/lfx-one/src/server/routes/projects.route.ts
@@ -18,6 +18,8 @@ router.get('/pending-action-surveys', (req, res, next) => projectController.getP
 
 router.get('/writer-summary', (req, res, next) => projectController.getWriterSummary(req, res, next));
 
+router.get('/slugs', (req, res, next) => projectController.getProjectSlugs(req, res, next));
+
 router.get('/:slug', (req, res, next) => projectController.getProjectBySlug(req, res, next));
 
 router.get('/:uid/permissions', (req, res, next) => projectController.getProjectPermissions(req, res, next));

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -248,6 +248,18 @@ describe('AccessCheckService — batching', () => {
     expect(result.has('proj-100#writer')).toBe(false);
     // Two WARN logs: one per-chunk and one terminal partial-result.
     expect(loggerWarning).toHaveBeenCalledTimes(2);
+    expect(loggerWarning).toHaveBeenCalledWith(
+      req,
+      expect.any(String),
+      expect.stringContaining('chunk 1 failed'),
+      expect.objectContaining({ chunk_index: 1, err: chunkError })
+    );
+    expect(loggerWarning).toHaveBeenCalledWith(
+      req,
+      expect.any(String),
+      expect.stringContaining('partial'),
+      expect.objectContaining({ failed_chunks: 1, batch_count: 2, duration_ms: expect.any(Number) })
+    );
   });
 
   it('fails the rejected chunk closed but preserves results from fulfilled chunks', async () => {

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -254,7 +254,7 @@ describe('AccessCheckService — batching', () => {
       req,
       expect.any(String),
       expect.stringContaining('chunk 1 failed'),
-      expect.objectContaining({ chunk_index: 1, err: chunkError })
+      expect.objectContaining({ chunk_index: 1, chunk_count: 2, err: chunkError })
     );
     expect(loggerWarning).toHaveBeenCalledWith(
       req,
@@ -288,7 +288,7 @@ describe('AccessCheckService — batching', () => {
       req,
       expect.any(String),
       expect.stringContaining('chunk 1 failed'),
-      expect.objectContaining({ chunk_index: 1, err: chunkError })
+      expect.objectContaining({ chunk_index: 1, chunk_count: 2, err: chunkError })
     );
     // Terminal warning signals partial results so monitoring alerts on "success" do not fire.
     // Also asserts duration_ms is present — logger.warning has no startTime param so it is

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -13,7 +13,7 @@ import { beforeEach, describe, expect, it, vi } from 'vitest';
 // matches, so an unreset mock lets an unrelated earlier test's `logger.error(..., new Error('boom'))`
 // call silently satisfy a later `toHaveBeenCalledWith(..., new Error('boom'), ...)` assertion even
 // if the code path under test never ran.
-const { proxyRequest, loggerError } = vi.hoisted(() => ({ proxyRequest: vi.fn(), loggerError: vi.fn() }));
+const { proxyRequest, loggerError, loggerWarning } = vi.hoisted(() => ({ proxyRequest: vi.fn(), loggerError: vi.fn(), loggerWarning: vi.fn() }));
 
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
@@ -25,12 +25,15 @@ vi.mock('./logger.service', () => ({
     startOperation: vi.fn(() => 0),
     success: vi.fn(),
     error: loggerError,
-    warning: vi.fn(),
+    warning: loggerWarning,
     debug: vi.fn(),
     info: vi.fn(),
     sanitize: (v: unknown) => v,
   },
 }));
+// ACCESS_CHECK_BATCH_SIZE is imported at runtime by access-check.service.ts — the alias isn't
+// wired into this app's vitest config, so it must be stubbed (same pattern as project.service.spec.ts).
+vi.mock('@lfx-one/shared/constants', () => ({ ACCESS_CHECK_BATCH_SIZE: 100 }));
 
 import type { Request } from 'express';
 
@@ -44,6 +47,7 @@ describe('AccessCheckService.checkAccess', () => {
   beforeEach(() => {
     proxyRequest.mockReset();
     loggerError.mockReset();
+    loggerWarning.mockReset();
     service = new AccessCheckService();
   });
 
@@ -147,6 +151,7 @@ describe('AccessCheckService.checkAccessStrict / checkSingleAccessStrict', () =>
   beforeEach(() => {
     proxyRequest.mockReset();
     loggerError.mockReset();
+    loggerWarning.mockReset();
     service = new AccessCheckService();
   });
 
@@ -176,5 +181,70 @@ describe('AccessCheckService.checkAccessStrict / checkSingleAccessStrict', () =>
 
     expect(result.size).toBe(0);
     expect(proxyRequest).not.toHaveBeenCalled();
+  });
+});
+
+describe('AccessCheckService — batching', () => {
+  let service: AccessCheckService;
+
+  // Build N access-check requests for distinct project IDs.
+  function makeResources(count: number): Array<{ resource: 'project'; id: string; access: 'writer' }> {
+    return Array.from({ length: count }, (_, i) => ({ resource: 'project' as const, id: `proj-${i}`, access: 'writer' as const }));
+  }
+
+  // Build a mock upstream response granting access to each of the given requests.
+  function mockResponse(resources: Array<{ resource: string; id: string; access: string }>, granted = true): { results: string[] } {
+    return { results: resources.map((r) => `${r.resource}:${r.id}#${r.access}@user:alice\t${granted}`) };
+  }
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    loggerError.mockReset();
+    loggerWarning.mockReset();
+    service = new AccessCheckService();
+  });
+
+  it('issues exactly one POST when the resource count is at the batch size limit (100)', async () => {
+    const resources = makeResources(100);
+    proxyRequest.mockResolvedValueOnce(mockResponse(resources, true));
+
+    const result = await service.checkAccess(req, resources);
+
+    expect(proxyRequest).toHaveBeenCalledTimes(1);
+    expect(result.get('proj-0#writer')).toBe(true);
+    expect(result.get('proj-99#writer')).toBe(true);
+  });
+
+  it('fans out to two POSTs when the resource count exceeds the batch size (101 resources → chunks of 100 and 1)', async () => {
+    const resources = makeResources(101);
+    // First chunk: resources 0–99, second chunk: resource 100.
+    proxyRequest.mockResolvedValueOnce(mockResponse(resources.slice(0, 100), true));
+    proxyRequest.mockResolvedValueOnce(mockResponse(resources.slice(100), false));
+
+    const result = await service.checkAccess(req, resources);
+
+    expect(proxyRequest).toHaveBeenCalledTimes(2);
+    // Results from both chunks are merged into one map.
+    expect(result.get('proj-0#writer')).toBe(true);
+    expect(result.get('proj-99#writer')).toBe(true);
+    expect(result.get('proj-100#writer')).toBe(false);
+  });
+
+  it('fails the rejected chunk closed but preserves results from fulfilled chunks', async () => {
+    const resources = makeResources(101);
+    // Chunk 1 (resources 0–99) succeeds; chunk 2 (resource 100) fails.
+    proxyRequest.mockResolvedValueOnce(mockResponse(resources.slice(0, 100), true));
+    proxyRequest.mockRejectedValueOnce(new Error('chunk-failure'));
+
+    const result = await service.checkAccess(req, resources);
+
+    // Fulfilled chunk results are present.
+    expect(result.get('proj-0#writer')).toBe(true);
+    expect(result.get('proj-99#writer')).toBe(true);
+    // The failed chunk's resource is absent from the result map → defaults to false for callers.
+    expect(result.has('proj-100#writer')).toBe(false);
+    // A warning is emitted for the failed chunk so the incident is traceable.
+    expect(loggerWarning).toHaveBeenCalledTimes(1);
+    expect(loggerWarning).toHaveBeenCalledWith(req, expect.any(String), expect.stringContaining('chunk 1 failed'), expect.objectContaining({ chunk_index: 1 }));
   });
 });

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -256,11 +256,13 @@ describe('AccessCheckService — batching', () => {
       expect.objectContaining({ chunk_index: 1, err: chunkError })
     );
     // Terminal warning signals partial results so monitoring alerts on "success" do not fire.
+    // Also asserts duration_ms is present — logger.warning has no startTime param so it is
+    // injected manually; this assertion catches a future accidental removal.
     expect(loggerWarning).toHaveBeenCalledWith(
       req,
       expect.any(String),
       expect.stringContaining('partial'),
-      expect.objectContaining({ failed_chunks: 1, batch_count: 2 })
+      expect.objectContaining({ failed_chunks: 1, batch_count: 2, duration_ms: expect.any(Number) })
     );
   });
 });

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -188,12 +188,12 @@ describe('AccessCheckService — batching', () => {
   let service: AccessCheckService;
 
   // Build N access-check requests for distinct project IDs.
-  function makeResources(count: number): Array<{ resource: 'project'; id: string; access: 'writer' }> {
+  function makeResources(count: number): { resource: 'project'; id: string; access: 'writer' }[] {
     return Array.from({ length: count }, (_, i) => ({ resource: 'project' as const, id: `proj-${i}`, access: 'writer' as const }));
   }
 
   // Build a mock upstream response granting access to each of the given requests.
-  function mockResponse(resources: Array<{ resource: string; id: string; access: string }>, granted = true): { results: string[] } {
+  function mockResponse(resources: { resource: string; id: string; access: string }[], granted = true): { results: string[] } {
     return { results: resources.map((r) => `${r.resource}:${r.id}#${r.access}@user:alice\t${granted}`) };
   }
 
@@ -213,6 +213,8 @@ describe('AccessCheckService — batching', () => {
     expect(proxyRequest).toHaveBeenCalledTimes(1);
     expect(result.get('proj-0#writer')).toBe(true);
     expect(result.get('proj-99#writer')).toBe(true);
+    // Single-batch path should emit no warnings — all resources resolved in one POST.
+    expect(loggerWarning).not.toHaveBeenCalled();
   });
 
   it('fans out to two POSTs when the resource count exceeds the batch size (101 resources → chunks of 100 and 1)', async () => {

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -230,6 +230,26 @@ describe('AccessCheckService — batching', () => {
     expect(result.get('proj-100#writer')).toBe(false);
   });
 
+  it('does not throw from checkAccessStrict when a chunk in the multi-batch path rejects', async () => {
+    // Promise.allSettled absorbs chunk failures even in strict mode — only single-batch
+    // calls (<=ACCESS_CHECK_BATCH_SIZE) propagate errors through checkAccessStrict.
+    const resources = makeResources(101);
+    const chunkError = new Error('chunk-failure');
+    // First chunk (0-based index 0, resources 0–99) succeeds;
+    // second chunk (0-based index 1, resource 100) fails.
+    proxyRequest.mockResolvedValueOnce(mockResponse(resources.slice(0, 100), true));
+    proxyRequest.mockRejectedValueOnce(chunkError);
+
+    // checkAccessStrict does NOT throw — the multi-batch path absorbs chunk failures.
+    const result = await service.checkAccessStrict(req, resources);
+
+    expect(result.get('proj-0#writer')).toBe(true);
+    // Failed chunk's key is absent (not false), defaulting to false at the call site.
+    expect(result.has('proj-100#writer')).toBe(false);
+    // Two WARN logs: one per-chunk and one terminal partial-result.
+    expect(loggerWarning).toHaveBeenCalledTimes(2);
+  });
+
   it('fails the rejected chunk closed but preserves results from fulfilled chunks', async () => {
     const resources = makeResources(101);
     const chunkError = new Error('chunk-failure');

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -232,9 +232,10 @@ describe('AccessCheckService — batching', () => {
 
   it('fails the rejected chunk closed but preserves results from fulfilled chunks', async () => {
     const resources = makeResources(101);
+    const chunkError = new Error('chunk-failure');
     // Chunk 1 (resources 0–99) succeeds; chunk 2 (resource 100) fails.
     proxyRequest.mockResolvedValueOnce(mockResponse(resources.slice(0, 100), true));
-    proxyRequest.mockRejectedValueOnce(new Error('chunk-failure'));
+    proxyRequest.mockRejectedValueOnce(chunkError);
 
     const result = await service.checkAccess(req, resources);
 
@@ -243,8 +244,21 @@ describe('AccessCheckService — batching', () => {
     expect(result.get('proj-99#writer')).toBe(true);
     // The failed chunk's resource is absent from the result map → defaults to false for callers.
     expect(result.has('proj-100#writer')).toBe(false);
-    // A warning is emitted for the failed chunk so the incident is traceable.
-    expect(loggerWarning).toHaveBeenCalledTimes(1);
-    expect(loggerWarning).toHaveBeenCalledWith(req, expect.any(String), expect.stringContaining('chunk 1 failed'), expect.objectContaining({ chunk_index: 1 }));
+    // Two warnings: one per-chunk warning and one terminal partial-result warning.
+    expect(loggerWarning).toHaveBeenCalledTimes(2);
+    // Per-chunk warning preserves the rejection value as `err` for full Pino serialization.
+    expect(loggerWarning).toHaveBeenCalledWith(
+      req,
+      expect.any(String),
+      expect.stringContaining('chunk 1 failed'),
+      expect.objectContaining({ chunk_index: 1, err: chunkError })
+    );
+    // Terminal warning signals partial results so monitoring alerts on "success" do not fire.
+    expect(loggerWarning).toHaveBeenCalledWith(
+      req,
+      expect.any(String),
+      expect.stringContaining('partial'),
+      expect.objectContaining({ failed_chunks: 1, batch_count: 2 })
+    );
   });
 });

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -242,8 +242,10 @@ describe('AccessCheckService — batching', () => {
     // Fulfilled chunk results are present.
     expect(result.get('proj-0#writer')).toBe(true);
     expect(result.get('proj-99#writer')).toBe(true);
-    // The failed chunk's resource is absent from the result map → defaults to false for callers.
+    // The failed chunk's key is intentionally not written to the map (not set to false) —
+    // callers using `get(...) ?? false` or `get(...) || false` both default correctly.
     expect(result.has('proj-100#writer')).toBe(false);
+    expect(result.get('proj-100#writer')).toBeUndefined();
     // Two warnings: one per-chunk warning and one terminal partial-result warning.
     expect(loggerWarning).toHaveBeenCalledTimes(2);
     // Per-chunk warning preserves the rejection value as `err` for full Pino serialization.

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -232,9 +232,9 @@ describe('AccessCheckService — batching', () => {
     expect(result.get('proj-100#writer')).toBe(false);
   });
 
-  it('does not throw from checkAccessStrict when a chunk in the multi-batch path rejects', async () => {
-    // Promise.allSettled absorbs chunk failures even in strict mode — only single-batch
-    // calls (<=ACCESS_CHECK_BATCH_SIZE) propagate errors through checkAccessStrict.
+  it('throws from checkAccessStrict when a chunk in the multi-batch path rejects', async () => {
+    // The strict contract holds regardless of batch count: any chunk failure causes a throw
+    // after all chunks settle and per-chunk WARNs are logged.
     const resources = makeResources(101);
     const chunkError = new Error('chunk-failure');
     // First chunk (0-based index 0, resources 0–99) succeeds;
@@ -242,13 +242,9 @@ describe('AccessCheckService — batching', () => {
     proxyRequest.mockResolvedValueOnce(mockResponse(resources.slice(0, 100), true));
     proxyRequest.mockRejectedValueOnce(chunkError);
 
-    // checkAccessStrict does NOT throw — the multi-batch path absorbs chunk failures.
-    const result = await service.checkAccessStrict(req, resources);
-
-    expect(result.get('proj-0#writer')).toBe(true);
-    // Failed chunk's key is absent (not false), defaulting to false at the call site.
-    expect(result.has('proj-100#writer')).toBe(false);
-    // Two WARN logs: one per-chunk and one terminal partial-result.
+    await expect(service.checkAccessStrict(req, resources)).rejects.toThrow('chunk-failure');
+    // Per-chunk and terminal partial-result WARNs are still emitted before the throw so the
+    // terminal warning always appears in logs even on the strict path.
     expect(loggerWarning).toHaveBeenCalledTimes(2);
     expect(loggerWarning).toHaveBeenCalledWith(
       req,
@@ -262,6 +258,9 @@ describe('AccessCheckService — batching', () => {
       expect.stringContaining('partial'),
       expect.objectContaining({ failed_chunks: 1, batch_count: 2, duration_ms: expect.any(Number) })
     );
+    // checkAccessStrict's catch block logs at ERROR before rethrowing — exactly one call.
+    expect(loggerError).toHaveBeenCalledTimes(1);
+    expect(loggerError).toHaveBeenCalledWith(req, expect.any(String), expect.any(Number), chunkError, expect.objectContaining({ request_count: 101 }));
   });
 
   it('fails the rejected chunk closed but preserves results from fulfilled chunks', async () => {

--- a/apps/lfx-one/src/server/services/access-check.service.spec.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.spec.ts
@@ -233,7 +233,8 @@ describe('AccessCheckService — batching', () => {
   it('fails the rejected chunk closed but preserves results from fulfilled chunks', async () => {
     const resources = makeResources(101);
     const chunkError = new Error('chunk-failure');
-    // Chunk 1 (resources 0–99) succeeds; chunk 2 (resource 100) fails.
+    // First chunk (0-based index 0, resources 0–99) succeeds;
+    // second chunk (0-based index 1, resource 100) fails.
     proxyRequest.mockResolvedValueOnce(mockResponse(resources.slice(0, 100), true));
     proxyRequest.mockRejectedValueOnce(chunkError);
 

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -47,6 +47,7 @@ export class AccessCheckService {
     const { operationName, startTime } = this.beginCheckOperation(req, resources);
 
     try {
+      // success/warning logged inside performCheck; only error is logged here on propagation.
       return await this.performCheck(req, resources, operationName, startTime, options);
     } catch (error) {
       logger.error(req, operationName, startTime, error, {
@@ -89,6 +90,7 @@ export class AccessCheckService {
 
     const { operationName, startTime } = this.beginCheckOperation(req, resources);
     try {
+      // success/warning logged inside performCheck; only error is logged here on propagation.
       return await this.performCheck(req, resources, operationName, startTime, options);
     } catch (error) {
       // Unlike checkAccess, this rethrows rather than degrading — but still logs, so a failed

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -264,6 +264,7 @@ export class AccessCheckService {
         // chunk_index is 0-based — "chunk 0" is the first batch, "chunk 1" the second, etc.
         logger.warning(req, operationName, `Access-check batch chunk ${i} failed, failing closed for its resources`, {
           chunk_index: i,
+          chunk_count: chunks.length,
           chunk_size: chunks[i].length,
           err: result.reason,
         });

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -76,6 +76,7 @@ export class AccessCheckService {
    * where the upstream call fails before any settling occurs. Callers passing more than
    * ACCESS_CHECK_BATCH_SIZE resources will not benefit from the strict guarantee — prefer
    * `checkAccessStrict` for single-resource or small bounded-count calls only.
+   * (search: checkAccessStrict-batch-limit-caveat — locate all callers before raising the limit)
    * @param req Express request object with auth context
    * @param resources Array of resources to check access for
    * @param options Optional per-call overrides (e.g. explicit bearer token)
@@ -263,7 +264,7 @@ export class AccessCheckService {
         // chunk_index is 0-based — "chunk 0" is the first batch, "chunk 1" the second, etc.
         logger.warning(req, operationName, `Access-check batch chunk ${i} failed, failing closed for its resources`, {
           chunk_index: i,
-          chunk_size: chunks[i]?.length ?? 0,
+          chunk_size: chunks[i].length,
           err: result.reason,
         });
       }

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -264,7 +264,8 @@ export class AccessCheckService {
       // Log at WARN rather than success — partial results are a recoverable degradation, not a
       // clean completion. A monitoring alert keyed on "operation succeeded" should not fire here.
       // logger.warning has no startTime param, so duration_ms is added manually to preserve
-      // latency data for incident correlation.
+      // latency data for incident correlation. logger.success (else branch) computes duration
+      // internally from startTime — this mirrors that same arithmetic for the degraded path.
       logger.warning(req, operationName, `${failedChunks} of ${chunks.length} access-check chunks failed; results are partial`, {
         ...sharedMetadata,
         duration_ms: Date.now() - startTime,

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -198,14 +198,14 @@ export class AccessCheckService {
   }
 
   /**
-   * Performs the access-check request/response round trip with no error handling — callers decide
-   * whether to degrade (`checkAccess`) or propagate (`checkAccessStrict`).
+   * Performs the access-check request/response round trip and logs its own completion.
+   * Callers own error handling: `checkAccess` degrades, `checkAccessStrict` propagates.
    *
    * When the resource count exceeds ACCESS_CHECK_BATCH_SIZE the tuples are split into bounded
    * chunks and fanned out with Promise.allSettled. Fulfilled chunks are merged; rejected chunks
-   * fail closed (their resources get `false`) and are logged at WARN. This preserves the
-   * existing fail-closed contract while ensuring a single bad chunk does not silently discard
-   * results from the successful ones.
+   * fail closed (their keys are absent from the result map, defaulting to false at lookup) and
+   * are logged at WARN. On clean completion logger.success is called; on partial failure
+   * logger.warning is called instead so monitoring alerts keyed on success do not fire.
    */
   private async performCheck(
     req: Request,

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -66,7 +66,9 @@ export class AccessCheckService {
    * (all chunks rejected) — are absorbed: the method returns a partial or empty result map and
    * logs a WARN rather than throwing. `checkAccessStrict` propagates only when `performCheck`
    * itself throws, which happens on single-batch calls (≤ACCESS_CHECK_BATCH_SIZE resources)
-   * where the upstream call fails before any settling occurs.
+   * where the upstream call fails before any settling occurs. Callers passing more than
+   * ACCESS_CHECK_BATCH_SIZE resources will not benefit from the strict guarantee — prefer
+   * `checkAccessStrict` for single-resource or small bounded-count calls only.
    * @param req Express request object with auth context
    * @param resources Array of resources to check access for
    * @param options Optional per-call overrides (e.g. explicit bearer token)

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -244,9 +244,10 @@ export class AccessCheckService {
         failedChunks++;
         // Fail closed for the resources in this chunk — their keys are not in the result map,
         // so callers' downstream key lookups will return undefined and default to false.
+        // chunk_index is 0-based — "chunk 0" is the first batch, "chunk 1" the second, etc.
         logger.warning(req, operationName, `Access-check batch chunk ${i} failed, failing closed for its resources`, {
           chunk_index: i,
-          chunk_size: chunks[i]!.length,
+          chunk_size: chunks[i]?.length ?? 0,
           err: result.reason,
         });
       }

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -31,6 +31,13 @@ export class AccessCheckService {
    * @param resources Array of resources to check access for
    * @param options Optional per-call overrides (e.g. explicit bearer token)
    * @returns Map keyed by "id#access" to their access status (e.g. "meeting-1#organizer")
+   *
+   * Note: for calls with more than ACCESS_CHECK_BATCH_SIZE resources, `performCheck` fans out
+   * with Promise.allSettled and absorbs per-chunk failures internally — the catch block here
+   * is only reached for single-batch calls (≤ACCESS_CHECK_BATCH_SIZE resources) where the
+   * upstream call fails before any settling occurs. Multi-batch callers receive a partial
+   * result map (failed chunks absent, defaulting to false at lookup) rather than the
+   * all-false fallback map built here.
    */
   public async checkAccess(req: Request, resources: AccessCheckRequest[], options?: ApiRequestOptions): Promise<Map<string, boolean>> {
     if (resources.length === 0) {

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -33,11 +33,10 @@ export class AccessCheckService {
    * @returns Map keyed by "id#access" to their access status (e.g. "meeting-1#organizer")
    *
    * Note: for calls with more than ACCESS_CHECK_BATCH_SIZE resources, `performCheck` fans out
-   * with Promise.allSettled and absorbs per-chunk failures internally — the catch block here
-   * is only reached for single-batch calls (≤ACCESS_CHECK_BATCH_SIZE resources) where the
-   * upstream call fails before any settling occurs. Multi-batch callers receive a partial
-   * result map (failed chunks absent, defaulting to false at lookup) rather than the
-   * all-false fallback map built here.
+   * with Promise.allSettled and absorbs per-chunk failures — failed chunks are absent from the
+   * result map (defaulting to false at lookup) rather than propagating. The all-false fallback
+   * map here is only returned when a single-batch call (≤ACCESS_CHECK_BATCH_SIZE resources)
+   * throws before any settling occurs.
    */
   public async checkAccess(req: Request, resources: AccessCheckRequest[], options?: ApiRequestOptions): Promise<Map<string, boolean>> {
     if (resources.length === 0) {
@@ -69,15 +68,10 @@ export class AccessCheckService {
    * of degrading to "no access". For callers that must distinguish "resolved: no access" (403)
    * from "couldn't verify" (503) — `checkAccess`'s fallback collapses that distinction.
    *
-   * Note: when the resource count exceeds ACCESS_CHECK_BATCH_SIZE, requests are split into chunks
-   * and fanned out with Promise.allSettled. Per-chunk failures — including total batch failure
-   * (all chunks rejected) — are absorbed: the method returns a partial or empty result map and
-   * logs a WARN rather than throwing. `checkAccessStrict` propagates only when `performCheck`
-   * itself throws, which happens on single-batch calls (≤ACCESS_CHECK_BATCH_SIZE resources)
-   * where the upstream call fails before any settling occurs. Callers passing more than
-   * ACCESS_CHECK_BATCH_SIZE resources will not benefit from the strict guarantee — prefer
-   * `checkAccessStrict` for single-resource or small bounded-count calls only.
-   * (search: checkAccessStrict-batch-limit-caveat — locate all callers before raising the limit)
+   * When the resource count exceeds ACCESS_CHECK_BATCH_SIZE, requests are split into chunks and
+   * fanned out with Promise.allSettled. Any per-chunk failure (including total batch failure)
+   * causes this method to throw after all chunks have settled and per-chunk WARNs have been
+   * logged — preserving the strict error-propagation contract across all batch sizes.
    * @param req Express request object with auth context
    * @param resources Array of resources to check access for
    * @param options Optional per-call overrides (e.g. explicit bearer token)
@@ -91,7 +85,7 @@ export class AccessCheckService {
     const { operationName, startTime } = this.beginCheckOperation(req, resources);
     try {
       // success/warning logged inside performCheck; only error is logged here on propagation.
-      return await this.performCheck(req, resources, operationName, startTime, options);
+      return await this.performCheck(req, resources, operationName, startTime, options, true);
     } catch (error) {
       // Unlike checkAccess, this rethrows rather than degrading — but still logs, so a failed
       // strict check leaves the same terminal error record as any other failed operation instead
@@ -222,16 +216,19 @@ export class AccessCheckService {
    *
    * When the resource count exceeds ACCESS_CHECK_BATCH_SIZE the tuples are split into bounded
    * chunks and fanned out with Promise.allSettled. Fulfilled chunks are merged; rejected chunks
-   * fail closed (their keys are absent from the result map, defaulting to false at lookup) and
-   * are logged at WARN. On clean completion logger.success is called; on partial failure
-   * logger.warning is called instead so monitoring alerts keyed on success do not fire.
+   * are logged at WARN. When `throwOnChunkFailure` is true (strict path), any chunk rejection
+   * causes a throw after all chunks settle and per-chunk WARNs are emitted. When false
+   * (degraded path), failed chunks fail closed (keys absent, defaulting to false at lookup).
+   * On clean completion logger.success is called; on partial failure logger.warning is called
+   * instead so monitoring alerts keyed on success do not fire.
    */
   private async performCheck(
     req: Request,
     resources: AccessCheckRequest[],
     operationName: string,
     startTime: number,
-    options?: ApiRequestOptions
+    options?: ApiRequestOptions,
+    throwOnChunkFailure: boolean = false
   ): Promise<Map<string, boolean>> {
     if (resources.length <= ACCESS_CHECK_BATCH_SIZE) {
       const resultMap = await this.performSingleCheck(req, resources, options);
@@ -290,6 +287,15 @@ export class AccessCheckService {
         ...sharedMetadata,
         duration_ms: Date.now() - startTime,
       });
+
+      // Strict callers must be able to distinguish "denied" from "couldn't verify" — throw
+      // after all chunks have settled and per-chunk WARNs have been emitted so the terminal
+      // warning above always appears in logs before the rethrow. The first rejection reason
+      // is surfaced; checkAccessStrict's catch block logs it at ERROR before rethrowing.
+      if (throwOnChunkFailure) {
+        const firstFailure = settled.find((r) => r.status === 'rejected') as PromiseRejectedResult;
+        throw firstFailure.reason;
+      }
     } else {
       logger.success(req, operationName, startTime, sharedMetadata);
     }

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -252,12 +252,20 @@ export class AccessCheckService {
       }
     }
 
-    logger.success(req, operationName, startTime, {
+    const metadata = {
       request_count: resources.length,
       granted_count: Array.from(resultMap.values()).filter(Boolean).length,
       batch_count: chunks.length,
       failed_chunks: failedChunks,
-    });
+    };
+
+    if (failedChunks > 0) {
+      // Log at WARN rather than success — partial results are a recoverable degradation, not a
+      // clean completion. A monitoring alert keyed on "operation succeeded" should not fire here.
+      logger.warning(req, operationName, `${failedChunks} of ${chunks.length} access-check chunks failed; results are partial`, metadata);
+    } else {
+      logger.success(req, operationName, startTime, metadata);
+    }
 
     return resultMap;
   }

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -252,7 +252,7 @@ export class AccessCheckService {
       }
     }
 
-    const metadata = {
+    const sharedMetadata = {
       request_count: resources.length,
       granted_count: Array.from(resultMap.values()).filter(Boolean).length,
       batch_count: chunks.length,
@@ -262,9 +262,14 @@ export class AccessCheckService {
     if (failedChunks > 0) {
       // Log at WARN rather than success — partial results are a recoverable degradation, not a
       // clean completion. A monitoring alert keyed on "operation succeeded" should not fire here.
-      logger.warning(req, operationName, `${failedChunks} of ${chunks.length} access-check chunks failed; results are partial`, metadata);
+      // logger.warning has no startTime param, so duration_ms is added manually to preserve
+      // latency data for incident correlation.
+      logger.warning(req, operationName, `${failedChunks} of ${chunks.length} access-check chunks failed; results are partial`, {
+        ...sharedMetadata,
+        duration_ms: Date.now() - startTime,
+      });
     } else {
-      logger.success(req, operationName, startTime, metadata);
+      logger.success(req, operationName, startTime, sharedMetadata);
     }
 
     return resultMap;

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -221,6 +221,12 @@ export class AccessCheckService {
    * (degraded path), failed chunks fail closed (keys absent, defaulting to false at lookup).
    * On clean completion logger.success is called; on partial failure logger.warning is called
    * instead so monitoring alerts keyed on success do not fire.
+   *
+   * Concurrency: all chunks are issued in parallel (no pool cap). LFX has ~500 projects
+   * (ACCESS_CHECK_BATCH_SIZE = 100), so the maximum concurrent chunk count is ~5 — the same
+   * order of magnitude as sequential concurrent requests from different users, so no concurrency
+   * limiter is warranted. If a future caller drives chunk counts into the dozens, revisit with
+   * a traversal-slot or p-limit guard (see `acquireTraversalSlot` in project.service.ts).
    */
   private async performCheck(
     req: Request,

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -202,8 +202,10 @@ export class AccessCheckService {
    * whether to degrade (`checkAccess`) or propagate (`checkAccessStrict`).
    *
    * When the resource count exceeds ACCESS_CHECK_BATCH_SIZE the tuples are split into bounded
-   * chunks and fanned out with Promise.all, keeping each POST payload small so OpenFGA latency
-   * stays proportional to batch size rather than growing unbounded with page size.
+   * chunks and fanned out with Promise.allSettled. Fulfilled chunks are merged; rejected chunks
+   * fail closed (their resources get `false`) and are logged at WARN. This preserves the
+   * existing fail-closed contract while ensuring a single bad chunk does not silently discard
+   * results from the successful ones.
    */
   private async performCheck(
     req: Request,
@@ -227,12 +229,26 @@ export class AccessCheckService {
       chunks.push(resources.slice(i, i + ACCESS_CHECK_BATCH_SIZE));
     }
 
-    const batchResults = await Promise.all(chunks.map((chunk) => this.performSingleCheck(req, chunk, options)));
+    const settled = await Promise.allSettled(chunks.map((chunk) => this.performSingleCheck(req, chunk, options)));
 
     const resultMap = new Map<string, boolean>();
-    for (const batchMap of batchResults) {
-      for (const [key, value] of batchMap) {
-        resultMap.set(key, value);
+    let failedChunks = 0;
+
+    for (let i = 0; i < settled.length; i++) {
+      const result = settled[i];
+      if (result.status === 'fulfilled') {
+        for (const [key, value] of result.value) {
+          resultMap.set(key, value);
+        }
+      } else {
+        failedChunks++;
+        // Fail closed for the resources in this chunk — their keys are not in the result map,
+        // so callers' downstream key lookups will return undefined and default to false.
+        logger.warning(req, operationName, `Access-check batch chunk ${i} failed, failing closed for its resources`, {
+          chunk_index: i,
+          chunk_size: chunks[i]!.length,
+          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+        });
       }
     }
 
@@ -240,6 +256,7 @@ export class AccessCheckService {
       request_count: resources.length,
       granted_count: Array.from(resultMap.values()).filter(Boolean).length,
       batch_count: chunks.length,
+      failed_chunks: failedChunks,
     });
 
     return resultMap;

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -60,6 +60,12 @@ export class AccessCheckService {
    * Check access permissions for multiple resources, letting upstream failures propagate instead
    * of degrading to "no access". For callers that must distinguish "resolved: no access" (403)
    * from "couldn't verify" (503) — `checkAccess`'s fallback collapses that distinction.
+   *
+   * Note: when the resource count exceeds ACCESS_CHECK_BATCH_SIZE, requests are split into chunks
+   * and fanned out with Promise.allSettled. Per-chunk failures are treated as partial degradation
+   * (the chunk's keys are absent from the result map, defaulting to false at lookup) rather than
+   * propagated errors — this is an internal batching detail, not an upstream service failure.
+   * Only a complete call failure (all chunks rejected, or the service itself unreachable) throws.
    * @param req Express request object with auth context
    * @param resources Array of resources to check access for
    * @param options Optional per-call overrides (e.g. explicit bearer token)

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { ACCESS_CHECK_BATCH_SIZE } from '@lfx-one/shared/constants';
 import {
   AccessCheckAccessType,
   AccessCheckApiRequest,
@@ -199,6 +200,10 @@ export class AccessCheckService {
   /**
    * Performs the access-check request/response round trip with no error handling — callers decide
    * whether to degrade (`checkAccess`) or propagate (`checkAccessStrict`).
+   *
+   * When the resource count exceeds ACCESS_CHECK_BATCH_SIZE the tuples are split into bounded
+   * chunks and fanned out with Promise.all, keeping each POST payload small so OpenFGA latency
+   * stays proportional to batch size rather than growing unbounded with page size.
    */
   private async performCheck(
     req: Request,
@@ -207,6 +212,44 @@ export class AccessCheckService {
     startTime: number,
     options?: ApiRequestOptions
   ): Promise<Map<string, boolean>> {
+    if (resources.length <= ACCESS_CHECK_BATCH_SIZE) {
+      const resultMap = await this.performSingleCheck(req, resources, options);
+      logger.success(req, operationName, startTime, {
+        request_count: resources.length,
+        granted_count: Array.from(resultMap.values()).filter(Boolean).length,
+        batch_count: 1,
+      });
+      return resultMap;
+    }
+
+    const chunks: AccessCheckRequest[][] = [];
+    for (let i = 0; i < resources.length; i += ACCESS_CHECK_BATCH_SIZE) {
+      chunks.push(resources.slice(i, i + ACCESS_CHECK_BATCH_SIZE));
+    }
+
+    const batchResults = await Promise.all(chunks.map((chunk) => this.performSingleCheck(req, chunk, options)));
+
+    const resultMap = new Map<string, boolean>();
+    for (const batchMap of batchResults) {
+      for (const [key, value] of batchMap) {
+        resultMap.set(key, value);
+      }
+    }
+
+    logger.success(req, operationName, startTime, {
+      request_count: resources.length,
+      granted_count: Array.from(resultMap.values()).filter(Boolean).length,
+      batch_count: chunks.length,
+    });
+
+    return resultMap;
+  }
+
+  /**
+   * Sends a single POST to the access-check service and parses the response into a map.
+   * No error handling — `performCheck` owns that boundary.
+   */
+  private async performSingleCheck(req: Request, resources: AccessCheckRequest[], options?: ApiRequestOptions): Promise<Map<string, boolean>> {
     // Transform requests to the expected API format
     const apiRequests = resources.map((resource) => `${resource.resource}:${resource.id}#${resource.access}`);
 
@@ -263,11 +306,6 @@ export class AccessCheckService {
       // Fail closed when the upstream response omits this tuple
       resultMap.set(`${resource.id}#${resource.access}`, result?.hasAccess ?? false);
     }
-
-    logger.success(req, operationName, startTime, {
-      request_count: resources.length,
-      granted_count: Array.from(resultMap.values()).filter(Boolean).length,
-    });
 
     return resultMap;
   }

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -62,10 +62,11 @@ export class AccessCheckService {
    * from "couldn't verify" (503) — `checkAccess`'s fallback collapses that distinction.
    *
    * Note: when the resource count exceeds ACCESS_CHECK_BATCH_SIZE, requests are split into chunks
-   * and fanned out with Promise.allSettled. Per-chunk failures are treated as partial degradation
-   * (the chunk's keys are absent from the result map, defaulting to false at lookup) rather than
-   * propagated errors — this is an internal batching detail, not an upstream service failure.
-   * Only a complete call failure (all chunks rejected, or the service itself unreachable) throws.
+   * and fanned out with Promise.allSettled. Per-chunk failures — including total batch failure
+   * (all chunks rejected) — are absorbed: the method returns a partial or empty result map and
+   * logs a WARN rather than throwing. `checkAccessStrict` propagates only when `performCheck`
+   * itself throws, which happens on single-batch calls (≤ACCESS_CHECK_BATCH_SIZE resources)
+   * where the upstream call fails before any settling occurs.
    * @param req Express request object with auth context
    * @param resources Array of resources to check access for
    * @param options Optional per-call overrides (e.g. explicit bearer token)

--- a/apps/lfx-one/src/server/services/access-check.service.ts
+++ b/apps/lfx-one/src/server/services/access-check.service.ts
@@ -247,7 +247,7 @@ export class AccessCheckService {
         logger.warning(req, operationName, `Access-check batch chunk ${i} failed, failing closed for its resources`, {
           chunk_index: i,
           chunk_size: chunks[i]!.length,
-          error: result.reason instanceof Error ? result.reason.message : String(result.reason),
+          err: result.reason,
         });
       }
     }

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -268,6 +268,44 @@ describe('ProjectService — create picker methods', () => {
     });
   });
 
+  describe('getProjectSlugs', () => {
+    it('returns slug strings for all non-root projects', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'a', slug: 'a' }, { uid: 'b', slug: 'b' }]));
+
+      const result = await service.getProjectSlugs(req);
+
+      expect(result.sort()).toEqual(['a', 'b']);
+    });
+
+    it('excludes the ROOT pseudo-project without calling addAccessToResources', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'root', slug: 'root' }]));
+
+      const result = await service.getProjectSlugs(req);
+
+      expect(result).toEqual([]);
+      expect(addAccessToResources).not.toHaveBeenCalled();
+    });
+
+    it('follows page_token across pages and returns accumulated slugs', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'a', slug: 'a' }], 'next-token'));
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'b', slug: 'b' }]));
+
+      const result = await service.getProjectSlugs(req);
+
+      expect(result.sort()).toEqual(['a', 'b']);
+      expect(proxyRequest).toHaveBeenCalledTimes(2);
+      expect(proxyRequest.mock.calls[1][4]).toMatchObject({ page_token: 'next-token' });
+    });
+
+    it('never calls addAccessToResources (no access-check overhead)', async () => {
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'x', slug: 'x' }]));
+
+      await service.getProjectSlugs(req);
+
+      expect(addAccessToResources).not.toHaveBeenCalled();
+    });
+  });
+
   describe('getChildProjects', () => {
     it('queries parent=project:<uid> and filters to writer-permitted children', async () => {
       proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'child-1', slug: 'child-1' }]));

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -297,7 +297,7 @@ describe('ProjectService — create picker methods', () => {
       expect(proxyRequest.mock.calls[1][4]).toMatchObject({ page_token: 'next-token' });
     });
 
-    it('never calls addAccessToResources (no access-check overhead)', async () => {
+    it('does not call addAccessToResources for a standard non-root project', async () => {
       proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'x', slug: 'x' }]));
 
       await service.getProjectSlugs(req);

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -310,6 +310,15 @@ describe('ProjectService — create picker methods', () => {
 
       expect(addAccessToResources).not.toHaveBeenCalled();
     });
+
+    it('throws when a subsequent page fails (failOnPartial: true — partial slug set drops affiliations)', async () => {
+      // First page succeeds; second page fails. With failOnPartial: true the caller receives an
+      // error rather than a truncated slug list that silently misrepresents affiliation state.
+      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'a', slug: 'a' }], 'next-token'));
+      proxyRequest.mockRejectedValueOnce(new Error('page-fail'));
+
+      await expect(service.getProjectSlugs(req)).rejects.toThrow('page-fail');
+    });
   });
 
   describe('getChildProjects', () => {

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -300,7 +300,7 @@ describe('ProjectService — create picker methods', () => {
       expect(result.sort()).toEqual(['a', 'b']);
       expect(proxyRequest).toHaveBeenCalledTimes(2);
       expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', page_size: 500 });
-      expect(proxyRequest.mock.calls[1][4]).toMatchObject({ page_token: 'next-token' });
+      expect(proxyRequest.mock.calls[1][4]).toMatchObject({ type: 'project', page_size: 500, page_token: 'next-token' });
     });
 
     it('does not call addAccessToResources for a standard non-root project', async () => {

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -270,7 +270,12 @@ describe('ProjectService — create picker methods', () => {
 
   describe('getProjectSlugs', () => {
     it('returns slug strings for all non-root projects', async () => {
-      proxyRequest.mockResolvedValueOnce(pageOf([{ uid: 'a', slug: 'a' }, { uid: 'b', slug: 'b' }]));
+      proxyRequest.mockResolvedValueOnce(
+        pageOf([
+          { uid: 'a', slug: 'a' },
+          { uid: 'b', slug: 'b' },
+        ])
+      );
 
       const result = await service.getProjectSlugs(req);
 

--- a/apps/lfx-one/src/server/services/project.service.spec.ts
+++ b/apps/lfx-one/src/server/services/project.service.spec.ts
@@ -294,6 +294,7 @@ describe('ProjectService — create picker methods', () => {
 
       expect(result.sort()).toEqual(['a', 'b']);
       expect(proxyRequest).toHaveBeenCalledTimes(2);
+      expect(proxyRequest.mock.calls[0][4]).toMatchObject({ type: 'project', page_size: 500 });
       expect(proxyRequest.mock.calls[1][4]).toMatchObject({ page_token: 'next-token' });
     });
 

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -7551,6 +7551,14 @@ export class ProjectService {
    * tree (GH-1676 review).
    */
 
+  private async acquireTraversalSlot(gate: { active: number; queue: (() => void)[] }): Promise<void> {
+    if (gate.active < FOUNDATION_DESCENDANT_TRAVERSAL_SIBLING_CONCURRENCY) {
+      gate.active += 1;
+      return;
+    }
+    return new Promise((resolve) => gate.queue.push(resolve));
+  }
+
   /**
    * Shared paginated fetch for all public projects, with ROOT filtered out.
    * Both `getProjects` (access-checked) and `getProjectSlugs` (slug-only) delegate here
@@ -7575,14 +7583,6 @@ export class ProjectService {
 
     // ROOT is an administrative pseudo-project used only for persona detection — never surface it in user lists.
     return resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
-  }
-
-  private async acquireTraversalSlot(gate: { active: number; queue: (() => void)[] }): Promise<void> {
-    if (gate.active < FOUNDATION_DESCENDANT_TRAVERSAL_SIBLING_CONCURRENCY) {
-      gate.active += 1;
-      return;
-    }
-    return new Promise((resolve) => gate.queue.push(resolve));
   }
 
   /** Releases a traversal slot acquired via {@link acquireTraversalSlot}, waking the next queued caller if any. */

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -338,6 +338,27 @@ export class ProjectService {
   }
 
   /**
+   * Fetches slugs for all projects without an access-check round trip.
+   * Use this when the caller only needs slugs — it skips addAccessToResources
+   * entirely, eliminating the OpenFGA POST that getProjects() incurs.
+   */
+  public async getProjectSlugs(req: Request): Promise<string[]> {
+    const params = {
+      type: 'project',
+      page_size: QUERY_SERVICE_PAGE_SIZE,
+    };
+
+    const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    return resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG).map((p) => p.slug);
+  }
+
+  /**
    * Fetches a single project by ID
    */
   public async getProjectById(req: Request, uid: string, access: boolean = true, includeMeetingCoordinator: boolean = false): Promise<Project> {

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -338,32 +338,6 @@ export class ProjectService {
   }
 
   /**
-   * Shared paginated fetch for all public projects, with ROOT filtered out.
-   * Both `getProjects` (access-checked) and `getProjectSlugs` (slug-only) delegate here
-   * so the query params, pagination loop, and ROOT filter stay in one place.
-   * @param extraQuery Optional caller-supplied query overrides merged into params (e.g. from getProjects).
-   */
-  private async fetchAllProjectsFiltered(req: Request, extraQuery: Record<string, any> = {}): Promise<Project[]> {
-    const params = {
-      ...extraQuery,
-      type: 'project',
-      // Overrides any caller-supplied page_size — the query service's 50-result default turns
-      // a large org's project list into a long sequential page scan (GH-1735).
-      page_size: QUERY_SERVICE_PAGE_SIZE,
-    };
-
-    const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
-    );
-
-    // ROOT is an administrative pseudo-project used only for persona detection — never surface it in user lists.
-    return resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
-  }
-
-  /**
    * Fetches a single project by ID
    */
   public async getProjectById(req: Request, uid: string, access: boolean = true, includeMeetingCoordinator: boolean = false): Promise<Project> {
@@ -7576,6 +7550,33 @@ export class ProjectService {
    * spin up its own concurrency budget, multiplying real fan-out past the cap under a wide+deep
    * tree (GH-1676 review).
    */
+
+  /**
+   * Shared paginated fetch for all public projects, with ROOT filtered out.
+   * Both `getProjects` (access-checked) and `getProjectSlugs` (slug-only) delegate here
+   * so the query params, pagination loop, and ROOT filter stay in one place.
+   * @param extraQuery Optional caller-supplied query overrides merged into params (e.g. from getProjects).
+   */
+  private async fetchAllProjectsFiltered(req: Request, extraQuery: Record<string, any> = {}): Promise<Project[]> {
+    const params = {
+      ...extraQuery,
+      type: 'project',
+      // Overrides any caller-supplied page_size — the query service's 50-result default turns
+      // a large org's project list into a long sequential page scan (GH-1735).
+      page_size: QUERY_SERVICE_PAGE_SIZE,
+    };
+
+    const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>
+      this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+        ...params,
+        ...(pageToken && { page_token: pageToken }),
+      })
+    );
+
+    // ROOT is an administrative pseudo-project used only for persona detection — never surface it in user lists.
+    return resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
+  }
+
   private async acquireTraversalSlot(gate: { active: number; queue: (() => void)[] }): Promise<void> {
     if (gate.active < FOUNDATION_DESCENDANT_TRAVERSAL_SIBLING_CONCURRENCY) {
       gate.active += 1;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -315,8 +315,31 @@ export class ProjectService {
    * Fetches all projects based on query parameters
    */
   public async getProjects(req: Request, query: Record<string, any> = {}): Promise<Project[]> {
+    const filtered = await this.fetchAllProjectsFiltered(req, query);
+
+    // Add writer access field to all projects
+    return await this.accessCheckService.addAccessToResources(req, filtered, 'project');
+  }
+
+  /**
+   * Fetches slugs for all projects without an access-check round trip.
+   * Use this when the caller only needs slugs — it skips addAccessToResources
+   * entirely, eliminating the OpenFGA POST that getProjects() incurs.
+   */
+  public async getProjectSlugs(req: Request): Promise<string[]> {
+    const filtered = await this.fetchAllProjectsFiltered(req);
+    return filtered.map((p) => p.slug);
+  }
+
+  /**
+   * Shared paginated fetch for all public projects, with ROOT filtered out.
+   * Both `getProjects` (access-checked) and `getProjectSlugs` (slug-only) delegate here
+   * so the query params, pagination loop, and ROOT filter stay in one place.
+   * @param extraQuery Optional caller-supplied query overrides merged into params (e.g. from getProjects).
+   */
+  private async fetchAllProjectsFiltered(req: Request, extraQuery: Record<string, any> = {}): Promise<Project[]> {
     const params = {
-      ...query,
+      ...extraQuery,
       type: 'project',
       // Overrides any caller-supplied page_size — the query service's 50-result default turns
       // a large org's project list into a long sequential page scan (GH-1735).
@@ -331,31 +354,7 @@ export class ProjectService {
     );
 
     // ROOT is an administrative pseudo-project used only for persona detection — never surface it in user lists.
-    const filtered = resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
-
-    // Add writer access field to all projects
-    return await this.accessCheckService.addAccessToResources(req, filtered, 'project');
-  }
-
-  /**
-   * Fetches slugs for all projects without an access-check round trip.
-   * Use this when the caller only needs slugs — it skips addAccessToResources
-   * entirely, eliminating the OpenFGA POST that getProjects() incurs.
-   */
-  public async getProjectSlugs(req: Request): Promise<string[]> {
-    const params = {
-      type: 'project',
-      page_size: QUERY_SERVICE_PAGE_SIZE,
-    };
-
-    const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
-    );
-
-    return resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG).map((p) => p.slug);
+    return resources.filter((p) => p.slug !== ROOT_PROJECT_SLUG);
   }
 
   /**

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -7550,7 +7550,6 @@ export class ProjectService {
    * spin up its own concurrency budget, multiplying real fan-out past the cap under a wide+deep
    * tree (GH-1676 review).
    */
-
   private async acquireTraversalSlot(gate: { active: number; queue: (() => void)[] }): Promise<void> {
     if (gate.active < FOUNDATION_DESCENDANT_TRAVERSAL_SIBLING_CONCURRENCY) {
       gate.active += 1;

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -332,7 +332,7 @@ export class ProjectService {
    * a 'fields' parameter here to further reduce transfer cost.
    */
   public async getProjectSlugs(req: Request): Promise<string[]> {
-    logger.debug(req, 'get_project_slugs', 'Fetching all project slugs');
+    logger.debug(req, 'get_project_slugs', 'Fetching all project slugs', {});
     const filtered = await this.fetchAllProjectsFiltered(req);
     return filtered.map((p) => p.slug);
   }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -327,6 +327,7 @@ export class ProjectService {
    * entirely, eliminating the OpenFGA POST that getProjects() incurs.
    */
   public async getProjectSlugs(req: Request): Promise<string[]> {
+    logger.debug(req, 'get_project_slugs', 'Fetching all project slugs');
     const filtered = await this.fetchAllProjectsFiltered(req);
     return filtered.map((p) => p.slug);
   }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -333,7 +333,10 @@ export class ProjectService {
    */
   public async getProjectSlugs(req: Request): Promise<string[]> {
     logger.debug(req, 'get_project_slugs', 'Fetching all project slugs', { page_size: QUERY_SERVICE_PAGE_SIZE });
-    const filtered = await this.fetchAllProjectsFiltered(req);
+    // failOnPartial: a truncated slug list silently drops affiliations from CDP matching —
+    // a user whose project was on a failed page appears as not LFX-affiliated. Throw instead
+    // so the caller receives an error and can surface it rather than returning a stale/false view.
+    const filtered = await this.fetchAllProjectsFiltered(req, {}, true);
     return filtered.map((p) => p.slug);
   }
 
@@ -7563,8 +7566,11 @@ export class ProjectService {
    * Both `getProjects` (access-checked) and `getProjectSlugs` (slug-only) delegate here
    * so the query params, pagination loop, and ROOT filter stay in one place.
    * @param extraQuery Optional caller-supplied query overrides merged into params (e.g. from getProjects).
+   * @param failOnPartial When true, a pagination failure throws instead of returning a truncated
+   *   list. Pass true for slug-only callers where a partial slug set silently drops affiliations;
+   *   leave false (default) for access-checked callers where a partial list degrades gracefully.
    */
-  private async fetchAllProjectsFiltered(req: Request, extraQuery: Record<string, any> = {}): Promise<Project[]> {
+  private async fetchAllProjectsFiltered(req: Request, extraQuery: Record<string, any> = {}, failOnPartial: boolean = false): Promise<Project[]> {
     const params = {
       ...extraQuery,
       type: 'project',
@@ -7573,11 +7579,14 @@ export class ProjectService {
       page_size: QUERY_SERVICE_PAGE_SIZE,
     };
 
-    const resources = await fetchAllQueryResources<Project>(req, (pageToken) =>
-      this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
-        ...params,
-        ...(pageToken && { page_token: pageToken }),
-      })
+    const resources = await fetchAllQueryResources<Project>(
+      req,
+      (pageToken) =>
+        this.microserviceProxy.proxyRequest<QueryServiceResponse<Project>>(req, 'LFX_V2_SERVICE', '/query/resources', 'GET', {
+          ...params,
+          ...(pageToken && { page_token: pageToken }),
+        }),
+      { failOnPartial }
     );
 
     // ROOT is an administrative pseudo-project used only for persona detection — never surface it in user lists.

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -332,7 +332,7 @@ export class ProjectService {
    * a 'fields' parameter here to further reduce transfer cost.
    */
   public async getProjectSlugs(req: Request): Promise<string[]> {
-    logger.debug(req, 'get_project_slugs', 'Fetching all project slugs', {});
+    logger.debug(req, 'get_project_slugs', 'Fetching all project slugs', { page_size: QUERY_SERVICE_PAGE_SIZE });
     const filtered = await this.fetchAllProjectsFiltered(req);
     return filtered.map((p) => p.slug);
   }

--- a/apps/lfx-one/src/server/services/project.service.ts
+++ b/apps/lfx-one/src/server/services/project.service.ts
@@ -325,6 +325,11 @@ export class ProjectService {
    * Fetches slugs for all projects without an access-check round trip.
    * Use this when the caller only needs slugs — it skips addAccessToResources
    * entirely, eliminating the OpenFGA POST that getProjects() incurs.
+   *
+   * Note: the query-service payload is as wide as getProjects() (full Project
+   * objects); only the FGA round trip is eliminated, not the response payload
+   * size. If the upstream query service ever supports field projection, pass
+   * a 'fields' parameter here to further reduce transfer cost.
    */
   public async getProjectSlugs(req: Request): Promise<string[]> {
     logger.debug(req, 'get_project_slugs', 'Fetching all project slugs');

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -31,6 +31,13 @@ export const MEETING_PASSWORD_HEADER = 'x-meeting-password';
 export const QUERY_SERVICE_FILTERS_OR_BATCH_SIZE = 100;
 
 /**
+ * Maximum number of access-check tuples per POST request to the access-check service.
+ * @description Bounds OpenFGA payload size and latency. When the caller has more than this many
+ * tuples to check, split into chunks of this size and fan out with Promise.all.
+ */
+export const ACCESS_CHECK_BATCH_SIZE = 100;
+
+/**
  * NATS configuration constants
  * @description Configuration for NATS messaging system used for inter-service communication
  * @readonly

--- a/packages/shared/src/constants/api.constants.ts
+++ b/packages/shared/src/constants/api.constants.ts
@@ -33,7 +33,7 @@ export const QUERY_SERVICE_FILTERS_OR_BATCH_SIZE = 100;
 /**
  * Maximum number of access-check tuples per POST request to the access-check service.
  * @description Bounds OpenFGA payload size and latency. When the caller has more than this many
- * tuples to check, split into chunks of this size and fan out with Promise.all.
+ * tuples to check, split into chunks of this size and fan out with Promise.allSettled.
  */
 export const ACCESS_CHECK_BATCH_SIZE = 100;
 


### PR DESCRIPTION
## Summary

Closes #1901

Two independent optimizations to reduce unnecessary `/api/projects` access-check (OpenFGA) load:

### 1. `GET /api/projects/slugs` — skip the OpenFGA round trip for affiliations

`ProfileAffiliationsComponent` fetched the full access-checked project list (`GET /api/projects`) solely to build a `Set<string>` of slugs for matching — the `writer` field was discarded. This PR adds a lightweight `GET /api/projects/slugs` endpoint that returns `string[]` directly, with no `AccessCheckService` call. The affiliations component now calls `getProjectSlugs()` instead of `getProjects()`.

**Before:** `GET /api/projects` → query service + OpenFGA for every project → strip everything except slug  
**After:** `GET /api/projects/slugs` → query service only → return slugs

### 2. Access-check batching in `AccessCheckService.performCheck`

`performCheck` previously sent all tuples in a single unbounded POST to the access-check service. When a caller passed a large project list the payload grew proportionally, increasing OpenFGA latency for every request on that code path.

`performCheck` now chunks the resource array into batches of `ACCESS_CHECK_BATCH_SIZE = 100` and fans out with `Promise.allSettled`. Fulfilled chunks are merged; rejected chunks fail closed (their keys are absent from the result map, defaulting to `false` at lookup) and are logged at WARN. A new `checkAccessStrict` note documents the batch-size ceiling on its error-propagation guarantee.

## Files changed

| File | Change |
|---|---|
| `packages/shared/src/constants/api.constants.ts` | Add `ACCESS_CHECK_BATCH_SIZE = 100` |
| `apps/lfx-one/src/server/services/access-check.service.ts` | Batch `performCheck`; extract `performSingleCheck`; add `checkAccessStrict` caveat |
| `apps/lfx-one/src/server/services/access-check.service.spec.ts` | Tests for tuple-order independence, batching, partial failure, and strict propagation |
| `apps/lfx-one/src/server/services/project.service.ts` | Add `getProjectSlugs` backend service method |
| `apps/lfx-one/src/server/services/project.service.spec.ts` | Tests for `getProjectSlugs` (pagination, ROOT filtering, no access check) |
| `apps/lfx-one/src/server/controllers/project.controller.ts` | Add `getProjectSlugs` controller handler |
| `apps/lfx-one/src/server/controllers/project.controller.spec.ts` | Tests for `getProjectSlugs` controller |
| `apps/lfx-one/src/server/routes/projects.route.ts` | Add `GET /slugs` before `/:slug` param route |
| `apps/lfx-one/src/app/shared/services/project.service.ts` | Add `getProjectSlugs()` frontend service method with caching |
| `apps/lfx-one/src/app/shared/services/project.service.spec.ts` | Frontend service tests |
| `apps/lfx-one/src/app/modules/profile/affiliations/profile-affiliations.component.ts` | Switch from `getProjects()` to `getProjectSlugs()` |

## Trade-offs documented

- **`console.error` in frontend `ProjectService.getProjectSlugs`**: follows the established file-wide pattern (all other `catchError` blocks in this service use `console.error`). Fixing in isolation would be inconsistent; addressed together in a follow-up.
- **`checkAccessStrict` batch-limit caveat**: documented in JSDoc with a searchable anchor (`checkAccessStrict-batch-limit-caveat`). All current callers pass a single resource via `checkSingleAccessStrict`, so the ceiling doesn't affect any live code path.

## Verification

- `yarn build` — passes (7m40s clean build)
- `yarn lint` — passes
- `yarn check-types` — passes (implicit in build)
- 30 commits, all GPG-signed (`G`) and DCO signed-off
- Unit tests added: batching boundary tests, single-batch no-warning assertion, per-chunk failure isolation, `getProjectSlugs` pagination, ROOT filtering, no-access-check guard