### PR TITLE
docs(cla): document the M2 additions on the CLAs tab

### DIFF
--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -66,7 +66,7 @@ Go to [**Profile & Account**](/profile) and open the **CLAs** tab (`/profile/cla
 
 ## What is the difference between an ICLA and an ECLA?
 
-An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from the CLAs tab when available. An **ECLA** (Employee CLA) means you are covered under your employer's **CCLA** (Corporate CLA) via the company's **Approved List**; the CLAs tab lists it with the company name and no individual PDF. See [CLAs](../my-clas/).
+An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can download its PDF from the CLAs tab when EasyCLA has the file. An **ECLA** (Employee CLA) means your employer holds a **CCLA** (Corporate CLA) and you were approved under it via the company's **Approved List**; the CLAs tab lists it with the company name and no individual PDF, and keeps listing it with a status that says so if that coverage later ends. See [CLAs](../my-clas/).
 
 ## Why don't my signed CLAs show up on the CLAs tab?
 

--- a/docs/user/account/faq/index.md
+++ b/docs/user/account/faq/index.md
@@ -4,7 +4,7 @@ description: Frequently asked questions about account settings, affiliations, id
 audience: [all]
 product_area: Account
 tags: [account, faq, settings, affiliations, cla, easycla, transactions, billing]
-last_updated: 2026-08-17
+last_updated: 2026-08-28
 intercom_collection: Account
 ---
 
@@ -70,11 +70,19 @@ An **ICLA** (Individual CLA) is an agreement you signed as yourself — you can 
 
 ## Why don't my signed CLAs show up on the CLAs tab?
 
-The CLAs tab matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-dont-my-signed-clas-show-up).
+The CLAs tab matches agreements to your LF username, verified emails, and linked GitHub accounts. If those values do not match the identity you used when signing (for example a work email or GitHub account that is not linked to this LFX profile), the CLA will not appear. Open [Identities](/profile/identities), link the Email or GitHub accounts you used when signing, then return to **CLAs**. More detail: [Why don't my signed CLAs show up?](../my-clas/#why-don-t-my-signed-clas-show-up).
 
 ## Can I sign a CLA from the CLAs tab?
 
-No. The CLAs tab is read-only and only shows agreements already on file. Signing happens outside this tab, and the signing process may evolve. See [CLAs](../my-clas/) and the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+You can start there. Select **Sign CLA**, search for the project, CLA group, or repository you need to sign for, and choose which linked GitHub account to sign under. Self Serve then hands you off to the EasyCLA Contributor Console, which presents and records the agreement — the signing itself does not happen in Self Serve. See [How do I sign a new CLA?](../my-clas/#how-do-i-sign-a-new-cla).
+
+## What do the CLA status labels mean?
+
+**Valid** means the agreement covers your contributions. **Needs attention** means an Employee CLA no longer covers you, usually because you have dropped off your employer's **Approved List**. **Invalidated** means the agreement is no longer in force — someone removed you from an Approved List, a maintainer invalidated your ICLA, or the CLA group was deleted. **Revoked** is reserved for a sanctions-screening outcome against your employer and cannot be changed from Self Serve. See [What do the status labels mean?](../my-clas/#what-do-the-status-labels-mean).
+
+## How do I ask my employer's CLA manager to approve or remove my ECLA?
+
+Open the **⋮** menu on the Employee CLA row and choose **Request approval** (when you are no longer on the Approved List) or **Request Removal**. Select which CLA managers to notify, optionally add a message, and select **Send**. The request only notifies them — a manager makes the actual change in the Corporate CLA Console. See [How do I ask my CLA manager to approve or remove my ECLA?](../my-clas/#how-do-i-ask-my-cla-manager-to-approve-or-remove-my-ecla).
 
 ## What purchases appear in my transaction history?
 

--- a/docs/user/account/index.md
+++ b/docs/user/account/index.md
@@ -4,7 +4,7 @@ description: Manage your LFX account — work history and affiliations, identiti
 audience: [all]
 product_area: Account
 tags: [account, settings, affiliations, identities, individual-enrollment, cla, transactions]
-last_updated: 2026-08-17
+last_updated: 2026-08-28
 intercom_collection: Account
 ---
 
@@ -17,7 +17,7 @@ Your personal identity details (name, photo, About Me, primary email, and locati
 - Review and update your work history and project affiliations
 - Manage the identities used to attribute your contributions
 - Enroll in the Linux Foundation Individual Supporter plan
-- View your Individual CLAs (ICLAs) and Employee CLA (ECLA) coverage
+- View your Individual CLAs (ICLAs) and Employee CLA (ECLA) coverage, and start signing a new CLA
 - View your Linux Foundation purchase history
 - Manage your email addresses, password, and developer API token
 
@@ -29,14 +29,14 @@ All authenticated users have an account. Every user can view and manage their ow
 
 Account areas live under the **Profile & Account** hub. Go to **app.lfx.dev**, select [**Profile & Account**](/profile) from the left navigation sidebar, and choose a tab:
 
-| Tab                         | Route                            | Description                                                    | Documentation                                     |
-| --------------------------- | -------------------------------- | -------------------------------------------------------------- | ------------------------------------------------- |
-| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                     | [Work history & Affiliations](./work-history/)    |
-| Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work    | [Identities](./identities/)                       |
-| Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan       | [Individual Enrollment](./individual-enrollment/) |
-| CLAs                        | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage (read-only) | [CLAs](./my-clas/)                                |
-| Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                         | [Transactions](./transactions/)                   |
-| Settings                    | `/profile/settings`              | Email addresses, password, and developer API token             | [Settings](./settings/)                           |
+| Tab                         | Route                            | Description                                                                               | Documentation                                     |
+| --------------------------- | -------------------------------- | ----------------------------------------------------------------------------------------- | ------------------------------------------------- |
+| Work history & Affiliations | `/profile/attributions`          | Your work history and project affiliations                                                | [Work history & Affiliations](./work-history/)    |
+| Identities                  | `/profile/identities`            | Connected accounts used to identify and attribute your work                               | [Identities](./identities/)                       |
+| Individual Enrollment       | `/profile/individual-enrollment` | Enroll in the Linux Foundation Individual Supporter plan                                  | [Individual Enrollment](./individual-enrollment/) |
+| CLAs                        | `/profile/clas`                  | Your signed ICLAs and Employee CLA (ECLA) coverage, and where you start signing a new CLA | [CLAs](./my-clas/)                                |
+| Transactions                | `/profile/transactions`          | Your Linux Foundation purchase history                                                    | [Transactions](./transactions/)                   |
+| Settings                    | `/profile/settings`              | Email addresses, password, and developer API token                                        | [Settings](./settings/)                           |
 
 `/profile` opens the **Work history & Affiliations** tab by default.
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -12,7 +12,7 @@ These steps apply to any signed-in user on LFX Self Serve.
 
 **CLAs** is a tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. The CLAs tab answers: _which agreements have I signed, under which projects am I covered, and does any of them need attention?_
 
-From this tab you can also start signing a new CLA and ask your employer's CLA managers to approve or remove an Employee CLA. Self Serve does not complete either of those itself — it hands you off to EasyCLA, which does. See [What Self Serve does not do](#what-self-serve-does-not-do).
+From this tab you can also start signing a new CLA, and ask your employer's CLA managers to approve or remove an Employee CLA. Neither is completed here, but the two end differently: signing hands you off to the EasyCLA Contributor Console, while a manager request is submitted from this tab and a CLA manager then acts on it in the Corporate CLA Console. See [What Self Serve does not do](#what-self-serve-does-not-do).
 
 For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
@@ -76,7 +76,8 @@ When EasyCLA recorded the account used to sign, the **Signed** cell adds a secon
 
 - _Signed as \<username\> (GitHub)_
 - _Signed as \<username\> (GitLab)_
-- _Signed as \<identity\>_ — for Gerrit, and for agreements identified by LF login or email address, which carry no platform label
+- _Signed as \<username\> (Gerrit)_
+- _Signed as \<identity\>_ — with no platform label, when EasyCLA recorded the identity but not the platform it came from, which covers agreements identified by LF login or email address
 
 This line is informational. It tells you which of your accounts an agreement is attached to, which is useful when you have several linked identities and are working out why a project still asks you to sign.
 
@@ -86,14 +87,14 @@ The line is omitted when EasyCLA has no signing identity on record for that agre
 
 Each row ends with a **⋮** menu listing only the actions available for that agreement. A row with no available actions shows no **⋮** at all.
 
-| Action                     | When it appears                                                                                                       |
-| -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
-| **Download PDF**           | On an ICLA when EasyCLA has the signed file                                                                           |
-| **Download PDF** (greyed)  | On every ECLA, annotated _Covered by Corporate CLA (CCLA)_ — employee coverage has no individual document to download |
-| **Request approval**       | On an ECLA that is no longer on your employer's **Approved List**                                                     |
-| **Request Removal**        | On any ECLA that is not **Revoked**                                                                                   |
-| **Contact CLA Manager**    | On a **Valid** or **Needs attention** ECLA                                                                            |
-| **Manage in CCLA Console** | On an ECLA where EasyCLA records you as a CLA manager for that company's Corporate CLA                                |
+| Action                     | When it appears                                                                                                                            |
+| -------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Download PDF**           | On an ICLA when EasyCLA has the signed file                                                                                                |
+| **Download PDF** (greyed)  | On an ECLA that is not **Revoked**, annotated _Covered by Corporate CLA (CCLA)_ — employee coverage has no individual document to download |
+| **Request approval**       | On an ECLA that is no longer on your employer's **Approved List**                                                                          |
+| **Request Removal**        | On any ECLA that is not **Revoked**                                                                                                        |
+| **Contact CLA Manager**    | On a **Valid** or **Needs attention** ECLA                                                                                                 |
+| **Manage in CCLA Console** | On an ECLA where EasyCLA records you as a CLA manager for that company's Corporate CLA                                                     |
 
 You will not see a **⋮** on:
 
@@ -124,7 +125,7 @@ Three ECLA-only actions reach the CLA managers who hold your employer's Corporat
 All three open the same dialog:
 
 1. Self Serve loads the CLA managers for that agreement and pre-selects all of them. Clear anyone you would rather not contact.
-2. Optionally add a note in **Message**.
+2. Add a **Message**. This is optional for **Request approval** and **Request Removal**. It is required for **Contact CLA Manager**, where the message is the whole point of the action — **Send** stays disabled until you write one.
 3. Select **Send**.
 
 What you see afterwards:
@@ -161,7 +162,7 @@ The info banner on the CLAs tab also points to the Identities flow (_Link your E
 
 Yes for an **ICLA**, when EasyCLA has the signed file — choose **Download PDF** from the row's **⋮** menu. When EasyCLA does not have the file, the row offers no download.
 
-No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. The menu shows **Download PDF** greyed out and annotated _Covered by Corporate CLA (CCLA)_.
+No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. On an ECLA that has a **⋮** menu, the menu shows **Download PDF** greyed out and annotated _Covered by Corporate CLA (CCLA)_. A **Revoked** ECLA has no menu at all, so it shows nothing.
 
 ## What Self Serve does not do
 

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -1,18 +1,18 @@
 ---
 title: CLAs
-description: View your signed Individual and Employee CLAs in LFX Self Serve, and understand why an agreement might not appear.
+description: View your signed Individual and Employee CLAs in LFX Self Serve, start signing a new one, and ask a CLA manager to approve or remove your Employee CLA.
 audience: [all]
 product_area: Account
-tags: [account, cla, easycla, icla, ecla, identities]
-last_updated: 2026-08-11
+tags: [account, cla, easycla, icla, ecla, ccla, identities, signing]
+last_updated: 2026-08-28
 intercom_collection: Account
 ---
 
 These steps apply to any signed-in user on LFX Self Serve.
 
-**CLAs** is a read-only tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. The CLAs tab answers: _which agreements have I signed, and under which projects am I covered?_
+**CLAs** is a tab under the Profile & Account hub that lists the Contributor License Agreements (CLAs) EasyCLA has on file for you. A CLA is the agreement that covers your contributions to a Linux Foundation project that requires one. The CLAs tab answers: _which agreements have I signed, under which projects am I covered, and does any of them need attention?_
 
-You cannot sign a CLA from this page. Signing happens outside the CLAs tab, and the signing process may evolve; this page only shows agreements already on file.
+From this tab you can also start signing a new CLA and ask your employer's CLA managers to approve or remove an Employee CLA. Self Serve does not complete either of those itself — it hands you off to EasyCLA, which does. See [What Self Serve does not do](#what-self-serve-does-not-do).
 
 For broader EasyCLA concepts (what a CLA is, project and corporate consoles, troubleshooting), see the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla).
 
@@ -22,7 +22,7 @@ For broader EasyCLA concepts (what a CLA is, project and corporate consoles, tro
 2. Select [**Profile & Account**](/profile) from the left navigation sidebar.
 3. Open the **CLAs** tab, or go directly to `/profile/clas`.
 
-Agreements are matched from your signed-in session and your linked [Email and GitHub identities](/profile/identities). You never search or type a project name here.
+Agreements are matched from your signed-in session and your linked [Email and GitHub identities](/profile/identities). You never search or type a project name to see your existing agreements.
 
 ## What is the difference between ICLA and ECLA?
 
@@ -36,16 +36,17 @@ In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered und
 
 ## What does the CLAs list show?
 
-When agreements are found, the CLAs tab shows a table with four columns:
+When agreements are found, the CLAs tab shows a table with these columns:
 
-| Column       | Contents                                                                                                            |
-| ------------ | ------------------------------------------------------------------------------------------------------------------- |
-| **Project**  | Project logo (or a placeholder), project name, and — when it differs — the CLA group name as secondary text         |
-| **Type**     | `ICLA`, or `ECLA · <company name>`                                                                                  |
-| **Signed**   | The date the agreement was signed                                                                                   |
-| **Document** | **Download PDF** for an ICLA when available (else _PDF unavailable_); _Covered by Corporate CLA (CCLA)_ for an ECLA |
+| Column      | Contents                                                                                                                                                 |
+| ----------- | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **Project** | Project logo (or a placeholder), project name, and — when it differs — the CLA group name as secondary text                                              |
+| **Type**    | `ICLA`, or `ECLA · <company name>`                                                                                                                       |
+| **Status**  | Whether the agreement is in force — see [What do the status labels mean?](#what-do-the-status-labels-mean)                                               |
+| **Signed**  | The date the agreement was signed, and — when EasyCLA recorded it — the account it was signed under                                                      |
+| ⋮ (actions) | The actions available for that row, such as **Download PDF** or **Request Removal** — see [What can I do from a CLA row?](#what-can-i-do-from-a-cla-row) |
 
-Only currently valid agreements appear on this list.
+Agreements that are no longer in force stay on the list with a status that says so, rather than disappearing. That is deliberate: seeing that an agreement was invalidated is more useful than seeing nothing.
 
 ### Why does the CLAs tab say I have no CLAs?
 
@@ -54,7 +55,89 @@ If nothing matches your linked identities, you see:
 - **No CLAs on file yet**
 - _We haven't found any signed ICLAs or ECLAs for your linked identities._
 
-That does not always mean you never signed — see the next section.
+That does not always mean you never signed — see [Why don't my signed CLAs show up?](#why-don-t-my-signed-clas-show-up).
+
+## What do the status labels mean?
+
+| Status              | What it means                                                                                                                                                                    | Applies to |
+| ------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------- |
+| **Valid**           | The agreement is in force and covers your contributions. Nothing to do.                                                                                                          | ICLA, ECLA |
+| **Needs attention** | You were approved once, but the agreement no longer covers you — most often because you have dropped off your employer's **Approved List**.                                      | ECLA only  |
+| **Invalidated**     | The agreement is no longer in force. A CLA manager removed you from your employer's **Approved List**, a project maintainer invalidated your ICLA, or the CLA group was deleted. | ICLA, ECLA |
+| **Revoked**         | Your employer was flagged by sanctions screening. This is set by EasyCLA, cannot be changed from Self Serve, and leaves no actions on the row.                                   | ECLA only  |
+
+When an ECLA needs attention because you are no longer on the Approved List, the row adds a line under the status: _No longer matches \<company\>'s approval criteria._
+
+**Invalidated and Revoked are not the same thing**, and the tab keeps them visibly apart on purpose. **Revoked** is only ever a sanctions-screening outcome. Being removed from an Approved List — including at your own request — or having a maintainer invalidate your ICLA shows as **Invalidated**, so that an ordinary administrative change is never presented as a screening result.
+
+## Which identity was a CLA signed under?
+
+When EasyCLA recorded the account used to sign, the **Signed** cell adds a second line under the date:
+
+- _Signed as \<username\> (GitHub)_
+- _Signed as \<username\> (GitLab)_
+- _Signed as \<identity\>_ — for Gerrit, and for agreements identified by LF login or email address, which carry no platform label
+
+This line is informational. It tells you which of your accounts an agreement is attached to, which is useful when you have several linked identities and are working out why a project still asks you to sign.
+
+The line is omitted when EasyCLA has no signing identity on record for that agreement. That applies equally to ICLAs and ECLAs — a missing line means missing data, not a difference between the two types.
+
+## What can I do from a CLA row?
+
+Each row ends with a **⋮** menu listing only the actions available for that agreement. A row with no available actions shows no **⋮** at all.
+
+| Action                     | When it appears                                                                                                       |
+| -------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| **Download PDF**           | On an ICLA when EasyCLA has the signed file                                                                           |
+| **Download PDF** (greyed)  | On every ECLA, annotated _Covered by Corporate CLA (CCLA)_ — employee coverage has no individual document to download |
+| **Request approval**       | On an ECLA that is no longer on your employer's **Approved List**                                                     |
+| **Request Removal**        | On any ECLA that is not **Revoked**                                                                                   |
+| **Contact CLA Manager**    | On a **Valid** or **Needs attention** ECLA                                                                            |
+| **Manage in CCLA Console** | On an ECLA where EasyCLA records you as a CLA manager for that company's Corporate CLA                                |
+
+You will not see a **⋮** on:
+
+- Any **Revoked** row — these are read-only
+- An **Invalidated** ICLA
+- An ICLA whose signed file EasyCLA does not have
+
+## How do I sign a new CLA?
+
+Select **Sign CLA** at the top right of the CLAs tab.
+
+1. In the **Sign a CLA** dialog, type at least three characters. You can search by project name, CLA group name, a linked GitHub, GitLab, or Gerrit organization, or by pasting a repository link.
+2. Each result shows why it matched — project name, CLA group name, linked organization, or repository link — so you can tell near-identical names apart.
+3. Select the right result and choose **Continue to sign**.
+4. Choose which of your linked GitHub accounts to sign under, then select **Continue to sign** again. Nothing is selected for you, and the step appears even when you have only one account linked — its job is to tell you which identity the agreement will be recorded against. If you have no GitHub account linked, the step says so and offers a link to [Identities](/profile/identities); you cannot continue past it until you link one.
+5. Self Serve hands you off to the EasyCLA Contributor Console, which presents and records the agreement. When you finish there, you are returned to the CLAs tab.
+
+If the search returns more matches than it can display, narrow the term — the dialog tells you when results were truncated.
+
+## How do I ask my CLA manager to approve or remove my ECLA?
+
+Three ECLA-only actions reach the CLA managers who hold your employer's Corporate CLA. None of them changes the agreement itself; a manager acts on it in the Corporate CLA Console.
+
+- **Request approval** — offered when your ECLA is no longer on your employer's Approved List. It asks the managers to approve you again.
+- **Request Removal** — offered on any ECLA that is not Revoked. It asks the managers to remove your ECLA, which starts the process of invalidating it on your behalf.
+- **Contact CLA Manager** — offered on a Valid or Needs-attention ECLA. It sends a free-text message rather than a specific request, for anything the other two do not cover.
+
+All three open the same dialog:
+
+1. Self Serve loads the CLA managers for that agreement and pre-selects all of them. Clear anyone you would rather not contact.
+2. Optionally add a note in **Message**.
+3. Select **Send**.
+
+What you see afterwards:
+
+| Outcome              | What it means                                                                                                             |
+| -------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| **Request sent**     | The managers you selected will be notified.                                                                               |
+| **Request recorded** | The request was stored, but no manager email could be delivered. Follow up with your employer's CLA managers another way. |
+| No managers listed   | _No CLA manager is currently reachable for this company._ Contact Linux Foundation support for help.                      |
+
+**Contact CLA Manager** phrases the same two outcomes as _Message sent_ and _Message recorded_, because it carries a message rather than a request.
+
+A recorded request or message is not a failure on your part and does not need re-sending — it means Self Serve stored it but your employer's CLA managers have no deliverable email address on file.
 
 ## Why don't my signed CLAs show up?
 
@@ -76,17 +159,22 @@ The info banner on the CLAs tab also points to the Identities flow (_Link your E
 
 ## Can I download my signed CLA PDF?
 
-Yes for an **ICLA**, when EasyCLA has the signed file — use **Download PDF** in the Document column. If the file is missing, the row shows _PDF unavailable_.
+Yes for an **ICLA**, when EasyCLA has the signed file — choose **Download PDF** from the row's **⋮** menu. When EasyCLA does not have the file, the row offers no download.
 
-No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. The Document column shows _Covered by Corporate CLA (CCLA)_.
+No for an **ECLA**. Employee coverage is under your company's Corporate CLA (CCLA), so there is no individual PDF to download. The menu shows **Download PDF** greyed out and annotated _Covered by Corporate CLA (CCLA)_.
 
-## Can I sign a CLA from the CLAs tab?
+## What Self Serve does not do
 
-No. The CLAs tab is read-only. Signing happens outside this tab, and the process may evolve. See the [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) for current guidance.
+The CLAs tab shows your agreements and starts requests about them. It never:
+
+- **Runs the signing ceremony.** The agreement is presented and signed in the EasyCLA Contributor Console. Self Serve only hands you off to it.
+- **Approves, invalidates, or revokes an agreement.** Those changes are made by a CLA manager in the Corporate CLA Console, by a project maintainer, or by EasyCLA's own screening — never by this tab, including when you use **Request Removal**.
+- **Edits your employer's Approved List.**
 
 ## Related
 
 - [Account overview](../) — all account areas and navigation
 - [Account FAQ](../faq/) — short answers to common account questions, including CLAs
+- [Identities](../identities/) — link the Email and GitHub accounts your CLAs are matched against
 - [Edit your profile](../../profile/edit-profile/) — name, photo, About Me, primary email, and location
 - [EasyCLA documentation](https://docs.linuxfoundation.org/lfx/easycla) — CLA concepts, consoles, and troubleshooting outside Self Serve

--- a/docs/user/account/my-clas/index.md
+++ b/docs/user/account/my-clas/index.md
@@ -26,11 +26,11 @@ Agreements are matched from your signed-in session and your linked [Email and Gi
 
 ## What is the difference between ICLA and ECLA?
 
-| Type                      | What it means                                                                                                      | On CLAs                                                                  | Document                                                                        |
-| ------------------------- | ------------------------------------------------------------------------------------------------------------------ | ------------------------------------------------------------------------ | ------------------------------------------------------------------------------- |
-| **ICLA** (Individual CLA) | You signed as yourself for a project                                                                               | Listed                                                                   | **Download PDF** when EasyCLA has the signed file (otherwise _PDF unavailable_) |
-| **ECLA** (Employee CLA)   | You are covered because your employer holds a Corporate CLA (CCLA) and you are on that company's **Approved List** | Listed (shows the employer name)                                         | No individual PDF — shown as _Covered by Corporate CLA (CCLA)_                  |
-| **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                              | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab                          |
+| Type                      | What it means                                                                                                  | On CLAs                                                                  | Document                                                                                       |
+| ------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| **ICLA** (Individual CLA) | You signed as yourself for a project                                                                           | Listed                                                                   | **Download PDF** when EasyCLA has the signed file; otherwise the row offers no download        |
+| **ECLA** (Employee CLA)   | Your employer holds a Corporate CLA (CCLA) and you were approved under it via that company's **Approved List** | Listed (shows the employer name), and stays listed if the coverage ends  | No individual PDF — where the row has a **⋮** menu, it shows _Covered by Corporate CLA (CCLA)_ |
+| **CCLA** (Corporate CLA)  | Signed by a company CLA manager; covers employees via the company's **Approved List**                          | Not listed as its own row — it is the parent agreement an ECLA hangs off | Managed in the corporate EasyCLA flow, not on this tab                                         |
 
 In short: an **ICLA** is _your_ paperwork; an **ECLA** means you are covered under your company's **CCLA**.
 
@@ -76,8 +76,8 @@ When EasyCLA recorded the account used to sign, the **Signed** cell adds a secon
 
 - _Signed as \<username\> (GitHub)_
 - _Signed as \<username\> (GitLab)_
-- _Signed as \<username\> (Gerrit)_
-- _Signed as \<identity\>_ — with no platform label, when EasyCLA recorded the identity but not the platform it came from, which covers agreements identified by LF login or email address
+- _Signed as \<username\> (Gerrit)_ — also used for agreements identified by LF login or email address, which have no separate platform of their own
+- _Signed as \<identity\>_ — with no platform label, when EasyCLA recorded an identity but no recognised platform for it
 
 This line is informational. It tells you which of your accounts an agreement is attached to, which is useful when you have several linked identities and are working out why a project still asks you to sign.
 


### PR DESCRIPTION
Refs #1800

## Summary

The CLAs page still described a read-only tab, which stopped being true when M2
shipped. This rewrites `docs/user/account/my-clas/index.md` against what actually
ships, and corrects the account overview and the account FAQ where their CLA
claims had become false.

New on the CLAs page:

- **Status labels** — Valid, Needs attention, Invalidated, Revoked, and why
  Invalidated and Revoked are deliberately kept apart, so that an administrative
  removal is never presented as a sanctions-screening result.
- **Signed-under identity** — the per-row line, and that a missing line means
  missing data rather than a difference between ICLA and ECLA.
- **The per-row ⋮ menu** — which actions appear on which rows, and the three
  cases where a row carries no menu at all.
- **Sign a new CLA** — the search, the GitHub account step, and the hand-off to
  the EasyCLA Contributor Console.
- **The three ECLA manager requests** — Request approval, Request Removal and
  Contact CLA Manager share one dialog; the sent / recorded outcomes are
  explained, including that a recorded outcome is not a user error.
- **What Self Serve does not do** — no signing ceremony, no approve / invalidate
  / revoke, no Approved List edits.

## One incidental fix

The account FAQ's deep link into the CLAs page has been broken on `main`: it
pointed at `#why-dont-my-signed-clas-show-up`, while the docs portal slugifies
*don't* to `don-t`. Nothing catches this — markdownlint's MD051 fragment rule is
disabled repo-wide and CI has no link checker. All 14 fragment links under
`docs/user/**` now verify against the generated manifest.

## Verification

- `yarn format:check`, `yarn lint:check`, `check-headers.sh` — pass
- `yarn workspace lfx-one-ui docs:check` — manifest, search index, sitemap, file
  coverage, navigation reachability and byte-stability across two runs all OK
- `markdownlint` — clean on the three changed files. Four pre-existing MD024
  duplicate-heading errors remain in dashboards, events, profile and trainings,
  none of which this branch touches.

## Out of scope

Invalidated and Revoked dates, tracked in #1913. The status section says nothing
about dates, which matches what ships today; it needs one added line if #1913
lands.

## Test plan

- [ ] Copy reviewed for accuracy against DEV
- [ ] The status descriptions match intended product behaviour