### PR TITLE
feat(mktg-os): restore marketplace feature flag

### DIFF
--- a/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.spec.ts
@@ -1,0 +1,145 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PLATFORM_ID, signal } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { Route, Router, UrlSegment, UrlTree } from '@angular/router';
+import { FeatureFlagService } from '@shared/services/feature-flag.service';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { mktgOsAgentsEnabledGuard } from './mktg-os-agents-enabled.guard';
+
+describe('mktgOsAgentsEnabledGuard', () => {
+  let getFlagOverride: ReturnType<typeof vi.fn>;
+  let providerReady: ReturnType<typeof signal<boolean>>;
+  let getBooleanFlag: ReturnType<typeof vi.fn>;
+  let queryParams: Record<string, string | undefined>;
+  let router: { url: string; parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
+
+  const projectRoute: Route = { path: 'project/mktg-os-agents', data: { lens: 'project' } };
+  const foundationRoute: Route = { path: 'foundation/mktg-os-agents', data: { lens: 'foundation' } };
+  const segments: UrlSegment[] = [];
+
+  const runGuard = (route: Route = projectRoute): ReturnType<typeof mktgOsAgentsEnabledGuard> =>
+    TestBed.runInInjectionContext(() => mktgOsAgentsEnabledGuard(route, segments));
+
+  beforeEach(() => {
+    getFlagOverride = vi.fn().mockReturnValue(undefined);
+    providerReady = signal(true);
+    getBooleanFlag = vi.fn().mockReturnValue(signal(false));
+    queryParams = {};
+
+    router = {
+      url: '/project/mktg-os-agents',
+      parseUrl: vi.fn().mockImplementation(() => ({ queryParams })),
+      createUrlTree: vi.fn().mockImplementation((commands: string[], opts: unknown) => ({ denied: commands[0], opts }) as unknown as UrlTree),
+    };
+
+    TestBed.configureTestingModule({
+      providers: [
+        {
+          provide: FeatureFlagService,
+          useValue: { getFlagOverride, providerReady: providerReady.asReadonly(), getBooleanFlag },
+        },
+        { provide: Router, useValue: router },
+        { provide: PLATFORM_ID, useValue: 'browser' },
+      ],
+    });
+  });
+
+  it('allows on the server without evaluating the flag (SSR fast path)', async () => {
+    TestBed.overrideProvider(PLATFORM_ID, { useValue: 'server' });
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(getFlagOverride).not.toHaveBeenCalled();
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+
+  it('allows when the local override says the flag is on, without waiting for READY', async () => {
+    getFlagOverride.mockReturnValue(true);
+    providerReady.set(false);
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+
+  it('redirects to project overview when the local override says the flag is off, without waiting for READY', async () => {
+    getFlagOverride.mockReturnValue(false);
+    providerReady.set(false);
+
+    const result = await runGuard();
+
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: {} } });
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+
+  it('preserves the project query on an override deny', async () => {
+    getFlagOverride.mockReturnValue(false);
+    queryParams = { project: 'my-project' };
+
+    const result = await runGuard();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/project/overview'], { queryParams: { project: 'my-project' } });
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'my-project' } } });
+  });
+
+  it('redirects a foundation deep link to foundation overview when the override is off', async () => {
+    getFlagOverride.mockReturnValue(false);
+
+    const result = await runGuard(foundationRoute);
+
+    expect(result).toEqual({ denied: '/foundation/overview', opts: { queryParams: {} } });
+  });
+
+  it('allows once the provider is ready and the flag is on', async () => {
+    getBooleanFlag.mockReturnValue(signal(true));
+
+    const result = await runGuard();
+
+    expect(result).toBe(true);
+  });
+
+  it('redirects to project overview once the provider is ready and the flag is off', async () => {
+    getBooleanFlag.mockReturnValue(signal(false));
+
+    const result = await runGuard();
+
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: {} } });
+  });
+
+  it('redirects a foundation deep link to foundation overview when the flag is off', async () => {
+    getBooleanFlag.mockReturnValue(signal(false));
+
+    const result = await runGuard(foundationRoute);
+
+    expect(result).toEqual({ denied: '/foundation/overview', opts: { queryParams: {} } });
+  });
+
+  it('preserves the project query when the flag is off after READY', async () => {
+    getBooleanFlag.mockReturnValue(signal(false));
+    queryParams = { project: 'my-project' };
+
+    const result = await runGuard();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/project/overview'], { queryParams: { project: 'my-project' } });
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'my-project' } } });
+  });
+
+  it('fails closed to the lens overview when the provider never becomes ready', async () => {
+    vi.useFakeTimers();
+    providerReady.set(false);
+
+    const pending = runGuard();
+    await vi.advanceTimersByTimeAsync(5000);
+    const result = await pending;
+
+    vi.useRealTimers();
+
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: {} } });
+    expect(getBooleanFlag).not.toHaveBeenCalled();
+  });
+});

--- a/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.spec.ts
+++ b/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.spec.ts
@@ -13,12 +13,26 @@ describe('mktgOsAgentsEnabledGuard', () => {
   let getFlagOverride: ReturnType<typeof vi.fn>;
   let providerReady: ReturnType<typeof signal<boolean>>;
   let getBooleanFlag: ReturnType<typeof vi.fn>;
-  let queryParams: Record<string, string | undefined>;
-  let router: { url: string; parseUrl: ReturnType<typeof vi.fn>; createUrlTree: ReturnType<typeof vi.fn> };
+  let getCurrentNavigation: ReturnType<typeof vi.fn>;
+  let router: {
+    url: string;
+    parseUrl: ReturnType<typeof vi.fn>;
+    createUrlTree: ReturnType<typeof vi.fn>;
+    getCurrentNavigation: ReturnType<typeof vi.fn>;
+  };
 
   const projectRoute: Route = { path: 'project/mktg-os-agents', data: { lens: 'project' } };
   const foundationRoute: Route = { path: 'foundation/mktg-os-agents', data: { lens: 'foundation' } };
   const segments: UrlSegment[] = [];
+
+  const parseQueryParams = (url: string): Record<string, string> => {
+    const query = url.split('?')[1];
+    return query ? Object.fromEntries(new URLSearchParams(query)) : {};
+  };
+
+  const setNavigationProject = (project: string): void => {
+    getCurrentNavigation.mockReturnValue({ extractedUrl: { queryParams: { project } } });
+  };
 
   const runGuard = (route: Route = projectRoute): ReturnType<typeof mktgOsAgentsEnabledGuard> =>
     TestBed.runInInjectionContext(() => mktgOsAgentsEnabledGuard(route, segments));
@@ -27,12 +41,13 @@ describe('mktgOsAgentsEnabledGuard', () => {
     getFlagOverride = vi.fn().mockReturnValue(undefined);
     providerReady = signal(true);
     getBooleanFlag = vi.fn().mockReturnValue(signal(false));
-    queryParams = {};
+    getCurrentNavigation = vi.fn().mockReturnValue(null);
 
     router = {
       url: '/project/mktg-os-agents',
-      parseUrl: vi.fn().mockImplementation(() => ({ queryParams })),
+      parseUrl: vi.fn().mockImplementation((url: string) => ({ queryParams: parseQueryParams(url) })),
       createUrlTree: vi.fn().mockImplementation((commands: string[], opts: unknown) => ({ denied: commands[0], opts }) as unknown as UrlTree),
+      getCurrentNavigation,
     };
 
     TestBed.configureTestingModule({
@@ -79,7 +94,28 @@ describe('mktgOsAgentsEnabledGuard', () => {
 
   it('preserves the project query on an override deny', async () => {
     getFlagOverride.mockReturnValue(false);
-    queryParams = { project: 'my-project' };
+    setNavigationProject('my-project');
+
+    const result = await runGuard();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/project/overview'], { queryParams: { project: 'my-project' } });
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'my-project' } } });
+  });
+
+  it('preserves the project query from the in-flight URL when router.url has none', async () => {
+    getFlagOverride.mockReturnValue(false);
+    router.url = '/project/overview';
+    setNavigationProject('my-project');
+
+    const result = await runGuard();
+
+    expect(router.createUrlTree).toHaveBeenCalledWith(['/project/overview'], { queryParams: { project: 'my-project' } });
+    expect(result).toEqual({ denied: '/project/overview', opts: { queryParams: { project: 'my-project' } } });
+  });
+
+  it('falls back to router.url when no navigation is in flight', async () => {
+    getFlagOverride.mockReturnValue(false);
+    router.url = '/project/mktg-os-agents?project=my-project';
 
     const result = await runGuard();
 
@@ -121,7 +157,7 @@ describe('mktgOsAgentsEnabledGuard', () => {
 
   it('preserves the project query when the flag is off after READY', async () => {
     getBooleanFlag.mockReturnValue(signal(false));
-    queryParams = { project: 'my-project' };
+    setNavigationProject('my-project');
 
     const result = await runGuard();
 

--- a/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
@@ -1,14 +1,64 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { CanMatchFn } from '@angular/router';
+import { isPlatformBrowser } from '@angular/common';
+import { inject, PLATFORM_ID } from '@angular/core';
+import { toObservable } from '@angular/core/rxjs-interop';
+import { CanMatchFn, Route, Router, UrlTree } from '@angular/router';
+import { MKTG_OS_AGENTS_ENABLED_FLAG } from '@lfx-one/shared/constants';
+import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
+
+import { FeatureFlagService } from '../services/feature-flag.service';
+
+function deniedOverview(router: Router, route: Route): UrlTree {
+  const lens = route.data?.['lens'] === 'foundation' ? 'foundation' : 'project';
+  const project = router.parseUrl(router.url).queryParams['project'];
+  return router.createUrlTree([`/${lens}/overview`], {
+    queryParams: project ? { project } : {},
+  });
+}
 
 /**
  * CanMatch guard for /project|foundation/mktg-os-agents.
  *
- * TODO(mktg-os GA): flag gate bypassed for now (Joan, 2026-08-19) — the
- * marketplace ships visible while it iterates. Restore the LaunchDarkly
- * `mktg-os-agents-enabled` check (provider-READY wait, fail closed) from git
- * history before GA hardening.
+ * Dark-launch gate behind `mktg-os-agents-enabled`. SSR defers to the browser.
+ * Browser waits for provider READY and fails closed. A local override (non-production
+ * only) decides before READY so a pinned false cannot lose to a timeout.
  */
-export const mktgOsAgentsEnabledGuard: CanMatchFn = () => true;
+export const mktgOsAgentsEnabledGuard: CanMatchFn = async (route) => {
+  const platformId = inject(PLATFORM_ID);
+
+  // LaunchDarkly is unavailable during SSR, so the browser run of this guard makes the real decision.
+  if (!isPlatformBrowser(platformId)) {
+    return true;
+  }
+
+  const featureFlagService = inject(FeatureFlagService);
+  const router = inject(Router);
+
+  // A locally pinned value decides on its own, before the provider is consulted at all. Waiting
+  // first would let a readiness timeout answer for it, and a pinned `false` must never be
+  // overridden. Non-production builds only. See `FEATURE_FLAG_OVERRIDE_STORAGE_KEY`.
+  const override = featureFlagService.getFlagOverride(MKTG_OS_AGENTS_ENABLED_FLAG);
+  if (override !== undefined) {
+    return override ? true : deniedOverview(router, route);
+  }
+
+  if (!featureFlagService.providerReady()) {
+    const ready = await firstValueFrom(
+      toObservable(featureFlagService.providerReady).pipe(
+        filter((isReady): isReady is true => isReady === true),
+        timeout(5000),
+        catchError(() => of(false))
+      )
+    );
+    // Provider never became ready in time (LD slow / unreachable) → fail CLOSED. This is a
+    // dark launch, so failing open would show the marketplace to anyone whenever LaunchDarkly
+    // is slow.
+    if (!ready) {
+      return deniedOverview(router, route);
+    }
+  }
+
+  return featureFlagService.getBooleanFlag(MKTG_OS_AGENTS_ENABLED_FLAG, false)() ? true : deniedOverview(router, route);
+};

--- a/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
+++ b/apps/lfx-one/src/app/shared/guards/mktg-os-agents-enabled.guard.ts
@@ -10,9 +10,18 @@ import { catchError, filter, firstValueFrom, of, timeout } from 'rxjs';
 
 import { FeatureFlagService } from '../services/feature-flag.service';
 
+function queryProject(value: unknown): string | undefined {
+  if (typeof value === 'string' && value.length > 0) {
+    return value;
+  }
+
+  return undefined;
+}
+
 function deniedOverview(router: Router, route: Route): UrlTree {
   const lens = route.data?.['lens'] === 'foundation' ? 'foundation' : 'project';
-  const project = router.parseUrl(router.url).queryParams['project'];
+  const project =
+    queryProject(router.getCurrentNavigation()?.extractedUrl.queryParams['project']) ?? queryProject(router.parseUrl(router.url).queryParams['project']);
   return router.createUrlTree([`/${lens}/overview`], {
     queryParams: project ? { project } : {},
   });

--- a/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
+++ b/apps/lfx-one/src/app/shared/services/sidebar-nav.service.ts
@@ -9,6 +9,7 @@ import {
   DOCUMENT_LABEL,
   MAILING_LIST_LABEL,
   MARKETING_OPS_FGA_ENABLED_FLAG,
+  MKTG_OS_AGENTS_ENABLED_FLAG,
   MKTG_OS_AGENTS_LABEL,
   ORG_LENS_ENABLED_FLAG,
   ORG_LENS_ROI_ENABLED_FLAG,
@@ -46,8 +47,8 @@ export class SidebarNavService {
   private readonly isOrgLensEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ENABLED_FLAG, false);
   /** Dark-launch gate for the Akrites admin dashboard; hides the Security nav section when off. */
   private readonly isAkritesEnabled = this.featureFlagService.getBooleanFlag(AKRITES_ENABLED_FLAG, false);
-  /** TODO(mktg-os GA): flag gate bypassed for now (Joan, 2026-08-19) — restore getBooleanFlag(MKTG_OS_AGENTS_ENABLED_FLAG, false) before GA. */
-  private readonly isMktgOsAgentsEnabled: Signal<boolean> = computed(() => true);
+  /** Dark-launch gate for the Marketing OS marketplace; hides the Project Lens nav item when off. */
+  private readonly isMktgOsAgentsEnabled = this.featureFlagService.getBooleanFlag(MKTG_OS_AGENTS_ENABLED_FLAG, false);
   /** Dark-launch gate for the Org Lens ROI Metrics page; hides its org-lens nav entry when off. */
   private readonly isOrgLensRoiEnabled = this.featureFlagService.getBooleanFlag(ORG_LENS_ROI_ENABLED_FLAG, false);
   /** Dual-gated with `ServerFeatureFlag.MarketingOpsFga` — unlocks Marketing nav for marketing_auditor/campaign_manager grants (LFXV2-2235/LFXV2-2236). */


### PR DESCRIPTION
## Summary
- Restore `mktg-os-agents-enabled` on the Project Lens Marketing OS nav item and marketplace routes. #1649 had left both hardcoded on.
- Fail closed when LaunchDarkly is unread or slow. Denied deep links land on `/{lens}/overview` and keep the `project` query when present.
- Targeting stays in LaunchDarkly. No new flag and no BFF change.

Closes #1939

## Test plan
- [ ] Local `yarn start`: pin `localStorage.lfx-feature-flag-overrides` to `{ "mktg-os-agents-enabled": false }`, reload, confirm Project Lens hides Marketing OS and `/project/mktg-os-agents?project=<slug>` redirects to `/project/overview`
- [ ] Pin the same key to `true`, reload, confirm Marketing OS sits between Documents and Governance and the marketplace loads
- [ ] Clear the override and confirm DEV LaunchDarkly targeting matches (on the allow-list sees it, off the list does not)
- [ ] `yarn workspace lfx-one-ui ng test --watch=false --include='**/mktg-os-agents-enabled.guard.spec.ts'`


Made with [Cursor](https://cursor.com)