### PR TITLE
fix(profile): explain and recover from a blank linux-email forward

### DIFF
--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -230,6 +230,40 @@ test.describe('Linux.com email — forwarding target visibility', () => {
   });
 });
 
+test.describe('Linux.com email — forward re-auth (#1935)', () => {
+  test('shows the re-auth panel instead of the blank select when the forward target could not be read', async ({ page }) => {
+    // Pre-latch the one-shot redirect guard so the page renders the recoverable panel
+    // instead of immediately bouncing to authorizeUrl.
+    await page.addInitScript(() => sessionStorage.setItem('linux-email:forward-reauth-attempted', '1'));
+    await stubIdentities(page);
+    const aliasEmail = `${ALIAS}@${DOMAIN}`;
+    await page.route('**/api/profile/linux-email', (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      const body: LinuxAliasData = {
+        state: 'claimed',
+        domain: DOMAIN,
+        alias: ALIAS,
+        email: aliasEmail,
+        forwardTo: null,
+        primaryEmail: PRIMARY_EMAIL,
+        forwardAuthRequired: true,
+        authorizeUrl: 'https://app.dev.lfx.dev/api/profile/auth/start?returnTo=/profile/identities',
+      };
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    });
+
+    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-forward-reauth')).toBeVisible();
+    await expect(page.getByTestId('linux-email-forward-reauth-button')).toBeVisible();
+    await expect(page.getByTestId('linux-email-forward-select')).not.toBeAttached();
+    await expect(page.getByTestId('linux-email-forward-empty')).not.toBeAttached();
+  });
+});
+
 test.describe('Linux.com email — service unavailable', () => {
   test('renders the whole-tab retry panel when the alias service is unavailable', async ({ page }) => {
     // getLinuxAlias reads user_emails.read server-side; when that (or any downstream

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -236,9 +236,8 @@ test.describe('Linux.com email — forwarding target visibility', () => {
 /**
  * Stub the alias GET as claimed with forwardAuthRequired, and pre-latch the one-shot
  * redirect guard so the page renders the recoverable panel instead of bouncing to
- * authorizeUrl. Omit authorizeUrl to exercise the defensive dead-end copy — the BFF
- * always pairs authorizeUrl with forwardAuthRequired, so this shape isn't one the
- * server actually produces, but the component guards against the contract drifting.
+ * authorizeUrl. Omit authorizeUrl to exercise the dead-end copy — the server emits
+ * this exact shape when Flow C itself is unconfigured (no authorizeUrl to offer).
  */
 async function stubClaimedNeedsReauth(page: Page, authorizeUrl?: string): Promise<void> {
   await page.addInitScript((key) => sessionStorage.setItem(key, '1'), LINUX_EMAIL_FORWARD_REAUTH_KEY);

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -26,6 +26,8 @@ import { expect, Page, test } from '@playwright/test';
 const DOMAIN = 'example.org';
 const ALIAS = 'jane-doe';
 const PRIMARY_EMAIL = 'jane.doe@example.com';
+// Tab load involves an identities fetch plus the alias fetch — longer than Playwright's default.
+const PANEL_TIMEOUT = 10_000;
 
 function skipWhenAuthMissing(page: Page): void {
   try {
@@ -47,7 +49,7 @@ async function gotoIdentitiesAndExpectClaimedPanel(page: Page): Promise<void> {
   await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
   skipWhenAuthMissing(page);
   await expect(page).not.toHaveURL(/auth0\.com/);
-  await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+  await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: PANEL_TIMEOUT });
 }
 
 /** Stub the identities fetch the tab needs to render deterministically. */
@@ -111,7 +113,7 @@ test.describe('Linux.com email — partial claim failure recovery', () => {
     await expect(page).not.toHaveURL(/auth0\.com/);
 
     // Starting state: purchased but unclaimed — the claim form is shown.
-    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: PANEL_TIMEOUT });
 
     await page.getByTestId('linux-email-alias-input').locator('input').fill(ALIAS);
     await page.getByTestId('linux-email-claim-forward-select').click();
@@ -122,8 +124,8 @@ test.describe('Linux.com email — partial claim failure recovery', () => {
     // claimed/edit view (not left stuck on the claim form) and surfaces a guiding toast.
     // The toast assertion runs first — PrimeNG toasts have a short default lifetime, so
     // checking it after the other awaits below risks it disappearing before we see it.
-    await expect(page.getByText(/set your forwarding address below/i)).toBeVisible({ timeout: 10000 });
-    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText(/set your forwarding address below/i)).toBeVisible({ timeout: PANEL_TIMEOUT });
+    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: PANEL_TIMEOUT });
     await expect(page.getByTestId('linux-email-claimed-address')).toContainText(`${ALIAS}@${DOMAIN}`);
     await expect(page.getByTestId('linux-email-forward-form')).toBeVisible();
 
@@ -203,7 +205,7 @@ test.describe('Linux.com email — forwarding target visibility', () => {
     skipWhenAuthMissing(page);
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: PANEL_TIMEOUT });
     await expect(page.getByTestId('linux-email-claim-forward-select')).toBeVisible();
     await expect(page.getByText('Choose one of your verified email addresses.')).toBeVisible();
   });
@@ -226,7 +228,7 @@ test.describe('Linux.com email — forwarding target visibility', () => {
     await expect(page).not.toHaveURL(/auth0\.com/);
 
     // Let the tab finish rendering before asserting no /emails fetch was made.
-    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-claim-panel')).toBeVisible({ timeout: PANEL_TIMEOUT });
     expect(emailsFetchCount).toBe(0);
   });
 });
@@ -293,7 +295,7 @@ test.describe('Linux.com email — service unavailable', () => {
     skipWhenAuthMissing(page);
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    await expect(page.getByTestId('linux-email-retry-button')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-retry-button')).toBeVisible({ timeout: PANEL_TIMEOUT });
     await expect(page.getByTestId('linux-email-claim-panel')).not.toBeAttached();
     await expect(page.getByTestId('linux-email-claimed-panel')).not.toBeAttached();
   });
@@ -330,7 +332,7 @@ test.describe('Linux.com email — service unavailable', () => {
     skipWhenAuthMissing(page);
     await expect(page).not.toHaveURL(/auth0\.com/);
 
-    await expect(page.getByTestId('linux-email-retry-button')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-retry-button')).toBeVisible({ timeout: PANEL_TIMEOUT });
     await expect(page.getByTestId('linux-email-claim-panel')).not.toBeAttached();
     await expect(page.getByTestId('linux-email-claimed-panel')).not.toBeAttached();
 

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -38,6 +38,18 @@ function skipWhenAuthMissing(page: Page): void {
   }
 }
 
+/**
+ * Navigate and wait for the claimed panel to render. Routes/init scripts must be
+ * registered before this — Playwright can't retroactively intercept a request or
+ * seed sessionStorage for a navigation that already happened.
+ */
+async function gotoIdentitiesAndExpectClaimedPanel(page: Page): Promise<void> {
+  await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+}
+
 /** Stub the identities fetch the tab needs to render deterministically. */
 async function stubIdentities(page: Page): Promise<void> {
   await page.route('**/api/profile/identities', (route) => {
@@ -137,11 +149,7 @@ test.describe('Linux.com email — forwarding target visibility', () => {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
-    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
-    skipWhenAuthMissing(page);
-    await expect(page).not.toHaveURL(/auth0\.com/);
-
-    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+    await gotoIdentitiesAndExpectClaimedPanel(page);
     await expect(page.getByTestId('linux-email-forward-select')).toBeVisible();
     await expect(page.getByTestId('linux-email-forward-empty')).not.toBeAttached();
     await expect(page.getByText('Add another verified email to change this.')).toBeVisible();
@@ -163,11 +171,7 @@ test.describe('Linux.com email — forwarding target visibility', () => {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
-    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
-    skipWhenAuthMissing(page);
-    await expect(page).not.toHaveURL(/auth0\.com/);
-
-    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+    await gotoIdentitiesAndExpectClaimedPanel(page);
     await expect(page.getByTestId('linux-email-forward-select')).toBeVisible();
     // The preserved external target is the selected option — proves the preservation branch fired.
     await expect(page.getByTestId('linux-email-forward-select')).toContainText(externalForward);
@@ -186,11 +190,7 @@ test.describe('Linux.com email — forwarding target visibility', () => {
       return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
     });
 
-    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
-    skipWhenAuthMissing(page);
-    await expect(page).not.toHaveURL(/auth0\.com/);
-
-    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+    await gotoIdentitiesAndExpectClaimedPanel(page);
     await expect(page.getByTestId('linux-email-forward-empty')).toBeVisible();
     await expect(page.getByTestId('linux-email-forward-select')).not.toBeAttached();
   });
@@ -254,18 +254,6 @@ async function stubClaimedNeedsReauth(page: Page, authorizeUrl?: string): Promis
     };
     return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
   });
-}
-
-/**
- * Navigate and wait for the claimed panel to render. Routes/init scripts must be
- * registered before this — Playwright can't retroactively intercept a request or
- * seed sessionStorage for a navigation that already happened.
- */
-async function gotoIdentitiesAndExpectClaimedPanel(page: Page): Promise<void> {
-  await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
-  skipWhenAuthMissing(page);
-  await expect(page).not.toHaveURL(/auth0\.com/);
-  await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
 }
 
 test.describe('Linux.com email — forward re-auth (#1935)', () => {

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -231,33 +231,48 @@ test.describe('Linux.com email — forwarding target visibility', () => {
   });
 });
 
+/**
+ * Stub the alias GET as claimed with forwardAuthRequired, and pre-latch the one-shot
+ * redirect guard so the page renders the recoverable panel instead of bouncing to
+ * authorizeUrl. Omit authorizeUrl to exercise the "Flow C unconfigured" dead-end copy.
+ */
+async function stubClaimedNeedsReauth(page: Page, authorizeUrl?: string): Promise<void> {
+  await page.addInitScript((key) => sessionStorage.setItem(key, '1'), LINUX_EMAIL_FORWARD_REAUTH_KEY);
+  await stubIdentities(page);
+  const aliasEmail = `${ALIAS}@${DOMAIN}`;
+  await page.route('**/api/profile/linux-email', (route) => {
+    if (route.request().method() !== 'GET') return route.fallback();
+    const body: LinuxAliasData = {
+      state: 'claimed',
+      domain: DOMAIN,
+      alias: ALIAS,
+      email: aliasEmail,
+      forwardTo: null,
+      primaryEmail: PRIMARY_EMAIL,
+      forwardAuthRequired: true,
+      ...(authorizeUrl ? { authorizeUrl } : {}),
+    };
+    return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+  });
+}
+
+/**
+ * Navigate and wait for the claimed panel to render. Routes/init scripts must be
+ * registered before this — Playwright can't retroactively intercept a request or
+ * seed sessionStorage for a navigation that already happened.
+ */
+async function gotoIdentitiesAndExpectClaimedPanel(page: Page): Promise<void> {
+  await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+}
+
 test.describe('Linux.com email — forward re-auth (#1935)', () => {
   test('shows the re-auth panel instead of the blank select when the forward target could not be read', async ({ page }) => {
-    // Pre-latch the one-shot redirect guard so the page renders the recoverable panel
-    // instead of immediately bouncing to authorizeUrl.
-    await page.addInitScript((key) => sessionStorage.setItem(key, '1'), LINUX_EMAIL_FORWARD_REAUTH_KEY);
-    await stubIdentities(page);
-    const aliasEmail = `${ALIAS}@${DOMAIN}`;
-    await page.route('**/api/profile/linux-email', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = {
-        state: 'claimed',
-        domain: DOMAIN,
-        alias: ALIAS,
-        email: aliasEmail,
-        forwardTo: null,
-        primaryEmail: PRIMARY_EMAIL,
-        forwardAuthRequired: true,
-        authorizeUrl: 'https://app.dev.lfx.dev/api/profile/auth/start?returnTo=/profile/identities',
-      };
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-    });
+    await stubClaimedNeedsReauth(page, 'https://app.dev.lfx.dev/api/profile/auth/start?returnTo=/profile/identities');
+    await gotoIdentitiesAndExpectClaimedPanel(page);
 
-    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
-    skipWhenAuthMissing(page);
-    await expect(page).not.toHaveURL(/auth0\.com/);
-
-    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('linux-email-forward-reauth')).toBeVisible();
     await expect(page.getByTestId('linux-email-forward-reauth-button')).toBeVisible();
     await expect(page.getByTestId('linux-email-forward-select')).not.toBeAttached();
@@ -265,29 +280,9 @@ test.describe('Linux.com email — forward re-auth (#1935)', () => {
   });
 
   test('falls back to unavailable copy with no button when Flow C is unconfigured (no authorizeUrl)', async ({ page }) => {
-    await page.addInitScript((key) => sessionStorage.setItem(key, '1'), LINUX_EMAIL_FORWARD_REAUTH_KEY);
-    await stubIdentities(page);
-    const aliasEmail = `${ALIAS}@${DOMAIN}`;
-    await page.route('**/api/profile/linux-email', (route) => {
-      if (route.request().method() !== 'GET') return route.fallback();
-      const body: LinuxAliasData = {
-        state: 'claimed',
-        domain: DOMAIN,
-        alias: ALIAS,
-        email: aliasEmail,
-        forwardTo: null,
-        primaryEmail: PRIMARY_EMAIL,
-        forwardAuthRequired: true,
-        // No authorizeUrl — Flow C is unconfigured server-side.
-      };
-      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
-    });
+    await stubClaimedNeedsReauth(page);
+    await gotoIdentitiesAndExpectClaimedPanel(page);
 
-    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
-    skipWhenAuthMissing(page);
-    await expect(page).not.toHaveURL(/auth0\.com/);
-
-    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
     await expect(page.getByTestId('linux-email-forward-reauth')).toBeVisible();
     await expect(page.getByTestId('linux-email-forward-reauth-copy')).toContainText("re-authorization isn't available right now");
     await expect(page.getByTestId('linux-email-forward-reauth-button')).not.toBeAttached();

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -19,6 +19,7 @@
  * separate `/api/profile/emails` fetch.
  */
 
+import { LINUX_EMAIL_FORWARD_REAUTH_KEY } from '@lfx-one/shared/constants';
 import type { LinuxAliasData } from '@lfx-one/shared/interfaces';
 import { expect, Page, test } from '@playwright/test';
 
@@ -234,7 +235,7 @@ test.describe('Linux.com email — forward re-auth (#1935)', () => {
   test('shows the re-auth panel instead of the blank select when the forward target could not be read', async ({ page }) => {
     // Pre-latch the one-shot redirect guard so the page renders the recoverable panel
     // instead of immediately bouncing to authorizeUrl.
-    await page.addInitScript(() => sessionStorage.setItem('linux-email:forward-reauth-attempted', '1'));
+    await page.addInitScript((key) => sessionStorage.setItem(key, '1'), LINUX_EMAIL_FORWARD_REAUTH_KEY);
     await stubIdentities(page);
     const aliasEmail = `${ALIAS}@${DOMAIN}`;
     await page.route('**/api/profile/linux-email', (route) => {
@@ -261,6 +262,35 @@ test.describe('Linux.com email — forward re-auth (#1935)', () => {
     await expect(page.getByTestId('linux-email-forward-reauth-button')).toBeVisible();
     await expect(page.getByTestId('linux-email-forward-select')).not.toBeAttached();
     await expect(page.getByTestId('linux-email-forward-empty')).not.toBeAttached();
+  });
+
+  test('falls back to unavailable copy with no button when Flow C is unconfigured (no authorizeUrl)', async ({ page }) => {
+    await page.addInitScript((key) => sessionStorage.setItem(key, '1'), LINUX_EMAIL_FORWARD_REAUTH_KEY);
+    await stubIdentities(page);
+    const aliasEmail = `${ALIAS}@${DOMAIN}`;
+    await page.route('**/api/profile/linux-email', (route) => {
+      if (route.request().method() !== 'GET') return route.fallback();
+      const body: LinuxAliasData = {
+        state: 'claimed',
+        domain: DOMAIN,
+        alias: ALIAS,
+        email: aliasEmail,
+        forwardTo: null,
+        primaryEmail: PRIMARY_EMAIL,
+        forwardAuthRequired: true,
+        // No authorizeUrl — Flow C is unconfigured server-side.
+      };
+      return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+    });
+
+    await page.goto('/profile/identities', { waitUntil: 'domcontentloaded' });
+    skipWhenAuthMissing(page);
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await expect(page.getByTestId('linux-email-claimed-panel')).toBeVisible({ timeout: 10000 });
+    await expect(page.getByTestId('linux-email-forward-reauth')).toBeVisible();
+    await expect(page.getByTestId('linux-email-forward-reauth-copy')).toContainText("re-authorization isn't available right now");
+    await expect(page.getByTestId('linux-email-forward-reauth-button')).not.toBeAttached();
   });
 });
 

--- a/apps/lfx-one/e2e/profile-linux-email.spec.ts
+++ b/apps/lfx-one/e2e/profile-linux-email.spec.ts
@@ -236,7 +236,9 @@ test.describe('Linux.com email — forwarding target visibility', () => {
 /**
  * Stub the alias GET as claimed with forwardAuthRequired, and pre-latch the one-shot
  * redirect guard so the page renders the recoverable panel instead of bouncing to
- * authorizeUrl. Omit authorizeUrl to exercise the "Flow C unconfigured" dead-end copy.
+ * authorizeUrl. Omit authorizeUrl to exercise the defensive dead-end copy — the BFF
+ * always pairs authorizeUrl with forwardAuthRequired, so this shape isn't one the
+ * server actually produces, but the component guards against the contract drifting.
  */
 async function stubClaimedNeedsReauth(page: Page, authorizeUrl?: string): Promise<void> {
   await page.addInitScript((key) => sessionStorage.setItem(key, '1'), LINUX_EMAIL_FORWARD_REAUTH_KEY);

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -138,7 +138,7 @@ describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-
  * specific message (not the old generic "Authorization failed. Please try again." for every code).
  */
 describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', () => {
-  it('toasts the specific message for a mapped Flow C error code', async () => {
+  async function setup(error: string): Promise<{ add: ReturnType<typeof vi.fn> }> {
     const add = vi.fn();
     const userServiceMock = {
       user: signal({ user_id: 'u1' } as unknown as User),
@@ -156,7 +156,7 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
       imports: [ProfileLayoutComponent],
       providers: [
         { provide: PLATFORM_ID, useValue: 'browser' },
-        { provide: ActivatedRoute, useValue: { queryParams: of({ error: 'user_mismatch' }) } },
+        { provide: ActivatedRoute, useValue: { queryParams: of({ error }) } },
         { provide: Router, useValue: { url: '/profile', navigateByUrl: vi.fn() } },
         { provide: UserService, useValue: userServiceMock },
         { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
@@ -168,6 +168,12 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
     const fixture = TestBed.createComponent(ProfileLayoutComponent);
     fixture.detectChanges();
     await fixture.whenStable();
+
+    return { add };
+  }
+
+  it('toasts the specific message for a mapped Flow C error code', async () => {
+    const { add } = await setup('user_mismatch');
 
     expect(add).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -181,35 +187,7 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
   it('does not toast an inherited Object.prototype key as an error message', async () => {
     // Regression guard: params['error'] is unvalidated input — a plain-object lookup without
     // an own-property check would resolve 'toString' to Object.prototype.toString (truthy).
-    const add = vi.fn();
-    const userServiceMock = {
-      user: signal({ user_id: 'u1' } as unknown as User),
-      impersonating: signal(false),
-      uploadedAvatarUrl: signal<string | null>(null),
-      effectiveAvatarUrl: computed(() => ''),
-      identitiesRefresh$: EMPTY,
-      getCurrentUserProfile: vi.fn(() => of({ user: {}, profile: null } as unknown as CombinedProfile)),
-      updateUserProfile: vi.fn(() => of({})),
-      getIdentities: vi.fn(() => of([])),
-    };
-
-    TestBed.resetTestingModule();
-    TestBed.configureTestingModule({
-      imports: [ProfileLayoutComponent],
-      providers: [
-        { provide: PLATFORM_ID, useValue: 'browser' },
-        { provide: ActivatedRoute, useValue: { queryParams: of({ error: 'toString' }) } },
-        { provide: Router, useValue: { url: '/profile', navigateByUrl: vi.fn() } },
-        { provide: UserService, useValue: userServiceMock },
-        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
-        { provide: MessageService, useValue: { add } },
-      ],
-    });
-    TestBed.overrideComponent(ProfileLayoutComponent, { set: { template: '', imports: [] } });
-
-    const fixture = TestBed.createComponent(ProfileLayoutComponent);
-    fixture.detectChanges();
-    await fixture.whenStable();
+    const { add } = await setup('toString');
 
     expect(add).not.toHaveBeenCalled();
   });

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -177,4 +177,40 @@ describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', ()
       })
     );
   });
+
+  it('does not toast an inherited Object.prototype key as an error message', async () => {
+    // Regression guard: params['error'] is unvalidated input — a plain-object lookup without
+    // an own-property check would resolve 'toString' to Object.prototype.toString (truthy).
+    const add = vi.fn();
+    const userServiceMock = {
+      user: signal({ user_id: 'u1' } as unknown as User),
+      impersonating: signal(false),
+      uploadedAvatarUrl: signal<string | null>(null),
+      effectiveAvatarUrl: computed(() => ''),
+      identitiesRefresh$: EMPTY,
+      getCurrentUserProfile: vi.fn(() => of({ user: {}, profile: null } as unknown as CombinedProfile)),
+      updateUserProfile: vi.fn(() => of({})),
+      getIdentities: vi.fn(() => of([])),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ProfileLayoutComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: ActivatedRoute, useValue: { queryParams: of({ error: 'toString' }) } },
+        { provide: Router, useValue: { url: '/profile', navigateByUrl: vi.fn() } },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add } },
+      ],
+    });
+    TestBed.overrideComponent(ProfileLayoutComponent, { set: { template: '', imports: [] } });
+
+    const fixture = TestBed.createComponent(ProfileLayoutComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(add).not.toHaveBeenCalled();
+  });
 });

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.spec.ts
@@ -132,3 +132,49 @@ describe('ProfileLayoutComponent — Flow C cold-return read-your-writes (LFXV2-
     expect(fixture.componentInstance.aboutMe()).toBe('OLD BIO');
   });
 });
+
+/**
+ * Guards issue #1935's PROFILE_AUTH_ERROR_MESSAGES lookup: a Flow C error code toasts its own
+ * specific message (not the old generic "Authorization failed. Please try again." for every code).
+ */
+describe('ProfileLayoutComponent — Flow C error message ownership (#1935)', () => {
+  it('toasts the specific message for a mapped Flow C error code', async () => {
+    const add = vi.fn();
+    const userServiceMock = {
+      user: signal({ user_id: 'u1' } as unknown as User),
+      impersonating: signal(false),
+      uploadedAvatarUrl: signal<string | null>(null),
+      effectiveAvatarUrl: computed(() => ''),
+      identitiesRefresh$: EMPTY,
+      getCurrentUserProfile: vi.fn(() => of({ user: {}, profile: null } as unknown as CombinedProfile)),
+      updateUserProfile: vi.fn(() => of({})),
+      getIdentities: vi.fn(() => of([])),
+    };
+
+    TestBed.resetTestingModule();
+    TestBed.configureTestingModule({
+      imports: [ProfileLayoutComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: ActivatedRoute, useValue: { queryParams: of({ error: 'user_mismatch' }) } },
+        { provide: Router, useValue: { url: '/profile', navigateByUrl: vi.fn() } },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add } },
+      ],
+    });
+    TestBed.overrideComponent(ProfileLayoutComponent, { set: { template: '', imports: [] } });
+
+    const fixture = TestBed.createComponent(ProfileLayoutComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+
+    expect(add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        severity: 'error',
+        summary: 'Authorization Error',
+        detail: 'You authorized a different account. Please sign in as yourself and try again.',
+      })
+    );
+  });
+});

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -5,7 +5,7 @@ import { isPlatformBrowser, NgClass } from '@angular/common';
 import { ChangeDetectionStrategy, Component, computed, inject, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { takeUntilDestroyed, toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { ActivatedRoute, Router, RouterLink, RouterLinkActive, RouterOutlet } from '@angular/router';
-import { MY_CLAS_ENABLED_FLAG, normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, TSHIRT_SIZES } from '@lfx-one/shared/constants';
+import { MY_CLAS_ENABLED_FLAG, normalizeTShirtSize, PENDING_PROFILE_SAVE_KEY, PROFILE_AUTH_ERROR_MESSAGES, TSHIRT_SIZES } from '@lfx-one/shared/constants';
 import { CombinedProfile, EnrichedIdentity, ProfileHeaderData, ProfileTab, ProfileUpdateRequest, UserMetadata } from '@lfx-one/shared/interfaces';
 import { buildProfileTabs } from '@lfx-one/shared/utils';
 import { FeatureFlagService } from '@services/feature-flag.service';
@@ -19,16 +19,6 @@ import { ProfileEditDrawerService } from '../../modules/profile/components/profi
 import { ProfileVisibilityDrawerComponent } from '../../modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.component';
 import { ProfileVisibilityDrawerService } from '../../modules/profile/components/profile-visibility-drawer/profile-visibility-drawer.service';
 import { ProfilePanelComponent } from './profile-panel/profile-panel.component';
-
-// Error codes that originate from the Flow C profile-auth (/passwordless/callback) flow.
-// Child routes (e.g. identities) handle their own error codes — do not swallow them here.
-const PROFILE_AUTH_ERROR_CODES = new Set([
-  'profile_auth_not_configured',
-  'profile_auth_failed',
-  'token_exchange_failed',
-  'login_session_invalid',
-  'user_mismatch',
-]);
 
 /**
  * ProfileLayoutComponent is the shell for the Profile & Account hub. It provides:
@@ -172,7 +162,8 @@ export class ProfileLayoutComponent {
         this.clearAuthQueryParams();
       }
 
-      if (PROFILE_AUTH_ERROR_CODES.has(params['error'])) {
+      const authErrorMessage = PROFILE_AUTH_ERROR_MESSAGES[params['error']];
+      if (authErrorMessage) {
         // Clear any stash from the redirect that failed — otherwise it outlives this failed
         // attempt and gets replayed by the next unrelated Flow C success (see handleProfileAuthReturn).
         if (isPlatformBrowser(this.platformId)) {
@@ -181,7 +172,7 @@ export class ProfileLayoutComponent {
         this.messageService.add({
           severity: 'error',
           summary: 'Authorization Error',
-          detail: 'Authorization failed. Please try again.',
+          detail: authErrorMessage,
         });
         this.clearAuthQueryParams();
       }

--- a/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
+++ b/apps/lfx-one/src/app/layouts/profile-layout/profile-layout.component.ts
@@ -162,8 +162,11 @@ export class ProfileLayoutComponent {
         this.clearAuthQueryParams();
       }
 
-      const authErrorMessage = PROFILE_AUTH_ERROR_MESSAGES[params['error']];
-      if (authErrorMessage) {
+      // hasOwn guard: params['error'] is unvalidated user input — an inherited Object.prototype
+      // key (e.g. 'toString') would otherwise resolve as a truthy, non-string "message".
+      const errorCode = params['error'];
+      if (typeof errorCode === 'string' && Object.hasOwn(PROFILE_AUTH_ERROR_MESSAGES, errorCode)) {
+        const authErrorMessage = PROFILE_AUTH_ERROR_MESSAGES[errorCode];
         // Clear any stash from the redirect that failed — otherwise it outlives this failed
         // attempt and gets replayed by the next unrelated Flow C success (see handleProfileAuthReturn).
         if (isPlatformBrowser(this.platformId)) {

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
@@ -76,4 +76,11 @@ describe('ProfileIdentitiesComponent — Flow C vs identity-link error ownership
     const { add } = await setup({ error: 'toString' });
     expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'An error occurred. Please try again.' }));
   });
+
+  it('does not toast for an empty error param', async () => {
+    // Regression guard: `typeof params['error'] === 'string'` alone is true for '' — the
+    // truthiness check must survive alongside it, or a bare ?error= starts toasting/clearing.
+    const { add } = await setup({ error: '' });
+    expect(add).not.toHaveBeenCalled();
+  });
 });

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
@@ -1,0 +1,72 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PLATFORM_ID, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { ActivatedRoute } from '@angular/router';
+import { UserService } from '@services/user.service';
+import { MessageService } from 'primeng/api';
+import { DialogService } from 'primeng/dynamicdialog';
+import { EMPTY, of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProfileIdentitiesComponent } from './profile-identities.component';
+
+/**
+ * Guards issue #1935's ownership split: Flow C (/passwordless/callback) error codes are already
+ * toasted once by ProfileLayoutComponent (alive on this route) — this component must skip them
+ * rather than toast a second time, and keep owning the identity-link (social auth) codes.
+ */
+describe('ProfileIdentitiesComponent — Flow C vs identity-link error ownership (#1935)', () => {
+  async function setup(queryParams: Record<string, string>): Promise<{ fixture: ComponentFixture<ProfileIdentitiesComponent>; add: ReturnType<typeof vi.fn> }> {
+    const add = vi.fn();
+    const userServiceMock = {
+      impersonating: signal(false),
+      identitiesRefresh$: EMPTY,
+      getIdentities: vi.fn(() => of([])),
+      refreshUserIdentities: vi.fn(),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ProfileIdentitiesComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: ActivatedRoute, useValue: { snapshot: { queryParams } } },
+        { provide: UserService, useValue: userServiceMock },
+        { provide: MessageService, useValue: { add } },
+        { provide: DialogService, useValue: { open: vi.fn() } },
+      ],
+    });
+    // Empty template: exercise ngOnInit's error handling without the dialog/panel child graph.
+    TestBed.overrideComponent(ProfileIdentitiesComponent, { set: { template: '', imports: [] } });
+
+    const fixture = TestBed.createComponent(ProfileIdentitiesComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return { fixture, add };
+  }
+
+  beforeEach(() => {
+    TestBed.resetTestingModule();
+  });
+
+  it('does not toast a Flow C (profile-auth) code — the layout owns it', async () => {
+    const { add } = await setup({ error: 'profile_auth_failed' });
+    expect(add).not.toHaveBeenCalled();
+  });
+
+  it('toasts the specific message for a social-auth-owned code', async () => {
+    const { add } = await setup({ error: 'social_auth_failed' });
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Social authentication failed. Please try again.' }));
+  });
+
+  it('toasts the specific message for no_code', async () => {
+    const { add } = await setup({ error: 'no_code' });
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'Authorization did not complete. Please try again.' }));
+  });
+
+  it('falls back to the generic message for an unmapped code', async () => {
+    const { add } = await setup({ error: 'zzz_unknown' });
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'An error occurred. Please try again.' }));
+  });
+});

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.spec.ts
@@ -69,4 +69,11 @@ describe('ProfileIdentitiesComponent — Flow C vs identity-link error ownership
     const { add } = await setup({ error: 'zzz_unknown' });
     expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'An error occurred. Please try again.' }));
   });
+
+  it('treats an inherited Object.prototype key as unmapped rather than a truthy hit', async () => {
+    // Regression guard: without an own-property check, 'toString' would resolve to
+    // Object.prototype.toString in both maps — wrongly suppressing the toast here.
+    const { add } = await setup({ error: 'toString' });
+    expect(add).toHaveBeenCalledWith(expect.objectContaining({ severity: 'error', detail: 'An error occurred. Please try again.' }));
+  });
 });

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -10,6 +10,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import { CardComponent } from '@components/card/card.component';
 import { MenuComponent } from '@components/menu/menu.component';
 import { MessageComponent } from '@components/message/message.component';
+import { IDENTITY_LINK_ERROR_MESSAGES, PROFILE_AUTH_ERROR_MESSAGES } from '@lfx-one/shared/constants';
 import {
   AddAccountDialogData,
   ConnectedIdentityFull,
@@ -92,16 +93,14 @@ export class ProfileIdentitiesComponent implements OnInit {
       this.conflictDetected.set(true);
       this.clearQueryParams();
     } else if (params['error']) {
-      const errorMap: Record<string, string> = {
-        social_auth_failed: 'Social authentication failed. Please try again.',
-        invalid_state: 'Security validation failed. Please try again.',
-        link_failed: 'Failed to link identity. Please try again.',
-        social_verification_failed: 'Identity verification failed. Please try again.',
-        invalid_provider: 'Invalid identity provider specified.',
-        no_management_token: 'Authorization expired. Please try again.',
-        no_identity_token: 'No identity token received. Please try again.',
-      };
-      this.messageService.add({ severity: 'error', summary: 'Error', detail: errorMap[params['error']] || 'An error occurred. Please try again.' });
+      // Flow C (/passwordless/callback) codes are owned by ProfileLayoutComponent, which is
+      // alive on this route and already toasts them — skip here to avoid a double toast.
+      if (PROFILE_AUTH_ERROR_MESSAGES[params['error']]) return;
+      this.messageService.add({
+        severity: 'error',
+        summary: 'Error',
+        detail: IDENTITY_LINK_ERROR_MESSAGES[params['error']] || 'An error occurred. Please try again.',
+      });
       this.clearQueryParams();
     }
   }

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -92,7 +92,7 @@ export class ProfileIdentitiesComponent implements OnInit {
     } else if (params['error'] === 'already_linked') {
       this.conflictDetected.set(true);
       this.clearQueryParams();
-    } else if (typeof params['error'] === 'string') {
+    } else if (typeof params['error'] === 'string' && params['error']) {
       const errorCode = params['error'];
       // Flow C (/passwordless/callback) codes are owned by ProfileLayoutComponent, which is
       // alive on this route and already toasts them — skip here to avoid a double toast.

--- a/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/identities/profile-identities.component.ts
@@ -92,14 +92,17 @@ export class ProfileIdentitiesComponent implements OnInit {
     } else if (params['error'] === 'already_linked') {
       this.conflictDetected.set(true);
       this.clearQueryParams();
-    } else if (params['error']) {
+    } else if (typeof params['error'] === 'string') {
+      const errorCode = params['error'];
       // Flow C (/passwordless/callback) codes are owned by ProfileLayoutComponent, which is
       // alive on this route and already toasts them — skip here to avoid a double toast.
-      if (PROFILE_AUTH_ERROR_MESSAGES[params['error']]) return;
+      // hasOwn guard: errorCode is unvalidated user input — an inherited Object.prototype key
+      // (e.g. 'toString') would otherwise resolve as a truthy hit in either map below.
+      if (Object.hasOwn(PROFILE_AUTH_ERROR_MESSAGES, errorCode)) return;
       this.messageService.add({
         severity: 'error',
         summary: 'Error',
-        detail: IDENTITY_LINK_ERROR_MESSAGES[params['error']] || 'An error occurred. Please try again.',
+        detail: Object.hasOwn(IDENTITY_LINK_ERROR_MESSAGES, errorCode) ? IDENTITY_LINK_ERROR_MESSAGES[errorCode] : 'An error occurred. Please try again.',
       });
       this.clearQueryParams();
     }

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -176,7 +176,7 @@
                         <i class="fa-light fa-triangle-exclamation shrink-0"></i>
                         <span class="text-sm font-semibold">Forwarding address unavailable</span>
                       </div>
-                      <p class="text-sm font-normal text-gray-900">
+                      <p class="text-sm font-normal text-gray-900" data-testid="linux-email-forward-reauth-copy">
                         @if (forwardAuthorizeUrl()) {
                           We couldn't read your current forwarding address. Re-authorize to view and change it.
                         } @else {

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -180,6 +180,7 @@
                         @if (forwardAuthorizeUrl()) {
                           We couldn't read your current forwarding address. Re-authorize to view and change it.
                         } @else {
+                          <!-- Defensive: the BFF always pairs authorizeUrl with forwardAuthRequired, so this branch guards a contract drift rather than a reachable server state. -->
                           We couldn't read your current forwarding address, and re-authorization isn't available right now. Please try again later.
                         }
                       </p>
@@ -201,17 +202,19 @@
               } @else {
                 <div class="flex flex-col gap-0.5">
                   <span class="text-sm font-medium text-gray-700">Forward to</span>
-                  <p class="text-xs text-gray-500">
-                    @if (impersonating()) {
-                      Forwarding details aren't available while impersonating.
-                    } @else if (forwardNotSet() && forwardOptions().length) {
-                      Forwarding isn't set yet — choose an address.
-                    } @else if (forwardOptions().length && hasForwardOptions()) {
-                      Choose one of your verified email addresses.
-                    } @else if (forwardOptions().length) {
-                      Add another verified email to change this.
-                    }
-                  </p>
+                  @if (impersonating() || forwardOptions().length) {
+                    <p class="text-xs text-gray-500">
+                      @if (impersonating()) {
+                        Forwarding details aren't available while impersonating.
+                      } @else if (forwardNotSet()) {
+                        Forwarding isn't set yet — choose an address.
+                      } @else if (hasForwardOptions()) {
+                        Choose one of your verified email addresses.
+                      } @else {
+                        Add another verified email to change this.
+                      }
+                    </p>
+                  }
                 </div>
                 @if (forwardOptions().length) {
                   <lfx-select

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -176,7 +176,13 @@
                         <i class="fa-light fa-triangle-exclamation shrink-0"></i>
                         <span class="text-sm font-semibold">Forwarding address unavailable</span>
                       </div>
-                      <p class="text-sm font-normal text-gray-900">We couldn't read your current forwarding address. Re-authorize to view and change it.</p>
+                      <p class="text-sm font-normal text-gray-900">
+                        @if (forwardAuthorizeUrl()) {
+                          We couldn't read your current forwarding address. Re-authorize to view and change it.
+                        } @else {
+                          We couldn't read your current forwarding address, and re-authorization isn't available right now. Please try again later.
+                        }
+                      </p>
                       @if (forwardAuthorizeUrl()) {
                         <lfx-button
                           size="small"
@@ -198,7 +204,7 @@
                   <p class="text-xs text-gray-500">
                     @if (impersonating()) {
                       Forwarding details aren't available while impersonating.
-                    } @else if (forwardNotSet()) {
+                    } @else if (forwardNotSet() && forwardOptions().length) {
                       Forwarding isn't set yet — choose an address.
                     } @else if (forwardOptions().length && hasForwardOptions()) {
                       Choose one of your verified email addresses.

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -168,49 +168,77 @@
 
             <!-- Forward to form -->
             <form [formGroup]="editForm" (ngSubmit)="updateForward()" class="flex flex-col gap-3 pt-5" data-testid="linux-email-forward-form">
-              <div class="flex flex-col gap-0.5">
-                <span class="text-sm font-medium text-gray-700">Forward to</span>
-                @if (forwardOptions().length) {
+              @if (forwardReauthRequired()) {
+                <lfx-message severity="warn" styleClass="!p-3" data-testid="linux-email-forward-reauth">
+                  <ng-template #content>
+                    <div class="flex flex-col gap-3 items-start">
+                      <div class="flex items-center gap-2">
+                        <i class="fa-light fa-triangle-exclamation shrink-0"></i>
+                        <span class="text-sm font-semibold">Forwarding address unavailable</span>
+                      </div>
+                      <p class="text-sm font-normal text-gray-900">We couldn't read your current forwarding address. Re-authorize to view and change it.</p>
+                      @if (forwardAuthorizeUrl()) {
+                        <lfx-button
+                          size="small"
+                          label="Re-authorize"
+                          icon="fa-light fa-rotate-right"
+                          severity="secondary"
+                          variant="outlined"
+                          [disabled]="impersonating()"
+                          [ariaLabel]="impersonating() ? 'This action is unavailable while impersonating another user' : undefined"
+                          (onClick)="reauthorizeForward()"
+                          data-testid="linux-email-forward-reauth-button"></lfx-button>
+                      }
+                    </div>
+                  </ng-template>
+                </lfx-message>
+              } @else {
+                <div class="flex flex-col gap-0.5">
+                  <span class="text-sm font-medium text-gray-700">Forward to</span>
                   <p class="text-xs text-gray-500">
-                    @if (hasForwardOptions()) {
+                    @if (impersonating()) {
+                      Forwarding details aren't available while impersonating.
+                    } @else if (forwardNotSet()) {
+                      Forwarding isn't set yet — choose an address.
+                    } @else if (forwardOptions().length && hasForwardOptions()) {
                       Choose one of your verified email addresses.
-                    } @else {
+                    } @else if (forwardOptions().length) {
                       Add another verified email to change this.
                     }
                   </p>
+                </div>
+                @if (forwardOptions().length) {
+                  <lfx-select
+                    [form]="editForm"
+                    control="forwardTo"
+                    [options]="forwardOptions()"
+                    placeholder="Select a verified email"
+                    size="small"
+                    styleClass="w-full"
+                    appendTo="body"
+                    data-testid="linux-email-forward-select"></lfx-select>
+                  @if (editForm.controls.forwardTo.touched && editForm.controls.forwardTo.invalid) {
+                    <div class="text-red-600 text-xs" data-testid="linux-email-forward-error">Please choose a forwarding address.</div>
+                  }
+                } @else {
+                  <lfx-message
+                    severity="warn"
+                    text="You don't have a verified email address to forward to yet. Add and verify an email address first, then return here to set up forwarding."
+                    styleClass="!p-3"
+                    data-testid="linux-email-forward-empty"></lfx-message>
                 }
-              </div>
-              @if (forwardOptions().length) {
-                <lfx-select
-                  [form]="editForm"
-                  control="forwardTo"
-                  [options]="forwardOptions()"
-                  placeholder="Select a verified email"
-                  size="small"
-                  styleClass="w-full"
-                  appendTo="body"
-                  data-testid="linux-email-forward-select"></lfx-select>
-                @if (editForm.controls.forwardTo.touched && editForm.controls.forwardTo.invalid) {
-                  <div class="text-red-600 text-xs" data-testid="linux-email-forward-error">Please choose a forwarding address.</div>
+                @if (forwardDirty()) {
+                  <lfx-button
+                    type="submit"
+                    label="Save"
+                    icon="fa-light fa-check"
+                    severity="info"
+                    size="small"
+                    [disabled]="editForm.invalid || savingForward() || impersonating()"
+                    [ariaLabel]="impersonating() ? 'This action is unavailable while impersonating another user' : undefined"
+                    [loading]="savingForward()"
+                    data-testid="linux-email-forward-save-button"></lfx-button>
                 }
-              } @else {
-                <lfx-message
-                  severity="warn"
-                  text="You don't have a verified email address to forward to yet. Add and verify an email address first, then return here to set up forwarding."
-                  styleClass="!p-3"
-                  data-testid="linux-email-forward-empty"></lfx-message>
-              }
-              @if (forwardDirty()) {
-                <lfx-button
-                  type="submit"
-                  label="Save"
-                  icon="fa-light fa-check"
-                  severity="info"
-                  size="small"
-                  [disabled]="editForm.invalid || savingForward() || impersonating()"
-                  [ariaLabel]="impersonating() ? 'This action is unavailable while impersonating another user' : undefined"
-                  [loading]="savingForward()"
-                  data-testid="linux-email-forward-save-button"></lfx-button>
               }
             </form>
           </div>

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.html
@@ -180,7 +180,7 @@
                         @if (forwardAuthorizeUrl()) {
                           We couldn't read your current forwarding address. Re-authorize to view and change it.
                         } @else {
-                          <!-- Defensive: the BFF always pairs authorizeUrl with forwardAuthRequired, so this branch guards a contract drift rather than a reachable server state. -->
+                          <!-- Reached when Flow C itself is unconfigured — the BFF omits authorizeUrl, so there's nowhere to send the user. -->
                           We couldn't read your current forwarding address, and re-authorization isn't available right now. Please try again later.
                         }
                       </p>

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
@@ -1,0 +1,168 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { PLATFORM_ID, signal } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { provideNoopAnimations } from '@angular/platform-browser/animations';
+import { provideRouter } from '@angular/router';
+import { LinuxAliasData } from '@lfx-one/shared/interfaces';
+import { UserService } from '@services/user.service';
+import { MessageService } from 'primeng/api';
+import { of } from 'rxjs';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { ProfileLinuxEmailComponent } from './profile-linux-email.component';
+
+/**
+ * Guards issue #1935 — the "Forward to" select rendering blank with no explanation when a
+ * claimed alias's forward target can't be read without a Flow C management token. The panel
+ * must swap the select for a re-auth action instead, and the FORWARD_SET_FAILED /
+ * forward-genuinely-unset path (which does NOT set forwardAuthRequired) must keep working —
+ * that's the path the issue's literal fix (gating on forwardTo === null) would have broken.
+ */
+describe('ProfileLinuxEmailComponent — forward re-auth state (#1935)', () => {
+  const REAUTH_FLAG_KEY = 'linux-email:forward-reauth-attempted';
+
+  const claimedNeedsReauth: LinuxAliasData = {
+    state: 'claimed',
+    domain: 'linux.com',
+    alias: 'jsmith',
+    email: 'jsmith@linux.com',
+    forwardTo: null,
+    primaryEmail: 'jsmith@example.org',
+    forwardAuthRequired: true,
+    authorizeUrl: 'https://app.dev.lfx.dev/api/profile/auth/start?returnTo=/profile/identities',
+  };
+
+  const claimedForwardUnset: LinuxAliasData = {
+    state: 'claimed',
+    domain: 'linux.com',
+    alias: 'jsmith',
+    email: 'jsmith@linux.com',
+    forwardTo: null,
+    primaryEmail: 'jsmith@example.org',
+  };
+
+  const claimedWithForward: LinuxAliasData = {
+    state: 'claimed',
+    domain: 'linux.com',
+    alias: 'jsmith',
+    email: 'jsmith@linux.com',
+    forwardTo: 'jsmith@example.org',
+    primaryEmail: 'jsmith@example.org',
+  };
+
+  async function setup(alias: LinuxAliasData): Promise<{ fixture: ComponentFixture<ProfileLinuxEmailComponent>; locationHref: () => string }> {
+    const hrefState = { value: 'https://app.dev.lfx.dev/profile/identities' };
+    // jsdom throws on a bare `window.location.href = …` navigation; stub the setter so the
+    // redirect is observable instead of erroring the test.
+    Object.defineProperty(window, 'location', {
+      configurable: true,
+      value: {
+        ...window.location,
+        get href() {
+          return hrefState.value;
+        },
+        set href(v: string) {
+          hrefState.value = v;
+        },
+      },
+    });
+
+    const userServiceMock = {
+      impersonating: signal(false),
+      getLinuxAlias: vi.fn(() => of(alias)),
+    };
+
+    TestBed.configureTestingModule({
+      imports: [ProfileLinuxEmailComponent],
+      providers: [
+        { provide: PLATFORM_ID, useValue: 'browser' },
+        { provide: UserService, useValue: userServiceMock },
+        // p-toast (rendered by the template) subscribes to MessageService's real Subjects on
+        // init — a plain { add: vi.fn() } mock leaves them undefined and throws there.
+        MessageService,
+        // lfx-button's p-button always binds [routerLink], which injects ActivatedRoute even
+        // when the input is undefined; lfx-message's p-message plays a synthetic animation.
+        provideRouter([]),
+        provideNoopAnimations(),
+      ],
+    });
+
+    const fixture = TestBed.createComponent(ProfileLinuxEmailComponent);
+    fixture.detectChanges();
+    await fixture.whenStable();
+    return { fixture, locationHref: () => hrefState.value };
+  }
+
+  beforeEach(() => {
+    sessionStorage.clear();
+    TestBed.resetTestingModule();
+  });
+
+  it('shows the re-auth panel (not the select) when the guard is already set, with the control left empty', async () => {
+    sessionStorage.setItem(REAUTH_FLAG_KEY, '1');
+    const { fixture, locationHref } = await setup(claimedNeedsReauth);
+    const component = fixture.componentInstance;
+
+    expect(component.forwardReauthRequired()).toBe(true);
+    expect(component.editForm.controls.forwardTo.value).toBe('');
+    // Guard already latched — no further automatic redirect.
+    expect(locationHref()).toBe('https://app.dev.lfx.dev/profile/identities');
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('[data-testid="linux-email-forward-reauth"]')).toBeTruthy();
+    expect(compiled.querySelector('[data-testid="linux-email-forward-select"]')).toBeFalsy();
+  });
+
+  it('redirects once to authorizeUrl when the guard is unset, and latches it', async () => {
+    const { locationHref } = await setup(claimedNeedsReauth);
+
+    expect(locationHref()).toBe(claimedNeedsReauth.authorizeUrl);
+    expect(sessionStorage.getItem(REAUTH_FLAG_KEY)).toBe('1');
+  });
+
+  it('reauthorizeForward() navigates to authorizeUrl and leaves the guard intact', async () => {
+    sessionStorage.setItem(REAUTH_FLAG_KEY, '1');
+    const { fixture, locationHref } = await setup(claimedNeedsReauth);
+
+    fixture.componentInstance.reauthorizeForward();
+
+    expect(locationHref()).toBe(claimedNeedsReauth.authorizeUrl);
+    // Regression guard: clearing this here would reopen the automatic-redirect loop
+    // maybeReauthForForward exists to prevent.
+    expect(sessionStorage.getItem(REAUTH_FLAG_KEY)).toBe('1');
+  });
+
+  it('keeps the select usable when the forward is genuinely unset (no forwardAuthRequired)', async () => {
+    const { fixture } = await setup(claimedForwardUnset);
+    const component = fixture.componentInstance;
+
+    expect(component.forwardReauthRequired()).toBe(false);
+    expect(component.forwardNotSet()).toBe(true);
+
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('[data-testid="linux-email-forward-select"]')).toBeTruthy();
+    expect(compiled.querySelector('[data-testid="linux-email-forward-reauth"]')).toBeFalsy();
+  });
+
+  it('excludes the alias itself from forwardOptions and shows the empty state with no other verified email', async () => {
+    const { fixture } = await setup({ ...claimedForwardUnset, primaryEmail: claimedForwardUnset.email });
+    const component = fixture.componentInstance;
+
+    expect(component.forwardOptions()).toEqual([]);
+    const compiled = fixture.nativeElement as HTMLElement;
+    expect(compiled.querySelector('[data-testid="linux-email-forward-empty"]')).toBeTruthy();
+    expect(compiled.querySelector('[data-testid="linux-email-forward-select"]')).toBeFalsy();
+  });
+
+  it('selects the real forward target when one is present, with no dirty state', async () => {
+    const { fixture } = await setup(claimedWithForward);
+    const component = fixture.componentInstance;
+
+    expect(component.forwardReauthRequired()).toBe(false);
+    expect(component.forwardNotSet()).toBe(false);
+    expect(component.editForm.controls.forwardTo.value).toBe('jsmith@example.org');
+    expect(component.forwardDirty()).toBe(false);
+  });
+});

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
@@ -5,6 +5,7 @@ import { PLATFORM_ID, signal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
+import { LINUX_EMAIL_FORWARD_REAUTH_KEY } from '@lfx-one/shared/constants';
 import { LinuxAliasData } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -21,7 +22,7 @@ import { ProfileLinuxEmailComponent } from './profile-linux-email.component';
  * that's the path the issue's literal fix (gating on forwardTo === null) would have broken.
  */
 describe('ProfileLinuxEmailComponent — forward re-auth state (#1935)', () => {
-  const REAUTH_FLAG_KEY = 'linux-email:forward-reauth-attempted';
+  const REAUTH_FLAG_KEY = LINUX_EMAIL_FORWARD_REAUTH_KEY;
 
   const claimedNeedsReauth: LinuxAliasData = {
     state: 'claimed',

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.spec.ts
@@ -10,7 +10,7 @@ import { LinuxAliasData } from '@lfx-one/shared/interfaces';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
 import { of } from 'rxjs';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { ProfileLinuxEmailComponent } from './profile-linux-email.component';
 
@@ -23,6 +23,7 @@ import { ProfileLinuxEmailComponent } from './profile-linux-email.component';
  */
 describe('ProfileLinuxEmailComponent — forward re-auth state (#1935)', () => {
   const REAUTH_FLAG_KEY = LINUX_EMAIL_FORWARD_REAUTH_KEY;
+  const originalLocation = Object.getOwnPropertyDescriptor(window, 'location');
 
   const claimedNeedsReauth: LinuxAliasData = {
     state: 'claimed',
@@ -99,6 +100,12 @@ describe('ProfileLinuxEmailComponent — forward re-auth state (#1935)', () => {
   beforeEach(() => {
     sessionStorage.clear();
     TestBed.resetTestingModule();
+  });
+
+  afterEach(() => {
+    // setup() replaces window.location on every call — restore it so the stub doesn't
+    // leak into other tests/files sharing this jsdom window.
+    if (originalLocation) Object.defineProperty(window, 'location', originalLocation);
   });
 
   it('shows the re-auth panel (not the select) when the guard is already set, with the control left empty', async () => {

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -77,7 +77,8 @@ export class ProfileLinuxEmailComponent {
   // harmful here (it renders blank), so the template swaps it for a re-auth panel instead.
   public forwardReauthRequired = computed(() => this.state() === 'claimed' && !!this.data()?.forwardAuthRequired);
 
-  // Absent when Flow C is unconfigured server-side — gates whether the re-auth button can render.
+  // Defensive: the BFF always pairs authorizeUrl with forwardAuthRequired, so this should never
+  // be empty while forwardReauthRequired() is true. Guards against that contract drifting.
   public forwardAuthorizeUrl = computed(() => this.data()?.authorizeUrl ?? '');
 
   // Forward is genuinely unset (not unreadable) — the FORWARD_SET_FAILED recovery path and the

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -75,8 +75,8 @@ export class ProfileLinuxEmailComponent {
   // harmful here (it renders blank), so the template swaps it for a re-auth panel instead.
   public forwardReauthRequired = computed(() => this.state() === 'claimed' && !!this.data()?.forwardAuthRequired);
 
-  // Defensive: the BFF always pairs authorizeUrl with forwardAuthRequired, so this should never
-  // be empty while forwardReauthRequired() is true. Guards against that contract drifting.
+  // Can be empty while forwardReauthRequired() is true — the BFF omits authorizeUrl when Flow C
+  // itself is unconfigured, since there's nowhere to send the client to re-authorize.
   public forwardAuthorizeUrl = computed(() => this.data()?.authorizeUrl ?? '');
 
   // Forward is genuinely unset (not unreadable) — the FORWARD_SET_FAILED recovery path and the

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -1,8 +1,6 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Generated with [Claude Code](https://claude.ai/code)
-
 import { isPlatformBrowser } from '@angular/common';
 import { Component, computed, inject, input, PLATFORM_ID, Signal, signal } from '@angular/core';
 import { toSignal } from '@angular/core/rxjs-interop';

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -13,6 +13,7 @@ import { CardComponent } from '@components/card/card.component';
 import { InputTextComponent } from '@components/input-text/input-text.component';
 import { MessageComponent } from '@components/message/message.component';
 import { SelectComponent } from '@components/select/select.component';
+import { LINUX_EMAIL_FORWARD_REAUTH_KEY } from '@lfx-one/shared/constants';
 import { EnrichedIdentity, LinuxAliasData, LinuxForwardOption } from '@lfx-one/shared/interfaces';
 import { linuxAliasValidator } from '@lfx-one/shared/validators';
 import { UserService } from '@services/user.service';
@@ -37,7 +38,7 @@ export class ProfileLinuxEmailComponent {
   public readonly identities = input<EnrichedIdentity[]>([]);
 
   // One-shot guard (sessionStorage key) so a tokenless re-auth round-trip can't loop.
-  private readonly reauthFlagKey = 'linux-email:forward-reauth-attempted';
+  private readonly reauthFlagKey = LINUX_EMAIL_FORWARD_REAUTH_KEY;
 
   // Set on FORWARD_SET_FAILED so the recovery toast can be shown once the refreshed
   // alias state is known, instead of assuming the refetch lands on 'claimed'.

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -72,6 +72,17 @@ export class ProfileLinuxEmailComponent {
   public domain = computed(() => this.data()?.domain ?? '');
   public email = computed(() => this.data()?.email ?? null);
 
+  // The forward target couldn't be read (no Flow C token in session) — the select is actively
+  // harmful here (it renders blank), so the template swaps it for a re-auth panel instead.
+  public forwardReauthRequired = computed(() => this.state() === 'claimed' && !!this.data()?.forwardAuthRequired);
+
+  // Absent when Flow C is unconfigured server-side — gates whether the re-auth button can render.
+  public forwardAuthorizeUrl = computed(() => this.data()?.authorizeUrl ?? '');
+
+  // Forward is genuinely unset (not unreadable) — the FORWARD_SET_FAILED recovery path and the
+  // impersonation read-only path both land here. Drives an honest hint on the still-usable select.
+  public forwardNotSet = computed(() => this.state() === 'claimed' && !this.data()?.forwardTo && !this.data()?.forwardAuthRequired);
+
   // True only when the user has changed the forward-to selection from its saved value.
   public forwardDirty: Signal<boolean> = this.initForwardDirty();
 
@@ -200,6 +211,21 @@ export class ProfileLinuxEmailComponent {
     // it must not consume a stale pending flag from an earlier claim() failure.
     this.pendingForwardRecoveryToast = false;
     this.refresh.next();
+  }
+
+  /**
+   * Manual recovery for a still-tokenless return. Deliberately does NOT clear reauthFlagKey —
+   * doing so would let maybeReauthForForward fire a second automatic redirect on a still-
+   * tokenless return. This button is the recovery path and stays available on every reload,
+   * which is what makes the one-shot guard recoverable without reopening the redirect loop it
+   * exists to prevent.
+   */
+  public reauthorizeForward(): void {
+    if (!isPlatformBrowser(this.platformId)) return;
+    const url = this.forwardAuthorizeUrl();
+    if (url) {
+      window.location.href = url;
+    }
   }
 
   // Private methods

--- a/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
+++ b/apps/lfx-one/src/app/modules/profile/linux-email/profile-linux-email.component.ts
@@ -282,11 +282,11 @@ export class ProfileLinuxEmailComponent {
   }
 
   /**
-   * A claimed alias always has a forward target, but the server can only read it
-   * with a Flow C management token. When that token is absent the server flags
-   * `forwardAuthRequired`; redirect once to load the real target instead of
-   * silently showing the primary email. The one-shot guard prevents a loop if the
-   * round-trip returns still tokenless (or the user cancels).
+   * A claimed alias's forward target can only be read with a Flow C management
+   * token. When that token is absent the server flags `forwardAuthRequired`;
+   * redirect once to load the real target instead of silently showing the
+   * primary email. The one-shot guard prevents a loop if the round-trip returns
+   * still tokenless (or the user cancels).
    */
   private maybeReauthForForward(alias: LinuxAliasData | null): void {
     if (!isPlatformBrowser(this.platformId)) return;

--- a/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.spec.ts
@@ -4,9 +4,26 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Hoisted mocks — defined before any module is imported so vi.mock factories can reference them.
-const { getUsernameFromAuthMock, generateM2MTokenMock, objectStoreSvc, userSvc, profileAuthSvc } = vi.hoisted(() => ({
+const {
+  getUsernameFromAuthMock,
+  generateM2MTokenMock,
+  getEffectiveEmailMock,
+  getEffectiveSubMock,
+  isImpersonatingMock,
+  getLinuxForwardDomainMock,
+  objectStoreSvc,
+  userSvc,
+  profileAuthSvc,
+  emailVerificationSvc,
+  forwardsSvc,
+  enrollmentSvc,
+} = vi.hoisted(() => ({
   getUsernameFromAuthMock: vi.fn(),
   generateM2MTokenMock: vi.fn(),
+  getEffectiveEmailMock: vi.fn(),
+  getEffectiveSubMock: vi.fn(),
+  isImpersonatingMock: vi.fn(() => false),
+  getLinuxForwardDomainMock: vi.fn(() => 'linux.com'),
   objectStoreSvc: {
     uploadProfilePicture: vi.fn(),
     ensureBucket: vi.fn(),
@@ -18,6 +35,15 @@ const { getUsernameFromAuthMock, generateM2MTokenMock, objectStoreSvc, userSvc, 
   profileAuthSvc: {
     isProfileAuthConfigured: vi.fn(() => false),
     getManagementToken: vi.fn(),
+  },
+  emailVerificationSvc: {
+    getUserEmails: vi.fn(),
+  },
+  forwardsSvc: {
+    getForward: vi.fn(),
+  },
+  enrollmentSvc: {
+    hasLinuxComAddon: vi.fn(),
   },
 }));
 
@@ -38,13 +64,13 @@ vi.mock('@lfx-one/shared/utils', () => ({ isIdentityAlreadyLinkedError: vi.fn(()
 
 vi.mock('../utils/auth-helper', () => ({
   getUsernameFromAuth: getUsernameFromAuthMock,
-  getEffectiveEmail: vi.fn(),
-  getEffectiveSub: vi.fn(),
+  getEffectiveEmail: getEffectiveEmailMock,
+  getEffectiveSub: getEffectiveSubMock,
   getEffectiveUsername: vi.fn(),
-  isImpersonating: vi.fn(() => false),
+  isImpersonating: isImpersonatingMock,
 }));
 vi.mock('../utils/m2m-token.util', () => ({ generateM2MToken: generateM2MTokenMock }));
-vi.mock('../helpers/linux-forward.helper', () => ({ getLinuxForwardDomain: vi.fn() }));
+vi.mock('../helpers/linux-forward.helper', () => ({ getLinuxForwardDomain: getLinuxForwardDomainMock }));
 vi.mock('../services/logger.service', () => ({
   logger: {
     startOperation: vi.fn(() => 0),
@@ -68,17 +94,17 @@ vi.mock('../services/cdp.service', () => ({
 }));
 vi.mock('../services/email-verification.service', () => ({
   EmailVerificationService: vi.fn(function () {
-    return {};
+    return emailVerificationSvc;
   }),
 }));
 vi.mock('../services/enrollment.service', () => ({
   EnrollmentService: vi.fn(function () {
-    return {};
+    return enrollmentSvc;
   }),
 }));
 vi.mock('../services/forwards.service', () => ({
   ForwardsService: vi.fn(function () {
-    return {};
+    return forwardsSvc;
   }),
 }));
 vi.mock('../services/social-verification.service', () => ({
@@ -235,5 +261,77 @@ describe('ProfileController.uploadProfilePicture', () => {
     expect(next).toHaveBeenCalledWith(uploadError);
     expect(res.status).not.toHaveBeenCalled();
     expect(userSvc.updateUserMetadata).not.toHaveBeenCalled();
+  });
+});
+
+describe('ProfileController.getLinuxAlias', () => {
+  let controller: ProfileController;
+
+  const claimedEmails = { primary_email: 'user@example.com', alternate_emails: [{ email: 'alias@linux.com' }] };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    getLinuxForwardDomainMock.mockReturnValue('linux.com');
+    getEffectiveSubMock.mockReturnValue('auth0|user123');
+    getEffectiveEmailMock.mockReturnValue('user@example.com');
+    isImpersonatingMock.mockReturnValue(false);
+    profileAuthSvc.isProfileAuthConfigured.mockReturnValue(false);
+    profileAuthSvc.getManagementToken.mockReturnValue(undefined);
+    emailVerificationSvc.getUserEmails.mockResolvedValue(claimedEmails);
+    controller = new ProfileController();
+  });
+
+  it('reports forwardAuthRequired without authorizeUrl when Flow C is not configured', async () => {
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getLinuxAlias(buildReq(), res, next);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ state: 'claimed', forwardAuthRequired: true }));
+    expect(res.json.mock.calls[0][0]).not.toHaveProperty('authorizeUrl');
+    expect(forwardsSvc.getForward).not.toHaveBeenCalled();
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('reports forwardAuthRequired with authorizeUrl when Flow C is configured but no management token is in session', async () => {
+    profileAuthSvc.isProfileAuthConfigured.mockReturnValue(true);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getLinuxAlias(buildReq({ headers: { referer: '/profile/linux-email' } }), res, next);
+
+    expect(res.json).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'claimed',
+        forwardAuthRequired: true,
+        authorizeUrl: '/api/profile/auth/start?returnTo=%2Fprofile%2Flinux-email',
+      })
+    );
+  });
+
+  it('omits forwardAuthRequired and reads the forward target when a management token is present', async () => {
+    profileAuthSvc.isProfileAuthConfigured.mockReturnValue(true);
+    profileAuthSvc.getManagementToken.mockReturnValue('mgmt-token');
+    forwardsSvc.getForward.mockResolvedValue({ target_email: 'forward@example.com' });
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getLinuxAlias(buildReq(), res, next);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ state: 'claimed', forwardTo: 'forward@example.com' }));
+    expect(res.json.mock.calls[0][0]).not.toHaveProperty('forwardAuthRequired');
+  });
+
+  it('suppresses forwardAuthRequired during impersonation even without a management token', async () => {
+    isImpersonatingMock.mockReturnValue(true);
+    profileAuthSvc.isProfileAuthConfigured.mockReturnValue(true);
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getLinuxAlias(buildReq(), res, next);
+
+    expect(res.json).toHaveBeenCalledWith(expect.objectContaining({ state: 'claimed', forwardTo: null }));
+    expect(res.json.mock.calls[0][0]).not.toHaveProperty('forwardAuthRequired');
+    expect(forwardsSvc.getForward).not.toHaveBeenCalled();
   });
 });

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -674,8 +674,8 @@ export class ProfileController {
           return;
         }
 
-        // Needs the Flow C management token to read the forward; ask the client to re-authorize
-        // when it's absent (flow configured). Suppressed during impersonation — a write-path only the real user can trigger.
+        // Needs the Flow C management token to read the forward; prompt the client to re-authorize when
+        // it's absent. Suppressed under impersonation — the re-auth would rewrite the impersonator's own session.
         const forwardAuthRequired = !isImpersonating(req) && !managementToken && this.profileAuthService.isProfileAuthConfigured();
 
         logger.success(req, 'get_linux_alias', startTime, { state: 'claimed' });

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -666,21 +666,16 @@ export class ProfileController {
         const managementToken = isImpersonating(req) ? null : this.profileAuthService.getManagementToken(req);
         const forward = managementToken ? await this.forwardsService.getForward(req, managementToken, domain) : null;
 
-        // A claimed alias always has a forward target. If we had a management token but the read
-        // still came back null, the forwards-service was unreachable (timeout/no-responder) — degrade
-        // to service_unavailable (retry panel) rather than emitting a claimed state with a null
-        // forward, which the client could misread and overwrite on Save.
+        // Null with a token means forwards-service was unreachable — degrade to service_unavailable
+        // instead of emitting a claimed state with a null forward the client could overwrite on Save.
         if (managementToken && forward === null) {
           logger.success(req, 'get_linux_alias', startTime, { state: 'service_unavailable' });
           res.json(this.linuxAliasState('service_unavailable', domain));
           return;
         }
 
-        // A claimed alias always has a forward target, but reading it needs the Flow C
-        // management token. When it's absent (and the flow is configured), tell the client
-        // to re-authorize so it can load the real target instead of defaulting to primary.
-        // Suppress the re-auth prompt during impersonation — it is a write-path the impersonator
-        // must not trigger against their own session while viewing the target read-only.
+        // Needs the Flow C management token to read the forward; ask the client to re-authorize
+        // when it's absent (flow configured). Suppressed during impersonation — a write-path only the real user can trigger.
         const forwardAuthRequired = !isImpersonating(req) && !managementToken && this.profileAuthService.isProfileAuthConfigured();
 
         logger.success(req, 'get_linux_alias', startTime, { state: 'claimed' });

--- a/apps/lfx-one/src/server/controllers/profile.controller.ts
+++ b/apps/lfx-one/src/server/controllers/profile.controller.ts
@@ -674,9 +674,13 @@ export class ProfileController {
           return;
         }
 
-        // Needs the Flow C management token to read the forward; prompt the client to re-authorize when
-        // it's absent. Suppressed under impersonation — the re-auth would rewrite the impersonator's own session.
-        const forwardAuthRequired = !isImpersonating(req) && !managementToken && this.profileAuthService.isProfileAuthConfigured();
+        // The forward is unreadable without a Flow C management token — true regardless of whether
+        // Flow C is even configured, so the client can't mistake "unreadable" for "unset". Suppressed
+        // under impersonation — the re-auth would rewrite the impersonator's own session.
+        const forwardAuthRequired = !isImpersonating(req) && !managementToken;
+        // Re-authorization is only offered when Flow C is actually configured; otherwise there's no
+        // authorizeUrl to send the client to and it falls back to the "try again later" copy.
+        const canReauth = forwardAuthRequired && this.profileAuthService.isProfileAuthConfigured();
 
         logger.success(req, 'get_linux_alias', startTime, { state: 'claimed' });
         res.json({
@@ -689,7 +693,9 @@ export class ProfileController {
           ...(forwardAuthRequired
             ? {
                 forwardAuthRequired: true,
-                authorizeUrl: `/api/profile/auth/start?returnTo=${encodeURIComponent((req.headers['referer'] as string) || '/profile/linux-email')}`,
+                ...(canReauth
+                  ? { authorizeUrl: `/api/profile/auth/start?returnTo=${encodeURIComponent((req.headers['referer'] as string) || '/profile/linux-email')}` }
+                  : {}),
               }
             : {}),
         } satisfies LinuxAliasData);

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -13,6 +13,14 @@ import { CdpIdentityType, IdentityProvider, IdentityProviderOption, ProfileTab }
 export const PENDING_PROFILE_SAVE_KEY = 'lfx_profile_pending_save';
 
 /**
+ * sessionStorage key for the one-shot Linux.com forward re-auth redirect guard.
+ * Written by ProfileLinuxEmailComponent before its automatic Flow C redirect so a
+ * still-tokenless return can't loop; shared with its e2e/unit specs so a rename
+ * can't silently desync the guard from what the tests pre-latch or assert.
+ */
+export const LINUX_EMAIL_FORWARD_REAUTH_KEY = 'linux-email:forward-reauth-attempted';
+
+/**
  * Maximum length of the free-text "About Me" (bio) profile field. Shared across
  * the BFF validator, the reactive-form validator, and the textarea's maxlength
  * so the client and server enforce a single contract.

--- a/packages/shared/src/constants/profile.constants.ts
+++ b/packages/shared/src/constants/profile.constants.ts
@@ -169,3 +169,35 @@ export const LFX_ONE_WORK_EXPERIENCE_SOURCE = 'lfxOne';
  * owning LFID would enable account enumeration.
  */
 export const EMAIL_ALREADY_LINKED_MESSAGE = 'This email is already linked to another account';
+
+/**
+ * Error codes from the Flow C profile-auth (`/passwordless/callback`) round trip,
+ * owned by ProfileLayoutComponent — it's alive on every /profile/* route, so it
+ * handles these once regardless of which tab triggered the flow. `invalid_state`
+ * and `no_code` are emitted by both this callback and the identity-link callback
+ * and can't be disambiguated from the code alone, so they live only in
+ * IDENTITY_LINK_ERROR_MESSAGES below to avoid a double toast.
+ */
+export const PROFILE_AUTH_ERROR_MESSAGES: Readonly<Record<string, string>> = {
+  profile_auth_not_configured: 'Authorization is not available right now. Please try again later.',
+  profile_auth_failed: 'Authorization failed. Please try again.',
+  token_exchange_failed: 'Authorization failed. Please try again.',
+  login_session_invalid: 'Your session has expired. Please sign in again.',
+  user_mismatch: 'You authorized a different account. Please sign in as yourself and try again.',
+};
+
+/**
+ * Error codes from the identity-link (social auth) callback, owned by
+ * ProfileIdentitiesComponent. See the note on PROFILE_AUTH_ERROR_MESSAGES above
+ * for why invalid_state / no_code live here rather than in that map.
+ */
+export const IDENTITY_LINK_ERROR_MESSAGES: Readonly<Record<string, string>> = {
+  social_auth_failed: 'Social authentication failed. Please try again.',
+  invalid_state: 'Security validation failed. Please try again.',
+  link_failed: 'Failed to link identity. Please try again.',
+  social_verification_failed: 'Identity verification failed. Please try again.',
+  invalid_provider: 'Invalid identity provider specified.',
+  no_management_token: 'Authorization expired. Please try again.',
+  no_identity_token: 'No identity token received. Please try again.',
+  no_code: 'Authorization did not complete. Please try again.',
+};

--- a/packages/shared/src/interfaces/linux-email.interface.ts
+++ b/packages/shared/src/interfaces/linux-email.interface.ts
@@ -45,10 +45,12 @@ export interface LinuxAliasData {
   /**
    * True in the `claimed` state when the forwarding target could not be read
    * because no profile-management token is in session. The client should
-   * redirect to `authorizeUrl` (Flow C) to load the real target.
+   * redirect to `authorizeUrl` (Flow C) to load the real target — when it's
+   * present. Set regardless of whether Flow C is configured, so the client
+   * can distinguish "unreadable" from "not set".
    */
   forwardAuthRequired?: boolean;
-  /** Flow C authorization URL to call when `forwardAuthRequired` is true. */
+  /** Flow C authorization URL to call when `forwardAuthRequired` is true. Omitted when Flow C isn't configured — there's nowhere to send the client. */
   authorizeUrl?: string;
 }
 


### PR DESCRIPTION
## Summary

- The Linux.com "Forward to" dropdown on Profile → Identities rendered blank with the
  "Select a verified email" placeholder and no explanation when the server couldn't read
  the current forward target — indistinguishable from a broken control.
- Root cause: reading a claimed alias's forward target requires a Flow C (Auth0
  Management-audience) re-auth token. Without one, the server returns `forwardTo: null` +
  `forwardAuthRequired: true`, and the client had no UI for that state.
- Added a re-auth panel (mirroring the existing `service_unavailable` panel) that explains
  the state and offers a "Re-authorize" action, gated on `forwardAuthRequired` rather than
  `forwardTo === null` — so the existing "forward genuinely unset" recovery path (after a
  partial claim) still shows the select instead of being hidden.
- Split the Flow C callback's `?error=<code>` handling into two owned maps
  (`PROFILE_AUTH_ERROR_MESSAGES` on the layout, `IDENTITY_LINK_ERROR_MESSAGES` on the
  identities component) so each code produces exactly one specific toast instead of a
  generic message or a double toast.
- Added/extended specs across the touched components and an e2e spec for the new re-auth
  panel and error-toast behavior.

## Trade-offs (documented, not fixed in this PR)

- `invalid_state`/`no_code` Flow C error codes produce no toast and leave `?error=...`
  stuck in the URL when the return route isn't `/profile/identities` (pre-existing gap,
  not introduced here — needs a design decision on fix shape, deferred).
- No `profile-linux-email-robust.spec.ts` structural e2e companion yet (pre-existing gap
  in this module's e2e coverage, not introduced here).

Fixes #1935
