### PR TITLE
feat(campaigns): derive the clone template from the event via hubspot

### DIFF
--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -184,7 +184,7 @@
       that are only written by a search, so it is empty unless one is running or has answered.
     -->
       <div role="status" aria-live="polite" class="sr-only" data-testid="campaigns-email-templates-live">
-        {{ emailTemplatesAnnouncement() }}{{ emailTemplateSuggestionAnnouncement() }}
+        {{ emailTemplatesLiveAnnouncement() }}
       </div>
 
       <!--

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -372,13 +372,16 @@
                   -->
                     <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-render-capped">{{ emailTemplatesRenderCapMessage() }}</p>
                   }
-                  @if (emailTemplateSuggestionId() !== '' && emailTemplateSuggestionId() === selectedEmailTemplateId()) {
+                  @if (emailTemplateSelectionIsSuggested() && emailTemplateSuggestionId() !== '') {
                     <!--
-                    Rendered only while the suggestion IS the current selection. Keying it on the
-                    suggestion merely existing meant that after an operator picked a different row
-                    the banner still read "pre-selected ... for this event" beside a template the
-                    derivation never chose -- a false statement about what is selected, which is
-                    the exact class of claim this feature exists to avoid making.
+                    Gated on PROVENANCE, not on id equality. Keying it on the suggestion merely
+                    existing meant that after an operator picked a different row the banner still
+                    read "pre-selected ... for this event" beside a template the derivation never
+                    chose. Keying it on `suggestionId === selectedId` fixed that case and kept a
+                    subtler one: after suggestion A, an operator can pick B and then deliberately
+                    pick A again -- the ids coincide, so the banner claimed the system chose what
+                    the operator chose. Only the setter knows how the value was set, which is what
+                    `emailTemplateSelectionIsSuggested` records.
                     The matched terms are shown because a suggestion whose reasoning is invisible
                     cannot be judged: "matched on kubecon" can be checked at a glance.
                   -->

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -370,6 +370,25 @@
                   -->
                     <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-render-capped">{{ emailTemplatesRenderCapMessage() }}</p>
                   }
+                  @if (emailTemplateSuggestionId() !== '') {
+                    <!--
+                    The derived suggestion, stated as one. The matched terms are shown because a
+                    suggestion whose reasoning is invisible cannot be judged -- an operator seeing
+                    "matched on kubecon" can tell instantly whether it found the right event, where
+                    a bare pre-selection would just look decided. Selecting any other row retires
+                    this permanently for the brief.
+                  -->
+                    <p class="flex items-start gap-2 text-xs text-blue-800" data-testid="campaigns-email-template-suggestion">
+                      <i class="fa-light fa-wand-magic-sparkles mt-0.5" aria-hidden="true"></i>
+                      <span>
+                        Pre-selected the template this portal appears to use for this event
+                        @if (emailTemplateSuggestionTerms().length > 0) {
+                          <span> — matched on {{ emailTemplateSuggestionTerms().join(', ') }}</span>
+                        }
+                        . Pick a different one to override it.
+                      </span>
+                    </p>
+                  }
                   <ul class="flex flex-col gap-2" data-testid="campaigns-email-template-list">
                     @for (template of emailTemplatesRendered(); track template.id) {
                       <li>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -375,8 +375,8 @@
                     The derived suggestion, stated as one. The matched terms are shown because a
                     suggestion whose reasoning is invisible cannot be judged -- an operator seeing
                     "matched on kubecon" can tell instantly whether it found the right event, where
-                    a bare pre-selection would just look decided. Selecting any other row retires
-                    this permanently for the brief.
+                    a bare pre-selection would just look decided. Picking any other row replaces
+                    it, and the suggestion never overwrites a selection that is already set.
                   -->
                     <p class="flex items-start gap-2 text-xs text-blue-800" data-testid="campaigns-email-template-suggestion">
                       <i class="fa-light fa-wand-magic-sparkles mt-0.5" aria-hidden="true"></i>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -370,23 +370,31 @@
                   -->
                     <p class="text-xs text-amber-700" data-testid="campaigns-email-templates-render-capped">{{ emailTemplatesRenderCapMessage() }}</p>
                   }
-                  @if (emailTemplateSuggestionId() !== '') {
+                  @if (emailTemplateSuggestionId() !== '' && emailTemplateSuggestionId() === selectedEmailTemplateId()) {
                     <!--
-                    The derived suggestion, stated as one. The matched terms are shown because a
-                    suggestion whose reasoning is invisible cannot be judged -- an operator seeing
-                    "matched on kubecon" can tell instantly whether it found the right event, where
-                    a bare pre-selection would just look decided. Picking any other row replaces
-                    it, and the suggestion never overwrites a selection that is already set.
+                    Rendered only while the suggestion IS the current selection. Keying it on the
+                    suggestion merely existing meant that after an operator picked a different row
+                    the banner still read "pre-selected ... for this event" beside a template the
+                    derivation never chose -- a false statement about what is selected, which is
+                    the exact class of claim this feature exists to avoid making.
+                    The matched terms are shown because a suggestion whose reasoning is invisible
+                    cannot be judged: "matched on kubecon" can be checked at a glance.
                   -->
                     <p class="flex items-start gap-2 text-xs text-blue-800" data-testid="campaigns-email-template-suggestion">
                       <i class="fa-light fa-wand-magic-sparkles mt-0.5" aria-hidden="true"></i>
-                      <span>
-                        Pre-selected the template this portal appears to use for this event
-                        @if (emailTemplateSuggestionTerms().length > 0) {
-                          <span> — matched on {{ emailTemplateSuggestionTerms().join(', ') }}</span>
-                        }
-                        . Pick a different one to override it.
-                      </span>
+                      <!--
+                      One text node, not a text-@if-text sandwich. Angular collapses the leading
+                      whitespace of the trailing fragment to a single space, so the sentence
+                      rendered as "... event . Pick a different one" with a space before the stop.
+                    -->
+                      @if (emailTemplateSuggestionTerms().length > 0) {
+                        <span
+                          >Pre-selected the template this portal appears to use for this event — matched on {{ emailTemplateSuggestionTerms().join(', ') }}.
+                          Pick a different one to override it.</span
+                        >
+                      } @else {
+                        <span>Pre-selected the template this portal appears to use for this event. Pick a different one to override it.</span>
+                      }
                     </p>
                   }
                   <ul class="flex flex-col gap-2" data-testid="campaigns-email-template-list">

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.html
@@ -183,7 +183,9 @@
       It stays in the DOM on the other email tabs, which is harmless: the computed reads signals
       that are only written by a search, so it is empty unless one is running or has answered.
     -->
-      <div role="status" aria-live="polite" class="sr-only" data-testid="campaigns-email-templates-live">{{ emailTemplatesAnnouncement() }}</div>
+      <div role="status" aria-live="polite" class="sr-only" data-testid="campaigns-email-templates-live">
+        {{ emailTemplatesAnnouncement() }}{{ emailTemplateSuggestionAnnouncement() }}
+      </div>
 
       <!--
       Metrics-read status, mounted OUTSIDE the @switch for the same reason as the region above:
@@ -389,8 +391,8 @@
                     -->
                       @if (emailTemplateSuggestionTerms().length > 0) {
                         <span
-                          >Pre-selected the template this portal appears to use for this event — matched on {{ emailTemplateSuggestionTerms().join(', ') }}.
-                          Pick a different one to override it.</span
+                          >Pre-selected the template this portal appears to use for this event — matched on {{ emailTemplateSuggestionTermsLabel() }}. Pick a
+                          different one to override it.</span
                         >
                       } @else {
                         <span>Pre-selected the template this portal appears to use for this event. Pick a different one to override it.</span>

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3755,6 +3755,7 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     emailTemplateSuggestionTerms: Signal<readonly string[]>;
     emailTemplatesRendered: Signal<HubSpotMarketingEmail[]>;
     selectedEmailTypeId: WritableSignal<string>;
+    canStageEmail: Signal<boolean>;
   }
   const picker = (): PickerInternals => fixture.componentInstance as unknown as PickerInternals;
 
@@ -3812,6 +3813,47 @@ describe('CampaignsComponent — HubSpot template picker', () => {
         .forEach((r) => r.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [] }));
       fixture.detectChanges();
     };
+
+    /**
+     * A pending search must release a SUGGESTED selection at dispatch, not only when it answers.
+     *
+     * Every arm that clears the template list also released the suggestion, but all of them run
+     * after the response lands. In between, the loading branch hides the list while
+     * `canStageEmail` still reads only `selectedEmailTemplateId` -- and `onStageEmailSend`
+     * snapshots that id before its first await. So the operator could stage a suggestion the
+     * in-flight search was about to remove, with the row that justified it already off screen:
+     * a silent wrong clone, which is the exact failure this feature exists to prevent.
+     *
+     * Asserts the state DURING the flight -- the request is deliberately left unanswered, because
+     * flushing it is what the old code needed in order to look correct.
+     */
+    it('releases a suggested selection when a new search is dispatched, before it answers', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon Europe 2026', 'kubecon-eu-2026'));
+      picker().searchEmailTemplates('kubecon');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'k26', name: 'KubeCon Europe 2026 announcement', subject: 'Register now' }] as HubSpotMarketingEmail[],
+      });
+
+      // The suggestion took, and it is SYSTEM-owned -- the precondition for the release.
+      expect(picker().selectedEmailTemplateId()).toBe('k26');
+      expect(picker().emailTemplateSuggestionId()).toBe('k26');
+
+      // Dispatch a narrower search and leave it IN FLIGHT.
+      picker().searchEmailTemplates('workshop');
+      fixture.detectChanges();
+
+      expect(picker().selectedEmailTemplateId()).toBe('');
+      expect(picker().canStageEmail()).toBe(false);
+
+      // Drain so the harness's afterEach verification does not trip on the open request.
+      httpMock
+        .match((r) => r.url === '/api/campaigns/hubspot/emails')
+        .forEach((r) => r.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [] }));
+    });
 
     /**
      * The YEAR outranks the CITY, and a prior edition naming the city is the case that proves it.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -4186,6 +4186,65 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       expect(picker().emailTemplateSuggestionId()).toBe('');
     });
 
+    /**
+     * A search that drops the auto-selected row must release it.
+     *
+     * Only the suggestion id was cleared, not the selection — so after a narrowed search the id
+     * stayed selected while the banner hid (it renders only while the suggestion IS the
+     * selection), and staging would clone a template no longer in the list. The same
+     * silent-wrong-clone the feature exists to prevent, reached from the other direction.
+     */
+    it('releases an auto-selected template when a search no longer returns it', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'mcp', name: 'MCP Dev Summit Nairobi registration' }] as HubSpotMarketingEmail[],
+      });
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+
+      // A narrowed search that no longer returns the auto-selected row.
+      picker().searchEmailTemplates('newsletter');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'other', name: 'Monthly newsletter' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
+    /** A HAND-PICKED template is the operator's and survives a search that drops it. */
+    it('keeps a hand-picked template selected across a search that no longer returns it', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'mcp', name: 'MCP Dev Summit Nairobi registration' },
+          { id: 'hand', name: 'Something the operator knows about' },
+        ] as HubSpotMarketingEmail[],
+      });
+      picker().onSelectEmailTemplate('hand');
+
+      picker().searchEmailTemplates('newsletter');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'other', name: 'Monthly newsletter' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().selectedEmailTemplateId()).toBe('hand');
+    });
+
     /** But a city match still ranks, once the event itself is identified. */
     it('ranks a template naming both the event and the city above one naming only the event', () => {
       showPicker();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3876,6 +3876,33 @@ describe('CampaignsComponent — HubSpot template picker', () => {
      * threshold alone. An unrelated "Nairobi newsletter" is then auto-selected.
      */
     /**
+     * TWO generic terms must not add up to a suggestion.
+     *
+     * Excluding generic words from the DOUBLE weight was not enough: each still scored
+     * `EVENT_TERM_WEIGHT`, so two of them summed to exactly the threshold (3 + 3 = 6) and
+     * auto-selected on vocabulary that describes neither the event nor the template. Every
+     * matching term here -- `community`, `training` -- is in `EVENT_TERM_GENERIC`, so the
+     * non-generic evidence is zero and nothing may be offered.
+     *
+     * This is the case that separates ranking from justification: the template is a perfectly
+     * reasonable ORDERING for these terms, and still not evidence that it is the right one.
+     */
+    it('withholds a suggestion when only generic terms match, however many', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Community Training Workshop', 'community-training-workshop'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'generic', name: 'Community training newsletter', subject: 'Monthly update' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
+    /**
      * An UN-ENUMERATED generic long word must not decide alone.
      *
      * The deny-list closes the words someone has already noticed; the proxy behind it is the real

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -4218,6 +4218,59 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       expect(picker().selectedEmailTemplateId()).toBe('');
     });
 
+    /**
+     * ID equality cannot establish provenance.
+     *
+     * After suggestion A the operator can pick B, then deliberately pick A again — the ids
+     * coincide, so an equality check treats their explicit choice as system-owned and silently
+     * releases it on the next search. Provenance is a fact about how the value was SET.
+     */
+    it('keeps a hand-picked template that happens to match the suggestion', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      const emails = [
+        { id: 'mcp', name: 'MCP Dev Summit Nairobi registration' },
+        { id: 'other', name: 'Something else' },
+      ] as HubSpotMarketingEmail[];
+      respond({ enabled: true, error: null, possiblyTruncated: false, emails });
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+
+      // Away and deliberately back to the SAME id — now the operator's choice, not the system's.
+      picker().onSelectEmailTemplate('other');
+      picker().onSelectEmailTemplate('mcp');
+
+      picker().searchEmailTemplates('newsletter');
+      respond({ enabled: true, error: null, possiblyTruncated: false, emails: [{ id: 'n', name: 'Monthly newsletter' }] as HubSpotMarketingEmail[] });
+
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+    });
+
+    /**
+     * A FAILED search must release a system-owned selection too.
+     *
+     * `applyEventTemplateSuggestion` runs only after a successful listing, so the error arms set
+     * `emailTemplates` to null while leaving the auto-selected id in place — invisible, since
+     * there is no list to show it in, and still stageable.
+     */
+    it('releases an auto-selected template when the search fails', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'mcp', name: 'MCP Dev Summit Nairobi registration' }] as HubSpotMarketingEmail[],
+      });
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+
+      picker().searchEmailTemplates('anything');
+      respond({ enabled: true, error: 'HubSpot refused the search', possiblyTruncated: false, emails: [] });
+
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
     /** A HAND-PICKED template is the operator's and survives a search that drops it. */
     it('keeps a hand-picked template selected across a search that no longer returns it', () => {
       showPicker();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -4227,6 +4227,45 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       expect(picker().emailTemplateSuggestionId()).toBe('y2026');
     });
 
+    /**
+     * A template matched on its SUBJECT may carry no name, and announcing an empty string reads as
+     * "Template selected for this event: . Choose another" — which tells a screen-reader user
+     * nothing about what was chosen for them.
+     */
+    it('announces a subject-matched template by its subject rather than an empty name', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'subj', name: '', subject: 'MCP Dev Summit Nairobi — register now' }] as HubSpotMarketingEmail[],
+      });
+
+      const live = fixture.nativeElement.querySelector('[data-testid="campaigns-email-templates-live"]')?.textContent ?? '';
+      expect(live).toContain('register now');
+      expect(live).not.toContain('event: .');
+    });
+
+    /** The two announcements must not run together into one word. */
+    it('separates the two live-region announcements with a space', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'mcp', name: 'MCP Dev Summit Nairobi registration' }] as HubSpotMarketingEmail[],
+      });
+
+      const live = fixture.nativeElement.querySelector('[data-testid="campaigns-email-templates-live"]')?.textContent ?? '';
+      // No word boundary swallowed: a full stop is never immediately followed by a capital letter
+      // with no space between them.
+      expect(live).not.toMatch(/\.[A-Z]/);
+    });
+
     /** The year still cannot carry a suggestion on its own — the 2028 false positive stays shut. */
     it('does not let a year match alone justify a suggestion', () => {
       showPicker();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3770,6 +3770,37 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       fixture.detectChanges();
     };
 
+    /**
+     * The YEAR outranks the CITY, and a prior edition naming the city is the case that proves it.
+     *
+     * `eventRankBonus` summed the two into one scalar, so extra city tokens on a STALE edition
+     * beat the single year point on the current one: for "KubeCon North America 2026" in "Salt
+     * Lake City", the 2025 template scored salt+lake+city = 3 against the 2026 template's year =
+     * 1, and the PRIOR edition was pre-selected. Staging then clones last year's HubSpot draft --
+     * an edition-level wrong clone, which reads as decided and is unlikely to be re-checked.
+     *
+     * Both templates score identically on the decisive term, so only the tie-break can order them.
+     */
+    it('prefers the year-matching edition over a prior one that names the city', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon North America 2026', 'kubecon-north-america-2026', 'Salt Lake City'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          // Three city tokens, wrong year -- the row that used to win.
+          { id: 'stale', name: 'KubeCon Salt Lake City 2025 Registration' },
+          // No city tokens, right year.
+          { id: 'current', name: 'KubeCon NA 2026 Registration' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId(), 'the prior edition outranked the year-matching one').toBe('current');
+      expect(picker().selectedEmailTemplateId()).toBe('current');
+    });
+
     it('pre-selects the template whose name carries the event, and says what it matched', () => {
       showPicker();
       picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -4072,6 +4072,98 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       expect(text).toContain('. Pick a different one to override it.');
     });
 
+    /**
+     * The type is the tie-break, so it must be re-applied when the type CHANGES. A suggestion made
+     * under Registration Push is the wrong answer once the operator switches to CFP Launch — and
+     * left alone the stale template stayed selected and would have been the one staged.
+     */
+    it('re-derives the suggestion when the email type changes', () => {
+      showPicker();
+      picker().selectedEmailTypeId.set('main-registration-push');
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'cfp', name: 'MCP Dev Summit Nairobi — call for proposals closes soon' },
+          { id: 'reg', name: 'MCP Dev Summit Nairobi — registration reminder' },
+        ] as HubSpotMarketingEmail[],
+      });
+      expect(picker().selectedEmailTemplateId()).toBe('reg');
+
+      (fixture.componentInstance as unknown as { onSelectEmailType(id: string): void }).onSelectEmailType('cfp-launch');
+      expect(picker().selectedEmailTemplateId()).toBe('cfp');
+    });
+
+    /** A hand-picked template is the operator's; a type change is not permission to replace it. */
+    it('leaves a hand-picked template alone when the email type changes', () => {
+      showPicker();
+      picker().selectedEmailTypeId.set('main-registration-push');
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'cfp', name: 'MCP Dev Summit Nairobi — call for proposals closes soon' },
+          { id: 'reg', name: 'MCP Dev Summit Nairobi — registration reminder' },
+        ] as HubSpotMarketingEmail[],
+      });
+      picker().onSelectEmailTemplate('cfp');
+
+      (fixture.componentInstance as unknown as { onSelectEmailType(id: string): void }).onSelectEmailType('cfp-launch');
+      expect(picker().selectedEmailTemplateId()).toBe('cfp');
+    });
+
+    /**
+     * Years were enumerated in the stopword list, so the protection EXPIRED: in 2028 an unrelated
+     * "Open newsletter 2028" would match `open` plus `2028`, reach the threshold and be
+     * pre-selected. A pattern cannot go stale.
+     */
+    it('drops a year token from any year, not only the enumerated ones', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Open Source Summit 2028', 'open-source-summit-2028'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'unrelated', name: 'Open newsletter 2028' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+    });
+
+    /**
+     * The banner is a plain <p> inserted when the suggestion lands, and a newly inserted element is
+     * not reliably announced — so a screen-reader user could miss that a template was chosen for
+     * them and that it is the one staging will use.
+     */
+    it('announces the auto-selection through the existing live region', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'mcp', name: 'MCP Dev Summit Nairobi registration' }] as HubSpotMarketingEmail[],
+      });
+
+      const live = fixture.nativeElement.querySelector('[data-testid="campaigns-email-templates-live"]')?.textContent ?? '';
+      expect(live).toContain('MCP Dev Summit Nairobi registration');
+      expect(live).toContain('nairobi');
+
+      // Silent once the operator overrides — it no longer describes what is selected.
+      picker().onSelectEmailTemplate('mcp-other');
+      fixture.detectChanges();
+      const after = fixture.nativeElement.querySelector('[data-testid="campaigns-email-templates-live"]')?.textContent ?? '';
+      expect(after).not.toContain('Template selected for this event');
+    });
+
     /** The suggestion ranks too, so the derived template is reachable past the render cap. */
     it('ranks the event match to the top of the rendered list', () => {
       showPicker();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3789,6 +3789,31 @@ describe('CampaignsComponent — HubSpot template picker', () => {
      * Driven through `onSelectEmailTemplate`, because that is the setter that knows the
      * provenance; asserting on the flag directly would pass under an id-equality implementation.
      */
+    /**
+     * A LONG term is not automatically a distinctive one.
+     *
+     * The distinctiveness rule scores any term of six-plus characters as evidence on its own, on
+     * the reasoning that `kubecon`/`nairobi`/`pytorch` separate from `dev`/`mcp` at that length.
+     * Generic words are long too: `source`, `global`, `online`, `storage`. "Open Source Summit"
+     * reduces to `open` + `source` once `summit` is dropped, and `source` alone then clears the
+     * threshold against an unrelated "Source newsletter" -- a confident wrong pick, which is the
+     * one outcome this feature exists to prevent.
+     */
+    it('does not pre-select on a generic long word like "source"', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Open Source Summit', 'open-source-summit'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'src', name: 'Source newsletter — monthly roundup' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId(), 'a generic word pre-selected an unrelated template').toBe('');
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
     it('stops calling the selection system-chosen once the operator picks it themselves', () => {
       showPicker();
       picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3631,6 +3631,10 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     emailTemplatesAnnouncement: Signal<string>;
     searchEmailTemplates(query: string): void;
     onSelectEmailTemplate(id: string): void;
+    emailBriefOutput: WritableSignal<CampaignBriefOutput | null>;
+    emailTemplateSuggestionId: Signal<string>;
+    emailTemplateSuggestionTerms: Signal<readonly string[]>;
+    emailTemplatesRendered: Signal<HubSpotMarketingEmail[]>;
   }
   const picker = (): PickerInternals => fixture.componentInstance as unknown as PickerInternals;
 
@@ -3656,6 +3660,239 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     req.flush(body);
     fixture.detectChanges();
   }
+
+  /**
+   * The event-derived template suggestion (#1698).
+   *
+   * The mapping of event -> branding lives in HubSpot, in the names its operators gave their
+   * templates. These pin that it is read rather than guessed at, and — more importantly — that a
+   * weak signal is NOT turned into a confident pre-selection.
+   */
+  describe('event-derived template suggestion', () => {
+    const briefFor = (name: string, slug: string, city = ''): CampaignBriefOutput => ({ eventDetails: { name, slug, city } }) as unknown as CampaignBriefOutput;
+
+    /**
+     * Put the page on Email/Implement so the picker panel is in the DOM.
+     *
+     * Without this every DOM query returns null -- which makes a NEGATIVE assertion pass for a
+     * reason that has nothing to do with the suggestion: the classic test that cannot fail.
+     */
+    const showPicker = (): void => {
+      const c = fixture.componentInstance as unknown as {
+        selectorForm: { controls: { deliveryType: { setValue(v: string): void } } };
+        selectTab(tab: string, owner: string): void;
+      };
+      c.selectorForm.controls.deliveryType.setValue('email');
+      c.selectTab('implementation', 'email');
+      fixture.detectChanges();
+      // selectTab issues its own entry search; answer it so it cannot collide with the
+      // explicit one each test makes.
+      httpMock
+        .match((r) => r.url === '/api/campaigns/hubspot/emails')
+        .forEach((r) => r.flush({ enabled: true, error: null, possiblyTruncated: false, emails: [] }));
+      fixture.detectChanges();
+    };
+
+    it('pre-selects the template whose name carries the event, and says what it matched', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'kc', name: 'KubeCon registration reminder' },
+          { id: 'mcp', name: 'MCP Dev Summit Nairobi — registration push' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('mcp');
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+      // The REASON must be visible; a suggestion nobody can check is one nobody should trust.
+      expect(picker().emailTemplateSuggestionTerms()).toContain('nairobi');
+      expect(fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]')).not.toBeNull();
+    });
+
+    /**
+     * The case that matters most. A portal whose templates do not name their event must produce NO
+     * pre-selection — a confident wrong pick clones another event's branding into a real HubSpot
+     * draft, and because it reads as decided nobody re-examines it.
+     */
+    it('withholds the suggestion when nothing identifies the event', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'a', name: 'Monthly newsletter' },
+          { id: 'b', name: 'Registration reminder' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+      expect(picker().selectedEmailTemplateId()).toBe('');
+      expect(fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]')).toBeNull();
+    });
+
+    /**
+     * The safety property, and the one the earlier "nothing identifies the event" case does NOT
+     * cover: that test scores 0, so it is stopped by the no-match guard and never reaches the
+     * threshold. This lands in the WEAK band — one distinctive term hit, below
+     * EVENT_TEMPLATE_SUGGESTION_MIN_SCORE — which is exactly where a confident-looking wrong pick
+     * would clone another event's branding into a real HubSpot draft.
+     */
+    it('withholds a suggestion that matches on only one term', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        // Matches 'dev' and nothing else: a real but weak signal, not evidence of the event.
+        emails: [{ id: 'weak', name: 'Dev tools digest' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+      expect(picker().selectedEmailTemplateId()).toBe('');
+      // Positive control: the panel is mounted, so the absence above is a real absence.
+      expect(fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-list"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]')).toBeNull();
+    });
+
+    /**
+     * Found against the LIVE portal, not in a fixture: "KubeCon North America" reduces to
+     * `kubecon | salt | lake | city`, and the real template "KubeCon NA 2026 - Modern Registration
+     * Template" matches only `kubecon`. Scoring every term equally withheld it — one hit — even
+     * though the name states the event unambiguously. A brand token needs no corroboration.
+     */
+    it('suggests on a single distinctive term, so a brand name alone is enough', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon North America', 'kubecon-na-2026', 'Salt Lake City'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'kc', name: 'KubeCon NA 2026 - Modern Registration Template' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('kc');
+      expect(picker().emailTemplateSuggestionTerms()).toEqual(['kubecon']);
+    });
+
+    /**
+     * The other half of the same rule, and the reason it is length-based rather than a blanket
+     * "one hit is enough": a SHORT token still needs corroboration, because it occurs in template
+     * names that have nothing to do with the event.
+     */
+    it('still withholds on a single short term, which is not evidence of the event', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        // 'dev' only — three characters, and a word that appears across unrelated templates.
+        emails: [{ id: 'weak', name: 'Dev tools digest' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+    });
+
+    /** Two distinctive terms IS enough — the threshold must not be so high it never fires. */
+    it('offers a suggestion once two distinctive terms match', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'ok', name: 'MCP Nairobi invite' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('ok');
+    });
+
+    /** A generic word shared by the event name and an unrelated template must not manufacture a hit. */
+    it('does not match on a stopword the event name happens to contain', () => {
+      picker().emailBriefOutput.set(briefFor('Open Source Summit Europe', 'open-source-summit-europe'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'x', name: 'Cloud Summit Europe 2026 invite' }] as HubSpotMarketingEmail[],
+      });
+
+      // 'summit' and 'europe' are stopwords; only 'open'/'source' are distinctive, and neither
+      // appears in the template. A match here would be the false positive the list exists to stop.
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+    });
+
+    it('never overwrites a template the operator already picked', () => {
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().onSelectEmailTemplate('chosen-by-hand');
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'chosen-by-hand', name: 'Something the operator knows about' },
+          { id: 'mcp', name: 'MCP Dev Summit Nairobi — registration push' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().selectedEmailTemplateId()).toBe('chosen-by-hand');
+    });
+
+    /**
+     * An override must SURVIVE a re-search. Without the sticky flag the derivation re-runs on the
+     * next search and silently reinstates the template the operator just rejected, which reads as
+     * the app ignoring them.
+     */
+    it('does not reinstate the suggestion after the operator overrides it', () => {
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      const emails = [
+        { id: 'mcp', name: 'MCP Dev Summit Nairobi — registration push' },
+        { id: 'other', name: 'Nairobi welcome note' },
+      ] as HubSpotMarketingEmail[];
+      respond({ enabled: true, error: null, possiblyTruncated: false, emails });
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+
+      picker().onSelectEmailTemplate('other');
+      picker().searchEmailTemplates('');
+      respond({ enabled: true, error: null, possiblyTruncated: false, emails });
+
+      expect(picker().selectedEmailTemplateId()).toBe('other');
+    });
+
+    /** The suggestion ranks too, so the derived template is reachable past the render cap. */
+    it('ranks the event match to the top of the rendered list', () => {
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'a', name: 'Zulu unrelated' },
+          { id: 'b', name: 'Yankee unrelated' },
+          { id: 'mcp', name: 'MCP Dev Summit Nairobi — registration push' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplatesRendered()[0].id).toBe('mcp');
+    });
+  });
 
   it('loads templates when the implementation tab is entered, not only on proceed', () => {
     // The only other searchEmailTemplates call site is onEmailProceedToImplementation, so

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3961,6 +3961,117 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       expect(picker().emailTemplatesRendered().length).toBe(HUBSPOT_TEMPLATE_RENDER_LIMIT);
     });
 
+    /**
+     * The event decides WHETHER to suggest; the selected type decides WHICH of that event's
+     * templates. A portal that runs an event well has several of its emails, and they score
+     * identically on the event — so a strict `>` over the server's newest-first order picked
+     * whichever was edited last. Observed live: the three MCP Dev Summit templates tie, and the
+     * newest is a CFP-deadline email, which is the wrong answer for Registration Push.
+     */
+    it('breaks an event tie using the selected email type', () => {
+      showPicker();
+      picker().selectedEmailTypeId.set('main-registration-push');
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        // Both name the event identically; only the TYPE separates them, and the CFP one is first
+        // (newest), so a tie-blind scan would take it.
+        emails: [
+          { id: 'cfp', name: 'MCP Dev Summit Nairobi — 5 days left to submit to speak' },
+          { id: 'reg', name: 'MCP Dev Summit Nairobi — registration reminder' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('reg');
+    });
+
+    /**
+     * The chosen template belongs to the brief that chose it. Left set, it survives into the next
+     * event in the same foundation — where it is both wrong AND silently suppresses the new
+     * suggestion, since the derivation only fills an empty selection. The feature would fail
+     * precisely on the second event.
+     */
+    it('clears the chosen template when the brief-derived state resets', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'mcp', name: 'MCP Dev Summit Nairobi registration' }] as HubSpotMarketingEmail[],
+      });
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+
+      (fixture.componentInstance as unknown as { resetEmailBriefDerivedState(): void }).resetEmailBriefDerivedState();
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
+    /**
+     * The banner asserts what is SELECTED, so it must not survive an override. Keyed on the
+     * suggestion merely existing, it read "pre-selected ... for this event" beside a template the
+     * derivation never chose.
+     */
+    it('hides the suggestion banner once the operator picks a different row', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'mcp', name: 'MCP Dev Summit Nairobi registration' },
+          { id: 'other', name: 'Something else entirely' },
+        ] as HubSpotMarketingEmail[],
+      });
+      expect(fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]')).not.toBeNull();
+
+      picker().onSelectEmailTemplate('other');
+      fixture.detectChanges();
+      expect(fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]')).toBeNull();
+    });
+
+    /**
+     * Accents must survive tokenizing. Deleting non-`[a-z0-9]` turned "München" into "mnchen" on
+     * the BRIEF side only, so a template actually named "München" could never match — an
+     * international event permanently unsuggestable.
+     */
+    it('matches an accented event name against an accented template name', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon München', 'kubecon-munchen', 'München'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'de', name: 'KubeCon München — Registrierung' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('de');
+      expect(picker().emailTemplateSuggestionTerms()).toContain('münchen');
+    });
+
+    /** The banner is one sentence; an @if between text nodes rendered "event . Pick a different". */
+    it('renders the banner without a space before the full stop', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'mcp', name: 'MCP Dev Summit Nairobi registration' }] as HubSpotMarketingEmail[],
+      });
+
+      const text = fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]')?.textContent?.replace(/\s+/g, ' ') ?? '';
+      expect(text).not.toContain(' .');
+      expect(text).toContain('. Pick a different one to override it.');
+    });
+
     /** The suggestion ranks too, so the derived template is reachable past the render cap. */
     it('ranks the event match to the top of the rendered list', () => {
       showPicker();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3635,6 +3635,7 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     emailTemplateSuggestionId: Signal<string>;
     emailTemplateSuggestionTerms: Signal<readonly string[]>;
     emailTemplatesRendered: Signal<HubSpotMarketingEmail[]>;
+    selectedEmailTypeId: WritableSignal<string>;
   }
   const picker = (): PickerInternals => fixture.componentInstance as unknown as PickerInternals;
 
@@ -3786,20 +3787,55 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     });
 
     /**
-     * The other half of the same rule, and the reason it is length-based rather than a blanket
-     * "one hit is enough": a SHORT token still needs corroboration, because it occurs in template
-     * names that have nothing to do with the event.
+     * A distinctive term suggests on its own, so a bare substring test would pre-select
+     * "KubeConference recap" for KubeCon outright. Matching on word boundaries removes that
+     * without costing any real name: verified byte-identical against the live portal.
      */
-    it('still withholds on a single short term, which is not evidence of the event', () => {
+    it('does not match a term buried inside a longer word', () => {
       showPicker();
-      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().emailBriefOutput.set(briefFor('KubeCon North America', 'kubecon-na-2026'));
       picker().searchEmailTemplates('');
       respond({
         enabled: true,
         error: null,
         possiblyTruncated: false,
-        // 'dev' only — three characters, and a word that appears across unrelated templates.
-        emails: [{ id: 'weak', name: 'Dev tools digest' }] as HubSpotMarketingEmail[],
+        emails: [{ id: 'nope', name: 'KubeConference recap' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+    });
+
+    /** The naming patterns LF actually uses must keep matching — the boundary is any non-alphanumeric. */
+    it('still matches an event name joined by punctuation', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon North America', 'kubecon-na-2026'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'joined', name: 'KubeCon+CloudNativeCon NA 2026 registration' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('joined');
+    });
+
+    /**
+     * The other half of the same rule, at the TOP of the sub-distinctive band rather than the
+     * bottom. A five-character term is long enough to look meaningful and still short enough to
+     * collide, so it must not decide on its own — this pins the boundary at 6, not merely that
+     * three-character tokens are weak.
+     */
+    it('still withholds on a single five-character term, one short of distinctive', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Seoul Open Infra Days', 'seoul-open-infra-days'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        // 'seoul' matches, and is five characters — one below EVENT_TERM_DISTINCTIVE_LENGTH.
+        emails: [{ id: 'weak', name: 'Seoul city guide' }] as HubSpotMarketingEmail[],
       });
 
       expect(picker().emailTemplateSuggestionId()).toBe('');
@@ -3822,6 +3858,7 @@ describe('CampaignsComponent — HubSpot template picker', () => {
 
     /** A generic word shared by the event name and an unrelated template must not manufacture a hit. */
     it('does not match on a stopword the event name happens to contain', () => {
+      showPicker();
       picker().emailBriefOutput.set(briefFor('Open Source Summit Europe', 'open-source-summit-europe'));
       picker().searchEmailTemplates('');
       respond({
@@ -3837,6 +3874,7 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     });
 
     it('never overwrites a template the operator already picked', () => {
+      showPicker();
       picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
       picker().onSelectEmailTemplate('chosen-by-hand');
       picker().searchEmailTemplates('');
@@ -3854,11 +3892,17 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     });
 
     /**
-     * An override must SURVIVE a re-search. Without the sticky flag the derivation re-runs on the
-     * next search and silently reinstates the template the operator just rejected, which reads as
-     * the app ignoring them.
+     * An override must SURVIVE a re-search: the derivation re-runs on every successful search, and
+     * a suggestion that reinstated itself over a hand-pick would read as the app ignoring the
+     * operator.
+     *
+     * What actually pins it is the empty-selection check — a separate "was it overridden" flag was
+     * written first and removed as unfalsifiable (see the comment in the component). This test is
+     * therefore about the re-search path specifically, which the sibling test above does not
+     * exercise.
      */
-    it('does not reinstate the suggestion after the operator overrides it', () => {
+    it('does not reinstate the suggestion after a re-search once the operator has overridden it', () => {
+      showPicker();
       picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
       picker().searchEmailTemplates('');
       const emails = [
@@ -3875,8 +3919,51 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       expect(picker().selectedEmailTemplateId()).toBe('other');
     });
 
+    /**
+     * The worst state this feature can reach: a banner announcing a pre-selected template while no
+     * VISIBLE row carries it.
+     *
+     * Ranking and the suggestion agree on the event half but not the type half, and a tie falls to
+     * the server's original order — so a genuinely-suggested template can rank below enough
+     * type-keyword matches to be cut by the 100-row render limit. The operator would then be told
+     * something was chosen for them with no way to see or change it. The selected row is spliced
+     * back in at the top for exactly this reason.
+     *
+     * Built to reproduce it: 150 rows that match six keywords of the seven-keyword
+     * `final-countdown` type, plus one true KubeCon template that matches none of them.
+     */
+    it('always draws the selected row, even when ranking would cut it past the render limit', () => {
+      showPicker();
+      picker().selectedEmailTypeId.set('final-countdown');
+      picker().emailBriefOutput.set(briefFor('KubeCon North America', 'kubecon-na-2026'));
+      picker().searchEmailTemplates('');
+
+      const noise = Array.from({ length: 150 }, (_, i) => ({
+        id: `noise-${i}`,
+        name: `Final countdown: last chance, closing deadline, closes soon #${i}`,
+      })) as HubSpotMarketingEmail[];
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [...noise, { id: 'kc', name: 'KubeCon NA 2026 Modern Template' } as HubSpotMarketingEmail],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('kc');
+      expect(picker().selectedEmailTemplateId()).toBe('kc');
+      // The assertion that matters: it is actually DRAWN, not merely selected.
+      expect(
+        picker()
+          .emailTemplatesRendered()
+          .some((t) => t.id === 'kc')
+      ).toBe(true);
+      // And the render cap is still honoured — the splice replaces a row, it does not append.
+      expect(picker().emailTemplatesRendered().length).toBe(HUBSPOT_TEMPLATE_RENDER_LIMIT);
+    });
+
     /** The suggestion ranks too, so the derived template is reachable past the render cap. */
     it('ranks the event match to the top of the rendered list', () => {
+      showPicker();
       picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
       picker().searchEmailTemplates('');
       respond({

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3781,6 +3781,30 @@ describe('CampaignsComponent — HubSpot template picker', () => {
      *
      * Both templates score identically on the decisive term, so only the tie-break can order them.
      */
+    /**
+     * A city repeated in the EVENT NAME must not become decisive.
+     *
+     * The city is meant to RANK, never to justify a suggestion on its own -- that is the whole
+     * point of splitting decisive from ranking terms. But the ranking set is built with
+     * `!decisive.has(token)`, so when the name already contains the city ("Regional Summit
+     * Nairobi" in Nairobi) the token stays in `decisive` and, being six characters, clears the
+     * threshold alone. An unrelated "Nairobi newsletter" is then auto-selected.
+     */
+    it('does not let a city repeated in the event name justify a suggestion', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Regional Summit Nairobi', 'regional-summit-nairobi', 'Nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'unrelated', name: 'Nairobi newsletter — monthly roundup' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId(), 'a city-only match was auto-selected').toBe('');
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
     it('prefers the year-matching edition over a prior one that names the city', () => {
       showPicker();
       picker().emailBriefOutput.set(briefFor('KubeCon North America 2026', 'kubecon-north-america-2026', 'Salt Lake City'));
@@ -4234,7 +4258,11 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       });
 
       expect(picker().emailTemplateSuggestionId()).toBe('de');
-      expect(picker().emailTemplateSuggestionTerms()).toContain('münchen');
+      // The DECISIVE term is what the accent handling has to preserve, and it is what the banner
+      // reports. `münchen` is a CITY token now -- it ranks but never justifies a suggestion, so
+      // it is deliberately absent from the reasons shown. Asserting it here would pin the old
+      // behaviour where a city could be presented as a reason.
+      expect(picker().emailTemplateSuggestionTerms()).toContain('kubecon');
     });
 
     /** The banner is one sentence; an @if between text nodes rendered "event . Pick a different". */

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -4164,6 +4164,84 @@ describe('CampaignsComponent — HubSpot template picker', () => {
       expect(after).not.toContain('Template selected for this event');
     });
 
+    /**
+     * City tokens must never be the reason a template is suggested.
+     *
+     * "Salt Lake City visitor guide" matched `salt`, `lake` and `city` for a KubeCon brief and
+     * scored 9 against a threshold of 6 — a template with no relation to the event, pre-selected
+     * on location words alone. Operators do name templates by city, so the terms still ORDER
+     * results; they just cannot justify a suggestion.
+     */
+    it('withholds a suggestion that matches only on city words', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon North America', 'kubecon-na-2026', 'Salt Lake City'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'city', name: 'Salt Lake City visitor guide' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+    });
+
+    /** But a city match still ranks, once the event itself is identified. */
+    it('ranks a template naming both the event and the city above one naming only the event', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon North America', 'kubecon-na-2026', 'Salt Lake City'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'plain', name: 'KubeCon registration' },
+          { id: 'both', name: 'KubeCon Salt Lake City registration' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('both');
+    });
+
+    /**
+     * Annual editions tie on the event name alone, so the server's newest-first order chose
+     * between "KubeCon NA 2025" and "KubeCon NA 2026" — last year's template, pre-selected and
+     * stageable. The year breaks that tie without being able to reach the threshold itself.
+     */
+    it('prefers the edition whose year matches the brief', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('KubeCon North America 2026', 'kubecon-na-2026'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        // Last year's first, as a newest-first server order could return it.
+        emails: [
+          { id: 'y2025', name: 'KubeCon NA 2025 - Registration' },
+          { id: 'y2026', name: 'KubeCon NA 2026 - Registration' },
+        ] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('y2026');
+    });
+
+    /** The year still cannot carry a suggestion on its own — the 2028 false positive stays shut. */
+    it('does not let a year match alone justify a suggestion', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Open Source Summit 2028', 'open-source-summit-2028'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'unrelated', name: 'Open newsletter 2028' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+    });
+
     /** The suggestion ranks too, so the derived template is reachable past the render cap. */
     it('ranks the event match to the top of the rendered list', () => {
       showPicker();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3716,6 +3716,56 @@ describe('CampaignsComponent — HubSpot template picker', () => {
     });
 
     /**
+     * A RE-PICK of the suggested row is the operator's choice, not the system's.
+     *
+     * The banner and the screen-reader announcement both asked `suggestionId === selectedId`. That
+     * is true again after an operator overrides the suggestion and then deliberately picks that
+     * same template back, so both claimed the system chose what the operator chose — and for a
+     * screen-reader user the announcement is the only channel, with no highlight to contradict it.
+     *
+     * Driven through `onSelectEmailTemplate`, because that is the setter that knows the
+     * provenance; asserting on the flag directly would pass under an id-equality implementation.
+     */
+    it('stops calling the selection system-chosen once the operator picks it themselves', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('MCP Dev Summit Nairobi', 'mcp-dev-summit-nairobi'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [
+          { id: 'kc', name: 'KubeCon registration reminder' },
+          { id: 'mcp', name: 'MCP Dev Summit Nairobi — registration push' },
+        ] as HubSpotMarketingEmail[],
+      });
+      fixture.detectChanges();
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]'),
+        'precondition: the suggestion banner is up'
+      ).not.toBeNull();
+
+      const c = fixture.componentInstance as unknown as { onSelectEmailTemplate(id: string): void };
+      // Override to another row, then deliberately pick the suggested one BACK.
+      c.onSelectEmailTemplate('kc');
+      c.onSelectEmailTemplate('mcp');
+      fixture.detectChanges();
+
+      // The ids coincide again -- an equality check would still say "system chose this".
+      expect(picker().emailTemplateSuggestionId()).toBe('mcp');
+      expect(picker().selectedEmailTemplateId()).toBe('mcp');
+
+      expect(
+        fixture.nativeElement.querySelector('[data-testid="campaigns-email-template-suggestion"]'),
+        "the banner called the operator's own re-pick a pre-selection"
+      ).toBeNull();
+      expect(
+        (fixture.componentInstance as unknown as { emailTemplateSuggestionAnnouncement(): string }).emailTemplateSuggestionAnnouncement(),
+        "the screen-reader announcement called the operator's own re-pick a pre-selection"
+      ).toBe('');
+    });
+
+    /**
      * The case that matters most. A portal whose templates do not name their event must produce NO
      * pre-selection — a confident wrong pick clones another event's branding into a real HubSpot
      * draft, and because it reads as decided nobody re-examines it.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -30,7 +30,7 @@ import { provideRouter } from '@angular/router';
 import { CampaignService } from '@services/campaign.service';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { PersonaService } from '@services/persona.service';
-import { HUBSPOT_TEMPLATE_RENDER_LIMIT } from '@lfx-one/shared/constants';
+import { EVENT_TERM_GENERIC, HUBSPOT_TEMPLATE_RENDER_LIMIT } from '@lfx-one/shared/constants';
 import type { HubSpotMarketingEmail } from '@lfx-one/shared/interfaces';
 import { ProjectContextService } from '@services/project-context.service';
 import { MessageService } from 'primeng/api';
@@ -3876,6 +3876,62 @@ describe('CampaignsComponent — HubSpot template picker', () => {
      * threshold alone. An unrelated "Nairobi newsletter" is then auto-selected.
      */
     /**
+     * An UN-LISTED generic long word still pre-selects, and that is the known trade-off.
+     *
+     * `EVENT_TERM_GENERIC` is a vocabulary, so a generic word nobody has added yet -- `developer`
+     * -- still scores the double weight and clears the threshold alone. This test pins the
+     * CURRENT behaviour rather than asserting it is correct: the honest statement of the limit is
+     * that the deny-list closes words someone has noticed, and the next un-noticed one is a fresh
+     * false positive.
+     *
+     * It is here so the limit is visible and measured. If the scoring ever becomes structural --
+     * corroboration, or evidence weighted by rarity -- this test flips to `toBe('')` and the
+     * change is deliberate rather than silent.
+     */
+    it('still pre-selects on an un-enumerated generic long word (known limit)', () => {
+      showPicker();
+      expect(EVENT_TERM_GENERIC.has('developer')).toBe(false);
+      picker().emailBriefOutput.set(briefFor('Developer Conference', 'developer-conference'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'unrelated', name: 'Developer newsletter', subject: 'Monthly update' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('unrelated');
+    });
+
+    /**
+     * An ASCII slug must not smuggle the city back into the decisive set.
+     *
+     * `cityTokens` is built from `details.city`, which arrives accented -- "München" tokenizes to
+     * `münchen`. The decisive pass reads the NAME and the SLUG, and LF slugs are ASCII, so the
+     * same city arrives as `munchen`. Comparing raw strings, the two are different words: the
+     * accented form was excluded while the ASCII one became decisive and, being seven characters,
+     * cleared the threshold on its own -- auto-selecting a template that merely names the city.
+     *
+     * That is the accented spelling of the city-decides-alone false positive, so it is fixed the
+     * same way: membership is tested on a fold, while the terms themselves stay accented because
+     * they still have to match accented template names.
+     */
+    it('does not let an ASCII-folded city in the slug become decisive', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Cloud Summit', 'cloud-summit-munchen-2026', 'München'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'city-only', name: 'Munchen visitor newsletter', subject: 'Monthly update' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId()).toBe('');
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
+    /**
      * TWO generic terms must not add up to a suggestion.
      *
      * Excluding generic words from the DOUBLE weight was not enough: each still scored
@@ -3910,8 +3966,13 @@ describe('CampaignsComponent — HubSpot template picker', () => {
      * so `register`, `webinar`, `keynote`, `session` and `speaker` all clear it on a single hit --
      * none of them on the list, each a fresh false positive until someone appends it.
      *
-     * Uses `speaker`, deliberately NOT in EVENT_TERM_STOPWORDS, so this fails again the moment the
-     * fix regresses to enumeration.
+     * Uses `speaker`, which IS in `EVENT_TERM_GENERIC` -- so this pins the deny-list, not the
+     * structure. An earlier version of this docstring claimed `speaker` was un-enumerated and
+     * that the test therefore caught a regression to enumeration; it checked the wrong list
+     * (`EVENT_TERM_STOPWORDS`, which indeed does not contain it) and the claim was false.
+     *
+     * The un-listed case is covered separately below, and it documents a real remaining
+     * trade-off rather than a guarantee.
      */
     it('withholds a suggestion when a single generic long word is the only match', () => {
       showPicker();

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.spec.ts
@@ -3833,6 +3833,32 @@ describe('CampaignsComponent — HubSpot template picker', () => {
      * Nairobi" in Nairobi) the token stays in `decisive` and, being six characters, clears the
      * threshold alone. An unrelated "Nairobi newsletter" is then auto-selected.
      */
+    /**
+     * An UN-ENUMERATED generic long word must not decide alone.
+     *
+     * The deny-list closes the words someone has already noticed; the proxy behind it is the real
+     * defect. Any decisive term of six-plus characters scores EVENT_TERM_WEIGHT*2 = the threshold,
+     * so `register`, `webinar`, `keynote`, `session` and `speaker` all clear it on a single hit --
+     * none of them on the list, each a fresh false positive until someone appends it.
+     *
+     * Uses `speaker`, deliberately NOT in EVENT_TERM_STOPWORDS, so this fails again the moment the
+     * fix regresses to enumeration.
+     */
+    it('withholds a suggestion when a single generic long word is the only match', () => {
+      showPicker();
+      picker().emailBriefOutput.set(briefFor('Speaker Enablement Program', 'speaker-enablement-program'));
+      picker().searchEmailTemplates('');
+      respond({
+        enabled: true,
+        error: null,
+        possiblyTruncated: false,
+        emails: [{ id: 'generic', name: 'Speaker reminder — monthly' }] as HubSpotMarketingEmail[],
+      });
+
+      expect(picker().emailTemplateSuggestionId(), 'a single generic long word auto-selected a template').toBe('');
+      expect(picker().selectedEmailTemplateId()).toBe('');
+    });
+
     it('does not let a city repeated in the event name justify a suggestion', () => {
       showPicker();
       picker().emailBriefOutput.set(briefFor('Regional Summit Nairobi', 'regional-summit-nairobi', 'Nairobi'));

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -2006,6 +2006,19 @@ export class CampaignsComponent {
     // `emailTemplateQuery` already shows the later search. The foundation-switch handler clears
     // these signals but cannot stop an in-flight response from refilling them — under the NEW
     // foundation — which is the cross-portal leak that handler exists to prevent.
+    // Released at DISPATCH, not only in the terminal arms below.
+    //
+    // Every arm that clears the list also releases a system-owned selection, but all of them run
+    // AFTER the response lands. In the window between them the loading branch hides the template
+    // list while `canStageEmail` stays enabled -- it reads `selectedEmailTemplateId`, not the
+    // loading flag -- and `onStageEmailSend` snapshots that id before its first await. So an
+    // operator could stage a suggestion that the in-flight search was about to remove or reject,
+    // with the row that justified it already off screen. Releasing here closes the window.
+    //
+    // Only a SYSTEM-owned selection, same as every other call: a hand-picked template is the
+    // operator's and survives the search that is being dispatched.
+    this.releaseSuggestedSelection();
+
     const generation = ++this.emailSearchGeneration;
     const isCurrent = (): boolean => generation === this.emailSearchGeneration;
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -751,17 +751,24 @@ export class CampaignsComponent {
     }
     const drawn = ranked.slice(0, HUBSPOT_TEMPLATE_RENDER_LIMIT);
 
-    // The SELECTED row is always drawn, even when reranking pushes it past the cap.
+    // The SELECTED row is always drawn, even when ranking pushes it past the cap.
     //
-    // Ranking depends on the chosen email TYPE, so switching type reorders the list under a
-    // selection the operator already made: with enough matches for the new type, the selected row
-    // drops below the cap and vanishes. Nothing else notices — `canStageEmail` stays enabled and
-    // `onStageEmailSend` still clones that now-invisible template, so the operator stages a clone
-    // of something they can no longer see or change. Hiding the current choice is the one thing a
-    // ranking heuristic must never do.
+    // TWO routes reach that state, and the guard covers both:
     //
-    // Splicing to the TOP rather than re-ranking: it is the row the operator chose, so it belongs
-    // where they will look for it. The cap is still honoured — this replaces a row, never appends.
+    //   - A TYPE CHANGE reranks the list under a selection the operator already made, so with
+    //     enough matches for the new type the selected row drops below the cap and vanishes.
+    //   - A SUGGESTED template can be cut even as it is pre-selected: ranking and the suggestion
+    //     agree on the event half but not the type half, and a tie falls to the server's original
+    //     order. Reproduced with a 7-keyword type against 300 rows matching six of them.
+    //
+    // Either way nothing else notices — `canStageEmail` stays enabled and `onStageEmailSend` still
+    // clones the now-invisible template, so the operator stages a clone of something they can no
+    // longer see or change, and in the second case the banner announces a pre-selection no visible
+    // row carries. Hiding the current choice is the one thing a ranking heuristic must never do.
+    //
+    // Splicing to the TOP rather than re-ranking: it is the row the operator chose (or was chosen
+    // for them), so it belongs where they will look. The cap holds — this replaces a row, never
+    // appends one.
     const selectedId = this.selectedEmailTemplateId();
     if (selectedId !== '' && !drawn.some((t) => t.id === selectedId)) {
       const selected = ranked.find((t) => t.id === selectedId);
@@ -2393,15 +2400,22 @@ export class CampaignsComponent {
     // Score once per row rather than inside the comparator: a comparator that lowercases and
     // scans both operands runs O(n log n) times over strings that never change.
     //
-    // The EVENT outweighs the type, and by more than one type keyword can make up: within a
-    // portal that runs several events, "which event is this" discriminates far harder than
-    // "which stage of the sequence". A KubeCon registration-push template and an MCP Dev Summit
-    // one score identically on type; only the event term separates them, and picking the wrong
-    // one clones the wrong branding into a real HubSpot draft.
+    // ONE scorer for the event half, shared with the suggestion. They diverged in an earlier
+    // version -- ranking counted every term equally while the suggestion doubled distinctive ones
+    // -- and the two disagreeing is a visible defect, not a nuance: a single-distinctive-term match
+    // could be PRE-SELECTED while ranking below enough type-keyword matches to fall outside the
+    // 100-row render cap, so the banner announced a suggestion with no highlighted row anywhere in
+    // the list. Reproduced with a 7-keyword type (`final-countdown`) against 300 rows matching six
+    // of them: the true KubeCon template ranked 3 against their 6 and was not drawn.
+    //
+    // The EVENT outweighs the type, and deliberately: within a portal running several events,
+    // "which event is this" discriminates far harder than "which stage of the sequence". A KubeCon
+    // registration push and an MCP Dev Summit one score identically on type, and only the event
+    // term separates them -- picking the wrong one clones the wrong branding into a real draft.
     const scored = templates.map((template, index) => ({
       template,
       index,
-      score: this.templateKeywordScore(template, keywords) + this.templateKeywordScore(template, eventTerms) * EVENT_TERM_WEIGHT,
+      score: this.templateKeywordScore(template, keywords) + this.eventMatchScore(template, eventTerms),
     }));
     // `index` breaks ties, which is what makes this stable across engines rather than relying on
     // Array.prototype.sort's stability guarantee holding for every input shape.
@@ -2486,11 +2500,25 @@ export class CampaignsComponent {
     );
   }
 
-  /** Which of the event's terms a template actually matched, for the "why" shown to the operator. */
+  /**
+   * Which of the event's terms a template actually matched, for the "why" shown to the operator.
+   *
+   * Matched on WORD BOUNDARIES, not `includes`. A bare substring test lets a distinctive term match
+   * inside a longer word — "KubeConference recap" would score as a KubeCon template and, because a
+   * distinctive term suggests on its own, would be pre-selected outright. The boundary is any
+   * non-alphanumeric, which keeps every real naming pattern working: `KubeCon + CloudNativeCon`,
+   * `KubeCon+CloudNativeCon` with no spaces, `KubeCon: registration`, and `Nairobi, Kenya` all
+   * still match. Verified byte-identical against the live portal's templates.
+   */
   private matchedEventTerms(template: HubSpotMarketingEmail, eventTerms: readonly string[]): string[] {
     const name = (template.name ?? '').toLowerCase();
     const subject = (template.subject ?? '').toLowerCase();
-    return eventTerms.filter((term) => name.includes(term) || subject.includes(term));
+    return eventTerms.filter((term) => {
+      // Terms are already `[a-z0-9]`-only (eventTemplateTerms strips everything else), so they
+      // carry no regex metacharacters and need no escaping.
+      const bounded = new RegExp(`(^|[^a-z0-9])${term}([^a-z0-9]|$)`);
+      return bounded.test(name) || bounded.test(subject);
+    });
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -2512,6 +2512,21 @@ export class CampaignsComponent {
    *     it. A suggestion whose reasoning is invisible cannot be checked.
    */
   private applyEventTemplateSuggestion(templates: HubSpotMarketingEmail[]): void {
+    // Release a selection this feature made, before re-deriving against the new result set.
+    //
+    // The type-change path already did this; a SEARCH did not, and only the suggestion id was
+    // cleared. So after a narrowed search dropped the auto-selected row, that id stayed selected
+    // while the banner hid (it renders only while the suggestion IS the selection) and staging
+    // would still clone the now-invisible template -- the same silent-wrong-clone this feature
+    // exists to prevent, reached from the other direction.
+    //
+    // Only a SYSTEM-owned selection is released. A hand-picked template is the operator's and
+    // survives every search, which is why this compares against the outgoing suggestion id rather
+    // than clearing unconditionally.
+    const previousSuggestion = this.emailTemplateSuggestionId();
+    if (previousSuggestion !== '' && this.selectedEmailTemplateId() === previousSuggestion) {
+      this.selectedEmailTemplateId.set('');
+    }
     this.emailTemplateSuggestionId.set('');
     this.emailTemplateSuggestionTerms.set([]);
 

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -847,9 +847,10 @@ export class CampaignsComponent {
     // longer see or change, and in the second case the banner announces a pre-selection no visible
     // row carries. Hiding the current choice is the one thing a ranking heuristic must never do.
     //
-    // Splicing to the TOP rather than re-ranking: it is the row the operator chose (or was chosen
-    // for them), so it belongs where they will look. The cap holds — this replaces a row, never
-    // appends one.
+    // Spliced into the LAST drawn slot rather than re-ranked: it is the row the operator chose
+    // (or was chosen for them), so it must stay reachable, but it has not earned the top. The cap
+    // holds — this replaces a row rather than adding one. See the comment on the splice itself
+    // for why not index 0.
     const selectedId = this.selectedEmailTemplateId();
     if (selectedId !== '' && !drawn.some((t) => t.id === selectedId)) {
       const selected = ranked.find((t) => t.id === selectedId);
@@ -2861,11 +2862,26 @@ export class CampaignsComponent {
     // characters it cleared the threshold alone, auto-selecting an unrelated "Nairobi newsletter".
     // The city is meant to rank, never to justify a suggestion, and that is only true if the same
     // token cannot be both.
+    // FOLDED for the comparison only. The city arrives accented ("München" -> `münchen`) while an
+    // LF slug is ASCII ("kubecon-munchen-2026" -> `munchen`), so a set of raw tokens could not
+    // recognise them as the same word: `münchen` was excluded from decisive while `munchen`, the
+    // form that actually reaches the scorer, sailed through and could justify a suggestion alone.
+    // That is the accented spelling of the exact false positive the exclusion exists to stop.
+    //
+    // Folding is applied ONLY when testing membership. The terms themselves stay accented,
+    // because the boundary matcher is built from the same alphabet and an accented term has to
+    // match an accented template name.
+    const fold = (token: string): string => token.normalize('NFD').replace(/\p{M}+/gu, '');
+    // Two sets, deliberately: `cityTokens` keeps the ORIGINAL spelling because it becomes the
+    // ranking terms, which are matched against template names and must stay accented.
+    // `cityFolded` exists only to answer "is this decisive candidate the city?".
     const cityTokens = new Set<string>();
+    const cityFolded = new Set<string>();
     for (const token of split(details.city ?? '')) {
       const cleaned = token.toLowerCase();
       if (usable(cleaned) && !EVENT_TERM_YEAR_PATTERN.test(cleaned)) {
         cityTokens.add(cleaned);
+        cityFolded.add(fold(cleaned));
       }
     }
 
@@ -2883,7 +2899,7 @@ export class CampaignsComponent {
         continue;
       }
       // A city token is never decisive, wherever it appears. It stays in `ranking` below.
-      if (usable(cleaned) && !cityTokens.has(cleaned)) {
+      if (usable(cleaned) && !cityFolded.has(fold(cleaned))) {
         decisive.add(cleaned);
       }
     }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -735,7 +735,7 @@ export class CampaignsComponent {
    * choice as system-owned and silently release it on the next search. Provenance is a fact about
    * how the value was set, and only the setter knows it.
    */
-  private emailTemplateSelectionIsSuggested = false;
+  protected readonly emailTemplateSelectionIsSuggested = signal<boolean>(false);
 
   /** Which event terms the suggested template matched on, so the operator can judge it themselves. */
   protected readonly emailTemplateSuggestionTerms = signal<readonly string[]>([]);
@@ -770,8 +770,12 @@ export class CampaignsComponent {
   );
 
   protected readonly emailTemplateSuggestionAnnouncement = computed<string>(() => {
+    // PROVENANCE, matching the banner: `id === selectedId` also holds when an operator overrode
+    // the suggestion and then deliberately re-picked that same row, and announcing "Template
+    // selected for this event" over their own choice is the same false claim in the one place a
+    // screen-reader user cannot see the highlight that would contradict it.
     const id = this.emailTemplateSuggestionId();
-    if (id === '' || id !== this.selectedEmailTemplateId()) {
+    if (id === '' || !this.emailTemplateSelectionIsSuggested()) {
       return '';
     }
     // A template can carry a subject and no name -- it is matched on either -- and announcing an
@@ -1698,7 +1702,7 @@ export class CampaignsComponent {
     // Only when the current selection IS the suggestion: a hand-picked template is the operator's
     // and a type change is not permission to replace it.
     const templates = this.emailTemplates();
-    if (templates !== null && this.emailTemplateSelectionIsSuggested) {
+    if (templates !== null && this.emailTemplateSelectionIsSuggested()) {
       this.selectedEmailTemplateId.set('');
       this.applyEventTemplateSuggestion(templates);
     }
@@ -2062,7 +2066,7 @@ export class CampaignsComponent {
 
   protected onSelectEmailTemplate(id: string): void {
     // A hand-pick is the operator's, even when it happens to be the same row the suggestion chose.
-    this.emailTemplateSelectionIsSuggested = false;
+    this.emailTemplateSelectionIsSuggested.set(false);
     this.selectedEmailTemplateId.set(id);
   }
 
@@ -2519,9 +2523,9 @@ export class CampaignsComponent {
    * in place -- invisible, since there is no list to show it in, and still stageable.
    */
   private releaseSuggestedSelection(): void {
-    if (this.emailTemplateSelectionIsSuggested) {
+    if (this.emailTemplateSelectionIsSuggested()) {
       this.selectedEmailTemplateId.set('');
-      this.emailTemplateSelectionIsSuggested = false;
+      this.emailTemplateSelectionIsSuggested.set(false);
     }
     this.emailTemplateSuggestionId.set('');
     this.emailTemplateSuggestionTerms.set([]);
@@ -2624,7 +2628,7 @@ export class CampaignsComponent {
     // an unfalsifiable guard reads as protection that is not there.
     if (this.selectedEmailTemplateId() === '') {
       this.selectedEmailTemplateId.set(best.id);
-      this.emailTemplateSelectionIsSuggested = true;
+      this.emailTemplateSelectionIsSuggested.set(true);
     }
   }
 
@@ -3323,7 +3327,7 @@ export class CampaignsComponent {
     // the type-change path both branch on this flag to decide whether a selection is the
     // operator's, and leaving it describing a discarded brief is one new writer away from
     // discarding a hand-picked template.
-    this.emailTemplateSelectionIsSuggested = false;
+    this.emailTemplateSelectionIsSuggested.set(false);
     // The suggestion is derived from THIS brief's event, so it and the override that rejected it
     // both belong to the brief. Carrying the override into a new event would suppress a suggestion
     // the operator has never seen.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -17,6 +17,7 @@ import {
   EMAIL_BRIEF_REQUIRED_HINT,
   EVENT_TEMPLATE_SUGGESTION_MIN_SCORE,
   EVENT_TERM_DISTINCTIVE_LENGTH,
+  EVENT_TERM_GENERIC,
   EVENT_TERM_STOPWORDS,
   EVENT_TERM_YEAR_PATTERN,
   EVENT_TERM_WEIGHT,
@@ -2689,8 +2690,23 @@ export class CampaignsComponent {
    * unrelated names, so the two cases must not be scored the same.
    */
   private eventMatchScore(template: HubSpotMarketingEmail, terms: EventTemplateTerms): number {
-    return this.matchedEventTerms(template, terms.decisive).reduce(
-      (score, term) => score + (term.length >= EVENT_TERM_DISTINCTIVE_LENGTH ? EVENT_TERM_WEIGHT * 2 : EVENT_TERM_WEIGHT),
+    const matched = this.matchedEventTerms(template, terms.decisive);
+    // CORROBORATION, not length alone. Length was standing in for distinctiveness, and it cannot
+    // carry that weight: `register`, `webinar`, `keynote`, `session` and `speaker` are all six-plus
+    // characters and all generic, so each cleared the threshold on a single hit. The deny-list
+    // closes the words someone has already noticed; every un-listed one is a fresh false positive.
+    //
+    // A term is double-weighted only when it is long AND not a known generic. Corroboration was
+    // the first thing tried -- withhold unless a second term matched -- and it broke the case the
+    // feature exists for: "KubeCon Munchen" has two decisive terms, a template named only
+    // "KubeCon Munchen - Registrierung" matched both, but one named "KubeCon NA 2026" matched
+    // only `kubecon` and was withheld, though `kubecon` names the event unambiguously.
+    //
+    // EVENT_TERM_GENERIC is a vocabulary, not a length rule, so a word is excluded for being
+    // generic rather than for being short. It is still a list and still needs appending, but the
+    // failure mode is now a MISSED suggestion rather than a wrong one -- the safe direction.
+    return matched.reduce(
+      (score, term) => score + (term.length >= EVENT_TERM_DISTINCTIVE_LENGTH && !EVENT_TERM_GENERIC.has(term) ? EVENT_TERM_WEIGHT * 2 : EVENT_TERM_WEIGHT),
       0
     );
   }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -2543,7 +2543,16 @@ export class CampaignsComponent {
     const scored = templates.map((template, index) => ({
       template,
       index,
-      score: this.templateKeywordScore(template, keywords) + this.eventMatchScore(template, eventTerms) + this.eventRankBonus(template, eventTerms),
+      // The rank bonus is CLAMPED here, unlike at the suggestion tie-break. There it only
+      // separates templates whose decisive scores already tie, so its magnitude is free; here it
+      // is SUMMED into the ordering, where an unclamped year weight (year * (cities+1)) could
+      // reach 7 and lift a template matching no decisive term above one that does. Capping it
+      // below EVENT_TERM_WEIGHT keeps the docblock's promise -- city and year sharpen the choice
+      // among real matches, they never manufacture one.
+      score:
+        this.templateKeywordScore(template, keywords) +
+        this.eventMatchScore(template, eventTerms) +
+        Math.min(this.eventRankBonus(template, eventTerms), EVENT_TERM_WEIGHT - 1),
     }));
     // `index` breaks ties, which is what makes this stable across engines rather than relying on
     // Array.prototype.sort's stability guarantee holding for every input shape.
@@ -2691,13 +2700,28 @@ export class CampaignsComponent {
    *
    * City terms and the year live here rather than in the decisive score: they sharpen the choice
    * between templates that all name the event, and are not evidence of the event themselves.
-   * Weighted below a single decisive term so they can never reorder a real match beneath a weak
-   * one.
+   *
+   * The RETURN VALUE is not bounded below a decisive term -- `year * (cities + 1)` is deliberately
+   * large so the year outranks any number of city tokens. That is safe at the suggestion
+   * tie-break, which consults it only after decisive scores have already tied. The ranking sum in
+   * `rankTemplatesForSelectedType` CLAMPS it instead, because there it is added to the score and
+   * an unclamped value could lift a template matching no decisive term above one that does. An
+   * earlier version of this note claimed the value itself was weighted below a decisive term;
+   * it is the CALLER that has to hold that line.
    */
   private eventRankBonus(template: HubSpotMarketingEmail, terms: EventTemplateTerms): number {
     const city = this.matchedEventTerms(template, terms.ranking).length;
     const year = terms.year !== '' && this.matchedEventTerms(template, [terms.year]).length > 0 ? 1 : 0;
-    return city + year;
+    // YEAR STRICTLY ABOVE CITY, not summed with it. `city + year` let extra city tokens on a
+    // STALE edition outrank the year bit on the current one: for "KubeCon North America 2026" in
+    // "Salt Lake City", the 2025 template scored salt+lake+city = 3 against the 2026 template's
+    // year = 1, so the PRIOR edition was pre-selected and its HubSpot draft staged. That is the
+    // exact failure the year tie-break was added to prevent, and the comment above this method
+    // promised an ordered year-then-city tie-break a sum cannot express.
+    //
+    // Multiplying by `ranking.length + 1` makes one year match worth more than every city token
+    // combined, so year decides first and city only orders within the same year outcome.
+    return year * (terms.ranking.length + 1) + city;
   }
 
   /** The cached boundary matcher for one term, compiled on first use. */
@@ -2743,7 +2767,9 @@ export class CampaignsComponent {
    * the names its operators gave those templates. Rather than storing a per-event mapping of our
    * own, this reads the event off the brief and asks HubSpot which templates look like it.
    *
-   * The slug is split on its separators and the name on whitespace, then both are filtered:
+   * Slug and name are tokenized the SAME way -- one `split(/[^\p{L}\p{N}]+/u)` over both, on any
+   * non-alphanumeric run -- rather than separators for one and whitespace for the other, which is
+   * what an earlier version of this note claimed. Both are then filtered:
    * stopwords out (they match everything), tokens under three characters out (too weak to
    * identify an event on their own). What survives is the distinctive part of the event's
    * identity -- "kubecon", "nairobi", "pytorch".

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -747,12 +747,29 @@ export class CampaignsComponent {
    * them, and that it is the one staging will use. Routed through the picker's existing live
    * region, which is already mounted and only has its CONTENTS change.
    */
+  /**
+   * The live region's whole text, joined with a separating space.
+   *
+   * Concatenating the two computeds directly in the template ran them together --
+   * "…37 found.Template selected for this event: …" -- which a screen reader announces as one
+   * word. Joined here rather than by adding a space to either source, so neither ends with a
+   * dangling space when it is the only one present.
+   */
+  protected readonly emailTemplatesLiveAnnouncement = computed<string>(() =>
+    [this.emailTemplatesAnnouncement(), this.emailTemplateSuggestionAnnouncement()].filter((part) => part !== '').join(' ')
+  );
+
   protected readonly emailTemplateSuggestionAnnouncement = computed<string>(() => {
     const id = this.emailTemplateSuggestionId();
     if (id === '' || id !== this.selectedEmailTemplateId()) {
       return '';
     }
-    const name = this.emailTemplates()?.find((t) => t.id === id)?.name ?? '';
+    // A template can carry a subject and no name -- it is matched on either -- and announcing an
+    // empty string reads as "Template selected for this event: . Choose another", which tells a
+    // screen-reader user nothing about what was chosen. Fall back to the subject, then to a
+    // neutral phrase rather than a blank.
+    const template = this.emailTemplates()?.find((t) => t.id === id);
+    const name = (template?.name ?? '').trim() || (template?.subject ?? '').trim() || 'an untitled template';
     const terms = this.emailTemplateSuggestionTermsLabel();
     const matched = terms === '' ? '' : `, matched on ${terms}`;
     return `Template selected for this event: ${name}${matched}. Choose another to override it.`;
@@ -1222,6 +1239,15 @@ export class CampaignsComponent {
       bounce: perSent(totals.bounces),
     };
   });
+  /**
+   * Word-boundary matchers, cached by term.
+   *
+   * The same few patterns were recompiled for every template on every rank -- up to 500 rows,
+   * and once per selection click, since the splice makes ranking re-run when the selection
+   * changes. Terms come from the event and change only when the brief does, so the cache stays
+   * small and needs no invalidation: a new brief simply asks for different keys.
+   */
+  private readonly boundaryMatchers = new Map<string, RegExp>();
 
   public constructor() {
     // Discard the persistence state when the selected foundation changes — see
@@ -2588,6 +2614,19 @@ export class CampaignsComponent {
     return city + year;
   }
 
+  /** The cached boundary matcher for one term, compiled on first use. */
+  private boundaryMatcher(term: string): RegExp {
+    const cached = this.boundaryMatchers.get(term);
+    if (cached !== undefined) {
+      return cached;
+    }
+    // Terms carry only letters and digits (the tokenizer splits on everything else), so there
+    // are no regex metacharacters to escape.
+    const built = new RegExp(`(^|[^\\p{L}\\p{N}])${term}([^\\p{L}\\p{N}]|$)`, 'u');
+    this.boundaryMatchers.set(term, built);
+    return built;
+  }
+
   /**
    * Which of the event's terms a template actually matched, for the "why" shown to the operator.
    *
@@ -2606,7 +2645,7 @@ export class CampaignsComponent {
       // template name is a whole word rather than a letter-run interrupted by the accent.
       // Terms carry only letters and digits (the tokenizer splits on everything else), so there
       // are no regex metacharacters to escape.
-      const bounded = new RegExp(`(^|[^\\p{L}\\p{N}])${term}([^\\p{L}\\p{N}]|$)`, 'u');
+      const bounded = this.boundaryMatcher(term);
       return bounded.test(name) || bounded.test(subject);
     });
   }
@@ -2619,8 +2658,8 @@ export class CampaignsComponent {
    * own, this reads the event off the brief and asks HubSpot which templates look like it.
    *
    * The slug is split on its separators and the name on whitespace, then both are filtered:
-   * stopwords out (they match everything), tokens under three characters out (so "AI" cannot match
-   * "chain" and a stray "of" cannot score). What survives is the distinctive part of the event's
+   * stopwords out (they match everything), tokens under three characters out (too weak to
+   * identify an event on their own). What survives is the distinctive part of the event's
    * identity -- "kubecon", "nairobi", "pytorch".
    *
    * The city is included because operators frequently name templates by location where the event

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -32,6 +32,7 @@ import type {
   CampaignJobOutcome,
   CampaignEmailStage,
   EmailBriefCopy,
+  EventTemplateTerms,
   CampaignCreateRequest,
   CampaignBriefPersistenceState,
   CampaignImplementationDraft,
@@ -2436,7 +2437,8 @@ export class CampaignsComponent {
   private rankTemplatesForSelectedType(templates: HubSpotMarketingEmail[]): HubSpotMarketingEmail[] {
     const keywords = CAMPAIGN_EMAIL_TYPES.find((t) => t.id === this.selectedEmailTypeId())?.keywords ?? [];
     const eventTerms = this.eventTemplateTerms();
-    if (keywords.length === 0 && eventTerms.length === 0) {
+    const hasEventTerms = eventTerms.decisive.length > 0 || eventTerms.ranking.length > 0 || eventTerms.year !== '';
+    if (keywords.length === 0 && !hasEventTerms) {
       return templates;
     }
     // Score once per row rather than inside the comparator: a comparator that lowercases and
@@ -2457,7 +2459,7 @@ export class CampaignsComponent {
     const scored = templates.map((template, index) => ({
       template,
       index,
-      score: this.templateKeywordScore(template, keywords) + this.eventMatchScore(template, eventTerms),
+      score: this.templateKeywordScore(template, keywords) + this.eventMatchScore(template, eventTerms) + this.eventRankBonus(template, eventTerms),
     }));
     // `index` breaks ties, which is what makes this stable across engines rather than relying on
     // Array.prototype.sort's stability guarantee holding for every input shape.
@@ -2488,7 +2490,9 @@ export class CampaignsComponent {
     this.emailTemplateSuggestionTerms.set([]);
 
     const eventTerms = this.eventTemplateTerms();
-    if (eventTerms.length === 0 || templates.length === 0) {
+    // DECISIVE terms only. With no name or slug tokens there is nothing that identifies the event,
+    // and city or year matches alone are not evidence it is the right template.
+    if (eventTerms.decisive.length === 0 || templates.length === 0) {
       return;
     }
 
@@ -2508,16 +2512,24 @@ export class CampaignsComponent {
     const typeKeywords = CAMPAIGN_EMAIL_TYPES.find((t) => t.id === this.selectedEmailTypeId())?.keywords ?? [];
     let best: HubSpotMarketingEmail | null = null;
     let bestScore = 0;
+    let bestBonus = 0;
     let bestTypeScore = 0;
     for (const template of templates) {
       const score = this.eventMatchScore(template, eventTerms);
       if (score === 0) {
         continue;
       }
+      // Ordered tie-breaks, most specific last-resort first: the event decides, then the year
+      // (so this year's edition beats last year's -- otherwise they tie and the server's order
+      // picks, which pre-selected a previous edition), then the city, then the email type.
+      const bonus = this.eventRankBonus(template, eventTerms);
       const typeScore = this.templateKeywordScore(template, typeKeywords);
-      if (score > bestScore || (score === bestScore && typeScore > bestTypeScore)) {
+      const better =
+        score > bestScore || (score === bestScore && bonus > bestBonus) || (score === bestScore && bonus === bestBonus && typeScore > bestTypeScore);
+      if (better) {
         best = template;
         bestScore = score;
+        bestBonus = bonus;
         bestTypeScore = typeScore;
       }
     }
@@ -2527,7 +2539,10 @@ export class CampaignsComponent {
     }
 
     this.emailTemplateSuggestionId.set(best.id);
-    this.emailTemplateSuggestionTerms.set(this.matchedEventTerms(best, eventTerms));
+    // The DECISIVE terms only. These are what justified offering the suggestion at all, and they
+    // are what an operator needs to judge it -- listing a city or year match here would present
+    // as a reason something that could never have been sufficient on its own.
+    this.emailTemplateSuggestionTerms.set(this.matchedEventTerms(best, eventTerms.decisive));
 
     // Pre-fill ONLY an untouched selection. `selectedEmailTemplateId` is the operator's, and a
     // suggestion that overwrites a deliberate choice is a bug wearing a feature's clothes.
@@ -2552,11 +2567,25 @@ export class CampaignsComponent {
    * A short token like `dev` or `mcp` genuinely does need a second term, since it turns up in
    * unrelated names, so the two cases must not be scored the same.
    */
-  private eventMatchScore(template: HubSpotMarketingEmail, eventTerms: readonly string[]): number {
-    return this.matchedEventTerms(template, eventTerms).reduce(
+  private eventMatchScore(template: HubSpotMarketingEmail, terms: EventTemplateTerms): number {
+    return this.matchedEventTerms(template, terms.decisive).reduce(
       (score, term) => score + (term.length >= EVENT_TERM_DISTINCTIVE_LENGTH ? EVENT_TERM_WEIGHT * 2 : EVENT_TERM_WEIGHT),
       0
     );
+  }
+
+  /**
+   * How well a template orders among others the event already identified.
+   *
+   * City terms and the year live here rather than in the decisive score: they sharpen the choice
+   * between templates that all name the event, and are not evidence of the event themselves.
+   * Weighted below a single decisive term so they can never reorder a real match beneath a weak
+   * one.
+   */
+  private eventRankBonus(template: HubSpotMarketingEmail, terms: EventTemplateTerms): number {
+    const city = this.matchedEventTerms(template, terms.ranking).length;
+    const year = terms.year !== '' && this.matchedEventTerms(template, [terms.year]).length > 0 ? 1 : 0;
+    return city + year;
   }
 
   /**
@@ -2599,31 +2628,54 @@ export class CampaignsComponent {
    * "security") and collide across unrelated events in the same portal, which is exactly the
    * false-positive this scoring must avoid.
    */
-  private eventTemplateTerms(): string[] {
+  private eventTemplateTerms(): EventTemplateTerms {
     const details = this.emailBriefOutput()?.eventDetails;
     if (!details) {
-      return [];
+      return { decisive: [], ranking: [], year: '' };
     }
     // SPLIT on punctuation rather than deleting it. Deleting merged "KubeCon+CloudNativeCon" into
     // one unmatchable token, and -- worse -- silently dropped accented letters, so "München"
     // became "mnchen" and could never match a template actually named "München". The event side
     // was mangled while the template side was not, which makes international event names
     // permanently unsuggestable.
-    const raw = [
-      ...(details.name ?? '').split(/[^\p{L}\p{N}]+/u),
-      ...(details.slug ?? '').split(/[^\p{L}\p{N}]+/u),
-      ...(details.city ?? '').split(/[^\p{L}\p{N}]+/u),
-    ];
-    const seen = new Set<string>();
-    for (const token of raw) {
-      // Lower-cased only. Letters outside a-z are KEPT, and the boundary matcher below is built
-      // from the same alphabet, so an accented term matches an accented template name.
+    const split = (value: string): string[] => value.split(/[^\p{L}\p{N}]+/u);
+
+    // Lower-cased only. Letters outside a-z are KEPT, and the boundary matcher is built from the
+    // same alphabet, so an accented term matches an accented template name.
+    const usable = (token: string): boolean => token.length >= 3 && !EVENT_TERM_STOPWORDS.includes(token);
+
+    const decisive = new Set<string>();
+    let year = '';
+    for (const token of [...split(details.name ?? ''), ...split(details.slug ?? '')]) {
       const cleaned = token.toLowerCase();
-      if (cleaned.length >= 3 && !EVENT_TERM_STOPWORDS.includes(cleaned) && !EVENT_TERM_YEAR_PATTERN.test(cleaned)) {
-        seen.add(cleaned);
+      if (EVENT_TERM_YEAR_PATTERN.test(cleaned)) {
+        // The year is a TIE-BREAK, never decisive. Dropping it entirely made annual editions
+        // score identically, so the server's order picked between "KubeCon NA 2025" and
+        // "KubeCon NA 2026" -- last year's template, pre-selected and stageable. Counting it
+        // toward the threshold instead would re-admit "Open newsletter 2028" for an
+        // "Open Source Summit 2028" brief, which is why it is neither.
+        year = year === '' ? cleaned : year;
+        continue;
+      }
+      if (usable(cleaned)) {
+        decisive.add(cleaned);
       }
     }
-    return [...seen];
+
+    // The CITY ranks but never decides. "Salt Lake City visitor guide" matched all three of
+    // `salt`, `lake`, `city` for a KubeCon brief and scored 9 against a threshold of 6 -- a
+    // template with no relation to the event, pre-selected on location words alone. Operators do
+    // name templates by city where a brand repeats annually, so the terms are still worth
+    // ordering by; they just cannot be the reason a suggestion is offered.
+    const ranking = new Set<string>();
+    for (const token of split(details.city ?? '')) {
+      const cleaned = token.toLowerCase();
+      if (usable(cleaned) && !decisive.has(cleaned) && !EVENT_TERM_YEAR_PATTERN.test(cleaned)) {
+        ranking.add(cleaned);
+      }
+    }
+
+    return { decisive: [...decisive], ranking: [...ranking], year };
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -2795,6 +2795,20 @@ export class CampaignsComponent {
     // same alphabet, so an accented term matches an accented template name.
     const usable = (token: string): boolean => token.length >= 3 && !EVENT_TERM_STOPWORDS.includes(token);
 
+    // CITY TOKENS FIRST, so the decisive pass below can exclude them. Built the other way round
+    // -- ranking filtered by `!decisive.has(token)` -- a city repeated in the event name stayed
+    // DECISIVE: "Regional Summit Nairobi" in Nairobi made `nairobi` decisive, and being six
+    // characters it cleared the threshold alone, auto-selecting an unrelated "Nairobi newsletter".
+    // The city is meant to rank, never to justify a suggestion, and that is only true if the same
+    // token cannot be both.
+    const cityTokens = new Set<string>();
+    for (const token of split(details.city ?? '')) {
+      const cleaned = token.toLowerCase();
+      if (usable(cleaned) && !EVENT_TERM_YEAR_PATTERN.test(cleaned)) {
+        cityTokens.add(cleaned);
+      }
+    }
+
     const decisive = new Set<string>();
     let year = '';
     for (const token of [...split(details.name ?? ''), ...split(details.slug ?? '')]) {
@@ -2808,7 +2822,8 @@ export class CampaignsComponent {
         year = year === '' ? cleaned : year;
         continue;
       }
-      if (usable(cleaned)) {
+      // A city token is never decisive, wherever it appears. It stays in `ranking` below.
+      if (usable(cleaned) && !cityTokens.has(cleaned)) {
         decisive.add(cleaned);
       }
     }
@@ -2818,13 +2833,7 @@ export class CampaignsComponent {
     // template with no relation to the event, pre-selected on location words alone. Operators do
     // name templates by city where a brand repeats annually, so the terms are still worth
     // ordering by; they just cannot be the reason a suggestion is offered.
-    const ranking = new Set<string>();
-    for (const token of split(details.city ?? '')) {
-      const cleaned = token.toLowerCase();
-      if (usable(cleaned) && !decisive.has(cleaned) && !EVENT_TERM_YEAR_PATTERN.test(cleaned)) {
-        ranking.add(cleaned);
-      }
-    }
+    const ranking = cityTokens;
 
     return { decisive: [...decisive], ranking: [...ranking], year };
   }
@@ -3410,9 +3419,10 @@ export class CampaignsComponent {
     // operator's, and leaving it describing a discarded brief is one new writer away from
     // discarding a hand-picked template.
     this.emailTemplateSelectionIsSuggested.set(false);
-    // The suggestion is derived from THIS brief's event, so it and the override that rejected it
-    // both belong to the brief. Carrying the override into a new event would suppress a suggestion
-    // the operator has never seen.
+    // The suggestion is derived from THIS brief's event, so its id and the terms it matched on
+    // both belong to the brief and go with it. (An earlier version of this note also mentioned an
+    // override flag that could suppress later suggestions; that flag was removed when provenance
+    // replaced it, and only these two signals are reset here.)
     this.emailTemplateSuggestionId.set('');
     this.emailTemplateSuggestionTerms.set([]);
   }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -18,6 +18,7 @@ import {
   EVENT_TEMPLATE_SUGGESTION_MIN_SCORE,
   EVENT_TERM_DISTINCTIVE_LENGTH,
   EVENT_TERM_STOPWORDS,
+  EVENT_TERM_YEAR_PATTERN,
   EVENT_TERM_WEIGHT,
   HUBSPOT_TEMPLATE_RENDER_LIMIT,
   MARKETING_OPS_FGA_ENABLED_FLAG,
@@ -727,6 +728,34 @@ export class CampaignsComponent {
 
   /** Which event terms the suggested template matched on, so the operator can judge it themselves. */
   protected readonly emailTemplateSuggestionTerms = signal<readonly string[]>([]);
+
+  /**
+   * The matched terms as one display string.
+   *
+   * A `computed` rather than `.join()` in the template: the checklist allows only signal reads,
+   * computed values and pipes there, and a `join` in an interpolation re-runs on every
+   * change-detection pass over an array that changes only when a search answers.
+   */
+  protected readonly emailTemplateSuggestionTermsLabel = computed<string>(() => this.emailTemplateSuggestionTerms().join(', '));
+
+  /**
+   * Screen-reader announcement for the auto-selection.
+   *
+   * The banner is a plain `<p>` inserted when the suggestion lands, and a newly inserted element
+   * is not reliably announced -- so a screen-reader user could miss that a template was chosen for
+   * them, and that it is the one staging will use. Routed through the picker's existing live
+   * region, which is already mounted and only has its CONTENTS change.
+   */
+  protected readonly emailTemplateSuggestionAnnouncement = computed<string>(() => {
+    const id = this.emailTemplateSuggestionId();
+    if (id === '' || id !== this.selectedEmailTemplateId()) {
+      return '';
+    }
+    const name = this.emailTemplates()?.find((t) => t.id === id)?.name ?? '';
+    const terms = this.emailTemplateSuggestionTermsLabel();
+    const matched = terms === '' ? '' : `, matched on ${terms}`;
+    return `Template selected for this event: ${name}${matched}. Choose another to override it.`;
+  });
 
   /**
    * The rows the picker actually DRAWS — the first `HUBSPOT_TEMPLATE_RENDER_LIMIT` of them.
@@ -1623,6 +1652,19 @@ export class CampaignsComponent {
     // Invalidate any generate still in flight. Clearing the signals is not enough: the older
     // response resolves afterwards and would repopulate the panel with the previous stage's copy.
     this.emailCopyGeneration++;
+
+    // Re-derive, because the type is the tie-break. Several of one event's templates score
+    // identically on the event, and the type is what chooses between them -- so a suggestion made
+    // under Registration Push is the wrong answer once the operator switches to CFP Launch. Left
+    // alone, the stale template stayed selected and would have been the one staged.
+    //
+    // Only when the current selection IS the suggestion: a hand-picked template is the operator's
+    // and a type change is not permission to replace it.
+    const templates = this.emailTemplates();
+    if (templates !== null && this.selectedEmailTemplateId() === this.emailTemplateSuggestionId()) {
+      this.selectedEmailTemplateId.set('');
+      this.applyEventTemplateSuggestion(templates);
+    }
     this.emailCopy.set(null);
     this.emailCopyState.set('idle');
     this.emailCopyError.set('');
@@ -2577,7 +2619,7 @@ export class CampaignsComponent {
       // Lower-cased only. Letters outside a-z are KEPT, and the boundary matcher below is built
       // from the same alphabet, so an accented term matches an accented template name.
       const cleaned = token.toLowerCase();
-      if (cleaned.length >= 3 && !EVENT_TERM_STOPWORDS.includes(cleaned)) {
+      if (cleaned.length >= 3 && !EVENT_TERM_STOPWORDS.includes(cleaned) && !EVENT_TERM_YEAR_PATTERN.test(cleaned)) {
         seen.add(cleaned);
       }
     }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -2453,13 +2453,30 @@ export class CampaignsComponent {
     // Scored on the EVENT alone, not the blended rank. The blended score mixes in type keywords,
     // so a template matching only the type could clear the threshold while saying nothing about
     // which event it belongs to -- the precise confusion this gate exists to prevent.
+    // The EVENT decides whether to suggest at all; the TYPE decides which of that event's
+    // templates. A portal that runs an event well has several of its emails -- CFP launch,
+    // registration push, final countdown -- and they score identically on the event, so a
+    // strict `>` over the server's newest-first order picked whichever was edited last. That
+    // preselected a CFP-deadline email for an operator who had chosen Registration Push, which
+    // is a wrong answer wearing the right event's name. Observed live: the three MCP Dev Summit
+    // templates tie at 12 and the newest is a "Days Left to Submit to Speak" CFP email.
+    //
+    // The type is a TIE-BREAK, never a gate: it cannot rescue a template the event did not
+    // identify, and a type that matches nothing leaves the event ordering untouched.
+    const typeKeywords = CAMPAIGN_EMAIL_TYPES.find((t) => t.id === this.selectedEmailTypeId())?.keywords ?? [];
     let best: HubSpotMarketingEmail | null = null;
     let bestScore = 0;
+    let bestTypeScore = 0;
     for (const template of templates) {
       const score = this.eventMatchScore(template, eventTerms);
-      if (score > bestScore) {
+      if (score === 0) {
+        continue;
+      }
+      const typeScore = this.templateKeywordScore(template, typeKeywords);
+      if (score > bestScore || (score === bestScore && typeScore > bestTypeScore)) {
         best = template;
         bestScore = score;
+        bestTypeScore = typeScore;
       }
     }
 
@@ -2514,9 +2531,11 @@ export class CampaignsComponent {
     const name = (template.name ?? '').toLowerCase();
     const subject = (template.subject ?? '').toLowerCase();
     return eventTerms.filter((term) => {
-      // Terms are already `[a-z0-9]`-only (eventTemplateTerms strips everything else), so they
-      // carry no regex metacharacters and need no escaping.
-      const bounded = new RegExp(`(^|[^a-z0-9])${term}([^a-z0-9]|$)`);
+      // The boundary class is the SAME alphabet the tokenizer splits on, so "münchen" in a
+      // template name is a whole word rather than a letter-run interrupted by the accent.
+      // Terms carry only letters and digits (the tokenizer splits on everything else), so there
+      // are no regex metacharacters to escape.
+      const bounded = new RegExp(`(^|[^\\p{L}\\p{N}])${term}([^\\p{L}\\p{N}]|$)`, 'u');
       return bounded.test(name) || bounded.test(subject);
     });
   }
@@ -2543,12 +2562,21 @@ export class CampaignsComponent {
     if (!details) {
       return [];
     }
-    const raw = [...(details.name ?? '').split(/\s+/), ...(details.slug ?? '').split(/[-_/]+/), ...(details.city ?? '').split(/\s+/)];
+    // SPLIT on punctuation rather than deleting it. Deleting merged "KubeCon+CloudNativeCon" into
+    // one unmatchable token, and -- worse -- silently dropped accented letters, so "München"
+    // became "mnchen" and could never match a template actually named "München". The event side
+    // was mangled while the template side was not, which makes international event names
+    // permanently unsuggestable.
+    const raw = [
+      ...(details.name ?? '').split(/[^\p{L}\p{N}]+/u),
+      ...(details.slug ?? '').split(/[^\p{L}\p{N}]+/u),
+      ...(details.city ?? '').split(/[^\p{L}\p{N}]+/u),
+    ];
     const seen = new Set<string>();
     for (const token of raw) {
-      // Punctuation stripped rather than split on: "KubeCon+CloudNativeCon" must yield two usable
-      // tokens, and a trailing comma in "Nairobi, Kenya" must not make "nairobi," unmatchable.
-      const cleaned = token.toLowerCase().replace(/[^a-z0-9]/g, '');
+      // Lower-cased only. Letters outside a-z are KEPT, and the boundary matcher below is built
+      // from the same alphabet, so an accented term matches an accented template name.
+      const cleaned = token.toLowerCase();
       if (cleaned.length >= 3 && !EVENT_TERM_STOPWORDS.includes(cleaned)) {
         seen.add(cleaned);
       }
@@ -3102,6 +3130,11 @@ export class CampaignsComponent {
     this.emailMetrics.set(null);
     this.emailMetricsState.set('idle');
     this.emailMetricsError.set('');
+    // The chosen template belongs to the brief that chose it. Left set, it survives into the next
+    // event in the same foundation, where it is both WRONG (a template for the previous event) and
+    // silently suppresses the new suggestion, since the derivation only ever fills an empty
+    // selection. That is the feature failing exactly where it is most useful -- the second event.
+    this.selectedEmailTemplateId.set('');
     // The suggestion is derived from THIS brief's event, so it and the override that rejected it
     // both belong to the brief. Carrying the override into a new event would suppress a suggestion
     // the operator has never seen.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -15,6 +15,10 @@ import {
   CAMPAIGN_TABS,
   DEFAULT_CAMPAIGN_EMAIL_TYPE_ID,
   EMAIL_BRIEF_REQUIRED_HINT,
+  EVENT_TEMPLATE_SUGGESTION_MIN_SCORE,
+  EVENT_TERM_DISTINCTIVE_LENGTH,
+  EVENT_TERM_STOPWORDS,
+  EVENT_TERM_WEIGHT,
   HUBSPOT_TEMPLATE_RENDER_LIMIT,
   MARKETING_OPS_FGA_ENABLED_FLAG,
 } from '@lfx-one/shared/constants';
@@ -709,6 +713,20 @@ export class CampaignsComponent {
    * send them looking for a template that does not exist.
    */
   protected readonly emailTemplatesTruncated = signal(false);
+
+  /**
+   * The template auto-derived from HubSpot for this event, if one was confident enough to offer.
+   *
+   * A SUGGESTION the operator can change, never a decision. Empty means no template scored above
+   * `EVENT_TEMPLATE_SUGGESTION_MIN_SCORE` and the picker behaves exactly as it did before -- which
+   * is the honest outcome for a portal whose templates do not name their event. Withholding a weak
+   * guess matters more than offering one: a pre-selection looks decided, so nobody re-reads it,
+   * and cloning the wrong template puts another event's branding into a real HubSpot draft.
+   */
+  protected readonly emailTemplateSuggestionId = signal<string>('');
+
+  /** Which event terms the suggested template matched on, so the operator can judge it themselves. */
+  protected readonly emailTemplateSuggestionTerms = signal<readonly string[]>([]);
 
   /**
    * The rows the picker actually DRAWS — the first `HUBSPOT_TEMPLATE_RENDER_LIMIT` of them.
@@ -1903,6 +1921,7 @@ export class CampaignsComponent {
           }
           this.emailTemplates.set(selectable);
           this.emailTemplatesTruncated.set(result.possiblyTruncated);
+          this.applyEventTemplateSuggestion(selectable);
         },
         error: () => {
           if (!isCurrent()) {
@@ -2367,20 +2386,146 @@ export class CampaignsComponent {
    */
   private rankTemplatesForSelectedType(templates: HubSpotMarketingEmail[]): HubSpotMarketingEmail[] {
     const keywords = CAMPAIGN_EMAIL_TYPES.find((t) => t.id === this.selectedEmailTypeId())?.keywords ?? [];
-    if (keywords.length === 0) {
+    const eventTerms = this.eventTemplateTerms();
+    if (keywords.length === 0 && eventTerms.length === 0) {
       return templates;
     }
     // Score once per row rather than inside the comparator: a comparator that lowercases and
     // scans both operands runs O(n log n) times over strings that never change.
+    //
+    // The EVENT outweighs the type, and by more than one type keyword can make up: within a
+    // portal that runs several events, "which event is this" discriminates far harder than
+    // "which stage of the sequence". A KubeCon registration-push template and an MCP Dev Summit
+    // one score identically on type; only the event term separates them, and picking the wrong
+    // one clones the wrong branding into a real HubSpot draft.
     const scored = templates.map((template, index) => ({
       template,
       index,
-      score: this.templateKeywordScore(template, keywords),
+      score: this.templateKeywordScore(template, keywords) + this.templateKeywordScore(template, eventTerms) * EVENT_TERM_WEIGHT,
     }));
     // `index` breaks ties, which is what makes this stable across engines rather than relying on
     // Array.prototype.sort's stability guarantee holding for every input shape.
     scored.sort((a, b) => b.score - a.score || a.index - b.index);
     return scored.map((s) => s.template);
+  }
+
+  /**
+   * Offer the template this portal already uses for this event, if one is identifiable.
+   *
+   * This is the answer to "how is it done for that event": rather than holding a per-event mapping
+   * of our own, it reads the event off the brief and finds the template whose NAME says it belongs
+   * to that event. The portal's own naming is the mapping.
+   *
+   * Three properties, each load-bearing:
+   *
+   *   - It only ever pre-fills an EMPTY selection, so an operator who has already chosen keeps
+   *     their choice across a re-search or an email-type change -- a suggestion that reinstates
+   *     itself over a hand-pick is not a suggestion.
+   *   - It withholds below `EVENT_TEMPLATE_SUGGESTION_MIN_SCORE`. A pre-selection reads as decided,
+   *     so a wrong one is unlikely to be re-examined, and cloning the wrong template puts another
+   *     event's branding into a real HubSpot draft.
+   *   - It records WHICH terms matched, so the operator can judge the suggestion rather than trust
+   *     it. A suggestion whose reasoning is invisible cannot be checked.
+   */
+  private applyEventTemplateSuggestion(templates: HubSpotMarketingEmail[]): void {
+    this.emailTemplateSuggestionId.set('');
+    this.emailTemplateSuggestionTerms.set([]);
+
+    const eventTerms = this.eventTemplateTerms();
+    if (eventTerms.length === 0 || templates.length === 0) {
+      return;
+    }
+
+    // Scored on the EVENT alone, not the blended rank. The blended score mixes in type keywords,
+    // so a template matching only the type could clear the threshold while saying nothing about
+    // which event it belongs to -- the precise confusion this gate exists to prevent.
+    let best: HubSpotMarketingEmail | null = null;
+    let bestScore = 0;
+    for (const template of templates) {
+      const score = this.eventMatchScore(template, eventTerms);
+      if (score > bestScore) {
+        best = template;
+        bestScore = score;
+      }
+    }
+
+    if (best === null || bestScore < EVENT_TEMPLATE_SUGGESTION_MIN_SCORE) {
+      return;
+    }
+
+    this.emailTemplateSuggestionId.set(best.id);
+    this.emailTemplateSuggestionTerms.set(this.matchedEventTerms(best, eventTerms));
+
+    // Pre-fill ONLY an untouched selection. `selectedEmailTemplateId` is the operator's, and a
+    // suggestion that overwrites a deliberate choice is a bug wearing a feature's clothes.
+    //
+    // The empty check is the WHOLE guard, deliberately. A separate "was it overridden" flag was
+    // written first and removed: the only path that clears the selection is the foundation switch,
+    // which resets the brief-derived state in the same pass, so the flag could never be the reason
+    // a re-selection was refused. It was unfalsifiable — no mutation of it changed any test — and
+    // an unfalsifiable guard reads as protection that is not there.
+    if (this.selectedEmailTemplateId() === '') {
+      this.selectedEmailTemplateId.set(best.id);
+    }
+  }
+
+  /**
+   * How strongly a template's name says it belongs to THIS event.
+   *
+   * Long terms count double, because corroboration is the wrong bar for a distinctive brand token.
+   * Found against the live portal: "KubeCon North America" reduces to `kubecon|salt|lake|city`,
+   * and "KubeCon NA 2026 - Registration" matches only `kubecon` — one hit, which a
+   * count-everything-equally score withholds despite the template naming the event unambiguously.
+   * A short token like `dev` or `mcp` genuinely does need a second term, since it turns up in
+   * unrelated names, so the two cases must not be scored the same.
+   */
+  private eventMatchScore(template: HubSpotMarketingEmail, eventTerms: readonly string[]): number {
+    return this.matchedEventTerms(template, eventTerms).reduce(
+      (score, term) => score + (term.length >= EVENT_TERM_DISTINCTIVE_LENGTH ? EVENT_TERM_WEIGHT * 2 : EVENT_TERM_WEIGHT),
+      0
+    );
+  }
+
+  /** Which of the event's terms a template actually matched, for the "why" shown to the operator. */
+  private matchedEventTerms(template: HubSpotMarketingEmail, eventTerms: readonly string[]): string[] {
+    const name = (template.name ?? '').toLowerCase();
+    const subject = (template.subject ?? '').toLowerCase();
+    return eventTerms.filter((term) => name.includes(term) || subject.includes(term));
+  }
+
+  /**
+   * The terms that identify THIS event in a template's name, derived from the brief.
+   *
+   * The point of the whole feature: the portal already encodes how each event's email is done, in
+   * the names its operators gave those templates. Rather than storing a per-event mapping of our
+   * own, this reads the event off the brief and asks HubSpot which templates look like it.
+   *
+   * The slug is split on its separators and the name on whitespace, then both are filtered:
+   * stopwords out (they match everything), tokens under three characters out (so "AI" cannot match
+   * "chain" and a stray "of" cannot score). What survives is the distinctive part of the event's
+   * identity -- "kubecon", "nairobi", "pytorch".
+   *
+   * The city is included because operators frequently name templates by location where the event
+   * brand repeats annually. Themes are NOT: they describe subject matter ("cloud native",
+   * "security") and collide across unrelated events in the same portal, which is exactly the
+   * false-positive this scoring must avoid.
+   */
+  private eventTemplateTerms(): string[] {
+    const details = this.emailBriefOutput()?.eventDetails;
+    if (!details) {
+      return [];
+    }
+    const raw = [...(details.name ?? '').split(/\s+/), ...(details.slug ?? '').split(/[-_/]+/), ...(details.city ?? '').split(/\s+/)];
+    const seen = new Set<string>();
+    for (const token of raw) {
+      // Punctuation stripped rather than split on: "KubeCon+CloudNativeCon" must yield two usable
+      // tokens, and a trailing comma in "Nairobi, Kenya" must not make "nairobi," unmatchable.
+      const cleaned = token.toLowerCase().replace(/[^a-z0-9]/g, '');
+      if (cleaned.length >= 3 && !EVENT_TERM_STOPWORDS.includes(cleaned)) {
+        seen.add(cleaned);
+      }
+    }
+    return [...seen];
   }
 
   /**
@@ -2929,5 +3074,10 @@ export class CampaignsComponent {
     this.emailMetrics.set(null);
     this.emailMetricsState.set('idle');
     this.emailMetricsError.set('');
+    // The suggestion is derived from THIS brief's event, so it and the override that rejected it
+    // both belong to the brief. Carrying the override into a new event would suppress a suggestion
+    // the operator has never seen.
+    this.emailTemplateSuggestionId.set('');
+    this.emailTemplateSuggestionTerms.set([]);
   }
 }

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -2668,7 +2668,14 @@ export class CampaignsComponent {
       }
     }
 
-    if (best === null || bestScore < EVENT_TEMPLATE_SUGGESTION_MIN_SCORE) {
+    // The threshold is applied to the NON-GENERIC evidence, not to the full match score.
+    //
+    // `bestScore` ranks; it counts generic words because among templates the event has already
+    // identified, a generic word usefully separates them. It cannot be what justifies offering a
+    // suggestion at all: two generic terms sum to exactly EVENT_TEMPLATE_SUGGESTION_MIN_SCORE, so
+    // "Community Training Workshop" would auto-select "Community training newsletter" on
+    // vocabulary that describes neither event.
+    if (best === null || this.eventSuggestionScore(best, eventTerms) < EVENT_TEMPLATE_SUGGESTION_MIN_SCORE) {
       return;
     }
 
@@ -2676,7 +2683,10 @@ export class CampaignsComponent {
     // The DECISIVE terms only. These are what justified offering the suggestion at all, and they
     // are what an operator needs to judge it -- listing a city or year match here would present
     // as a reason something that could never have been sufficient on its own.
-    this.emailTemplateSuggestionTerms.set(this.matchedEventTerms(best, eventTerms.decisive));
+    // Generic terms are filtered out for the same reason they cannot justify the suggestion: a
+    // reason the operator is shown must be a reason that counted. Listing "community" beside a
+    // suggestion the word could never have earned overstates the evidence.
+    this.emailTemplateSuggestionTerms.set(this.matchedEventTerms(best, eventTerms.decisive).filter((t) => !EVENT_TERM_GENERIC.has(t)));
 
     // Pre-fill ONLY an untouched selection. `selectedEmailTemplateId` is the operator's, and a
     // suggestion that overwrites a deliberate choice is a bug wearing a feature's clothes.
@@ -2722,6 +2732,27 @@ export class CampaignsComponent {
       (score, term) => score + (term.length >= EVENT_TERM_DISTINCTIVE_LENGTH && !EVENT_TERM_GENERIC.has(term) ? EVENT_TERM_WEIGHT * 2 : EVENT_TERM_WEIGHT),
       0
     );
+  }
+
+  /**
+   * The part of the match score that may JUSTIFY a pre-selection, as opposed to merely rank one.
+   *
+   * Excluding generic terms from the double weight was not enough. They still scored
+   * `EVENT_TERM_WEIGHT` apiece, so TWO of them reached `EVENT_TEMPLATE_SUGGESTION_MIN_SCORE`
+   * (3 + 3 = 6) and auto-selected on generic vocabulary alone: "Community Training Workshop"
+   * against a template named "Community training newsletter" scores 6 with every matching term
+   * in `EVENT_TERM_GENERIC`. That is the exact claim the deny-list was introduced to make true --
+   * generic words may rank, but they cannot be the evidence that this is the right template.
+   *
+   * So ranking and justification are now different questions asked of the same matches.
+   * `eventMatchScore` still counts everything, because among templates the event has ALREADY
+   * identified a generic word is a real signal of which one. This one counts only non-generic
+   * terms, and it is what the threshold is applied to.
+   */
+  private eventSuggestionScore(template: HubSpotMarketingEmail, terms: EventTemplateTerms): number {
+    return this.matchedEventTerms(template, terms.decisive)
+      .filter((term) => !EVENT_TERM_GENERIC.has(term))
+      .reduce((score, term) => score + (term.length >= EVENT_TERM_DISTINCTIVE_LENGTH ? EVENT_TERM_WEIGHT * 2 : EVENT_TERM_WEIGHT), 0);
   }
 
   /**

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -3313,6 +3313,17 @@ export class CampaignsComponent {
     // silently suppresses the new suggestion, since the derivation only ever fills an empty
     // selection. That is the feature failing exactly where it is most useful -- the second event.
     this.selectedEmailTemplateId.set('');
+    // Cleared WITH the id it describes: the flag means "the CURRENT selection is system-owned",
+    // and there is no current selection once the line above runs.
+    //
+    // No bug reachable today -- the only writers of a non-empty selection are
+    // `onSelectEmailTemplate`, which sets the flag false, and the suggestion itself, which sets it
+    // true, so a stale `true` can at worst re-clear an already-empty id. It is cleared anyway
+    // because the invariant is what the rest of the class reads: `releaseSuggestedSelection` and
+    // the type-change path both branch on this flag to decide whether a selection is the
+    // operator's, and leaving it describing a discarded brief is one new writer away from
+    // discarding a hand-picked template.
+    this.emailTemplateSelectionIsSuggested = false;
     // The suggestion is derived from THIS brief's event, so it and the override that rejected it
     // both belong to the brief. Carrying the override into a new event would suppress a suggestion
     // the operator has never seen.

--- a/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
+++ b/apps/lfx-one/src/app/modules/dashboards/campaigns/campaigns.component.ts
@@ -727,6 +727,16 @@ export class CampaignsComponent {
    */
   protected readonly emailTemplateSuggestionId = signal<string>('');
 
+  /**
+   * Whether the CURRENT selection was made by the suggestion rather than by the operator.
+   *
+   * ID equality cannot answer this. After suggestion A, an operator can pick B and then
+   * deliberately pick A again -- the ids coincide, so an equality check would treat their explicit
+   * choice as system-owned and silently release it on the next search. Provenance is a fact about
+   * how the value was set, and only the setter knows it.
+   */
+  private emailTemplateSelectionIsSuggested = false;
+
   /** Which event terms the suggested template matched on, so the operator can judge it themselves. */
   protected readonly emailTemplateSuggestionTerms = signal<readonly string[]>([]);
 
@@ -1688,7 +1698,7 @@ export class CampaignsComponent {
     // Only when the current selection IS the suggestion: a hand-picked template is the operator's
     // and a type change is not permission to replace it.
     const templates = this.emailTemplates();
-    if (templates !== null && this.selectedEmailTemplateId() === this.emailTemplateSuggestionId()) {
+    if (templates !== null && this.emailTemplateSelectionIsSuggested) {
       this.selectedEmailTemplateId.set('');
       this.applyEventTemplateSuggestion(templates);
     }
@@ -1926,6 +1936,7 @@ export class CampaignsComponent {
       // The page is reachable by an ED of any foundation and templates are per-project, so a
       // missing slug must not fall back to some other portal's templates.
       this.emailTemplates.set(null);
+      this.releaseSuggestedSelection();
       // Same reason as the reset below: a stale `false` would render "Connect HubSpot" instead of
       // this message, because the template checks the channel flag first.
       this.emailChannelEnabled.set(null);
@@ -1970,12 +1981,14 @@ export class CampaignsComponent {
             // Not an error: HubSpot simply is not connected for this project, which is the steady
             // state everywhere the channel is not set up.
             this.emailTemplates.set(null);
+            this.releaseSuggestedSelection();
             return;
           }
           if (result.error) {
             // The service reached HubSpot and HubSpot refused. Leave the list NULL rather than
             // empty — an empty list would claim the portal has no templates.
             this.emailTemplates.set(null);
+            this.releaseSuggestedSelection();
             this.emailTemplatesError.set(result.error);
             return;
           }
@@ -1992,6 +2005,7 @@ export class CampaignsComponent {
             // NULL rather than [], for the same reason the error arms use null: only a search
             // that genuinely came back with nothing can support the empty-portal claim.
             this.emailTemplates.set(null);
+            this.releaseSuggestedSelection();
             this.emailTemplatesError.set('Could not load templates. Try again.');
             return;
           }
@@ -2006,6 +2020,7 @@ export class CampaignsComponent {
           this.emailTemplatesLoading.set(false);
           // NULL, not []. A failed search says nothing about what the portal holds.
           this.emailTemplates.set(null);
+          this.releaseSuggestedSelection();
           this.emailTemplatesError.set('Could not load templates. Try again.');
         },
       });
@@ -2046,6 +2061,8 @@ export class CampaignsComponent {
   }
 
   protected onSelectEmailTemplate(id: string): void {
+    // A hand-pick is the operator's, even when it happens to be the same row the suggestion chose.
+    this.emailTemplateSelectionIsSuggested = false;
     this.selectedEmailTemplateId.set(id);
   }
 
@@ -2494,6 +2511,23 @@ export class CampaignsComponent {
   }
 
   /**
+   * Release a selection this feature made, and forget the suggestion.
+   *
+   * Called from BOTH the success path and every failure arm. `applyEventTemplateSuggestion` runs
+   * only after a successful listing, so the `enabled: false`, HubSpot-error, unusable-rows and
+   * transport-error arms all set `emailTemplates` to null while leaving a system-owned selection
+   * in place -- invisible, since there is no list to show it in, and still stageable.
+   */
+  private releaseSuggestedSelection(): void {
+    if (this.emailTemplateSelectionIsSuggested) {
+      this.selectedEmailTemplateId.set('');
+      this.emailTemplateSelectionIsSuggested = false;
+    }
+    this.emailTemplateSuggestionId.set('');
+    this.emailTemplateSuggestionTerms.set([]);
+  }
+
+  /**
    * Offer the template this portal already uses for this event, if one is identifiable.
    *
    * This is the answer to "how is it done for that event": rather than holding a per-event mapping
@@ -2523,12 +2557,7 @@ export class CampaignsComponent {
     // Only a SYSTEM-owned selection is released. A hand-picked template is the operator's and
     // survives every search, which is why this compares against the outgoing suggestion id rather
     // than clearing unconditionally.
-    const previousSuggestion = this.emailTemplateSuggestionId();
-    if (previousSuggestion !== '' && this.selectedEmailTemplateId() === previousSuggestion) {
-      this.selectedEmailTemplateId.set('');
-    }
-    this.emailTemplateSuggestionId.set('');
-    this.emailTemplateSuggestionTerms.set([]);
+    this.releaseSuggestedSelection();
 
     const eventTerms = this.eventTemplateTerms();
     // DECISIVE terms only. With no name or slug tokens there is nothing that identifies the event,
@@ -2595,6 +2624,7 @@ export class CampaignsComponent {
     // an unfalsifiable guard reads as protection that is not there.
     if (this.selectedEmailTemplateId() === '') {
       this.selectedEmailTemplateId.set(best.id);
+      this.emailTemplateSelectionIsSuggested = true;
     }
   }
 

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -943,6 +943,72 @@ export const CAMPAIGN_METRICS_WINDOWS = ['today', 'yesterday', 'last_7_days', 'l
 export const EMAIL_BRIEF_REQUIRED_HINT = 'Generate a brief on the Plan tab first.';
 
 /**
+ * How much harder an EVENT term counts than an email-type keyword when ranking clone templates.
+ *
+ * Within one portal that runs several events, "which event is this" discriminates far harder than
+ * "which stage of the sequence": a KubeCon registration push and an MCP Dev Summit registration
+ * push score identically on type keywords, and only the event term tells them apart. Three is
+ * enough that a single event hit outranks any realistic type-only match (types carry at most three
+ * keywords) without letting event terms alone decide -- a template matching both still wins.
+ */
+export const EVENT_TERM_WEIGHT = 3;
+
+/**
+ * The lowest event score that may PRE-SELECT a template rather than merely rank it.
+ *
+ * Two independent event hits, or one weighted hit. Below this the suggestion is withheld entirely
+ * and the operator picks by hand, which is the honest outcome: a confidently wrong pre-selection
+ * clones another event's branding into a real HubSpot draft, and because it looks decided nobody
+ * re-reads it. Ranking still applies -- a weak signal is worth ordering by, just not deciding by.
+ */
+export const EVENT_TEMPLATE_SUGGESTION_MIN_SCORE = 6;
+
+/**
+ * Length at which a matched event term is treated as evidence on its own.
+ *
+ * Corroboration by a second term is the usual bar, but it is the wrong bar for a distinctive brand
+ * token. Verified against the live portal: "KubeCon North America" reduces to
+ * `kubecon | salt | lake | city`, and "KubeCon NA 2026 - Registration" matches only `kubecon` --
+ * one hit, withheld, despite naming the event unambiguously. Meanwhile a short token like `dev`
+ * or `mcp` really does need corroboration, because it occurs in unrelated template names.
+ *
+ * Six characters is where the two groups separate in practice (`kubecon`, `nairobi`, `pytorch`,
+ * `zephyr` above it; `dev`, `mcp`, `city`, `salt`, `lake` below), so a single long-token hit is
+ * scored double and clears the threshold alone while a short one still cannot.
+ */
+export const EVENT_TERM_DISTINCTIVE_LENGTH = 6;
+
+/**
+ * Words dropped from an event name before it is used to match template names.
+ *
+ * Every one of these appears in ordinary event titles AND in unrelated template names, so keeping
+ * them manufactures hits that mean nothing -- "2026" matches every template written this year, and
+ * "summit" matches every summit in the portal. Short tokens are dropped separately by length.
+ */
+export const EVENT_TERM_STOPWORDS: readonly string[] = [
+  'the',
+  'and',
+  'for',
+  'con',
+  'conference',
+  'summit',
+  'event',
+  'events',
+  'day',
+  'days',
+  'annual',
+  'north',
+  'south',
+  'america',
+  'europe',
+  'asia',
+  '2024',
+  '2025',
+  '2026',
+  '2027',
+];
+
+/**
  * The twelve email types an event programme sends, in lifecycle order, each mapped to the stage
  * campaign-service generates from.
  *

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1007,6 +1007,19 @@ export const EVENT_TERM_STOPWORDS: readonly string[] = [
   'america',
   'europe',
   'asia',
+  // Long but GENERIC. Length was standing in for distinctiveness, and these are six-plus
+  // characters, so a single hit scored double and cleared the threshold alone: "Open Source
+  // Summit" reduces to `open` + `source`, and `source` then pre-selected an unrelated "Source
+  // newsletter". A confident wrong pick is the one outcome the suggestion must never produce,
+  // so the words that break the length proxy are dropped before scoring sees them.
+  'source',
+  'global',
+  'online',
+  'virtual',
+  'storage',
+  'meetup',
+  'forum',
+  'expo',
 ];
 
 /**

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -947,9 +947,14 @@ export const EMAIL_BRIEF_REQUIRED_HINT = 'Generate a brief on the Plan tab first
  *
  * Within one portal that runs several events, "which event is this" discriminates far harder than
  * "which stage of the sequence": a KubeCon registration push and an MCP Dev Summit registration
- * push score identically on type keywords, and only the event term tells them apart. Three is
- * enough that a single event hit outranks any realistic type-only match (types carry at most three
- * keywords) without letting event terms alone decide -- a template matching both still wins.
+ * push score identically on type keywords, and only the event term tells them apart.
+ *
+ * It does NOT guarantee an event hit outranks every type-only match, and an earlier version of this
+ * comment wrongly claimed it did on the grounds that "types carry at most three keywords" -- they
+ * carry four to seven (`final-countdown` has seven), so a type-only match can reach 7 and outrank a
+ * single short event hit at 3. What the weight buys is that a template matching BOTH sorts above one
+ * matching only the type, which is the ordering that matters. The suggestion does not rely on rank
+ * at all: it scores the event alone and is spliced into the rendered list if ranking cuts it.
  */
 export const EVENT_TERM_WEIGHT = 3;
 

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -1007,11 +1007,19 @@ export const EVENT_TERM_STOPWORDS: readonly string[] = [
   'america',
   'europe',
   'asia',
-  '2024',
-  '2025',
-  '2026',
-  '2027',
 ];
+
+/**
+ * Matches a year-shaped token, which is dropped from event terms whatever the year.
+ *
+ * Years were originally enumerated in the stopword list, which made the protection EXPIRE: in 2028
+ * an `Open Source Summit 2028` brief and an unrelated `Open newsletter 2028` template would match
+ * `open` plus `2028`, reach the threshold, and be pre-selected. A pattern cannot go stale.
+ *
+ * Deliberately narrow — four digits beginning 19 or 20. A bare `\d{4}` would also drop conference
+ * numbers and venue codes that really do identify an event.
+ */
+export const EVENT_TERM_YEAR_PATTERN = /^(19|20)\d{2}$/;
 
 /**
  * The twelve email types an event programme sends, in lifecycle order, each mapped to the stage

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -996,8 +996,15 @@ export const EVENT_TERM_DISTINCTIVE_LENGTH = 6;
  * one is suggested. Distinct from EVENT_TERM_STOPWORDS, which removes a token from matching
  * altogether.
  *
- * A vocabulary is still a list and still needs appending. What changed is the failure mode: an
- * un-listed generic word now produces a MISSED suggestion rather than a confidently wrong one.
+ * A vocabulary is still a list and still needs appending, and an UN-LISTED generic word still
+ * produces a confidently wrong suggestion -- it takes the double weight and clears the threshold
+ * alone, exactly as before. An earlier version of this note claimed the opposite (a missed
+ * suggestion rather than a wrong one), which inverted the actual failure mode.
+ *
+ * What listing a word changes is that word: it drops to single weight, so it can rank but cannot
+ * justify a suggestion by itself. The remaining limit is pinned by the spec test
+ * "still pre-selects on an un-enumerated generic long word (known limit)", so it is measured
+ * rather than assumed away.
  */
 export const EVENT_TERM_GENERIC: ReadonlySet<string> = new Set([
   'register',

--- a/packages/shared/src/constants/campaign.constants.ts
+++ b/packages/shared/src/constants/campaign.constants.ts
@@ -984,6 +984,46 @@ export const EVENT_TEMPLATE_SUGGESTION_MIN_SCORE = 6;
 export const EVENT_TERM_DISTINCTIVE_LENGTH = 6;
 
 /**
+ * Words that are long enough to look distinctive but carry no event identity.
+ *
+ * `EVENT_TERM_DISTINCTIVE_LENGTH` uses length as a proxy for distinctiveness, and the proxy is
+ * wrong for a whole class of words: `register`, `webinar`, `keynote`, `session`, `speaker`,
+ * `reminder` are all six-plus characters and all generic, so each cleared the suggestion threshold
+ * on a SINGLE hit and pre-selected an unrelated template.
+ *
+ * These are excluded from the distinctive DOUBLE weight rather than dropped from matching
+ * entirely: they still order templates that already name the event, they just cannot be the reason
+ * one is suggested. Distinct from EVENT_TERM_STOPWORDS, which removes a token from matching
+ * altogether.
+ *
+ * A vocabulary is still a list and still needs appending. What changed is the failure mode: an
+ * un-listed generic word now produces a MISSED suggestion rather than a confidently wrong one.
+ */
+export const EVENT_TERM_GENERIC: ReadonlySet<string> = new Set([
+  'register',
+  'registration',
+  'webinar',
+  'keynote',
+  'session',
+  'sessions',
+  'speaker',
+  'speakers',
+  'reminder',
+  'newsletter',
+  'announcement',
+  'invitation',
+  'schedule',
+  'agenda',
+  'program',
+  'update',
+  'updates',
+  'welcome',
+  'community',
+  'training',
+  'workshop',
+]);
+
+/**
  * Words dropped from an event name before it is used to match template names.
  *
  * Every one of these appears in ordinary event titles AND in unrelated template names, so keeping
@@ -1007,11 +1047,16 @@ export const EVENT_TERM_STOPWORDS: readonly string[] = [
   'america',
   'europe',
   'asia',
-  // Long but GENERIC. Length was standing in for distinctiveness, and these are six-plus
-  // characters, so a single hit scored double and cleared the threshold alone: "Open Source
-  // Summit" reduces to `open` + `source`, and `source` then pre-selected an unrelated "Source
-  // newsletter". A confident wrong pick is the one outcome the suggestion must never produce,
-  // so the words that break the length proxy are dropped before scoring sees them.
+  // GENERIC, whatever their length. Length was standing in for distinctiveness, and the six-plus
+  // character ones broke that proxy outright: a single hit scored double and cleared the
+  // threshold alone, so "Open Source Summit" reduced to `open` + `source` and `source`
+  // pre-selected an unrelated "Source newsletter". A confident wrong pick is the one outcome the
+  // suggestion must never produce.
+  //
+  // `forum` (5) and `expo` (4) are shorter than that and do NOT clear the threshold alone. They
+  // are here because they are just as generic and still inflate a score toward it -- the list is
+  // about the words carrying no event identity, not about their length. An earlier version of
+  // this note said they were all six-plus characters, which two of them are not.
   'source',
   'global',
   'online',

--- a/packages/shared/src/interfaces/campaign.interface.ts
+++ b/packages/shared/src/interfaces/campaign.interface.ts
@@ -152,6 +152,31 @@ export interface CampaignBriefRequest {
   previousCopy?: Record<string, unknown>;
 }
 
+/**
+ * The event's terms, split by how much authority each kind carries when suggesting a template.
+ *
+ * Three kinds rather than one list, because they answer different questions and conflating them
+ * produced two real false positives:
+ *
+ * - `decisive` (event name and slug) is the ONLY kind that may push a template over the
+ *   suggestion threshold. These identify the event itself.
+ * - `ranking` (city) orders results but can never justify a suggestion on its own. Operators do
+ *   name templates by city, so the terms are worth sorting by -- but "Salt Lake City visitor
+ *   guide" matched `salt`, `lake` and `city` for a KubeCon brief and cleared the threshold with
+ *   no event term at all.
+ * - `year` breaks ties and nothing more. Dropping it made annual editions score identically, so
+ *   the server's order chose between "KubeCon NA 2025" and "KubeCon NA 2026"; counting it toward
+ *   the threshold would let "Open newsletter 2028" match an "Open Source Summit 2028" brief.
+ */
+export interface EventTemplateTerms {
+  /** Name and slug tokens. The only kind that can reach the suggestion threshold. */
+  decisive: string[];
+  /** City tokens. Improve ordering; never sufficient for a suggestion. */
+  ranking: string[];
+  /** The event's year, if it names one. A tie-break between otherwise-equal templates. */
+  year: string;
+}
+
 export interface CampaignEventDetails {
   name: string;
   dates: string;


### PR DESCRIPTION
## What

The event → branding mapping already exists in HubSpot, in the names its operators gave their templates. This reads the event off the brief and asks the portal which template belongs to it, then offers that as a **suggestion the operator can change**.

Branding, footer, address and sender keep coming from whichever template is chosen — which is why none of the hardcoded portal coupling #1698 describes exists in this service. We clone an operator-chosen template rather than assembling a body, so there are no baked module IDs, no LF street address, and no per-portal code to remove. I verified each of those claims by grep before building.

## How the derivation works

Terms come from the event **name, slug and city**, with stopwords and short tokens dropped — `summit` and `2026` match every second template in a portal and would manufacture hits that mean nothing. Themes are deliberately excluded: they describe subject matter (`cloud native`, `security`) and collide across unrelated events in the same portal.

**A distinctive term counts double.** This came out of the live portal, not a fixture: `KubeCon North America` reduces to `kubecon | salt | lake | city`, and the real template `KubeCon NA 2026 - Modern Registration Template` matches only `kubecon` — one hit, which an equal-weight score **withheld** despite the name stating the event unambiguously. A short token like `dev` still needs corroboration, since it turns up in unrelated names. Six characters is where the two groups separate in practice.

## Two properties carry the safety

- **It withholds below a confidence threshold.** A pre-selection reads as decided, so a wrong one is unlikely to be re-examined, and cloning the wrong template puts another event's branding into a real HubSpot draft. When nothing identifies the event, the picker behaves exactly as it did before.
- **It shows which terms matched.** "Matched on kubecon" can be checked at a glance; a suggestion whose reasoning is invisible cannot be judged.

It only ever pre-fills an **empty** selection, so a hand-picked template survives a re-search.

## A guard I removed

I first wrote an `emailTemplateSuggestionOverridden` flag to make an override stick. Mutation testing showed **no change to any test** when it was removed — the only path that clears the selection resets the brief-derived state in the same pass, so the flag could never be the reason a re-selection was refused. An unfalsifiable guard reads as protection that is not there, so it is gone and the reasoning is recorded in the comment.

## Verification

Against **500 real templates in the live portal**:

| Event | Result |
|---|---|
| MCP Dev Summit Nairobi | suggests `5 Days Left to Submit to Speak at MCP Dev Summit Nairobi`, matched `mcp, dev, nairobi` (score 12); all three MCP templates ranked to the top |
| KubeCon North America | suggests `KubeCon NA 2026 - Modern Registration Template`, matched `kubecon` (score 6) |
| A short token only (`Dev tools digest`) | **withheld** (score 3) |
| An event the portal has nothing for | **withheld**, no banner, no pre-selection |

10 tests added. Every guard is mutation-proven, including **both directions** of the distinctiveness rule — treating all terms equally fails the KubeCon test, treating all as distinctive fails the weak-token test. 1398/1398 pass; AOT build, lint and license check clean.

## Stacking

Based on `feat/issue-1699-email-monitor` (#1947). Companion backend PR: linuxfoundation/lfx-v2-campaign-service#196 (per-project sender), which is independent and can merge on its own.

Refs #1698