### PR TITLE
feat(meetings): group filter and entry point for the public calendar

### DIFF
--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -12,16 +12,33 @@
       <div class="mb-6">
         <div class="flex justify-between items-center w-full gap-4">
           <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>
-          @if (activeLens() !== 'me' && canWriteMeetings()) {
-            <lfx-button
-              icon="fa-light fa-calendar"
-              severity="info"
-              [attr.data-testid]="'meeting-create-button'"
-              label="Create Meeting"
-              size="small"
-              [routerLink]="['/meetings', 'create']">
-            </lfx-button>
-          }
+          <div class="flex items-center gap-2">
+            <!-- Gated independently of Create Meeting: the public calendar is a read-only view anyone
+                 with project context can share, so it is not behind meeting write access. -->
+            @if (publicCalendarUrl(); as calendarUrl) {
+              <lfx-button
+                icon="fa-light fa-globe"
+                severity="secondary"
+                [outlined]="true"
+                [attr.data-testid]="'public-calendar-button'"
+                label="Public Calendar"
+                size="small"
+                [href]="calendarUrl"
+                target="_blank"
+                rel="noopener noreferrer">
+              </lfx-button>
+            }
+            @if (activeLens() !== 'me' && canWriteMeetings()) {
+              <lfx-button
+                icon="fa-light fa-calendar"
+                severity="info"
+                [attr.data-testid]="'meeting-create-button'"
+                label="Create Meeting"
+                size="small"
+                [routerLink]="['/meetings', 'create']">
+              </lfx-button>
+            }
+          </div>
         </div>
         <p class="mt-1 text-sm text-gray-500">Coordinate decisions, align stakeholders, and maintain transparent governance in your project</p>
       </div>

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.html
@@ -10,9 +10,11 @@
   } @else {
     <div class="mt-3 mb-8">
       <div class="mb-6">
-        <div class="flex justify-between items-center w-full gap-4">
+        <!-- Stacks below sm: the heading plus two labelled actions cannot fit the mobile content width,
+             and the actions wrap so neither is clipped at high zoom. -->
+        <div class="flex flex-col gap-3 w-full sm:flex-row sm:justify-between sm:items-center sm:gap-4">
           <h1 class="font-display font-light text-2xl">{{ activeLens() === 'me' ? 'My Meetings' : 'Meetings' }}</h1>
-          <div class="flex items-center gap-2">
+          <div class="flex flex-wrap items-center gap-2">
             <!-- Gated independently of Create Meeting: the public calendar is a read-only view anyone
                  with project context can share, so it is not behind meeting write access. -->
             @if (publicCalendarUrl(); as calendarUrl) {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -353,13 +353,17 @@ export class MeetingsDashboardComponent {
 
   /**
    * Anonymous, shareable view of this project's PUBLIC meetings — the link a maintainer hands to their
-   * community. Null until the active project context resolves, and on the Me lens, which spans projects
-   * and so has no single public calendar to point at.
+   * community. Null until the active project context resolves.
+   *
+   * Restricted to the two project-scoped lenses. `me` spans projects, and `org` keeps a retained
+   * foundation/project selection that the reader is not currently looking at — linking from there would
+   * point at unrelated context. `NavLens` names exactly this pair.
    */
   private initPublicCalendarUrl(): Signal<string | null> {
     return computed(() => {
       const slug = this.project()?.slug;
-      if (!slug || this.activeLens() === 'me') {
+      const lens = this.activeLens();
+      if (!slug || (lens !== 'foundation' && lens !== 'project')) {
         return null;
       }
       return `/projects/${encodeURIComponent(slug)}/calendar`;

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -126,6 +126,18 @@ export class MeetingsDashboardComponent {
   public project: Signal<ProjectContext | null>;
   protected readonly canWrite = this.projectContextService.canWrite;
   protected readonly canWriteMeetings: Signal<boolean> = this.initCanWriteMeetings();
+  /**
+   * Anonymous, shareable view of this project's PUBLIC meetings — the link a maintainer hands to their
+   * community. Null until the active project context resolves, and on the Me lens, which spans projects
+   * and so has no single public calendar to point at.
+   */
+  protected readonly publicCalendarUrl: Signal<string | null> = computed(() => {
+    const slug = this.project()?.slug;
+    if (!slug || this.activeLens() === 'me') {
+      return null;
+    }
+    return `/projects/${encodeURIComponent(slug)}/calendar`;
+  });
   protected readonly isFiltered = this.initIsFiltered();
   public loadingMore = signal(false);
   public hasMore: Signal<boolean>;

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -126,18 +126,7 @@ export class MeetingsDashboardComponent {
   public project: Signal<ProjectContext | null>;
   protected readonly canWrite = this.projectContextService.canWrite;
   protected readonly canWriteMeetings: Signal<boolean> = this.initCanWriteMeetings();
-  /**
-   * Anonymous, shareable view of this project's PUBLIC meetings — the link a maintainer hands to their
-   * community. Null until the active project context resolves, and on the Me lens, which spans projects
-   * and so has no single public calendar to point at.
-   */
-  protected readonly publicCalendarUrl: Signal<string | null> = computed(() => {
-    const slug = this.project()?.slug;
-    if (!slug || this.activeLens() === 'me') {
-      return null;
-    }
-    return `/projects/${encodeURIComponent(slug)}/calendar`;
-  });
+  protected readonly publicCalendarUrl: Signal<string | null> = this.initPublicCalendarUrl();
   protected readonly isFiltered = this.initIsFiltered();
   public loadingMore = signal(false);
   public hasMore: Signal<boolean>;
@@ -360,6 +349,21 @@ export class MeetingsDashboardComponent {
     } else {
       this.loadMoreUpcoming$.next(pageToken);
     }
+  }
+
+  /**
+   * Anonymous, shareable view of this project's PUBLIC meetings — the link a maintainer hands to their
+   * community. Null until the active project context resolves, and on the Me lens, which spans projects
+   * and so has no single public calendar to point at.
+   */
+  private initPublicCalendarUrl(): Signal<string | null> {
+    return computed(() => {
+      const slug = this.project()?.slug;
+      if (!slug || this.activeLens() === 'me') {
+        return null;
+      }
+      return `/projects/${encodeURIComponent(slug)}/calendar`;
+    });
   }
 
   private initCanWriteMeetings(): Signal<boolean> {

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
@@ -20,15 +20,22 @@
         </h1>
         <p class="text-sm text-gray-500" data-testid="public-project-calendar-subtitle">
           {{ total() }} {{ total() === 1 ? 'meeting' : 'meetings' }}
+          <!-- The count is filtered whenever the URL carries a group, so it must be labelled as such even
+               when the directory is unavailable to name that group — an unqualified count reads as the
+               project's whole calendar. -->
           @if (activeCommittee(); as committee) {
             in {{ committee.name }}
+          } @else if (activeCommitteeUid()) {
+            in the selected group
           }
         </p>
       }
     </header>
 
-    <!-- Filter needs the public group directory; the legend only needs rendered events, so they gate apart -->
-    @if (committeeOptions().length > 1 || legendItems().length) {
+    <!-- Filter needs the public group directory; the legend only needs rendered events, so they gate apart.
+         An applied filter also opens this row on its own, so the escape hatch below stays reachable when
+         the directory is unavailable and the dropdown cannot render. -->
+    @if (committeeOptions().length > 1 || activeCommitteeUid() || legendItems().length) {
       <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between" data-testid="public-project-calendar-filters">
         @if (committeeOptions().length > 1) {
           <div class="flex items-center gap-2">
@@ -45,6 +52,17 @@
               (onChange)="onCommitteeChange($event)"
               data-testid="public-project-calendar-committee-filter" />
           </div>
+        } @else if (activeCommitteeUid()) {
+          <!-- Filtered, but the directory that populates the dropdown is unavailable. Without this the
+               reader is stuck on a filtered calendar with no control that clears it. -->
+          <lfx-button
+            icon="fa-light fa-calendar"
+            severity="secondary"
+            [outlined]="true"
+            label="View all meetings"
+            size="small"
+            (click)="clearCommitteeFilter()"
+            data-testid="public-project-calendar-clear-filter" />
         }
 
         <!-- Names every colour on the canvas, including the past and cancelled treatments that override
@@ -84,15 +102,17 @@
         (ctaClick)="clearCommitteeFilter()"
         data-testid="public-project-calendar-unknown-committee" />
     } @else if (total() === 0) {
+      <!-- Keyed on the raw UID, not the resolved group: the filter is applied whether or not the
+           directory could name it, and claiming the project has no meetings would be false. -->
       <lfx-empty-state
         icon="fa-light fa-calendar-xmark"
         title="No public meetings"
         [subtitle]="
-          activeCommittee()
-            ? 'This group has no public meetings on the calendar yet.'
+          activeCommitteeUid()
+            ? 'No public meetings on the calendar for the selected group yet.'
             : 'This project has no public meetings on the calendar yet. Check back soon.'
         "
-        [ctaLabel]="activeCommittee() ? 'View all meetings' : undefined"
+        [ctaLabel]="activeCommitteeUid() ? 'View all meetings' : undefined"
         ctaIcon="fa-light fa-calendar"
         (ctaClick)="clearCommitteeFilter()"
         data-testid="public-project-calendar-empty" />

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
@@ -27,24 +27,28 @@
       }
     </header>
 
-    <!-- Group filter — only rendered once the public group directory has loaded -->
-    @if (committeeOptions().length > 1) {
+    <!-- Filter needs the public group directory; the legend only needs rendered events, so they gate apart -->
+    @if (committeeOptions().length > 1 || legendItems().length) {
       <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between" data-testid="public-project-calendar-filters">
-        <div class="flex items-center gap-2">
-          <label for="public-calendar-committee-filter" class="text-sm text-gray-700">Group</label>
-          <lfx-select
-            inputId="public-calendar-committee-filter"
-            ariaLabel="Filter calendar by group"
-            [form]="committeeForm"
-            control="committee"
-            [options]="committeeOptions()"
-            placeholder="All groups"
-            styleClass="w-full sm:w-64"
-            (onChange)="onCommitteeChange($event)"
-            dataTest="public-project-calendar-committee-filter" />
-        </div>
+        @if (committeeOptions().length > 1) {
+          <div class="flex items-center gap-2">
+            <!-- A span, not a label: PrimeNG renders the non-editable select as role="combobox" on a
+                 span, which `for` cannot target — the association has to go through aria-labelledby. -->
+            <span id="public-calendar-committee-filter-label" class="text-sm text-gray-700">Group</span>
+            <lfx-select
+              ariaLabelledBy="public-calendar-committee-filter-label"
+              [form]="committeeForm"
+              control="committee"
+              [options]="committeeOptions()"
+              placeholder="All groups"
+              styleClass="w-full sm:w-64"
+              (onChange)="onCommitteeChange($event)"
+              dataTest="public-project-calendar-committee-filter" />
+          </div>
+        }
 
-        <!-- Legend: the color key is duplicated in each event's title suffix, so color is never the only cue -->
+        <!-- Names every colour on the canvas, including the past and cancelled treatments that override
+             a group's own colour, so hue is never the only carrier of meaning -->
         @if (legendItems().length) {
           <ul class="flex flex-wrap items-center gap-x-4 gap-y-2" data-testid="public-project-calendar-legend">
             @for (item of legendItems(); track item.label) {

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
@@ -18,9 +18,45 @@
             Calendar
           }
         </h1>
-        <p class="text-sm text-gray-500" data-testid="public-project-calendar-subtitle">{{ total() }} {{ total() === 1 ? 'meeting' : 'meetings' }}</p>
+        <p class="text-sm text-gray-500" data-testid="public-project-calendar-subtitle">
+          {{ total() }} {{ total() === 1 ? 'meeting' : 'meetings' }}
+          @if (activeCommittee(); as committee) {
+            in {{ committee.name }}
+          }
+        </p>
       }
     </header>
+
+    <!-- Group filter — only rendered once the public group directory has loaded -->
+    @if (committeeOptions().length > 1) {
+      <div class="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between" data-testid="public-project-calendar-filters">
+        <div class="flex items-center gap-2">
+          <label for="public-calendar-committee-filter" class="text-sm text-gray-700">Group</label>
+          <lfx-select
+            inputId="public-calendar-committee-filter"
+            ariaLabel="Filter calendar by group"
+            [form]="committeeForm"
+            control="committee"
+            [options]="committeeOptions()"
+            placeholder="All groups"
+            styleClass="w-full sm:w-64"
+            (onChange)="onCommitteeChange($event)"
+            dataTest="public-project-calendar-committee-filter" />
+        </div>
+
+        <!-- Legend: the color key is duplicated in each event's title suffix, so color is never the only cue -->
+        @if (legendItems().length) {
+          <ul class="flex flex-wrap items-center gap-x-4 gap-y-2" data-testid="public-project-calendar-legend">
+            @for (item of legendItems(); track item.label) {
+              <li class="flex items-center gap-1.5 text-xs text-gray-600">
+                <span class="h-2.5 w-2.5 rounded-sm" [style.background-color]="item.color" aria-hidden="true"></span>
+                {{ item.label }}
+              </li>
+            }
+          </ul>
+        }
+      </div>
+    }
 
     <!-- Error state -->
     @if (fetchError()) {
@@ -34,6 +70,28 @@
       <div class="flex flex-col gap-3 rounded-lg border border-gray-200 bg-white p-4" data-testid="public-project-calendar-skeleton">
         <p-skeleton width="100%" height="24rem" />
       </div>
+    } @else if (unknownCommittee()) {
+      <lfx-empty-state
+        icon="fa-light fa-users-slash"
+        title="Group not found"
+        subtitle="This link points to a group that is not part of this project's public directory. It may have been renamed, made private, or removed."
+        ctaLabel="View all meetings"
+        ctaIcon="fa-light fa-calendar"
+        (ctaClick)="clearCommitteeFilter()"
+        data-testid="public-project-calendar-unknown-committee" />
+    } @else if (total() === 0) {
+      <lfx-empty-state
+        icon="fa-light fa-calendar-xmark"
+        title="No public meetings"
+        [subtitle]="
+          activeCommittee()
+            ? 'This group has no public meetings on the calendar yet.'
+            : 'This project has no public meetings on the calendar yet. Check back soon.'
+        "
+        [ctaLabel]="activeCommittee() ? 'View all meetings' : undefined"
+        ctaIcon="fa-light fa-calendar"
+        (ctaClick)="clearCommitteeFilter()"
+        data-testid="public-project-calendar-empty" />
     } @else {
       <div class="rounded-lg border border-gray-200 bg-white p-4" data-testid="public-project-calendar-container">
         <lfx-fullcalendar

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.html
@@ -43,7 +43,7 @@
               placeholder="All groups"
               styleClass="w-full sm:w-64"
               (onChange)="onCommitteeChange($event)"
-              dataTest="public-project-calendar-committee-filter" />
+              data-testid="public-project-calendar-committee-filter" />
           </div>
         }
 

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
@@ -4,25 +4,42 @@
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { ActivatedRoute, provideRouter } from '@angular/router';
+import { ActivatedRoute, provideRouter, Router } from '@angular/router';
+import { BEHAVIORAL_CLASS_CALENDAR_COLORS } from '@lfx-one/shared/constants';
+import { GroupService } from '@services/group.service';
 import { MeetingService } from '@services/meeting.service';
 import { headerTestProviders, installMatchMediaShim } from '@shared/testing/header-test-providers';
 import { BehaviorSubject, of, throwError } from 'rxjs';
 import { beforeAll, describe, expect, it, vi } from 'vitest';
 
-import type { PublicCalendarMeeting, PublicProjectMeetingsResponse } from '@lfx-one/shared/interfaces';
+import type { EventInput } from '@fullcalendar/core';
+import type { PublicCalendarMeeting, PublicGroupSummary, PublicProjectMeetingsResponse } from '@lfx-one/shared/interfaces';
 
 import { PublicProjectCalendarComponent } from './public-project-calendar.component';
 
 beforeAll(installMatchMediaShim);
 
+const TSC_UID = '11111111-1111-4111-8111-111111111111';
+const BOARD_UID = '22222222-2222-4222-8222-222222222222';
+
 function meeting(over: Partial<PublicCalendarMeeting> = {}): PublicCalendarMeeting {
   return {
     id: 'meeting-1',
     title: 'Technical Steering Committee',
-    start_time: '2026-09-01T15:00:00Z',
+    start_time: '2999-09-01T15:00:00Z',
     duration: 60,
     timezone: 'America/New_York',
+    ...over,
+  };
+}
+
+function group(over: Partial<PublicGroupSummary> = {}): PublicGroupSummary {
+  return {
+    uid: TSC_UID,
+    name: 'TSC',
+    category: 'Technical Steering Committee',
+    behavioral_class: 'oversight-committee',
+    context: { scope: 'project', foundation_uid: 'f1', foundation_name: 'CNCF', foundation_slug: 'cncf' },
     ...over,
   };
 }
@@ -39,19 +56,34 @@ function response(over: Partial<PublicProjectMeetingsResponse> = {}): PublicProj
 describe('PublicProjectCalendarComponent', () => {
   let fixture: ComponentFixture<PublicProjectCalendarComponent>;
   let getPublicProjectMeetings: ReturnType<typeof vi.fn>;
+  let getPublicProjectGroups: ReturnType<typeof vi.fn>;
   let queryParamMap: BehaviorSubject<Map<string, string>>;
+
+  /** Reads the protected signals the template binds to, without loosening their visibility in the component. */
+  function instance(): { calendarEvents: () => EventInput[]; initialView: () => string; clearCommitteeFilter: () => void } {
+    return fixture.componentInstance as unknown as {
+      calendarEvents: () => EventInput[];
+      initialView: () => string;
+      clearCommitteeFilter: () => void;
+    };
+  }
 
   async function render(
     options: {
       response?: PublicProjectMeetingsResponse;
       fail?: boolean;
+      groups?: PublicGroupSummary[];
+      groupsFail?: boolean;
       slug?: string;
       query?: Map<string, string>;
     } = {}
   ): Promise<void> {
-    const { fail = false, slug = 'kubernetes' } = options;
+    const { fail = false, groupsFail = false, slug = 'kubernetes' } = options;
     queryParamMap = new BehaviorSubject(options.query ?? new Map<string, string>());
     getPublicProjectMeetings = vi.fn(() => (fail ? throwError(() => new Error('upstream 503')) : of(options.response ?? response())));
+    getPublicProjectGroups = vi.fn(() =>
+      groupsFail ? throwError(() => new Error('directory 503')) : of({ groups: options.groups ?? [], total: (options.groups ?? []).length })
+    );
 
     TestBed.resetTestingModule();
     await TestBed.configureTestingModule({
@@ -62,6 +94,7 @@ describe('PublicProjectCalendarComponent', () => {
         provideHttpClient(),
         provideHttpClientTesting(),
         { provide: MeetingService, useValue: { getPublicProjectMeetings } },
+        { provide: GroupService, useValue: { getPublicProjectGroups } },
         // After provideRouter, which also provides ActivatedRoute — the last provider wins, and the
         // router's own empty paramMap would otherwise silently swallow the slug/committee assertions.
         {
@@ -93,17 +126,17 @@ describe('PublicProjectCalendarComponent', () => {
   });
 
   it('scopes the request to a committee when ?committee= is present', async () => {
-    await render({ query: new Map([['committee', 'committee-uid-1234']]) });
+    await render({ query: new Map([['committee', TSC_UID]]) });
 
-    expect(getPublicProjectMeetings).toHaveBeenCalledWith('kubernetes', 'committee-uid-1234');
+    expect(getPublicProjectMeetings).toHaveBeenCalledWith('kubernetes', TSC_UID);
   });
 
   it('opens on the week view when ?view=week, and the month view otherwise', async () => {
     await render({ query: new Map([['view', 'week']]) });
-    expect((fixture.componentInstance as unknown as { initialView: () => string }).initialView()).toBe('timeGridWeek');
+    expect(instance().initialView()).toBe('timeGridWeek');
 
     await render();
-    expect((fixture.componentInstance as unknown as { initialView: () => string }).initialView()).toBe('dayGridMonth');
+    expect(instance().initialView()).toBe('dayGridMonth');
   });
 
   it('does not refetch when only ?view changes', async () => {
@@ -123,10 +156,106 @@ describe('PublicProjectCalendarComponent', () => {
     await render();
     expect(getPublicProjectMeetings).toHaveBeenCalledTimes(1);
 
-    queryParamMap.next(new Map([['committee', 'committee-uid-1234']]));
+    queryParamMap.next(new Map([['committee', TSC_UID]]));
     await fixture.whenStable();
 
     expect(getPublicProjectMeetings).toHaveBeenCalledTimes(2);
-    expect(getPublicProjectMeetings).toHaveBeenLastCalledWith('kubernetes', 'committee-uid-1234');
+    expect(getPublicProjectMeetings).toHaveBeenLastCalledWith('kubernetes', TSC_UID);
+  });
+
+  describe('group filter', () => {
+    it('renders the filter and a colour legend once the public directory resolves', async () => {
+      await render({
+        groups: [group()],
+        response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
+      });
+
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-filters"]')).not.toBeNull();
+      const legend = fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]');
+      expect(legend?.textContent).toContain('Oversight');
+    });
+
+    it('does not render the filter when the directory has no groups', async () => {
+      await render({ groups: [] });
+
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-filters"]')).toBeNull();
+    });
+
+    it('keeps rendering the calendar when the group directory fetch fails', async () => {
+      // The directory only supplies labels and colours — losing it must not escalate to the page error state.
+      await render({ groupsFail: true });
+
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-container"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-error"]')).toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-filters"]')).toBeNull();
+    });
+
+    it('colours events by behavioural class and suffixes the group name when unfiltered', async () => {
+      await render({
+        groups: [group()],
+        response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
+      });
+
+      const [event] = instance().calendarEvents();
+      expect(event.title).toBe('Technical Steering Committee · TSC');
+      expect(event.backgroundColor).toBe(BEHAVIORAL_CLASS_CALENDAR_COLORS['oversight-committee'].bg);
+    });
+
+    it('drops the redundant group suffix while a filter is applied', async () => {
+      await render({
+        groups: [group()],
+        query: new Map([['committee', TSC_UID]]),
+        response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
+      });
+
+      const [event] = instance().calendarEvents();
+      expect(event.title).toBe('Technical Steering Committee');
+      expect(event.backgroundColor).toBe(BEHAVIORAL_CLASS_CALENDAR_COLORS['oversight-committee'].bg);
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]')).toBeNull();
+    });
+
+    it('leaves committees missing from the public directory unlabelled', async () => {
+      // A PUBLIC meeting can belong to a committee the directory does not list; nothing about it,
+      // name included, is publishable, so the event falls back to default styling.
+      await render({
+        groups: [group()],
+        response: response({ meetings: [meeting({ committee_uids: [BOARD_UID] })] }),
+      });
+
+      const [event] = instance().calendarEvents();
+      expect(event.title).toBe('Technical Steering Committee');
+      expect(event.backgroundColor).not.toBe(BEHAVIORAL_CLASS_CALENDAR_COLORS['oversight-committee'].bg);
+    });
+
+    it('distinguishes an unknown committee filter from an empty calendar', async () => {
+      await render({
+        groups: [group()],
+        query: new Map([['committee', BOARD_UID]]),
+        response: response({ meetings: [], total: 0 }),
+      });
+
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-unknown-committee"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-empty"]')).toBeNull();
+    });
+
+    it('shows the empty state when a known group has no public meetings', async () => {
+      await render({
+        groups: [group()],
+        query: new Map([['committee', TSC_UID]]),
+        response: response({ meetings: [], total: 0 }),
+      });
+
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-empty"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-unknown-committee"]')).toBeNull();
+    });
+
+    it('clears the filter through the URL so the view stays shareable', async () => {
+      await render({ groups: [group()], query: new Map([['committee', TSC_UID]]) });
+      const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);
+
+      instance().clearCommitteeFilter();
+
+      expect(navigate).toHaveBeenCalledWith([], expect.objectContaining({ queryParams: { committee: null }, queryParamsHandling: 'merge' }));
+    });
   });
 });

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
@@ -21,6 +21,8 @@ beforeAll(installMatchMediaShim);
 
 const TSC_UID = '11111111-1111-4111-8111-111111111111';
 const BOARD_UID = '22222222-2222-4222-8222-222222222222';
+/** Comfortably ended, so the occurrence renders with the past treatment rather than its group colour. */
+const PAST_START = '2020-01-01T15:00:00Z';
 
 function meeting(over: Partial<PublicCalendarMeeting> = {}): PublicCalendarMeeting {
   return {
@@ -167,12 +169,24 @@ describe('PublicProjectCalendarComponent', () => {
     it('renders the filter and a colour legend once the public directory resolves', async () => {
       await render({
         groups: [group()],
-        response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
+        response: response({
+          meetings: [meeting({ committee_uids: [TSC_UID] }), meeting({ id: 'meeting-2', start_time: PAST_START, committee_uids: [TSC_UID] })],
+        }),
       });
 
       expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-filters"]')).not.toBeNull();
       const legend = fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]');
       expect(legend?.textContent).toContain('Oversight');
+      expect(legend?.textContent).toContain('Past');
+    });
+
+    it('suppresses a legend that would carry a single colour, which distinguishes nothing', async () => {
+      await render({
+        groups: [group()],
+        response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
+      });
+
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]')).toBeNull();
     });
 
     it('does not render the filter when the directory has no groups', async () => {
@@ -211,7 +225,45 @@ describe('PublicProjectCalendarComponent', () => {
       const [event] = instance().calendarEvents();
       expect(event.title).toBe('Technical Steering Committee');
       expect(event.backgroundColor).toBe(BEHAVIORAL_CLASS_CALENDAR_COLORS['oversight-committee'].bg);
-      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]')).toBeNull();
+    });
+
+    it('prefers the server-computed behavioural class over one derived from the category', async () => {
+      // Guards against the calendar's colours drifting from the badges the public group directory
+      // renders, which read `behavioral_class` directly.
+      await render({
+        groups: [group({ behavioral_class: 'governing-board' })],
+        response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
+      });
+
+      const [event] = instance().calendarEvents();
+      expect(event.backgroundColor).toBe(BEHAVIORAL_CLASS_CALENDAR_COLORS['governing-board'].bg);
+    });
+
+    it('names only the colours actually on the canvas, not the ones the groups imply', async () => {
+      // The oversight meeting has ended, so it renders in the past treatment rather than its group's
+      // colour. A legend built from committee associations would advertise an "Oversight" swatch that
+      // appears nowhere on screen — worse than no legend, since the legend is the colour key.
+      await render({
+        groups: [group(), group({ uid: BOARD_UID, name: 'Governing Board', behavioral_class: 'governing-board' })],
+        response: response({
+          meetings: [meeting({ committee_uids: [TSC_UID], start_time: PAST_START }), meeting({ id: 'meeting-2', committee_uids: [BOARD_UID] })],
+        }),
+      });
+
+      const legend = fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]');
+      expect(legend?.textContent).toContain('Past');
+      expect(legend?.textContent).toContain('Boards');
+      expect(legend?.textContent).not.toContain('Oversight');
+    });
+
+    it('treats a malformed committee param as an unknown group without calling the feed', async () => {
+      // The server rejects a non-UUID committee with a 400, which would otherwise surface as the
+      // generic page error rather than the group-not-found state it really is.
+      await render({ groups: [group()], query: new Map([['committee', 'tsc']]) });
+
+      expect(getPublicProjectMeetings).not.toHaveBeenCalled();
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-unknown-committee"]')).not.toBeNull();
+      expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-error"]')).toBeNull();
     });
 
     it('leaves committees missing from the public directory unlabelled', async () => {

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
@@ -23,6 +23,8 @@ const TSC_UID = '11111111-1111-4111-8111-111111111111';
 const BOARD_UID = '22222222-2222-4222-8222-222222222222';
 /** Comfortably ended, so the occurrence renders with the past treatment rather than its group colour. */
 const PAST_START = '2020-01-01T15:00:00Z';
+/** Far enough out that the occurrence is never past, isolating the cancelled treatment. */
+const FUTURE_START = '2999-09-01T15:00:00Z';
 
 function meeting(over: Partial<PublicCalendarMeeting> = {}): PublicCalendarMeeting {
   return {
@@ -180,13 +182,33 @@ describe('PublicProjectCalendarComponent', () => {
       expect(legend?.textContent).toContain('Past');
     });
 
-    it('suppresses a legend that would carry a single colour, which distinguishes nothing', async () => {
-      await render({
-        groups: [group()],
-        response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
-      });
+    it('suppresses a lone unattributed swatch, which names only an absence', async () => {
+      // No directory match, so every event takes the fallback fill. "No publicly listed group" as the
+      // only key tells the reader nothing the calendar does not already show.
+      await render({ groups: [], response: response({ meetings: [meeting()] }) });
 
       expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]')).toBeNull();
+    });
+
+    // A cancelled or past event keeps its ordinary title — the fill is the only thing marking its state,
+    // so dropping a single-entry legend here would leave colour as the sole carrier of meaning.
+    it('keeps a single-entry legend when that colour is the only cancellation cue', async () => {
+      await render({
+        groups: [group()],
+        response: response({
+          meetings: [
+            meeting({
+              committee_uids: [TSC_UID],
+              occurrences: [{ occurrence_id: 'o1', start_time: FUTURE_START, duration: 30 }],
+              cancelled_occurrences: ['o1'],
+            }),
+          ],
+        }),
+      });
+
+      const legend = fixture.nativeElement.querySelector('[data-testid="public-project-calendar-legend"]');
+      expect(legend).not.toBeNull();
+      expect(legend.textContent).toContain('Cancelled');
     });
 
     it('does not render the filter when the directory has no groups', async () => {

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.spec.ts
@@ -301,6 +301,39 @@ describe('PublicProjectCalendarComponent', () => {
       expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-unknown-committee"]')).toBeNull();
     });
 
+    // The directory resolves the group's *name*; the URL decides whether a filter is applied at all.
+    // Keying the filtered affordances on the name conflated the two, so a directory outage silently
+    // presented a filtered calendar as the project's whole calendar, with no control that cleared it.
+    describe('filter applied while the group directory is unavailable', () => {
+      it('does not claim the project has no meetings, and still offers the escape', async () => {
+        await render({
+          groupsFail: true,
+          query: new Map([['committee', TSC_UID]]),
+          response: response({ meetings: [], total: 0 }),
+        });
+
+        const empty = fixture.nativeElement.querySelector('[data-testid="public-project-calendar-empty"]');
+        expect(empty).not.toBeNull();
+        expect(empty.textContent).toContain('selected group');
+        expect(empty.textContent).not.toContain('This project has no public meetings');
+        expect(empty.textContent).toContain('View all meetings');
+        // Not the unknown-group state: an empty directory cannot prove the UID is bad.
+        expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-unknown-committee"]')).toBeNull();
+      });
+
+      it('labels the filtered count and renders a clear-filter control in place of the dropdown', async () => {
+        await render({
+          groupsFail: true,
+          query: new Map([['committee', TSC_UID]]),
+          response: response({ meetings: [meeting({ committee_uids: [TSC_UID] })] }),
+        });
+
+        expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-subtitle"]').textContent).toContain('in the selected group');
+        expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-committee-filter"]')).toBeNull();
+        expect(fixture.nativeElement.querySelector('[data-testid="public-project-calendar-clear-filter"]')).not.toBeNull();
+      });
+    });
+
     it('clears the filter through the URL so the view stays shareable', async () => {
       await render({ groups: [group()], query: new Map([['committee', TSC_UID]]) });
       const navigate = vi.spyOn(TestBed.inject(Router), 'navigate').mockResolvedValue(true);

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -11,7 +11,7 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { HeaderComponent } from '@components/header/header.component';
 import { SelectComponent } from '@components/select/select.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { BEHAVIORAL_CLASS_CONFIG } from '@lfx-one/shared/constants';
+import { BEHAVIORAL_CLASS_CONFIG, MEETING_TYPE_COLORS } from '@lfx-one/shared/constants';
 import {
   CalendarLegendItem,
   GroupBehavioralClass,
@@ -76,7 +76,9 @@ export class PublicProjectCalendarComponent {
     { label: 'All groups', value: null },
     ...this.groups()
       .map((group) => ({ label: group.name, value: group.uid }))
-      .sort((a, b) => a.label.localeCompare(b.label)),
+      // Locale pinned because this page is server-rendered: an unpinned sort can order names one way in
+      // Node and another in the browser, which would reshuffle the options during hydration.
+      .sort((a, b) => a.label.localeCompare(b.label, 'en')),
   ]);
 
   protected readonly activeCommittee: Signal<PublicCalendarCommittee | undefined> = computed(() => {
@@ -146,13 +148,18 @@ export class PublicProjectCalendarComponent {
   /**
    * The colors on screen and what each one means — see `resolvePublicCalendarLegend`.
    *
-   * Suppressed below two entries: one color distinguishes nothing, so there is no key to explain, and a
-   * lone "No group" swatch (an unfiltered calendar with no group directory) is pure noise.
+   * Only a lone unattributed swatch is suppressed: it names the absence of a group, which tells a reader
+   * nothing the calendar does not already show. Every other single-entry legend is kept, because the
+   * cancelled and past fills are the sole carrier of that state — those events keep their ordinary
+   * titles, so dropping the key would leave color as the only signal (WCAG 1.4.1).
    */
   private initLegendItems(): Signal<CalendarLegendItem[]> {
     return computed(() => {
       const legend = resolvePublicCalendarLegend(this.calendarEvents());
-      return legend.length > 1 ? legend : [];
+      if (legend.length === 1 && legend[0].color === MEETING_TYPE_COLORS['default'].bg) {
+        return [];
+      }
+      return legend;
     });
   }
 

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -6,6 +6,7 @@ import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
 import { FormControl, FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FullCalendarComponent } from '@app/shared/components/fullcalendar/fullcalendar.component';
+import { ButtonComponent } from '@components/button/button.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { HeaderComponent } from '@components/header/header.component';
 import { SelectComponent } from '@components/select/select.component';
@@ -35,7 +36,7 @@ import { catchError, combineLatest, distinctUntilChanged, map, of, switchMap } f
 
 @Component({
   selector: 'lfx-public-project-calendar',
-  imports: [FullCalendarComponent, EmptyStateComponent, HeaderComponent, SelectComponent, SkeletonModule],
+  imports: [ButtonComponent, FullCalendarComponent, EmptyStateComponent, HeaderComponent, SelectComponent, SkeletonModule],
   templateUrl: './public-project-calendar.component.html',
 })
 export class PublicProjectCalendarComponent {

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -43,12 +43,12 @@ export class PublicProjectCalendarComponent {
   private readonly meetingService = inject(MeetingService);
   private readonly groupService = inject(GroupService);
 
-  protected readonly loading = signal(true);
-  protected readonly fetchError = signal(false);
-
   protected readonly committeeForm = new FormGroup({
     committee: new FormControl<string | null>(null),
   });
+
+  protected readonly loading = signal(true);
+  protected readonly fetchError = signal(false);
 
   private readonly calendarData: Signal<PublicProjectMeetingsResponse | null> = this.initCalendarData();
   private readonly groups: Signal<PublicGroupSummary[]> = this.initGroups();
@@ -59,17 +59,7 @@ export class PublicProjectCalendarComponent {
   protected readonly projectName: Signal<string> = computed(() => this.calendarData()?.project?.name ?? '');
   protected readonly total: Signal<number> = computed(() => this.calendarData()?.total ?? 0);
 
-  /**
-   * Publicly listed groups keyed by UID — the only source of committee names and colors on this page.
-   * The meetings feed publishes committee UIDs without names, so a committee missing from the directory
-   * stays anonymous rather than having a non-public name rendered.
-   */
-  private readonly committeesByUid: Signal<Record<string, PublicCalendarCommittee>> = computed(() =>
-    this.groups().reduce<Record<string, PublicCalendarCommittee>>((byUid, group) => {
-      byUid[group.uid] = { uid: group.uid, name: group.name, behavioralClass: getGroupBehavioralClass(group.category) };
-      return byUid;
-    }, {})
-  );
+  private readonly committeesByUid: Signal<Record<string, PublicCalendarCommittee>> = this.initCommitteesByUid();
 
   private readonly committeeContext: Signal<PublicCalendarCommitteeContext> = computed(() => ({
     activeCommitteeUid: this.activeCommitteeUid() ?? undefined,
@@ -110,29 +100,7 @@ export class PublicProjectCalendarComponent {
     return (this.calendarData()?.meetings ?? []).flatMap((meeting) => publicMeetingToCalendarEvents(meeting, context) as EventInput[]);
   });
 
-  /**
-   * Group types present in the rendered events, paired with the color those events carry. Renders only
-   * when unfiltered — under a filter every event shares one color and the dropdown already names it.
-   */
-  protected readonly legendItems: Signal<CalendarLegendItem[]> = computed(() => {
-    if (this.activeCommitteeUid()) {
-      return [];
-    }
-
-    const committeesByUid = this.committeesByUid();
-    const behavioralClasses = new Set<GroupBehavioralClass>();
-    for (const meeting of this.calendarData()?.meetings ?? []) {
-      const committee = resolvePublicCalendarCommittee(meeting, { committeesByUid });
-      if (committee) {
-        behavioralClasses.add(committee.behavioralClass);
-      }
-    }
-
-    return [...behavioralClasses].map((behavioralClass) => ({
-      label: BEHAVIORAL_CLASS_CONFIG[behavioralClass].label,
-      color: BEHAVIORAL_CLASS_CALENDAR_COLORS[behavioralClass].bg,
-    }));
-  });
+  protected readonly legendItems: Signal<CalendarLegendItem[]> = this.initLegendItems();
 
   public constructor() {
     // The URL stays authoritative for the dropdown so deep links and browser back/forward are reflected.
@@ -175,6 +143,46 @@ export class PublicProjectCalendarComponent {
 
   // Private initializer functions
 
+  /**
+   * Publicly listed groups keyed by UID — the only source of committee names and colors on this page.
+   * The meetings feed publishes committee UIDs without names, so a committee missing from the directory
+   * stays anonymous rather than having a non-public name rendered.
+   */
+  private initCommitteesByUid(): Signal<Record<string, PublicCalendarCommittee>> {
+    return computed(() =>
+      this.groups().reduce<Record<string, PublicCalendarCommittee>>((byUid, group) => {
+        byUid[group.uid] = { uid: group.uid, name: group.name, behavioralClass: getGroupBehavioralClass(group.category) };
+        return byUid;
+      }, {})
+    );
+  }
+
+  /**
+   * Group types present in the rendered events, paired with the color those events carry. Renders only
+   * when unfiltered — under a filter every event shares one color and the dropdown already names it.
+   */
+  private initLegendItems(): Signal<CalendarLegendItem[]> {
+    return computed(() => {
+      if (this.activeCommitteeUid()) {
+        return [];
+      }
+
+      const committeesByUid = this.committeesByUid();
+      const behavioralClasses = new Set<GroupBehavioralClass>();
+      for (const meeting of this.calendarData()?.meetings ?? []) {
+        const committee = resolvePublicCalendarCommittee(meeting, { committeesByUid });
+        if (committee) {
+          behavioralClasses.add(committee.behavioralClass);
+        }
+      }
+
+      return [...behavioralClasses].map((behavioralClass) => ({
+        label: BEHAVIORAL_CLASS_CONFIG[behavioralClass].label,
+        color: BEHAVIORAL_CLASS_CALENDAR_COLORS[behavioralClass].bg,
+      }));
+    });
+  }
+
   private initInitialView(): Signal<string> {
     return toSignal(this.route.queryParamMap.pipe(map((params) => (params.get('view') === 'week' ? 'timeGridWeek' : 'dayGridMonth'))), {
       initialValue: 'dayGridMonth',
@@ -201,8 +209,13 @@ export class PublicProjectCalendarComponent {
           this.groupService.getPublicProjectGroups(slug).pipe(
             map((response) => response.groups ?? []),
             // A directory failure costs the filter, labels, and legend but not the calendar itself, so
-            // degrade to an unlabelled calendar instead of surfacing the page-level error state.
-            catchError(() => of<PublicGroupSummary[]>([]))
+            // degrade to an unlabelled calendar instead of surfacing the page-level error state. Logged
+            // because the degrade is otherwise invisible: the page still renders and nothing tells an
+            // operator the filter silently vanished.
+            catchError((error) => {
+              console.error(`Failed to load the public group directory for project ${slug}:`, error);
+              return of<PublicGroupSummary[]>([]);
+            })
           )
         )
       ),
@@ -225,6 +238,8 @@ export class PublicProjectCalendarComponent {
               this.loading.set(false);
               return response;
             }),
+            // Not logged here: MeetingService.getPublicProjectMeetings already logs the failure before
+            // rethrowing, unlike GroupService, which has no handler of its own.
             catchError(() => {
               this.loading.set(false);
               this.fetchError.set(true);

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -10,7 +10,7 @@ import { EmptyStateComponent } from '@components/empty-state/empty-state.compone
 import { HeaderComponent } from '@components/header/header.component';
 import { SelectComponent } from '@components/select/select.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { BEHAVIORAL_CLASS_CALENDAR_COLORS, BEHAVIORAL_CLASS_CONFIG } from '@lfx-one/shared/constants';
+import { BEHAVIORAL_CLASS_CONFIG } from '@lfx-one/shared/constants';
 import {
   CalendarLegendItem,
   GroupBehavioralClass,
@@ -22,9 +22,10 @@ import {
 } from '@lfx-one/shared/interfaces';
 import {
   getGroupBehavioralClass,
+  isUuid,
   publicMeetingToCalendarEvents,
   resolveMeetingCalendarClickRoute,
-  resolvePublicCalendarCommittee,
+  resolvePublicCalendarLegend,
 } from '@lfx-one/shared/utils';
 import { GroupService } from '@services/group.service';
 import { MeetingService } from '@services/meeting.service';
@@ -86,12 +87,24 @@ export class PublicProjectCalendarComponent {
   });
 
   /**
-   * True when `?committee=` names a group the public directory does not list — a stale bookmark or a
-   * hand-edited URL. Distinguished from "no meetings" so the reader is told the filter is the problem.
-   * Requires a loaded directory: an empty `groups()` means not-yet-loaded or a failed fetch, neither of
-   * which proves the UID is bad.
+   * True when `?committee=` cannot name a group anyone could reach — a stale bookmark or a hand-edited
+   * URL. Distinguished from "no meetings" so the reader is told the filter is the problem.
+   *
+   * A malformed value is decided without waiting for the directory: nothing that isn't a UUID can ever
+   * match, and the request is skipped for it. A well-formed value needs a loaded directory before it can
+   * be called unknown — an empty `groups()` means not-yet-loaded or a failed fetch, neither of which
+   * proves the UID is bad.
    */
-  protected readonly unknownCommittee: Signal<boolean> = computed(() => !!this.activeCommitteeUid() && this.groups().length > 0 && !this.activeCommittee());
+  protected readonly unknownCommittee: Signal<boolean> = computed(() => {
+    const uid = this.activeCommitteeUid();
+    if (!uid) {
+      return false;
+    }
+    if (!isUuid(uid)) {
+      return true;
+    }
+    return this.groups().length > 0 && !this.activeCommittee();
+  });
 
   // publicMeetingToCalendarEvents (not meetingToCalendarEvents) — the public mapper never places a
   // meeting password in extendedProps, so a click can't forward one into the join URL, history, or referrer.
@@ -151,36 +164,35 @@ export class PublicProjectCalendarComponent {
   private initCommitteesByUid(): Signal<Record<string, PublicCalendarCommittee>> {
     return computed(() =>
       this.groups().reduce<Record<string, PublicCalendarCommittee>>((byUid, group) => {
-        byUid[group.uid] = { uid: group.uid, name: group.name, behavioralClass: getGroupBehavioralClass(group.category) };
+        byUid[group.uid] = { uid: group.uid, name: group.name, behavioralClass: this.toBehavioralClass(group) };
         return byUid;
       }, {})
     );
   }
 
   /**
-   * Group types present in the rendered events, paired with the color those events carry. Renders only
-   * when unfiltered — under a filter every event shares one color and the dropdown already names it.
+   * The colors on screen and what each one means — see `resolvePublicCalendarLegend`.
+   *
+   * Suppressed below two entries: one color distinguishes nothing, so there is no key to explain, and a
+   * lone "No group" swatch (an unfiltered calendar with no group directory) is pure noise.
    */
   private initLegendItems(): Signal<CalendarLegendItem[]> {
     return computed(() => {
-      if (this.activeCommitteeUid()) {
-        return [];
-      }
-
-      const committeesByUid = this.committeesByUid();
-      const behavioralClasses = new Set<GroupBehavioralClass>();
-      for (const meeting of this.calendarData()?.meetings ?? []) {
-        const committee = resolvePublicCalendarCommittee(meeting, { committeesByUid });
-        if (committee) {
-          behavioralClasses.add(committee.behavioralClass);
-        }
-      }
-
-      return [...behavioralClasses].map((behavioralClass) => ({
-        label: BEHAVIORAL_CLASS_CONFIG[behavioralClass].label,
-        color: BEHAVIORAL_CLASS_CALENDAR_COLORS[behavioralClass].bg,
-      }));
+      const legend = resolvePublicCalendarLegend(this.calendarEvents());
+      return legend.length > 1 ? legend : [];
     });
+  }
+
+  /**
+   * Prefers the server-computed `behavioral_class` so the calendar's colors cannot drift from the badges
+   * the public group directory renders for the same groups. Falls back to deriving from `category` only
+   * when the field is missing or carries a class this build does not know.
+   */
+  private toBehavioralClass(group: PublicGroupSummary): GroupBehavioralClass {
+    if (group.behavioral_class && group.behavioral_class in BEHAVIORAL_CLASS_CONFIG) {
+      return group.behavioral_class as GroupBehavioralClass;
+    }
+    return getGroupBehavioralClass(group.category);
   }
 
   private initInitialView(): Signal<string> {
@@ -233,6 +245,15 @@ export class PublicProjectCalendarComponent {
         switchMap(({ slug, committeeUid }) => {
           this.loading.set(true);
           this.fetchError.set(false);
+
+          // The server rejects a non-UUID `committee` with a 400, which would surface as the generic
+          // "Unable to load calendar" error rather than the "group not found" state this actually is.
+          // Skip the round trip and let `unknownCommittee` render.
+          if (committeeUid && !isUuid(committeeUid)) {
+            this.loading.set(false);
+            return of(null);
+          }
+
           return this.meetingService.getPublicProjectMeetings(slug, committeeUid).pipe(
             map((response) => {
               this.loading.set(false);

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -86,25 +86,7 @@ export class PublicProjectCalendarComponent {
     return this.committeesByUid()[uid];
   });
 
-  /**
-   * True when `?committee=` cannot name a group anyone could reach — a stale bookmark or a hand-edited
-   * URL. Distinguished from "no meetings" so the reader is told the filter is the problem.
-   *
-   * A malformed value is decided without waiting for the directory: nothing that isn't a UUID can ever
-   * match, and the request is skipped for it. A well-formed value needs a loaded directory before it can
-   * be called unknown — an empty `groups()` means not-yet-loaded or a failed fetch, neither of which
-   * proves the UID is bad.
-   */
-  protected readonly unknownCommittee: Signal<boolean> = computed(() => {
-    const uid = this.activeCommitteeUid();
-    if (!uid) {
-      return false;
-    }
-    if (!isUuid(uid)) {
-      return true;
-    }
-    return this.groups().length > 0 && !this.activeCommittee();
-  });
+  protected readonly unknownCommittee: Signal<boolean> = this.initUnknownCommittee();
 
   // publicMeetingToCalendarEvents (not meetingToCalendarEvents) — the public mapper never places a
   // meeting password in extendedProps, so a click can't forward one into the join URL, history, or referrer.
@@ -144,16 +126,6 @@ export class PublicProjectCalendarComponent {
     this.applyCommitteeFilter(null);
   }
 
-  /** Writes the filter to the URL rather than to local state, keeping the view shareable and bookmarkable. */
-  private applyCommitteeFilter(committeeUid: string | null): void {
-    void this.router.navigate([], {
-      relativeTo: this.route,
-      // A null value drops the key, so clearing the filter yields a clean URL rather than `?committee=`.
-      queryParams: { committee: committeeUid || null },
-      queryParamsHandling: 'merge',
-    });
-  }
-
   // Private initializer functions
 
   /**
@@ -184,15 +156,25 @@ export class PublicProjectCalendarComponent {
   }
 
   /**
-   * Prefers the server-computed `behavioral_class` so the calendar's colors cannot drift from the badges
-   * the public group directory renders for the same groups. Falls back to deriving from `category` only
-   * when the field is missing or carries a class this build does not know.
+   * True when `?committee=` cannot name a group anyone could reach — a stale bookmark or a hand-edited
+   * URL. Distinguished from "no meetings" so the reader is told the filter is the problem.
+   *
+   * A malformed value is decided without waiting for the directory: nothing that isn't a UUID can ever
+   * match, and the request is skipped for it. A well-formed value needs a loaded directory before it can
+   * be called unknown — an empty `groups()` means not-yet-loaded or a failed fetch, neither of which
+   * proves the UID is bad.
    */
-  private toBehavioralClass(group: PublicGroupSummary): GroupBehavioralClass {
-    if (group.behavioral_class && group.behavioral_class in BEHAVIORAL_CLASS_CONFIG) {
-      return group.behavioral_class as GroupBehavioralClass;
-    }
-    return getGroupBehavioralClass(group.category);
+  private initUnknownCommittee(): Signal<boolean> {
+    return computed(() => {
+      const uid = this.activeCommitteeUid();
+      if (!uid) {
+        return false;
+      }
+      if (!isUuid(uid)) {
+        return true;
+      }
+      return this.groups().length > 0 && !this.activeCommittee();
+    });
   }
 
   private initInitialView(): Signal<string> {
@@ -271,5 +253,29 @@ export class PublicProjectCalendarComponent {
       ),
       { initialValue: null }
     );
+  }
+
+  // Private helper methods
+
+  /** Writes the filter to the URL rather than to local state, keeping the view shareable and bookmarkable. */
+  private applyCommitteeFilter(committeeUid: string | null): void {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      // A null value drops the key, so clearing the filter yields a clean URL rather than `?committee=`.
+      queryParams: { committee: committeeUid || null },
+      queryParamsHandling: 'merge',
+    });
+  }
+
+  /**
+   * Prefers the server-computed `behavioral_class` so the calendar's colors cannot drift from the badges
+   * the public group directory renders for the same groups. Falls back to deriving from `category` only
+   * when the field is missing or carries a class this build does not know.
+   */
+  private toBehavioralClass(group: PublicGroupSummary): GroupBehavioralClass {
+    if (group.behavioral_class && group.behavioral_class in BEHAVIORAL_CLASS_CONFIG) {
+      return group.behavioral_class as GroupBehavioralClass;
+    }
+    return getGroupBehavioralClass(group.category);
   }
 }

--- a/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/public-project-calendar/public-project-calendar.component.ts
@@ -2,43 +2,149 @@
 // SPDX-License-Identifier: MIT
 
 import { Component, computed, inject, signal, Signal } from '@angular/core';
-import { toSignal } from '@angular/core/rxjs-interop';
+import { takeUntilDestroyed, toSignal } from '@angular/core/rxjs-interop';
+import { FormControl, FormGroup } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 import { FullCalendarComponent } from '@app/shared/components/fullcalendar/fullcalendar.component';
 import { EmptyStateComponent } from '@components/empty-state/empty-state.component';
 import { HeaderComponent } from '@components/header/header.component';
+import { SelectComponent } from '@components/select/select.component';
 import { EventClickArg, EventInput } from '@fullcalendar/core';
-import { MeetingCalendarClickProps, PublicProjectMeetingsResponse } from '@lfx-one/shared/interfaces';
-import { publicMeetingToCalendarEvents, resolveMeetingCalendarClickRoute } from '@lfx-one/shared/utils';
+import { BEHAVIORAL_CLASS_CALENDAR_COLORS, BEHAVIORAL_CLASS_CONFIG } from '@lfx-one/shared/constants';
+import {
+  CalendarLegendItem,
+  GroupBehavioralClass,
+  MeetingCalendarClickProps,
+  PublicCalendarCommittee,
+  PublicCalendarCommitteeContext,
+  PublicGroupSummary,
+  PublicProjectMeetingsResponse,
+} from '@lfx-one/shared/interfaces';
+import {
+  getGroupBehavioralClass,
+  publicMeetingToCalendarEvents,
+  resolveMeetingCalendarClickRoute,
+  resolvePublicCalendarCommittee,
+} from '@lfx-one/shared/utils';
+import { GroupService } from '@services/group.service';
 import { MeetingService } from '@services/meeting.service';
+import { SelectChangeEvent } from 'primeng/select';
 import { SkeletonModule } from 'primeng/skeleton';
 import { catchError, combineLatest, distinctUntilChanged, map, of, switchMap } from 'rxjs';
 
 @Component({
   selector: 'lfx-public-project-calendar',
-  imports: [FullCalendarComponent, EmptyStateComponent, HeaderComponent, SkeletonModule],
+  imports: [FullCalendarComponent, EmptyStateComponent, HeaderComponent, SelectComponent, SkeletonModule],
   templateUrl: './public-project-calendar.component.html',
 })
 export class PublicProjectCalendarComponent {
   private readonly route = inject(ActivatedRoute);
   private readonly router = inject(Router);
   private readonly meetingService = inject(MeetingService);
+  private readonly groupService = inject(GroupService);
 
   protected readonly loading = signal(true);
   protected readonly fetchError = signal(false);
 
+  protected readonly committeeForm = new FormGroup({
+    committee: new FormControl<string | null>(null),
+  });
+
   private readonly calendarData: Signal<PublicProjectMeetingsResponse | null> = this.initCalendarData();
+  private readonly groups: Signal<PublicGroupSummary[]> = this.initGroups();
 
   protected readonly initialView: Signal<string> = this.initInitialView();
+  protected readonly activeCommitteeUid: Signal<string | null> = this.initActiveCommitteeUid();
 
   protected readonly projectName: Signal<string> = computed(() => this.calendarData()?.project?.name ?? '');
   protected readonly total: Signal<number> = computed(() => this.calendarData()?.total ?? 0);
 
+  /**
+   * Publicly listed groups keyed by UID — the only source of committee names and colors on this page.
+   * The meetings feed publishes committee UIDs without names, so a committee missing from the directory
+   * stays anonymous rather than having a non-public name rendered.
+   */
+  private readonly committeesByUid: Signal<Record<string, PublicCalendarCommittee>> = computed(() =>
+    this.groups().reduce<Record<string, PublicCalendarCommittee>>((byUid, group) => {
+      byUid[group.uid] = { uid: group.uid, name: group.name, behavioralClass: getGroupBehavioralClass(group.category) };
+      return byUid;
+    }, {})
+  );
+
+  private readonly committeeContext: Signal<PublicCalendarCommitteeContext> = computed(() => ({
+    activeCommitteeUid: this.activeCommitteeUid() ?? undefined,
+    committeesByUid: this.committeesByUid(),
+  }));
+
+  /**
+   * Every group in the project's public directory, not only those with meetings in the current feed —
+   * narrowing to groups that happen to appear would empty the dropdown as soon as a filter is applied.
+   */
+  protected readonly committeeOptions: Signal<{ label: string; value: string | null }[]> = computed(() => [
+    { label: 'All groups', value: null },
+    ...this.groups()
+      .map((group) => ({ label: group.name, value: group.uid }))
+      .sort((a, b) => a.label.localeCompare(b.label)),
+  ]);
+
+  protected readonly activeCommittee: Signal<PublicCalendarCommittee | undefined> = computed(() => {
+    const uid = this.activeCommitteeUid();
+    if (!uid) {
+      return undefined;
+    }
+    return this.committeesByUid()[uid];
+  });
+
+  /**
+   * True when `?committee=` names a group the public directory does not list — a stale bookmark or a
+   * hand-edited URL. Distinguished from "no meetings" so the reader is told the filter is the problem.
+   * Requires a loaded directory: an empty `groups()` means not-yet-loaded or a failed fetch, neither of
+   * which proves the UID is bad.
+   */
+  protected readonly unknownCommittee: Signal<boolean> = computed(() => !!this.activeCommitteeUid() && this.groups().length > 0 && !this.activeCommittee());
+
   // publicMeetingToCalendarEvents (not meetingToCalendarEvents) — the public mapper never places a
   // meeting password in extendedProps, so a click can't forward one into the join URL, history, or referrer.
-  protected readonly calendarEvents: Signal<EventInput[]> = computed(() =>
-    (this.calendarData()?.meetings ?? []).flatMap((m) => publicMeetingToCalendarEvents(m) as EventInput[])
-  );
+  protected readonly calendarEvents: Signal<EventInput[]> = computed(() => {
+    const context = this.committeeContext();
+    return (this.calendarData()?.meetings ?? []).flatMap((meeting) => publicMeetingToCalendarEvents(meeting, context) as EventInput[]);
+  });
+
+  /**
+   * Group types present in the rendered events, paired with the color those events carry. Renders only
+   * when unfiltered — under a filter every event shares one color and the dropdown already names it.
+   */
+  protected readonly legendItems: Signal<CalendarLegendItem[]> = computed(() => {
+    if (this.activeCommitteeUid()) {
+      return [];
+    }
+
+    const committeesByUid = this.committeesByUid();
+    const behavioralClasses = new Set<GroupBehavioralClass>();
+    for (const meeting of this.calendarData()?.meetings ?? []) {
+      const committee = resolvePublicCalendarCommittee(meeting, { committeesByUid });
+      if (committee) {
+        behavioralClasses.add(committee.behavioralClass);
+      }
+    }
+
+    return [...behavioralClasses].map((behavioralClass) => ({
+      label: BEHAVIORAL_CLASS_CONFIG[behavioralClass].label,
+      color: BEHAVIORAL_CLASS_CALENDAR_COLORS[behavioralClass].bg,
+    }));
+  });
+
+  public constructor() {
+    // The URL stays authoritative for the dropdown so deep links and browser back/forward are reflected.
+    // Per frontend-checklist §5 this is a toObservable/RxJS subscription rather than an effect().
+    this.route.queryParamMap.pipe(takeUntilDestroyed()).subscribe((params) => {
+      const uid = params.get('committee');
+      const control = this.committeeForm.controls.committee;
+      if (control.value !== uid) {
+        control.setValue(uid, { emitEvent: false });
+      }
+    });
+  }
 
   /** Handles FullCalendar event click — navigates to the public meeting join page. Cancelled occurrences are inert. */
   protected onCalendarEventClick(arg: EventClickArg): void {
@@ -49,12 +155,59 @@ export class PublicProjectCalendarComponent {
     void this.router.navigate(route.path, route.queryParams ? { queryParams: route.queryParams } : undefined);
   }
 
+  protected onCommitteeChange(event: SelectChangeEvent): void {
+    this.applyCommitteeFilter((event.value as string | null) ?? null);
+  }
+
+  protected clearCommitteeFilter(): void {
+    this.applyCommitteeFilter(null);
+  }
+
+  /** Writes the filter to the URL rather than to local state, keeping the view shareable and bookmarkable. */
+  private applyCommitteeFilter(committeeUid: string | null): void {
+    void this.router.navigate([], {
+      relativeTo: this.route,
+      // A null value drops the key, so clearing the filter yields a clean URL rather than `?committee=`.
+      queryParams: { committee: committeeUid || null },
+      queryParamsHandling: 'merge',
+    });
+  }
+
   // Private initializer functions
 
   private initInitialView(): Signal<string> {
     return toSignal(this.route.queryParamMap.pipe(map((params) => (params.get('view') === 'week' ? 'timeGridWeek' : 'dayGridMonth'))), {
       initialValue: 'dayGridMonth',
     });
+  }
+
+  private initActiveCommitteeUid(): Signal<string | null> {
+    return toSignal(
+      this.route.queryParamMap.pipe(
+        map((params) => params.get('committee')),
+        distinctUntilChanged()
+      ),
+      { initialValue: null }
+    );
+  }
+
+  private initGroups(): Signal<PublicGroupSummary[]> {
+    return toSignal(
+      this.route.paramMap.pipe(
+        map((params) => params.get('projectSlug') ?? ''),
+        // The directory is not scoped by the committee filter, so only a project change warrants a refetch.
+        distinctUntilChanged(),
+        switchMap((slug) =>
+          this.groupService.getPublicProjectGroups(slug).pipe(
+            map((response) => response.groups ?? []),
+            // A directory failure costs the filter, labels, and legend but not the calendar itself, so
+            // degrade to an unlabelled calendar instead of surfacing the page-level error state.
+            catchError(() => of<PublicGroupSummary[]>([]))
+          )
+        )
+      ),
+      { initialValue: [] as PublicGroupSummary[] }
+    );
   }
 
   private initCalendarData(): Signal<PublicProjectMeetingsResponse | null> {

--- a/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.spec.ts
@@ -191,7 +191,7 @@ describe('CommitteeController.getCommitteeCalendar', () => {
   });
 
   it('passes the resolved committee name through to buildVCalendar as calname', async () => {
-    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_ID, name: 'Technical Steering Committee' });
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_ID, name: 'Technical Steering Committee', public: true });
     const req = buildCalendarReq();
     const res = buildRes();
     const next = vi.fn();
@@ -201,6 +201,34 @@ describe('CommitteeController.getCommitteeCalendar', () => {
     expect(next).not.toHaveBeenCalled();
     expect(buildVCalendar).toHaveBeenCalledWith(expect.anything(), expect.any(String), 'Technical Steering Committee');
     expect(res.send).toHaveBeenCalled();
+  });
+
+  // A committee UID is obtainable anonymously from the public meetings feed, so this endpoint must not
+  // become a lookup that turns a UID the public group directory withholds into that group's name.
+  it('withholds the calname for a committee the public group directory does not list', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_ID, name: 'Private Security Committee', public: false });
+    const req = buildCalendarReq();
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getCommitteeCalendar(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    expect(buildVCalendar).toHaveBeenCalledWith(expect.anything(), expect.any(String), undefined);
+    expect(JSON.stringify((buildVCalendar as any).mock.calls)).not.toContain('Private Security Committee');
+    // The feed itself is still served — its PUBLIC meetings are already discoverable elsewhere.
+    expect(res.send).toHaveBeenCalled();
+  });
+
+  it('withholds the calname when the committee omits the public flag entirely', async () => {
+    committeeSvc.getCommitteeById.mockResolvedValue({ uid: COMMITTEE_ID, name: 'Ambiguous Committee' });
+    const req = buildCalendarReq();
+    const res = buildRes();
+    const next = vi.fn();
+
+    await controller.getCommitteeCalendar(req, res, next);
+
+    expect(buildVCalendar).toHaveBeenCalledWith(expect.anything(), expect.any(String), undefined);
   });
 
   it('falls back to an undefined calname (still 200) when the committee name lookup fails', async () => {

--- a/apps/lfx-one/src/server/controllers/committee.controller.ts
+++ b/apps/lfx-one/src/server/controllers/committee.controller.ts
@@ -1505,9 +1505,9 @@ export class CommitteeController {
     }
 
     try {
-      // When called from the public route there is no OIDC session, so use an
-      // M2M token. When called from the authenticated route the user's bearer
-      // token is already on req and no replacement is needed.
+      // This endpoint is mounted only under /public/api, so there is no OIDC session and no caller-
+      // supplied bearer token to reuse — hence M2M. The guard stays defensive in case it is ever
+      // additionally mounted behind auth.
       if (!req.bearerToken) {
         req.bearerToken = await generateM2MToken(req);
       }
@@ -1521,7 +1521,12 @@ export class CommitteeController {
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
         this.committeeService
           .getCommitteeById(req, id)
-          .then((committee) => committee.name)
+          // Anonymous endpoint, and a committee UID is obtainable anonymously from the public meetings
+          // feed — including for committees the public group directory withholds. Publishing the name in
+          // X-WR-CALNAME would hand back exactly the label that directory refuses to list, so gate it on
+          // the same `public` flag `getPublicGroupById` enforces. The committee's PUBLIC meetings stay
+          // listed either way; they are already discoverable through the project's public feed.
+          .then((committee) => (committee.public ? committee.name : undefined))
           .catch((error) => {
             logger.warning(req, 'get_committee_calendar', 'Failed to resolve committee name for X-WR-CALNAME', { committee_id: id, err: error });
             return undefined;

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -373,7 +373,18 @@ describe('ProjectController.getProjectMeetings', () => {
     // Exact key set, not a list of absent keys — a delete-based strip would pass an "is X absent"
     // check for every field named here while still shipping the next sensitive field added upstream.
     expect(Object.keys(response.meetings[0]).sort()).toEqual(
-      ['cancelled_occurrences', 'duration', 'id', 'meeting_and_occurrence_id', 'occurrences', 'scheduled_start_time', 'start_time', 'timezone', 'title'].sort()
+      [
+        'cancelled_occurrences',
+        'committee_uids',
+        'duration',
+        'id',
+        'meeting_and_occurrence_id',
+        'occurrences',
+        'scheduled_start_time',
+        'start_time',
+        'timezone',
+        'title',
+      ].sort()
     );
     expect(response.total).toBe(1);
     expect(response.project).toEqual({ uid: PROJECT_UID, name: 'CNCF' });
@@ -396,6 +407,53 @@ describe('ProjectController.getProjectMeetings', () => {
     for (const key of ['password', 'passcode', 'host_key', 'zoom_config', 'organizers', 'created_by', 'owner']) {
       expect(serialized).not.toContain(key);
     }
+  });
+
+  it('publishes committee UIDs but never committee names', async () => {
+    // A PUBLIC meeting can be tied to a committee the public group directory does not list. The UID is
+    // opaque and already part of the `?committee=` contract; the name is not otherwise public, so the
+    // client resolves labels from the directory instead of trusting this payload.
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({
+        data:
+          resourceType === 'v1_meeting'
+            ? [
+                buildMeeting({
+                  committees: [
+                    { uid: 'committee-uid-1234', name: 'Private Security Committee' },
+                    { uid: 'committee-uid-5678', name: 'Board' },
+                  ],
+                }),
+              ]
+            : [],
+        page_token: undefined,
+      })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(res.json.mock.calls[0][0].meetings[0].committee_uids).toEqual(['committee-uid-1234', 'committee-uid-5678']);
+    const serialized = JSON.stringify(res.json.mock.calls[0][0]);
+    expect(serialized).not.toContain('Private Security Committee');
+    expect(serialized).not.toContain('Board');
+  });
+
+  it('drops committee entries with no UID and collapses duplicates', async () => {
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({
+        data:
+          resourceType === 'v1_meeting'
+            ? [buildMeeting({ committees: [{ uid: 'committee-uid-1234' }, { uid: 'committee-uid-1234' }, { uid: '' }] as any })]
+            : [],
+        page_token: undefined,
+      })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(res.json.mock.calls[0][0].meetings[0].committee_uids).toEqual(['committee-uid-1234']);
   });
 
   it('projects occurrences down to timestamps and status, dropping per-occurrence titles', async () => {

--- a/apps/lfx-one/src/server/controllers/project.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.spec.ts
@@ -11,12 +11,15 @@ const PROJECT_UID = 'project-2222';
 // into vitest (see vitest.config.ts), so the shared barrels the controller imports at
 // module load are stubbed here. `computeIsFoundation` is mocked so each test can drive
 // the foundation-vs-project branch without constructing a full Project graph.
-const { computeIsFoundationMock, generateM2MTokenMock, isUuidMock, meetingSvc, projectSvc } = vi.hoisted(() => ({
+const { computeIsFoundationMock, generateM2MTokenMock, isUuidMock, meetingSvc, projectSvc, committeeSvc } = vi.hoisted(() => ({
   computeIsFoundationMock: vi.fn(),
   generateM2MTokenMock: vi.fn(),
   isUuidMock: vi.fn(),
   meetingSvc: {
     getMeetings: vi.fn(),
+  },
+  committeeSvc: {
+    getCommittees: vi.fn(),
   },
   projectSvc: {
     getProjectIdBySlug: vi.fn(),
@@ -59,6 +62,11 @@ vi.mock('../services/project.service', () => ({
 vi.mock('../services/meeting.service', () => ({
   MeetingService: vi.fn(function () {
     return meetingSvc;
+  }),
+}));
+vi.mock('../services/committee.service', () => ({
+  CommitteeService: vi.fn(function () {
+    return committeeSvc;
   }),
 }));
 vi.mock('../services/logger.service', () => ({
@@ -356,6 +364,12 @@ describe('ProjectController.getProjectMeetings', () => {
     isUuidMock.mockImplementation((value: string) => value === PROJECT_UID || value === 'committee-uid-1234');
     projectSvc.getProjectById.mockResolvedValue(buildProject());
     meetingSvc.getMeetings.mockResolvedValue({ data: [], page_token: undefined });
+    // Default: both fixture committees are publicly listed, so tests that are not about visibility
+    // filtering see every association pass through.
+    committeeSvc.getCommittees.mockResolvedValue([
+      { uid: 'committee-uid-1234', name: 'Private Security Committee', public: true },
+      { uid: 'committee-uid-5678', name: 'Board', public: true },
+    ]);
   });
 
   it('returns only allowlisted calendar fields and the project envelope', async () => {
@@ -410,9 +424,8 @@ describe('ProjectController.getProjectMeetings', () => {
   });
 
   it('publishes committee UIDs but never committee names', async () => {
-    // A PUBLIC meeting can be tied to a committee the public group directory does not list. The UID is
-    // opaque and already part of the `?committee=` contract; the name is not otherwise public, so the
-    // client resolves labels from the directory instead of trusting this payload.
+    // The UID is opaque and already part of the `?committee=` contract; the name is not, so the client
+    // resolves labels from the public group directory instead of trusting this payload.
     meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
       Promise.resolve({
         data:
@@ -454,6 +467,62 @@ describe('ProjectController.getProjectMeetings', () => {
     await controller.getProjectMeetings(req, res, next);
 
     expect(res.json.mock.calls[0][0].meetings[0].committee_uids).toEqual(['committee-uid-1234']);
+  });
+
+  // The UID of a committee the directory withholds is itself disclosive: it lets an anonymous caller
+  // group meetings by a hidden committee, and hand that UID to other anonymous committee endpoints.
+  it('withholds UIDs of committees the public directory does not list', async () => {
+    committeeSvc.getCommittees.mockResolvedValue([
+      { uid: 'committee-uid-1234', name: 'Private Security Committee', public: false },
+      { uid: 'committee-uid-5678', name: 'Board', public: true },
+    ]);
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({
+        data: resourceType === 'v1_meeting' ? [buildMeeting({ committees: [{ uid: 'committee-uid-1234' }, { uid: 'committee-uid-5678' }] as any })] : [],
+        page_token: undefined,
+      })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(res.json.mock.calls[0][0].meetings[0].committee_uids).toEqual(['committee-uid-5678']);
+    expect(JSON.stringify(res.json.mock.calls[0][0])).not.toContain('committee-uid-1234');
+  });
+
+  it('fails closed on a committee lookup error, publishing no UIDs rather than every association', async () => {
+    committeeSvc.getCommittees.mockRejectedValue(new Error('committee service 503'));
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({
+        data: resourceType === 'v1_meeting' ? [buildMeeting({ committees: [{ uid: 'committee-uid-1234' }] as any })] : [],
+        page_token: undefined,
+      })
+    );
+    const { req, res, next } = buildMeetingsReqRes();
+
+    await controller.getProjectMeetings(req, res, next);
+
+    // Still a 200 with the calendar — the outage costs attribution, not the feed.
+    expect(next).not.toHaveBeenCalled();
+    expect(res.json.mock.calls[0][0].meetings).toHaveLength(1);
+    expect(res.json.mock.calls[0][0].meetings[0].committee_uids).toEqual([]);
+  });
+
+  it('returns no meetings when filtered by a committee the public directory does not list', async () => {
+    committeeSvc.getCommittees.mockResolvedValue([{ uid: 'committee-uid-5678', name: 'Board', public: true }]);
+    meetingSvc.getMeetings.mockImplementation((_req: any, _query: any, resourceType: string) =>
+      Promise.resolve({ data: resourceType === 'v1_meeting' ? [buildMeeting()] : [], page_token: undefined })
+    );
+    const { req, res, next } = buildMeetingsReqRes(PROJECT_UID, { committee: 'committee-uid-1234' });
+
+    await controller.getProjectMeetings(req, res, next);
+
+    expect(next).not.toHaveBeenCalled();
+    const response = res.json.mock.calls[0][0];
+    expect(response.meetings).toEqual([]);
+    expect(response.total).toBe(0);
+    // The project envelope still resolves, so the page renders its header rather than an error state.
+    expect(response.project.uid).toBe(PROJECT_UID);
   });
 
   it('projects occurrences down to timestamps and status, dropping per-occurrence titles', async () => {

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -1150,6 +1150,10 @@ export class ProjectController {
       cancelled_occurrences: meeting.cancelled_occurrences,
       scheduled_start_time: pastRow.scheduled_start_time,
       meeting_and_occurrence_id: pastRow.meeting_and_occurrence_id,
+      // UIDs only. `MeetingCommittee.name` is not published here: a PUBLIC meeting can be associated
+      // with a committee the public group directory does not list, and forwarding its name would leak
+      // an otherwise non-public group. Clients label from the directory instead.
+      committee_uids: [...new Set((meeting.committees ?? []).map((committee) => committee.uid).filter((uid): uid is string => !!uid))],
     };
   }
 }

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -23,6 +23,7 @@ import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { contentDispositionAttachment } from '../helpers/content-disposition.helper';
 import { buildVCalendar, fetchAllMeetingPages, meetingsToVEvents } from '../helpers/ics.helper';
 import { getStringQueryParam, validateUidParameter } from '../helpers/validation.helper';
+import { CommitteeService } from '../services/committee.service';
 import { logger } from '../services/logger.service';
 import { MeetingService } from '../services/meeting.service';
 import { ProjectService } from '../services/project.service';
@@ -38,6 +39,7 @@ export class ProjectController {
   private projectService: ProjectService = new ProjectService();
   // Injected here (not on ProjectService) to avoid circular dependency — mirrors CommitteeController.
   private meetingService: MeetingService = new MeetingService();
+  private committeeService: CommitteeService = new CommitteeService();
 
   /**
    * GET /projects
@@ -1009,7 +1011,7 @@ export class ProjectController {
       const projectUid = await this.resolveProjectIdentifier(req, id);
       const query = committeeUid ? { tags_all: [`project_uid:${projectUid}`, `committee_uid:${committeeUid}`] } : { tags: `project_uid:${projectUid}` };
 
-      const [upcoming, past, project] = await Promise.all([
+      const [upcoming, past, project, publicCommitteeUids] = await Promise.all([
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_meeting', false)),
         fetchAllMeetingPages((token) => this.meetingService.getMeetings(req, token ? { ...query, page_token: token } : query, 'v1_past_meeting', false)),
         // Project metadata only feeds the page header — degrade gracefully rather than failing the whole
@@ -1021,7 +1023,23 @@ export class ProjectController {
           });
           return undefined;
         }),
+        this.getPublicCommitteeUids(req, projectUid),
       ]);
+
+      // A committee the public directory does not list is not a valid filter here. Serving it would let an
+      // anonymous caller confirm which meetings belong to a non-public group, which is the correlation the
+      // UID projection below is meant to prevent — so answer as though the group simply has no meetings.
+      if (committeeUid && !publicCommitteeUids.has(committeeUid)) {
+        logger.success(req, 'get_project_meetings', startTime, {
+          project_id: id,
+          committee_uid: committeeUid,
+          meeting_count: 0,
+          rejected_non_public_committee: true,
+        });
+        res.setHeader('Cache-Control', 'public, max-age=300');
+        res.json({ meetings: [], total: 0, project: { uid: projectUid, name: project?.name ?? '' } } satisfies PublicProjectMeetingsResponse);
+        return;
+      }
 
       // Filter PRIVATE meetings from the public feed. Restricted (invited-guests-only) public meetings are
       // still listed so their existence is discoverable; join authorization is enforced separately at join time.
@@ -1030,7 +1048,7 @@ export class ProjectController {
       // must stay out of the payload even as new Meeting fields land upstream (LFXV2-2802).
       const meetings: PublicCalendarMeeting[] = [...upcoming, ...past]
         .filter((m) => m.visibility === MeetingVisibility.PUBLIC)
-        .map((m) => this.toPublicCalendarMeeting(m));
+        .map((m) => this.toPublicCalendarMeeting(m, publicCommitteeUids));
       const response: PublicProjectMeetingsResponse = {
         meetings,
         total: meetings.length,
@@ -1127,11 +1145,32 @@ export class ProjectController {
   }
 
   /**
+   * UIDs of this project's committees that the public group directory lists — the same `public` filter
+   * `getPublicGroupsByProject` applies, so the two surfaces cannot disagree on what is publicly visible.
+   *
+   * Fails closed: a committee-service error yields an empty set, so the feed degrades to an unlabelled
+   * calendar rather than falling back to publishing every association. The directory powering the client's
+   * labels comes from the same service, so it is unavailable in that window too.
+   */
+  private async getPublicCommitteeUids(req: Request, projectUid: string): Promise<ReadonlySet<string>> {
+    try {
+      const committees = await this.committeeService.getCommittees(req, { tags: `project_uid:${projectUid}` }, { skipMailingListEnrichment: true });
+      return new Set(committees.filter((committee) => committee.public && committee.uid).map((committee) => committee.uid));
+    } catch (error) {
+      logger.warning(req, 'get_project_meetings', 'Public committee lookup failed; serving the calendar without group attribution', {
+        project_uid: projectUid,
+        err: error,
+      });
+      return new Set<string>();
+    }
+  }
+
+  /**
    * Projects an indexed `v1_meeting` / `v1_past_meeting` record onto the credential-free shape served
    * by `GET /public/api/projects/:id/meetings`. Field-by-field allowlist, deliberately not a spread with
    * deletes — anything not named here can never reach an anonymous caller.
    */
-  private toPublicCalendarMeeting(meeting: Meeting | PastMeeting): PublicCalendarMeeting {
+  private toPublicCalendarMeeting(meeting: Meeting | PastMeeting, publicCommitteeUids: ReadonlySet<string>): PublicCalendarMeeting {
     const pastRow = meeting as Partial<PastMeeting>;
     return {
       id: meeting.id,
@@ -1150,12 +1189,14 @@ export class ProjectController {
       cancelled_occurrences: meeting.cancelled_occurrences,
       scheduled_start_time: pastRow.scheduled_start_time,
       meeting_and_occurrence_id: pastRow.meeting_and_occurrence_id,
-      // UIDs only. `MeetingCommittee.name` is not published here: a PUBLIC meeting can be associated
-      // with a committee the public group directory does not list, and forwarding its name would put
-      // that group's label on every meeting in the feed. Clients label from the directory instead.
-      // See `PublicCalendarMeeting.committee_uids` for what this does and does not guarantee — the
-      // pre-existing `GET /public/api/meetings/:id` still returns committee names anonymously.
-      committee_uids: [...new Set((meeting.committees ?? []).map((committee) => committee.uid).filter((uid): uid is string => !!uid))],
+      // Restricted to committees the public group directory lists, and UIDs only. A PUBLIC meeting can be
+      // associated with a non-public committee; publishing that committee's UID would let an anonymous
+      // caller correlate meetings by a group the directory deliberately hides, and its name would put a
+      // hidden group's label on the feed. Clients label from the directory, so a filtered UID would have
+      // been unusable to them anyway.
+      committee_uids: [
+        ...new Set((meeting.committees ?? []).map((committee) => committee.uid).filter((uid): uid is string => !!uid && publicCommitteeUids.has(uid))),
+      ],
     };
   }
 }

--- a/apps/lfx-one/src/server/controllers/project.controller.ts
+++ b/apps/lfx-one/src/server/controllers/project.controller.ts
@@ -1151,8 +1151,10 @@ export class ProjectController {
       scheduled_start_time: pastRow.scheduled_start_time,
       meeting_and_occurrence_id: pastRow.meeting_and_occurrence_id,
       // UIDs only. `MeetingCommittee.name` is not published here: a PUBLIC meeting can be associated
-      // with a committee the public group directory does not list, and forwarding its name would leak
-      // an otherwise non-public group. Clients label from the directory instead.
+      // with a committee the public group directory does not list, and forwarding its name would put
+      // that group's label on every meeting in the feed. Clients label from the directory instead.
+      // See `PublicCalendarMeeting.committee_uids` for what this does and does not guarantee — the
+      // pre-existing `GET /public/api/meetings/:id` still returns committee names anonymously.
       committee_uids: [...new Set((meeting.committees ?? []).map((committee) => committee.uid).filter((uid): uid is string => !!uid))],
     };
   }

--- a/packages/shared/src/constants/calendar-colors.constants.ts
+++ b/packages/shared/src/constants/calendar-colors.constants.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import type { CalendarColor, CalendarColorPair } from '../interfaces/calendar.interface';
+import type { GroupBehavioralClass } from '../interfaces/committee.interface';
 
 import { lfxColors } from './colors.constants';
 
@@ -14,6 +15,21 @@ export const MEETING_TYPE_COLORS: Record<string, CalendarColorPair> = {
   legal: { bg: lfxColors.amber[600], border: lfxColors.amber[700] },
   other: { bg: lfxColors.gray[600], border: lfxColors.gray[700] },
   default: { bg: lfxColors.blue[500], border: lfxColors.blue[600] },
+};
+
+/**
+ * Calendar color per group behavioral class, used to tint public project calendar events by committee.
+ * Hues track `BEHAVIORAL_CLASS_CONFIG` so the public calendar and the public group directory read as the
+ * same taxonomy. `ambassador-program` is the one divergence: the directory uses rose, which `lfxColors`
+ * does not carry, so red stands in as the nearest available hue.
+ */
+export const BEHAVIORAL_CLASS_CALENDAR_COLORS: Record<GroupBehavioralClass, CalendarColor> = {
+  'governing-board': { bg: lfxColors.violet[600], border: lfxColors.violet[700], text: lfxColors.white },
+  'oversight-committee': { bg: lfxColors.emerald[600], border: lfxColors.emerald[700], text: lfxColors.white },
+  'working-group': { bg: lfxColors.amber[600], border: lfxColors.amber[700], text: lfxColors.white },
+  'special-interest-group': { bg: lfxColors.blue[600], border: lfxColors.blue[700], text: lfxColors.white },
+  'ambassador-program': { bg: lfxColors.red[600], border: lfxColors.red[700], text: lfxColors.white },
+  other: { bg: lfxColors.gray[600], border: lfxColors.gray[700], text: lfxColors.white },
 };
 
 /** Calendar color for cancelled meeting occurrences. */

--- a/packages/shared/src/constants/calendar-colors.constants.ts
+++ b/packages/shared/src/constants/calendar-colors.constants.ts
@@ -23,14 +23,19 @@ export const MEETING_TYPE_COLORS: Record<string, CalendarColorPair> = {
  * Hues track `BEHAVIORAL_CLASS_CONFIG` so the public calendar and the public group directory read as the
  * same taxonomy. `ambassador-program` is the one divergence: the directory uses rose, which `lfxColors`
  * does not carry, so red stands in as the nearest available hue.
+ *
+ * Weight 700, not 600, because event titles and times render in white at 11px (`fullcalendar.component.scss`),
+ * which is small text and so needs 4.5:1 under WCAG AA. At 600 the emerald, amber, and blue fills land at
+ * 3.65:1, 3.20:1, and 4.04:1 and fail; every 700 fill clears it (5.03:1 at worst, amber). The whole scale
+ * moves together so the six classes stay one visually consistent set rather than a mix of weights.
  */
 export const BEHAVIORAL_CLASS_CALENDAR_COLORS: Record<GroupBehavioralClass, CalendarColor> = {
-  'governing-board': { bg: lfxColors.violet[600], border: lfxColors.violet[700], text: lfxColors.white },
-  'oversight-committee': { bg: lfxColors.emerald[600], border: lfxColors.emerald[700], text: lfxColors.white },
-  'working-group': { bg: lfxColors.amber[600], border: lfxColors.amber[700], text: lfxColors.white },
-  'special-interest-group': { bg: lfxColors.blue[600], border: lfxColors.blue[700], text: lfxColors.white },
-  'ambassador-program': { bg: lfxColors.red[600], border: lfxColors.red[700], text: lfxColors.white },
-  other: { bg: lfxColors.gray[600], border: lfxColors.gray[700], text: lfxColors.white },
+  'governing-board': { bg: lfxColors.violet[700], border: lfxColors.violet[800], text: lfxColors.white },
+  'oversight-committee': { bg: lfxColors.emerald[700], border: lfxColors.emerald[800], text: lfxColors.white },
+  'working-group': { bg: lfxColors.amber[700], border: lfxColors.amber[800], text: lfxColors.white },
+  'special-interest-group': { bg: lfxColors.blue[700], border: lfxColors.blue[800], text: lfxColors.white },
+  'ambassador-program': { bg: lfxColors.red[700], border: lfxColors.red[800], text: lfxColors.white },
+  other: { bg: lfxColors.gray[700], border: lfxColors.gray[800], text: lfxColors.white },
 };
 
 /** Calendar color for cancelled meeting occurrences. */
@@ -91,7 +96,9 @@ export const PUBLIC_CALENDAR_LEGEND: CalendarLegendItem[] = [
     label: BEHAVIORAL_CLASS_CONFIG[behavioralClass].label,
     color: BEHAVIORAL_CLASS_CALENDAR_COLORS[behavioralClass].bg,
   })),
-  { label: 'No group', color: MEETING_TYPE_COLORS['default'].bg },
+  // Not "No group": this fill also covers meetings whose only associations are groups the public
+  // directory withholds, so claiming they have none would be false. It states what a reader can verify.
+  { label: 'No publicly listed group', color: MEETING_TYPE_COLORS['default'].bg },
   { label: 'Past', color: PAST_MEETING_CALENDAR_COLOR.bg },
   { label: 'Cancelled', color: CANCELLED_COLOR.bg },
 ];

--- a/packages/shared/src/constants/calendar-colors.constants.ts
+++ b/packages/shared/src/constants/calendar-colors.constants.ts
@@ -1,10 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import type { CalendarColor, CalendarColorPair } from '../interfaces/calendar.interface';
+import type { CalendarColor, CalendarColorPair, CalendarLegendItem } from '../interfaces/calendar.interface';
 import type { GroupBehavioralClass } from '../interfaces/committee.interface';
 
 import { lfxColors } from './colors.constants';
+import { BEHAVIORAL_CLASS_CONFIG } from './committees.constants';
 
 /** Hex color config per meeting type for FullCalendar events (Tailwind classes don't apply inside FullCalendar). */
 export const MEETING_TYPE_COLORS: Record<string, CalendarColorPair> = {
@@ -73,3 +74,24 @@ export const PAST_SURVEY_CALENDAR_COLOR: CalendarColor = {
   border: lfxColors.violet[400],
   text: lfxColors.violet[700],
 };
+
+/**
+ * Every color the public project calendar can paint an event, in render order: the six behavioral
+ * classes, then the fallbacks for an event with no publicly listed group, and the state treatments that
+ * override the group tint entirely.
+ *
+ * Exhaustive by design — `resolvePublicCalendarLegend` filters it down to the colors a given set of
+ * events actually uses, so a missing entry here silently drops a swatch from the rendered legend.
+ * Class labels are read from `BEHAVIORAL_CLASS_CONFIG` so the calendar and the public group directory
+ * cannot disagree on what a group type is called. The `bg` values must stay pairwise distinct, since
+ * that filtering matches on color.
+ */
+export const PUBLIC_CALENDAR_LEGEND: CalendarLegendItem[] = [
+  ...(Object.keys(BEHAVIORAL_CLASS_CALENDAR_COLORS) as GroupBehavioralClass[]).map((behavioralClass) => ({
+    label: BEHAVIORAL_CLASS_CONFIG[behavioralClass].label,
+    color: BEHAVIORAL_CLASS_CALENDAR_COLORS[behavioralClass].bg,
+  })),
+  { label: 'No group', color: MEETING_TYPE_COLORS['default'].bg },
+  { label: 'Past', color: PAST_MEETING_CALENDAR_COLOR.bg },
+  { label: 'Cancelled', color: CANCELLED_COLOR.bg },
+];

--- a/packages/shared/src/interfaces/calendar.interface.ts
+++ b/packages/shared/src/interfaces/calendar.interface.ts
@@ -3,6 +3,8 @@
 
 import { EventInput } from '@fullcalendar/core';
 
+import type { GroupBehavioralClass } from './committee.interface';
+
 /** FullCalendar hex colors for event background and border. */
 export interface CalendarColorPair {
   bg: string;
@@ -25,6 +27,33 @@ export interface MeetingCalendarClickProps {
   pastMeetingResourceId?: string;
   voteId?: string;
   surveyId?: string;
+}
+
+/** A publicly listed group, resolved from the public group directory and keyed by committee UID. */
+export interface PublicCalendarCommittee {
+  uid: string;
+  /** Display name from the public group directory — safe to render, unlike the raw meeting association. */
+  name: string;
+  /** Behavioral class driving the event color; shared with the public group directory's taxonomy. */
+  behavioralClass: GroupBehavioralClass;
+}
+
+/** One swatch in a calendar color legend — the text counterpart to color-coded events. */
+export interface CalendarLegendItem {
+  label: string;
+  /** Hex fill matching the events it describes. */
+  color: string;
+}
+
+/** Committee context passed to `publicMeetingToCalendarEvents` for labelling and color-coding. */
+export interface PublicCalendarCommitteeContext {
+  /**
+   * Committee UID currently selected via `?committee=`. Disambiguates meetings tied to several
+   * committees, and suppresses the per-event label that every event would otherwise repeat.
+   */
+  activeCommitteeUid?: string;
+  /** Publicly listed committees by UID. Meetings whose committees are absent fall back to default styling. */
+  committeesByUid?: Record<string, PublicCalendarCommittee>;
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1470,6 +1470,14 @@ export interface PublicCalendarMeeting {
   scheduled_start_time?: string;
   /** Composite past-meeting id (e.g. "99152950841-1630560600000"); present only on `v1_past_meeting` rows */
   meeting_and_occurrence_id?: string;
+  /**
+   * Committee UIDs this meeting is associated with — opaque identifiers used to filter, label, and
+   * color-code the public calendar. Names are deliberately excluded: a PUBLIC meeting can be tied to a
+   * committee that the public group directory does not list, and that committee's name is not otherwise
+   * public. Clients resolve display names from `GET /public/api/projects/:id/groups`, so only publicly
+   * listed committees ever surface a visible label.
+   */
+  committee_uids?: string[];
 }
 
 /**

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1472,10 +1472,16 @@ export interface PublicCalendarMeeting {
   meeting_and_occurrence_id?: string;
   /**
    * Committee UIDs this meeting is associated with — opaque identifiers used to filter, label, and
-   * color-code the public calendar. Names are deliberately excluded: a PUBLIC meeting can be tied to a
-   * committee that the public group directory does not list, and that committee's name is not otherwise
-   * public. Clients resolve display names from `GET /public/api/projects/:id/groups`, so only publicly
-   * listed committees ever surface a visible label.
+   * color-code the public calendar. Names are deliberately excluded from *this* payload: a PUBLIC
+   * meeting can be tied to a committee the public group directory does not list, and forwarding its
+   * name here would publish that group's label alongside every meeting in the feed. Clients resolve
+   * display names from `GET /public/api/projects/:id/groups`, so only publicly listed committees ever
+   * surface a visible label on the calendar.
+   *
+   * Not a claim that the name is unavailable anywhere else: `GET /public/api/meetings/:id` still
+   * returns `committees[].name` to anonymous callers for a PUBLIC, non-restricted meeting. Narrowing
+   * that endpoint to `{uid, allowed_voting_statuses}` — and letting its join page label from the
+   * directory, as this calendar does — is a separate change against a pre-existing surface.
    */
   committee_uids?: string[];
 }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -1472,16 +1472,17 @@ export interface PublicCalendarMeeting {
   meeting_and_occurrence_id?: string;
   /**
    * Committee UIDs this meeting is associated with — opaque identifiers used to filter, label, and
-   * color-code the public calendar. Names are deliberately excluded from *this* payload: a PUBLIC
-   * meeting can be tied to a committee the public group directory does not list, and forwarding its
-   * name here would publish that group's label alongside every meeting in the feed. Clients resolve
-   * display names from `GET /public/api/projects/:id/groups`, so only publicly listed committees ever
-   * surface a visible label on the calendar.
+   * color-code the public calendar.
    *
-   * Not a claim that the name is unavailable anywhere else: `GET /public/api/meetings/:id` still
-   * returns `committees[].name` to anonymous callers for a PUBLIC, non-restricted meeting. Narrowing
-   * that endpoint to `{uid, allowed_voting_statuses}` — and letting its join page label from the
-   * directory, as this calendar does — is a separate change against a pre-existing surface.
+   * Restricted server-side to committees the public group directory lists, and never accompanied by a
+   * name. A PUBLIC meeting can be tied to a non-public committee; publishing that UID would let an
+   * anonymous caller correlate meetings by a group the directory deliberately hides, and the name would
+   * label the feed with that hidden group. Clients resolve display names from
+   * `GET /public/api/projects/:id/groups`, so a withheld UID would have been unusable to them anyway.
+   *
+   * Not a claim that a non-public committee's name is unreachable everywhere: `GET /public/api/meetings/:id`
+   * still returns `committees[].name` to anonymous callers for a PUBLIC, non-restricted meeting. Narrowing
+   * that endpoint is a separate change against a pre-existing surface.
    */
   committee_uids?: string[];
 }

--- a/packages/shared/src/utils/meeting-calendar.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.spec.ts
@@ -5,9 +5,20 @@ import '@angular/compiler';
 
 import { describe, expect, it } from 'vitest';
 
-import { BEHAVIORAL_CLASS_CALENDAR_COLORS, CANCELLED_COLOR, PAST_MEETING_CALENDAR_COLOR } from '../constants/calendar-colors.constants';
+import {
+  BEHAVIORAL_CLASS_CALENDAR_COLORS,
+  CANCELLED_COLOR,
+  MEETING_TYPE_COLORS,
+  PAST_MEETING_CALENDAR_COLOR,
+  PUBLIC_CALENDAR_LEGEND,
+} from '../constants/calendar-colors.constants';
 
-import { meetingToCalendarEvents, publicMeetingToCalendarEvents, resolveMeetingCalendarClickRoute } from './meeting-calendar.utils';
+import {
+  meetingToCalendarEvents,
+  publicMeetingToCalendarEvents,
+  resolveMeetingCalendarClickRoute,
+  resolvePublicCalendarLegend,
+} from './meeting-calendar.utils';
 
 import type { PublicCalendarMeeting } from '../interfaces';
 import type { PublicCalendarCommittee, PublicCalendarCommitteeContext } from '../interfaces/calendar.interface';
@@ -158,5 +169,38 @@ describe('publicMeetingToCalendarEvents', () => {
       expect(cancelled.backgroundColor).toBe(CANCELLED_COLOR.bg);
       expect(past.backgroundColor).toBe(PAST_MEETING_CALENDAR_COLOR.bg);
     });
+  });
+});
+
+describe('resolvePublicCalendarLegend', () => {
+  it('lists only the colours the given events actually use', () => {
+    const legend = resolvePublicCalendarLegend([{ backgroundColor: BEHAVIORAL_CLASS_CALENDAR_COLORS['working-group'].bg }]);
+
+    expect(legend.map((entry) => entry.label)).toEqual(['Working Groups']);
+  });
+
+  it('names the state treatments that override a group colour', () => {
+    const legend = resolvePublicCalendarLegend([{ backgroundColor: PAST_MEETING_CALENDAR_COLOR.bg }, { backgroundColor: CANCELLED_COLOR.bg }]);
+
+    expect(legend.map((entry) => entry.label)).toEqual(['Past', 'Cancelled']);
+  });
+
+  it('returns nothing for an empty calendar', () => {
+    expect(resolvePublicCalendarLegend([])).toEqual([]);
+  });
+
+  it('covers every colour the public mapper can emit', () => {
+    // The legend filters a fixed table, so a colour missing from PUBLIC_CALENDAR_LEGEND is not a
+    // visible error — it silently drops that swatch and leaves the hue unexplained.
+    const emittable = [
+      ...Object.values(BEHAVIORAL_CLASS_CALENDAR_COLORS).map((color) => color.bg),
+      MEETING_TYPE_COLORS['default'].bg,
+      PAST_MEETING_CALENDAR_COLOR.bg,
+      CANCELLED_COLOR.bg,
+    ];
+
+    expect(resolvePublicCalendarLegend(emittable.map((backgroundColor) => ({ backgroundColor })))).toHaveLength(emittable.length);
+    // Pairwise-distinct colours, otherwise the filter above cannot tell two entries apart.
+    expect(new Set(PUBLIC_CALENDAR_LEGEND.map((entry) => entry.color)).size).toBe(PUBLIC_CALENDAR_LEGEND.length);
   });
 });

--- a/packages/shared/src/utils/meeting-calendar.utils.spec.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.spec.ts
@@ -5,9 +5,12 @@ import '@angular/compiler';
 
 import { describe, expect, it } from 'vitest';
 
+import { BEHAVIORAL_CLASS_CALENDAR_COLORS, CANCELLED_COLOR, PAST_MEETING_CALENDAR_COLOR } from '../constants/calendar-colors.constants';
+
 import { meetingToCalendarEvents, publicMeetingToCalendarEvents, resolveMeetingCalendarClickRoute } from './meeting-calendar.utils';
 
 import type { PublicCalendarMeeting } from '../interfaces';
+import type { PublicCalendarCommittee, PublicCalendarCommitteeContext } from '../interfaces/calendar.interface';
 
 describe('meetingToCalendarEvents', () => {
   it('does not style in-progress v1_past_meeting rows as past', () => {
@@ -96,5 +99,64 @@ describe('publicMeetingToCalendarEvents', () => {
 
     expect(event.classNames).toContain('meeting-event-past');
     expect(resolveMeetingCalendarClickRoute(event.extendedProps!)?.path).toEqual(['/meetings', '99152950841-1630560600000']);
+  });
+
+  describe('committee attribution', () => {
+    const tsc: PublicCalendarCommittee = { uid: 'uid-tsc', name: 'TSC', behavioralClass: 'oversight-committee' };
+    const board: PublicCalendarCommittee = { uid: 'uid-board', name: 'Governing Board', behavioralClass: 'governing-board' };
+    const directory: PublicCalendarCommitteeContext = { committeesByUid: { [tsc.uid]: tsc, [board.uid]: board } };
+
+    it('colours the event by behavioural class and suffixes the group name', () => {
+      const [event] = publicMeetingToCalendarEvents(publicMeeting({ title: 'Weekly sync', committee_uids: [tsc.uid] }), directory);
+
+      expect(event.title).toBe('Weekly sync · TSC');
+      expect(event.backgroundColor).toBe(BEHAVIORAL_CLASS_CALENDAR_COLORS['oversight-committee'].bg);
+    });
+
+    it('prefers the actively filtered committee over the first association and drops the suffix', () => {
+      const [event] = publicMeetingToCalendarEvents(publicMeeting({ title: 'Weekly sync', committee_uids: [tsc.uid, board.uid] }), {
+        ...directory,
+        activeCommitteeUid: board.uid,
+      });
+
+      expect(event.title).toBe('Weekly sync');
+      expect(event.backgroundColor).toBe(BEHAVIORAL_CLASS_CALENDAR_COLORS['governing-board'].bg);
+    });
+
+    it('ignores committees absent from the public directory', () => {
+      // The feed publishes UIDs for every associated committee, including ones the public group
+      // directory does not list. Those must not colour or label anything.
+      const [event] = publicMeetingToCalendarEvents(publicMeeting({ title: 'Weekly sync', committee_uids: ['uid-private', tsc.uid] }), directory);
+
+      expect(event.title).toBe('Weekly sync · TSC');
+    });
+
+    it('renders default styling with no context, no committees, or no directory match', () => {
+      const bare = publicMeetingToCalendarEvents(publicMeeting({ title: 'Weekly sync' }))[0];
+      const unmatched = publicMeetingToCalendarEvents(publicMeeting({ title: 'Weekly sync', committee_uids: ['uid-private'] }), directory)[0];
+
+      expect(bare.title).toBe('Weekly sync');
+      expect(unmatched.title).toBe('Weekly sync');
+      expect(unmatched.backgroundColor).toBe(bare.backgroundColor);
+    });
+
+    it('keeps the cancelled and past treatments rather than the committee colour', () => {
+      // Cancelled/past state tells the reader more than which group owns the meeting, so it wins.
+      const [cancelled] = publicMeetingToCalendarEvents(
+        publicMeeting({
+          committee_uids: [tsc.uid],
+          cancelled_occurrences: ['1630560600'],
+          occurrences: [{ occurrence_id: '1630560600', start_time: new Date(Date.now() + 60 * 60_000).toISOString(), duration: 30 }],
+        }),
+        directory
+      );
+      const [past] = publicMeetingToCalendarEvents(
+        publicMeeting({ committee_uids: [tsc.uid], start_time: new Date(Date.now() - 3 * 60 * 60_000).toISOString() }),
+        directory
+      );
+
+      expect(cancelled.backgroundColor).toBe(CANCELLED_COLOR.bg);
+      expect(past.backgroundColor).toBe(PAST_MEETING_CALENDAR_COLOR.bg);
+    });
   });
 });

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -1,10 +1,11 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { BEHAVIORAL_CLASS_CALENDAR_COLORS } from '../constants/calendar-colors.constants';
+import { BEHAVIORAL_CLASS_CALENDAR_COLORS, PUBLIC_CALENDAR_LEGEND } from '../constants/calendar-colors.constants';
 import { Meeting, MeetingOccurrenceRoute, PastMeeting, PublicCalendarMeeting } from '../interfaces';
 import type {
   CalendarColor,
+  CalendarLegendItem,
   MeetingCalendarClickProps,
   MeetingCalendarEventInput,
   PublicCalendarCommittee,
@@ -226,6 +227,20 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting, co
       },
     },
   ];
+}
+
+/**
+ * Legend for a set of public calendar events, restricted to the colors those events actually use.
+ *
+ * Derived from the rendered events rather than from the meetings' committee associations because the
+ * cancelled and past treatments override the group tint: a month holding only finished oversight
+ * meetings renders entirely in the past color, and an association-derived legend would advertise a
+ * green "Oversight" swatch that appears nowhere on screen — worse than showing no legend at all, since
+ * the legend is what carries the color key for readers who cannot rely on hue (WCAG 1.4.1).
+ */
+export function resolvePublicCalendarLegend(events: Pick<MeetingCalendarEventInput, 'backgroundColor'>[]): CalendarLegendItem[] {
+  const colorsInUse = new Set(events.map((event) => event.backgroundColor));
+  return PUBLIC_CALENDAR_LEGEND.filter((entry) => colorsInUse.has(entry.color));
 }
 
 /**

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -1,8 +1,15 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { BEHAVIORAL_CLASS_CALENDAR_COLORS } from '../constants/calendar-colors.constants';
 import { Meeting, MeetingOccurrenceRoute, PastMeeting, PublicCalendarMeeting } from '../interfaces';
-import type { MeetingCalendarClickProps, MeetingCalendarEventInput } from '../interfaces/calendar.interface';
+import type {
+  CalendarColor,
+  MeetingCalendarClickProps,
+  MeetingCalendarEventInput,
+  PublicCalendarCommittee,
+  PublicCalendarCommitteeContext,
+} from '../interfaces/calendar.interface';
 import { Vote } from '../interfaces/poll.interface';
 import { Survey } from '../interfaces/survey.interface';
 
@@ -94,12 +101,66 @@ export function meetingToCalendarEvents(meeting: Meeting | PastMeeting): Meeting
 }
 
 /**
+ * Resolves the committee a public calendar event should be attributed to, or undefined when the meeting
+ * has no committee that the public group directory lists.
+ *
+ * A meeting can belong to several committees. The active `?committee=` filter wins when the meeting
+ * carries it; otherwise the first publicly listed committee is used, so attribution stays stable
+ * regardless of how many private committees the meeting is also tied to.
+ */
+export function resolvePublicCalendarCommittee(
+  meeting: Pick<PublicCalendarMeeting, 'committee_uids'>,
+  context?: PublicCalendarCommitteeContext
+): PublicCalendarCommittee | undefined {
+  const committeesByUid = context?.committeesByUid;
+  if (!committeesByUid) {
+    return undefined;
+  }
+
+  const uids = meeting.committee_uids ?? [];
+  const activeUid = context?.activeCommitteeUid;
+  if (activeUid && uids.includes(activeUid) && committeesByUid[activeUid]) {
+    return committeesByUid[activeUid];
+  }
+
+  return uids.map((uid) => committeesByUid[uid]).find((committee) => !!committee);
+}
+
+/**
+ * Committee tinting applies to live events only. Cancelled and past occurrences keep their existing
+ * muted treatments, which carry more meaning to a reader than the group the meeting belongs to.
+ */
+function resolvePublicCalendarColors(committee: PublicCalendarCommittee | undefined, isCancelled: boolean, isPast: boolean): CalendarColor {
+  if (isCancelled || isPast || !committee) {
+    return resolveMeetingCalendarColors(isCancelled, isPast);
+  }
+  return BEHAVIORAL_CLASS_CALENDAR_COLORS[committee.behavioralClass];
+}
+
+/**
+ * Suffixes the group name so the attribution is not conveyed by color alone (WCAG 1.4.1). Skipped while
+ * a committee filter is applied, where every event shares one group and the suffix is pure repetition.
+ */
+function resolvePublicCalendarTitle(title: string, committee: PublicCalendarCommittee | undefined, context?: PublicCalendarCommitteeContext): string {
+  if (!committee || context?.activeCommitteeUid) {
+    return title;
+  }
+  return `${title} · ${committee.name}`;
+}
+
+/**
  * Builds FullCalendar event inputs for anonymous/public calendar surfaces.
  * Takes the credential-free `PublicCalendarMeeting` projection rather than a full `Meeting`, so no
  * meeting password can reach client event state, click-through URLs, browser history, or referrers —
  * defense in depth behind the server-side allowlist on `GET /public/api/projects/:id/meetings`.
+ *
+ * `context` adds committee attribution — a color and a name suffix. Omit it and events render with the
+ * default meeting palette and bare titles.
  */
-export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): MeetingCalendarEventInput[] {
+export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting, context?: PublicCalendarCommitteeContext): MeetingCalendarEventInput[] {
+  const committee = resolvePublicCalendarCommittee(meeting, context);
+  const title = resolvePublicCalendarTitle(meeting.title, committee, context);
+
   if (meeting.occurrences && meeting.occurrences.length > 0) {
     return meeting.occurrences.map((occ) => {
       // `duration` is typed required, but indexed occurrences omit it when there is no per-occurrence
@@ -108,7 +169,7 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): M
       const occurrenceDuration = occ.duration ?? meeting.duration;
       const isCancelled = isMeetingOccurrenceCancelled(occ, meeting.cancelled_occurrences);
       const isPast = !isCancelled && isOccurrencePast(occ.start_time, occurrenceDuration);
-      const colors = resolveMeetingCalendarColors(isCancelled, isPast);
+      const colors = resolvePublicCalendarColors(committee, isCancelled, isPast);
       const classNames = ['meeting-event'];
       if (isCancelled) {
         classNames.push('cursor-default');
@@ -117,7 +178,7 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): M
       }
       return {
         id: `${meeting.id}-${occ.occurrence_id}`,
-        title: meeting.title,
+        title,
         start: occ.start_time,
         end: addMinutesToDate(occ.start_time, occurrenceDuration).toISOString(),
         backgroundColor: colors.bg,
@@ -138,7 +199,7 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): M
 
   const startTime = meeting.scheduled_start_time ?? meeting.start_time;
   const isPast = isOccurrencePast(startTime, meeting.duration);
-  const colors = resolveMeetingCalendarColors(false, isPast);
+  const colors = resolvePublicCalendarColors(committee, false, isPast);
   const resourceId = meeting.meeting_and_occurrence_id ?? meeting.id;
   const classNames = ['meeting-event'];
   if (isPast) {
@@ -148,7 +209,7 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting): M
   return [
     {
       id: resourceId,
-      title: meeting.title,
+      title,
       start: startTime,
       end: addMinutesToDate(startTime, meeting.duration).toISOString(),
       backgroundColor: colors.bg,

--- a/packages/shared/src/utils/meeting-calendar.utils.ts
+++ b/packages/shared/src/utils/meeting-calendar.utils.ts
@@ -232,11 +232,16 @@ export function publicMeetingToCalendarEvents(meeting: PublicCalendarMeeting, co
 /**
  * Legend for a set of public calendar events, restricted to the colors those events actually use.
  *
- * Derived from the rendered events rather than from the meetings' committee associations because the
- * cancelled and past treatments override the group tint: a month holding only finished oversight
- * meetings renders entirely in the past color, and an association-derived legend would advertise a
- * green "Oversight" swatch that appears nowhere on screen — worse than showing no legend at all, since
- * the legend is what carries the color key for readers who cannot rely on hue (WCAG 1.4.1).
+ * Derived from the resolved events rather than from the meetings' committee associations because the
+ * cancelled and past treatments override the group tint: a feed of only finished oversight meetings
+ * resolves entirely to the past color, and an association-derived legend would advertise a green
+ * "Oversight" swatch that is painted nowhere — worse than showing no legend at all, since the legend is
+ * what carries the color key for readers who cannot rely on hue (WCAG 1.4.1).
+ *
+ * Scoped to the events passed in, which callers supply as the whole loaded feed rather than the visible
+ * date range — so a swatch can still describe an event in a month the reader has not scrolled to. That
+ * narrows the mismatch above rather than eliminating it; closing it entirely would mean feeding this the
+ * viewport range from FullCalendar's `datesSet`.
  */
 export function resolvePublicCalendarLegend(events: Pick<MeetingCalendarEventInput, 'backgroundColor'>[]): CalendarLegendItem[] {
   const colorsInUse = new Set(events.map((event) => event.backgroundColor));


### PR DESCRIPTION
Follow-up to #1907. Adds the two things that PR left open: a way to reach the public calendar from inside the app, and a way to narrow it to one group.

## What changed

**Group filter.** The public project calendar gains a group dropdown backed by the public group directory, with the selection held in the URL (`?committee=<uid>`) so a filtered view stays shareable and survives back/forward. Events are tinted by the group's behavioral class and suffixed with the group name, and a legend names every color actually on the canvas — the color is never the only carrier of meaning (WCAG 1.4.1).

**Entry point.** The meetings dashboard gets a "Public Calendar" button linking to the project's public calendar. It is gated on project context but deliberately *not* on meeting write access — the public calendar is a read-only view that any persona with project context can share.

**Committee UIDs on the public feed.** `GET /public/api/projects/:id/meetings` now publishes `committee_uids` so the client can match meetings to the directory. UIDs only — never names. A PUBLIC meeting can be tied to a committee the public directory does not list, and forwarding that committee's name would put a non-public group's label on every meeting in the feed. Clients resolve display names from the directory, so only publicly listed groups ever get a visible label on the calendar.

## Security fix included

Publishing those UIDs made a latent hole in the committee ICS endpoint reachable. `GET /public/api/committees/:uid/calendar.ics` is anonymous, validated only the UID's character set, and emitted the committee's name in `X-WR-CALNAME` with no visibility check — so a UID harvested from the meetings feed resolved to the name the group directory deliberately withholds. Neither half was exploitable alone; this branch supplied the previously unguessable capability token.

The name is now gated on the same `public` flag `getPublicGroupById` already enforces, and fails closed when the flag is absent (upstream defaults it to `false`). The committee's PUBLIC meetings stay listed, since they are already discoverable through the project's public feed — only the identifying label is withheld. Rejecting the request outright was considered and rejected: it would change behavior on a pre-existing endpoint without closing any additional disclosure.

### Scope of that fix — please read before assuming it is complete

Review surfaced that this closes the ICS hop but **not** every anonymous path from a committee UID to a non-public committee's name. `GET /public/api/meetings/:id` still returns `committees[].name` to anonymous callers for any PUBLIC, non-restricted meeting, and the public join page renders those names as tags. That endpoint predates this branch, so this is not a regression introduced here, but it does mean the feed's UIDs still map to names by a different hop.

I have kept this PR to the surface it actually made reachable, and corrected the code comments so they no longer claim a repo-wide property that does not hold. The follow-up worth doing separately: project `meeting.committees` down to `{uid, allowed_voting_statuses}` for anonymous callers on `/public/api/meetings/:id` and let the join page label from the public group directory, exactly as this calendar page does. Happy to fold that in here instead if reviewers would rather see it land together.

## Notable decisions

- **Filtered affordances key on the raw committee UID, not the resolved group.** The directory resolves a group's *name*; the URL decides whether a filter is applied. Conflating the two meant a directory outage presented a filtered calendar as the project's whole calendar, with no control that cleared it.
- **The legend is derived from resolved events, not committee associations.** Cancelled and past treatments override the group tint, so an association-derived legend could advertise a swatch painted nowhere on screen. It is scoped to the loaded feed rather than the visible date range — that narrows the mismatch without eliminating it, and the doc comment says so; closing it fully means wiring FullCalendar's `datesSet`, which is out of scope here.
- **A malformed `?committee=` value short-circuits client-side.** The server rejects a non-UUID with a 400, which would surface as a generic "Unable to load calendar" rather than the "group not found" state it actually is.

## Testing

- `packages/shared` — 15 tests on committee attribution, color resolution, title suffixing, and legend derivation, including one asserting the legend covers every color the mapper can emit and that those colors stay pairwise distinct.
- `project.controller.spec.ts` — 34 tests, including a full-payload negative assertion that no committee name is serialized, plus exact-key-set enforcement so a future field addition fails loudly.
- `committee.controller.spec.ts` — 11 tests, covering name withholding for a non-public committee and for one that omits the flag entirely (fails closed).
- `public-project-calendar.component.spec.ts` — 21 tests across the filter, legend, empty states, malformed params, and the directory-outage-while-filtered combination.

Full suites green: 2133 server, 1314 app.

Not covered: E2E for the empty states. Angular's HTTP transfer cache serializes SSR-fetched data into the document, so Playwright's `page.route` cannot intercept it — mocking these states reliably needs fixtures this suite does not yet have. Documented rather than papered over with a flaky test.

## Reviewer note

The diff is against `main` — #1907 merged while this was in flight, so this branch was rebased off it and now stands alone.