### PR TITLE
feat(committees): add "this week so far" activity tally

### DIFF
--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -288,8 +288,12 @@ async function mockCurrentBrief(page: Page, initial: WeeklyBriefCurrentResponse)
   let current = initial;
   // Await the route registration so it's installed before any page.goto()
   // — `void page.route(...)` races with navigation and can leak through to
-  // the network on fast runs.
-  await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current`, async (route) => {
+  // the network on fast runs. Trailing `*` on the glob (GH-1922) — the client now appends
+  // `?includeCurrentActivity=...` to this exact URL (weekly-brief.service.ts's getWeeklyBrief),
+  // and Playwright's route glob anchors against the full URL including the query string, so a
+  // bare glob silently stops matching and every test using this mock falls through to the live
+  // dev backend instead of the fixture.
+  await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current*`, async (route) => {
     if (route.request().method() !== 'GET') {
       await route.fallback();
       return;
@@ -1054,7 +1058,7 @@ test.describe('WG Weekly Brief card — Edit → Save round-trip', () => {
     const editedText = 'Edited brief — manish reviewed and tightened the language for the maintainers list.';
     const editedBrief: WeeklyBrief = { ...GENERATED_BRIEF, state: 'edited', brief_text: editedText, revision: GENERATED_BRIEF.revision + 1 };
 
-    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current`, async (route) => {
+    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current*`, async (route) => {
       if (route.request().method() === 'PUT') {
         capturedPutBody = route.request().postDataJSON() as { brief_text?: string; revision?: number };
         // After save, GET should return the edited brief.
@@ -1120,7 +1124,7 @@ test.describe('WG Weekly Brief card — Generate from empty', () => {
     // re-evaluating and remounting the card) can add an extra initial-load GET that
     // would desync a count-based sequence.
     let generateAccepted = false;
-    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current`, async (route) => {
+    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current*`, async (route) => {
       if (route.request().method() !== 'GET') {
         await route.fallback();
         return;
@@ -1196,7 +1200,7 @@ test.describe('WG Weekly Brief card — loads directly into the generating state
     // identical reason — this test hadn't been updated to match).
     let getCount = 0;
     let showTerminal = false;
-    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current`, async (route) => {
+    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current*`, async (route) => {
       if (route.request().method() !== 'GET') {
         await route.fallback();
         return;
@@ -1242,7 +1246,7 @@ test.describe('WG Weekly Brief card — read failure (flag ON)', () => {
     // until the test itself flips `retried` right before the explicit Retry click, so any
     // number of incidental remount GETs still land on the failure branch.
     let retried = false;
-    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current`, async (route) => {
+    await page.route(`**/api/committees/${TEST_COMMITTEE_UID}/weekly-briefs/current*`, async (route) => {
       if (!retried) {
         await route.fulfill({
           status: 503,

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1016,7 +1016,7 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
     await expect(page.getByTestId('weekly-brief-card-current-activity')).toHaveCount(0);
   });
 
-  test('renders nothing (not "no activity yet") when current_activity is absent — the live-mode backend gap', async ({ page }) => {
+  test('renders nothing (not "no activity yet") when current_activity is absent — a server-side degrade', async ({ page }) => {
     await mockCommitteeShell(page, { category: 'Board' });
     await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
 

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -1026,6 +1026,22 @@ test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-19
 
     await expect(page.getByTestId('weekly-brief-card-current-activity')).toHaveCount(0);
   });
+
+  test('renders "no activity yet" when current_activity is present but empty — a genuine quiet week-so-far, distinct from the absent case above', async ({
+    page,
+  }) => {
+    await mockCommitteeShell(page, { category: 'Board' });
+    await mockCurrentBrief(page, {
+      brief: GENERATED_BRIEF,
+      throttle: USED_THROTTLE_AFTER_GENERATE,
+      current_activity: { window_start: '2026-08-24T00:00:00.000Z', window_end: '2026-08-27T12:00:00.000Z', source_refs: [] },
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    await expect(page.getByTestId('weekly-brief-card-current-activity')).toContainText('no activity yet', { timeout: DATA_LOAD_TIMEOUT });
+  });
 });
 
 test.describe('WG Weekly Brief card — Edit → Save round-trip', () => {

--- a/apps/lfx-one/e2e/weekly-brief-card.spec.ts
+++ b/apps/lfx-one/e2e/weekly-brief-card.spec.ts
@@ -963,6 +963,71 @@ test.describe('WG Weekly Brief card — Sources disclosure & dedupe (LFXV2-3335)
   });
 });
 
+test.describe('WG Weekly Brief card — "This week so far" activity tally (GH-1922)', () => {
+  test('renders the multi-kind caption for a governance committee and expands a kind to its underlying items', async ({ page }) => {
+    await mockCommitteeShell(page, { category: 'Board' });
+    await mockCurrentBrief(page, {
+      brief: GENERATED_BRIEF,
+      throttle: USED_THROTTLE_AFTER_GENERATE,
+      current_activity: {
+        window_start: '2026-08-24T00:00:00.000Z',
+        window_end: '2026-08-27T12:00:00.000Z',
+        source_refs: [
+          { id: 'act-meeting-1', kind: 'meeting', title: 'Board Sync' },
+          { id: 'act-vote-1', kind: 'vote', title: 'Q3 Resolution' },
+        ],
+      },
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+
+    const tally = page.getByTestId('weekly-brief-card-current-activity');
+    await expect(tally).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+    await expect(tally).toContainText('This week so far:');
+    await expect(tally).toContainText('1 meeting held');
+    await expect(tally).toContainText('1 vote closed');
+
+    const toggle = page.getByTestId('weekly-brief-card-current-activity-toggle-meeting');
+    await expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await expect(page.getByTestId('weekly-brief-card-current-activity-items-meeting')).toHaveCount(0);
+
+    await toggle.click();
+    await expect(toggle).toHaveAttribute('aria-expanded', 'true');
+    await expect(page.getByTestId('weekly-brief-card-current-activity-items-meeting')).toContainText('Board Sync');
+  });
+
+  test('does not render for a non-governance committee, even with current-week activity present', async ({ page }) => {
+    await mockCommitteeShell(page); // default category: 'Working Group'
+    await mockCurrentBrief(page, {
+      brief: GENERATED_BRIEF,
+      throttle: USED_THROTTLE_AFTER_GENERATE,
+      current_activity: {
+        window_start: '2026-08-24T00:00:00.000Z',
+        window_end: '2026-08-27T12:00:00.000Z',
+        source_refs: [{ id: 'act-meeting-1', kind: 'meeting', title: 'Some Meeting' }],
+      },
+    });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await expect(page.getByTestId('weekly-brief-card-body')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await expect(page.getByTestId('weekly-brief-card-current-activity')).toHaveCount(0);
+  });
+
+  test('renders nothing (not "no activity yet") when current_activity is absent — the live-mode backend gap', async ({ page }) => {
+    await mockCommitteeShell(page, { category: 'Board' });
+    await mockCurrentBrief(page, { brief: GENERATED_BRIEF, throttle: USED_THROTTLE_AFTER_GENERATE });
+
+    await page.goto(COMMITTEE_URL, { waitUntil: 'domcontentloaded' });
+    await expect(page).not.toHaveURL(/auth0\.com/);
+    await expect(page.getByTestId('weekly-brief-card-body')).toBeVisible({ timeout: DATA_LOAD_TIMEOUT });
+
+    await expect(page.getByTestId('weekly-brief-card-current-activity')).toHaveCount(0);
+  });
+});
+
 test.describe('WG Weekly Brief card — Edit → Save round-trip', () => {
   test('PUT request carries the modified brief text, and UI re-renders with the "Edited" badge', async ({ page }) => {
     await mockCommitteeShell(page);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -6,7 +6,9 @@
     <!--
       "This week so far" activity tally (GH-1922) — a raw count of the current, not-yet-closed
       week's activity, separate from the AI Assistant card's own completed-week brief below (a
-      board meeting held today won't appear in that brief until next week). No card border, no
+      board meeting held today won't appear in that brief until next week, Sunday through
+      Friday — briefWindow()'s own Saturday branch makes the brief cover the current week too on
+      that one day, so the two can describe the same window then). No card border, no
       AI iconography, no "contains private source data" banner: this is a count query, not
       generated prose. Board/Government Advisory Council committees only for v1
       (isGoverningBoardCommittee). role="group" makes the container naming-capable so
@@ -20,11 +22,12 @@
       <span>This week so far:</span>
       @if (currentActivity().length) {
         @for (section of currentActivity(); track section.kind; let last = $last) {
+          @let sectionExpanded = expandedActivityKinds().has(section.kind);
           <button
             type="button"
             class="inline border-0 bg-transparent p-0 text-xs text-gray-500 underline decoration-dotted cursor-pointer hover:text-gray-700 transition-colors"
-            [attr.aria-expanded]="expandedActivityKinds().has(section.kind)"
-            [attr.aria-controls]="expandedActivityKinds().has(section.kind) ? 'weekly-brief-card-current-activity-items-' + section.kind : null"
+            [attr.aria-expanded]="sectionExpanded"
+            [attr.aria-controls]="sectionExpanded ? 'weekly-brief-card-current-activity-items-' + section.kind : null"
             (click)="onToggleActivityKind(section.kind)"
             [attr.data-testid]="'weekly-brief-card-current-activity-toggle-' + section.kind">
             <!-- Comma is part of the button's own text, not a sibling flex item — a separate

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -24,7 +24,7 @@
             type="button"
             class="inline border-0 bg-transparent p-0 text-xs text-gray-500 underline decoration-dotted cursor-pointer hover:text-gray-700 transition-colors"
             [attr.aria-expanded]="expandedActivityKinds().has(section.kind)"
-            [attr.aria-controls]="'weekly-brief-card-current-activity-items-' + section.kind"
+            [attr.aria-controls]="expandedActivityKinds().has(section.kind) ? 'weekly-brief-card-current-activity-items-' + section.kind : null"
             (click)="onToggleActivityKind(section.kind)"
             [attr.data-testid]="'weekly-brief-card-current-activity-toggle-' + section.kind">
             <!-- Comma is part of the button's own text, not a sibling flex item — a separate

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -19,7 +19,7 @@
       role="group"
       [attr.aria-label]="currentActivityLine()"
       data-testid="weekly-brief-card-current-activity">
-      <span>This week so far:</span>
+      <span>{{ currentActivityPrefix }}</span>
       @if (currentActivity().length) {
         @for (section of currentActivity(); track section.kind; let last = $last) {
           @let sectionExpanded = expandedActivityKinds().has(section.kind);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -2,16 +2,19 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 @if (canEdit()) {
-  @if (isGovernanceCommittee() && !fetchLoading() && hasCurrentActivityData()) {
+  @if (isGoverningBoardCommittee() && !fetchLoading() && hasCurrentActivityData()) {
     <!--
       "This week so far" activity tally (GH-1922) — a raw count of the current, not-yet-closed
       week's activity, separate from the AI Assistant card's own completed-week brief below (a
       board meeting held today won't appear in that brief until next week). No card border, no
       AI iconography, no "contains private source data" banner: this is a count query, not
-      generated prose. Governance committees only for v1 (isGovernanceCommittee).
+      generated prose. Board/Government Advisory Council committees only for v1
+      (isGoverningBoardCommittee). role="group" makes the container naming-capable so
+      aria-label is actually announced — a bare <div> has no implicit role that supports one.
     -->
     <div
       class="flex flex-wrap items-baseline gap-x-1 gap-y-1 text-xs text-gray-500"
+      role="group"
       [attr.aria-label]="currentActivityLine()"
       data-testid="weekly-brief-card-current-activity">
       <span>This week so far:</span>
@@ -21,10 +24,14 @@
             type="button"
             class="inline border-0 bg-transparent p-0 text-xs text-gray-500 underline decoration-dotted cursor-pointer hover:text-gray-700 transition-colors"
             [attr.aria-expanded]="expandedActivityKinds().has(section.kind)"
+            [attr.aria-controls]="'weekly-brief-card-current-activity-items-' + section.kind"
             (click)="onToggleActivityKind(section.kind)"
             [attr.data-testid]="'weekly-brief-card-current-activity-toggle-' + section.kind">
-            {{ section.countText }}</button
-          ><span>{{ last ? '' : ',' }}</span>
+            <!-- Comma is part of the button's own text, not a sibling flex item — a separate
+                 element here would pick up gap-x-1 as space BEFORE the comma (misrendering
+                 "1 meeting held , 1 vote closed") and could wrap onto its own line. -->
+            {{ section.countText }}{{ last ? '' : ',' }}
+          </button>
         }
       } @else {
         <span>no activity yet</span>
@@ -32,7 +39,10 @@
     </div>
     @for (section of currentActivity(); track section.kind) {
       @if (expandedActivityKinds().has(section.kind)) {
-        <div class="flex flex-col gap-0.5 pl-2" [attr.data-testid]="'weekly-brief-card-current-activity-items-' + section.kind">
+        <div
+          class="flex flex-col gap-0.5 pl-2"
+          [id]="'weekly-brief-card-current-activity-items-' + section.kind"
+          [attr.data-testid]="'weekly-brief-card-current-activity-items-' + section.kind">
           @for (ref of section.refs; track ref.id) {
             <span class="text-xs text-gray-500">{{ ref.title || section.label }}</span>
           }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.html
@@ -2,6 +2,44 @@
 <!-- SPDX-License-Identifier: MIT -->
 
 @if (canEdit()) {
+  @if (isGovernanceCommittee() && !fetchLoading() && hasCurrentActivityData()) {
+    <!--
+      "This week so far" activity tally (GH-1922) — a raw count of the current, not-yet-closed
+      week's activity, separate from the AI Assistant card's own completed-week brief below (a
+      board meeting held today won't appear in that brief until next week). No card border, no
+      AI iconography, no "contains private source data" banner: this is a count query, not
+      generated prose. Governance committees only for v1 (isGovernanceCommittee).
+    -->
+    <div
+      class="flex flex-wrap items-baseline gap-x-1 gap-y-1 text-xs text-gray-500"
+      [attr.aria-label]="currentActivityLine()"
+      data-testid="weekly-brief-card-current-activity">
+      <span>This week so far:</span>
+      @if (currentActivity().length) {
+        @for (section of currentActivity(); track section.kind; let last = $last) {
+          <button
+            type="button"
+            class="inline border-0 bg-transparent p-0 text-xs text-gray-500 underline decoration-dotted cursor-pointer hover:text-gray-700 transition-colors"
+            [attr.aria-expanded]="expandedActivityKinds().has(section.kind)"
+            (click)="onToggleActivityKind(section.kind)"
+            [attr.data-testid]="'weekly-brief-card-current-activity-toggle-' + section.kind">
+            {{ section.countText }}</button
+          ><span>{{ last ? '' : ',' }}</span>
+        }
+      } @else {
+        <span>no activity yet</span>
+      }
+    </div>
+    @for (section of currentActivity(); track section.kind) {
+      @if (expandedActivityKinds().has(section.kind)) {
+        <div class="flex flex-col gap-0.5 pl-2" [attr.data-testid]="'weekly-brief-card-current-activity-items-' + section.kind">
+          @for (ref of section.refs; track ref.id) {
+            <span class="text-xs text-gray-500">{{ ref.title || section.label }}</span>
+          }
+        </div>
+      }
+    }
+  }
   @if (fetchLoading()) {
     <lfx-card>
       <div class="flex flex-col gap-3">

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -757,6 +757,16 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       // double duty (releases pollActive AND clears generating), and a poll that stops without
       // clearing generating strands the card on "Generating…" with no way out but a reload.
       expect(component.generating()).toBe(false);
+
+      // The other half of finalize's double duty: pollActive must also have been released, or
+      // pollUntilTerminal's own re-entrancy guard (`if (!isPlatformBrowser... || this.pollActive)
+      // return`) makes every later Regenerate set generating() with no poll left to ever clear
+      // it — a deeper version of the same dead end. Proven by actually regenerating again and
+      // confirming a new poll tick fires.
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief.mock.calls).toHaveLength(3);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -661,13 +661,47 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
 
     expect(generateWeeklyBrief).toHaveBeenCalled();
     // GenerateWeeklyBriefResponse has neither field at all — regenerating a brief doesn't change
-    // this week's activity, and the brief actually still on screen at this point is the
-    // pre-regenerate one (res.brief only lands once generation completes), so its rating is still
-    // accurate too. Both must survive the 202 handler rather than vanish until the next
-    // pollUntilTerminal tick lands.
+    // this week's activity, and a bare 202 (no res.brief) means the brief still on screen is
+    // genuinely the pre-regenerate one, so its rating is still accurate too. Both must survive
+    // the 202 handler rather than vanish until the next pollUntilTerminal tick lands.
     expect(component.hasCurrentActivityData()).toBe(true);
     expect(component.callerRating()).toBe('up');
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el.textContent as string).toContain('1 meeting held');
+  });
+
+  it('drops (not carries forward) caller_rating when the 202 envelope itself already carries a new brief', async () => {
+    const generateWeeklyBrief = vi.fn(() =>
+      of({
+        brief: {
+          uid: 'brief-2',
+          committee_uid: 'committee-board',
+          window_start: '2026-08-02T00:00:00Z',
+          window_end: '2026-08-08T23:59:59Z',
+          state: 'generating',
+          brief_text: '',
+          source_refs: [],
+          prompt_version: 'v1',
+          model: 'test-model',
+          regeneration_count: 1,
+          private_source_present: false,
+          created_at: '2026-08-08T00:00:00Z',
+          updated_at: '2026-08-08T00:00:00Z',
+          revision: 2,
+        },
+      } as GenerateWeeklyBriefResponse)
+    );
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief, 'up');
+    expect(component.callerRating()).toBe('up');
+
+    component.onGenerate();
+    await fixture.whenStable();
+
+    // The type allows a populated res.brief on the 202 — the old rating describes the
+    // pre-regenerate revision, not this new one, so it must NOT carry forward here (contrast
+    // the bare-202 case above, where it correctly does).
+    expect(component.callerRating()).toBeNull();
+    // current_activity is unaffected either way — it isn't scoped to a brief revision.
+    expect(component.hasCurrentActivityData()).toBe(true);
   });
 });

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -552,6 +552,45 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(el.textContent as string).toContain('2 meetings held');
   });
 
+  it('puts the comma inside each toggle button — not a separate element that would pick up the flex gap as space before it', async () => {
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync'), activityRef('vote-1', 'vote', 'Q3 Resolution')]);
+
+    const meetingToggle = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-toggle-meeting"]');
+    const voteToggle = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-toggle-vote"]');
+    expect((meetingToggle.textContent as string).replace(/\s+/g, ' ').trim()).toBe('1 meeting held,');
+    // Last item has no trailing comma.
+    expect((voteToggle.textContent as string).replace(/\s+/g, ' ').trim()).toBe('1 vote closed');
+  });
+
+  it('sets role="group" + aria-label on the container, and aria-controls on each toggle pointing at its revealed list id', async () => {
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')]);
+
+    const container = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect(container.getAttribute('role')).toBe('group');
+    expect(container.getAttribute('aria-label')).toContain('1 meeting held');
+
+    const toggle = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-toggle-meeting"]');
+    expect(toggle.getAttribute('aria-controls')).toBe('weekly-brief-card-current-activity-items-meeting');
+
+    await clickTestId('weekly-brief-card-current-activity-toggle-meeting');
+    const items = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-items-meeting"]');
+    expect(items.getAttribute('id')).toBe(toggle.getAttribute('aria-controls'));
+  });
+
+  it('rolls an unrecognized kind into an "Other" bucket instead of dropping it, and does not render the false "no activity yet" line', async () => {
+    await setup(BOARD_COMMITTEE, [activityRef('future-1', 'some_future_kind', 'A Brand New Source Kind')]);
+
+    const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect(el).not.toBeNull();
+    expect(el.textContent).not.toContain('no activity yet');
+    expect((el.textContent as string).replace(/\s+/g, ' ')).toContain('1 other update');
+
+    await clickTestId('weekly-brief-card-current-activity-toggle-other');
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-items-other"]').textContent).toContain(
+      'A Brand New Source Kind'
+    );
+  });
+
   it('renders "no activity yet" when current_activity is present but empty (a genuine quiet week-so-far)', async () => {
     await setup(BOARD_COMMITTEE, []);
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -619,6 +619,34 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]')).toBeNull();
   });
 
+  it('renders nothing when current_activity is explicitly null (the BFF\'s settled "doesn\'t apply" state) — same as absent, not "no activity yet"', async () => {
+    // A real getWeeklyBrief response can carry current_activity: null (distinct from the key
+    // being absent entirely — see WeeklyBriefCurrentResponse.current_activity's doc comment).
+    // hasCurrentActivityData's `!!` check must treat both the same for rendering purposes; only
+    // the poll loop's opt-out decision cares about the distinction.
+    getWeeklyBrief = vi.fn(() => of({ ...briefResponse(null), current_activity: null }));
+    await TestBed.configureTestingModule({
+      imports: [WeeklyBriefCardComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })) } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        ConfirmationService,
+        { provide: UserService, useValue: { impersonating: signal(false) } },
+      ],
+    }).compileComponents();
+    fixture = TestBed.createComponent(WeeklyBriefCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('committee', BOARD_COMMITTEE);
+    fixture.componentRef.setInput('canEdit', true);
+    await fixture.whenStable();
+
+    expect(component.hasCurrentActivityData()).toBe(false);
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]')).toBeNull();
+  });
+
   it('clicking a kind reveals its underlying ref titles, and clicking again collapses it', async () => {
     await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync'), activityRef('vote-1', 'vote', 'Q3 Resolution')]);
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -1,6 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
+import { HttpErrorResponse } from '@angular/common/http';
 import { signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
@@ -954,11 +955,13 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       component.onGenerate();
       await vi.advanceTimersByTimeAsync(0);
 
-      // The first tick after generate fails outright (a stand-in for the tick's own HTTP timeout
-      // or a network error) before any response — this asked (includeCurrentActivity: true), but
-      // must NOT count against WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, since the server
-      // never had a chance to answer.
-      getWeeklyBrief.mockImplementationOnce(() => throwError(() => new Error('network error')));
+      // A transport-level failure (status: 0 — connection refused, DNS failure, CORS block: the
+      // request never reached, or never got a response from, the BFF at all) — this asked
+      // (includeCurrentActivity: true), but must NOT count against
+      // WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, since the server never had a chance to
+      // answer. Contrast the sibling tests below: a TimeoutError or a real HTTP error status BOTH
+      // mean the BFF received the request, so both count against the cap; only status === 0 does not.
+      getWeeklyBrief.mockImplementationOnce(() => throwError(() => new HttpErrorResponse({ status: 0 })));
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-board', { includeCurrentActivity: true });
       // A failed tick degrades gracefully — it must not look like a terminal state and stop the
@@ -1015,6 +1018,44 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       }
       // The cap is already spent — one tick earlier than the sibling network-failure test, since
       // the timed-out tick counted.
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2 + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, 'committee-board', { includeCurrentActivity: false });
+
+      getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(component.generating()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('DOES burn the ask-attempt cap on a tick that gets a real HTTP error response — the BFF received and processed the request, it just failed to answer well', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
+
+    fakePollTimers();
+    try {
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Unlike the "fails before reaching the server" test above (status: 0), a real HTTP error
+      // status means the request DID reach the BFF and got a response — even a failing one. This
+      // is the exact bug a bot reviewer caught: refunding on "any non-TimeoutError" also refunded
+      // on a persistent 500/503, defeating the cap for a persistently-ERRORING (not just slow)
+      // upstream the same way the earlier TimeoutError bug did for a persistently-slow one.
+      getWeeklyBrief.mockImplementationOnce(() => throwError(() => new HttpErrorResponse({ status: 503 })));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-board', { includeCurrentActivity: true });
+      expect(component.generating()).toBe(true);
+
+      // Only WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS - 1 further real asks remain — the
+      // 503 tick above already spent one slot, same as the sibling TimeoutError test.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(1)));
+      for (let attempt = 0; attempt < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS - 1; attempt++) {
+        await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+        expect(getWeeklyBrief).toHaveBeenNthCalledWith(3 + attempt, 'committee-board', { includeCurrentActivity: true });
+      }
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(getWeeklyBrief).toHaveBeenNthCalledWith(2 + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, 'committee-board', { includeCurrentActivity: false });
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -441,3 +441,165 @@ describe('WeeklyBriefCardComponent — Sources disclosure (LFXV2-3335)', () => {
     expect(component.expandedSourceGroups().size).toBe(0);
   });
 });
+
+/**
+ * Covers the "this week so far" activity tally (GH-1922): the caption for a multi-kind and an
+ * all-zero week, the governance-only gate (Board vs. a non-governance category), the
+ * absent-vs-empty distinction that keeps live mode's backend gap from rendering a misleading
+ * "no activity yet", the per-kind click-to-reveal (mirroring LFXV2-3335's group toggle), and
+ * reset on committee navigation.
+ */
+describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => {
+  let fixture: ComponentFixture<WeeklyBriefCardComponent>;
+  let component: WeeklyBriefCardComponent;
+  let getWeeklyBrief: ReturnType<typeof vi.fn>;
+
+  const BOARD_COMMITTEE: Committee = { uid: 'committee-board', name: 'Board of Directors', project_uid: 'project-1', category: 'Board' } as Committee;
+  const WORKING_GROUP_COMMITTEE: Committee = {
+    uid: 'committee-wg',
+    name: 'Some Working Group',
+    project_uid: 'project-1',
+    category: 'Working Group',
+  } as Committee;
+
+  function activityRef(id: string, kind: string, title: string): WeeklyBriefSourceRef {
+    return { id, kind, title };
+  }
+
+  /** `activityRefs: null` omits `current_activity` entirely — simulates the live-mode backend gap. */
+  function briefResponse(activityRefs: WeeklyBriefSourceRef[] | null): WeeklyBriefCurrentResponse {
+    return {
+      brief: {
+        uid: 'brief-1',
+        committee_uid: 'committee-board',
+        window_start: '2026-08-02T00:00:00Z',
+        window_end: '2026-08-08T23:59:59Z',
+        state: 'generated',
+        brief_text: 'Weekly summary.',
+        source_refs: [],
+        prompt_version: 'v1',
+        model: 'test-model',
+        regeneration_count: 0,
+        private_source_present: false,
+        created_at: '2026-08-08T00:00:00Z',
+        updated_at: '2026-08-08T00:00:00Z',
+        revision: 1,
+      },
+      throttle: { generates_used: 0, generates_limit: 2, regenerations_used: 0, regenerations_limit: 3, window_resets_at: '2026-08-09T00:00:00Z' },
+      caller_rating: null,
+      ...(activityRefs !== null
+        ? { current_activity: { window_start: '2026-08-24T00:00:00Z', window_end: '2026-08-27T12:00:00Z', source_refs: activityRefs } }
+        : {}),
+    };
+  }
+
+  async function setup(committee: Committee, activityRefs: WeeklyBriefSourceRef[] | null): Promise<void> {
+    getWeeklyBrief = vi.fn(() => of(briefResponse(activityRefs)));
+
+    await TestBed.configureTestingModule({
+      imports: [WeeklyBriefCardComponent],
+      providers: [
+        provideRouter([]),
+        provideNoopAnimations(),
+        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })) } },
+        { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
+        { provide: MessageService, useValue: { add: vi.fn() } },
+        // Real service — see the Share to Slack describe block's docblock above for why.
+        ConfirmationService,
+        { provide: UserService, useValue: { impersonating: signal(false) } },
+      ],
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(WeeklyBriefCardComponent);
+    component = fixture.componentInstance;
+    fixture.componentRef.setInput('committee', committee);
+    fixture.componentRef.setInput('canEdit', true);
+    await fixture.whenStable();
+  }
+
+  /** Clicks a data-testid element and flushes it, failing loudly if the element isn't there. */
+  async function clickTestId(testId: string): Promise<HTMLElement> {
+    const el = fixture.nativeElement.querySelector(`[data-testid="${testId}"]`) as HTMLElement | null;
+    expect(el).not.toBeNull();
+    el!.click();
+    await fixture.whenStable();
+    return el!;
+  }
+
+  it('renders a comma-separated, kind-ordered caption for a governance committee with multi-kind activity', async () => {
+    await setup(BOARD_COMMITTEE, [
+      activityRef('meeting-1', 'meeting', 'Board Sync'),
+      activityRef('vote-1', 'vote', 'Q3 Resolution'),
+      activityRef('doc-1', 'doc', 'Meeting Minutes'),
+    ]);
+
+    const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect(el).not.toBeNull();
+    const text = (el.textContent as string).replace(/\s+/g, ' ').trim();
+    expect(text).toContain('This week so far:');
+    expect(text).toContain('1 meeting held');
+    expect(text).toContain('1 vote closed');
+    expect(text).toContain('1 document added');
+    // WEEKLY_BRIEF_SOURCE_SECTIONS order: meeting, vote, ..., doc.
+    expect(text.indexOf('1 meeting held')).toBeLessThan(text.indexOf('1 vote closed'));
+    expect(text.indexOf('1 vote closed')).toBeLessThan(text.indexOf('1 document added'));
+  });
+
+  it('pluralizes a kind with more than one ref this week', async () => {
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync'), activityRef('meeting-2', 'meeting', 'Committee Sync')]);
+
+    const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect(el.textContent as string).toContain('2 meetings held');
+  });
+
+  it('renders "no activity yet" when current_activity is present but empty (a genuine quiet week-so-far)', async () => {
+    await setup(BOARD_COMMITTEE, []);
+
+    const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect(el).not.toBeNull();
+    expect(el.textContent).toContain('no activity yet');
+  });
+
+  it('renders nothing at all when current_activity is absent — the live-mode backend gap must not be presented as "no activity yet" (GH-1922)', async () => {
+    await setup(BOARD_COMMITTEE, null);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]')).toBeNull();
+  });
+
+  it('does not render the tally for a non-governance committee, even with activity present', async () => {
+    await setup(WORKING_GROUP_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Some Meeting')]);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]')).toBeNull();
+  });
+
+  it('clicking a kind reveals its underlying ref titles, and clicking again collapses it', async () => {
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync'), activityRef('vote-1', 'vote', 'Q3 Resolution')]);
+
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-items-meeting"]')).toBeNull();
+
+    const toggle = await clickTestId('weekly-brief-card-current-activity-toggle-meeting');
+    expect(toggle.getAttribute('aria-expanded')).toBe('true');
+    const items = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-items-meeting"]');
+    expect(items).not.toBeNull();
+    expect(items.textContent).toContain('Board Sync');
+    // The vote kind wasn't toggled — its items stay collapsed.
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-items-vote"]')).toBeNull();
+
+    await clickTestId('weekly-brief-card-current-activity-toggle-meeting');
+    expect(toggle.getAttribute('aria-expanded')).toBe('false');
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-items-meeting"]')).toBeNull();
+  });
+
+  it('clears expandedActivityKinds when navigating to a different committee', async () => {
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')]);
+
+    await clickTestId('weekly-brief-card-current-activity-toggle-meeting');
+    expect(component.expandedActivityKinds().has('meeting')).toBe(true);
+
+    getWeeklyBrief.mockReturnValue(of(briefResponse(null)));
+    fixture.componentRef.setInput('committee', WORKING_GROUP_COMMITTEE);
+    await fixture.whenStable();
+
+    expect(component.expandedActivityKinds().size).toBe(0);
+  });
+});

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -840,6 +840,32 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     }
   });
 
+  it("never asks for current_activity on a non-governance committee's poll — the initial load's deliberate opt-out (absent) must not be mistaken for a transient degrade", async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    // null activityRefs on setup — matches what a real includeCurrentActivity: false initial
+    // load actually returns (current_activity key absent), not a governance committee's
+    // transient degrade.
+    await setup(WORKING_GROUP_COMMITTEE, null, generateWeeklyBrief);
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
+
+    fakePollTimers();
+    try {
+      getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
+
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+
+      expect(getWeeklyBrief.mock.calls).toHaveLength(2);
+      // false, not true — before this fix, current_activity being absent alone would have made
+      // this tick ask, spending a wasted upstream fan-out on a committee the client already
+      // knows can never render the tally.
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-wg', { includeCurrentActivity: false });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('stops re-asking for current_activity after WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS ticks, even though it is still absent', async () => {
     const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
     await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -565,7 +565,8 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(text).toContain('1 meeting held');
     expect(text).toContain('1 vote closed');
     expect(text).toContain('1 document added');
-    // WEEKLY_BRIEF_SOURCE_SECTIONS order: meeting, vote, ..., doc.
+    // WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES order: meeting, vote, ..., doc — the list
+    // initCurrentActivitySections actually iterates, not WEEKLY_BRIEF_SOURCE_SECTIONS.
     expect(text.indexOf('1 meeting held')).toBeLessThan(text.indexOf('1 vote closed'));
     expect(text.indexOf('1 vote closed')).toBeLessThan(text.indexOf('1 document added'));
   });

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -733,7 +733,12 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
 
-      expect(getWeeklyBrief).toHaveBeenLastCalledWith('committee-board', { includeCurrentActivity: false });
+      // Length asserted explicitly — every tick here carries the same includeCurrentActivity:
+      // false args, so toHaveBeenLastCalledWith alone would pass silently even if the poll kept
+      // ticking past the terminal revision (the "poll doesn't stop" regression this suite exists
+      // to catch), same reasoning as the sibling test below.
+      expect(getWeeklyBrief.mock.calls).toHaveLength(2);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-board', { includeCurrentActivity: false });
       // The tick's own response has no current_activity key — this must still read as present,
       // merged forward from before the tick, not blanked out.
       expect(component.hasCurrentActivityData()).toBe(true);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -674,7 +674,11 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const generateWeeklyBrief = vi.fn(() =>
       of({
         brief: {
-          uid: 'brief-2',
+          // Same uid as briefResponse()'s fixture — upstream's regenerate reuses the existing
+          // brief's uid and only bumps revision (verified against
+          // group_weekly_brief_generator.go: "brief.UID = existing.UID"), so this fixture keeps
+          // the uid fixed and changes only revision/state, matching the real shape.
+          uid: 'brief-1',
           committee_uid: 'committee-board',
           window_start: '2026-08-02T00:00:00Z',
           window_end: '2026-08-08T23:59:59Z',
@@ -703,5 +707,11 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(component.callerRating()).toBeNull();
     // current_activity is unaffected either way — it isn't scoped to a brief revision.
     expect(component.hasCurrentActivityData()).toBe(true);
+    // No DOM assertion on the rating buttons themselves: onGenerate() sets generating() before
+    // this response ever lands, which switches the template into the generating-state branch
+    // (weekly-brief-card.component.html:62) — the rating buttons live in the later
+    // renderableBrief branch and are not rendered at all here. Confirm that directly, so this
+    // test still proves there is no stale-rated control visible for the value we just dropped.
+    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-rating-up-button"]')).toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -541,6 +541,16 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     return el!;
   }
 
+  it('hints includeCurrentActivity: true on the initial load for a governance committee — it already knows this from its own committee input', async () => {
+    await setup(BOARD_COMMITTEE, []);
+    expect(getWeeklyBrief).toHaveBeenCalledWith('committee-board', { includeCurrentActivity: true });
+  });
+
+  it('hints includeCurrentActivity: false on the initial load for a non-governance committee — the tally section can never render either way', async () => {
+    await setup(WORKING_GROUP_COMMITTEE, null);
+    expect(getWeeklyBrief).toHaveBeenCalledWith('committee-wg', { includeCurrentActivity: false });
+  });
+
   it('renders a comma-separated, kind-ordered caption for a governance committee with multi-kind activity', async () => {
     await setup(BOARD_COMMITTEE, [
       activityRef('meeting-1', 'meeting', 'Board Sync'),

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -6,7 +6,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { WEEKLY_BRIEF_SOURCES_COLLAPSE_THRESHOLD } from '@lfx-one/shared/constants';
-import { Committee, GenerateWeeklyBriefResponse, WeeklyBriefCurrentResponse, WeeklyBriefSourceRef } from '@lfx-one/shared/interfaces';
+import { Committee, GenerateWeeklyBriefResponse, WeeklyBriefCurrentResponse, WeeklyBriefRating, WeeklyBriefSourceRef } from '@lfx-one/shared/interfaces';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
 import { WeeklyBriefService } from '@services/weekly-brief.service';
@@ -467,7 +467,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
   }
 
   /** `activityRefs: null` omits `current_activity` entirely — simulates a server-side degrade (non-governance committee, or a failed lookup/fetch — see weekly-brief.service.ts#buildCurrentActivity). */
-  function briefResponse(activityRefs: WeeklyBriefSourceRef[] | null): WeeklyBriefCurrentResponse {
+  function briefResponse(activityRefs: WeeklyBriefSourceRef[] | null, callerRating: WeeklyBriefRating | null = null): WeeklyBriefCurrentResponse {
     return {
       brief: {
         uid: 'brief-1',
@@ -486,7 +486,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
         revision: 1,
       },
       throttle: { generates_used: 0, generates_limit: 2, regenerations_used: 0, regenerations_limit: 3, window_resets_at: '2026-08-09T00:00:00Z' },
-      caller_rating: null,
+      caller_rating: callerRating,
       ...(activityRefs !== null
         ? { current_activity: { window_start: '2026-08-24T00:00:00Z', window_end: '2026-08-27T12:00:00Z', source_refs: activityRefs } }
         : {}),
@@ -496,9 +496,10 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
   async function setup(
     committee: Committee,
     activityRefs: WeeklyBriefSourceRef[] | null,
-    generateWeeklyBrief: ReturnType<typeof vi.fn> = vi.fn()
+    generateWeeklyBrief: ReturnType<typeof vi.fn> = vi.fn(),
+    callerRating: WeeklyBriefRating | null = null
   ): Promise<void> {
-    getWeeklyBrief = vi.fn(() => of(briefResponse(activityRefs)));
+    getWeeklyBrief = vi.fn(() => of(briefResponse(activityRefs, callerRating)));
 
     await TestBed.configureTestingModule({
       imports: [WeeklyBriefCardComponent],
@@ -649,19 +650,23 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(component.expandedActivityKinds().size).toBe(0);
   });
 
-  it('preserves current_activity through a generate/regenerate round-trip — the 202 envelope never carries it', async () => {
+  it('preserves current_activity and caller_rating through a generate/regenerate round-trip — the 202 envelope carries neither', async () => {
     const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
-    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief);
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief, 'up');
     expect(component.hasCurrentActivityData()).toBe(true);
+    expect(component.callerRating()).toBe('up');
 
     component.onGenerate();
     await fixture.whenStable();
 
     expect(generateWeeklyBrief).toHaveBeenCalled();
-    // GenerateWeeklyBriefResponse has no current_activity field at all — regenerating a brief
-    // doesn't change this week's activity, so the tally must survive the 202 handler rather than
-    // vanish until the next pollUntilTerminal tick lands.
+    // GenerateWeeklyBriefResponse has neither field at all — regenerating a brief doesn't change
+    // this week's activity, and the brief actually still on screen at this point is the
+    // pre-regenerate one (res.brief only lands once generation completes), so its rating is still
+    // accurate too. Both must survive the 202 handler rather than vanish until the next
+    // pollUntilTerminal tick lands.
     expect(component.hasCurrentActivityData()).toBe(true);
+    expect(component.callerRating()).toBe('up');
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el.textContent as string).toContain('1 meeting held');
   });

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -5,7 +5,11 @@ import { signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { WEEKLY_BRIEF_POLL_INTERVAL_MS, WEEKLY_BRIEF_SOURCES_COLLAPSE_THRESHOLD } from '@lfx-one/shared/constants';
+import {
+  WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS,
+  WEEKLY_BRIEF_POLL_INTERVAL_MS,
+  WEEKLY_BRIEF_SOURCES_COLLAPSE_THRESHOLD,
+} from '@lfx-one/shared/constants';
 import { Committee, GenerateWeeklyBriefResponse, WeeklyBriefCurrentResponse, WeeklyBriefRating, WeeklyBriefSourceRef } from '@lfx-one/shared/interfaces';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
@@ -820,6 +824,49 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(getWeeklyBrief.mock.calls).toHaveLength(3);
       // A stopped stream must also have cleared the spinner — see the sibling test above.
+      expect(component.generating()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('stops re-asking for current_activity after WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS ticks, even though it is still absent', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
+
+    fakePollTimers();
+    try {
+      // Every tick keeps the same (non-terminal) revision and never carries current_activity —
+      // models a persistently failing tally fan-out (e.g. an upstream error caught inside
+      // buildCurrentActivity), not a one-off transient degrade the poll should keep retrying
+      // forever for.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(1)));
+
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The first WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS ticks after setup's own initial
+      // call each still ask.
+      for (let attempt = 0; attempt < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS; attempt++) {
+        await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+        expect(getWeeklyBrief).toHaveBeenNthCalledWith(2 + attempt, 'committee-board', { includeCurrentActivity: true });
+      }
+
+      // The next tick — past the cap — stops asking, even though current_activity is still
+      // absent and nothing has changed about the committee's governance status.
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2 + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, 'committee-board', { includeCurrentActivity: false });
+
+      // And stays capped — a further tick still doesn't ask, proving this is a permanent cap for
+      // the rest of this poll cycle, not a one-tick skip that resumes asking right after.
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(3 + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, 'committee-board', { includeCurrentActivity: false });
+
+      // Terminate the poll cleanly (a new terminal revision) so no open subscription leaks past
+      // this test.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(component.generating()).toBe(false);
     } finally {
       vi.useRealTimers();

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -493,6 +493,12 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     };
   }
 
+  /** A poll-tick response at `revision` — terminal by state; whether it's *newly* terminal (and so stops the poll) depends on the caller's priorRevision. */
+  function pollTick(revision: number, extra: Partial<WeeklyBriefCurrentResponse> = {}): WeeklyBriefCurrentResponse {
+    const base = briefResponse(null);
+    return { brief: { ...base.brief!, revision }, throttle: base.throttle, ...extra };
+  }
+
   async function setup(
     committee: Committee,
     activityRefs: WeeklyBriefSourceRef[] | null,
@@ -728,7 +734,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     try {
       // A new terminal revision with no current_activity of its own — a real
       // includeCurrentActivity: false response shape — so the poll stops after this one tick.
-      getWeeklyBrief.mockImplementation(() => of({ brief: { ...briefResponse(null).brief, revision: 2 }, throttle: briefResponse(null).throttle }));
+      getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
 
       component.onGenerate();
       // Flushes the generate POST's own response before the poll's timer(4000, 4000) has even
@@ -764,7 +770,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       // it — a deeper version of the same dead end. Proven by actually regenerating again and
       // confirming a new poll tick fires. A genuinely new terminal revision (not the same 2 as
       // before) so this second poll settles too, rather than leaving an open subscription behind.
-      getWeeklyBrief.mockImplementation(() => of({ brief: { ...briefResponse(null).brief, revision: 3 }, throttle: briefResponse(null).throttle }));
+      getWeeklyBrief.mockImplementation(() => of(pollTick(3)));
       component.onGenerate();
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
@@ -789,11 +795,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       // First tick: same revision as before (not terminal, so the poll keeps ticking) but WITH
       // current_activity: null — a settled "doesn't apply" answer the merge must adopt. Second
       // tick: a new terminal revision, to let the poll stop cleanly.
-      getWeeklyBrief
-        .mockImplementationOnce(() =>
-          of({ brief: { ...briefResponse(null).brief, revision: 1 }, throttle: briefResponse(null).throttle, current_activity: null })
-        )
-        .mockImplementation(() => of({ brief: { ...briefResponse(null).brief, revision: 2 }, throttle: briefResponse(null).throttle }));
+      getWeeklyBrief.mockImplementationOnce(() => of(pollTick(1, { current_activity: null }))).mockImplementation(() => of(pollTick(2)));
 
       component.onGenerate();
       await vi.advanceTimersByTimeAsync(0);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -6,7 +6,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
 import { WEEKLY_BRIEF_SOURCES_COLLAPSE_THRESHOLD } from '@lfx-one/shared/constants';
-import { Committee, WeeklyBriefCurrentResponse, WeeklyBriefSourceRef } from '@lfx-one/shared/interfaces';
+import { Committee, GenerateWeeklyBriefResponse, WeeklyBriefCurrentResponse, WeeklyBriefSourceRef } from '@lfx-one/shared/interfaces';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
 import { WeeklyBriefService } from '@services/weekly-brief.service';
@@ -493,7 +493,11 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     };
   }
 
-  async function setup(committee: Committee, activityRefs: WeeklyBriefSourceRef[] | null): Promise<void> {
+  async function setup(
+    committee: Committee,
+    activityRefs: WeeklyBriefSourceRef[] | null,
+    generateWeeklyBrief: ReturnType<typeof vi.fn> = vi.fn()
+  ): Promise<void> {
     getWeeklyBrief = vi.fn(() => of(briefResponse(activityRefs)));
 
     await TestBed.configureTestingModule({
@@ -501,7 +505,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       providers: [
         provideRouter([]),
         provideNoopAnimations(),
-        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })) } },
+        { provide: WeeklyBriefService, useValue: { getWeeklyBrief, listWeeklyBriefs: vi.fn(() => of({ data: [] })), generateWeeklyBrief } },
         { provide: FeatureFlagService, useValue: { getBooleanFlag: vi.fn(() => signal(false)) } },
         { provide: MessageService, useValue: { add: vi.fn() } },
         // Real service — see the Share to Slack describe block's docblock above for why.
@@ -562,19 +566,22 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect((voteToggle.textContent as string).replace(/\s+/g, ' ').trim()).toBe('1 vote closed');
   });
 
-  it('sets role="group" + aria-label on the container, and aria-controls on each toggle pointing at its revealed list id', async () => {
+  it('sets role="group" + aria-label on the container, and aria-controls on each toggle only once its revealed list actually exists', async () => {
     await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')]);
 
     const container = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(container.getAttribute('role')).toBe('group');
     expect(container.getAttribute('aria-label')).toContain('1 meeting held');
 
+    // Collapsed by default: the @if-guarded list this would point at isn't rendered yet, so
+    // aria-controls must be absent rather than reference a nonexistent id (axe aria-valid-attr-value).
     const toggle = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-toggle-meeting"]');
-    expect(toggle.getAttribute('aria-controls')).toBe('weekly-brief-card-current-activity-items-meeting');
+    expect(toggle.getAttribute('aria-controls')).toBeNull();
 
     await clickTestId('weekly-brief-card-current-activity-toggle-meeting');
     const items = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity-items-meeting"]');
-    expect(items.getAttribute('id')).toBe(toggle.getAttribute('aria-controls'));
+    expect(items.getAttribute('id')).toBe('weekly-brief-card-current-activity-items-meeting');
+    expect(toggle.getAttribute('aria-controls')).toBe(items.getAttribute('id'));
   });
 
   it('rolls an unrecognized kind into an "Other" bucket instead of dropping it, and does not render the false "no activity yet" line', async () => {
@@ -640,5 +647,22 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     await fixture.whenStable();
 
     expect(component.expandedActivityKinds().size).toBe(0);
+  });
+
+  it('preserves current_activity through a generate/regenerate round-trip — the 202 envelope never carries it', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief);
+    expect(component.hasCurrentActivityData()).toBe(true);
+
+    component.onGenerate();
+    await fixture.whenStable();
+
+    expect(generateWeeklyBrief).toHaveBeenCalled();
+    // GenerateWeeklyBriefResponse has no current_activity field at all — regenerating a brief
+    // doesn't change this week's activity, so the tally must survive the 202 handler rather than
+    // vanish until the next pollUntilTerminal tick lands.
+    expect(component.hasCurrentActivityData()).toBe(true);
+    const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
+    expect(el.textContent as string).toContain('1 meeting held');
   });
 });

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -703,14 +703,14 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
    * `timer(delay, period)` schedules its periodic emissions via `setInterval`, not repeated
    * `setTimeout` calls, so faking only `setTimeout` (as the two prior commits in this sequence
    * tried) leaves the poll's own timer running on the real clock and `vi.advanceTimersByTimeAsync`
-   * advances nothing it's actually waiting on. Deliberately does NOT fake `Date`'s siblings this
-   * suite doesn't need, and — critically — the tests below never call `fixture.whenStable()` while
-   * fake timers are active: zoneless Angular's own change-detection stability tracking depends on
-   * some faked-by-default primitive (`requestAnimationFrame` is the prime suspect, though the
-   * exact mechanism wasn't root-caused), and calling it here hangs indefinitely. Assertions read
-   * component signals directly instead (`hasCurrentActivityData()`, the `getWeeklyBrief` spy's
-   * call args) — `vi.advanceTimersByTimeAsync`'s own microtask flushing is sufficient for those to
-   * be current by the time it resolves.
+   * advances nothing it's actually waiting on. Deliberately excludes `requestAnimationFrame` and
+   * every other vitest-fakes-by-default primitive this suite doesn't need — critically, zoneless
+   * Angular's own change-detection stability tracking depends on one of them (`rAF` is the prime
+   * suspect, though the exact mechanism wasn't root-caused), and faking it hangs
+   * `fixture.whenStable()` indefinitely. For that reason the tests below never call
+   * `fixture.whenStable()` while fake timers are active — assertions read component signals and
+   * the `getWeeklyBrief` spy's call args directly instead, which `vi.advanceTimersByTimeAsync`'s
+   * own microtask flushing keeps current without it.
    */
   function fakePollTimers(): void {
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] });
@@ -747,6 +747,9 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     // null activityRefs — current_activity starts absent (e.g. a degraded initial lookup).
     await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
     expect(component.hasCurrentActivityData()).toBe(false);
+    // setup()'s own initial getWeeklyBrief call — pinned so the nth-call assertions below have a
+    // known starting index regardless of what setup() does internally.
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
 
     fakePollTimers();
     try {
@@ -762,14 +765,19 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       component.onGenerate();
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
-      expect(getWeeklyBrief).toHaveBeenLastCalledWith('committee-board', { includeCurrentActivity: true });
+      // Length asserted explicitly, not just the last call's args — a call count that isn't
+      // exactly 2 means either the tick never fired or fired more than once, either of which
+      // would make toHaveBeenLastCalledWith silently read the wrong call.
+      expect(getWeeklyBrief.mock.calls).toHaveLength(2);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-board', { includeCurrentActivity: true });
 
       // The second tick is the real proof: if the first tick's fresh null had been discarded by
       // a `??` merge (rather than adopted via `!== undefined`), current_activity would still
       // read as absent here and this second tick would ask again with `true` — forever, on every
       // subsequent tick, which is the exact regression this commit exists to fix.
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
-      expect(getWeeklyBrief).toHaveBeenLastCalledWith('committee-board', { includeCurrentActivity: false });
+      expect(getWeeklyBrief.mock.calls).toHaveLength(3);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(3, 'committee-board', { includeCurrentActivity: false });
     } finally {
       vi.useRealTimers();
     }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -5,7 +5,7 @@ import { signal, WritableSignal } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { provideNoopAnimations } from '@angular/platform-browser/animations';
 import { provideRouter } from '@angular/router';
-import { WEEKLY_BRIEF_SOURCES_COLLAPSE_THRESHOLD } from '@lfx-one/shared/constants';
+import { WEEKLY_BRIEF_POLL_INTERVAL_MS, WEEKLY_BRIEF_SOURCES_COLLAPSE_THRESHOLD } from '@lfx-one/shared/constants';
 import { Committee, GenerateWeeklyBriefResponse, WeeklyBriefCurrentResponse, WeeklyBriefRating, WeeklyBriefSourceRef } from '@lfx-one/shared/interfaces';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
@@ -696,6 +696,83 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(component.callerRating()).toBe('up');
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el.textContent as string).toContain('1 meeting held');
+  });
+
+  /**
+   * `vi.useFakeTimers` must fake `setTimeout`/`clearTimeout`/`setInterval`/`clearInterval` — RxJS's
+   * `timer(delay, period)` schedules its periodic emissions via `setInterval`, not repeated
+   * `setTimeout` calls, so faking only `setTimeout` (as the two prior commits in this sequence
+   * tried) leaves the poll's own timer running on the real clock and `vi.advanceTimersByTimeAsync`
+   * advances nothing it's actually waiting on. Deliberately does NOT fake `Date`'s siblings this
+   * suite doesn't need, and — critically — the tests below never call `fixture.whenStable()` while
+   * fake timers are active: zoneless Angular's own change-detection stability tracking depends on
+   * some faked-by-default primitive (`requestAnimationFrame` is the prime suspect, though the
+   * exact mechanism wasn't root-caused), and calling it here hangs indefinitely. Assertions read
+   * component signals directly instead (`hasCurrentActivityData()`, the `getWeeklyBrief` spy's
+   * call args) — `vi.advanceTimersByTimeAsync`'s own microtask flushing is sufficient for those to
+   * be current by the time it resolves.
+   */
+  function fakePollTimers(): void {
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] });
+  }
+
+  it('a poll tick opts out (includeCurrentActivity: false) once current_activity is already present, and merges it forward since the tick carries none', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief);
+    expect(component.hasCurrentActivityData()).toBe(true);
+
+    fakePollTimers();
+    try {
+      // A new terminal revision with no current_activity of its own — a real
+      // includeCurrentActivity: false response shape — so the poll stops after this one tick.
+      getWeeklyBrief.mockImplementation(() => of({ brief: { ...briefResponse(null).brief, revision: 2 }, throttle: briefResponse(null).throttle }));
+
+      component.onGenerate();
+      // Flushes the generate POST's own response before the poll's timer(4000, 4000) has even
+      // started, then advances one full interval to trigger its first tick.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+
+      expect(getWeeklyBrief).toHaveBeenLastCalledWith('committee-board', { includeCurrentActivity: false });
+      // The tick's own response has no current_activity key — this must still read as present,
+      // merged forward from before the tick, not blanked out.
+      expect(component.hasCurrentActivityData()).toBe(true);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('a poll tick keeps asking (includeCurrentActivity: true) while current_activity is absent, and a settled null it comes back with is not discarded as "no value" (the exact case ?? got wrong)', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    // null activityRefs — current_activity starts absent (e.g. a degraded initial lookup).
+    await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
+    expect(component.hasCurrentActivityData()).toBe(false);
+
+    fakePollTimers();
+    try {
+      // First tick: same revision as before (not terminal, so the poll keeps ticking) but WITH
+      // current_activity: null — a settled "doesn't apply" answer the merge must adopt. Second
+      // tick: a new terminal revision, to let the poll stop cleanly.
+      getWeeklyBrief
+        .mockImplementationOnce(() =>
+          of({ brief: { ...briefResponse(null).brief, revision: 1 }, throttle: briefResponse(null).throttle, current_activity: null })
+        )
+        .mockImplementation(() => of({ brief: { ...briefResponse(null).brief, revision: 2 }, throttle: briefResponse(null).throttle }));
+
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenLastCalledWith('committee-board', { includeCurrentActivity: true });
+
+      // The second tick is the real proof: if the first tick's fresh null had been discarded by
+      // a `??` merge (rather than adopted via `!== undefined`), current_activity would still
+      // read as absent here and this second tick would ask again with `true` — forever, on every
+      // subsequent tick, which is the exact regression this commit exists to fix.
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenLastCalledWith('committee-board', { includeCurrentActivity: false });
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it('drops (not carries forward) caller_rating when the 202 envelope itself already carries a new brief', async () => {

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -910,6 +910,84 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     }
   });
 
+  it('resets the ask-attempt budget on a new poll cycle — currentActivityAskAttempts is scoped per pollUntilTerminal call, not the component instance', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
+
+    fakePollTimers();
+    try {
+      // First cycle: spend the entire ask-attempt budget, same as the sibling cap test above.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(1)));
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+      for (let attempt = 0; attempt < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS; attempt++) {
+        await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      }
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenLastCalledWith('committee-board', { includeCurrentActivity: false });
+      // Terminate the first poll (revision 2) so a second Regenerate can start a fresh one.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(component.generating()).toBe(false);
+      const callsAfterFirstCycle = getWeeklyBrief.mock.calls.length;
+
+      // Second cycle: current_activity is absent again (e.g. the tally keeps failing) — if the
+      // budget were a component field instead of scoped inside pollUntilTerminal, it would
+      // already read as exhausted here and this tick would never ask.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(3)));
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(callsAfterFirstCycle + 1, 'committee-board', { includeCurrentActivity: true });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('adopts a real current_activity a poll tick returns — hasCurrentActivityData flips false to true, the actual success case the retry budget exists to reach', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
+    expect(component.hasCurrentActivityData()).toBe(false);
+
+    fakePollTimers();
+    try {
+      // First tick: same revision as before (not terminal — keeps polling), now WITH a real,
+      // non-empty current_activity — the success case, not just the settled-null case the
+      // sibling "keeps asking" test already covers. Second tick: a new terminal revision, so the
+      // poll stops cleanly.
+      getWeeklyBrief
+        .mockImplementationOnce(() =>
+          of(
+            pollTick(1, {
+              current_activity: {
+                window_start: '2026-08-24T00:00:00Z',
+                window_end: '2026-08-27T12:00:00Z',
+                source_refs: [activityRef('meeting-1', 'meeting', 'Board Sync')],
+              },
+            })
+          )
+        )
+        .mockImplementation(() => of(pollTick(2)));
+
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+
+      // Signal-level assertions only — under fake timers (see fakePollTimers's own docblock)
+      // zoneless Angular's change-detection scheduler can't run, so a DOM query here would read
+      // stale content rather than proving anything about this tick's effect.
+      expect(component.hasCurrentActivityData()).toBe(true);
+      expect(component.currentActivity()).toEqual([expect.objectContaining({ kind: 'meeting', countText: '1 meeting held' })]);
+
+      // Let the poll terminate cleanly.
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(component.generating()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it('drops (not carries forward) caller_rating when the 202 envelope itself already carries a new brief', async () => {
     const generateWeeklyBrief = vi.fn(() =>
       of({

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -703,15 +703,12 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
 
     // The type allows a populated res.brief on the 202 — the old rating describes the
     // pre-regenerate revision, not this new one, so it must NOT carry forward here (contrast
-    // the bare-202 case above, where it correctly does).
+    // the bare-202 case above, where it correctly does). No DOM assertion alongside this: the
+    // rating buttons live in the renderableBrief template branch, which generating() (already
+    // true by this point) routes around regardless of caller_rating's value — a DOM query here
+    // would pass or fail on branch structure alone, not on the drop this test actually exercises.
     expect(component.callerRating()).toBeNull();
     // current_activity is unaffected either way — it isn't scoped to a brief revision.
     expect(component.hasCurrentActivityData()).toBe(true);
-    // No DOM assertion on the rating buttons themselves: onGenerate() sets generating() before
-    // this response ever lands, which switches the template into the generating-state branch
-    // (weekly-brief-card.component.html:62) — the rating buttons live in the later
-    // renderableBrief branch and are not rendered at all here. Confirm that directly, so this
-    // test still proves there is no stale-rated control visible for the value we just dropped.
-    expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-rating-up-button"]')).toBeNull();
   });
 });

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -466,7 +466,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     return { id, kind, title };
   }
 
-  /** `activityRefs: null` omits `current_activity` entirely — simulates the live-mode backend gap. */
+  /** `activityRefs: null` omits `current_activity` entirely — simulates a server-side degrade (non-governance committee, or a failed lookup/fetch — see weekly-brief.service.ts#buildCurrentActivity). */
   function briefResponse(activityRefs: WeeklyBriefSourceRef[] | null): WeeklyBriefCurrentResponse {
     return {
       brief: {
@@ -599,7 +599,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(el.textContent).toContain('no activity yet');
   });
 
-  it('renders nothing at all when current_activity is absent — the live-mode backend gap must not be presented as "no activity yet" (GH-1922)', async () => {
+  it('renders nothing at all when current_activity is absent — a server-side degrade must not be presented as "no activity yet" (GH-1922)', async () => {
     await setup(BOARD_COMMITTEE, null);
 
     expect(fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]')).toBeNull();

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -753,6 +753,10 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       // with the poll never stopping — only a further advance catches it).
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(getWeeklyBrief.mock.calls).toHaveLength(2);
+      // A stopped stream must also have cleared the spinner — pollUntilTerminal's finalize does
+      // double duty (releases pollActive AND clears generating), and a poll that stops without
+      // clearing generating strands the card on "Generating…" with no way out but a reload.
+      expect(component.generating()).toBe(false);
     } finally {
       vi.useRealTimers();
     }
@@ -800,6 +804,8 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       // tell "stopped" apart from "haven't looked far enough yet".
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(getWeeklyBrief.mock.calls).toHaveLength(3);
+      // A stopped stream must also have cleared the spinner — see the sibling test above.
+      expect(component.generating()).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -10,7 +10,14 @@ import {
   WEEKLY_BRIEF_POLL_INTERVAL_MS,
   WEEKLY_BRIEF_SOURCES_COLLAPSE_THRESHOLD,
 } from '@lfx-one/shared/constants';
-import { Committee, GenerateWeeklyBriefResponse, WeeklyBriefCurrentResponse, WeeklyBriefRating, WeeklyBriefSourceRef } from '@lfx-one/shared/interfaces';
+import {
+  Committee,
+  GenerateWeeklyBriefResponse,
+  WeeklyBriefCurrentResponse,
+  WeeklyBriefRating,
+  WeeklyBriefSourceRef,
+  WeeklyBriefThrottle,
+} from '@lfx-one/shared/interfaces';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
 import { WeeklyBriefService } from '@services/weekly-brief.service';
@@ -699,24 +706,51 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     expect(component.expandedActivityKinds().size).toBe(0);
   });
 
-  it('preserves current_activity and caller_rating through a generate/regenerate round-trip — the 202 envelope carries neither', async () => {
+  it('preserves current_activity, caller_rating, brief, and throttle through a generate/regenerate round-trip — the 202 envelope carries none of them', async () => {
     const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
     await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief, 'up');
     expect(component.hasCurrentActivityData()).toBe(true);
     expect(component.callerRating()).toBe('up');
+    const briefBeforeGenerate = component.brief();
+    const throttleBeforeGenerate = component.throttle();
 
     component.onGenerate();
     await fixture.whenStable();
 
     expect(generateWeeklyBrief).toHaveBeenCalled();
-    // GenerateWeeklyBriefResponse has neither field at all — regenerating a brief doesn't change
-    // this week's activity, and a bare 202 (no res.brief) means the brief still on screen is
-    // genuinely the pre-regenerate one, so its rating is still accurate too. Both must survive
-    // the 202 handler rather than vanish until the next pollUntilTerminal tick lands.
+    // GenerateWeeklyBriefResponse has none of these fields at all — regenerating a brief doesn't
+    // change this week's activity, and a bare 202 (no res.brief/res.throttle) means the brief and
+    // throttle still on screen are genuinely the pre-regenerate ones, so their rating is still
+    // accurate too. All four must survive the 202 handler's `res.x ?? prev?.x ?? null` fallbacks
+    // rather than vanish until the next pollUntilTerminal tick lands — this is the behavior the
+    // handler's `.set()` -> `.update()` change exists for.
     expect(component.hasCurrentActivityData()).toBe(true);
     expect(component.callerRating()).toBe('up');
+    expect(component.brief()).toEqual(briefBeforeGenerate);
+    expect(component.throttle()).toEqual(throttleBeforeGenerate);
     const el = fixture.nativeElement.querySelector('[data-testid="weekly-brief-card-current-activity"]');
     expect(el.textContent as string).toContain('1 meeting held');
+  });
+
+  it('adopts a throttle the 202 envelope DOES carry, rather than keeping the pre-generate value', async () => {
+    const newThrottle: WeeklyBriefThrottle = {
+      generates_used: 2,
+      generates_limit: 2,
+      regenerations_used: 0,
+      regenerations_limit: 3,
+      window_resets_at: '2026-08-09T00:00:00Z',
+    };
+    const generateWeeklyBrief = vi.fn(() => of({ throttle: newThrottle } as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief);
+    expect(component.throttle()).not.toEqual(newThrottle);
+
+    component.onGenerate();
+    await fixture.whenStable();
+
+    // A generate response that DOES report throttle (the normal shape — upstream bumps
+    // generates_used before returning) must be adopted immediately, not deferred to the next poll
+    // tick — the fallback exists for the fields a bare 202 omits, not to ignore ones it supplies.
+    expect(component.throttle()).toEqual(newThrottle);
   });
 
   /**
@@ -902,6 +936,49 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
 
       // Terminate the poll cleanly (a new terminal revision) so no open subscription leaks past
       // this test.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(component.generating()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('does not burn the ask-attempt cap on a tick that fails before reaching the server — only a tick that actually got an answer counts', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
+
+    fakePollTimers();
+    try {
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // The first tick after generate fails outright (a stand-in for the tick's own HTTP timeout
+      // or a network error) before any response — this asked (includeCurrentActivity: true), but
+      // must NOT count against WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, since the server
+      // never had a chance to answer.
+      getWeeklyBrief.mockImplementationOnce(() => throwError(() => new Error('network error')));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-board', { includeCurrentActivity: true });
+      // A failed tick degrades gracefully — it must not look like a terminal state and stop the
+      // poll (see the pipe's own comment in weekly-brief-card.component.ts).
+      expect(component.generating()).toBe(true);
+
+      // Every subsequent tick succeeds but still reports no current_activity. If the failed tick
+      // above had wrongly consumed a slot (the bug this test pins the fix for), the cap would be
+      // reached one tick earlier than this loop expects.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(1)));
+      for (let attempt = 0; attempt < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS; attempt++) {
+        await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+        expect(getWeeklyBrief).toHaveBeenNthCalledWith(3 + attempt, 'committee-board', { includeCurrentActivity: true });
+      }
+      // Past the full cap now (one failed ask + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS
+      // real ones) — this next tick stops asking.
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(3 + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, 'committee-board', { includeCurrentActivity: false });
+
+      // Terminate the poll cleanly so no open subscription leaks past this test.
       getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(component.generating()).toBe(false);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -23,7 +23,7 @@ import { UserService } from '@services/user.service';
 import { WeeklyBriefService } from '@services/weekly-brief.service';
 import { ConfirmationService, MessageService } from 'primeng/api';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { of, throwError } from 'rxjs';
+import { of, throwError, TimeoutError } from 'rxjs';
 
 import { WeeklyBriefCardComponent } from './weekly-brief-card.component';
 
@@ -979,6 +979,45 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       expect(getWeeklyBrief).toHaveBeenNthCalledWith(3 + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, 'committee-board', { includeCurrentActivity: false });
 
       // Terminate the poll cleanly so no open subscription leaks past this test.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(component.generating()).toBe(false);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it('DOES burn the ask-attempt cap on a tick that times out waiting for a response — the server may still be doing the fan-out work the client gave up on', async () => {
+    const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
+    await setup(BOARD_COMMITTEE, null, generateWeeklyBrief);
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
+
+    fakePollTimers();
+    try {
+      component.onGenerate();
+      await vi.advanceTimersByTimeAsync(0);
+
+      // Unlike the sibling "fails before reaching the server" test above, a TimeoutError DOES
+      // count against the cap — aborting the client-side wait doesn't cancel the BFF's in-flight
+      // getCommitteeBase + getCommitteeActivity fan-out, so this tick genuinely cost what the cap
+      // exists to bound, even though no response ever came back.
+      getWeeklyBrief.mockImplementationOnce(() => throwError(() => new TimeoutError()));
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-board', { includeCurrentActivity: true });
+      expect(component.generating()).toBe(true);
+
+      // Only WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS - 1 further real asks remain — the
+      // timed-out tick above already spent one slot.
+      getWeeklyBrief.mockImplementation(() => of(pollTick(1)));
+      for (let attempt = 0; attempt < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS - 1; attempt++) {
+        await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+        expect(getWeeklyBrief).toHaveBeenNthCalledWith(3 + attempt, 'committee-board', { includeCurrentActivity: true });
+      }
+      // The cap is already spent — one tick earlier than the sibling network-failure test, since
+      // the timed-out tick counted.
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief).toHaveBeenNthCalledWith(2 + WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, 'committee-board', { includeCurrentActivity: false });
+
       getWeeklyBrief.mockImplementation(() => of(pollTick(2)));
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(component.generating()).toBe(false);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -720,6 +720,9 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
     await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief);
     expect(component.hasCurrentActivityData()).toBe(true);
+    // setup()'s own initial getWeeklyBrief call — pinned so the nth-call assertions below have a
+    // known starting index regardless of what setup() does internally.
+    expect(getWeeklyBrief.mock.calls).toHaveLength(1);
 
     fakePollTimers();
     try {
@@ -733,15 +736,23 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
 
-      // Length asserted explicitly — every tick here carries the same includeCurrentActivity:
-      // false args, so toHaveBeenLastCalledWith alone would pass silently even if the poll kept
-      // ticking past the terminal revision (the "poll doesn't stop" regression this suite exists
-      // to catch), same reasoning as the sibling test below.
+      // Length asserted explicitly, not just the last call's args — a call count that isn't
+      // exactly 2 means either the tick never fired or (e.g. a regressed pollActive guard) fired
+      // more than once within this same window, either of which would make
+      // toHaveBeenLastCalledWith silently read the wrong call.
       expect(getWeeklyBrief.mock.calls).toHaveLength(2);
       expect(getWeeklyBrief).toHaveBeenNthCalledWith(2, 'committee-board', { includeCurrentActivity: false });
       // The tick's own response has no current_activity key — this must still read as present,
       // merged forward from before the tick, not blanked out.
       expect(component.hasCurrentActivityData()).toBe(true);
+
+      // Proves takeWhile actually stopped the poll on this terminal revision, not just that this
+      // one tick's own args were right — the call count above alone can't distinguish "the poll
+      // stopped" from "we just haven't advanced far enough to see the next tick yet" (confirmed
+      // by mutation-testing isNewTerminal to always return false: the assertions above still pass
+      // with the poll never stopping — only a further advance catches it).
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief.mock.calls).toHaveLength(2);
     } finally {
       vi.useRealTimers();
     }
@@ -783,6 +794,12 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(getWeeklyBrief.mock.calls).toHaveLength(3);
       expect(getWeeklyBrief).toHaveBeenNthCalledWith(3, 'committee-board', { includeCurrentActivity: false });
+
+      // Proves the poll actually stopped on tick 2's terminal revision, not just that tick 2's
+      // own args were right — see the sibling test above for why a further advance is needed to
+      // tell "stopped" apart from "haven't looked far enough yet".
+      await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
+      expect(getWeeklyBrief.mock.calls).toHaveLength(3);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.spec.ts
@@ -716,7 +716,7 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
     vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout', 'setInterval', 'clearInterval', 'Date'] });
   }
 
-  it('a poll tick opts out (includeCurrentActivity: false) once current_activity is already present, and merges it forward since the tick carries none', async () => {
+  it('a poll tick opts out once current_activity is present and merges it forward, then the poll fully stops (generating/pollActive both clear) so a later Regenerate can start a new poll', async () => {
     const generateWeeklyBrief = vi.fn(() => of({} as GenerateWeeklyBriefResponse));
     await setup(BOARD_COMMITTEE, [activityRef('meeting-1', 'meeting', 'Board Sync')], generateWeeklyBrief);
     expect(component.hasCurrentActivityData()).toBe(true);
@@ -762,11 +762,14 @@ describe('WeeklyBriefCardComponent — Current activity tally (GH-1922)', () => 
       // pollUntilTerminal's own re-entrancy guard (`if (!isPlatformBrowser... || this.pollActive)
       // return`) makes every later Regenerate set generating() with no poll left to ever clear
       // it — a deeper version of the same dead end. Proven by actually regenerating again and
-      // confirming a new poll tick fires.
+      // confirming a new poll tick fires. A genuinely new terminal revision (not the same 2 as
+      // before) so this second poll settles too, rather than leaving an open subscription behind.
+      getWeeklyBrief.mockImplementation(() => of({ brief: { ...briefResponse(null).brief, revision: 3 }, throttle: briefResponse(null).throttle }));
       component.onGenerate();
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_POLL_INTERVAL_MS);
       expect(getWeeklyBrief.mock.calls).toHaveLength(3);
+      expect(component.generating()).toBe(false);
     } finally {
       vi.useRealTimers();
     }

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -822,11 +822,17 @@ export class WeeklyBriefCardComponent {
         // (and the attempt cap) indefinitely, since exhaustMap only completes once its
         // last active inner subscription settles.
         exhaustMap(() =>
-          // includeCurrentActivity: false (GH-1922) — this week's activity can't change
-          // mid-poll, so re-running that fan-out on every tick only multiplies its upstream
-          // cost for a value the poll's first tick (via the initial load) already has. Merged
-          // back onto the response below rather than fetched again.
-          this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: false }).pipe(
+          // includeCurrentActivity (GH-1922): only opt out once a value is already in hand —
+          // this week's activity can't change mid-poll, so re-running the fan-out for a value
+          // already held is pure waste. But if the initial load left current_activity absent
+          // (a governance committee whose lookup/fetch degraded — see
+          // weekly-brief.service.ts#buildCurrentActivity), keep asking on every tick so a
+          // transient failure can still self-heal instead of staying blank for the rest of the
+          // poll and beyond, with nothing left to re-fetch it once the poll ends. A
+          // non-governance committee (also current_activity: undefined) re-asks too, but
+          // buildCurrentActivity short-circuits cheaply for those right after the category
+          // read, well before the expensive activity aggregation.
+          this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: !this.briefResponse()?.current_activity }).pipe(
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),
             catchError((err: unknown) => {
               console.error('[weekly-brief-card] poll tick failed, will retry', err);
@@ -838,10 +844,10 @@ export class WeeklyBriefCardComponent {
         // a transient poll failure must not look like a terminal state and stop the poll.
         filter((response): response is WeeklyBriefCurrentResponse => response !== null),
         tap((response) => {
-          // response never carries current_activity (includeCurrentActivity: false above) —
-          // preserve whatever the card already has instead of letting a plain .set() blank it
-          // out for the rest of this poll.
-          this.briefResponse.update((prev) => ({ ...response, current_activity: prev?.current_activity }));
+          // A tick that opted out (see above) carries no current_activity of its own — fall
+          // back to whatever the card already has rather than letting a plain .set() blank a
+          // good value out just because this particular tick didn't ask for a fresh one.
+          this.briefResponse.update((prev) => ({ ...response, current_activity: response.current_activity ?? prev?.current_activity }));
           // Same reasoning as initBriefResponseSubscription's subscribe: a fresh GET
           // supersedes any optimistic overlay.
           this.optimisticRating.set(null);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -246,13 +246,14 @@ export class WeeklyBriefCardComponent {
   // brief's own completed week, so it isn't part of WeeklyBrief itself.
   public readonly currentActivity: Signal<WeeklyBriefCurrentActivitySection[]> = this.initCurrentActivitySections();
 
-  // Distinguishes "no value to show" (absent — a transient server-side lookup/fetch degrade —
-  // or null — a settled non-governance/full-page answer; see WeeklyBriefCurrentResponse's own
-  // current_activity doc comment, in @lfx-one/shared/interfaces, for that three-state contract,
-  // which pollUntilTerminal's poll loop below depends on but rendering here doesn't) from "the
-  // field is a real object, every kind possibly zero" (a genuine quiet week) — the template
-  // must render neither line nor "no activity yet" for the former, only the latter (GH-1922:
-  // "do NOT fabricate ... degrade gracefully").
+  // Distinguishes "no value to show" (absent — either a transient server-side degrade, or this
+  // card's own deliberate includeCurrentActivity: false opt-out — or null — a settled
+  // non-governance/full-page answer; see WeeklyBriefCurrentResponse's own current_activity doc
+  // comment, in @lfx-one/shared/interfaces, for that three-state contract, which
+  // pollUntilTerminal's poll loop below depends on but rendering here doesn't) from "the field
+  // is a real object, every kind possibly zero" (a genuine quiet week) — the template must
+  // render neither line nor "no activity yet" for the former, only the latter (GH-1922: "do NOT
+  // fabricate ... degrade gracefully").
   public readonly hasCurrentActivityData: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity);
 
   // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet".

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -369,10 +369,14 @@ export class WeeklyBriefCardComponent {
           // description and its 202 example) — reusing the pre-regenerate rating against that
           // new revision would misattribute, so this drops it whenever res.brief lands and
           // lets the poll's first GET restore the correct value for that revision instead.
+          // Spreads `prev` rather than enumerating every field — `current_activity` carries
+          // forward unchanged for free, and a future field added to WeeklyBriefCurrentResponse
+          // survives this update by default instead of being silently dropped on every
+          // generate/regenerate.
           this.briefResponse.update((prev) => ({
-            brief: res.brief ?? this.brief(),
-            throttle: res.throttle ?? this.throttle(),
-            current_activity: prev?.current_activity,
+            ...prev,
+            brief: res.brief ?? prev?.brief ?? null,
+            throttle: res.throttle ?? prev?.throttle ?? null,
             caller_rating: res.brief ? null : prev?.caller_rating,
           }));
           // On Regenerate, currentBrief.revision is the pre-regenerate revision — pollUntilTerminal

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -882,13 +882,16 @@ export class WeeklyBriefCardComponent {
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),
             catchError((err: unknown) => {
               console.error('[weekly-brief-card] poll tick failed, will retry', err);
-              // Undo the optimistic increment above: a tick that never reached the server (this
-              // tick's own HTTP timeout, or any other error) never got a chance to answer, so it
-              // must not count against the cap the same way a tick that DID answer — even with a
-              // transient `undefined` — does. Without this, a run of ordinary network hiccups
-              // could exhaust WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS on its own, before
-              // the fan-out this cap actually exists to bound ever got asked.
-              if (shouldAskCurrentActivity) currentActivityAskAttempts -= 1;
+              // Undo the optimistic increment above only for a request that never reached the
+              // BFF at all (a genuine network/connection failure) — NOT for this tick's own
+              // `timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS)` above. Aborting the client-side XHR on
+              // that timeout does not cancel the server-side work already in flight — the BFF
+              // still pays getCommitteeBase + getCommitteeActivity's fan-out for a tick this
+              // client gave up waiting on. Refunding the slot for a TimeoutError would let a
+              // persistently slow (not erroring) upstream — the exact case
+              // WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS exists to bound — re-ask on every
+              // one of up to WEEKLY_BRIEF_MAX_POLL_ATTEMPTS ticks instead of stopping at the cap.
+              if (shouldAskCurrentActivity && !(err instanceof TimeoutError)) currentActivityAskAttempts -= 1;
               return of(null as WeeklyBriefCurrentResponse | null);
             })
           );

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -14,6 +14,7 @@ import { TextareaComponent } from '@components/textarea/textarea.component';
 import { WeeklyBriefArchiveDrawerComponent } from '../weekly-brief-archive-drawer/weekly-brief-archive-drawer.component';
 import { SourceChipContextDirective } from './source-chip-context.directive';
 import {
+  WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS,
   WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES,
   WEEKLY_BRIEF_ERROR_REASON,
   WEEKLY_BRIEF_MAX_POLL_ATTEMPTS,
@@ -801,6 +802,10 @@ export class WeeklyBriefCardComponent {
     this.pollTimedOut.set(false);
     let ticks = 0;
     let observedTerminal = false;
+    // Bounds how many ticks keep re-asking for current_activity while it stays undefined — see
+    // WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS's own doc comment for why this needs its
+    // own, smaller cap than the poll's overall WEEKLY_BRIEF_MAX_POLL_ATTEMPTS.
+    let currentActivityAskAttempts = 0;
     const isNewTerminal = (response: WeeklyBriefCurrentResponse): boolean => {
       const b = response.brief;
       if (!b || !WEEKLY_BRIEF_TERMINAL_STATES.has(b.state)) return false;
@@ -823,7 +828,7 @@ export class WeeklyBriefCardComponent {
         // exhaustMap wait itself — otherwise a single hung request would block `complete`
         // (and the attempt cap) indefinitely, since exhaustMap only completes once its
         // last active inner subscription settles.
-        exhaustMap(() =>
+        exhaustMap(() => {
           // includeCurrentActivity (GH-1922): only opt out once the current_activity KEY is
           // actually present on the response — `=== undefined` here, not a falsy/truthy check,
           // because the BFF distinguishes "couldn't determine yet" (key absent — transient,
@@ -832,14 +837,24 @@ export class WeeklyBriefCardComponent {
           // WeeklyBriefCurrentResponse.current_activity's doc comment). A `!value` check would
           // treat that settled `null` the same as "unknown" and re-ask forever for exactly the
           // two cases that can never resolve differently within this poll cycle.
-          this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: this.briefResponse()?.current_activity === undefined }).pipe(
+          //
+          // Also capped at WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, separately from the
+          // undefined check above — an upstream that keeps failing this specific fan-out (not
+          // the brief generation itself) would otherwise get asked again on every one of up to
+          // WEEKLY_BRIEF_MAX_POLL_ATTEMPTS ticks for an answer that keeps failing the same way.
+          // Only increment on a tick that actually asks — a tick that already opted out (settled
+          // null/present, or the cap already hit) must not keep advancing the counter past the cap.
+          const shouldAskCurrentActivity =
+            this.briefResponse()?.current_activity === undefined && currentActivityAskAttempts < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS;
+          if (shouldAskCurrentActivity) currentActivityAskAttempts += 1;
+          return this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: shouldAskCurrentActivity }).pipe(
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),
             catchError((err: unknown) => {
               console.error('[weekly-brief-card] poll tick failed, will retry', err);
               return of(null as WeeklyBriefCurrentResponse | null);
             })
-          )
-        ),
+          );
+        }),
         // Drop failed ticks entirely rather than feeding `null` into takeWhile below —
         // a transient poll failure must not look like a terminal state and stop the poll.
         filter((response): response is WeeklyBriefCurrentResponse => response !== null),

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -662,14 +662,18 @@ export class WeeklyBriefCardComponent {
     });
   }
 
-  // Groups current_activity.source_refs into fixed-order kind-sections driven by
-  // WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES — NOT by cross-referencing WEEKLY_BRIEF_SOURCE_SECTIONS
-  // by kind, since that could silently produce a phrase-less, blank-labeled toggle for a kind
-  // present in one list but not the other (PHRASES is the sole source of truth for which kinds
-  // the tally recognizes; see its doc comment). Any ref whose kind ISN'T recognized there rolls
-  // into a trailing "N other updates" bucket, mirroring initSourceChipSections's "Other"
-  // catch-all — without it, a week whose only activity is an unrecognized kind would render the
-  // misleading "no activity yet" line instead of admitting the tally just can't name it.
+  // Groups current_activity.source_refs into fixed-order kind-sections. Section MEMBERSHIP (which
+  // kinds exist, and in what order) is driven by WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES alone — NOT
+  // by cross-referencing WEEKLY_BRIEF_SOURCE_SECTIONS by kind, since that could silently produce a
+  // countText-less section for a kind present in one list but not the other (PHRASES is the sole
+  // source of truth for which kinds the tally recognizes; see its doc comment). The section's
+  // display LABEL, in contrast, is looked up from WEEKLY_BRIEF_SOURCE_SECTIONS below — reusing the
+  // Sources row's existing label strings rather than duplicating them in PHRASES too — with a
+  // `?? kind` fallback that's what actually prevents a blank label if the two lists ever diverge on
+  // a kind's presence. Any ref whose kind ISN'T recognized by PHRASES rolls into a trailing "N
+  // other updates" bucket, mirroring initSourceChipSections's "Other" catch-all — without it, a
+  // week whose only activity is an unrecognized kind would render the misleading "no activity yet"
+  // line instead of admitting the tally just can't name it.
   private initCurrentActivitySections(): Signal<WeeklyBriefCurrentActivitySection[]> {
     return computed(() => {
       const refs = this.briefResponse()?.current_activity?.source_refs ?? [];

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -369,10 +369,14 @@ export class WeeklyBriefCardComponent {
           // description and its 202 example) — reusing the pre-regenerate rating against that
           // new revision would misattribute, so this drops it whenever res.brief lands and
           // lets the poll's first GET restore the correct value for that revision instead.
-          // Spreads `prev` rather than enumerating every field — `current_activity` carries
-          // forward unchanged for free, and a future field added to WeeklyBriefCurrentResponse
-          // survives this update by default instead of being silently dropped on every
-          // generate/regenerate.
+          // Spreads `prev` rather than enumerating every field, so a week-scoped field like
+          // current_activity (unaffected by a brief request) carries forward by construction
+          // instead of needing to be named here. This is NOT a universal safety improvement,
+          // though: a brief-scoped field — keyed to the specific brief/revision, like
+          // caller_rating above — is wrong to carry forward once res.brief lands, and spreading
+          // would silently do exactly that unless explicitly overridden, same as caller_rating
+          // is below. A future field must be classified as one or the other, not assumed safe by
+          // default either way.
           this.briefResponse.update((prev) => ({
             ...prev,
             brief: res.brief ?? prev?.brief ?? null,

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -744,7 +744,13 @@ export class WeeklyBriefCardComponent {
           this.fetchLoading.set(true);
           this.fetchError.set(false);
           this.pollTimedOut.set(false);
-          return this.weeklyBriefService.getWeeklyBrief(uid).pipe(
+          // includeCurrentActivity: this.isGoverningBoardCommittee() (GH-1922) — the template
+          // already gates the whole tally section on isGoverningBoardCommittee() independently
+          // of current_activity's presence (see the template's top-level @if), so for the
+          // majority of committees that aren't governance-classified, skipping the server's
+          // fan-out here costs nothing in the UI — the section wouldn't render either way — and
+          // saves a wasted upstream GET on every non-governance committee's card load.
+          return this.weeklyBriefService.getWeeklyBrief(uid, { includeCurrentActivity: this.isGoverningBoardCommittee() }).pipe(
             catchError((err: unknown) => {
               // A failed read (e.g. upstream 503) must not look like "no brief
               // yet" — flag it so the template can show a distinct, retryable

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -846,8 +846,8 @@ export class WeeklyBriefCardComponent {
           // two cases that can never resolve differently within this poll cycle.
           //
           // Also gated on isGoverningBoardCommittee() — a non-governance committee's every
-          // non-poll load (see initBriefResponseSubscription — initial load, and any
-          // refresh$-triggered re-fetch) deliberately opts out too, which leaves current_activity
+          // non-poll load (see initBriefResponseSubscription's own combineLatest sources for
+          // what triggers one) deliberately opts out too, which leaves current_activity
           // absent (not the settled null a fan-out call would have produced). Without this extra
           // gate, that deliberate client-side opt-out would look exactly like a transient degrade
           // and cost one wasted ask on the first poll tick, before the server's own settled null

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -239,15 +239,17 @@ export class WeeklyBriefCardComponent {
   public readonly isGoverningBoardCommittee: Signal<boolean> = computed(() => isGoverningBoard(this.committee().category));
 
   // Current, in-progress-week activity — a BFF enrichment on the response envelope (like
-  // caller_rating), absent in live mode until committee-service ships in-progress-week counts
-  // (GH-1922). Read from briefResponse, not brief(): it's scoped to a different window than
-  // the brief's own completed week, so it isn't part of WeeklyBrief itself.
+  // caller_rating), sourced server-side from CommitteeActivityService's existing live
+  // meeting/vote/document aggregation (GH-1922), so it's populated identically in mock and live
+  // mode. Read from briefResponse, not brief(): it's scoped to a different window than the
+  // brief's own completed week, so it isn't part of WeeklyBrief itself.
   public readonly currentActivity: Signal<WeeklyBriefCurrentActivitySection[]> = this.initCurrentActivitySections();
 
-  // Distinguishes "the field is absent" (live mode's backend gap — nothing to say) from
-  // "the field is present but every kind is zero" (mock mode, or a real quiet week once live
-  // support ships) — the template must render neither line nor "no activity yet" for the
-  // former, only the latter (GH-1922 Phase 2: "do NOT fabricate ... degrade gracefully").
+  // Distinguishes "the field is absent" (non-governance committee, or the server-side
+  // lookup/fetch degraded — see weekly-brief.service.ts#buildCurrentActivity — nothing to say)
+  // from "the field is present but every kind is zero" (a genuine quiet week) — the template
+  // must render neither line nor "no activity yet" for the former, only the latter (GH-1922:
+  // "do NOT fabricate ... degrade gracefully").
   public readonly hasCurrentActivityData: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity);
 
   // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet".

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -356,16 +356,20 @@ export class WeeklyBriefCardComponent {
           // Upstream marks nothing Required on the 202 envelope — a bare 202 with no
           // brief/throttle must not wipe what's already rendered (most visible on
           // Regenerate, where a real brief is on screen when this fires). Same reasoning
-          // extends to current_activity (GH-1922) and caller_rating: the brief actually shown
-          // here is still the pre-regenerate one (res.brief is only populated once generation
-          // completes) until pollUntilTerminal's first tick replaces it with a fresh GET, so
-          // both fields still correctly describe what's on screen and must carry forward
-          // rather than drop until that tick lands.
+          // extends to current_activity (GH-1922): this week's activity doesn't change just
+          // because a brief was requested, so it always carries forward regardless of whether
+          // res.brief itself landed. caller_rating is narrower: it describes specific brief
+          // content, so it only carries forward when res.brief is absent. Upstream's own
+          // contract documents brief as normally populated on this response (the new,
+          // just-created `state: 'generating'` revision, per GroupWeeklyBriefGenerateResult's
+          // description and its 202 example) — reusing the pre-regenerate rating against that
+          // new revision would misattribute, so this drops it whenever res.brief lands and
+          // lets the poll's first GET restore the correct value for that revision instead.
           this.briefResponse.update((prev) => ({
             brief: res.brief ?? this.brief(),
             throttle: res.throttle ?? this.throttle(),
             current_activity: prev?.current_activity,
-            caller_rating: prev?.caller_rating,
+            caller_rating: res.brief ? null : prev?.caller_rating,
           }));
           // On Regenerate, currentBrief.revision is the pre-regenerate revision — pollUntilTerminal
           // uses it to reject a first tick that reads back that same (stale) terminal brief instead

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -356,13 +356,16 @@ export class WeeklyBriefCardComponent {
           // Upstream marks nothing Required on the 202 envelope — a bare 202 with no
           // brief/throttle must not wipe what's already rendered (most visible on
           // Regenerate, where a real brief is on screen when this fires). Same reasoning
-          // extends to current_activity (GH-1922): generating a brief doesn't change this
-          // week's activity, so carry the prior value forward rather than dropping it until
-          // the next pollUntilTerminal tick lands.
+          // extends to current_activity (GH-1922) and caller_rating: the brief actually shown
+          // here is still the pre-regenerate one (res.brief is only populated once generation
+          // completes) until pollUntilTerminal's first tick replaces it with a fresh GET, so
+          // both fields still correctly describe what's on screen and must carry forward
+          // rather than drop until that tick lands.
           this.briefResponse.update((prev) => ({
             brief: res.brief ?? this.brief(),
             throttle: res.throttle ?? this.throttle(),
             current_activity: prev?.current_activity,
+            caller_rating: prev?.caller_rating,
           }));
           // On Regenerate, currentBrief.revision is the pre-regenerate revision — pollUntilTerminal
           // uses it to reject a first tick that reads back that same (stale) terminal brief instead

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -14,6 +14,7 @@ import { TextareaComponent } from '@components/textarea/textarea.component';
 import { WeeklyBriefArchiveDrawerComponent } from '../weekly-brief-archive-drawer/weekly-brief-archive-drawer.component';
 import { SourceChipContextDirective } from './source-chip-context.directive';
 import {
+  WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES,
   WEEKLY_BRIEF_ERROR_REASON,
   WEEKLY_BRIEF_MAX_POLL_ATTEMPTS,
   WEEKLY_BRIEF_POLL_INTERVAL_MS,
@@ -30,6 +31,7 @@ import {
   ShareWeeklyBriefResult,
   ValidationError,
   WeeklyBrief,
+  WeeklyBriefCurrentActivitySection,
   WeeklyBriefCurrentResponse,
   WeeklyBriefRating,
   WeeklyBriefSourceChip,
@@ -37,7 +39,7 @@ import {
   WeeklyBriefSourceChipSection,
   WeeklyBriefThrottle,
 } from '@lfx-one/shared/interfaces';
-import { formatUtcDateRangeLabel, mapWeeklyBriefSourceRefsToChips } from '@lfx-one/shared/utils';
+import { formatUtcDateRangeLabel, isGoverningBoard, mapWeeklyBriefSourceRefsToChips } from '@lfx-one/shared/utils';
 import { FeatureFlagService } from '@services/feature-flag.service';
 import { UserService } from '@services/user.service';
 import { WeeklyBriefService } from '@services/weekly-brief.service';
@@ -161,6 +163,10 @@ export class WeeklyBriefCardComponent {
   public readonly sourcesExpanded = signal(false);
   public readonly expandedSourceGroups = signal<Set<string>>(new Set());
 
+  // "This week so far" activity-tally disclosure state (GH-1922) — same click-to-reveal
+  // shape as expandedSourceGroups above, keyed by kind instead of chip id.
+  public readonly expandedActivityKinds = signal<Set<string>>(new Set());
+
   // Written by both the initial-load pipeline and the post-generate poll (see
   // initBriefResponseSubscription / pollUntilTerminal) — a plain signal rather than
   // toSignal(), since the poll needs to push updates outside that pipeline's own stream.
@@ -223,6 +229,32 @@ export class WeeklyBriefCardComponent {
   // (LFXV2-3335) — precomputed here rather than re-derived in the template (frontend-checklist
   // §4). See initSourceChipSections for the "Other" catch-all rationale.
   public readonly sourceChipSections: Signal<WeeklyBriefSourceChipSection[]> = this.initSourceChipSections();
+
+  // Gates the "this week so far" activity tally (GH-1922) to governance committees for v1 —
+  // Board/Government Advisory Council today. `committee().category` is always populated on
+  // this input (unlike `behavioralClass`, which is only decorated on the dashboard's own data
+  // path, not this one), so this derives the classification directly rather than reading a
+  // field that isn't there.
+  public readonly isGovernanceCommittee: Signal<boolean> = computed(() => isGoverningBoard(this.committee()?.category));
+
+  // Current, in-progress-week activity — a BFF enrichment on the response envelope (like
+  // caller_rating), absent in live mode until committee-service ships in-progress-week counts
+  // (GH-1922). Read from briefResponse, not brief(): it's scoped to a different window than
+  // the brief's own completed week, so it isn't part of WeeklyBrief itself.
+  public readonly currentActivity: Signal<WeeklyBriefCurrentActivitySection[]> = this.initCurrentActivitySections();
+
+  // Distinguishes "the field is absent" (live mode's backend gap — nothing to say) from
+  // "the field is present but every kind is zero" (mock mode, or a real quiet week once live
+  // support ships) — the template must render neither line nor "no activity yet" for the
+  // former, only the latter (GH-1922 Phase 2: "do NOT fabricate ... degrade gracefully").
+  public readonly hasCurrentActivityData: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity);
+
+  // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet".
+  public readonly currentActivityLine: Signal<string> = computed(() => {
+    const sections = this.currentActivity();
+    if (!sections.length) return 'This week so far: no activity yet';
+    return `This week so far: ${sections.map((section) => section.countText).join(', ')}`;
+  });
 
   // "no_sources" is the only error_reason meaningful to the UI today (LFXV2-3000) —
   // a committee with zero activity in the lookback window, not a genuine generation
@@ -578,6 +610,20 @@ export class WeeklyBriefCardComponent {
     });
   }
 
+  // Level-1/only disclosure for the "this week so far" tally, keyed by kind (GH-1922) — same
+  // shape as onToggleSourceGroup.
+  public onToggleActivityKind(kind: string): void {
+    this.expandedActivityKinds.update((expanded) => {
+      const next = new Set(expanded);
+      if (next.has(kind)) {
+        next.delete(kind);
+      } else {
+        next.add(kind);
+      }
+      return next;
+    });
+  }
+
   // Private initializer functions
   // Groups sourceChips() into the fixed-order kind-sections defined by WEEKLY_BRIEF_SOURCE_SECTIONS
   // (LFXV2-3335), appending a trailing "Other" section for any chip whose kind isn't one of the
@@ -592,6 +638,23 @@ export class WeeklyBriefCardComponent {
       const sections = WEEKLY_BRIEF_SOURCE_SECTIONS.map(({ kind, label }) => ({ kind, label, chips: chips.filter((chip) => chip.kind === kind) }));
       sections.push({ kind: 'other', label: 'Other', chips: chips.filter((chip) => !known.has(chip.kind)) });
       return sections.filter((section) => section.chips.length > 0);
+    });
+  }
+
+  // Groups current_activity.source_refs into the same fixed-order kinds as
+  // WEEKLY_BRIEF_SOURCE_SECTIONS (GH-1922), each with its precomputed "N <kind> <verb>" count
+  // text (WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES). No "Other" catch-all here, unlike
+  // initSourceChipSections: this is a raw count sentence, not a disclosure list — an
+  // unrecognized future kind would have no phrasing to render anyway, so it's silently
+  // excluded from the tally rather than mis-rendered.
+  private initCurrentActivitySections(): Signal<WeeklyBriefCurrentActivitySection[]> {
+    return computed(() => {
+      const refs = this.briefResponse()?.current_activity?.source_refs ?? [];
+      return WEEKLY_BRIEF_SOURCE_SECTIONS.map(({ kind, label }) => {
+        const kindRefs = refs.filter((ref) => ref.kind === kind);
+        const phrase = WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES.find((p) => p.kind === kind);
+        return { kind, label, refs: kindRefs, countText: phrase ? `${kindRefs.length} ${kindRefs.length === 1 ? phrase.singular : phrase.plural}` : '' };
+      }).filter((section) => section.refs.length > 0);
     });
   }
 
@@ -629,6 +692,8 @@ export class WeeklyBriefCardComponent {
       // reset in this block.
       this.sourcesExpanded.set(false);
       this.expandedSourceGroups.set(new Set());
+      // Reset "this week so far" disclosure state (GH-1922) — same rationale.
+      this.expandedActivityKinds.set(new Set());
     });
 
     // Archive preflight — fires once per committee as soon as the uid is known,

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -822,7 +822,11 @@ export class WeeklyBriefCardComponent {
         // (and the attempt cap) indefinitely, since exhaustMap only completes once its
         // last active inner subscription settles.
         exhaustMap(() =>
-          this.weeklyBriefService.getWeeklyBrief(committeeUid).pipe(
+          // includeCurrentActivity: false (GH-1922) — this week's activity can't change
+          // mid-poll, so re-running that fan-out on every tick only multiplies its upstream
+          // cost for a value the poll's first tick (via the initial load) already has. Merged
+          // back onto the response below rather than fetched again.
+          this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: false }).pipe(
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),
             catchError((err: unknown) => {
               console.error('[weekly-brief-card] poll tick failed, will retry', err);
@@ -834,7 +838,10 @@ export class WeeklyBriefCardComponent {
         // a transient poll failure must not look like a terminal state and stop the poll.
         filter((response): response is WeeklyBriefCurrentResponse => response !== null),
         tap((response) => {
-          this.briefResponse.set(response);
+          // response never carries current_activity (includeCurrentActivity: false above) —
+          // preserve whatever the card already has instead of letting a plain .set() blank it
+          // out for the rest of this poll.
+          this.briefResponse.update((prev) => ({ ...response, current_activity: prev?.current_activity }));
           // Same reasoning as initBriefResponseSubscription's subscribe: a fresh GET
           // supersedes any optimistic overlay.
           this.optimisticRating.set(null);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -355,8 +355,15 @@ export class WeeklyBriefCardComponent {
         next: (res) => {
           // Upstream marks nothing Required on the 202 envelope — a bare 202 with no
           // brief/throttle must not wipe what's already rendered (most visible on
-          // Regenerate, where a real brief is on screen when this fires).
-          this.briefResponse.set({ brief: res.brief ?? this.brief(), throttle: res.throttle ?? this.throttle() });
+          // Regenerate, where a real brief is on screen when this fires). Same reasoning
+          // extends to current_activity (GH-1922): generating a brief doesn't change this
+          // week's activity, so carry the prior value forward rather than dropping it until
+          // the next pollUntilTerminal tick lands.
+          this.briefResponse.update((prev) => ({
+            brief: res.brief ?? this.brief(),
+            throttle: res.throttle ?? this.throttle(),
+            current_activity: prev?.current_activity,
+          }));
           // On Regenerate, currentBrief.revision is the pre-regenerate revision — pollUntilTerminal
           // uses it to reject a first tick that reads back that same (stale) terminal brief instead
           // of the new one still being written. undefined on a fresh generate (no prior revision to

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -845,13 +845,14 @@ export class WeeklyBriefCardComponent {
           // treat that settled `null` the same as "unknown" and re-ask forever for exactly the
           // two cases that can never resolve differently within this poll cycle.
           //
-          // Also gated on isGoverningBoardCommittee() — a non-governance committee's initial
-          // load (see initBriefResponseSubscription) deliberately opts out too, which leaves
-          // current_activity absent (not the settled null a fan-out call would have produced).
-          // Without this extra gate, that deliberate client-side opt-out would look exactly like
-          // a transient degrade and cost one wasted ask on the first poll tick, before the
-          // server's own settled null ever had a chance to stop it — undoing part of the
-          // initial-load fix's savings in the one code path (a generating card) it runs in.
+          // Also gated on isGoverningBoardCommittee() — a non-governance committee's every
+          // non-poll load (see initBriefResponseSubscription — initial load, and any
+          // refresh$-triggered re-fetch) deliberately opts out too, which leaves current_activity
+          // absent (not the settled null a fan-out call would have produced). Without this extra
+          // gate, that deliberate client-side opt-out would look exactly like a transient degrade
+          // and cost one wasted ask on the first poll tick, before the server's own settled null
+          // ever had a chance to stop it — undoing part of that opt-out's savings in the one code
+          // path (a generating card) it runs in.
           //
           // Also capped at WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, separately from the
           // undefined check above — an upstream that keeps failing this specific fan-out (not

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -844,14 +844,25 @@ export class WeeklyBriefCardComponent {
           // treat that settled `null` the same as "unknown" and re-ask forever for exactly the
           // two cases that can never resolve differently within this poll cycle.
           //
+          // Also gated on isGoverningBoardCommittee() — a non-governance committee's initial
+          // load (see initBriefResponseSubscription) deliberately opts out too, which leaves
+          // current_activity absent (not the settled null a fan-out call would have produced).
+          // Without this extra gate, that deliberate client-side opt-out would look exactly like
+          // a transient degrade and cost one wasted ask on the first poll tick, before the
+          // server's own settled null ever had a chance to stop it — undoing part of the
+          // initial-load fix's savings in the one code path (a generating card) it runs in.
+          //
           // Also capped at WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS, separately from the
           // undefined check above — an upstream that keeps failing this specific fan-out (not
           // the brief generation itself) would otherwise get asked again on every one of up to
           // WEEKLY_BRIEF_MAX_POLL_ATTEMPTS ticks for an answer that keeps failing the same way.
           // Only increment on a tick that actually asks — a tick that already opted out (settled
-          // null/present, or the cap already hit) must not keep advancing the counter past the cap.
+          // null/present, not governance, or the cap already hit) must not keep advancing the
+          // counter past the cap.
           const shouldAskCurrentActivity =
-            this.briefResponse()?.current_activity === undefined && currentActivityAskAttempts < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS;
+            this.isGoverningBoardCommittee() &&
+            this.briefResponse()?.current_activity === undefined &&
+            currentActivityAskAttempts < WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS;
           if (shouldAskCurrentActivity) currentActivityAskAttempts += 1;
           return this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: shouldAskCurrentActivity }).pipe(
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -256,11 +256,16 @@ export class WeeklyBriefCardComponent {
   // fabricate ... degrade gracefully").
   public readonly hasCurrentActivityData: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity);
 
+  // Single source of truth for the visible prefix, shared with the template's own span
+  // (weekly-brief-card.component.html) so the accessible name (currentActivityLine, below) and
+  // the visible text can't drift apart on a future copy edit.
+  protected readonly currentActivityPrefix = 'This week so far:';
+
   // "This week so far: 1 meeting held, 1 vote closed" / "This week so far: no activity yet".
   public readonly currentActivityLine: Signal<string> = computed(() => {
     const sections = this.currentActivity();
-    if (!sections.length) return 'This week so far: no activity yet';
-    return `This week so far: ${sections.map((section) => section.countText).join(', ')}`;
+    if (!sections.length) return `${this.currentActivityPrefix} no activity yet`;
+    return `${this.currentActivityPrefix} ${sections.map((section) => section.countText).join(', ')}`;
   });
 
   // "no_sources" is the only error_reason meaningful to the UI today (LFXV2-3000) —

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -230,12 +230,13 @@ export class WeeklyBriefCardComponent {
   // §4). See initSourceChipSections for the "Other" catch-all rationale.
   public readonly sourceChipSections: Signal<WeeklyBriefSourceChipSection[]> = this.initSourceChipSections();
 
-  // Gates the "this week so far" activity tally (GH-1922) to governance committees for v1 —
-  // Board/Government Advisory Council today. `committee().category` is always populated on
-  // this input (unlike `behavioralClass`, which is only decorated on the dashboard's own data
-  // path, not this one), so this derives the classification directly rather than reading a
-  // field that isn't there.
-  public readonly isGovernanceCommittee: Signal<boolean> = computed(() => isGoverningBoard(this.committee()?.category));
+  // Gates the "this week so far" activity tally (GH-1922) to Board/Government Advisory Council
+  // committees only for v1 — named for exactly that (not the broader `isGovernanceClass`, which
+  // also matches oversight-committee/TSC/Legal/Finance). `committee().category` is always
+  // populated on this input (unlike `behavioralClass`, which is only decorated on the
+  // dashboard's own data path, not this one), so this derives the classification directly
+  // rather than reading a field that isn't there.
+  public readonly isGoverningBoardCommittee: Signal<boolean> = computed(() => isGoverningBoard(this.committee().category));
 
   // Current, in-progress-week activity — a BFF enrichment on the response envelope (like
   // caller_rating), absent in live mode until committee-service ships in-progress-week counts
@@ -641,20 +642,28 @@ export class WeeklyBriefCardComponent {
     });
   }
 
-  // Groups current_activity.source_refs into the same fixed-order kinds as
-  // WEEKLY_BRIEF_SOURCE_SECTIONS (GH-1922), each with its precomputed "N <kind> <verb>" count
-  // text (WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES). No "Other" catch-all here, unlike
-  // initSourceChipSections: this is a raw count sentence, not a disclosure list — an
-  // unrecognized future kind would have no phrasing to render anyway, so it's silently
-  // excluded from the tally rather than mis-rendered.
+  // Groups current_activity.source_refs into fixed-order kind-sections driven by
+  // WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES — NOT by cross-referencing WEEKLY_BRIEF_SOURCE_SECTIONS
+  // by kind, since that could silently produce a phrase-less, blank-labeled toggle for a kind
+  // present in one list but not the other (PHRASES is the sole source of truth for which kinds
+  // the tally recognizes; see its doc comment). Any ref whose kind ISN'T recognized there rolls
+  // into a trailing "N other updates" bucket, mirroring initSourceChipSections's "Other"
+  // catch-all — without it, a week whose only activity is an unrecognized kind would render the
+  // misleading "no activity yet" line instead of admitting the tally just can't name it.
   private initCurrentActivitySections(): Signal<WeeklyBriefCurrentActivitySection[]> {
     return computed(() => {
       const refs = this.briefResponse()?.current_activity?.source_refs ?? [];
-      return WEEKLY_BRIEF_SOURCE_SECTIONS.map(({ kind, label }) => {
+      const known = new Set(WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES.map((phrase) => phrase.kind));
+      const sections = WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES.map(({ kind, singular, plural }) => {
         const kindRefs = refs.filter((ref) => ref.kind === kind);
-        const phrase = WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES.find((p) => p.kind === kind);
-        return { kind, label, refs: kindRefs, countText: phrase ? `${kindRefs.length} ${kindRefs.length === 1 ? phrase.singular : phrase.plural}` : '' };
-      }).filter((section) => section.refs.length > 0);
+        const label = WEEKLY_BRIEF_SOURCE_SECTIONS.find((section) => section.kind === kind)?.label ?? kind;
+        return { kind, label, refs: kindRefs, countText: `${kindRefs.length} ${kindRefs.length === 1 ? singular : plural}` };
+      });
+      const otherRefs = refs.filter((ref) => !known.has(ref.kind));
+      if (otherRefs.length > 0) {
+        sections.push({ kind: 'other', label: 'Other', refs: otherRefs, countText: `${otherRefs.length} other update${otherRefs.length === 1 ? '' : 's'}` });
+      }
+      return sections.filter((section) => section.refs.length > 0);
     });
   }
 

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -882,6 +882,13 @@ export class WeeklyBriefCardComponent {
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),
             catchError((err: unknown) => {
               console.error('[weekly-brief-card] poll tick failed, will retry', err);
+              // Undo the optimistic increment above: a tick that never reached the server (this
+              // tick's own HTTP timeout, or any other error) never got a chance to answer, so it
+              // must not count against the cap the same way a tick that DID answer — even with a
+              // transient `undefined` — does. Without this, a run of ordinary network hiccups
+              // could exhaust WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS on its own, before
+              // the fan-out this cap actually exists to bound ever got asked.
+              if (shouldAskCurrentActivity) currentActivityAskAttempts -= 1;
               return of(null as WeeklyBriefCurrentResponse | null);
             })
           );

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -882,16 +882,19 @@ export class WeeklyBriefCardComponent {
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),
             catchError((err: unknown) => {
               console.error('[weekly-brief-card] poll tick failed, will retry', err);
-              // Undo the optimistic increment above only for a request that never reached the
-              // BFF at all (a genuine network/connection failure) — NOT for this tick's own
-              // `timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS)` above. Aborting the client-side XHR on
-              // that timeout does not cancel the server-side work already in flight — the BFF
-              // still pays getCommitteeBase + getCommitteeActivity's fan-out for a tick this
-              // client gave up waiting on. Refunding the slot for a TimeoutError would let a
-              // persistently slow (not erroring) upstream — the exact case
+              // Undo the optimistic increment above ONLY for a transport-level failure — the
+              // request never reached, or never got a response from, the BFF at all
+              // (HttpErrorResponse.status === 0: connection refused, DNS failure, CORS block,
+              // etc.). Neither of the other two error shapes qualifies: this tick's own
+              // `timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS)` above (TimeoutError) doesn't cancel the
+              // server-side work already in flight, and a real HTTP error response (4xx/5xx,
+              // status !== 0) means the BFF DID receive and process the request — it just failed
+              // to answer well. Refunding for either would let a persistently slow OR persistently
+              // erroring (not just erroring) upstream — the exact case
               // WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS exists to bound — re-ask on every
               // one of up to WEEKLY_BRIEF_MAX_POLL_ATTEMPTS ticks instead of stopping at the cap.
-              if (shouldAskCurrentActivity && !(err instanceof TimeoutError)) currentActivityAskAttempts -= 1;
+              const isTransportFailure = err instanceof HttpErrorResponse && err.status === 0;
+              if (shouldAskCurrentActivity && isTransportFailure) currentActivityAskAttempts -= 1;
               return of(null as WeeklyBriefCurrentResponse | null);
             })
           );

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -245,9 +245,11 @@ export class WeeklyBriefCardComponent {
   // brief's own completed week, so it isn't part of WeeklyBrief itself.
   public readonly currentActivity: Signal<WeeklyBriefCurrentActivitySection[]> = this.initCurrentActivitySections();
 
-  // Distinguishes "the field is absent" (non-governance committee, or the server-side
-  // lookup/fetch degraded — see weekly-brief.service.ts#buildCurrentActivity — nothing to say)
-  // from "the field is present but every kind is zero" (a genuine quiet week) — the template
+  // Distinguishes "no value to show" (absent — a transient server-side lookup/fetch degrade —
+  // or null — a settled non-governance/full-page answer; see weekly-brief.service.ts's
+  // WeeklyBriefCurrentResponse.current_activity doc comment for that three-state contract,
+  // which pollUntilTerminal's poll loop below depends on but rendering here doesn't) from "the
+  // field is a real object, every kind possibly zero" (a genuine quiet week) — the template
   // must render neither line nor "no activity yet" for the former, only the latter (GH-1922:
   // "do NOT fabricate ... degrade gracefully").
   public readonly hasCurrentActivityData: Signal<boolean> = computed(() => !!this.briefResponse()?.current_activity);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -822,17 +822,15 @@ export class WeeklyBriefCardComponent {
         // (and the attempt cap) indefinitely, since exhaustMap only completes once its
         // last active inner subscription settles.
         exhaustMap(() =>
-          // includeCurrentActivity (GH-1922): only opt out once a value is already in hand —
-          // this week's activity can't change mid-poll, so re-running the fan-out for a value
-          // already held is pure waste. But if the initial load left current_activity absent
-          // (a governance committee whose lookup/fetch degraded — see
-          // weekly-brief.service.ts#buildCurrentActivity), keep asking on every tick so a
-          // transient failure can still self-heal instead of staying blank for the rest of the
-          // poll and beyond, with nothing left to re-fetch it once the poll ends. A
-          // non-governance committee (also current_activity: undefined) re-asks too, but
-          // buildCurrentActivity short-circuits cheaply for those right after the category
-          // read, well before the expensive activity aggregation.
-          this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: !this.briefResponse()?.current_activity }).pipe(
+          // includeCurrentActivity (GH-1922): only opt out once the current_activity KEY is
+          // actually present on the response — `=== undefined` here, not a falsy/truthy check,
+          // because the BFF distinguishes "couldn't determine yet" (key absent — transient,
+          // worth asking again) from "known, settled, doesn't apply" (key present as `null` —
+          // non-governance, or this week's activity fills a full page; see
+          // WeeklyBriefCurrentResponse.current_activity's doc comment). A `!value` check would
+          // treat that settled `null` the same as "unknown" and re-ask forever for exactly the
+          // two cases that can never resolve differently within this poll cycle.
+          this.weeklyBriefService.getWeeklyBrief(committeeUid, { includeCurrentActivity: this.briefResponse()?.current_activity === undefined }).pipe(
             timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS),
             catchError((err: unknown) => {
               console.error('[weekly-brief-card] poll tick failed, will retry', err);
@@ -844,10 +842,16 @@ export class WeeklyBriefCardComponent {
         // a transient poll failure must not look like a terminal state and stop the poll.
         filter((response): response is WeeklyBriefCurrentResponse => response !== null),
         tap((response) => {
-          // A tick that opted out (see above) carries no current_activity of its own — fall
+          // A tick that opted out (see above) carries no current_activity key of its own — fall
           // back to whatever the card already has rather than letting a plain .set() blank a
           // good value out just because this particular tick didn't ask for a fresh one.
-          this.briefResponse.update((prev) => ({ ...response, current_activity: response.current_activity ?? prev?.current_activity }));
+          // `!== undefined`, not `??`: a tick that DID ask can come back with a settled `null`
+          // (see the exhaustMap above), which must overwrite a stale prior `undefined` — `??`
+          // would treat that fresh `null` as nullish too and wrongly keep falling back to prev.
+          this.briefResponse.update((prev) => ({
+            ...response,
+            current_activity: response.current_activity !== undefined ? response.current_activity : prev?.current_activity,
+          }));
           // Same reasoning as initBriefResponseSubscription's subscribe: a fresh GET
           // supersedes any optimistic overlay.
           this.optimisticRating.set(null);

--- a/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
+++ b/apps/lfx-one/src/app/modules/committees/components/weekly-brief-card/weekly-brief-card.component.ts
@@ -246,8 +246,8 @@ export class WeeklyBriefCardComponent {
   public readonly currentActivity: Signal<WeeklyBriefCurrentActivitySection[]> = this.initCurrentActivitySections();
 
   // Distinguishes "no value to show" (absent — a transient server-side lookup/fetch degrade —
-  // or null — a settled non-governance/full-page answer; see weekly-brief.service.ts's
-  // WeeklyBriefCurrentResponse.current_activity doc comment for that three-state contract,
+  // or null — a settled non-governance/full-page answer; see WeeklyBriefCurrentResponse's own
+  // current_activity doc comment, in @lfx-one/shared/interfaces, for that three-state contract,
   // which pollUntilTerminal's poll loop below depends on but rendering here doesn't) from "the
   // field is a real object, every kind possibly zero" (a genuine quiet week) — the template
   // must render neither line nor "no activity yet" for the former, only the latter (GH-1922:

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.spec.ts
@@ -1,0 +1,57 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { provideHttpClient } from '@angular/common/http';
+import { HttpTestingController, provideHttpClientTesting } from '@angular/common/http/testing';
+import { TestBed } from '@angular/core/testing';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import { WeeklyBriefService } from './weekly-brief.service';
+
+/**
+ * `getWeeklyBrief`'s `includeCurrentActivity` option (GH-1922) is what lets
+ * weekly-brief-card.component.ts's `pollUntilTerminal` opt out of the current_activity
+ * fan-out on every poll tick — see WeeklyBriefService#getCurrentBrief's (server) doc comment
+ * for the upstream-cost rationale. This spec covers only the HTTP-param construction; the
+ * merge-forward behavior on the client lives in weekly-brief-card.component.spec.ts.
+ */
+describe('WeeklyBriefService — getWeeklyBrief includeCurrentActivity (GH-1922)', () => {
+  let service: WeeklyBriefService;
+  let http: HttpTestingController;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [WeeklyBriefService, provideHttpClient(), provideHttpClientTesting()],
+    });
+    service = TestBed.inject(WeeklyBriefService);
+    http = TestBed.inject(HttpTestingController);
+  });
+
+  afterEach(() => {
+    http.verify();
+  });
+
+  it('sends no query param at all when includeCurrentActivity is omitted (the default-included case)', () => {
+    service.getWeeklyBrief('committee-1').subscribe();
+
+    const req = http.expectOne('/api/committees/committee-1/weekly-briefs/current');
+    expect(req.request.params.keys()).toEqual([]);
+    req.flush({ brief: null, throttle: null });
+  });
+
+  it('sends no query param when includeCurrentActivity is explicitly true — matches the server default rather than being redundant over the wire', () => {
+    service.getWeeklyBrief('committee-1', { includeCurrentActivity: true }).subscribe();
+
+    const req = http.expectOne('/api/committees/committee-1/weekly-briefs/current');
+    expect(req.request.params.keys()).toEqual([]);
+    req.flush({ brief: null, throttle: null });
+  });
+
+  it('sends includeCurrentActivity=false only when explicitly opted out', () => {
+    service.getWeeklyBrief('committee-1', { includeCurrentActivity: false }).subscribe();
+
+    const req = http.expectOne((r) => r.url === '/api/committees/committee-1/weekly-briefs/current');
+    expect(req.request.params.get('includeCurrentActivity')).toBe('false');
+    req.flush({ brief: null, throttle: null });
+  });
+});

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -40,9 +40,15 @@ export class WeeklyBriefService {
    * "no brief yet, 2 generates available" — see LFXV2-2175 full-branch review.
    *
    * `includeCurrentActivity: false` (GH-1922) opts out of the current_activity tally on this
-   * read — see the BFF's `WeeklyBriefService#getCurrentBrief` doc comment for why the poll loop
-   * (`weekly-brief-card.component.ts`'s `pollUntilTerminal`) uses it on every tick but the
-   * initial load doesn't.
+   * read — see the BFF's `WeeklyBriefService#getCurrentBrief` doc comment for the upstream-cost
+   * rationale. The initial load never opts out. The poll loop
+   * (`weekly-brief-card.component.ts`'s `pollUntilTerminal`) opts out only once the
+   * current_activity KEY is present on what it already holds — `null` counts as present (a
+   * settled "doesn't apply" answer for a non-governance committee, or a week whose activity
+   * fills a full page) and stops the asking just as a real value would; only a genuinely absent
+   * key (a transient lookup/fetch failure) keeps the poll asking on every tick until it resolves
+   * — see `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the three-state
+   * absent/null/present contract this depends on.
    */
   public getWeeklyBrief(committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Observable<WeeklyBriefCurrentResponse> {
     const params = options.includeCurrentActivity === false ? { includeCurrentActivity: 'false' } : undefined;

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -41,13 +41,18 @@ export class WeeklyBriefService {
    *
    * `includeCurrentActivity: false` (GH-1922) opts out of the current_activity tally on this
    * read — see the BFF's `WeeklyBriefService#getCurrentBrief` doc comment for the upstream-cost
-   * rationale. The initial load never opts out. The poll loop
-   * (`weekly-brief-card.component.ts`'s `pollUntilTerminal`) opts out only once the
-   * current_activity KEY is present on what it already holds — `null` counts as present (a
-   * settled "doesn't apply" answer for a non-governance committee, or a week whose activity
-   * fills a full page) and stops the asking just as a real value would; only a genuinely absent
-   * key (a transient lookup/fetch failure) keeps the poll asking on every tick until it resolves
-   * — see `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the three-state
+   * rationale. Two independent callers opt out, each on its own signal:
+   * `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on the initial
+   * load whenever its own `isGoverningBoardCommittee()` is false — the template gates the whole
+   * tally section on that same signal regardless of what current_activity holds, so a
+   * non-governance committee's card load never needs the fan-out at all. Its `pollUntilTerminal`
+   * opts out on top of that (also gated on `isGoverningBoardCommittee()`, so it never mistakes
+   * that deliberate initial-load opt-out for a transient degrade) once the current_activity KEY
+   * is present on what it already holds — `null` counts as present (a settled "doesn't apply"
+   * answer for a non-governance committee, or a week whose activity fills a full page) and stops
+   * the asking just as a real value would; only a genuinely absent key on a governance committee
+   * (a transient lookup/fetch failure) keeps the poll asking, up to its own attempt cap — see
+   * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the three-state
    * absent/null/present contract this depends on.
    */
   public getWeeklyBrief(committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Observable<WeeklyBriefCurrentResponse> {

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -38,9 +38,15 @@ export class WeeklyBriefService {
    * real error, distinct from the server's own 200-with-null-brief "no brief yet" state.
    * A blanket fallback here would render a misconfigured deploy or a 404 identically to
    * "no brief yet, 2 generates available" — see LFXV2-2175 full-branch review.
+   *
+   * `includeCurrentActivity: false` (GH-1922) opts out of the current_activity tally on this
+   * read — see the BFF's `WeeklyBriefService#getCurrentBrief` doc comment for why the poll loop
+   * (`weekly-brief-card.component.ts`'s `pollUntilTerminal`) uses it on every tick but the
+   * initial load doesn't.
    */
-  public getWeeklyBrief(committeeId: string): Observable<WeeklyBriefCurrentResponse> {
-    return this.http.get<WeeklyBriefCurrentResponse>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`);
+  public getWeeklyBrief(committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Observable<WeeklyBriefCurrentResponse> {
+    const params = options.includeCurrentActivity === false ? { includeCurrentActivity: 'false' } : undefined;
+    return this.http.get<WeeklyBriefCurrentResponse>(`/api/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`, { params });
   }
 
   /**

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -43,10 +43,11 @@ export class WeeklyBriefService {
    * read — see the BFF's `WeeklyBriefService#getCurrentBrief` doc comment for the upstream-cost
    * rationale. Two independent callers opt out, each on its own signal:
    * `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on every
-   * non-poll load (initial load, and every `refresh$`-triggered re-fetch) whenever its own
-   * `isGoverningBoardCommittee()` is false — the template gates the whole tally section on that
-   * same signal regardless of what current_activity holds, so a non-governance committee never
-   * needs the fan-out on any of those loads. Its `pollUntilTerminal`
+   * non-poll load (see that method's `combineLatest` sources for what triggers one — not
+   * re-listed here, since it's exactly the kind of detail that drifts stale as those sources
+   * change) whenever its own `isGoverningBoardCommittee()` is false — the template gates the
+   * whole tally section on that same signal regardless of what current_activity holds, so a
+   * non-governance committee never needs the fan-out on any of those loads. Its `pollUntilTerminal`
    * opts out on top of that (also gated on `isGoverningBoardCommittee()`, so it never mistakes
    * that deliberate non-poll-load opt-out for a transient degrade) once the current_activity KEY
    * is present on what it already holds — `null` counts as present (a settled "doesn't apply"
@@ -54,8 +55,7 @@ export class WeeklyBriefService {
    * the asking just as a real value would; only a genuinely absent key on a governance committee
    * keeps the poll asking, up to its own attempt cap — see
    * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the three-state
-   * absent/null/present contract this depends on, including exactly what can leave the key
-   * absent on a governance committee.
+   * absent/null/present contract this depends on.
    */
   public getWeeklyBrief(committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Observable<WeeklyBriefCurrentResponse> {
     const params = options.includeCurrentActivity === false ? { includeCurrentActivity: 'false' } : undefined;

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -52,9 +52,10 @@ export class WeeklyBriefService {
    * is present on what it already holds — `null` counts as present (a settled "doesn't apply"
    * answer for a non-governance committee, or a week whose activity fills a full page) and stops
    * the asking just as a real value would; only a genuinely absent key on a governance committee
-   * (a transient lookup/fetch failure) keeps the poll asking, up to its own attempt cap — see
+   * keeps the poll asking, up to its own attempt cap — see
    * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the three-state
-   * absent/null/present contract this depends on.
+   * absent/null/present contract this depends on, including exactly what can leave the key
+   * absent on a governance committee.
    */
   public getWeeklyBrief(committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Observable<WeeklyBriefCurrentResponse> {
     const params = options.includeCurrentActivity === false ? { includeCurrentActivity: 'false' } : undefined;

--- a/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/app/shared/services/weekly-brief.service.ts
@@ -42,12 +42,13 @@ export class WeeklyBriefService {
    * `includeCurrentActivity: false` (GH-1922) opts out of the current_activity tally on this
    * read — see the BFF's `WeeklyBriefService#getCurrentBrief` doc comment for the upstream-cost
    * rationale. Two independent callers opt out, each on its own signal:
-   * `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on the initial
-   * load whenever its own `isGoverningBoardCommittee()` is false — the template gates the whole
-   * tally section on that same signal regardless of what current_activity holds, so a
-   * non-governance committee's card load never needs the fan-out at all. Its `pollUntilTerminal`
+   * `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on every
+   * non-poll load (initial load, and every `refresh$`-triggered re-fetch) whenever its own
+   * `isGoverningBoardCommittee()` is false — the template gates the whole tally section on that
+   * same signal regardless of what current_activity holds, so a non-governance committee never
+   * needs the fan-out on any of those loads. Its `pollUntilTerminal`
    * opts out on top of that (also gated on `isGoverningBoardCommittee()`, so it never mistakes
-   * that deliberate initial-load opt-out for a transient degrade) once the current_activity KEY
+   * that deliberate non-poll-load opt-out for a transient degrade) once the current_activity KEY
    * is present on what it already holds — `null` counts as present (a settled "doesn't apply"
    * answer for a non-governance committee, or a week whose activity fills a full page) and stops
    * the asking just as a real value would; only a genuinely absent key on a governance committee

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -57,16 +57,16 @@ vi.mock('../services/logger.service', () => ({
 
 import { WeeklyBriefController } from './weekly-brief.controller';
 
-function buildReq(body: unknown = {}): any {
-  return { params: { committeeId: COMMITTEE_ID }, body, path: '/test', log: {} };
+function buildReq(body: unknown = {}, query: Record<string, string> = {}): any {
+  return { params: { committeeId: COMMITTEE_ID }, query, body, path: '/test', log: {} };
 }
 
 function buildRatingReq(body: unknown = {}): any {
-  return { params: { committeeId: COMMITTEE_ID, briefUid: BRIEF_UID }, body, path: '/test', log: {} };
+  return { params: { committeeId: COMMITTEE_ID, briefUid: BRIEF_UID }, query: {}, body, path: '/test', log: {} };
 }
 
 function buildRes(): any {
-  return { status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn() };
+  return { status: vi.fn().mockReturnThis(), json: vi.fn(), send: vi.fn(), setHeader: vi.fn() };
 }
 
 describe('WeeklyBriefController', () => {
@@ -282,6 +282,33 @@ describe('WeeklyBriefController', () => {
 
       expect(weeklyBriefSvc.getCurrentBrief).not.toHaveBeenCalled();
       expect(next).toHaveBeenCalledWith(forbidden);
+    });
+
+    it('defaults includeCurrentActivity to true when the query param is absent (GH-1922)', async () => {
+      weeklyBriefSvc.getCurrentBrief.mockResolvedValue({ brief: null, throttle: null });
+
+      await controller.getCurrentBrief(buildReq(), buildRes(), vi.fn());
+
+      expect(weeklyBriefSvc.getCurrentBrief).toHaveBeenCalledWith(expect.anything(), COMMITTEE_ID, { includeCurrentActivity: true });
+    });
+
+    it('only opts out of includeCurrentActivity on an exact "false" query value — any other value keeps the default', async () => {
+      weeklyBriefSvc.getCurrentBrief.mockResolvedValue({ brief: null, throttle: null });
+
+      await controller.getCurrentBrief(buildReq({}, { includeCurrentActivity: 'false' }), buildRes(), vi.fn());
+      await controller.getCurrentBrief(buildReq({}, { includeCurrentActivity: 'nope' }), buildRes(), vi.fn());
+
+      expect(weeklyBriefSvc.getCurrentBrief).toHaveBeenNthCalledWith(1, expect.anything(), COMMITTEE_ID, { includeCurrentActivity: false });
+      expect(weeklyBriefSvc.getCurrentBrief).toHaveBeenNthCalledWith(2, expect.anything(), COMMITTEE_ID, { includeCurrentActivity: true });
+    });
+
+    it('sets Cache-Control: no-store — the response can carry per-user, FGA-filtered activity/rating content', async () => {
+      weeklyBriefSvc.getCurrentBrief.mockResolvedValue({ brief: null, throttle: null });
+      const res = buildRes();
+
+      await controller.getCurrentBrief(buildReq(), res, vi.fn());
+
+      expect(res.setHeader).toHaveBeenCalledWith('Cache-Control', 'no-store');
     });
   });
 

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -30,29 +30,35 @@ vi.mock('../helpers/committee-write-access.helper', () => ({ assertCommitteeWrit
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
 // `constants` is a real runtime import here (WEEKLY_BRIEF_TEXT_MAX_LENGTH), unlike
 // `interfaces` above — must be mocked or the real module load re-triggers the
-// Angular JIT-compilation failure this file's mocks otherwise avoid.
-vi.mock('@lfx-one/shared/constants', () => ({ WEEKLY_BRIEF_TEXT_MAX_LENGTH: 20_000 }));
+// Angular JIT-compilation failure this file's mocks otherwise avoid. The three AKRITES_* entries
+// exist only to satisfy validation.helper.ts's real (unmocked, see below) module-level
+// `AKRITES_*.map(...)` statements at import time — unrelated to anything this file's own tests
+// exercise.
+vi.mock('@lfx-one/shared/constants', () => ({
+  WEEKLY_BRIEF_TEXT_MAX_LENGTH: 20_000,
+  AKRITES_STEWARD_ROLE_OPTIONS: [],
+  AKRITES_ESCALATION_PATHS: [],
+  AKRITES_INACTIVE_REASON_OPTIONS: [],
+}));
+// validation.helper.ts's other exports (unrelated to getStringQueryParam/validateUidParameter)
+// import `@lfx-one/shared/utils` for `resolvePeriodRange`, which fails to JIT-compile outside an
+// Angular test bed — see validation.helper.spec.ts's own header comment for the full mechanism.
+vi.mock('@lfx-one/shared/utils', () => ({}));
 
-// validation.helper.ts pulls in @lfx-one/shared/constants + /utils for functions this
-// controller never calls (only validateUidParameter is used) — mock the whole module
-// rather than let those unrelated imports execute (matches committee.controller.spec.ts).
-vi.mock('../helpers/validation.helper', () => ({
+// Real getStringQueryParam (importOriginal), not a hand-copy — validation.helper.spec.ts already
+// proves the module loads once @lfx-one/shared/utils is stubbed, so there's no reason for this
+// spec's includeCurrentActivity tests to exercise a re-implementation that could silently drift
+// from what's actually shipped. validateUidParameter stays a custom stub — this controller's own
+// use of it needs no real upstream-shaped validation, just the has-a-uid gate the real one buries
+// under committee-uid-specific messaging.
+vi.mock('../helpers/validation.helper', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../helpers/validation.helper')>()),
   validateUidParameter: (uid: unknown, req: unknown, next: (err: Error) => void): uid is string => {
     if (typeof uid !== 'string' || uid.trim() === '') {
       next(new Error('uid is required'));
       return false;
     }
     return true;
-  },
-  // A hand-copy of the real narrowing logic (undefined on a missing/non-string query value), not
-  // a canned return — this spec's includeCurrentActivity tests exercise this copy, not the real
-  // function (the real module can't load here; its other exports pull in `@lfx-one/shared/utils`,
-  // which fails to JIT-compile outside an Angular test bed). `validation.helper.spec.ts` is the
-  // one place the real `getStringQueryParam` is loaded and its narrowing behavior actually pinned
-  // — this copy staying faithful to that is what makes the tests below meaningful.
-  getStringQueryParam: (req: { query: Record<string, unknown> }, name: string): string | undefined => {
-    const value = req.query[name];
-    return typeof value === 'string' ? value : undefined;
   },
 }));
 

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -309,6 +309,14 @@ describe('WeeklyBriefController', () => {
       expect(weeklyBriefSvc.getCurrentBrief).toHaveBeenNthCalledWith(2, expect.anything(), COMMITTEE_ID, { includeCurrentActivity: true });
     });
 
+    it('trims whitespace before comparing — "false" surrounded by spaces still opts out, not silently falling back to included', async () => {
+      weeklyBriefSvc.getCurrentBrief.mockResolvedValue({ brief: null, throttle: null });
+
+      await controller.getCurrentBrief(buildReq({}, { includeCurrentActivity: ' false ' }), buildRes(), vi.fn());
+
+      expect(weeklyBriefSvc.getCurrentBrief).toHaveBeenCalledWith(expect.anything(), COMMITTEE_ID, { includeCurrentActivity: false });
+    });
+
     it('sets Cache-Control: no-store — the response can carry per-user, FGA-filtered activity/rating content', async () => {
       weeklyBriefSvc.getCurrentBrief.mockResolvedValue({ brief: null, throttle: null });
       const res = buildRes();

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -28,8 +28,9 @@ vi.mock('../helpers/committee-write-access.helper', () => ({ assertCommitteeWrit
 // server-side vitest config (see vitest.config.ts's `resolve.alias`), so both barrels below are
 // real, unmocked modules loaded via `importOriginal` — not stubs. Kept as explicit `vi.mock(...,
 // importOriginal)` calls rather than left unmocked outright only so a future addition to this file
-// that genuinely needs a stub has an obvious place to add one, matching meeting.controller.spec.ts's
-// established idiom for the same three barrels.
+// that genuinely needs a stub has an obvious place to add one — the same `importOriginal` idiom
+// `meeting.controller.spec.ts` already establishes for `constants`/`enums`/`interfaces` (this file
+// only needs two of those three; `utils` below is a genuine stub, not this same idiom).
 vi.mock('@lfx-one/shared/interfaces', async (importOriginal) => importOriginal());
 vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal());
 // validation.helper.ts's other exports (unrelated to getStringQueryParam/validateUidParameter)

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -64,7 +64,7 @@ vi.mock('../services/logger.service', () => ({
 
 import { WeeklyBriefController } from './weekly-brief.controller';
 
-function buildReq(body: unknown = {}, query: Record<string, string> = {}): any {
+function buildReq(body: unknown = {}, query: Record<string, string | string[]> = {}): any {
   return { params: { committeeId: COMMITTEE_ID }, query, body, path: '/test', log: {} };
 }
 
@@ -315,6 +315,14 @@ describe('WeeklyBriefController', () => {
       await controller.getCurrentBrief(buildReq({}, { includeCurrentActivity: ' false ' }), buildRes(), vi.fn());
 
       expect(weeklyBriefSvc.getCurrentBrief).toHaveBeenCalledWith(expect.anything(), COMMITTEE_ID, { includeCurrentActivity: false });
+    });
+
+    it('keeps the default-included behavior for a repeated-key array — getStringQueryParam narrows that to undefined, not a string', async () => {
+      weeklyBriefSvc.getCurrentBrief.mockResolvedValue({ brief: null, throttle: null });
+
+      await controller.getCurrentBrief(buildReq({}, { includeCurrentActivity: ['false', 'false'] }), buildRes(), vi.fn());
+
+      expect(weeklyBriefSvc.getCurrentBrief).toHaveBeenCalledWith(expect.anything(), COMMITTEE_ID, { includeCurrentActivity: true });
     });
 
     it('sets Cache-Control: no-store — the response can carry per-user, FGA-filtered activity/rating content', async () => {

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -24,22 +24,14 @@ const { weeklyBriefSvc, assertCommitteeRead, assertCommitteeWrite } = vi.hoisted
 vi.mock('../helpers/committee-read-access.helper', () => ({ assertCommitteeRead }));
 vi.mock('../helpers/committee-write-access.helper', () => ({ assertCommitteeWrite }));
 
-// The `@lfx-one/shared/*` alias isn't wired into the server-side vitest config —
-// mocked defensively even though this controller's usage is type-only (matches
-// committee.controller.spec.ts's convention).
-vi.mock('@lfx-one/shared/interfaces', () => ({}));
-// `constants` is a real runtime import here (WEEKLY_BRIEF_TEXT_MAX_LENGTH), unlike
-// `interfaces` above — must be mocked or the real module load re-triggers the
-// Angular JIT-compilation failure this file's mocks otherwise avoid. The three AKRITES_* entries
-// exist only to satisfy validation.helper.ts's real (unmocked, see below) module-level
-// `AKRITES_*.map(...)` statements at import time — unrelated to anything this file's own tests
-// exercise.
-vi.mock('@lfx-one/shared/constants', () => ({
-  WEEKLY_BRIEF_TEXT_MAX_LENGTH: 20_000,
-  AKRITES_STEWARD_ROLE_OPTIONS: [],
-  AKRITES_ESCALATION_PATHS: [],
-  AKRITES_INACTIVE_REASON_OPTIONS: [],
-}));
+// `@lfx-one/shared` (the whole scope, not just `constants`/`interfaces`) IS wired into the
+// server-side vitest config (see vitest.config.ts's `resolve.alias`), so both barrels below are
+// real, unmocked modules loaded via `importOriginal` — not stubs. Kept as explicit `vi.mock(...,
+// importOriginal)` calls rather than left unmocked outright only so a future addition to this file
+// that genuinely needs a stub has an obvious place to add one, matching meeting.controller.spec.ts's
+// established idiom for the same three barrels.
+vi.mock('@lfx-one/shared/interfaces', async (importOriginal) => importOriginal());
+vi.mock('@lfx-one/shared/constants', async (importOriginal) => importOriginal());
 // validation.helper.ts's other exports (unrelated to getStringQueryParam/validateUidParameter)
 // import `@lfx-one/shared/utils` for `resolvePeriodRange`, which fails to JIT-compile outside an
 // Angular test bed — see validation.helper.spec.ts's own header comment for the full mechanism.

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -44,6 +44,13 @@ vi.mock('../helpers/validation.helper', () => ({
     }
     return true;
   },
+  // Real implementation (not a stub) — this spec's includeCurrentActivity tests exercise the
+  // actual narrowing behavior (undefined on a missing/non-string query value), not a canned
+  // return.
+  getStringQueryParam: (req: { query: Record<string, unknown> }, name: string): string | undefined => {
+    const value = req.query[name];
+    return typeof value === 'string' ? value : undefined;
+  },
 }));
 
 vi.mock('../services/weekly-brief.service', () => ({

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.spec.ts
@@ -44,9 +44,12 @@ vi.mock('../helpers/validation.helper', () => ({
     }
     return true;
   },
-  // Real implementation (not a stub) — this spec's includeCurrentActivity tests exercise the
-  // actual narrowing behavior (undefined on a missing/non-string query value), not a canned
-  // return.
+  // A hand-copy of the real narrowing logic (undefined on a missing/non-string query value), not
+  // a canned return — this spec's includeCurrentActivity tests exercise this copy, not the real
+  // function (the real module can't load here; its other exports pull in `@lfx-one/shared/utils`,
+  // which fails to JIT-compile outside an Angular test bed). `validation.helper.spec.ts` is the
+  // one place the real `getStringQueryParam` is loaded and its narrowing behavior actually pinned
+  // — this copy staying faithful to that is what makes the tests below meaningful.
   getStringQueryParam: (req: { query: Record<string, unknown> }, name: string): string | undefined => {
     const value = req.query[name];
     return typeof value === 'string' ? value : undefined;

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -177,7 +177,12 @@ export class WeeklyBriefController {
 
       await assertCommitteeRead(req, committeeId, 'get_weekly_brief_current');
 
-      const result = await this.weeklyBriefService.getCurrentBrief(req, committeeId);
+      // Lets the client's own poll loop (weekly-brief-card.component.ts's pollUntilTerminal)
+      // opt out of the current_activity (GH-1922) fan-out on every tick — see
+      // WeeklyBriefService#getCurrentBrief's doc comment for why that matters. Only `=false`
+      // opts out; any other value (including absent) keeps the default-included behavior.
+      const includeCurrentActivity = req.query['includeCurrentActivity'] !== 'false';
+      const result = await this.weeklyBriefService.getCurrentBrief(req, committeeId, { includeCurrentActivity });
 
       logger.success(req, 'get_weekly_brief_current', startTime, {
         committee_id: committeeId,
@@ -186,6 +191,10 @@ export class WeeklyBriefController {
         revision: result.brief?.revision,
       });
 
+      // Per-user, FGA-filtered activity (current_activity's source_refs; caller_rating) — must
+      // not sit in a shared or intermediary cache, same rationale as the sibling
+      // CommitteeActivityController.
+      res.setHeader('Cache-Control', 'no-store');
       res.json(result);
     } catch (error) {
       next(error);

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -8,7 +8,7 @@ import { NextFunction, Request, Response } from 'express';
 import { ServiceValidationError } from '../errors';
 import { assertCommitteeRead } from '../helpers/committee-read-access.helper';
 import { assertCommitteeWrite } from '../helpers/committee-write-access.helper';
-import { validateUidParameter } from '../helpers/validation.helper';
+import { getStringQueryParam, validateUidParameter } from '../helpers/validation.helper';
 import { logger } from '../services/logger.service';
 import { WeeklyBriefService } from '../services/weekly-brief.service';
 
@@ -180,8 +180,9 @@ export class WeeklyBriefController {
       // Lets the client's own poll loop (weekly-brief-card.component.ts's pollUntilTerminal)
       // opt out of the current_activity (GH-1922) fan-out on every tick — see
       // WeeklyBriefService#getCurrentBrief's doc comment for why that matters. Only `=false`
-      // opts out; any other value (including absent) keeps the default-included behavior.
-      const includeCurrentActivity = req.query['includeCurrentActivity'] !== 'false';
+      // opts out; any other value (including absent, or a repeated-key array from
+      // getStringQueryParam narrowing that to undefined) keeps the default-included behavior.
+      const includeCurrentActivity = getStringQueryParam(req, 'includeCurrentActivity') !== 'false';
       const result = await this.weeklyBriefService.getCurrentBrief(req, committeeId, { includeCurrentActivity });
 
       logger.success(req, 'get_weekly_brief_current', startTime, {

--- a/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
+++ b/apps/lfx-one/src/server/controllers/weekly-brief.controller.ts
@@ -177,12 +177,13 @@ export class WeeklyBriefController {
 
       await assertCommitteeRead(req, committeeId, 'get_weekly_brief_current');
 
-      // Lets the client's own poll loop (weekly-brief-card.component.ts's pollUntilTerminal)
-      // opt out of the current_activity (GH-1922) fan-out on every tick — see
+      // Lets the client (weekly-brief-card.component.ts — both its initial load and its poll
+      // loop's pollUntilTerminal) opt out of the current_activity (GH-1922) fan-out — see
       // WeeklyBriefService#getCurrentBrief's doc comment for why that matters. Only `=false`
-      // opts out; any other value (including absent, or a repeated-key array from
+      // (whitespace-trimmed, so `=%20false` still opts out rather than silently falling back to
+      // included) opts out; any other value (including absent, or a repeated-key array from
       // getStringQueryParam narrowing that to undefined) keeps the default-included behavior.
-      const includeCurrentActivity = getStringQueryParam(req, 'includeCurrentActivity') !== 'false';
+      const includeCurrentActivity = getStringQueryParam(req, 'includeCurrentActivity')?.trim() !== 'false';
       const result = await this.weeklyBriefService.getCurrentBrief(req, committeeId, { includeCurrentActivity });
 
       logger.success(req, 'get_weekly_brief_current', startTime, {

--- a/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
@@ -4,22 +4,16 @@
 import { describe, expect, it, vi } from 'vitest';
 
 // validation.helper.ts's OTHER exports (query-param validators unrelated to getStringQueryParam)
-// import `@lfx-one/shared/constants` and `@lfx-one/shared/utils` — both barrels transitively pull
-// Angular (`@angular/common`'s `PlatformLocation`, via `resolvePeriodRange`'s own barrel), which
-// fails to JIT-compile outside an Angular test bed (confirmed directly: importing this module
-// unmocked throws "JIT compilation failed for injectable PlatformLocation"). getStringQueryParam
-// itself has zero dependency on either import, so both are stubbed here — just enough to satisfy
-// the few module-level statements that read from them (`AKRITES_STEWARD_ROLE_OPTIONS.map(...)`
-// and its two siblings, evaluated at import time) — to load the REAL function rather than a
-// caller-side re-implementation. Every controller spec that exercises `getStringQueryParam`
-// mocks `../helpers/validation.helper` wholesale instead, for the same reason; this file is the
-// one place the real narrowing behavior (string | string[] | ParsedQs | undefined -> string |
-// undefined) is actually pinned.
-vi.mock('@lfx-one/shared/constants', () => ({
-  AKRITES_STEWARD_ROLE_OPTIONS: [],
-  AKRITES_ESCALATION_PATHS: [],
-  AKRITES_INACTIVE_REASON_OPTIONS: [],
-}));
+// import `@lfx-one/shared/utils` for `resolvePeriodRange` — that barrel transitively pulls
+// Angular (`@angular/common`'s `PlatformLocation`), which fails to JIT-compile outside an Angular
+// test bed (confirmed directly: importing this module without this mock throws "JIT compilation
+// failed for injectable PlatformLocation"). `@lfx-one/shared/constants` does NOT need mocking —
+// it carries no Angular-touching barrel, so the module-level `AKRITES_*.map(...)` statements other
+// exports rely on resolve against the real constants on their own. getStringQueryParam itself has
+// zero dependency on either import; this mock exists solely to let the module load. Every
+// controller spec that exercises `getStringQueryParam` mocks `../helpers/validation.helper`
+// wholesale instead, for the same reason; this file is the one place the real narrowing behavior
+// (string | string[] | ParsedQs | undefined -> string | undefined) is actually pinned.
 vi.mock('@lfx-one/shared/utils', () => ({}));
 
 import { getStringQueryParam } from './validation.helper';
@@ -35,5 +29,9 @@ describe('getStringQueryParam', () => {
 
   it('narrows an absent key to undefined', () => {
     expect(getStringQueryParam({ query: {} } as any, 'x')).toBeUndefined();
+  });
+
+  it('narrows a nested-object value to undefined — express parses ?x[a]=b into x: ParsedQs, not a string', () => {
+    expect(getStringQueryParam({ query: { x: { a: 'b' } } } as any, 'x')).toBeUndefined();
   });
 });

--- a/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
@@ -8,12 +8,14 @@ import { describe, expect, it, vi } from 'vitest';
 // Angular (`@angular/common`'s `PlatformLocation`), which fails to JIT-compile outside an Angular
 // test bed (confirmed directly: importing this module without this mock throws "JIT compilation
 // failed for injectable PlatformLocation"). `@lfx-one/shared/constants` does NOT need mocking — it
-// is plain-Node-safe by invariant; see `constants/index.spec.ts`, the single source of truth for
-// that guarantee. getStringQueryParam itself has zero dependency on either import; this mock
-// exists solely to let the module load. Every controller spec that exercises
-// `getStringQueryParam` mocks `../helpers/validation.helper` wholesale instead, for the same
-// reason; this file is the one place the real narrowing behavior (string | string[] | ParsedQs |
-// undefined -> string | undefined) is actually pinned.
+// is plain-Node-safe by invariant; see `packages/shared/src/constants/index.spec.ts`, the single
+// source of truth for that guarantee — and must not be mocked either: `validation.helper.ts`
+// evaluates `AKRITES_*.map(...)` at module scope, which would throw against a stubbed-empty
+// barrel. getStringQueryParam itself has zero dependency on either import; this mock exists
+// solely to let the module load. Every controller spec that exercises `getStringQueryParam`
+// mocks `../helpers/validation.helper` wholesale instead, for the same reason; this file is the
+// one place the real narrowing behavior (string | string[] | ParsedQs | undefined -> string |
+// undefined) is actually pinned.
 vi.mock('@lfx-one/shared/utils', () => ({}));
 
 import { getStringQueryParam } from './validation.helper';

--- a/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
@@ -7,13 +7,13 @@ import { describe, expect, it, vi } from 'vitest';
 // import `@lfx-one/shared/utils` for `resolvePeriodRange` — that barrel transitively pulls
 // Angular (`@angular/common`'s `PlatformLocation`), which fails to JIT-compile outside an Angular
 // test bed (confirmed directly: importing this module without this mock throws "JIT compilation
-// failed for injectable PlatformLocation"). `@lfx-one/shared/constants` does NOT need mocking —
-// it carries no Angular-touching barrel, so the module-level `AKRITES_*.map(...)` statements other
-// exports rely on resolve against the real constants on their own. getStringQueryParam itself has
-// zero dependency on either import; this mock exists solely to let the module load. Every
-// controller spec that exercises `getStringQueryParam` mocks `../helpers/validation.helper`
-// wholesale instead, for the same reason; this file is the one place the real narrowing behavior
-// (string | string[] | ParsedQs | undefined -> string | undefined) is actually pinned.
+// failed for injectable PlatformLocation"). `@lfx-one/shared/constants` does NOT need mocking — it
+// is plain-Node-safe by invariant; see `constants/index.spec.ts`, the single source of truth for
+// that guarantee. getStringQueryParam itself has zero dependency on either import; this mock
+// exists solely to let the module load. Every controller spec that exercises
+// `getStringQueryParam` mocks `../helpers/validation.helper` wholesale instead, for the same
+// reason; this file is the one place the real narrowing behavior (string | string[] | ParsedQs |
+// undefined -> string | undefined) is actually pinned.
 vi.mock('@lfx-one/shared/utils', () => ({}));
 
 import { getStringQueryParam } from './validation.helper';

--- a/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
@@ -1,0 +1,39 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+import { describe, expect, it, vi } from 'vitest';
+
+// validation.helper.ts's OTHER exports (query-param validators unrelated to getStringQueryParam)
+// import `@lfx-one/shared/constants` and `@lfx-one/shared/utils` — both barrels transitively pull
+// Angular (`@angular/common`'s `PlatformLocation`, via `resolvePeriodRange`'s own barrel), which
+// fails to JIT-compile outside an Angular test bed (confirmed directly: importing this module
+// unmocked throws "JIT compilation failed for injectable PlatformLocation"). getStringQueryParam
+// itself has zero dependency on either import, so both are stubbed here — just enough to satisfy
+// the few module-level statements that read from them (`AKRITES_STEWARD_ROLE_OPTIONS.map(...)`
+// and its two siblings, evaluated at import time) — to load the REAL function rather than a
+// caller-side re-implementation. Every controller spec that exercises `getStringQueryParam`
+// mocks `../helpers/validation.helper` wholesale instead, for the same reason; this file is the
+// one place the real narrowing behavior (string | string[] | ParsedQs | undefined -> string |
+// undefined) is actually pinned.
+vi.mock('@lfx-one/shared/constants', () => ({
+  AKRITES_STEWARD_ROLE_OPTIONS: [],
+  AKRITES_ESCALATION_PATHS: [],
+  AKRITES_INACTIVE_REASON_OPTIONS: [],
+}));
+vi.mock('@lfx-one/shared/utils', () => ({}));
+
+import { getStringQueryParam } from './validation.helper';
+
+describe('getStringQueryParam', () => {
+  it('returns the string value for a plain query param', () => {
+    expect(getStringQueryParam({ query: { x: 'y' } } as any, 'x')).toBe('y');
+  });
+
+  it('narrows a repeated-key array to undefined — express parses ?x=y&x=y into x: string[], not the first value', () => {
+    expect(getStringQueryParam({ query: { x: ['y', 'y'] } } as any, 'x')).toBeUndefined();
+  });
+
+  it('narrows an absent key to undefined', () => {
+    expect(getStringQueryParam({ query: {} } as any, 'x')).toBeUndefined();
+  });
+});

--- a/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
+++ b/apps/lfx-one/src/server/helpers/validation.helper.spec.ts
@@ -9,13 +9,15 @@ import { describe, expect, it, vi } from 'vitest';
 // test bed (confirmed directly: importing this module without this mock throws "JIT compilation
 // failed for injectable PlatformLocation"). `@lfx-one/shared/constants` does NOT need mocking — it
 // is plain-Node-safe by invariant; see `packages/shared/src/constants/index.spec.ts`, the single
-// source of truth for that guarantee — and must not be mocked either: `validation.helper.ts`
-// evaluates `AKRITES_*.map(...)` at module scope, which would throw against a stubbed-empty
-// barrel. getStringQueryParam itself has zero dependency on either import; this mock exists
-// solely to let the module load. Every controller spec that exercises `getStringQueryParam`
-// mocks `../helpers/validation.helper` wholesale instead, for the same reason; this file is the
-// one place the real narrowing behavior (string | string[] | ParsedQs | undefined -> string |
-// undefined) is actually pinned.
+// source of truth for that guarantee — and should not be mocked here regardless: a well-intentioned
+// partial stub (e.g. faking the `AKRITES_*` arrays this file's other exports read at module scope
+// with `[]`) doesn't even throw, it just silently empties out those exports' real allow-lists —
+// worse than the loud failure an entirely-missing stub would produce. getStringQueryParam itself
+// has zero dependency on either import; the `utils` mock below exists solely to let the module
+// load. `weekly-brief.controller.spec.ts` also now loads the real `getStringQueryParam` (via the
+// same `importOriginal` pattern, real `constants` included), so this is no longer the only place
+// it runs — but it's still the one place its narrowing behavior (string | string[] | ParsedQs |
+// undefined -> string | undefined) is directly, exhaustively pinned by name.
 vi.mock('@lfx-one/shared/utils', () => ({}));
 
 import { getStringQueryParam } from './validation.helper';

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -9,13 +9,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // The vitest shared alias resolves enums/interfaces for real; constants/utils keep importActual subfile
 // stubs because their barrels reach Angular. The service's interfaces import is `import type` — erased, no mock needed.
-const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, info } = vi.hoisted(() => ({
+const { proxyRequest, getMeetings, getVotes, encodeActivityPageToken, warning, info, debug } = vi.hoisted(() => ({
   proxyRequest: vi.fn(),
   getMeetings: vi.fn(),
   getVotes: vi.fn(),
   encodeActivityPageToken: vi.fn((cursor: { before: string; key: string }) => `token(${cursor.before}|${cursor.key})`),
   warning: vi.fn(),
   info: vi.fn(),
+  debug: vi.fn(),
 }));
 
 vi.mock('@lfx-one/shared/constants', async () => {
@@ -60,7 +61,7 @@ vi.mock('../helpers/committee-activity-query.helper', async (importOriginal) => 
   ...(await importOriginal<typeof import('../helpers/committee-activity-query.helper')>()),
   encodeActivityPageToken,
 }));
-vi.mock('./logger.service', () => ({ logger: { debug: vi.fn(), warning, info, startOperation: vi.fn(), success: vi.fn() } }));
+vi.mock('./logger.service', () => ({ logger: { debug, warning, info, startOperation: vi.fn(), success: vi.fn() } }));
 vi.mock('./meeting.service', () => ({
   MeetingService: class {
     public getMeetings = getMeetings;
@@ -896,6 +897,28 @@ describe('CommitteeActivityService', () => {
       await expect(
         service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: 'some-other-committee', enable_voting: true } as Committee)
       ).rejects.toThrow(ServiceValidationError);
+    });
+
+    it('logs the aggregation start/completion at DEBUG, not INFO, when knownCommittee is passed — this caller is a per-poll-tick tally, not the controller-driven feed the INFO rationale was written for', async () => {
+      getVotes.mockResolvedValue({ data: [vote()] });
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee);
+
+      expect(debug).toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
+      expect(debug).toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
+      expect(info).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
+      expect(info).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
+    });
+
+    it('logs the aggregation start/completion at INFO, as before, when the caller has not resolved the committee itself (the controller-driven feed path)', async () => {
+      getVotes.mockResolvedValue({ data: [vote()] });
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
+
+      expect(info).toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
+      expect(info).toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
+      expect(debug).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
+      expect(debug).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -78,7 +78,7 @@ vi.mock('./microservice-proxy.service', () => ({
 }));
 
 import { PollStatus, SurveyStatus } from '@lfx-one/shared/enums';
-import type { ActivityPageCursor, CommitteeActivityNoteAttachment, PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
+import type { ActivityPageCursor, Committee, CommitteeActivityNoteAttachment, PastMeeting, Survey, Vote } from '@lfx-one/shared/interfaces';
 
 import { ResourceNotFoundError, ServiceValidationError } from '../errors';
 import { CommitteeActivityService } from './committee-activity.service';
@@ -864,6 +864,30 @@ describe('CommitteeActivityService', () => {
       await expect(service.getCommitteeActivity(req, uidNeedingEncoding, { limit: 8 })).rejects.toMatchObject({
         path: '/committees/committee%201',
       });
+    });
+  });
+
+  describe('knownCommittee (caller already resolved the committee)', () => {
+    it('uses the passed-in committee instead of fetching it again', async () => {
+      getVotes.mockResolvedValue({ data: [vote()] });
+      proxyRequest.mockImplementation((r, s, path, m, query) => {
+        if (/^\/committees\/[^/]+$/.test(path)) throw new Error('fetchCommittee should not run when knownCommittee is provided');
+        return defaultProxyRequest(r, s, path, m, query);
+      });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee);
+
+      // enable_voting: true on the passed-in committee — votes are included, proving the
+      // knownCommittee value (not a stubbed-out default) actually drove the gating decision.
+      expect(result.data.map((e) => e.type)).toEqual(['vote_opened']);
+    });
+
+    it('still gates on enable_voting from the knownCommittee, not just skips the fetch', async () => {
+      getVotes.mockResolvedValue({ data: [vote()] });
+
+      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: false } as Committee);
+
+      expect(result.data).toEqual([]);
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -876,7 +876,12 @@ describe('CommitteeActivityService', () => {
         return defaultProxyRequest(r, s, path, m, query);
       });
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee);
+      const result = await service.getCommitteeActivity(
+        req,
+        COMMITTEE_UID,
+        { limit: 8 },
+        { knownCommittee: { uid: COMMITTEE_UID, enable_voting: true } as Committee }
+      );
 
       // enable_voting: true on the passed-in committee — votes are included, proving the
       // knownCommittee value (not a stubbed-out default) actually drove the gating decision.
@@ -886,7 +891,12 @@ describe('CommitteeActivityService', () => {
     it('still gates on enable_voting from the knownCommittee, not just skips the fetch', async () => {
       getVotes.mockResolvedValue({ data: [vote()] });
 
-      const result = await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: false } as Committee);
+      const result = await service.getCommitteeActivity(
+        req,
+        COMMITTEE_UID,
+        { limit: 8 },
+        { knownCommittee: { uid: COMMITTEE_UID, enable_voting: false } as Committee }
+      );
 
       expect(result.data).toEqual([]);
     });
@@ -895,7 +905,7 @@ describe('CommitteeActivityService', () => {
       // enable_voting decides the entire vote leg's visibility — a mismatched committee here
       // would silently add or hide votes for the real committeeUid with no error anywhere else.
       await expect(
-        service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: 'some-other-committee', enable_voting: true } as Committee)
+        service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { knownCommittee: { uid: 'some-other-committee', enable_voting: true } as Committee })
       ).rejects.toThrow(ServiceValidationError);
       // Pins the guard's value as a cheap tripwire — it must reject BEFORE the 5-leg upstream
       // fan-out starts, not just eventually throw after paying for it.
@@ -905,7 +915,12 @@ describe('CommitteeActivityService', () => {
     it('logs the aggregation start/completion at DEBUG, not INFO, when quietAggregationLog is passed — this caller is a per-poll-tick tally, not the controller-driven feed the INFO rationale was written for', async () => {
       getVotes.mockResolvedValue({ data: [vote()] });
 
-      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee, true);
+      await service.getCommitteeActivity(
+        req,
+        COMMITTEE_UID,
+        { limit: 8 },
+        { knownCommittee: { uid: COMMITTEE_UID, enable_voting: true } as Committee, quietAggregationLog: true }
+      );
 
       expect(debug).toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
       expect(debug).toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
@@ -927,7 +942,7 @@ describe('CommitteeActivityService', () => {
     it('still logs at INFO when knownCommittee is passed but quietAggregationLog is not — passing knownCommittee alone must not silence the log, since it exists only to skip a redundant fetch and says nothing about call frequency', async () => {
       getVotes.mockResolvedValue({ data: [vote()] });
 
-      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee);
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { knownCommittee: { uid: COMMITTEE_UID, enable_voting: true } as Committee });
 
       expect(info).toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
       expect(debug).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -897,6 +897,9 @@ describe('CommitteeActivityService', () => {
       await expect(
         service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: 'some-other-committee', enable_voting: true } as Committee)
       ).rejects.toThrow(ServiceValidationError);
+      // Pins the guard's value as a cheap tripwire — it must reject BEFORE the 5-leg upstream
+      // fan-out starts, not just eventually throw after paying for it.
+      expect(proxyRequest).not.toHaveBeenCalled();
     });
 
     it('logs the aggregation start/completion at DEBUG, not INFO, when quietAggregationLog is passed — this caller is a per-poll-tick tally, not the controller-driven feed the INFO rationale was written for', async () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -889,6 +889,14 @@ describe('CommitteeActivityService', () => {
 
       expect(result.data).toEqual([]);
     });
+
+    it('rejects a knownCommittee whose uid does not match committeeUid, rather than silently trusting it', async () => {
+      // enable_voting decides the entire vote leg's visibility — a mismatched committee here
+      // would silently add or hide votes for the real committeeUid with no error anywhere else.
+      await expect(
+        service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: 'some-other-committee', enable_voting: true } as Committee)
+      ).rejects.toThrow(ServiceValidationError);
+    });
   });
 
   describe('notes_added leg', () => {

--- a/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.spec.ts
@@ -899,10 +899,10 @@ describe('CommitteeActivityService', () => {
       ).rejects.toThrow(ServiceValidationError);
     });
 
-    it('logs the aggregation start/completion at DEBUG, not INFO, when knownCommittee is passed — this caller is a per-poll-tick tally, not the controller-driven feed the INFO rationale was written for', async () => {
+    it('logs the aggregation start/completion at DEBUG, not INFO, when quietAggregationLog is passed — this caller is a per-poll-tick tally, not the controller-driven feed the INFO rationale was written for', async () => {
       getVotes.mockResolvedValue({ data: [vote()] });
 
-      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee);
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee, true);
 
       expect(debug).toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
       expect(debug).toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
@@ -910,7 +910,7 @@ describe('CommitteeActivityService', () => {
       expect(info).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
     });
 
-    it('logs the aggregation start/completion at INFO, as before, when the caller has not resolved the committee itself (the controller-driven feed path)', async () => {
+    it('logs the aggregation start/completion at INFO, as before, when quietAggregationLog is omitted (the controller-driven feed path)', async () => {
       getVotes.mockResolvedValue({ data: [vote()] });
 
       await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 });
@@ -919,6 +919,15 @@ describe('CommitteeActivityService', () => {
       expect(info).toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
       expect(debug).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
       expect(debug).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Completed committee activity aggregation', expect.anything());
+    });
+
+    it('still logs at INFO when knownCommittee is passed but quietAggregationLog is not — passing knownCommittee alone must not silence the log, since it exists only to skip a redundant fetch and says nothing about call frequency', async () => {
+      getVotes.mockResolvedValue({ data: [vote()] });
+
+      await service.getCommitteeActivity(req, COMMITTEE_UID, { limit: 8 }, { uid: COMMITTEE_UID, enable_voting: true } as Committee);
+
+      expect(info).toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
+      expect(debug).not.toHaveBeenCalledWith(req, 'get_committee_activity', 'Starting committee activity aggregation', expect.anything());
     });
   });
 

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -200,12 +200,15 @@ export class CommitteeActivityService {
    * rather than silently trusted: `committee.enable_voting` (read below) decides whether the
    * entire vote leg is surfaced, so passing the wrong committee here would otherwise silently add
    * or hide a committee's votes. This rejection is loud to a direct caller (throws
-   * `ServiceValidationError`), but this method's one production caller —
-   * `weekly-brief.service.ts`'s `buildCurrentActivity` — wraps the whole call in a try/catch that
-   * degrades ANY thrown error the same way (log a warning, omit the tally, let the poll retry), so
-   * in production this specific bug wouldn't surface as a distinguishable failure either — the
-   * guard's real value is as a tripwire for a caller reachable directly (tests, a future non-degrading
-   * caller), and as a precondition the type signature alone can't express.
+   * `ServiceValidationError`) — this method's other production caller, `committee-activity.controller.ts`'s
+   * "Recent Activity" feed endpoint, never passes `knownCommittee` at all, so the guard is
+   * unreachable on that path — but the one caller that DOES pass it, `weekly-brief.service.ts`'s
+   * `buildCurrentActivity`, wraps the whole call in a try/catch that degrades ANY thrown error the
+   * same way (log a warning, omit the tally, let the poll retry), so in production this specific
+   * bug wouldn't surface there as a distinguishable failure either — the guard's real value is as
+   * a tripwire for a caller reachable directly (tests, or a future `knownCommittee` caller that
+   * doesn't degrade the way `buildCurrentActivity` does), and as a precondition the type signature
+   * alone can't express.
    */
   public async getCommitteeActivity(
     req: Request,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -188,7 +188,22 @@ export class CommitteeActivityService {
     this.voteService = new VoteService();
   }
 
-  public async getCommitteeActivity(req: Request, committeeUid: string, options: CommitteeActivityQuery): Promise<PaginatedResponse<ActivityEvent>> {
+  /**
+   * `knownCommittee` (optional): a caller that already fetched this committee for its own reasons
+   * (e.g. weekly-brief.service.ts's `buildCurrentActivity`, which must read `category` before it
+   * can even decide whether to call this method) can pass it here to skip this method's own
+   * `fetchCommittee` — otherwise every caller pays that GET twice for a committee it already had in
+   * hand. Only an optimization: omitting it costs one extra upstream call, not a correctness
+   * difference — this method still trusts a caller-supplied committee exactly as it would trust its
+   * own fetch, with the same fail-closed contract (see fetchCommittee's doc comment) resting on the
+   * caller instead when this parameter is used.
+   */
+  public async getCommitteeActivity(
+    req: Request,
+    committeeUid: string,
+    options: CommitteeActivityQuery,
+    knownCommittee?: Committee
+  ): Promise<PaginatedResponse<ActivityEvent>> {
     const { since: rawSince, cursor, limit } = options;
     // Same reject-not-degrade policy as the cursor/since checks below, for the same reason:
     // parseCommitteeActivityQuery already bounds page_size on the HTTP path, but this method is
@@ -350,7 +365,7 @@ export class CommitteeActivityService {
     logger.info(req, 'get_committee_activity', 'Starting committee activity aggregation', { committee_uid: committeeUid, fetch_size: fetchSize });
 
     const [committee, pastMeetingResult, voteResult, surveyResult, documentResult, notesResult] = await Promise.all([
-      this.fetchCommittee(req, committeeUid),
+      knownCommittee ? Promise.resolve(knownCommittee) : this.fetchCommittee(req, committeeUid),
       this.fetchPastMeetingEvents(req, committeeUid, since, before, fetchSize).catch((err) => {
         logger.warning(req, 'get_committee_activity', 'Failed to fetch past-meeting activity, continuing without it', { committee_uid: committeeUid, err });
         return { events: [], saturated: false };

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -189,14 +189,6 @@ export class CommitteeActivityService {
   }
 
   /**
-   * `callerOptions` is deliberately its own bag, not folded into `options: CommitteeActivityQuery`
-   * — that type is also the parsed, validated shape of `GET /api/committees/:uid/activity`'s query
-   * string (see its own doc comment), and neither `knownCommittee` nor `quietAggregationLog` is
-   * ever HTTP-parsed; mixing an internal caller-intent flag into a wire-query type would blur that
-   * boundary for no benefit (general-code-reviewer flagged the previous 5-positional-parameter
-   * signature as a footgun forcing callers to pass `undefined` to reach a later flag — this bag
-   * fixes the footgun without paying that cost).
-   *
    * `knownCommittee` (optional): a caller that already fetched this committee for its own reasons
    * (e.g. weekly-brief.service.ts's `buildCurrentActivity`, which must read `category` before it
    * can even decide whether to call this method) can pass it here to skip this method's own
@@ -224,6 +216,12 @@ export class CommitteeActivityService {
    * caller invoked at higher-than-once-per-request frequency (currently only
    * `weekly-brief.service.ts`'s per-poll-tick tally) to log the aggregation start/completion at
    * DEBUG instead of INFO — see those two log call sites' own comments for the full rationale.
+   *
+   * Both of the above live in `callerOptions`, a bag kept deliberately separate from
+   * `options: CommitteeActivityQuery` — that type is also the parsed, validated shape of
+   * `GET /api/committees/:uid/activity`'s query string (see its own doc comment), and neither
+   * `knownCommittee` nor `quietAggregationLog` is ever HTTP-parsed; mixing an internal
+   * caller-intent flag into a wire-query type would blur that boundary for no benefit.
    */
   public async getCommitteeActivity(
     req: Request,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -376,8 +376,17 @@ export class CommitteeActivityService {
     // (the closest precedent in this repo: a comparable multi-source read aggregation), not the
     // single-source enrichment services that stay at DEBUG throughout. A merge across 5
     // independently-paginated upstream sources with cursor/saturation logic is exactly the
-    // "complex multi-step orchestration" case logging-patterns.md reserves INFO for.
-    logger.info(req, 'get_committee_activity', 'Starting committee activity aggregation', { committee_uid: committeeUid, fetch_size: fetchSize });
+    // "complex multi-step orchestration" case logging-patterns.md reserves INFO for — but only for
+    // the controller-driven "Recent Activity" feed call this rationale was written for.
+    // `knownCommittee` (only ever passed by `weekly-brief.service.ts#buildCurrentActivity`, GH-1922)
+    // identifies the other caller: a per-poll-tick tally fan-out that can run up to
+    // `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` times per generate cycle, well past
+    // "significant business operation" frequency — DEBUG there instead, same call, same shape.
+    const aggregationLogLevel = knownCommittee ? 'debug' : 'info';
+    logger[aggregationLogLevel](req, 'get_committee_activity', 'Starting committee activity aggregation', {
+      committee_uid: committeeUid,
+      fetch_size: fetchSize,
+    });
 
     const [committee, pastMeetingResult, voteResult, surveyResult, documentResult, notesResult] = await Promise.all([
       knownCommittee ? Promise.resolve(knownCommittee) : this.fetchCommittee(req, committeeUid),
@@ -484,7 +493,8 @@ export class CommitteeActivityService {
     const hasMore = (windowed.length > limit || anyLegSaturated) && !!lastPageItem;
     const pageToken = hasMore && lastPageItem ? encodeActivityPageToken({ before: lastPageItem.event.occurred_at, key: lastPageItem.key }) : undefined;
 
-    logger.info(req, 'get_committee_activity', 'Completed committee activity aggregation', {
+    // Same knownCommittee-gated level as the "Starting" log above — see that call's comment.
+    logger[aggregationLogLevel](req, 'get_committee_activity', 'Completed committee activity aggregation', {
       committee_uid: committeeUid,
       meeting_count: pastMeetingResult.events.length,
       vote_count: voteResult.events.length,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -189,6 +189,14 @@ export class CommitteeActivityService {
   }
 
   /**
+   * `callerOptions` is deliberately its own bag, not folded into `options: CommitteeActivityQuery`
+   * — that type is also the parsed, validated shape of `GET /api/committees/:uid/activity`'s query
+   * string (see its own doc comment), and neither `knownCommittee` nor `quietAggregationLog` is
+   * ever HTTP-parsed; mixing an internal caller-intent flag into a wire-query type would blur that
+   * boundary for no benefit (general-code-reviewer flagged the previous 5-positional-parameter
+   * signature as a footgun forcing callers to pass `undefined` to reach a later flag — this bag
+   * fixes the footgun without paying that cost).
+   *
    * `knownCommittee` (optional): a caller that already fetched this committee for its own reasons
    * (e.g. weekly-brief.service.ts's `buildCurrentActivity`, which must read `category` before it
    * can even decide whether to call this method) can pass it here to skip this method's own
@@ -221,9 +229,9 @@ export class CommitteeActivityService {
     req: Request,
     committeeUid: string,
     options: CommitteeActivityQuery,
-    knownCommittee?: Committee,
-    quietAggregationLog = false
+    callerOptions: { knownCommittee?: Committee; quietAggregationLog?: boolean } = {}
   ): Promise<PaginatedResponse<ActivityEvent>> {
+    const { knownCommittee, quietAggregationLog = false } = callerOptions;
     if (knownCommittee && knownCommittee.uid !== committeeUid) {
       throw ServiceValidationError.forField('knownCommittee', 'knownCommittee.uid must match committeeUid', { operation: 'get_committee_activity' });
     }

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -214,7 +214,8 @@ export class CommitteeActivityService {
     req: Request,
     committeeUid: string,
     options: CommitteeActivityQuery,
-    knownCommittee?: Committee
+    knownCommittee?: Committee,
+    quietAggregationLog = false
   ): Promise<PaginatedResponse<ActivityEvent>> {
     if (knownCommittee && knownCommittee.uid !== committeeUid) {
       throw ServiceValidationError.forField('knownCommittee', 'knownCommittee.uid must match committeeUid', { operation: 'get_committee_activity' });
@@ -377,12 +378,14 @@ export class CommitteeActivityService {
     // single-source enrichment services that stay at DEBUG throughout. A merge across 5
     // independently-paginated upstream sources with cursor/saturation logic is exactly the
     // "complex multi-step orchestration" case logging-patterns.md reserves INFO for — but only for
-    // the controller-driven "Recent Activity" feed call this rationale was written for.
-    // `knownCommittee` (only ever passed by `weekly-brief.service.ts#buildCurrentActivity`, GH-1922)
-    // identifies the other caller: a per-poll-tick tally fan-out that can run up to
+    // a call at that frequency. `quietAggregationLog` (an explicit intent flag, deliberately NOT
+    // inferred from `knownCommittee` — that param exists only to skip a redundant committee fetch
+    // and says nothing about call frequency, so a future caller passing it purely for that saving
+    // must not silently lose its INFO logs) is set by `weekly-brief.service.ts#buildCurrentActivity`
+    // (GH-1922): a per-poll-tick tally fan-out that can run up to
     // `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` times per generate cycle, well past
     // "significant business operation" frequency — DEBUG there instead, same call, same shape.
-    const aggregationLogLevel = knownCommittee ? 'debug' : 'info';
+    const aggregationLogLevel = quietAggregationLog ? 'debug' : 'info';
     logger[aggregationLogLevel](req, 'get_committee_activity', 'Starting committee activity aggregation', {
       committee_uid: committeeUid,
       fetch_size: fetchSize,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -198,8 +198,14 @@ export class CommitteeActivityService {
    * own fetch, with the same fail-closed contract (see fetchCommittee's doc comment) resting on the
    * caller instead when this parameter is used. Not inert data, so a mismatched `uid` is rejected
    * rather than silently trusted: `committee.enable_voting` (read below) decides whether the
-   * entire vote leg is surfaced, so a future caller passing the wrong committee here would silently
-   * add or hide a committee's votes with no error anywhere else in the request.
+   * entire vote leg is surfaced, so passing the wrong committee here would otherwise silently add
+   * or hide a committee's votes. This rejection is loud to a direct caller (throws
+   * `ServiceValidationError`), but this method's one production caller —
+   * `weekly-brief.service.ts`'s `buildCurrentActivity` — wraps the whole call in a try/catch that
+   * degrades ANY thrown error the same way (log a warning, omit the tally, let the poll retry), so
+   * in production this specific bug wouldn't surface as a distinguishable failure either — the
+   * guard's real value is as a tripwire for a caller reachable directly (tests, a future non-degrading
+   * caller), and as a precondition the type signature alone can't express.
    */
   public async getCommitteeActivity(
     req: Request,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -209,6 +209,13 @@ export class CommitteeActivityService {
    * a tripwire for a caller reachable directly (tests, or a future `knownCommittee` caller that
    * doesn't degrade the way `buildCurrentActivity` does), and as a precondition the type signature
    * alone can't express.
+   *
+   * `quietAggregationLog` (optional, default `false`): deliberately independent of `knownCommittee`
+   * — passing a known committee only skips a redundant fetch and implies nothing about how often
+   * this method is called, so it must not double as a logging-verbosity switch. Set `true` for a
+   * caller invoked at higher-than-once-per-request frequency (currently only
+   * `weekly-brief.service.ts`'s per-poll-tick tally) to log the aggregation start/completion at
+   * DEBUG instead of INFO — see those two log call sites' own comments for the full rationale.
    */
   public async getCommitteeActivity(
     req: Request,
@@ -496,7 +503,7 @@ export class CommitteeActivityService {
     const hasMore = (windowed.length > limit || anyLegSaturated) && !!lastPageItem;
     const pageToken = hasMore && lastPageItem ? encodeActivityPageToken({ before: lastPageItem.event.occurred_at, key: lastPageItem.key }) : undefined;
 
-    // Same knownCommittee-gated level as the "Starting" log above — see that call's comment.
+    // Same quietAggregationLog-gated level as the "Starting" log above — see that call's comment.
     logger[aggregationLogLevel](req, 'get_committee_activity', 'Completed committee activity aggregation', {
       committee_uid: committeeUid,
       meeting_count: pastMeetingResult.events.length,

--- a/apps/lfx-one/src/server/services/committee-activity.service.ts
+++ b/apps/lfx-one/src/server/services/committee-activity.service.ts
@@ -196,7 +196,10 @@ export class CommitteeActivityService {
    * hand. Only an optimization: omitting it costs one extra upstream call, not a correctness
    * difference — this method still trusts a caller-supplied committee exactly as it would trust its
    * own fetch, with the same fail-closed contract (see fetchCommittee's doc comment) resting on the
-   * caller instead when this parameter is used.
+   * caller instead when this parameter is used. Not inert data, so a mismatched `uid` is rejected
+   * rather than silently trusted: `committee.enable_voting` (read below) decides whether the
+   * entire vote leg is surfaced, so a future caller passing the wrong committee here would silently
+   * add or hide a committee's votes with no error anywhere else in the request.
    */
   public async getCommitteeActivity(
     req: Request,
@@ -204,6 +207,9 @@ export class CommitteeActivityService {
     options: CommitteeActivityQuery,
     knownCommittee?: Committee
   ): Promise<PaginatedResponse<ActivityEvent>> {
+    if (knownCommittee && knownCommittee.uid !== committeeUid) {
+      throw ServiceValidationError.forField('knownCommittee', 'knownCommittee.uid must match committeeUid', { operation: 'get_committee_activity' });
+    }
     const { since: rawSince, cursor, limit } = options;
     // Same reject-not-degrade policy as the cursor/since checks below, for the same reason:
     // parseCommitteeActivityQuery already bounds page_size on the HTTP path, but this method is
@@ -389,7 +395,9 @@ export class CommitteeActivityService {
     ]);
 
     // A committee-lookup failure already rejected the whole Promise.all above (see fetchCommittee's
-    // doc comment) — by this line `committee` is always a resolved Committee.
+    // doc comment), or `committee` came from a caller-supplied `knownCommittee` — validated against
+    // `committeeUid` above and carrying the same fail-closed contract per this method's own doc
+    // comment. Either way, by this line `committee` is always a resolved, trustworthy Committee.
     const votingEnabled = committee.enable_voting;
     const sources: ActivityEvent[][] = [
       pastMeetingResult.events,

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -80,6 +80,7 @@ vi.mock('../services/logger.service', () => ({
 
 import type { Request } from 'express';
 
+import { MicroserviceError } from '../errors';
 import { fetchAllQueryResources } from '../helpers/query-service.helper';
 import { ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 import { logger } from '../services/logger.service';
@@ -898,9 +899,17 @@ describe('CommitteeService.getCommitteeCategory', () => {
   });
 
   it('propagates a genuine upstream error (e.g. 404) rather than normalizing it to undefined', async () => {
-    const upstreamError = new Error('not found');
-    proxyRequest.mockRejectedValueOnce(upstreamError);
+    const upstreamError = MicroserviceError.fromMicroserviceResponse(
+      404,
+      'Not Found',
+      undefined,
+      'LFX_V2_SERVICE',
+      `/committees/${COMMITTEE_UID}`,
+      'get_committee'
+    );
+    proxyRequest.mockRejectedValue(upstreamError);
 
-    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toBe(upstreamError);
+    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toBeInstanceOf(MicroserviceError);
+    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toMatchObject({ statusCode: 404 });
   });
 });

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -898,6 +898,15 @@ describe('CommitteeService.getCommitteeBase', () => {
     expect(result).toBeUndefined();
   });
 
+  it('strips chat_webhook_url before returning — this is a raw-upstream-fetch read path, same invariant as every other Committee-returning method', async () => {
+    proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, category: 'Board', chat_webhook_url: 'https://hooks.slack.com/services/T1/B1/secret' });
+
+    const result = await service.getCommitteeBase(req, COMMITTEE_UID);
+
+    expect(result).not.toHaveProperty('chat_webhook_url');
+    expect(result).toMatchObject({ uid: COMMITTEE_UID, category: 'Board' });
+  });
+
   it('propagates a genuine upstream error (e.g. 404) rather than normalizing it to undefined', async () => {
     const upstreamError = MicroserviceError.fromMicroserviceResponse(
       404,

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -410,27 +410,6 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
     });
   });
 
-  describe('getCommitteeCategory', () => {
-    it("returns category from a single plain GET, not getCommitteeById's enriched fan-out", async () => {
-      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', category: 'Board' });
-
-      const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
-
-      expect(result).toBe('Board');
-      // Exactly one upstream call — no settings, no access-check, unlike getCommitteeById above.
-      expect(proxyRequest).toHaveBeenCalledOnce();
-      expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_SERVICE', `/committees/${COMMITTEE_UID}`, 'GET');
-    });
-
-    it('returns undefined (not a thrown error) when the committee is not found', async () => {
-      proxyRequest.mockResolvedValueOnce(null);
-
-      const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
-
-      expect(result).toBeUndefined();
-    });
-  });
-
   describe('updateCommittee', () => {
     it('rejects a chat_webhook_url change (409 FEATURE_DISABLED) when the server-side kill switch is off, before touching upstream — independent of WG_WEEKLY_BRIEF_SLACK_FLAG, which is UI-only and never reaches this method', async () => {
       delete process.env[ServerFeatureFlag.WeeklyBriefSlack];
@@ -887,5 +866,41 @@ describe('CommitteeService.getCommitteesByIds', () => {
 
     await expect(service.getCommitteesByIds(req, [...firstBatch, ...secondBatch])).rejects.toThrow('boom');
     expect(logger.warning).toHaveBeenCalledWith(req, 'get_committees_by_ids', expect.any(String), expect.objectContaining({ batch_size: secondBatch.length }));
+  });
+});
+
+describe('CommitteeService.getCommitteeCategory', () => {
+  let service: CommitteeService;
+  const COMMITTEE_UID = 'committee-1';
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    service = new CommitteeService();
+  });
+
+  it("returns category from a single plain GET, not getCommitteeById's enriched fan-out", async () => {
+    proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', category: 'Board' });
+
+    const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
+
+    expect(result).toBe('Board');
+    // Exactly one upstream call — no settings, no access-check, unlike getCommitteeById.
+    expect(proxyRequest).toHaveBeenCalledOnce();
+    expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_SERVICE', `/committees/${COMMITTEE_UID}`, 'GET');
+  });
+
+  it('returns undefined when upstream resolves with no committee body (the empty-body-parses-to-null case, not a 404)', async () => {
+    proxyRequest.mockResolvedValueOnce(null);
+
+    const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
+
+    expect(result).toBeUndefined();
+  });
+
+  it('propagates a genuine upstream error (e.g. 404) rather than normalizing it to undefined', async () => {
+    const upstreamError = new Error('not found');
+    proxyRequest.mockRejectedValueOnce(upstreamError);
+
+    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toBe(upstreamError);
   });
 });

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -410,6 +410,27 @@ describe('CommitteeService — chat_webhook_url (LFXV2-3080)', () => {
     });
   });
 
+  describe('getCommitteeCategory', () => {
+    it("returns category from a single plain GET, not getCommitteeById's enriched fan-out", async () => {
+      proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', category: 'Board' });
+
+      const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
+
+      expect(result).toBe('Board');
+      // Exactly one upstream call — no settings, no access-check, unlike getCommitteeById above.
+      expect(proxyRequest).toHaveBeenCalledOnce();
+      expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_SERVICE', `/committees/${COMMITTEE_UID}`, 'GET');
+    });
+
+    it('returns undefined (not a thrown error) when the committee is not found', async () => {
+      proxyRequest.mockResolvedValueOnce(null);
+
+      const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
+
+      expect(result).toBeUndefined();
+    });
+  });
+
   describe('updateCommittee', () => {
     it('rejects a chat_webhook_url change (409 FEATURE_DISABLED) when the server-side kill switch is off, before touching upstream — independent of WG_WEEKLY_BRIEF_SLACK_FLAG, which is UI-only and never reaches this method', async () => {
       delete process.env[ServerFeatureFlag.WeeklyBriefSlack];

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -870,7 +870,7 @@ describe('CommitteeService.getCommitteesByIds', () => {
   });
 });
 
-describe('CommitteeService.getCommitteeCategory', () => {
+describe('CommitteeService.getCommitteeBase', () => {
   let service: CommitteeService;
   const COMMITTEE_UID = 'committee-1';
 
@@ -879,12 +879,12 @@ describe('CommitteeService.getCommitteeCategory', () => {
     service = new CommitteeService();
   });
 
-  it("returns category from a single plain GET, not getCommitteeById's enriched fan-out", async () => {
+  it("returns the base committee from a single plain GET, not getCommitteeById's enriched fan-out", async () => {
     proxyRequest.mockResolvedValueOnce({ uid: COMMITTEE_UID, name: 'Test', project_uid: 'project-1', category: 'Board' });
 
-    const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
+    const result = await service.getCommitteeBase(req, COMMITTEE_UID);
 
-    expect(result).toBe('Board');
+    expect(result).toMatchObject({ uid: COMMITTEE_UID, category: 'Board' });
     // Exactly one upstream call — no settings, no access-check, unlike getCommitteeById.
     expect(proxyRequest).toHaveBeenCalledOnce();
     expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_SERVICE', `/committees/${COMMITTEE_UID}`, 'GET');
@@ -893,7 +893,7 @@ describe('CommitteeService.getCommitteeCategory', () => {
   it('returns undefined when upstream resolves with no committee body (the empty-body-parses-to-null case, not a 404)', async () => {
     proxyRequest.mockResolvedValueOnce(null);
 
-    const result = await service.getCommitteeCategory(req, COMMITTEE_UID);
+    const result = await service.getCommitteeBase(req, COMMITTEE_UID);
 
     expect(result).toBeUndefined();
   });
@@ -912,6 +912,6 @@ describe('CommitteeService.getCommitteeCategory', () => {
     // Identity, not just type/status — proves the exact upstream error propagates rather than
     // getting caught and re-thrown as a freshly constructed lookalike (which a type/status-only
     // assertion couldn't tell apart from this).
-    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toBe(upstreamError);
+    await expect(service.getCommitteeBase(req, COMMITTEE_UID)).rejects.toBe(upstreamError);
   });
 });

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -909,12 +909,9 @@ describe('CommitteeService.getCommitteeCategory', () => {
     );
     proxyRequest.mockRejectedValueOnce(upstreamError);
 
-    const thrown = await service.getCommitteeCategory(req, COMMITTEE_UID).catch((e: unknown) => e);
-
     // Identity, not just type/status — proves the exact upstream error propagates rather than
-    // getting caught and re-thrown as a freshly constructed lookalike.
-    expect(thrown).toBe(upstreamError);
-    expect(thrown).toBeInstanceOf(MicroserviceError);
-    expect(thrown).toMatchObject({ statusCode: 404 });
+    // getting caught and re-thrown as a freshly constructed lookalike (which a type/status-only
+    // assertion couldn't tell apart from this).
+    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toBe(upstreamError);
   });
 });

--- a/apps/lfx-one/src/server/services/committee.service.spec.ts
+++ b/apps/lfx-one/src/server/services/committee.service.spec.ts
@@ -907,9 +907,14 @@ describe('CommitteeService.getCommitteeCategory', () => {
       `/committees/${COMMITTEE_UID}`,
       'get_committee'
     );
-    proxyRequest.mockRejectedValue(upstreamError);
+    proxyRequest.mockRejectedValueOnce(upstreamError);
 
-    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toBeInstanceOf(MicroserviceError);
-    await expect(service.getCommitteeCategory(req, COMMITTEE_UID)).rejects.toMatchObject({ statusCode: 404 });
+    const thrown = await service.getCommitteeCategory(req, COMMITTEE_UID).catch((e: unknown) => e);
+
+    // Identity, not just type/status — proves the exact upstream error propagates rather than
+    // getting caught and re-thrown as a freshly constructed lookalike.
+    expect(thrown).toBe(upstreamError);
+    expect(thrown).toBeInstanceOf(MicroserviceError);
+    expect(thrown).toMatchObject({ statusCode: 404 });
   });
 });

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -426,8 +426,9 @@ export class CommitteeService {
    * `category` alone (e.g. weekly-brief.service.ts's governance gate on the weekly-brief tally),
    * and `getCommitteeById`'s default options still cost three upstream calls — base GET,
    * settings, and an access-check — for data this caller throws away. `undefined` here means
-   * upstream resolved with no `category` on the body (including the empty-body-parses-to-`null`
-   * case `proxyRequest` itself documents) — NOT "committee not found": a genuine 404 or other
+   * upstream resolved with no `category` on the body — absent/null field, or an empty body
+   * (which `ApiClientService.executeRequest` parses to `null` via `text ? JSON.parse(text) :
+   * null`) — NOT "committee not found": a genuine 404 or other
    * upstream error status throws a `MicroserviceError` out of `proxyRequest` before this method
    * ever gets a value to read `.category` off of, same as `getCommitteeById`'s own upstream call.
    * Deliberately doesn't catch that throw and normalize it to `undefined` — existing callers of

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -437,6 +437,11 @@ export class CommitteeService {
    * write/detail paths that need it; a caller reaching only for the base record has nothing to write
    * to and no detail page to 404, so leaving the throw uncaught keeps that decision (log and degrade,
    * or propagate) with the caller instead of forcing one.
+   *
+   * Still runs the result through `stripChatWebhookUrl` — this is a public read path returning a raw
+   * upstream fetch, exactly the shape that helper's own doc comment says must be enrolled so
+   * `Committee.has_slack_webhook`'s "never returned by any read" invariant holds everywhere, not just
+   * the two hand-audited call sites its docblock predates this method by.
    */
   public async getCommitteeBase(req: Request, committeeId: string): Promise<Committee | undefined> {
     const committee = await this.microserviceProxy.proxyRequest<Committee | null>(
@@ -445,7 +450,7 @@ export class CommitteeService {
       `/committees/${encodeURIComponent(committeeId)}`,
       'GET'
     );
-    return committee ?? undefined;
+    return committee ? this.stripChatWebhookUrl(committee) : undefined;
   }
 
   /**
@@ -1896,7 +1901,7 @@ export class CommitteeService {
    * service via any HTTP response. Applied at every method that returns a `Committee`/`Committee[]`
    * built from a raw upstream fetch — `getCommittees`, `getDirectGrantCommittees`,
    * `searchCreatableCommittees`, `createCommittee`, `updateCommittee`, `getCommitteesByIds`
-   * (covers `getMyCommittees`) — so the "never returned by any read" invariant on
+   * (covers `getMyCommittees`), `getCommitteeBase` (GH-1922) — so the "never returned by any read" invariant on
    * {@link Committee.has_slack_webhook}'s doc comment holds everywhere, not just the two
    * hand-audited call sites. {@link getCommitteeById} calls this too, on top of (not instead of)
    * its own inline destructure of the base resource — the inline strip keeps the credential out

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -425,11 +425,16 @@ export class CommitteeService {
    * A single field read, not a `getCommitteeById` call with the rest discarded: this needs
    * `category` alone (e.g. weekly-brief.service.ts's governance gate on the weekly-brief tally),
    * and `getCommitteeById`'s default options still cost three upstream calls — base GET,
-   * settings, and an access-check — for data this caller throws away. `undefined`, not a thrown
-   * error, on a genuinely missing committee: existing callers of `getCommitteeById` already have
-   * their own not-found handling for the write/detail paths that need it; a caller reaching only
-   * for `category` has nothing to write to and no detail page to 404, so failing soft here keeps
-   * that decision (log and degrade, or propagate) with the caller instead of forcing one.
+   * settings, and an access-check — for data this caller throws away. `undefined` here means
+   * upstream resolved with no `category` on the body (including the empty-body-parses-to-`null`
+   * case `proxyRequest` itself documents) — NOT "committee not found": a genuine 404 or other
+   * upstream error status throws a `MicroserviceError` out of `proxyRequest` before this method
+   * ever gets a value to read `.category` off of, same as `getCommitteeById`'s own upstream call.
+   * Deliberately doesn't catch that throw and normalize it to `undefined` — existing callers of
+   * `getCommitteeById` already have their own not-found handling for the write/detail paths that
+   * need it; a caller reaching only for `category` has nothing to write to and no detail page to
+   * 404, so leaving the throw uncaught keeps that decision (log and degrade, or propagate) with
+   * the caller instead of forcing one.
    */
   public async getCommitteeCategory(req: Request, committeeId: string): Promise<string | undefined> {
     const committee = await this.microserviceProxy.proxyRequest<Committee | null>(

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -422,29 +422,30 @@ export class CommitteeService {
   }
 
   /**
-   * A single field read, not a `getCommitteeById` call with the rest discarded: this needs
-   * `category` alone (e.g. weekly-brief.service.ts's governance gate on the weekly-brief tally),
-   * and `getCommitteeById`'s default options still cost three upstream calls — base GET,
-   * settings, and an access-check — for data this caller throws away. `undefined` here means
-   * upstream resolved with no `category` on the body — absent/null field, or an empty body
-   * (which `ApiClientService.executeRequest` parses to `null` via `text ? JSON.parse(text) :
-   * null`) — NOT "committee not found": a genuine 404 or other
-   * upstream error status throws a `MicroserviceError` out of `proxyRequest` before this method
-   * ever gets a value to read `.category` off of, same as `getCommitteeById`'s own upstream call.
-   * Deliberately doesn't catch that throw and normalize it to `undefined` — existing callers of
-   * `getCommitteeById` already have their own not-found handling for the write/detail paths that
-   * need it; a caller reaching only for `category` has nothing to write to and no detail page to
-   * 404, so leaving the throw uncaught keeps that decision (log and degrade, or propagate) with
-   * the caller instead of forcing one.
+   * A single plain GET, not a `getCommitteeById` call with the rest discarded: a caller reaching
+   * only for the base record (e.g. weekly-brief.service.ts's `buildCurrentActivity`, which reads
+   * `category` for its governance gate and then passes this same resolved committee into
+   * `CommitteeActivityService.getCommitteeActivity` so that method doesn't pay an identical second
+   * fetch for a committee the caller already has) shouldn't pay `getCommitteeById`'s default-options
+   * cost of three upstream calls — base GET, settings, and an access-check — for data it throws
+   * away. `undefined` here means upstream resolved with no body at all — an empty body (which
+   * `ApiClientService.executeRequest` parses to `null` via `text ? JSON.parse(text) : null`) — NOT
+   * "committee not found": a genuine 404 or other upstream error status throws a `MicroserviceError`
+   * out of `proxyRequest` before this method ever gets a value to return, same as `getCommitteeById`'s
+   * own upstream call. Deliberately doesn't catch that throw and normalize it to `undefined` —
+   * existing callers of `getCommitteeById` already have their own not-found handling for the
+   * write/detail paths that need it; a caller reaching only for the base record has nothing to write
+   * to and no detail page to 404, so leaving the throw uncaught keeps that decision (log and degrade,
+   * or propagate) with the caller instead of forcing one.
    */
-  public async getCommitteeCategory(req: Request, committeeId: string): Promise<string | undefined> {
+  public async getCommitteeBase(req: Request, committeeId: string): Promise<Committee | undefined> {
     const committee = await this.microserviceProxy.proxyRequest<Committee | null>(
       req,
       'LFX_V2_SERVICE',
       `/committees/${encodeURIComponent(committeeId)}`,
       'GET'
     );
-    return committee?.category;
+    return committee ?? undefined;
   }
 
   /**

--- a/apps/lfx-one/src/server/services/committee.service.ts
+++ b/apps/lfx-one/src/server/services/committee.service.ts
@@ -422,6 +422,26 @@ export class CommitteeService {
   }
 
   /**
+   * A single field read, not a `getCommitteeById` call with the rest discarded: this needs
+   * `category` alone (e.g. weekly-brief.service.ts's governance gate on the weekly-brief tally),
+   * and `getCommitteeById`'s default options still cost three upstream calls — base GET,
+   * settings, and an access-check — for data this caller throws away. `undefined`, not a thrown
+   * error, on a genuinely missing committee: existing callers of `getCommitteeById` already have
+   * their own not-found handling for the write/detail paths that need it; a caller reaching only
+   * for `category` has nothing to write to and no detail page to 404, so failing soft here keeps
+   * that decision (log and degrade, or propagate) with the caller instead of forcing one.
+   */
+  public async getCommitteeCategory(req: Request, committeeId: string): Promise<string | undefined> {
+    const committee = await this.microserviceProxy.proxyRequest<Committee | null>(
+      req,
+      'LFX_V2_SERVICE',
+      `/committees/${encodeURIComponent(committeeId)}`,
+      'GET'
+    );
+    return committee?.category;
+  }
+
+  /**
    * Creates a new committee with optional settings
    */
   public async createCommittee(req: Request, data: CommitteeCreateData): Promise<Committee> {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -8,12 +8,12 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // still need mocking — `utils/index.ts` re-exports form.utils.ts, which imports `@angular/forms`,
 // and importing that barrel unmocked triggers Angular JIT-compilation failure in this worker (see
 // the deep `vi.importActual` on `committee.utils.ts` further down for the one function pulled
-// through the real module instead of a stub). `constants` also needs mocking, since this service
-// spreads WEEKLY_BRIEF_DEFAULT_THROTTLE at runtime (not just a type import) and MOCK_THROTTLE is
-// shared between the mock factory and the test assertions below so the two can't drift from each
-// other. (Deliberately not cross-checked against the real constants module here — `vi.importActual`
-// on the full `@lfx-one/shared/*` barrel would re-trigger the same JIT-compilation failure and
-// contaminate other spec files sharing the test worker.)
+// through the real module instead of a stub). `constants` is mocked too, not because the real
+// module can't load here, but for test control: the mock pins a deterministic
+// WEEKLY_BRIEF_DEFAULT_THROTTLE (MOCK_THROTTLE), shared between the factory and the assertions
+// below so the two can't drift from each other, without paying the real barrel's evaluation cost.
+// weekly-brief.constants.spec.ts is the named spec pinning MOCK_THROTTLE's shape against the real
+// constant, same pattern as that file's ACTIVITY_FEED_MAX_PAGE_SIZE pin further down.
 // A real Map-backed fake (not just call-arg assertions) so the rating tests below prove actual
 // upsert/clear round-trip behavior through the public API, not just "was called with X". Shared
 // by the action-items tests too — `weekly-brief.service.ts`'s rating and action-items code paths

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -599,7 +599,10 @@ describe('WeeklyBriefService', () => {
       };
       proxyRequest.mockResolvedValueOnce(upstreamResult);
 
-      const result = await service.getCurrentBrief(req, 'committee-1');
+      // includeCurrentActivity: false — this test is about the mock/live proxy passthrough,
+      // not the current_activity merge (covered by its own describe block below), so opt out
+      // to keep the assertion a true pass-through-by-reference check.
+      const result = await service.getCurrentBrief(req, 'committee-1', { includeCurrentActivity: false });
 
       expect(result).toBe(upstreamResult);
       expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_SERVICE', '/committees/committee-1/weekly-briefs/current', 'GET');
@@ -818,7 +821,7 @@ describe('WeeklyBriefService', () => {
       expect(refs[0].id).not.toBe(refs[1].id);
     });
 
-    it('omits current_activity (rather than publishing a truncated count) when the returned page itself is full', async () => {
+    it('sets current_activity to null (a settled, not a transient, absence) when the returned page itself is full', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
@@ -835,7 +838,10 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity).toBeUndefined();
+      // null, not undefined: more in-window activity only ever accumulates within a poll cycle,
+      // so a caller (the client's pollUntilTerminal) is right to treat this as settled and stop
+      // asking, unlike a genuine transient failure — see buildCurrentActivity's doc comment.
+      expect(result.current_activity).toBeNull();
       expect(logger.warning).toHaveBeenCalledWith(
         req,
         'get_weekly_brief_current_activity',
@@ -903,14 +909,17 @@ describe('WeeklyBriefService', () => {
       }
     });
 
-    it('never calls getCommitteeActivity for a non-governance committee, and current_activity stays undefined', async () => {
+    it('never calls getCommitteeActivity for a non-governance committee, and current_activity settles to null (not undefined)', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Working Group' });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
-      expect(result.current_activity).toBeUndefined();
+      // null, not undefined: this committee will never become governance-classified mid-poll,
+      // so a caller is right to treat this as settled and stop asking — see
+      // buildCurrentActivity's doc comment.
+      expect(result.current_activity).toBeNull();
     });
 
     it('skips the entire fan-out (getCommitteeById and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -1096,6 +1096,12 @@ describe('WeeklyBriefService', () => {
 
         expect(result.current_activity).toBeUndefined();
         expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
+        // A budget-driven omission must be visible in CloudWatch, same as this method's other
+        // omit-the-tally exits — see buildCurrentActivityWithBudget's own doc comment.
+        expect(logger.warning).toHaveBeenCalledWith(req, 'get_weekly_brief_current_activity', 'Current-activity budget elapsed, omitting the tally', {
+          committee_id: 'committee-1',
+          budget_ms: WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS,
+        });
       } finally {
         vi.useRealTimers();
       }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -437,7 +437,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — getActionItems only ever reads brief_text', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
       // actually trigger the fan-out this test exists to catch — not pass vacuously.
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       extractBriefActionItems.mockResolvedValue({ items: [] });
 
       await service.getActionItems(req, 'committee-1');
@@ -737,7 +737,7 @@ describe('WeeklyBriefService', () => {
       ],
     ])('populates current_activity for a governance committee, mapping kinds and excluding an in-progress vote (%s)', async (_label, setBackend) => {
       setBackend();
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -771,9 +771,10 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      // not.toBeNull(), not toBeDefined() — toBeDefined() passes on null too, and null-vs-object
-      // is exactly the distinction this feature's three-state contract depends on.
-      expect(result.current_activity).not.toBeNull();
+      // Asserts the real-object shape directly, not not.toBeNull()/toBeDefined() — both of those
+      // also pass on the OTHER two states (undefined, or toBeDefined() on null), and this
+      // feature's whole point is that absent/null/present are three distinct states, not two.
+      expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
       const refs = result.current_activity?.source_refs ?? [];
       expect(refs).toHaveLength(3);
       expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'vote']);
@@ -790,7 +791,7 @@ describe('WeeklyBriefService', () => {
 
     it('folds survey events into the "other" kind rather than dropping them', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -810,7 +811,7 @@ describe('WeeklyBriefService', () => {
 
     it('maps notes_added to kind "doc", and its id carries the meeting_scope discriminant so it cannot collide with a document_uploaded event sharing the same document_uid', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -845,7 +846,7 @@ describe('WeeklyBriefService', () => {
 
     it('sets current_activity to null (a settled, not a transient, absence) when the returned page itself is full', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         // ACTIVITY_FEED_MAX_PAGE_SIZE worth of in-window events — the actual signal that some of
         // them may have been cut, unlike a bare page_token (see the next test). Built from the
@@ -877,7 +878,7 @@ describe('WeeklyBriefService', () => {
 
     it("does NOT omit current_activity merely because page_token is present with a short page — a committee with >fetchSize lifetime notes/surveys saturates those legs regardless of the current week (see buildCurrentActivity's own doc comment)", async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -895,13 +896,15 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity).not.toBeNull();
+      // Asserts the real-object shape directly — see the sibling test above for why not
+      // not.toBeNull()/toBeDefined() alone.
+      expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
       expect(result.current_activity?.source_refs).toHaveLength(1);
     });
 
     it('renders a genuine quiet week as current_activity present with an empty source_refs array, not absent', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
@@ -915,7 +918,7 @@ describe('WeeklyBriefService', () => {
 
     it('passes currentWeekInProgressWindow().window_start as since, and never briefWindow()', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
       vi.useFakeTimers();
       try {
@@ -929,7 +932,7 @@ describe('WeeklyBriefService', () => {
           req,
           'committee-1',
           { since: '2026-01-11T00:00:00.000Z', limit: ACTIVITY_FEED_MAX_PAGE_SIZE },
-          { category: 'Board' }
+          { uid: 'committee-1', category: 'Board' }
         );
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
         expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
@@ -950,7 +953,7 @@ describe('WeeklyBriefService', () => {
 
     it('excludes an event whose occurred_at is after window_end — getCommitteeActivity has no upper-bound param of its own to enforce this', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
       vi.useFakeTimers();
       try {
@@ -1009,7 +1012,7 @@ describe('WeeklyBriefService', () => {
 
     it('skips the entire fan-out (getCommitteeBase and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
       const result = await service.getCurrentBrief(req, 'committee-1', { includeCurrentActivity: false });
 
@@ -1066,7 +1069,7 @@ describe('WeeklyBriefService', () => {
 
     it('degrades to current_activity: undefined (not a thrown error) when the activity fetch fails', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockRejectedValue(new Error('upstream unavailable'));
 
       const result = await service.getCurrentBrief(req, 'committee-1');
@@ -1085,7 +1088,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — rateBrief/clearBriefRating only ever read brief/caller_rating', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` inside
       // resolveRatableBrief would actually trigger the fan-out this test exists to catch.
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       const initial = await service.getCurrentBrief(userReq, 'committee-1');
       const briefUid = initial.brief!.uid;
       getCommitteeActivityMock.mockClear(); // the setup call above is allowed to fan out; only what follows is under test.
@@ -1449,7 +1452,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — shareToSlack only ever reads brief', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
       // actually trigger the fan-out this test exists to catch.
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       mockShareableBrief();
       mockCommittee();
       proxyRequest.mockResolvedValueOnce(undefined);
@@ -1612,7 +1615,7 @@ describe('WeeklyBriefService', () => {
       // calls getCommitteeById (for name/project_uid), while buildCurrentActivity — reachable
       // only via the regression this test guards against — calls getCommitteeBase.
       getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1', category: 'Board' });
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       mockShareableBrief();
 
       await service.shareBrief(nonImpersonatingReq, 'committee-1', 1);

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -933,6 +933,42 @@ describe('WeeklyBriefService', () => {
       }
     });
 
+    it('excludes an event whose occurred_at is after window_end — getCommitteeActivity has no upper-bound param of its own to enforce this', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
+
+        getCommitteeActivityMock.mockResolvedValue({
+          data: [
+            {
+              type: 'meeting_held',
+              // Ahead of window_end (2026-01-14T12:00:00.000Z) — e.g. a vote administratively
+              // ended with its own end_time still in the future (see mapVoteToEvent).
+              occurred_at: '2026-01-14T13:00:00.000Z',
+              committee_uid: 'committee-1',
+              payload: { meeting_id: 'm1', meeting_occurrence_id: 'm1-occ', title: 'Future Meeting', password: null },
+            },
+            {
+              type: 'meeting_held',
+              occurred_at: '2026-01-14T11:00:00.000Z',
+              committee_uid: 'committee-1',
+              payload: { meeting_id: 'm2', meeting_occurrence_id: 'm2-occ', title: 'Real Meeting', password: null },
+            },
+          ],
+          page_token: undefined,
+        });
+
+        const result = await service.getCurrentBrief(req, 'committee-1');
+
+        expect(result.current_activity?.source_refs).toEqual([{ id: 'm2-occ', kind: 'meeting', title: 'Real Meeting' }]);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it('never calls getCommitteeActivity for a non-governance committee, and current_activity settles to null (not undefined)', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ category: 'Working Group' });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -922,7 +922,7 @@ describe('WeeklyBriefService', () => {
       );
     });
 
-    it('does NOT settle to null when a full raw page is mostly future-stamped noise the window_end filter drops — the gate must run on the filtered count, not the raw page size', async () => {
+    it('DOES settle to null when a full raw page is mostly future-stamped noise the window_end filter drops — the descending sort in CommitteeActivityService means those rows can crowd out real in-window events before this method ever sees them, so the gate must run on the raw page size, not the filtered count', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
@@ -932,9 +932,12 @@ describe('WeeklyBriefService', () => {
 
         // A full raw page (ACTIVITY_FEED_MAX_PAGE_SIZE) where most rows are administratively-closed
         // votes stamped from a still-future end_time (see mapVoteToEvent) — the exact noise the
-        // window_end filter above the gate exists to drop. Only a handful are genuine in-window
-        // activity. If the gate ran on the raw page size (the bug this test pins the fix for), this
-        // committee would settle to null despite a comfortably-under-the-cap real count.
+        // window_end filter above the gate drops. Only a handful are genuine in-window activity.
+        // Pins the fix: CommitteeActivityService sorts its merged pool descending by occurred_at
+        // before capping to `limit`, so these future-stamped rows sort ABOVE real in-window rows
+        // and can occupy page slots a real event would otherwise have filled — a full raw page can
+        // mean real activity was pushed off before this method ever saw it, regardless of how much
+        // of what survived the window_end filter looks like a small, complete count.
         const futureNoise = Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE - 3 }, (_, i) => ({
           type: 'vote_closed' as const,
           occurred_at: '2026-01-14T13:00:00.000Z', // after window_end (2026-01-14T12:00:00.000Z)
@@ -951,32 +954,29 @@ describe('WeeklyBriefService', () => {
 
         const result = await service.getCurrentBrief(req, 'committee-1');
 
-        expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
-        expect(result.current_activity?.source_refs).toHaveLength(3);
-        expect(logger.warning).not.toHaveBeenCalledWith(
+        expect(result.current_activity).toBeNull();
+        expect(logger.warning).toHaveBeenCalledWith(
           req,
           'get_weekly_brief_current_activity',
           expect.stringContaining('fills a full page'),
-          expect.anything()
+          expect.objectContaining({ committee_id: 'committee-1' })
         );
       } finally {
         vi.useRealTimers();
       }
     });
 
-    it('DOES settle to null when a full raw page is mostly unrecognized-but-in-window event types — unlike window_end noise, an unmapped event is not proven irrelevant to the tally, so it must still count toward the truncation gate', async () => {
+    it('DOES settle to null when a full raw page is mostly unrecognized-but-in-window event types — an unmapped event is not proven irrelevant to the tally, so it must still count toward the truncation gate', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
       // DeferredActivityEvent ('member_joined' et al.) is a real ActivityEvent union member —
       // type-legal, never actually constructed by CommitteeActivityService today (see that
       // interface's own doc comment) — that mapActivityEventToCurrentActivityRef's `default:
-      // return null` branch exists to handle. Unlike the window_end-future-noise case (sibling
-      // test above), these events are genuinely in-window — this method just has no rendering for
-      // them — so a full raw page dominated by them must still gate to null: excluding them from
-      // the truncation count the way window_end drops are excluded would risk publishing an
-      // undercounted tally as fact the moment CommitteeActivityService starts constructing one of
-      // these kinds.
+      // return null` branch exists to handle. These events are genuinely in-window — this method
+      // just has no rendering for them — so a full raw page dominated by them gates to null, same
+      // as the future-noise case above: the gate runs on the raw `data.length`, not on what
+      // survived mapping, so composition doesn't change the outcome.
       const unrecognized = Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE - 2 }, () => ({
         type: 'member_joined' as const,
         occurred_at: '2026-01-12T10:00:00Z',
@@ -1063,13 +1063,13 @@ describe('WeeklyBriefService', () => {
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
         expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
         expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
-        // The dropped-events log must stay off the healthy path — pins the
-        // droppedAfterWindowEnd > 0 guard itself, not just the log's payload shape (which
-        // the sibling "excludes an event..." test already covers).
+        // The dropped/skipped-events log must stay off the healthy path — pins the
+        // droppedAfterWindowEnd > 0 || unmappedInWindow > 0 guard itself, not just the log's
+        // payload shape (which the sibling "excludes an event..." test already covers).
         expect(logger.debug).not.toHaveBeenCalledWith(
           req,
           'get_weekly_brief_current_activity',
-          'Dropped one or more events stamped after window_end',
+          'Dropped or skipped one or more events while building source_refs',
           expect.anything()
         );
       } finally {
@@ -1126,11 +1126,17 @@ describe('WeeklyBriefService', () => {
         // DEBUG, not WARN — this is a modeled, expected shape for an administratively-closed
         // vote (see mapVoteToEvent), not a data-quality anomaly; still logged, just not at a
         // level that pages someone for something the system already understands.
-        expect(logger.debug).toHaveBeenCalledWith(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
-          committee_id: 'committee-1',
-          dropped_count: 1,
-          window_end: '2026-01-14T12:00:00.000Z',
-        });
+        expect(logger.debug).toHaveBeenCalledWith(
+          req,
+          'get_weekly_brief_current_activity',
+          'Dropped or skipped one or more events while building source_refs',
+          {
+            committee_id: 'committee-1',
+            dropped_after_window_end: 1,
+            unmapped_in_window: 0,
+            window_end: '2026-01-14T12:00:00.000Z',
+          }
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -30,6 +30,7 @@ const {
   createNewsletterMock,
   sendNewsletterMock,
   deleteNewsletterMock,
+  getCommitteeActivityMock,
 } = vi.hoisted(() => {
   const valkeyStore = new Map<string, unknown>();
   const valkeyServiceMock = {
@@ -81,10 +82,15 @@ const {
     createNewsletterMock: vi.fn(),
     sendNewsletterMock: vi.fn(),
     deleteNewsletterMock: vi.fn(),
+    // buildCurrentActivity's (GH-1922) collaborator — controlled per-test in the
+    // 'current_activity (GH-1922)' describe blocks below; defaults to an empty feed (see the
+    // outer beforeEach) so unrelated tests elsewhere in this file never need to know it exists.
+    getCommitteeActivityMock: vi.fn(),
   };
 });
 
 vi.mock('@lfx-one/shared/constants', () => ({
+  ACTIVITY_FEED_MAX_PAGE_SIZE: 50,
   WEEKLY_BRIEF_DEFAULT_THROTTLE: MOCK_THROTTLE,
   WEEKLY_BRIEF_SHAREABLE_STATES: ['generated', 'edited', 'approved'],
   WEEKLY_BRIEF_ERROR_REASON: { NO_SOURCES: 'no_sources' },
@@ -101,7 +107,13 @@ vi.mock('@lfx-one/shared/interfaces', () => ({}));
 // `formatUtcDateRangeLabel` lives in the same `@lfx-one/shared/utils` barrel as
 // form.utils.ts, which imports `@angular/forms` — an unmocked import here would pull
 // in the real barrel and hit the same JIT-compilation failure the mocks above avoid.
-vi.mock('@lfx-one/shared/utils', () => ({ formatUtcDateRangeLabel: vi.fn(() => 'Jan 1 – Jan 7, 2026') }));
+// `isGoverningBoard` — minimal reimplementation (real one lives in committee.utils.ts, same
+// barrel/JIT-failure reasoning) sufficient for this file's fixtures, which only ever use
+// `category: 'Board'` or `category: 'Working Group'`.
+vi.mock('@lfx-one/shared/utils', () => ({
+  formatUtcDateRangeLabel: vi.fn(() => 'Jan 1 – Jan 7, 2026'),
+  isGoverningBoard: vi.fn((category: string | undefined) => category === 'Board' || category === 'Government Advisory Council'),
+}));
 
 vi.mock('./microservice-proxy.service', () => ({
   MicroserviceProxyService: class {
@@ -121,6 +133,14 @@ vi.mock('./committee.service', () => ({
   CommitteeService: class {
     public getCommitteeById = getCommitteeByIdMock;
     public hasMailingListStrict = hasMailingListStrictMock;
+  },
+}));
+// buildCurrentActivity's (GH-1922) collaborator — the same live meeting/vote/document
+// aggregation `committee-activity.service.spec.ts` covers on its own; this file only needs to
+// control what it returns, not re-verify its internal aggregation logic.
+vi.mock('./committee-activity.service', () => ({
+  CommitteeActivityService: class {
+    public getCommitteeActivity = getCommitteeActivityMock;
   },
 }));
 vi.mock('./newsletter.service', () => ({
@@ -247,6 +267,12 @@ describe('WeeklyBriefService', () => {
     service = new WeeklyBriefService();
     __resetMockBriefStateForTesting();
     valkeyStore.clear();
+    // Safe default for buildCurrentActivity's (GH-1922) collaborators — a non-governance
+    // committee with an empty activity feed, so every test elsewhere in this file that calls
+    // getCurrentBrief (the vast majority) never needs to know these mocks exist. Tests that
+    // specifically exercise current_activity override both below.
+    getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Working Group' });
+    getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
   });
 
   afterEach(() => {
@@ -375,34 +401,6 @@ describe('WeeklyBriefService', () => {
       process.env['NODE_ENV'] = 'production';
       await expect(service.getCurrentBrief(req, 'committee-1')).rejects.toThrow(/temporarily unavailable/);
       expect(proxyRequest).not.toHaveBeenCalled();
-    });
-
-    it('getCurrentBrief includes a non-zero current_activity fixture spanning multiple kinds (GH-1922)', async () => {
-      const result = await service.getCurrentBrief(req, 'committee-1');
-
-      expect(result.current_activity).toBeDefined();
-      const kinds = result.current_activity?.source_refs.map((ref) => ref.kind).sort();
-      expect(kinds).toEqual(['doc', 'meeting', 'vote']);
-    });
-
-    it('getCurrentBrief scopes current_activity to currentWeekInProgressWindow(), not briefWindow()', async () => {
-      // try/finally, not a trailing call: a failed assertion below must not skip
-      // useRealTimers() and leak fake timers into every later test in this file — this
-      // describe block's own beforeEach/afterEach only reset process.env, not timers.
-      vi.useFakeTimers();
-      try {
-        // 2026-01-14 is a Wednesday (UTC) — briefWindow() resolves to the *previous* week
-        // here, currentWeekInProgressWindow() must not.
-        vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
-
-        const result = await service.getCurrentBrief(req, 'committee-1');
-
-        expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
-        expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
-        expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
-      } finally {
-        vi.useRealTimers();
-      }
     });
 
     it('does not leak the WEEKLY_BRIEF_BACKEND env var name into the client-facing error message', async () => {
@@ -611,14 +609,6 @@ describe('WeeklyBriefService', () => {
       await expect(service.getCurrentBrief(req, 'committee-1')).rejects.toBe(notFound);
     });
 
-    it('getCurrentBrief does not fabricate current_activity — live mode is a pure passthrough with no upstream in-progress-week endpoint yet (GH-1922)', async () => {
-      proxyRequest.mockResolvedValueOnce({ brief: { uid: 'b1', state: 'generated' }, throttle: null });
-
-      const result = await service.getCurrentBrief(req, 'committee-1');
-
-      expect(result.current_activity).toBeUndefined();
-    });
-
     it('generateBrief forwards the real upstream status code (202 accepted)', async () => {
       const data = { brief: { uid: 'b1', state: 'generating' }, throttle: {} };
       proxyRequestWithResponse.mockResolvedValueOnce({ status: 202, data, statusText: 'Accepted', headers: {} });
@@ -698,6 +688,140 @@ describe('WeeklyBriefService', () => {
       proxyRequest.mockResolvedValueOnce({ brief: null, throttle: null });
       await service.getCurrentBrief(req, 'a/b c');
       expect(proxyRequest).toHaveBeenCalledWith(req, 'LFX_V2_SERVICE', '/committees/a%2Fb%20c/weekly-briefs/current', 'GET');
+    });
+  });
+
+  /**
+   * GH-1922 rework: `current_activity` is sourced from `CommitteeActivityService`'s existing
+   * live meeting/vote/document aggregation (mocked here via `getCommitteeActivityMock`), not a
+   * weekly-brief-specific mock/live split — these tests run against BOTH `getCurrentBrief`
+   * branches to prove that (mock mode still needs `delete process.env['WEEKLY_BRIEF_BACKEND']`
+   * for the *brief* itself to stay mocked; `current_activity` behaves identically either way).
+   */
+  describe('current_activity (GH-1922)', () => {
+    it.each([
+      ['mock mode', () => delete process.env['WEEKLY_BRIEF_BACKEND']],
+      [
+        'live mode',
+        () => {
+          process.env['WEEKLY_BRIEF_BACKEND'] = 'live';
+          proxyRequest.mockResolvedValue({ brief: { uid: 'b1', state: 'generated' }, throttle: null });
+        },
+      ],
+    ])('populates current_activity for a governance committee, mapping kinds and excluding an in-progress vote (%s)', async (_label, setBackend) => {
+      setBackend();
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({
+        data: [
+          {
+            type: 'meeting_held',
+            occurred_at: '2026-01-12T10:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { meeting_id: 'm1', meeting_occurrence_id: 'm1-occ', title: 'Board Sync', password: null },
+          },
+          {
+            type: 'vote_closed',
+            occurred_at: '2026-01-12T11:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { vote_uid: 'v1', name: 'Q3 Resolution', status: 'Ended' },
+          },
+          // Deliberately excluded from the tally — see mapActivityEventToCurrentActivityRef's doc comment.
+          {
+            type: 'vote_opened',
+            occurred_at: '2026-01-12T09:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { vote_uid: 'v2', name: 'Q4 Budget', status: 'Active' },
+          },
+          {
+            type: 'document_uploaded',
+            occurred_at: '2026-01-12T12:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { document_uid: 'd1', name: 'Minutes.pdf', document_type: 'file' },
+          },
+        ],
+        page_token: undefined,
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeDefined();
+      const refs = result.current_activity?.source_refs ?? [];
+      expect(refs).toHaveLength(3);
+      expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'vote']);
+      expect(refs.find((ref) => ref.kind === 'vote')?.title).toBe('Q3 Resolution');
+      expect(refs.some((ref) => ref.title === 'Q4 Budget')).toBe(false);
+    });
+
+    it('folds survey events into the "other" kind rather than dropping them', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({
+        data: [
+          {
+            type: 'survey_closed',
+            occurred_at: '2026-01-12T10:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { survey_uid: 's1', title: 'Annual Review', status: 'Closed' },
+          },
+        ],
+        page_token: undefined,
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity?.source_refs).toEqual([{ id: 'survey:s1', kind: 'other', title: 'Annual Review' }]);
+    });
+
+    it('passes currentWeekInProgressWindow().window_start as since, and never briefWindow()', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+
+      vi.useFakeTimers();
+      try {
+        // 2026-01-14 is a Wednesday (UTC) — briefWindow() resolves to the previous week here;
+        // currentWeekInProgressWindow() must not.
+        vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
+
+        const result = await service.getCurrentBrief(req, 'committee-1');
+
+        expect(getCommitteeActivityMock).toHaveBeenCalledWith(req, 'committee-1', { since: '2026-01-11T00:00:00.000Z', limit: expect.any(Number) });
+        expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
+        expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
+        expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('never calls getCommitteeActivity for a non-governance committee, and current_activity stays undefined', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Working Group' });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(result.current_activity).toBeUndefined();
+    });
+
+    it('degrades to current_activity: undefined (not a thrown error) when the committee lookup fails', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockRejectedValue(new Error('upstream unavailable'));
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeUndefined();
+      expect(result.brief).toBeDefined(); // the brief itself still renders — only the tally degrades
+    });
+
+    it('degrades to current_activity: undefined (not a thrown error) when the activity fetch fails', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockRejectedValue(new Error('upstream unavailable'));
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeUndefined();
+      expect(result.brief).toBeDefined();
     });
   });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -178,6 +178,7 @@ vi.mock('./valkey.service', () => ({
   valkeyService: valkeyServiceMock,
 }));
 
+import { ACTIVITY_FEED_MAX_PAGE_SIZE } from '@lfx-one/shared/constants';
 import type { Request } from 'express';
 
 import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID } from '../constants';
@@ -770,7 +771,9 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity).toBeDefined();
+      // not.toBeNull(), not toBeDefined() — toBeDefined() passes on null too, and null-vs-object
+      // is exactly the distinction this feature's three-state contract depends on.
+      expect(result.current_activity).not.toBeNull();
       const refs = result.current_activity?.source_refs ?? [];
       expect(refs).toHaveLength(3);
       expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'vote']);
@@ -844,9 +847,12 @@ describe('WeeklyBriefService', () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
-        // ACTIVITY_FEED_MAX_PAGE_SIZE (mocked to 50) worth of in-window events — the actual signal
-        // that some of them may have been cut, unlike a bare page_token (see the next test).
-        data: Array.from({ length: 50 }, (_, i) => ({
+        // ACTIVITY_FEED_MAX_PAGE_SIZE worth of in-window events — the actual signal that some of
+        // them may have been cut, unlike a bare page_token (see the next test). Built from the
+        // real (mocked) constant, not a bare literal, so this test can't silently drift out of
+        // sync with the production `data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE` gate it exists to
+        // exercise.
+        data: Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE }, (_, i) => ({
           type: 'meeting_held',
           occurred_at: '2026-01-12T10:00:00Z',
           committee_uid: 'committee-1',
@@ -889,7 +895,7 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity).toBeDefined();
+      expect(result.current_activity).not.toBeNull();
       expect(result.current_activity?.source_refs).toHaveLength(1);
     });
 
@@ -922,7 +928,7 @@ describe('WeeklyBriefService', () => {
         expect(getCommitteeActivityMock).toHaveBeenCalledWith(
           req,
           'committee-1',
-          { since: '2026-01-11T00:00:00.000Z', limit: expect.any(Number) },
+          { since: '2026-01-11T00:00:00.000Z', limit: ACTIVITY_FEED_MAX_PAGE_SIZE },
           { category: 'Board' }
         );
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
@@ -1019,7 +1025,10 @@ describe('WeeklyBriefService', () => {
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.current_activity).toBeUndefined();
-      expect(result.brief).toBeDefined(); // the brief itself still renders — only the tally degrades
+      // toMatchObject, not toBeDefined() — mock mode always synthesizes SOME brief object
+      // regardless of this path, so toBeDefined() alone can never fail here; this checks the
+      // brief actually carries its expected shape, not just "is not undefined".
+      expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
     });
 
     it('degrades to current_activity: undefined (not a thrown error) when the committee lookup returns nothing (the empty-body case)', async () => {
@@ -1030,7 +1039,7 @@ describe('WeeklyBriefService', () => {
 
       expect(result.current_activity).toBeUndefined();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
-      expect(result.brief).toBeDefined();
+      expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
     });
 
     it.each([
@@ -1063,7 +1072,7 @@ describe('WeeklyBriefService', () => {
       const result = await service.getCurrentBrief(req, 'committee-1');
 
       expect(result.current_activity).toBeUndefined();
-      expect(result.brief).toBeDefined();
+      expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
     });
   });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -928,6 +928,15 @@ describe('WeeklyBriefService', () => {
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
         expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
         expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
+        // The dropped-events warning must stay off the healthy path — pins the
+        // droppedAfterWindowEnd > 0 guard itself, not just the warning's payload shape (which
+        // the sibling "excludes an event..." test already covers).
+        expect(logger.warning).not.toHaveBeenCalledWith(
+          req,
+          'get_weekly_brief_current_activity',
+          'Dropped one or more events stamped after window_end',
+          expect.anything()
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -776,10 +776,11 @@ describe('WeeklyBriefService', () => {
       expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'vote']);
       expect(refs.find((ref) => ref.kind === 'vote')?.title).toBe('Q3 Resolution');
       expect(refs.some((ref) => ref.title === 'Q4 Budget')).toBe(false);
-      // Raw upstream uid, no kind prefix — weekly-brief.utils.ts's resolveSourceRefAction passes
-      // a meeting ref's id straight through as PastMeetingActivityFeedAction.meetingId and a vote
-      // ref's as VoteDrawerActivityFeedAction.voteUid; a `meeting:`/`vote:` prefix would reach
-      // either action as a corrupted id.
+      // No kind prefix on meeting/vote — see mapActivityEventToCurrentActivityRef's doc comment
+      // for why: a vote ref's id passes straight through as VoteDrawerActivityFeedAction.voteUid
+      // (a `vote:` prefix would reach that action as a corrupted id), and a meeting ref's id is
+      // deliberately the occurrence-scoped tracking id, not (yet) a click-through navigation id —
+      // same doc comment covers that known v1 residual.
       expect(refs.find((ref) => ref.kind === 'meeting')?.id).toBe('m1-occ');
       expect(refs.find((ref) => ref.kind === 'vote')?.id).toBe('v1');
     });
@@ -964,6 +965,32 @@ describe('WeeklyBriefService', () => {
 
       expect(result.current_activity).toBeUndefined();
       expect(result.brief).toBeDefined(); // the brief itself still renders — only the tally degrades
+    });
+
+    it('degrades to current_activity: undefined (not a thrown error) when the committee lookup returns nothing (the empty-body case)', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue(undefined);
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeUndefined();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(result.brief).toBeDefined();
+    });
+
+    it('degrades to current_activity: undefined (not null) when the committee resolves with no category — an anomaly, not a "not governance" verdict', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      // No `category` field at all — a malformed/partial body, not the empty-body case
+      // getCommitteeBase's own doc comment covers (that resolves to undefined, not an object).
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1' });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      // undefined, not null: isGoverningBoard(undefined) is false, so a naive category-only
+      // check would settle this to null (permanent "not governance") — this is a transient
+      // anomaly worth asking again on the next poll tick instead.
+      expect(result.current_activity).toBeUndefined();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
     it('degrades to current_activity: undefined (not a thrown error) when the activity fetch fails', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -855,10 +855,11 @@ describe('WeeklyBriefService', () => {
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         // ACTIVITY_FEED_MAX_PAGE_SIZE worth of in-window events — the actual signal that some of
-        // them may have been cut, unlike a bare page_token (see the next test). Built from the
-        // real (mocked) constant, not a bare literal, so this test can't silently drift out of
-        // sync with the production `data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE` gate it exists to
-        // exercise.
+        // them may have been cut, unlike a bare page_token (see the next test). `ACTIVITY_FEED_MAX_PAGE_SIZE`
+        // here resolves through this file's own `vi.mock('@lfx-one/shared/constants', ...)`, which
+        // hand-copies the real value rather than re-deriving it — so this only tracks production if
+        // that copy stays correct. `activity-event.constants.spec.ts` is the one place the REAL
+        // value is pinned; that's what actually guards this test against drifting out of sync.
         data: Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE }, (_, i) => ({
           type: 'meeting_held',
           occurred_at: '2026-01-12T10:00:00Z',
@@ -985,13 +986,25 @@ describe('WeeklyBriefService', () => {
               committee_uid: 'committee-1',
               payload: { meeting_id: 'm2', meeting_occurrence_id: 'm2-occ', title: 'Real Meeting', password: null },
             },
+            {
+              // Exactly ON window_end (not after it) — pins the filter's boundary as inclusive
+              // (`>`, not `>=`), since window_end IS "now" and an event landing exactly there is
+              // real in-window activity, not a future-dated anomaly like the vote above.
+              type: 'meeting_held',
+              occurred_at: '2026-01-14T12:00:00.000Z',
+              committee_uid: 'committee-1',
+              payload: { meeting_id: 'm3', meeting_occurrence_id: 'm3-occ', title: 'Boundary Meeting', password: null },
+            },
           ],
           page_token: undefined,
         });
 
         const result = await service.getCurrentBrief(req, 'committee-1');
 
-        expect(result.current_activity?.source_refs).toEqual([{ id: 'm2-occ', kind: 'meeting', title: 'Real Meeting' }]);
+        expect(result.current_activity?.source_refs).toEqual([
+          { id: 'm2-occ', kind: 'meeting', title: 'Real Meeting' },
+          { id: 'm3-occ', kind: 'meeting', title: 'Boundary Meeting' },
+        ]);
         // DEBUG, not WARN — this is a modeled, expected shape for an administratively-closed
         // vote (see mapVoteToEvent), not a data-quality anomaly; still logged, just not at a
         // level that pages someone for something the system already understands.
@@ -1027,6 +1040,10 @@ describe('WeeklyBriefService', () => {
       expect(getCommitteeBaseMock).not.toHaveBeenCalled();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(result.current_activity).toBeUndefined();
+      // toBeUndefined() alone can't tell "key absent" from "key present as undefined" apart — the
+      // exact distinction getCurrentBrief's conditional spread exists to maintain and the client's
+      // `=== undefined` gate reads. Load-bearing specifically on this opt-out path.
+      expect('current_activity' in result).toBe(false);
     });
 
     it('degrades to current_activity: undefined (not a thrown error) when the committee lookup fails', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -4,11 +4,13 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors access-check.service.spec.ts / committee.controller.spec.ts: the `@lfx-one/shared/*`
-// alias IS wired into this app's vitest config, but the `utils` and `interfaces` barrels below
-// still need mocking — `utils/index.ts` re-exports form.utils.ts, which imports `@angular/forms`,
-// and importing that barrel unmocked triggers Angular JIT-compilation failure in this worker (see
+// alias IS wired into this app's vitest config, but the `utils` barrel below still needs a real
+// factory stub — `utils/index.ts` re-exports form.utils.ts, which imports `@angular/forms`, and
+// importing that barrel unmocked triggers Angular JIT-compilation failure in this worker (see
 // the deep `vi.importActual` on `committee.utils.ts` further down for the one function pulled
-// through the real module instead of a stub). `constants` is mocked too, not because the real
+// through the real module instead of a stub). `interfaces` carries no such barrel member, so it
+// loads via `importOriginal()` — see that mock's own comment for why. `constants` is mocked too,
+// not because the real
 // module can't load here, but for test control: the mock pins a deterministic
 // WEEKLY_BRIEF_DEFAULT_THROTTLE (MOCK_THROTTLE) so the throttle assertions below start from a
 // known zero-used baseline, without paying the real barrel's evaluation cost.
@@ -115,7 +117,13 @@ vi.mock('@lfx-one/shared/constants', () => ({
 // '../constants' (this app's server-only constants, not the `@lfx-one/shared` package) is
 // plain string/number literals with no transitive Angular imports — safe to leave unmocked,
 // unlike the shared-package mocks above.
-vi.mock('@lfx-one/shared/interfaces', () => ({}));
+// A bare `() => ({})` stub here would silently empty out real runtime exports this barrel
+// carries (e.g. DashboardDrawerType, LifecycleStage — dashboard-metric.interface.ts), the same
+// "well-intentioned partial stub drops real values" hazard validation.helper.spec.ts warns
+// about elsewhere in this repo. importOriginal() is safe: interfaces/index.ts carries only
+// enums/interfaces/constants, no Angular — weekly-brief.controller.spec.ts already proves this
+// barrel loads fine unmocked under this same vitest config.
+vi.mock('@lfx-one/shared/interfaces', async (importOriginal) => importOriginal());
 // `formatUtcDateRangeLabel` lives in the same `@lfx-one/shared/utils` barrel as
 // form.utils.ts, which imports `@angular/forms` — an unmocked import here would pull
 // in the real barrel and hit the same JIT-compilation failure the mocks above avoid, so it
@@ -937,6 +945,42 @@ describe('WeeklyBriefService', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("does NOT settle to null when a full raw page is mostly unrecognized event types the mapper drops — same interaction as the window_end case, via mapActivityEventToCurrentActivityRef's default branch instead", async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+
+      // DeferredActivityEvent ('member_joined' et al.) is a real ActivityEvent union member —
+      // type-legal, never actually constructed by CommitteeActivityService today (see that
+      // interface's own doc comment) — that mapActivityEventToCurrentActivityRef's `default:
+      // return null` branch exists to handle. A full raw page dominated by these must filter down
+      // to the small genuine count, not settle to null the same way a full page of window_end-
+      // future noise must not (see the sibling test above).
+      const unrecognized = Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE - 2 }, () => ({
+        type: 'member_joined' as const,
+        occurred_at: '2026-01-12T10:00:00Z',
+        committee_uid: 'committee-1',
+        payload: {},
+      }));
+      const realActivity = Array.from({ length: 2 }, (_, i) => ({
+        type: 'meeting_held' as const,
+        occurred_at: '2026-01-12T10:00:00Z',
+        committee_uid: 'committee-1',
+        payload: { meeting_id: `m${i}`, meeting_occurrence_id: `m${i}-occ`, title: 'Board Sync', password: null },
+      }));
+      getCommitteeActivityMock.mockResolvedValue({ data: [...unrecognized, ...realActivity], page_token: undefined });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
+      expect(result.current_activity?.source_refs).toHaveLength(2);
+      expect(logger.warning).not.toHaveBeenCalledWith(
+        req,
+        'get_weekly_brief_current_activity',
+        expect.stringContaining('fills a full page'),
+        expect.anything()
+      );
     });
 
     it("does NOT omit current_activity merely because page_token is present with a short page — a committee with >fetchSize lifetime notes/surveys saturates those legs regardless of the current week (see buildCurrentActivity's own doc comment)", async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -913,6 +913,17 @@ describe('WeeklyBriefService', () => {
       expect(result.current_activity).toBeUndefined();
     });
 
+    it('skips the entire fan-out (getCommitteeById and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+
+      const result = await service.getCurrentBrief(req, 'committee-1', { includeCurrentActivity: false });
+
+      expect(getCommitteeByIdMock).not.toHaveBeenCalled();
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      expect(result.current_activity).toBeUndefined();
+    });
+
     it('degrades to current_activity: undefined (not a thrown error) when the committee lookup fails', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeByIdMock.mockRejectedValue(new Error('upstream unavailable'));

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -947,16 +947,19 @@ describe('WeeklyBriefService', () => {
       }
     });
 
-    it("does NOT settle to null when a full raw page is mostly unrecognized event types the mapper drops — same interaction as the window_end case, via mapActivityEventToCurrentActivityRef's default branch instead", async () => {
+    it('DOES settle to null when a full raw page is mostly unrecognized-but-in-window event types — unlike window_end noise, an unmapped event is not proven irrelevant to the tally, so it must still count toward the truncation gate', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
 
       // DeferredActivityEvent ('member_joined' et al.) is a real ActivityEvent union member —
       // type-legal, never actually constructed by CommitteeActivityService today (see that
       // interface's own doc comment) — that mapActivityEventToCurrentActivityRef's `default:
-      // return null` branch exists to handle. A full raw page dominated by these must filter down
-      // to the small genuine count, not settle to null the same way a full page of window_end-
-      // future noise must not (see the sibling test above).
+      // return null` branch exists to handle. Unlike the window_end-future-noise case (sibling
+      // test above), these events are genuinely in-window — this method just has no rendering for
+      // them — so a full raw page dominated by them must still gate to null: excluding them from
+      // the truncation count the way window_end drops are excluded would risk publishing an
+      // undercounted tally as fact the moment CommitteeActivityService starts constructing one of
+      // these kinds.
       const unrecognized = Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE - 2 }, () => ({
         type: 'member_joined' as const,
         occurred_at: '2026-01-12T10:00:00Z',
@@ -973,13 +976,12 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
-      expect(result.current_activity?.source_refs).toHaveLength(2);
-      expect(logger.warning).not.toHaveBeenCalledWith(
+      expect(result.current_activity).toBeNull();
+      expect(logger.warning).toHaveBeenCalledWith(
         req,
         'get_weekly_brief_current_activity',
         expect.stringContaining('fills a full page'),
-        expect.anything()
+        expect.objectContaining({ committee_id: 'committee-1' })
       );
     });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -386,18 +386,23 @@ describe('WeeklyBriefService', () => {
     });
 
     it('getCurrentBrief scopes current_activity to currentWeekInProgressWindow(), not briefWindow()', async () => {
+      // try/finally, not a trailing call: a failed assertion below must not skip
+      // useRealTimers() and leak fake timers into every later test in this file — this
+      // describe block's own beforeEach/afterEach only reset process.env, not timers.
       vi.useFakeTimers();
-      // 2026-01-14 is a Wednesday (UTC) — briefWindow() resolves to the *previous* week here,
-      // currentWeekInProgressWindow() must not.
-      vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
+      try {
+        // 2026-01-14 is a Wednesday (UTC) — briefWindow() resolves to the *previous* week
+        // here, currentWeekInProgressWindow() must not.
+        vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
 
-      const result = await service.getCurrentBrief(req, 'committee-1');
+        const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
-      expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
-      expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
-
-      vi.useRealTimers();
+        expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
+        expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
+        expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it('does not leak the WEEKLY_BRIEF_BACKEND env var name into the client-facing error message', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -978,20 +978,27 @@ describe('WeeklyBriefService', () => {
       expect(result.brief).toBeDefined();
     });
 
-    it('degrades to current_activity: undefined (not null) when the committee resolves with no category — an anomaly, not a "not governance" verdict', async () => {
-      delete process.env['WEEKLY_BRIEF_BACKEND'];
-      // No `category` field at all — a malformed/partial body, not the empty-body case
-      // getCommitteeBase's own doc comment covers (that resolves to undefined, not an object).
-      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1' });
+    it.each([
+      ['absent entirely', { uid: 'committee-1' }],
+      ['an empty string', { uid: 'committee-1', category: '' }],
+    ])(
+      'degrades to current_activity: undefined (not null) when the committee resolves with category %s — an anomaly, not a "not governance" verdict',
+      async (_label, committee) => {
+        delete process.env['WEEKLY_BRIEF_BACKEND'];
+        // Not the empty-body case getCommitteeBase's own doc comment covers (that resolves to
+        // undefined, not an object) — a resolved committee whose category isn't usable.
+        getCommitteeBaseMock.mockResolvedValue(committee);
 
-      const result = await service.getCurrentBrief(req, 'committee-1');
+        const result = await service.getCurrentBrief(req, 'committee-1');
 
-      // undefined, not null: isGoverningBoard(undefined) is false, so a naive category-only
-      // check would settle this to null (permanent "not governance") — this is a transient
-      // anomaly worth asking again on the next poll tick instead.
-      expect(result.current_activity).toBeUndefined();
-      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
-    });
+        // undefined, not null: isGoverningBoard('')/isGoverningBoard(undefined) are both false,
+        // so a naive falsy-only check on the RESULT of isGoverningBoard would settle this to null
+        // (permanent "not governance") — this is a transient anomaly worth asking again on the
+        // next poll tick instead.
+        expect(result.current_activity).toBeUndefined();
+        expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+      }
+    );
 
     it('degrades to current_activity: undefined (not a thrown error) when the activity fetch fails', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -897,6 +897,48 @@ describe('WeeklyBriefService', () => {
       );
     });
 
+    it('does NOT settle to null when a full raw page is mostly future-stamped noise the window_end filter drops — the gate must run on the filtered count, not the raw page size', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+
+      vi.useFakeTimers();
+      try {
+        vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
+
+        // A full raw page (ACTIVITY_FEED_MAX_PAGE_SIZE) where most rows are administratively-closed
+        // votes stamped from a still-future end_time (see mapVoteToEvent) — the exact noise the
+        // window_end filter above the gate exists to drop. Only a handful are genuine in-window
+        // activity. If the gate ran on the raw page size (the bug this test pins the fix for), this
+        // committee would settle to null despite a comfortably-under-the-cap real count.
+        const futureNoise = Array.from({ length: ACTIVITY_FEED_MAX_PAGE_SIZE - 3 }, (_, i) => ({
+          type: 'vote_closed' as const,
+          occurred_at: '2026-01-14T13:00:00.000Z', // after window_end (2026-01-14T12:00:00.000Z)
+          committee_uid: 'committee-1',
+          payload: { vote_uid: `future-v${i}`, name: 'Future Vote', status: 'Ended' as const },
+        }));
+        const realActivity = Array.from({ length: 3 }, (_, i) => ({
+          type: 'meeting_held' as const,
+          occurred_at: '2026-01-12T10:00:00Z',
+          committee_uid: 'committee-1',
+          payload: { meeting_id: `m${i}`, meeting_occurrence_id: `m${i}-occ`, title: 'Board Sync', password: null },
+        }));
+        getCommitteeActivityMock.mockResolvedValue({ data: [...futureNoise, ...realActivity], page_token: undefined });
+
+        const result = await service.getCurrentBrief(req, 'committee-1');
+
+        expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
+        expect(result.current_activity?.source_refs).toHaveLength(3);
+        expect(logger.warning).not.toHaveBeenCalledWith(
+          req,
+          'get_weekly_brief_current_activity',
+          expect.stringContaining('fills a full page'),
+          expect.anything()
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("does NOT omit current_activity merely because page_token is present with a short page — a committee with >fetchSize lifetime notes/surveys saturates those legs regardless of the current week (see buildCurrentActivity's own doc comment)", async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -280,7 +280,7 @@ describe('WeeklyBriefService', () => {
     // committee with an empty activity feed, so every test elsewhere in this file that calls
     // getCurrentBrief (the vast majority) never needs to know these mocks exist. Tests that
     // specifically exercise current_activity override both below.
-    getCommitteeBaseMock.mockResolvedValue({ category: 'Working Group' });
+    getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Working Group' });
     getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
     // shareBrief's own committee collaborator (unrelated to buildCurrentActivity — see
     // getCommitteeBaseMock above) — a safe default so tests elsewhere that incidentally
@@ -999,7 +999,7 @@ describe('WeeklyBriefService', () => {
 
     it('never calls getCommitteeActivity for a non-governance committee, and current_activity settles to null (not undefined)', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeBaseMock.mockResolvedValue({ category: 'Working Group' });
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Working Group' });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -944,12 +944,15 @@ describe('WeeklyBriefService', () => {
         getCommitteeActivityMock.mockResolvedValue({
           data: [
             {
-              type: 'meeting_held',
-              // Ahead of window_end (2026-01-14T12:00:00.000Z) — e.g. a vote administratively
-              // ended with its own end_time still in the future (see mapVoteToEvent).
+              // vote_closed, not meeting_held — this is the real mechanism that can produce an
+              // occurred_at ahead of "now": mapVoteToEvent stamps occurred_at from
+              // early_end_time ?? end_time for a closed vote, and an administratively-ended vote
+              // (status ENDED) can carry an end_time still in the future.
+              type: 'vote_closed',
+              // Ahead of window_end (2026-01-14T12:00:00.000Z).
               occurred_at: '2026-01-14T13:00:00.000Z',
               committee_uid: 'committee-1',
-              payload: { meeting_id: 'm1', meeting_occurrence_id: 'm1-occ', title: 'Future Meeting', password: null },
+              payload: { vote_uid: 'v1', name: 'Future Vote', status: 'Ended' },
             },
             {
               type: 'meeting_held',
@@ -964,6 +967,13 @@ describe('WeeklyBriefService', () => {
         const result = await service.getCurrentBrief(req, 'committee-1');
 
         expect(result.current_activity?.source_refs).toEqual([{ id: 'm2-occ', kind: 'meeting', title: 'Real Meeting' }]);
+        // A dropped event is a real data-quality anomaly, not an expected silent case — must
+        // warn like this method's other degrade paths, not drop quietly.
+        expect(logger.warning).toHaveBeenCalledWith(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
+          committee_id: 'committee-1',
+          dropped_count: 1,
+          window_end: '2026-01-14T12:00:00.000Z',
+        });
       } finally {
         vi.useRealTimers();
       }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -934,7 +934,7 @@ describe('WeeklyBriefService', () => {
       expect(result.current_activity).toBeNull();
     });
 
-    it('skips the entire fan-out (getCommitteeById and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {
+    it('skips the entire fan-out (getCommitteeCategory and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeCategoryMock.mockResolvedValue('Board');
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -4,13 +4,16 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 
 // Mirrors access-check.service.spec.ts / committee.controller.spec.ts: the `@lfx-one/shared/*`
-// alias isn't wired into this app's vitest config, so runtime collaborators need mocking —
-// including `constants`, since this service spreads WEEKLY_BRIEF_DEFAULT_THROTTLE at runtime
-// (not just a type import). MOCK_THROTTLE is shared between the mock factory and the test
-// assertions below so the two can't drift from each other. (Deliberately not cross-checked
-// against the real constants module here — `vi.importActual` on a real, unmocked
-// `@lfx-one/shared/*` import re-triggers the Angular JIT-compilation failure this file's
-// mocks exist to avoid, and it contaminates other spec files sharing the test worker.)
+// alias IS wired into this app's vitest config, but the `utils` and `interfaces` barrels below
+// still need mocking — `utils/index.ts` re-exports form.utils.ts, which imports `@angular/forms`,
+// and importing that barrel unmocked triggers Angular JIT-compilation failure in this worker (see
+// the deep `vi.importActual` on `committee.utils.ts` further down for the one function pulled
+// through the real module instead of a stub). `constants` also needs mocking, since this service
+// spreads WEEKLY_BRIEF_DEFAULT_THROTTLE at runtime (not just a type import) and MOCK_THROTTLE is
+// shared between the mock factory and the test assertions below so the two can't drift from each
+// other. (Deliberately not cross-checked against the real constants module here — `vi.importActual`
+// on the full `@lfx-one/shared/*` barrel would re-trigger the same JIT-compilation failure and
+// contaminate other spec files sharing the test worker.)
 // A real Map-backed fake (not just call-arg assertions) so the rating tests below prove actual
 // upsert/clear round-trip behavior through the public API, not just "was called with X". Shared
 // by the action-items tests too — `weekly-brief.service.ts`'s rating and action-items code paths
@@ -116,8 +119,11 @@ vi.mock('@lfx-one/shared/interfaces', () => ({}));
 // form.utils.ts, which imports `@angular/forms` — an unmocked import here would pull
 // in the real barrel and hit the same JIT-compilation failure the mocks above avoid, so it
 // stays a plain stub. `isGoverningBoard` is the REAL function (via `vi.importActual` on its own
-// deep module, not the barrel) — committee.utils.ts imports only enums/interfaces/constants, no
-// Angular, so it loads safely on its own. This governance gate decides whether the server pays
+// deep module, not the barrel). committee.utils.ts reaches date-time.utils/entity-route.utils/
+// string.utils and the deep constants files (a benign re-export cycle back through
+// committees.constants) — none of which touch `@angular/*`. It's the `utils/index.ts` barrel,
+// which re-exports form.utils.ts's `@angular/forms` import, that can't load here — depth isn't
+// what makes this safe, avoiding the barrel is. This governance gate decides whether the server pays
 // for the tally fan-out at all AND whether the client's poll keeps asking for one, so a stub
 // that's narrower than production (e.g. exact `'Board'` equality vs. the real
 // substring/normalization-based `getGroupBehavioralClass`) would let this file's assertions

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -790,7 +790,9 @@ describe('WeeklyBriefService', () => {
       // same doc comment covers that known v1 residual.
       expect(refs.find((ref) => ref.kind === 'meeting')?.id).toBe('m1-occ');
       expect(refs.find((ref) => ref.kind === 'vote')?.id).toBe('v1');
-      expect(refs.find((ref) => ref.kind === 'other')?.id).toBe('v2');
+      // Prefixed (unlike vote/meeting): "other" mixes vote_uid and survey_uid, two upstream
+      // uid namespaces that could otherwise collide in the same rendered @for section.
+      expect(refs.find((ref) => ref.kind === 'other')?.id).toBe('vote:v2');
     });
 
     it('folds survey events into the "other" kind rather than dropping them', async () => {
@@ -810,7 +812,7 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity?.source_refs).toEqual([{ id: 's1', kind: 'other', title: 'Annual Review' }]);
+      expect(result.current_activity?.source_refs).toEqual([{ id: 'survey:s1', kind: 'other', title: 'Annual Review' }]);
     });
 
     it('maps notes_added to kind "doc", and its id carries the meeting_scope discriminant so it cannot collide with a document_uploaded event sharing the same document_uid', async () => {
@@ -936,7 +938,8 @@ describe('WeeklyBriefService', () => {
           req,
           'committee-1',
           { since: '2026-01-11T00:00:00.000Z', limit: ACTIVITY_FEED_MAX_PAGE_SIZE },
-          { uid: 'committee-1', category: 'Board' }
+          { uid: 'committee-1', category: 'Board' },
+          true
         );
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
         expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -157,7 +157,7 @@ import { MicroserviceError } from '../errors';
 import { ServerFeatureFlag } from '../helpers/server-feature-flag.helper';
 
 import { logger } from './logger.service';
-import { __resetMockBriefStateForTesting, briefWindow, WeeklyBriefService } from './weekly-brief.service';
+import { __resetMockBriefStateForTesting, briefWindow, currentWeekInProgressWindow, WeeklyBriefService } from './weekly-brief.service';
 
 const req = {} as unknown as Request;
 const userReq = { oidc: { user: { nickname: 'alice', sub: 'auth0|alice-sub' } } } as unknown as Request;
@@ -187,6 +187,46 @@ describe('briefWindow', () => {
 
     expect(window_start).toBe('2026-01-11T00:00:00.000Z'); // this week's Sunday
     expect(window_end).toBe('2026-01-17T23:59:59.999Z'); // today
+  });
+});
+
+describe('currentWeekInProgressWindow (GH-1922)', () => {
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it('always looks at the current week, not the last completed one, on a weekday (Wednesday)', () => {
+    // 2026-01-14 is a Wednesday (UTC) — briefWindow() would resolve to the *previous* week here.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
+
+    const { window_start, window_end } = currentWeekInProgressWindow();
+
+    expect(window_start).toBe('2026-01-11T00:00:00.000Z'); // this week's Sunday, not last week's
+    expect(window_end).toBe('2026-01-14T12:00:00.000Z'); // now, not a fixed Saturday 23:59:59.999
+  });
+
+  it('on Sunday itself, the window starts and ends the same day', () => {
+    // 2026-01-11 is a Sunday (UTC).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-11T08:30:00.000Z'));
+
+    const { window_start, window_end } = currentWeekInProgressWindow();
+
+    expect(window_start).toBe('2026-01-11T00:00:00.000Z');
+    expect(window_end).toBe('2026-01-11T08:30:00.000Z');
+  });
+
+  it('on Saturday, matches briefWindow()’s start but ends at now instead of 23:59:59.999', () => {
+    // 2026-01-17 is a Saturday (UTC).
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-01-17T09:00:00.000Z'));
+
+    const inProgress = currentWeekInProgressWindow();
+    const completed = briefWindow();
+
+    expect(inProgress.window_start).toBe(completed.window_start);
+    expect(inProgress.window_end).toBe('2026-01-17T09:00:00.000Z');
   });
 });
 
@@ -335,6 +375,29 @@ describe('WeeklyBriefService', () => {
       process.env['NODE_ENV'] = 'production';
       await expect(service.getCurrentBrief(req, 'committee-1')).rejects.toThrow(/temporarily unavailable/);
       expect(proxyRequest).not.toHaveBeenCalled();
+    });
+
+    it('getCurrentBrief includes a non-zero current_activity fixture spanning multiple kinds (GH-1922)', async () => {
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeDefined();
+      const kinds = result.current_activity?.source_refs.map((ref) => ref.kind).sort();
+      expect(kinds).toEqual(['doc', 'meeting', 'vote']);
+    });
+
+    it('getCurrentBrief scopes current_activity to currentWeekInProgressWindow(), not briefWindow()', async () => {
+      vi.useFakeTimers();
+      // 2026-01-14 is a Wednesday (UTC) — briefWindow() resolves to the *previous* week here,
+      // currentWeekInProgressWindow() must not.
+      vi.setSystemTime(new Date('2026-01-14T12:00:00.000Z'));
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
+      expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
+      expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
+
+      vi.useRealTimers();
     });
 
     it('does not leak the WEEKLY_BRIEF_BACKEND env var name into the client-facing error message', async () => {
@@ -541,6 +604,14 @@ describe('WeeklyBriefService', () => {
       proxyRequest.mockRejectedValueOnce(notFound);
 
       await expect(service.getCurrentBrief(req, 'committee-1')).rejects.toBe(notFound);
+    });
+
+    it('getCurrentBrief does not fabricate current_activity — live mode is a pure passthrough with no upstream in-progress-week endpoint yet (GH-1922)', async () => {
+      proxyRequest.mockResolvedValueOnce({ brief: { uid: 'b1', state: 'generated' }, throttle: null });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeUndefined();
     });
 
     it('generateBrief forwards the real upstream status code (202 accepted)', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -98,7 +98,7 @@ const {
 
 vi.mock('@lfx-one/shared/constants', () => ({
   ACTIVITY_FEED_MAX_PAGE_SIZE: 50,
-  WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS: 10_000,
+  WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS: 3_000,
   WEEKLY_BRIEF_DEFAULT_THROTTLE: MOCK_THROTTLE,
   WEEKLY_BRIEF_SHAREABLE_STATES: ['generated', 'edited', 'approved'],
   WEEKLY_BRIEF_ERROR_REASON: { NO_SOURCES: 'no_sources' },
@@ -736,7 +736,7 @@ describe('WeeklyBriefService', () => {
           proxyRequest.mockResolvedValue({ brief: { uid: 'b1', state: 'generated' }, throttle: null });
         },
       ],
-    ])('populates current_activity for a governance committee, mapping kinds and excluding an in-progress vote (%s)', async (_label, setBackend) => {
+    ])('populates current_activity for a governance committee, mapping kinds and folding an in-progress vote into "other" (%s)', async (_label, setBackend) => {
       setBackend();
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
@@ -753,7 +753,9 @@ describe('WeeklyBriefService', () => {
             committee_uid: 'committee-1',
             payload: { vote_uid: 'v1', name: 'Q3 Resolution', status: 'Ended' },
           },
-          // Deliberately excluded from the tally — see mapActivityEventToCurrentActivityRef's doc comment.
+          // Not "vote closed" (the tally's only vote phrase), but also not dropped — folds into
+          // "other" instead of null, so an open-but-not-yet-closed vote doesn't produce a "no
+          // activity yet" tally directly beneath a "Recent Activity" feed that shows otherwise.
           {
             type: 'vote_opened',
             occurred_at: '2026-01-12T09:00:00Z',
@@ -777,10 +779,10 @@ describe('WeeklyBriefService', () => {
       // feature's whole point is that absent/null/present are three distinct states, not two.
       expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
       const refs = result.current_activity?.source_refs ?? [];
-      expect(refs).toHaveLength(3);
-      expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'vote']);
+      expect(refs).toHaveLength(4);
+      expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'other', 'vote']);
       expect(refs.find((ref) => ref.kind === 'vote')?.title).toBe('Q3 Resolution');
-      expect(refs.some((ref) => ref.title === 'Q4 Budget')).toBe(false);
+      expect(refs.find((ref) => ref.kind === 'other')?.title).toBe('Q4 Budget');
       // No kind prefix on meeting/vote — see mapActivityEventToCurrentActivityRef's doc comment
       // for why: a vote ref's id passes straight through as VoteDrawerActivityFeedAction.voteUid
       // (a `vote:` prefix would reach that action as a corrupted id), and a meeting ref's id is
@@ -788,6 +790,7 @@ describe('WeeklyBriefService', () => {
       // same doc comment covers that known v1 residual.
       expect(refs.find((ref) => ref.kind === 'meeting')?.id).toBe('m1-occ');
       expect(refs.find((ref) => ref.kind === 'vote')?.id).toBe('v1');
+      expect(refs.find((ref) => ref.kind === 'other')?.id).toBe('v2');
     });
 
     it('folds survey events into the "other" kind rather than dropping them', async () => {
@@ -1114,6 +1117,28 @@ describe('WeeklyBriefService', () => {
       } finally {
         vi.useRealTimers();
       }
+    });
+
+    it("degrades to current_activity: undefined (not a rejected getCurrentBrief) when the race itself rejects — buildCurrentActivityWithBudget must not lean on buildCurrentActivity's own try/catch to stay fail-soft", async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      // Bypasses buildCurrentActivity's own try/catch entirely, to prove
+      // buildCurrentActivityWithBudget's catch is a real, load-bearing guard and not dead code
+      // riding on a distant invariant.
+      vi.spyOn(
+        service as unknown as { buildCurrentActivity: (req: Request, committeeId: string) => Promise<unknown> },
+        'buildCurrentActivity'
+      ).mockRejectedValue(new Error('unexpected rejection'));
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeUndefined();
+      expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'get_weekly_brief_current_activity',
+        'Current-activity fan-out rejected unexpectedly, omitting the tally',
+        { committee_id: 'committee-1', err: expect.any(Error) }
+      );
     });
   });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -26,7 +26,7 @@ const {
   buildCacheKey,
   checkSingleAccessStrictMock,
   getCommitteeByIdMock,
-  getCommitteeCategoryMock,
+  getCommitteeBaseMock,
   hasMailingListStrictMock,
   createNewsletterMock,
   sendNewsletterMock,
@@ -81,10 +81,10 @@ const {
     getCommitteeByIdMock: vi.fn(),
     // buildCurrentActivity's (GH-1922) OWN gating collaborator — a separate mock from
     // getCommitteeByIdMock above, matching the production split (buildCurrentActivity calls
-    // CommitteeService#getCommitteeCategory, not #getCommitteeById — see its doc comment for
+    // CommitteeService#getCommitteeBase, not #getCommitteeById — see its doc comment for
     // why). Controlled per-test in the 'current_activity (GH-1922)' describe block and in each
     // internal caller's "never triggers the fan-out" regression guard.
-    getCommitteeCategoryMock: vi.fn(),
+    getCommitteeBaseMock: vi.fn(),
     hasMailingListStrictMock: vi.fn(),
     createNewsletterMock: vi.fn(),
     sendNewsletterMock: vi.fn(),
@@ -139,7 +139,7 @@ vi.mock('./logger.service', () => ({
 vi.mock('./committee.service', () => ({
   CommitteeService: class {
     public getCommitteeById = getCommitteeByIdMock;
-    public getCommitteeCategory = getCommitteeCategoryMock;
+    public getCommitteeBase = getCommitteeBaseMock;
     public hasMailingListStrict = hasMailingListStrictMock;
   },
 }));
@@ -279,10 +279,10 @@ describe('WeeklyBriefService', () => {
     // committee with an empty activity feed, so every test elsewhere in this file that calls
     // getCurrentBrief (the vast majority) never needs to know these mocks exist. Tests that
     // specifically exercise current_activity override both below.
-    getCommitteeCategoryMock.mockResolvedValue('Working Group');
+    getCommitteeBaseMock.mockResolvedValue({ category: 'Working Group' });
     getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
     // shareBrief's own committee collaborator (unrelated to buildCurrentActivity — see
-    // getCommitteeCategoryMock above) — a safe default so tests elsewhere that incidentally
+    // getCommitteeBaseMock above) — a safe default so tests elsewhere that incidentally
     // route through fetchBriefResponse's internal callers don't need their own override.
     getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1', category: 'Working Group' });
   });
@@ -436,7 +436,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — getActionItems only ever reads brief_text', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
       // actually trigger the fan-out this test exists to catch — not pass vacuously.
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       extractBriefActionItems.mockResolvedValue({ items: [] });
 
       await service.getActionItems(req, 'committee-1');
@@ -736,7 +736,7 @@ describe('WeeklyBriefService', () => {
       ],
     ])('populates current_activity for a governance committee, mapping kinds and excluding an in-progress vote (%s)', async (_label, setBackend) => {
       setBackend();
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -776,11 +776,17 @@ describe('WeeklyBriefService', () => {
       expect(refs.map((ref) => ref.kind).sort()).toEqual(['doc', 'meeting', 'vote']);
       expect(refs.find((ref) => ref.kind === 'vote')?.title).toBe('Q3 Resolution');
       expect(refs.some((ref) => ref.title === 'Q4 Budget')).toBe(false);
+      // Raw upstream uid, no kind prefix — weekly-brief.utils.ts's resolveSourceRefAction passes
+      // a meeting ref's id straight through as PastMeetingActivityFeedAction.meetingId and a vote
+      // ref's as VoteDrawerActivityFeedAction.voteUid; a `meeting:`/`vote:` prefix would reach
+      // either action as a corrupted id.
+      expect(refs.find((ref) => ref.kind === 'meeting')?.id).toBe('m1-occ');
+      expect(refs.find((ref) => ref.kind === 'vote')?.id).toBe('v1');
     });
 
     it('folds survey events into the "other" kind rather than dropping them', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -795,12 +801,12 @@ describe('WeeklyBriefService', () => {
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity?.source_refs).toEqual([{ id: 'survey:s1', kind: 'other', title: 'Annual Review' }]);
+      expect(result.current_activity?.source_refs).toEqual([{ id: 's1', kind: 'other', title: 'Annual Review' }]);
     });
 
     it('maps notes_added to kind "doc", and its id carries the meeting_scope discriminant so it cannot collide with a document_uploaded event sharing the same document_uid', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -835,7 +841,7 @@ describe('WeeklyBriefService', () => {
 
     it('sets current_activity to null (a settled, not a transient, absence) when the returned page itself is full', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         // ACTIVITY_FEED_MAX_PAGE_SIZE (mocked to 50) worth of in-window events — the actual signal
         // that some of them may have been cut, unlike a bare page_token (see the next test).
@@ -864,7 +870,7 @@ describe('WeeklyBriefService', () => {
 
     it("does NOT omit current_activity merely because page_token is present with a short page — a committee with >fetchSize lifetime notes/surveys saturates those legs regardless of the current week (see buildCurrentActivity's own doc comment)", async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -888,7 +894,7 @@ describe('WeeklyBriefService', () => {
 
     it('renders a genuine quiet week as current_activity present with an empty source_refs array, not absent', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
@@ -902,7 +908,7 @@ describe('WeeklyBriefService', () => {
 
     it('passes currentWeekInProgressWindow().window_start as since, and never briefWindow()', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
 
       vi.useFakeTimers();
       try {
@@ -912,7 +918,12 @@ describe('WeeklyBriefService', () => {
 
         const result = await service.getCurrentBrief(req, 'committee-1');
 
-        expect(getCommitteeActivityMock).toHaveBeenCalledWith(req, 'committee-1', { since: '2026-01-11T00:00:00.000Z', limit: expect.any(Number) });
+        expect(getCommitteeActivityMock).toHaveBeenCalledWith(
+          req,
+          'committee-1',
+          { since: '2026-01-11T00:00:00.000Z', limit: expect.any(Number) },
+          { category: 'Board' }
+        );
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
         expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
         expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
@@ -923,7 +934,7 @@ describe('WeeklyBriefService', () => {
 
     it('never calls getCommitteeActivity for a non-governance committee, and current_activity settles to null (not undefined)', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Working Group');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Working Group' });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
@@ -934,20 +945,20 @@ describe('WeeklyBriefService', () => {
       expect(result.current_activity).toBeNull();
     });
 
-    it('skips the entire fan-out (getCommitteeCategory and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {
+    it('skips the entire fan-out (getCommitteeBase and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
 
       const result = await service.getCurrentBrief(req, 'committee-1', { includeCurrentActivity: false });
 
-      expect(getCommitteeCategoryMock).not.toHaveBeenCalled();
+      expect(getCommitteeBaseMock).not.toHaveBeenCalled();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(result.current_activity).toBeUndefined();
     });
 
     it('degrades to current_activity: undefined (not a thrown error) when the committee lookup fails', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockRejectedValue(new Error('upstream unavailable'));
+      getCommitteeBaseMock.mockRejectedValue(new Error('upstream unavailable'));
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
@@ -957,7 +968,7 @@ describe('WeeklyBriefService', () => {
 
     it('degrades to current_activity: undefined (not a thrown error) when the activity fetch fails', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       getCommitteeActivityMock.mockRejectedValue(new Error('upstream unavailable'));
 
       const result = await service.getCurrentBrief(req, 'committee-1');
@@ -976,7 +987,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — rateBrief/clearBriefRating only ever read brief/caller_rating', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` inside
       // resolveRatableBrief would actually trigger the fan-out this test exists to catch.
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       const initial = await service.getCurrentBrief(userReq, 'committee-1');
       const briefUid = initial.brief!.uid;
       getCommitteeActivityMock.mockClear(); // the setup call above is allowed to fan out; only what follows is under test.
@@ -1340,7 +1351,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — shareToSlack only ever reads brief', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
       // actually trigger the fan-out this test exists to catch.
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       mockShareableBrief();
       mockCommittee();
       proxyRequest.mockResolvedValueOnce(undefined);
@@ -1501,9 +1512,9 @@ describe('WeeklyBriefService', () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
       // actually trigger the fan-out this test exists to catch. Both mocks: shareBrief itself
       // calls getCommitteeById (for name/project_uid), while buildCurrentActivity — reachable
-      // only via the regression this test guards against — calls getCommitteeCategory.
+      // only via the regression this test guards against — calls getCommitteeBase.
       getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1', category: 'Board' });
-      getCommitteeCategoryMock.mockResolvedValue('Board');
+      getCommitteeBaseMock.mockResolvedValue({ category: 'Board' });
       mockShareableBrief();
 
       await service.shareBrief(nonImpersonatingReq, 'committee-1', 1);

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -10,10 +10,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 // the deep `vi.importActual` on `committee.utils.ts` further down for the one function pulled
 // through the real module instead of a stub). `constants` is mocked too, not because the real
 // module can't load here, but for test control: the mock pins a deterministic
-// WEEKLY_BRIEF_DEFAULT_THROTTLE (MOCK_THROTTLE), shared between the factory and the assertions
-// below so the two can't drift from each other, without paying the real barrel's evaluation cost.
-// weekly-brief.constants.spec.ts is the named spec pinning MOCK_THROTTLE's shape against the real
-// constant, same pattern as that file's ACTIVITY_FEED_MAX_PAGE_SIZE pin further down.
+// WEEKLY_BRIEF_DEFAULT_THROTTLE (MOCK_THROTTLE) so the throttle assertions below start from a
+// known zero-used baseline, without paying the real barrel's evaluation cost.
+// weekly-brief.constants.spec.ts's WEEKLY_BRIEF_DEFAULT_THROTTLE test pins MOCK_THROTTLE's shape
+// against the real constant, same pattern as activity-event.constants.spec.ts's pin on
+// ACTIVITY_FEED_MAX_PAGE_SIZE, which guards this file's own hand-copy of that constant below.
 // A real Map-backed fake (not just call-arg assertions) so the rating tests below prove actual
 // upsert/clear round-trip behavior through the public API, not just "was called with X". Shared
 // by the action-items tests too — `weekly-brief.service.ts`'s rating and action-items code paths

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -1078,6 +1078,15 @@ describe('WeeklyBriefService', () => {
 
       expect(result.current_activity).toBeUndefined();
       expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
+      // Pins the BUDGET_ELAPSED sentinel's whole reason for existing: a plain buildCurrentActivity
+      // undefined (this test) must not be misread as a budget-elapsed degrade, which would fire
+      // the wrong warning message and mislead anyone debugging from CloudWatch alone.
+      expect(logger.warning).not.toHaveBeenCalledWith(
+        req,
+        'get_weekly_brief_current_activity',
+        'Current-activity budget elapsed, omitting the tally',
+        expect.anything()
+      );
     });
 
     it('degrades to current_activity: undefined once WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS elapses, rather than letting a slow (not erroring) upstream hold the whole response hostage', async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -939,8 +939,7 @@ describe('WeeklyBriefService', () => {
           req,
           'committee-1',
           { since: '2026-01-11T00:00:00.000Z', limit: ACTIVITY_FEED_MAX_PAGE_SIZE },
-          { uid: 'committee-1', category: 'Board' },
-          true
+          { knownCommittee: { uid: 'committee-1', category: 'Board' }, quietAggregationLog: true }
         );
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
         expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -1230,6 +1230,62 @@ describe('WeeklyBriefService', () => {
       );
     });
 
+    it('degrades to current_activity: undefined (not a thrown error, and regardless of count) when any_leg_failed is true, even though the returned page is short (GH-1967 review)', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      // A short, comfortably-under-cap page — the exact shape a failed leg degrades to in
+      // committee-activity.service.ts ({ events: [], saturated: false }), indistinguishable from
+      // a leg that genuinely had nothing this week without the any_leg_failed flag itself.
+      getCommitteeActivityMock.mockResolvedValue({
+        data: [
+          {
+            type: 'meeting_held',
+            occurred_at: '2026-01-12T10:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { meeting_id: 'm1', meeting_occurrence_id: 'm1-occ', title: 'Board Sync', password: null },
+          },
+        ],
+        page_token: undefined,
+        any_leg_saturated: false,
+        any_leg_failed: true,
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      // undefined, not null: unlike the page-fill gate, a leg failure is transient — the same
+      // upstream call may succeed on the next poll tick.
+      expect(result.current_activity).toBeUndefined();
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'get_weekly_brief_current_activity',
+        expect.stringContaining('leg'),
+        expect.objectContaining({ committee_id: 'committee-1' })
+      );
+    });
+
+    it("does NOT degrade current_activity when any_leg_saturated is true but any_leg_failed is false — saturation reflects lifetime, not this-week, volume for two of the five legs (see buildCurrentActivity's own doc comment)", async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({
+        data: [
+          {
+            type: 'meeting_held',
+            occurred_at: '2026-01-12T10:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { meeting_id: 'm1', meeting_occurrence_id: 'm1-occ', title: 'Board Sync', password: null },
+          },
+        ],
+        page_token: undefined,
+        any_leg_saturated: true,
+        any_leg_failed: false,
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: expect.any(Array) }));
+      expect(result.current_activity?.source_refs).toHaveLength(1);
+    });
+
     it('degrades to current_activity: undefined once WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS elapses, rather than letting a slow (not erroring) upstream hold the whole response hostage', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -421,6 +421,17 @@ describe('WeeklyBriefService', () => {
       delete process.env['NODE_ENV'];
     });
 
+    it('never triggers the current_activity fan-out (GH-1922) — getActionItems only ever reads brief_text', async () => {
+      // A governance committee, so a regression back to `this.getCurrentBrief` here would
+      // actually trigger the fan-out this test exists to catch — not pass vacuously.
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      extractBriefActionItems.mockResolvedValue({ items: [] });
+
+      await service.getActionItems(req, 'committee-1');
+
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
     it('caches extraction per revision — a second call for the same revision does not re-invoke AiService (cache hit)', async () => {
       extractBriefActionItems.mockResolvedValue({ items: [{ text: 'Onboard the new member' }] });
 
@@ -807,7 +818,33 @@ describe('WeeklyBriefService', () => {
       expect(refs[0].id).not.toBe(refs[1].id);
     });
 
-    it('omits current_activity (rather than publishing a truncated count) when the current week has more than one page of activity', async () => {
+    it('omits current_activity (rather than publishing a truncated count) when the returned page itself is full', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({
+        // ACTIVITY_FEED_MAX_PAGE_SIZE (mocked to 50) worth of in-window events — the actual signal
+        // that some of them may have been cut, unlike a bare page_token (see the next test).
+        data: Array.from({ length: 50 }, (_, i) => ({
+          type: 'meeting_held',
+          occurred_at: '2026-01-12T10:00:00Z',
+          committee_uid: 'committee-1',
+          payload: { meeting_id: `m${i}`, meeting_occurrence_id: `m${i}-occ`, title: 'Board Sync', password: null },
+        })),
+        page_token: undefined,
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeUndefined();
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'get_weekly_brief_current_activity',
+        expect.stringContaining('fills a full page'),
+        expect.objectContaining({ committee_id: 'committee-1' })
+      );
+    });
+
+    it("does NOT omit current_activity merely because page_token is present with a short page — a committee with >fetchSize lifetime notes/surveys saturates those legs regardless of the current week (see buildCurrentActivity's own doc comment)", async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
       getCommitteeActivityMock.mockResolvedValue({
@@ -819,18 +856,16 @@ describe('WeeklyBriefService', () => {
             payload: { meeting_id: 'm1', meeting_occurrence_id: 'm1-occ', title: 'Board Sync', password: null },
           },
         ],
-        page_token: 'more-events-exist',
+        // A real, non-truncating page_token: notes/surveys legs saturate on lifetime volume, not
+        // in-window volume — see committee-activity.service.ts's fetchNotesAddedEvents/
+        // fetchSurveyEvents doc comments.
+        page_token: 'saturated-on-an-unrelated-leg',
       });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
-      expect(result.current_activity).toBeUndefined();
-      expect(logger.warning).toHaveBeenCalledWith(
-        req,
-        'get_weekly_brief_current_activity',
-        expect.stringContaining('exceeds one page'),
-        expect.objectContaining({ committee_id: 'committee-1' })
-      );
+      expect(result.current_activity).toBeDefined();
+      expect(result.current_activity?.source_refs).toHaveLength(1);
     });
 
     it('renders a genuine quiet week as current_activity present with an empty source_refs array, not absent', async () => {
@@ -904,6 +939,20 @@ describe('WeeklyBriefService', () => {
     beforeEach(() => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       delete process.env['NODE_ENV'];
+    });
+
+    it('never triggers the current_activity fan-out (GH-1922) — rateBrief/clearBriefRating only ever read brief/caller_rating', async () => {
+      // A governance committee, so a regression back to `this.getCurrentBrief` inside
+      // resolveRatableBrief would actually trigger the fan-out this test exists to catch.
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      const initial = await service.getCurrentBrief(userReq, 'committee-1');
+      const briefUid = initial.brief!.uid;
+      getCommitteeActivityMock.mockClear(); // the setup call above is allowed to fan out; only what follows is under test.
+
+      await service.rateBrief(userReq, 'committee-1', briefUid, 'up', 1);
+      await service.clearBriefRating(userReq, 'committee-1', briefUid, 1);
+
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
     it('rate → re-rate (switch) → clear round-trips through getCurrentBrief().caller_rating', async () => {
@@ -1164,7 +1213,7 @@ describe('WeeklyBriefService', () => {
       checkSingleAccessStrictMock.mockResolvedValue(true);
     });
 
-    /** A brief in a shareable state, queued up for the getCurrentBrief call shareToSlack makes internally. */
+    /** A brief in a shareable state, queued up for the fetchBriefResponse call shareToSlack makes internally. */
     function mockShareableBrief(overrides: Record<string, unknown> = {}): void {
       proxyRequest.mockResolvedValueOnce({
         brief: {
@@ -1256,6 +1305,19 @@ describe('WeeklyBriefService', () => {
       });
     });
 
+    it('never triggers the current_activity fan-out (GH-1922) — shareToSlack only ever reads brief', async () => {
+      // A governance committee, so a regression back to `this.getCurrentBrief` here would
+      // actually trigger the fan-out this test exists to catch.
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      mockShareableBrief();
+      mockCommittee();
+      proxyRequest.mockResolvedValueOnce(undefined);
+
+      await service.shareToSlack(req, 'committee-1', 1);
+
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
+    });
+
     it('logs the sending user (as their opaque sub, not the human-readable username) on a successful send — the committee-service call carries no caller identity of its own beyond the bearer token, so this is the only record of who shared it', async () => {
       mockShareableBrief();
       mockCommittee();
@@ -1339,7 +1401,7 @@ describe('WeeklyBriefService', () => {
       sendNewsletterMock.mockResolvedValue({ total_recipients: 42 });
     });
 
-    /** A brief in a shareable state, queued up for the getCurrentBrief call shareBrief makes internally. */
+    /** A brief in a shareable state, queued up for the fetchBriefResponse call shareBrief makes internally. */
     function mockShareableBrief(overrides: Record<string, unknown> = {}): void {
       proxyRequest.mockResolvedValueOnce({
         brief: {
@@ -1401,6 +1463,17 @@ describe('WeeklyBriefService', () => {
         expect.objectContaining({ ed_reply_email: 'writer@example.com', committee_uids: ['committee-1'] })
       );
       expect(nonImpersonatingReq.bearerToken).toBe('writer-token');
+    });
+
+    it('never triggers the current_activity fan-out (GH-1922) — shareBrief only ever reads brief', async () => {
+      // A governance committee, so a regression back to `this.getCurrentBrief` here would
+      // actually trigger the fan-out this test exists to catch.
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1', category: 'Board' });
+      mockShareableBrief();
+
+      await service.shareBrief(nonImpersonatingReq, 'committee-1', 1);
+
+      expect(getCommitteeActivityMock).not.toHaveBeenCalled();
     });
 
     it("impersonating: authorizes and sends under the REAL staff member's token/email, not the impersonated target's, and restores the impersonation token afterward", async () => {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -98,6 +98,7 @@ const {
 
 vi.mock('@lfx-one/shared/constants', () => ({
   ACTIVITY_FEED_MAX_PAGE_SIZE: 50,
+  WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS: 10_000,
   WEEKLY_BRIEF_DEFAULT_THROTTLE: MOCK_THROTTLE,
   WEEKLY_BRIEF_SHAREABLE_STATES: ['generated', 'edited', 'approved'],
   WEEKLY_BRIEF_ERROR_REASON: { NO_SOURCES: 'no_sources' },
@@ -178,7 +179,7 @@ vi.mock('./valkey.service', () => ({
   valkeyService: valkeyServiceMock,
 }));
 
-import { ACTIVITY_FEED_MAX_PAGE_SIZE } from '@lfx-one/shared/constants';
+import { ACTIVITY_FEED_MAX_PAGE_SIZE, WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS } from '@lfx-one/shared/constants';
 import type { Request } from 'express';
 
 import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID } from '../constants';
@@ -937,10 +938,10 @@ describe('WeeklyBriefService', () => {
         expect(result.current_activity?.window_start).toBe('2026-01-11T00:00:00.000Z');
         expect(result.current_activity?.window_end).toBe('2026-01-14T12:00:00.000Z');
         expect(result.brief?.window_start).toBe('2026-01-04T00:00:00.000Z');
-        // The dropped-events warning must stay off the healthy path — pins the
-        // droppedAfterWindowEnd > 0 guard itself, not just the warning's payload shape (which
+        // The dropped-events log must stay off the healthy path — pins the
+        // droppedAfterWindowEnd > 0 guard itself, not just the log's payload shape (which
         // the sibling "excludes an event..." test already covers).
-        expect(logger.warning).not.toHaveBeenCalledWith(
+        expect(logger.debug).not.toHaveBeenCalledWith(
           req,
           'get_weekly_brief_current_activity',
           'Dropped one or more events stamped after window_end',
@@ -985,9 +986,10 @@ describe('WeeklyBriefService', () => {
         const result = await service.getCurrentBrief(req, 'committee-1');
 
         expect(result.current_activity?.source_refs).toEqual([{ id: 'm2-occ', kind: 'meeting', title: 'Real Meeting' }]);
-        // A dropped event is a real data-quality anomaly, not an expected silent case — must
-        // warn like this method's other degrade paths, not drop quietly.
-        expect(logger.warning).toHaveBeenCalledWith(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
+        // DEBUG, not WARN — this is a modeled, expected shape for an administratively-closed
+        // vote (see mapVoteToEvent), not a data-quality anomaly; still logged, just not at a
+        // level that pages someone for something the system already understands.
+        expect(logger.debug).toHaveBeenCalledWith(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
           committee_id: 'committee-1',
           dropped_count: 1,
           window_end: '2026-01-14T12:00:00.000Z',
@@ -1076,6 +1078,27 @@ describe('WeeklyBriefService', () => {
 
       expect(result.current_activity).toBeUndefined();
       expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
+    });
+
+    it('degrades to current_activity: undefined once WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS elapses, rather than letting a slow (not erroring) upstream hold the whole response hostage', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      // Never settles — models a slow, not a failing, upstream: buildCurrentActivity's own
+      // try/catch already covers the failing case (see the sibling test above).
+      // eslint-disable-next-line @typescript-eslint/no-empty-function -- deliberately never settles
+      getCommitteeActivityMock.mockReturnValue(new Promise(() => {}));
+
+      vi.useFakeTimers();
+      try {
+        const resultPromise = service.getCurrentBrief(req, 'committee-1');
+        await vi.advanceTimersByTimeAsync(WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS);
+        const result = await resultPromise;
+
+        expect(result.current_activity).toBeUndefined();
+        expect(result.brief).toMatchObject({ state: expect.any(String), brief_text: expect.any(String) });
+      } finally {
+        vi.useRealTimers();
+      }
     });
   });
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -772,6 +772,81 @@ describe('WeeklyBriefService', () => {
       expect(result.current_activity?.source_refs).toEqual([{ id: 'survey:s1', kind: 'other', title: 'Annual Review' }]);
     });
 
+    it('maps notes_added to kind "doc", and its id carries the meeting_scope discriminant so it cannot collide with a document_uploaded event sharing the same document_uid', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({
+        data: [
+          {
+            type: 'notes_added',
+            occurred_at: '2026-01-12T10:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { document_uid: 'shared-uid', name: 'Meeting Notes', document_type: 'file', meeting_scope: 'past' },
+          },
+          // Different upstream uid namespace (committee_document, not v1_past_meeting_attachment)
+          // coincidentally sharing the same raw document_uid — eventKey()'s own rationale for why
+          // committee-activity.service.ts prefixes with document_type/meeting_scope, not just the uid.
+          {
+            type: 'document_uploaded',
+            occurred_at: '2026-01-12T11:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { document_uid: 'shared-uid', name: 'Charter.pdf', document_type: 'file' },
+          },
+        ],
+        page_token: undefined,
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      const refs = result.current_activity?.source_refs ?? [];
+      expect(refs).toEqual([
+        { id: 'note:past:shared-uid', kind: 'doc', title: 'Meeting Notes' },
+        { id: 'document:file:shared-uid', kind: 'doc', title: 'Charter.pdf' },
+      ]);
+      // The whole point of the discriminant — two refs in the same kind, distinct ids.
+      expect(refs[0].id).not.toBe(refs[1].id);
+    });
+
+    it('omits current_activity (rather than publishing a truncated count) when the current week has more than one page of activity', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({
+        data: [
+          {
+            type: 'meeting_held',
+            occurred_at: '2026-01-12T10:00:00Z',
+            committee_uid: 'committee-1',
+            payload: { meeting_id: 'm1', meeting_occurrence_id: 'm1-occ', title: 'Board Sync', password: null },
+          },
+        ],
+        page_token: 'more-events-exist',
+      });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toBeUndefined();
+      expect(logger.warning).toHaveBeenCalledWith(
+        req,
+        'get_weekly_brief_current_activity',
+        expect.stringContaining('exceeds one page'),
+        expect.objectContaining({ committee_id: 'committee-1' })
+      );
+    });
+
+    it('renders a genuine quiet week as current_activity present with an empty source_refs array, not absent', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
+
+      const result = await service.getCurrentBrief(req, 'committee-1');
+
+      expect(result.current_activity).toEqual({
+        window_start: expect.any(String),
+        window_end: expect.any(String),
+        source_refs: [],
+      });
+    });
+
     it('passes currentWeekInProgressWindow().window_start as since, and never briefWindow()', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
       getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -114,13 +114,20 @@ vi.mock('@lfx-one/shared/constants', () => ({
 vi.mock('@lfx-one/shared/interfaces', () => ({}));
 // `formatUtcDateRangeLabel` lives in the same `@lfx-one/shared/utils` barrel as
 // form.utils.ts, which imports `@angular/forms` — an unmocked import here would pull
-// in the real barrel and hit the same JIT-compilation failure the mocks above avoid.
-// `isGoverningBoard` — minimal reimplementation (real one lives in committee.utils.ts, same
-// barrel/JIT-failure reasoning) sufficient for this file's fixtures, which only ever use
-// `category: 'Board'` or `category: 'Working Group'`.
-vi.mock('@lfx-one/shared/utils', () => ({
+// in the real barrel and hit the same JIT-compilation failure the mocks above avoid, so it
+// stays a plain stub. `isGoverningBoard` is the REAL function (via `vi.importActual` on its own
+// deep module, not the barrel) — committee.utils.ts imports only enums/interfaces/constants, no
+// Angular, so it loads safely on its own. This governance gate decides whether the server pays
+// for the tally fan-out at all AND whether the client's poll keeps asking for one, so a stub
+// that's narrower than production (e.g. exact `'Board'` equality vs. the real
+// substring/normalization-based `getGroupBehavioralClass`) would let this file's assertions
+// about the settled-`null`/non-governance branch stay green after the real predicate changed
+// underneath them.
+vi.mock('@lfx-one/shared/utils', async () => ({
   formatUtcDateRangeLabel: vi.fn(() => 'Jan 1 – Jan 7, 2026'),
-  isGoverningBoard: vi.fn((category: string | undefined) => category === 'Board' || category === 'Government Advisory Council'),
+  isGoverningBoard: (
+    await vi.importActual<typeof import('../../../../../packages/shared/src/utils/committee.utils')>('../../../../../packages/shared/src/utils/committee.utils')
+  ).isGoverningBoard,
 }));
 
 vi.mock('./microservice-proxy.service', () => ({
@@ -1133,6 +1140,30 @@ describe('WeeklyBriefService', () => {
           committee_id: 'committee-1',
           budget_ms: WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS,
         });
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it('resolves on the fast path without waiting for the budget, and clears its timer — proves this is a genuine race, not an accidental wait for the full duration, and that the timer handle does not leak', async () => {
+      delete process.env['WEEKLY_BRIEF_BACKEND'];
+      getCommitteeBaseMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
+
+      vi.useFakeTimers();
+      try {
+        const result = await service.getCurrentBrief(req, 'committee-1');
+
+        // A real object (not undefined), proving the fast leg — not the budget timeout — won the
+        // race: if `Promise.race` were accidentally `Promise.all`-like or otherwise waited for
+        // the budget, this assertion alone wouldn't distinguish that from the timeout path also
+        // resolving to a real value — the next assertion (no advance needed to get here, and the
+        // timer count check below) is what actually pins the race behavior.
+        expect(result.current_activity).toEqual(expect.objectContaining({ source_refs: [] }));
+        // No leaked timer handle: buildCurrentActivityWithBudget's `finally { clearTimeout(timer) }`
+        // must fire on the winning-leg path too, not just the timeout path the sibling test above
+        // covers — otherwise every fast GET /current still leaves a 3s handle running.
+        expect(vi.getTimerCount()).toBe(0);
       } finally {
         vi.useRealTimers();
       }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.spec.ts
@@ -26,6 +26,7 @@ const {
   buildCacheKey,
   checkSingleAccessStrictMock,
   getCommitteeByIdMock,
+  getCommitteeCategoryMock,
   hasMailingListStrictMock,
   createNewsletterMock,
   sendNewsletterMock,
@@ -78,6 +79,12 @@ const {
     // shareBrief's (LFXV2-2914 / LFXV2-3093) own committee + newsletter collaborators —
     // controlled per-test in the 'shareBrief' describe block below.
     getCommitteeByIdMock: vi.fn(),
+    // buildCurrentActivity's (GH-1922) OWN gating collaborator — a separate mock from
+    // getCommitteeByIdMock above, matching the production split (buildCurrentActivity calls
+    // CommitteeService#getCommitteeCategory, not #getCommitteeById — see its doc comment for
+    // why). Controlled per-test in the 'current_activity (GH-1922)' describe block and in each
+    // internal caller's "never triggers the fan-out" regression guard.
+    getCommitteeCategoryMock: vi.fn(),
     hasMailingListStrictMock: vi.fn(),
     createNewsletterMock: vi.fn(),
     sendNewsletterMock: vi.fn(),
@@ -132,6 +139,7 @@ vi.mock('./logger.service', () => ({
 vi.mock('./committee.service', () => ({
   CommitteeService: class {
     public getCommitteeById = getCommitteeByIdMock;
+    public getCommitteeCategory = getCommitteeCategoryMock;
     public hasMailingListStrict = hasMailingListStrictMock;
   },
 }));
@@ -271,8 +279,12 @@ describe('WeeklyBriefService', () => {
     // committee with an empty activity feed, so every test elsewhere in this file that calls
     // getCurrentBrief (the vast majority) never needs to know these mocks exist. Tests that
     // specifically exercise current_activity override both below.
-    getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Working Group' });
+    getCommitteeCategoryMock.mockResolvedValue('Working Group');
     getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
+    // shareBrief's own committee collaborator (unrelated to buildCurrentActivity — see
+    // getCommitteeCategoryMock above) — a safe default so tests elsewhere that incidentally
+    // route through fetchBriefResponse's internal callers don't need their own override.
+    getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1', category: 'Working Group' });
   });
 
   afterEach(() => {
@@ -424,7 +436,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — getActionItems only ever reads brief_text', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
       // actually trigger the fan-out this test exists to catch — not pass vacuously.
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       extractBriefActionItems.mockResolvedValue({ items: [] });
 
       await service.getActionItems(req, 'committee-1');
@@ -724,7 +736,7 @@ describe('WeeklyBriefService', () => {
       ],
     ])('populates current_activity for a governance committee, mapping kinds and excluding an in-progress vote (%s)', async (_label, setBackend) => {
       setBackend();
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -768,7 +780,7 @@ describe('WeeklyBriefService', () => {
 
     it('folds survey events into the "other" kind rather than dropping them', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -788,7 +800,7 @@ describe('WeeklyBriefService', () => {
 
     it('maps notes_added to kind "doc", and its id carries the meeting_scope discriminant so it cannot collide with a document_uploaded event sharing the same document_uid', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -823,7 +835,7 @@ describe('WeeklyBriefService', () => {
 
     it('sets current_activity to null (a settled, not a transient, absence) when the returned page itself is full', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       getCommitteeActivityMock.mockResolvedValue({
         // ACTIVITY_FEED_MAX_PAGE_SIZE (mocked to 50) worth of in-window events — the actual signal
         // that some of them may have been cut, unlike a bare page_token (see the next test).
@@ -852,7 +864,7 @@ describe('WeeklyBriefService', () => {
 
     it("does NOT omit current_activity merely because page_token is present with a short page — a committee with >fetchSize lifetime notes/surveys saturates those legs regardless of the current week (see buildCurrentActivity's own doc comment)", async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       getCommitteeActivityMock.mockResolvedValue({
         data: [
           {
@@ -876,7 +888,7 @@ describe('WeeklyBriefService', () => {
 
     it('renders a genuine quiet week as current_activity present with an empty source_refs array, not absent', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       getCommitteeActivityMock.mockResolvedValue({ data: [], page_token: undefined });
 
       const result = await service.getCurrentBrief(req, 'committee-1');
@@ -890,7 +902,7 @@ describe('WeeklyBriefService', () => {
 
     it('passes currentWeekInProgressWindow().window_start as since, and never briefWindow()', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
 
       vi.useFakeTimers();
       try {
@@ -911,7 +923,7 @@ describe('WeeklyBriefService', () => {
 
     it('never calls getCommitteeActivity for a non-governance committee, and current_activity settles to null (not undefined)', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Working Group' });
+      getCommitteeCategoryMock.mockResolvedValue('Working Group');
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
@@ -924,18 +936,18 @@ describe('WeeklyBriefService', () => {
 
     it('skips the entire fan-out (getCommitteeById and getCommitteeActivity) when includeCurrentActivity is false, even for a governance committee', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
 
       const result = await service.getCurrentBrief(req, 'committee-1', { includeCurrentActivity: false });
 
-      expect(getCommitteeByIdMock).not.toHaveBeenCalled();
+      expect(getCommitteeCategoryMock).not.toHaveBeenCalled();
       expect(getCommitteeActivityMock).not.toHaveBeenCalled();
       expect(result.current_activity).toBeUndefined();
     });
 
     it('degrades to current_activity: undefined (not a thrown error) when the committee lookup fails', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockRejectedValue(new Error('upstream unavailable'));
+      getCommitteeCategoryMock.mockRejectedValue(new Error('upstream unavailable'));
 
       const result = await service.getCurrentBrief(req, 'committee-1');
 
@@ -945,7 +957,7 @@ describe('WeeklyBriefService', () => {
 
     it('degrades to current_activity: undefined (not a thrown error) when the activity fetch fails', async () => {
       delete process.env['WEEKLY_BRIEF_BACKEND'];
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       getCommitteeActivityMock.mockRejectedValue(new Error('upstream unavailable'));
 
       const result = await service.getCurrentBrief(req, 'committee-1');
@@ -964,7 +976,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — rateBrief/clearBriefRating only ever read brief/caller_rating', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` inside
       // resolveRatableBrief would actually trigger the fan-out this test exists to catch.
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       const initial = await service.getCurrentBrief(userReq, 'committee-1');
       const briefUid = initial.brief!.uid;
       getCommitteeActivityMock.mockClear(); // the setup call above is allowed to fan out; only what follows is under test.
@@ -1328,7 +1340,7 @@ describe('WeeklyBriefService', () => {
     it('never triggers the current_activity fan-out (GH-1922) — shareToSlack only ever reads brief', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
       // actually trigger the fan-out this test exists to catch.
-      getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       mockShareableBrief();
       mockCommittee();
       proxyRequest.mockResolvedValueOnce(undefined);
@@ -1487,8 +1499,11 @@ describe('WeeklyBriefService', () => {
 
     it('never triggers the current_activity fan-out (GH-1922) — shareBrief only ever reads brief', async () => {
       // A governance committee, so a regression back to `this.getCurrentBrief` here would
-      // actually trigger the fan-out this test exists to catch.
+      // actually trigger the fan-out this test exists to catch. Both mocks: shareBrief itself
+      // calls getCommitteeById (for name/project_uid), while buildCurrentActivity — reachable
+      // only via the regression this test guards against — calls getCommitteeCategory.
       getCommitteeByIdMock.mockResolvedValue({ uid: 'committee-1', name: 'Test Committee', project_uid: 'project-1', category: 'Board' });
+      getCommitteeCategoryMock.mockResolvedValue('Board');
       mockShareableBrief();
 
       await service.shareBrief(nonImpersonatingReq, 'committee-1', 1);

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -7,6 +7,7 @@ import {
   NEWSLETTER_SUBJECT_MAX_LENGTH,
   VALKEY_CACHE,
   WEEKLY_BRIEF_ACTION_ITEMS_MAX,
+  WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS,
   WEEKLY_BRIEF_DEFAULT_THROTTLE,
   WEEKLY_BRIEF_ERROR_REASON,
   WEEKLY_BRIEF_SHAREABLE_STATES,
@@ -327,7 +328,7 @@ export class WeeklyBriefService {
     // write path (share, rate) and every read of just the AI-extracted action items.
     const [response, currentActivity] = await Promise.all([
       this.fetchBriefResponse(req, committeeId),
-      includeCurrentActivity ? this.buildCurrentActivity(req, committeeId) : Promise.resolve(undefined),
+      includeCurrentActivity ? this.buildCurrentActivityWithBudget(req, committeeId) : Promise.resolve(undefined),
     ]);
     // !== undefined, not truthiness — currentActivity can be null (a settled "doesn't apply"
     // answer, see buildCurrentActivity's doc comment), which is a real value the client needs
@@ -1194,6 +1195,34 @@ export class WeeklyBriefService {
   }
 
   /**
+   * Races `buildCurrentActivity` against `WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS` — see that
+   * constant's own doc comment for why this exists (a slow, not just an erroring, upstream must
+   * not hold the whole `GET /current` response hostage). Resolving to `undefined` on a lost race,
+   * not rejecting, is deliberate: it's the same value `buildCurrentActivity` itself already
+   * produces for any other transient failure, so `getCurrentBrief`'s caller — and the client's
+   * poll self-heal — can't tell a timeout apart from any other degrade, and don't need to. The
+   * loser of the race is not cancelled (`buildCurrentActivity` has no cancellation hook — its
+   * underlying upstream calls keep running until they settle or their own timeout fires). The
+   * trailing `.catch()` on it is defense-in-depth, not a live path today: `buildCurrentActivity`'s
+   * own try/catch already wraps everything it does, so it can never actually reject as written —
+   * kept so a late rejection stays harmless rather than an unhandled one if that invariant ever
+   * changes, same rationale as this file's other "unreached in practice" guards.
+   */
+  private async buildCurrentActivityWithBudget(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
+    let timer: NodeJS.Timeout;
+    const timeout = new Promise<undefined>((resolve) => {
+      timer = setTimeout(() => resolve(undefined), WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS);
+    });
+    const result = this.buildCurrentActivity(req, committeeId);
+    result.catch(() => undefined);
+    try {
+      return await Promise.race([result, timeout]);
+    } finally {
+      clearTimeout(timer!);
+    }
+  }
+
+  /**
    * Builds `WeeklyBriefCurrentResponse.current_activity` (GH-1922) from
    * `CommitteeActivityService.getCommitteeActivity` — the same live meeting/vote/document
    * aggregation that powers the committee "Recent Activity" feed, filtered to the current,
@@ -1337,12 +1366,16 @@ export class WeeklyBriefService {
         if (ref) refs.push(ref);
         return refs;
       }, []);
-      // A dropped event is a real upstream data-quality anomaly (a leg reporting an occurred_at
-      // ahead of "now" — see the filter's own comment above for which legs can do this), not an
-      // expected, silent case — matches this method's other degrade paths, which all warn rather
-      // than drop quietly.
+      // DEBUG, not WARN — the vote leg's occurred_at-ahead-of-"now" case (see the filter's own
+      // comment above) is a mapVoteToEvent-modeled, expected shape, not an anomaly: an
+      // administratively-ENDED vote with no early_end_time stamps occurred_at from its still-future
+      // end_time deliberately, and stays that way for the rest of that vote's scheduled term — so a
+      // WARN here would repeat on every GET /current for that committee for a case the system
+      // already knows about and models on purpose, not a genuine data-quality problem worth an
+      // operator's attention. Still logged (not silent) since a drop is still worth being able to
+      // find while debugging a tally that looks short.
       if (droppedAfterWindowEnd > 0) {
-        logger.warning(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
+        logger.debug(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
           committee_id: committeeId,
           dropped_count: droppedAfterWindowEnd,
           window_end,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -25,6 +25,7 @@ import {
   ShareWeeklyBriefToSlackResult,
   WeeklyBrief,
   WeeklyBriefActionItem,
+  WeeklyBriefCurrentActivity,
   WeeklyBriefCurrentResponse,
   WeeklyBriefRating,
 } from '@lfx-one/shared/interfaces';
@@ -96,6 +97,40 @@ export function briefWindow(): { window_start: string; window_end: string } {
   return {
     window_start: sunday.toISOString(),
     window_end: saturday.toISOString(),
+  };
+}
+
+/**
+ * Returns [this week's Sunday 00:00 UTC, now] — the in-progress-week semantics "this week so
+ * far" needs, as opposed to `briefWindow()`'s last-*completed*-week semantics (GH-1922). No
+ * Saturday-rollover branch: unlike `briefWindow()`, this always looks at the current week,
+ * every day of the week, including the still-open Sun–Fri span `briefWindow()` deliberately
+ * skips past.
+ */
+export function currentWeekInProgressWindow(): { window_start: string; window_end: string } {
+  const now = new Date();
+  const day = now.getUTCDay(); // 0 = Sunday
+  const sunday = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate() - day, 0, 0, 0, 0));
+  return { window_start: sunday.toISOString(), window_end: now.toISOString() };
+}
+
+/**
+ * Deterministic mock fixture for `WeeklyBriefCurrentResponse.current_activity` (GH-1922).
+ * Non-zero on purpose — mirrors the issue's own worked example ("1 meeting held, 1 vote
+ * closed, 1 document added") so mock mode exercises the multi-kind render, not just the
+ * empty state. Mock-only: there is no upstream committee-service endpoint for in-progress-week
+ * counts, so live mode never populates this field (see `getCurrentBrief`).
+ */
+function buildMockCurrentActivity(committeeId: string): WeeklyBriefCurrentActivity {
+  const { window_start, window_end } = currentWeekInProgressWindow();
+  return {
+    window_start,
+    window_end,
+    source_refs: [
+      { id: `mock-current-meeting-1-${committeeId}`, kind: 'meeting', title: 'Board Sync' },
+      { id: `mock-current-vote-1-${committeeId}`, kind: 'vote', title: 'Q3 Resolution' },
+      { id: `mock-current-doc-1-${committeeId}`, kind: 'doc', title: 'Meeting Minutes' },
+    ],
   };
 }
 
@@ -236,8 +271,12 @@ export class WeeklyBriefService {
           regenerations_used: brief.regeneration_count,
           window_resets_at: nextSundayIso(),
         },
+        current_activity: buildMockCurrentActivity(committeeId),
       };
     } else {
+      // No `current_activity` here — committee-service has no in-progress-week-counts
+      // endpoint yet (GH-1922), and this is a pure proxy passthrough, so the field is simply
+      // never present in the response rather than fabricated. Revisit once upstream adds it.
       logger.debug(req, 'get_weekly_brief_current', 'Proxying to committee-service', { committee_id: committeeId });
       response = await this.microserviceProxy.proxyRequest<WeeklyBriefCurrentResponse>(
         req,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1163,15 +1163,20 @@ export class WeeklyBriefService {
    * aggregation that powers the committee "Recent Activity" feed, filtered to the current,
    * not-yet-closed week. Gated to governance (Board/Government Advisory Council) committees only
    * — the only ones the client renders the tally for — so a non-Board committee's weekly-brief
-   * load never pays for `getCommitteeActivity`'s own 9-call upstream fan-out. The one
-   * `getCommitteeById` call needed to read `category` and make that gating decision runs for every
-   * committee regardless — it's a single lightweight lookup (the same cost
-   * `CommitteeActivityService`'s own internal `fetchCommittee` already pays on the "Recent
-   * Activity" feed), not the fan-out this comment is scoping. Fails soft to `undefined` (never an
-   * empty array) on any
-   * error, matching the client's existing absent-vs-present distinction between "couldn't
-   * determine" and "genuinely zero activity this week" (weekly-brief-card.component.ts's
-   * `hasCurrentActivityData`).
+   * load never pays for `getCommitteeActivity`'s own 9-call upstream fan-out. The gating read
+   * itself is NOT free, though: `getCommitteeById` fans out to three upstream calls of its own
+   * (base committee GET, settings, access-check) to read a `category` a plain GET would suffice
+   * for — every committee, governance or not, pays that regardless. Reusing the
+   * already-instantiated `committeeService` was a deliberate choice over a bare `proxyRequest`
+   * (the pattern `shareToSlack` uses below, for the same lightweight need): this method is
+   * invoked from every `getCurrentBrief` call, concurrently with `fetchBriefResponse`'s own
+   * `proxyRequest` call in live mode, and `proxyRequest` is a single shared mock this spec file's
+   * dozens of other describe blocks assert call counts/order against — a second, path-dispatched
+   * consumer of it would need surgical updates across all of them for a request-volume win with
+   * no correctness stake. Accepted as a known v1 cost, isolated to this one gating read. Fails
+   * soft to `undefined` (never an empty array) on any error, matching the client's existing
+   * absent-vs-present distinction between "couldn't determine" and "genuinely zero activity this
+   * week" (weekly-brief-card.component.ts's `hasCurrentActivityData`).
    *
    * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
    * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. Deliberately

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1309,12 +1309,15 @@ export class WeeklyBriefService {
 
       // Filtered to occurred_at <= window_end, not just >= window_start (the `since` param
       // above already narrows that half) — getCommitteeActivity has no `before`/upper-bound
-      // param of its own, and at least two legs can report an occurred_at ahead of "now": a
-      // vote administratively ended (status ENDED) with its own end_time still in the future
-      // stamps occurred_at from that future end_time (see mapVoteToEvent), and the survey leg's
-      // cutoff-driven occurred_at has the same shape (see fetchSurveyEvents in
-      // committee-activity.service.ts). Without this filter, window_end would advertise a bound
-      // the response doesn't actually honor. Numeric (Date.parse), not string, comparison —
+      // param of its own, and the vote leg can report an occurred_at arbitrarily far ahead of
+      // "now": a vote administratively ended (status ENDED) with its own end_time still in the
+      // future stamps occurred_at from that future end_time (see mapVoteToEvent). The survey
+      // leg's cutoff-driven occurred_at can NOT do the same — isCutoffDrivenClosure
+      // (committee-activity.service.ts) only adopts a cutoff once it's already passed, so the
+      // most it can exceed window_end by is this request's own in-flight latency between
+      // snapshotting window_end (above) and evaluating the cutoff, not an arbitrary future value.
+      // Without this filter, window_end would advertise a bound the response doesn't actually
+      // honor. Numeric (Date.parse), not string, comparison —
       // matches committee-activity.service.ts's own timestampValue convention rather than
       // assuming every occurred_at is byte-identically formatted to window_end's toISOString()
       // output. An unparseable occurred_at (NaN) is let through rather than dropped — unreachable

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -288,10 +288,12 @@ export class WeeklyBriefService {
    * activity cannot change mid-poll, so re-running the tally on every tick multiplies its real
    * upstream cost (getCommitteeById's 3 calls, plus getCommitteeActivity's own multi-call
    * aggregation for a governance committee) for a value that's already correct from the poll's
-   * first tick. The poll passes `includeCurrentActivity: false` only once it already holds a
-   * value, merging it forward client-side instead of re-fetching — and keeps asking (the
-   * default) whenever it doesn't, so a transient degrade on the initial load can still self-heal
-   * on a later tick rather than staying blank for the rest of the poll and beyond.
+   * first tick. The poll passes `includeCurrentActivity: false` only once the current_activity
+   * KEY is present on what it already holds (see `WeeklyBriefCurrentResponse.current_activity`'s
+   * doc comment for the absent/null/present contract this depends on — `null` is a settled
+   * answer and stops the asking same as a real value; only a genuinely absent key keeps the
+   * poll asking on every tick, so a transient degrade on the initial load can still self-heal on
+   * a later tick rather than staying blank for the rest of the poll and beyond).
    */
   public async getCurrentBrief(req: Request, committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Promise<WeeklyBriefCurrentResponse> {
     const includeCurrentActivity = options.includeCurrentActivity ?? true;
@@ -312,7 +314,10 @@ export class WeeklyBriefService {
       this.fetchBriefResponse(req, committeeId),
       includeCurrentActivity ? this.buildCurrentActivity(req, committeeId) : Promise.resolve(undefined),
     ]);
-    return currentActivity ? { ...response, current_activity: currentActivity } : response;
+    // !== undefined, not truthiness — currentActivity can be null (a settled "doesn't apply"
+    // answer, see buildCurrentActivity's doc comment), which is a real value the client needs
+    // to see, not an absence to fall through on.
+    return currentActivity !== undefined ? { ...response, current_activity: currentActivity } : response;
   }
 
   /**
@@ -1228,11 +1233,14 @@ export class WeeklyBriefService {
    * edge case relative to the `page_token`/`anyLegSaturated` gate this replaced (which fired on
    * nearly every long-lived board, every week).
    */
-  private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
+  private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
     try {
       logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
       const committee = await this.committeeService.getCommitteeById(req, committeeId);
-      if (!isGoverningBoard(committee.category)) return undefined;
+      // null, not undefined — see WeeklyBriefCurrentResponse.current_activity's doc comment.
+      // This committee will never become governance-classified mid-poll, so a caller (the
+      // client's pollUntilTerminal) can treat this as a settled answer and stop asking.
+      if (!isGoverningBoard(committee.category)) return null;
 
       const { window_start, window_end } = currentWeekInProgressWindow();
       const { data } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
@@ -1249,7 +1257,10 @@ export class WeeklyBriefService {
             committee_id: committeeId,
           }
         );
-        return undefined;
+        // null, not undefined — more in-window activity only ever accumulates within a poll
+        // cycle, never un-fills a full page, so this can't resolve differently on a later tick
+        // within the same cycle either.
+        return null;
       }
 
       const sourceRefs = data.reduce<WeeklyBriefSourceRef[]>((refs, event) => {
@@ -1263,6 +1274,8 @@ export class WeeklyBriefService {
         committee_id: committeeId,
         err,
       });
+      // undefined, not null — this failure is transient (a lookup/fetch error), unlike the two
+      // null cases above, so a caller is right to ask again.
       return undefined;
     }
   }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -304,11 +304,11 @@ export class WeeklyBriefService {
    * see `WeeklyBriefService#getWeeklyBrief` (the Angular client, `app/shared/services/`) for the
    * full breakdown:
    *   - `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on every
-   *     non-poll load (initial load, and every `refresh$`-triggered re-fetch — see that
-   *     component's own `refresh$.next()` call sites, not re-listed here to avoid this comment
-   *     drifting stale as they change) for any committee its own `isGoverningBoardCommittee()`
-   *     already reports as non-governance — the tally section can never render for one
-   *     regardless of what current_activity holds, so the fan-out would be pure waste.
+   *     non-poll load (see that method's `combineLatest` sources for what triggers one — not
+   *     re-listed here, since it's exactly the kind of detail that drifts stale as those sources
+   *     change) for any committee its own `isGoverningBoardCommittee()` already reports as
+   *     non-governance — the tally section can never render for one regardless of what
+   *     current_activity holds, so the fan-out would be pure waste.
    *   - `weekly-brief-card.component.ts`'s `pollUntilTerminal` is this endpoint's heaviest caller
    *     — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS` hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per
    *     generate/regenerate — and this week's activity cannot change mid-poll, so re-running the
@@ -1231,8 +1231,8 @@ export class WeeklyBriefService {
    * determine", worth asking again), `null` is settled ("known not to apply", see below), and a
    * real object is "genuinely zero activity this week" or more. `undefined`'s three actual causes
    * (see this method's body): `getCommitteeBase` resolves with no body at all; it resolves with a
-   * committee that carries no usable `category`; or any other error thrown by either upstream
-   * call, caught below.
+   * committee that carries no usable `category`; or any other error thrown while building the
+   * tally, caught below.
    * `weekly-brief-card.component.ts`'s `hasCurrentActivityData` collapses `undefined`/`null`
    * alike for rendering (neither is a value to show), but its `pollUntilTerminal` poll loop
    * depends on keeping them apart — see `WeeklyBriefCurrentResponse.current_activity`'s doc

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -288,8 +288,10 @@ export class WeeklyBriefService {
    * activity cannot change mid-poll, so re-running the tally on every tick multiplies its real
    * upstream cost (getCommitteeById's 3 calls, plus getCommitteeActivity's own multi-call
    * aggregation for a governance committee) for a value that's already correct from the poll's
-   * first tick. The poll passes `includeCurrentActivity: false` and merges the initial value
-   * forward client-side instead.
+   * first tick. The poll passes `includeCurrentActivity: false` only once it already holds a
+   * value, merging it forward client-side instead of re-fetching — and keeps asking (the
+   * default) whenever it doesn't, so a transient degrade on the initial load can still self-heal
+   * on a later tick rather than staying blank for the rest of the poll and beyond.
    */
   public async getCurrentBrief(req: Request, committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Promise<WeeklyBriefCurrentResponse> {
     const includeCurrentActivity = options.includeCurrentActivity ?? true;

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -159,8 +159,11 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds, but real governance activity the client's existing
  * "other" catch-all already surfaces rather than silently dropping; `other` has no
  * `resolveSourceRefAction` case (falls to its `default: return null`), so it carries no id
- * contract to protect either way, but is left unprefixed for the same "already unique on its own
- * uid" reason as vote.
+ * contract to protect the way `vote`'s or `meeting`'s does — but unlike those two, `other` mixes
+ * TWO upstream uid namespaces (`vote_uid` and `survey_uid`) in one rendered section, the same
+ * shape `doc`'s `document_type`/`meeting_scope` prefixing above already exists to guard, so both
+ * get the `vote:`/`survey:` prefix for the same reason, not left raw the way a single-namespace
+ * kind can be.
  *
  * `member_joined`/`member_left`/other deferred types are the only ones that actually reach the
  * `default: return null` branch below in practice: `CommitteeActivityService` never constructs
@@ -178,15 +181,19 @@ function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBrief
     // "Recent Activity" feed (mapActivityEventToDisplayText, activity-feed.utils.ts) already
     // renders vote_opened, so a week that opened a vote and this tally alone showed "no activity
     // yet" directly beneath a feed proving otherwise (general-code-reviewer, full-branch sweep).
+    // Prefixed, unlike `vote_closed` above: `other` now holds two upstream uid namespaces
+    // (vote_uid here, survey_uid below), the same two-namespace situation `doc`'s prefixing
+    // already exists to guard against, not the single-namespace case the unprefixed `vote` kind's
+    // own doc comment describes.
     case 'vote_opened':
-      return { id: event.payload.vote_uid, kind: 'other', title: event.payload.name };
+      return { id: `vote:${event.payload.vote_uid}`, kind: 'other', title: event.payload.name };
     case 'document_uploaded':
       return { id: `document:${event.payload.document_type}:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
     case 'notes_added':
       return { id: `note:${event.payload.meeting_scope}:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
     case 'survey_published':
     case 'survey_closed':
-      return { id: event.payload.survey_uid, kind: 'other', title: event.payload.title };
+      return { id: `survey:${event.payload.survey_uid}`, kind: 'other', title: event.payload.title };
     default:
       return null;
   }
@@ -1350,7 +1357,9 @@ export class WeeklyBriefService {
 
       const { window_start, window_end } = currentWeekInProgressWindow();
       // Passing `committee` (already resolved above) as getCommitteeActivity's knownCommittee —
-      // see this method's own doc comment for why.
+      // see this method's own doc comment for why. `quietAggregationLog: true` separately, since
+      // this is a per-poll-tick call, not the controller-driven feed read that method's own
+      // INFO-logging rationale is written for — see that call site's own comment.
       const { data } = await this.committeeActivityService.getCommitteeActivity(
         req,
         committeeId,
@@ -1358,7 +1367,8 @@ export class WeeklyBriefService {
           since: window_start,
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
         },
-        committee
+        committee,
+        /* quietAggregationLog */ true
       );
       logger.debug(req, 'get_weekly_brief_current_activity', 'Fetched current-week activity', { committee_id: committeeId, event_count: data.length });
       if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1185,27 +1185,17 @@ export class WeeklyBriefService {
    * not-yet-closed week. Gated to governance (Board/Government Advisory Council) committees only
    * — the only ones the client renders the tally for — so a non-Board committee's weekly-brief
    * load never pays for `getCommitteeActivity`'s own 9-call upstream fan-out. The gating read
-   * itself is NOT free, though: `getCommitteeById` fans out to three upstream calls of its own
-   * (base committee GET, settings, access-check) to read a `category` a plain GET would suffice
-   * for — every committee, governance or not, pays that regardless. Two cheaper alternatives were
-   * considered and both declined: a bare `proxyRequest` GET (the pattern `shareToSlack` uses
-   * above, for the same lightweight need) would run concurrently with `fetchBriefResponse`'s own
-   * `proxyRequest` call in live mode via the `Promise.all` above, and this spec file already has
-   * over a dozen order-sensitive `proxyRequest.mockResolvedValueOnce` queues elsewhere that a
-   * second, path-dispatched consumer risks silently shifting; `getCommitteesByIds` (a batched
-   * query-service read, used by `getMyCommittees`/`getMyPendingInvitations` — though for their own
-   * richer needs, not just `category`) avoids that mock family entirely, but `getMyCommittees`
-   * has to fall back to `membership.committee_category` when the indexed `category` comes back
-   * empty — an unquantified reliability gap, and a false negative on it would hide the tally for a
-   * real governance committee, worse than the extra calls this took instead. `getCommitteeById`
-   * reads the authoritative committee-service record directly, accepting the known extra cost
-   * over that unverified gap. Fails soft to `undefined` (never an empty array) on a genuine
-   * error — one of three states, not two: `undefined` is transient ("couldn't determine",
-   * worth asking again), `null` is settled ("known not to apply", see below), and a real object
-   * is "genuinely zero activity this week" or more. `weekly-brief-card.component.ts`'s
-   * `hasCurrentActivityData` collapses `undefined`/`null` alike for rendering (neither is a
-   * value to show), but its `pollUntilTerminal` poll loop depends on keeping them apart — see
-   * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the full contract.
+   * itself is `getCommitteeCategory` (a single plain GET), not `getCommitteeById` — this needs
+   * `category` alone, and `getCommitteeById`'s default options cost three upstream calls
+   * (including its own access-check, redundant with the controller's `assertCommitteeRead` on the
+   * same request) for data this call would only discard. Fails soft to `undefined` (never an
+   * empty array) on a genuine error — one of three states, not two: `undefined` is transient
+   * ("couldn't determine", worth asking again), `null` is settled ("known not to apply", see
+   * below), and a real object is "genuinely zero activity this week" or more.
+   * `weekly-brief-card.component.ts`'s `hasCurrentActivityData` collapses `undefined`/`null`
+   * alike for rendering (neither is a value to show), but its `pollUntilTerminal` poll loop
+   * depends on keeping them apart — see `WeeklyBriefCurrentResponse.current_activity`'s doc
+   * comment for the full contract.
    *
    * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
    * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. Deliberately
@@ -1242,11 +1232,21 @@ export class WeeklyBriefService {
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
     try {
       logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
-      const committee = await this.committeeService.getCommitteeById(req, committeeId);
+      const category = await this.committeeService.getCommitteeCategory(req, committeeId);
+      // undefined `category` here means the lookup itself came back empty (e.g. the committee
+      // vanished between the controller's assertCommitteeRead and this read) — a transient
+      // anomaly, not a governance verdict, so this falls through to the catch-equivalent
+      // undefined below rather than being asserted as "not governance".
+      if (category === undefined) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee category lookup returned nothing, omitting the tally', {
+          committee_id: committeeId,
+        });
+        return undefined;
+      }
       // null, not undefined — see WeeklyBriefCurrentResponse.current_activity's doc comment.
       // This committee will never become governance-classified mid-poll, so a caller (the
       // client's pollUntilTerminal) can treat this as a settled answer and stop asking.
-      if (!isGoverningBoard(committee.category)) return null;
+      if (!isGoverningBoard(category)) return null;
 
       const { window_start, window_end } = currentWeekInProgressWindow();
       const { data } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1236,11 +1236,11 @@ export class WeeklyBriefService {
     try {
       logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
       const category = await this.committeeService.getCommitteeCategory(req, committeeId);
-      // undefined `category` here means upstream resolved with no committee body at all (see
-      // getCommitteeCategory's own doc comment) — a genuine 404/upstream error throws instead
-      // and is caught below, same as any other failure in this method. Either way this is an
-      // anomaly, not a governance verdict, so it falls through to undefined rather than being
-      // asserted as "not governance".
+      // undefined `category` here means upstream resolved with no `category` on the body —
+      // absent/null field, or an empty body (see getCommitteeCategory's own doc comment) — a
+      // genuine 404/upstream error throws instead and is caught below, same as any other
+      // failure in this method. Either way this is an anomaly, not a governance verdict, so it
+      // falls through to undefined rather than being asserted as "not governance".
       if (category === undefined) {
         logger.warning(req, 'get_weekly_brief_current_activity', 'Committee category lookup returned nothing, omitting the tally', {
           committee_id: committeeId,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1339,13 +1339,17 @@ export class WeeklyBriefService {
    * individual leg's single upstream page can under-report while the merged, capped `data.length`
    * still lands under `limit`. Deliberately not re-derived here leg-by-leg — a summary of which mechanism hits which
    * leg is exactly the kind of detail that silently drifts out of sync with its source as that
-   * source evolves, and none of it crosses the `getCommitteeActivity` boundary as a signal this
-   * caller could gate on regardless: only a single merged `page_token` comes back, no per-leg flag.
-   * Closing this for real would need `getCommitteeActivity` to expose a per-leg completeness signal
-   * it doesn't return today — not done here to avoid changing the public contract of an endpoint
-   * the real "Recent Activity" feed also consumes, for a v1 tally where this is already a narrow
-   * edge case relative to the `page_token`/`anyLegSaturated` gate this replaced (which fired on
-   * nearly every long-lived board, every week).
+   * source evolves. This residual is narrower than it was when first written: `any_leg_failed`
+   * (GH-1967's addition to `CommitteeActivityResponse`) closes the outright-leg-error half of this
+   * gap — handled explicitly above, independent of this gate — leaving only the harder-to-signal
+   * half: a leg that fetched successfully but under-reported for a reason that isn't "erred" or
+   * "this specific committee's own upstream page saturated" (e.g. an FGA-filtered-empty page, or
+   * a sort-order mismatch against `occurred_at` — see committee-activity.service.ts's own
+   * comments). Nothing crosses the `getCommitteeActivity` boundary as a signal this caller could
+   * gate on for that narrower remainder today. `any_leg_saturated` deliberately still isn't part
+   * of this gate, unlike `any_leg_failed` above — see this method's own comment on why two of the
+   * five legs' saturation reflects lifetime volume, not this week's, and would falsely hide the
+   * tally for exactly the long-lived committees it exists to help.
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
     try {
@@ -1382,7 +1386,7 @@ export class WeeklyBriefService {
       // see this method's own doc comment for why. `quietAggregationLog: true` separately, since
       // this is a per-poll-tick call, not the controller-driven feed read that method's own
       // INFO-logging rationale is written for — see that call site's own comment.
-      const { data } = await this.committeeActivityService.getCommitteeActivity(
+      const { data, any_leg_failed } = await this.committeeActivityService.getCommitteeActivity(
         req,
         committeeId,
         {
@@ -1392,6 +1396,23 @@ export class WeeklyBriefService {
         { knownCommittee: committee, quietAggregationLog: true }
       );
       logger.debug(req, 'get_weekly_brief_current_activity', 'Fetched current-week activity', { committee_id: committeeId, event_count: data.length });
+      // `any_leg_failed` (GH-1967's addition to CommitteeActivityResponse, not available when
+      // this method was first written): unlike `any_leg_saturated` below, a leg failure isn't
+      // proportional to a committee's lifetime volume, so it carries none of the false-positive
+      // risk that rules out gating on saturation — a leg either errored on this call or it
+      // didn't. And unlike the page-fill gate below, this can under-report at ANY count,
+      // including a comfortably-under-cap or even zero one: a failed vote/meeting/document leg
+      // degrades to `{ events: [], saturated: false }` in committee-activity.service.ts,
+      // indistinguishable from a leg that genuinely had nothing this week. `undefined`, not
+      // `null` — a leg failure is transient (the same upstream call can succeed on the next poll
+      // tick), unlike the page-fill gate's `null`, which this method's own doc comment already
+      // establishes is provably permanent within a poll cycle.
+      if (any_leg_failed) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'One or more activity legs failed, omitting the tally rather than publishing an undercount', {
+          committee_id: committeeId,
+        });
+        return undefined;
+      }
 
       // Filtered to occurred_at <= window_end, not just >= window_start (the `since` param
       // above already narrows that half) — getCommitteeActivity has no `before`/upper-bound

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1169,15 +1169,22 @@ export class WeeklyBriefService {
    * `hasCurrentActivityData`).
    *
    * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
-   * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. A returned
-   * `page_token` means real events exist beyond it; unlike the paginated Recent Activity feed,
-   * this consumer renders a *count* ("N documents added"), so silently truncating would state a
-   * wrong number as fact — worse than the list-truncation the per-leg `saturated` flags already
-   * accept elsewhere in `CommitteeActivityService`. Treated as "couldn't determine" (`undefined`),
-   * not published truncated, matching this method's own fail-soft contract. Not looped to
+   * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. Deliberately
+   * NOT gated on the returned `page_token`/its underlying `anyLegSaturated` flag: two of the five
+   * legs (`fetchNotesAddedEvents`, `fetchSurveyEvents`) never push `since` upstream at all (see
+   * their own doc comments in `committee-activity.service.ts` for why), so they fetch each
+   * committee's newest `fetchSize` rows by `updated_desc` and filter to the window in memory —
+   * their own `saturated` flag reflects whether the committee has more than `fetchSize` *lifetime*
+   * notes/surveys, not whether THIS WEEK's activity was truncated. Gating on that would silently
+   * hide the tally for exactly the long-lived, active committees it exists to help. Instead, gate
+   * on `data.length` — the merged, window-filtered, already-capped-at-`limit` result: only when it
+   * actually fills the page (`>= limit`) can real in-window rows have been cut. Unlike the
+   * paginated Recent Activity feed, this consumer renders a *count* ("N documents added"), so
+   * silently truncating would state a wrong number as fact — treated as "couldn't determine"
+   * (`undefined`) instead, matching this method's own fail-soft contract. Not looped to
    * exhaustion — `decodePageToken`/`ActivityPageCursor` aren't exposed for a caller outside
-   * `committee-activity.service.ts` to do that today, and a committee clearing 50 events in one
-   * week is already an edge case this v1 tally accepts skipping.
+   * `committee-activity.service.ts` to do that today, and a committee generating 50 in-window
+   * events in one week is already an edge case this v1 tally accepts skipping.
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
     try {
@@ -1185,14 +1192,19 @@ export class WeeklyBriefService {
       if (!isGoverningBoard(committee.category)) return undefined;
 
       const { window_start, window_end } = currentWeekInProgressWindow();
-      const { data, page_token: pageToken } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
+      const { data } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
         since: window_start,
         limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
       });
-      if (pageToken) {
-        logger.warning(req, 'get_weekly_brief_current_activity', 'Current-week activity exceeds one page — omitting rather than publishing a truncated count', {
-          committee_id: committeeId,
-        });
+      if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
+        logger.warning(
+          req,
+          'get_weekly_brief_current_activity',
+          'Current-week activity fills a full page — omitting rather than publishing a truncated count',
+          {
+            committee_id: committeeId,
+          }
+        );
         return undefined;
       }
 
@@ -1212,10 +1224,11 @@ export class WeeklyBriefService {
   }
 
   /**
-   * Enriches a `getCurrentBrief` result with the caller's own rating on that exact brief
-   * revision (LFXV2-3042). Fails soft on every edge: no brief, no resolvable username, or a
-   * cache miss/fault all resolve to `caller_rating: null` rather than throwing — this is a
-   * convenience read for the UI's pre-lit thumb state, not a precondition for anything.
+   * Enriches a `fetchBriefResponse` result (called from both `getCurrentBrief` and every other
+   * internal caller that needs `brief`/`caller_rating`) with the caller's own rating on that
+   * exact brief revision (LFXV2-3042). Fails soft on every edge: no brief, no resolvable
+   * username, or a cache miss/fault all resolve to `caller_rating: null` rather than throwing —
+   * this is a convenience read for the UI's pre-lit thumb state, not a precondition for anything.
    */
   private async withCallerRating(req: Request, committeeId: string, response: WeeklyBriefCurrentResponse): Promise<WeeklyBriefCurrentResponse> {
     if (!response.brief) return response;
@@ -1248,7 +1261,7 @@ export class WeeklyBriefService {
    * the thumb against content the rater never actually reviewed (PR #1361 review). Matches the
    * optimistic-concurrency contract `saveBrief`/`shareBrief` already enforce for their own writes.
    *
-   * Also returns the brief's `caller_rating` (already resolved by `getCurrentBrief` →
+   * Also returns the brief's `caller_rating` (already resolved by `fetchBriefResponse` →
    * `withCallerRating` for this exact key) as `callerRating`, so `rateBrief`/`clearBriefRating`
    * can use it as `previous_rating` in their log line without a second, identical Valkey read for
    * a key this call already read.

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -180,7 +180,7 @@ function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBrief
     // tally's only vote phrase), but dropping it produced a same-page contradiction — the
     // "Recent Activity" feed (mapActivityEventToDisplayText, activity-feed.utils.ts) already
     // renders vote_opened, so a week that opened a vote and this tally alone showed "no activity
-    // yet" directly beneath a feed proving otherwise (general-code-reviewer, full-branch sweep).
+    // yet" directly beneath a feed proving otherwise.
     // Prefixed, unlike `vote_closed` above: `other` now holds two upstream uid namespaces
     // (vote_uid here, survey_uid below), the same two-namespace situation `doc`'s prefixing
     // already exists to guard against, not the single-namespace case the unprefixed `vote` kind's

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1259,17 +1259,23 @@ export class WeeklyBriefService {
     try {
       logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
       const committee = await this.committeeService.getCommitteeBase(req, committeeId);
-      // undefined `committee`, OR a resolved committee with no `category` (its type declares
-      // `category` required — committee.interface.ts — but that's a contract on well-formed
-      // upstream data, not a runtime guarantee against a malformed body), means upstream
-      // resolved with no usable category to classify on. A genuine 404/upstream error throws
-      // instead and is caught below, same as any other failure in this method. Either way this
-      // is an anomaly, not a governance verdict, so it falls through to undefined rather than
-      // being asserted as "not governance" — isGoverningBoard(undefined) below would otherwise
-      // return false and this would settle to `null` (permanent) for what might just be a
-      // transient partial response, worth asking again on the next poll tick.
-      if (committee === undefined || committee.category === undefined) {
-        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee lookup returned nothing usable to classify on, omitting the tally', {
+      if (committee === undefined) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee lookup returned nothing, omitting the tally', { committee_id: committeeId });
+        return undefined;
+      }
+      // Falsy, not just `=== undefined` — a resolved committee with no `category` (its type
+      // declares `category` required — committee.interface.ts — but that's a contract on
+      // well-formed upstream data, not a runtime guarantee against a malformed body) is
+      // unclassifiable the same way `getGroupBehavioralClass` itself already treats `undefined`,
+      // `null`, and `''` identically (`if (!category) return 'other'` — committee.utils.ts). A
+      // genuine 404/upstream error throws instead and is caught below, same as any other failure
+      // in this method. Either way this is an anomaly, not a governance verdict, so it falls
+      // through to undefined rather than being asserted as "not governance" —
+      // isGoverningBoard('')/isGoverningBoard(undefined) both return false, which would settle
+      // this to `null` (permanent) for what might just be a transient partial response, worth
+      // asking again on the next poll tick.
+      if (!committee.category) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee resolved with no usable category, omitting the tally', {
           committee_id: committeeId,
         });
         return undefined;

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1171,17 +1171,16 @@ export class WeeklyBriefService {
    * above, for the same lightweight need) would run concurrently with `fetchBriefResponse`'s own
    * `proxyRequest` call in live mode via the `Promise.all` above, and this spec file already has
    * over a dozen order-sensitive `proxyRequest.mockResolvedValueOnce` queues elsewhere that a
-   * second, path-dispatched consumer risks silently shifting; `getCommitteesByIds` (a single
-   * batched query-service call, used by `getMyCommittees`/`getMyPendingInvitations` for the same
-   * "just need `category`" need) avoids that mock entirely, but that same call site falls back to
-   * `membership.committee_category` when the indexed `category` comes back empty — a reliability
-   * gap not investigated here, and a false negative on it would hide the tally for a real
-   * governance committee, worse than the extra calls this took instead. Reusing the
-   * already-instantiated `committeeService.getCommitteeById` accepts the known extra cost in
-   * exchange for the same category reliability every other governance-gated read in this codebase
-   * already trusts. Fails soft to `undefined` (never an empty array) on any error, matching the
-   * client's existing absent-vs-present distinction between "couldn't determine" and "genuinely
-   * zero activity this week" (weekly-brief-card.component.ts's `hasCurrentActivityData`).
+   * second, path-dispatched consumer risks silently shifting; `getCommitteesByIds` (a batched
+   * query-service read, used by `getMyCommittees`/`getMyPendingInvitations` — though for their own
+   * richer needs, not just `category`) avoids that mock family entirely, but `getMyCommittees`
+   * has to fall back to `membership.committee_category` when the indexed `category` comes back
+   * empty — an unquantified reliability gap, and a false negative on it would hide the tally for a
+   * real governance committee, worse than the extra calls this took instead. `getCommitteeById`
+   * reads the authoritative committee-service record directly, accepting the known extra cost
+   * over that unverified gap. Fails soft to `undefined` (never an empty array) on any error,
+   * matching the client's existing absent-vs-present distinction between "couldn't determine" and
+   * "genuinely zero activity this week" (weekly-brief-card.component.ts's `hasCurrentActivityData`).
    *
    * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
    * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. Deliberately

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1303,18 +1303,23 @@ export class WeeklyBriefService {
    * notes/surveys, not whether THIS WEEK's activity was truncated. Gating on that would silently
    * hide the tally for exactly the long-lived, active committees it exists to help.
    *
-   * Gate on the filtered `sourceRefs.length`, not the raw merged/capped `data.length` — this
-   * method's body filters `data` to `occurred_at <= window_end` before the gate runs, specifically
-   * so a page saturated with administratively-closed, future-stamped votes (destined to be
-   * filtered out anyway) can't settle a comfortably-under-the-cap committee to `null`. When the
-   * filtered count itself fills the page (`>= limit`, which also implies nothing was filtered
-   * out — `sourceRefs.length` can never exceed `data.length`), real in-window rows may have been
-   * cut, so this returns `null` (a settled "can't state a count as fact" answer, not a transient
-   * "couldn't determine") rather than a truncated count stated as fact — see
+   * Gate on `sourceRefs.length + unmappedInWindow`, not the raw merged/capped `data.length` and
+   * not bare `sourceRefs.length` either — this method's body filters `data` to `occurred_at <=
+   * window_end` before the gate runs, specifically so a page saturated with administratively-
+   * closed, future-stamped votes (destined to be dropped anyway) can't settle a comfortably-
+   * under-the-cap committee to `null`. Only that window_end drop is safe to exclude, though:
+   * `unmappedInWindow` counts in-window events mapActivityEventToCurrentActivityRef doesn't
+   * recognize, which is NOT proof those events don't belong in the tally — just that this method
+   * can't render them yet — so the gate adds them back in rather than treating them the same as
+   * genuine out-of-window noise. When the sum fills the page (`>= limit`, which also implies
+   * nothing was dropped for the one proven-safe reason — window_end — since `sourceRefs.length +
+   * unmappedInWindow` can never exceed `data.length`), real in-window rows may have been cut, so
+   * this returns `null` (a settled "can't state a count as fact" answer, not a transient "couldn't
+   * determine") rather than a truncated count stated as fact — see
    * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for why `null` here, not
    * `undefined`.
    *
-   * Known v1 residual (accepted, not solved): `sourceRefs.length < limit` is a heuristic, not a
+   * Known v1 residual (accepted, not solved): `sourceRefs.length + unmappedInWindow < limit` is a heuristic, not a
    * proof of completeness. `committee-activity.service.ts` documents — in its own "Filter
    * dimension" (its exact label), sort-dimension ("Votes, surveys, files, and notes are all in a
    * different, genuinely-approximate bucket"), and FGA-post-filter comments — several ways an
@@ -1400,8 +1405,19 @@ export class WeeklyBriefService {
       // to be dropped here anyway, settling a comfortably-under-the-cap committee to `null` for no
       // real reason. Gating on the filtered count instead only trips when the events that actually
       // make it into the tally themselves fill the page.
+      // `unmappedInWindow` (events that pass the window_end filter but that
+      // mapActivityEventToCurrentActivityRef's `default: return null` branch doesn't recognize —
+      // unreached today, since CommitteeActivityService never constructs a DeferredActivityEvent,
+      // but type-legal) is tracked separately from droppedAfterWindowEnd and, unlike it, counts
+      // toward the truncation gate below. The two are NOT symmetric: a window-filtered event is
+      // *proven* not to belong in this week's tally (its occurred_at is after window_end), so
+      // excluding it from the gate is safe. An unmapped-but-in-window event is NOT proven
+      // irrelevant — it may well belong in the tally, this method just has no rendering for it —
+      // so a full raw page dominated by these must still be treated as possibly truncated, not
+      // waved through the way genuine future-noise is.
       const windowEndMs = Date.parse(window_end);
       let droppedAfterWindowEnd = 0;
+      let unmappedInWindow = 0;
       const sourceRefs = data.reduce<WeeklyBriefSourceRef[]>((refs, event) => {
         const eventMs = Date.parse(event.occurred_at);
         if (!Number.isNaN(eventMs) && eventMs > windowEndMs) {
@@ -1409,7 +1425,11 @@ export class WeeklyBriefService {
           return refs;
         }
         const ref = mapActivityEventToCurrentActivityRef(event);
-        if (ref) refs.push(ref);
+        if (ref) {
+          refs.push(ref);
+        } else {
+          unmappedInWindow += 1;
+        }
         return refs;
       }, []);
       // DEBUG, not WARN — the vote leg's occurred_at-ahead-of-"now" case (see the filter's own
@@ -1428,7 +1448,7 @@ export class WeeklyBriefService {
         });
       }
 
-      if (sourceRefs.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
+      if (sourceRefs.length + unmappedInWindow >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
         logger.warning(
           req,
           'get_weekly_brief_current_activity',

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1176,15 +1176,24 @@ export class WeeklyBriefService {
    * committee's newest `fetchSize` rows by `updated_desc` and filter to the window in memory —
    * their own `saturated` flag reflects whether the committee has more than `fetchSize` *lifetime*
    * notes/surveys, not whether THIS WEEK's activity was truncated. Gating on that would silently
-   * hide the tally for exactly the long-lived, active committees it exists to help. Instead, gate
-   * on `data.length` — the merged, window-filtered, already-capped-at-`limit` result: only when it
-   * actually fills the page (`>= limit`) can real in-window rows have been cut. Unlike the
-   * paginated Recent Activity feed, this consumer renders a *count* ("N documents added"), so
-   * silently truncating would state a wrong number as fact — treated as "couldn't determine"
-   * (`undefined`) instead, matching this method's own fail-soft contract. Not looped to
-   * exhaustion — `decodePageToken`/`ActivityPageCursor` aren't exposed for a caller outside
-   * `committee-activity.service.ts` to do that today, and a committee generating 50 in-window
-   * events in one week is already an edge case this v1 tally accepts skipping.
+   * hide the tally for exactly the long-lived, active committees it exists to help.
+   *
+   * Gate on `data.length` instead — the merged, window-filtered, already-capped-at-`limit` result:
+   * when it fills the page (`>= limit`), real in-window rows may have been cut, so this is treated
+   * as "couldn't determine" (`undefined`) rather than a truncated count stated as fact, matching
+   * this method's own fail-soft contract.
+   *
+   * Known v1 residual (accepted, not solved — same class of gap `committee-activity.service.ts`'s
+   * own "Known v1 limitation"/FGA-post-filter comments already document for this exact endpoint):
+   * `data.length < limit` is NOT a airtight completeness proof for the three legs that DO push
+   * `since` upstream (meetings/votes/documents) — `CommitteeActivityService`'s own docs note FGA
+   * access-checking runs after OpenSearch paginates, so one of those legs can come back under
+   * `fetchSize` visible rows on a single fetched page while `saturated` is still true, i.e. an
+   * under-count this guard won't catch. Closing that fully would need `getCommitteeActivity` to
+   * expose a window-bounded-only saturation signal (excluding notes/surveys) it doesn't return
+   * today — not done here to avoid changing the public contract of an endpoint the real "Recent
+   * Activity" feed also consumes, for a v1 tally where a committee generating ~50 in-window events
+   * in one week, right at the FGA-thinning boundary, is already a narrow edge case.
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
     try {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -129,9 +129,10 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * only vote phrase is literally "vote closed" (`WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES` has no
  * "vote opened" entry), and an in-progress, not-yet-closed vote isn't that yet. It still can't be
  * dropped outright (the `null` this file used to return here): the "Recent Activity" feed on the
- * same committee-overview page renders `vote_opened` directly, so a week that opened but hasn't
- * yet closed a vote must not report itself as "no activity yet" while the feed right below it
- * proves otherwise. `document_uploaded` and `notes_added` both collapse to kind `doc` — both are
+ * same committee-overview page renders `vote_opened` directly for any voting-enabled committee, so
+ * a week that opened but hasn't yet closed a vote must not report itself as "no activity yet"
+ * while the feed right below it proves otherwise. `document_uploaded` and `notes_added` both
+ * collapse to kind `doc` — both are
  * "a document-like artifact was added this week," and the tally doesn't need to distinguish
  * committee-document files/folders/links from meeting-attachment notes — but their ids DO carry
  * the same namespace discriminants `committee-activity.service.ts`'s own `eventKey()` uses
@@ -178,9 +179,9 @@ function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBrief
       return { id: event.payload.vote_uid, kind: 'vote', title: event.payload.name };
     // Folds into `other`, not dropped: an open-but-not-yet-closed vote isn't "vote closed" (the
     // tally's only vote phrase), but dropping it produced a same-page contradiction — the
-    // "Recent Activity" feed (mapActivityEventToFeedItem, activity-feed.utils.ts) already renders
-    // vote_opened for any committee with voting enabled, so a week whose only activity was opening
-    // a vote would have shown "no activity yet" directly beneath a feed proving otherwise.
+    // "Recent Activity" feed (mapActivityEventsToFeedItems, activity-feed.utils.ts) already
+    // renders vote_opened for any committee with voting enabled, so a week whose only activity was
+    // opening a vote would have shown "no activity yet" directly beneath a feed proving otherwise.
     // Prefixed, unlike `vote_closed` above: `other` now holds two upstream uid namespaces
     // (vote_uid here, survey_uid below), the same two-namespace situation `doc`'s prefixing
     // already exists to guard against, not the single-namespace case the unprefixed `vote` kind's

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -286,7 +286,7 @@ export class WeeklyBriefService {
    * `pollUntilTerminal`) is this endpoint's heaviest caller — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS`
    * hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per generate/regenerate — and this week's
    * activity cannot change mid-poll, so re-running the tally on every tick multiplies its real
-   * upstream cost (getCommitteeById's 3 calls, plus getCommitteeActivity's own multi-call
+   * upstream cost (getCommitteeCategory's one call, plus getCommitteeActivity's own multi-call
    * aggregation for a governance committee) for a value that's already correct from the poll's
    * first tick. The poll passes `includeCurrentActivity: false` only once the current_activity
    * KEY is present on what it already holds (see `WeeklyBriefCurrentResponse.current_activity`'s
@@ -307,9 +307,9 @@ export class WeeklyBriefService {
     // Only built here, not inside fetchBriefResponse — every internal caller that reuses that
     // helper (getActionItems, shareBrief, shareToSlack, resolveRatableBrief) only ever reads
     // brief/caller_rating off the result, so building the tally for them too would pay a real
-    // upstream fan-out (getCommitteeById, and for a governance committee, CommitteeActivityService's
-    // own multi-call aggregation) for a field they'd discard on every write path (share, rate) and
-    // every read of just the AI-extracted action items.
+    // upstream fan-out (getCommitteeCategory, and for a governance committee,
+    // CommitteeActivityService's own multi-call aggregation) for a field they'd discard on every
+    // write path (share, rate) and every read of just the AI-extracted action items.
     const [response, currentActivity] = await Promise.all([
       this.fetchBriefResponse(req, committeeId),
       includeCurrentActivity ? this.buildCurrentActivity(req, committeeId) : Promise.resolve(undefined),
@@ -1187,11 +1187,14 @@ export class WeeklyBriefService {
    * load never pays for `getCommitteeActivity`'s own 9-call upstream fan-out. The gating read
    * itself is `getCommitteeCategory` (a single plain GET), not `getCommitteeById` — this needs
    * `category` alone, and `getCommitteeById`'s default options cost three upstream calls
-   * (including its own access-check, redundant with the controller's `assertCommitteeRead` on the
-   * same request) for data this call would only discard. Fails soft to `undefined` (never an
-   * empty array) on a genuine error — one of three states, not two: `undefined` is transient
-   * ("couldn't determine", worth asking again), `null` is settled ("known not to apply", see
-   * below), and a real object is "genuinely zero activity this week" or more.
+   * (base GET, settings, an access-check) for data this call would only discard.
+   * `getCommitteeCategory` performs no access check of its own — safe here only because this
+   * method's one caller, `getCurrentBrief`, is reachable exclusively through the controller's
+   * `assertCommitteeRead` gate; a new caller of `getCommitteeCategory` would need its own. Fails
+   * soft to `undefined` (never an empty array) on a genuine error — one of three states, not two:
+   * `undefined` is transient ("couldn't determine", worth asking again), `null` is settled
+   * ("known not to apply", see below), and a real object is "genuinely zero activity this week"
+   * or more.
    * `weekly-brief-card.component.ts`'s `hasCurrentActivityData` collapses `undefined`/`null`
    * alike for rendering (neither is a value to show), but its `pollUntilTerminal` poll loop
    * depends on keeping them apart — see `WeeklyBriefCurrentResponse.current_activity`'s doc
@@ -1233,10 +1236,11 @@ export class WeeklyBriefService {
     try {
       logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
       const category = await this.committeeService.getCommitteeCategory(req, committeeId);
-      // undefined `category` here means the lookup itself came back empty (e.g. the committee
-      // vanished between the controller's assertCommitteeRead and this read) — a transient
-      // anomaly, not a governance verdict, so this falls through to the catch-equivalent
-      // undefined below rather than being asserted as "not governance".
+      // undefined `category` here means upstream resolved with no committee body at all (see
+      // getCommitteeCategory's own doc comment) — a genuine 404/upstream error throws instead
+      // and is caught below, same as any other failure in this method. Either way this is an
+      // anomaly, not a governance verdict, so it falls through to undefined rather than being
+      // asserted as "not governance".
       if (category === undefined) {
         logger.warning(req, 'get_weekly_brief_current_activity', 'Committee category lookup returned nothing, omitting the tally', {
           committee_id: committeeId,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1183,27 +1183,32 @@ export class WeeklyBriefService {
    * as "couldn't determine" (`undefined`) rather than a truncated count stated as fact, matching
    * this method's own fail-soft contract.
    *
-   * Known v1 residual (accepted, not solved — same class of gap `committee-activity.service.ts`'s
-   * own "Known v1 limitation" comment already documents for this exact endpoint): `data.length <
-   * limit` is NOT an airtight completeness proof, for two independent reasons neither leg-specific
-   * check above rules out:
-   *   - Meetings/votes/documents DO push `since` upstream, but `CommitteeActivityService`'s own
-   *     docs note two ways a leg can still under-report while `saturated` stays true: (a) FGA
-   *     access-checking runs after OpenSearch paginates, so a fetched page can come back with
-   *     fewer *visible* rows than requested; (b) votes/documents only narrow on an *approximating*
-   *     upstream `date_field` (not their real, multi-field `occurred_at`), so upstream can
-   *     over-include stale rows that the in-memory `since` pass then trims, again leaving
-   *     `data.length` under `limit` on a page that was genuinely truncated.
-   *   - Notes/surveys' `sort: updated_desc` resolves to the index's own audit `updated_at`, not a
-   *     domain timestamp — an edit or re-index of an old, out-of-window row can push a genuinely
-   *     in-window note/survey out of the top `fetchSize` entirely, with no `saturated` signal to
-   *     catch it at all (this is on top of, not instead of, why their `saturated` flag is ignored
-   *     above).
+   * Known v1 residual (accepted, not solved — same class of gap `committee-activity.service.ts`
+   * documents for this exact endpoint, across its filter-dimension, sort-dimension, and
+   * FGA-post-filter comments): `data.length < limit` is NOT an airtight completeness proof, for
+   * two independent reasons neither leg-specific check above rules out:
+   *   - Filter dimension (votes/documents): these legs push `since` upstream, but only via an
+   *     *approximating* `date_field` (not their real, multi-field `occurred_at`), and FGA
+   *     access-checking runs after OpenSearch paginates — both can leave a leg's single fetched
+   *     page short of every genuinely in-window row. FGA post-filtering can do this while
+   *     `saturated` stays true; the `date_field` approximation can do it either direction —
+   *     over-inclusion (stale rows the in-memory `since` pass trims, still costing a `fetchSize`
+   *     slot) or under-inclusion (a real in-window row excluded upstream before that pass ever
+   *     sees it, which the pass can only trim, never restore — `committee-activity.service.ts`
+   *     documents it as the backstop against over-inclusion, not under-inclusion). Meetings are
+   *     exempt from this bullet: their sort/filter field is derived identically to `occurred_at`,
+   *     so it's exact, not approximating.
+   *   - Sort dimension (votes/surveys/documents/notes): `sort: updated_desc` resolves to the
+   *     index's own write-audit `updated_at`, not a domain timestamp, for all four legs — an edit
+   *     or re-index of an old, out-of-window row can push a genuinely in-window row out of the top
+   *     `fetchSize` entirely. Each leg's own `saturated`/`page_token` flag is no help here either —
+   *     it's set for the same lifetime-volume reason that makes it unusable above (see this
+   *     method's own doc comment), not because this specific week's rows were displaced.
    * Closing either fully would need `getCommitteeActivity` to expose a per-leg completeness signal
    * it doesn't return today — not done here to avoid changing the public contract of an endpoint
    * the real "Recent Activity" feed also consumes, for a v1 tally where any of these is already a
-   * narrow edge case relative to the false-negative this commit fixes (which fired on nearly every
-   * long-lived board, every week).
+   * narrow edge case relative to the `page_token`/`anyLegSaturated` gate this replaced (which fired
+   * on nearly every long-lived board, every week).
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
     try {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -128,13 +128,17 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * (`WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`), and an in-progress, not-yet-closed vote isn't that
  * yet. `document_uploaded` and `notes_added` both collapse to kind `doc` — both are "a
  * document-like artifact was added this week," and the tally doesn't need to distinguish
- * committee-document files/folders/links from meeting-attachment notes; their ids are prefixed
- * per source (mirroring `committee-activity.service.ts`'s own `eventKey()` convention) since
- * they're different upstream uid namespaces and could otherwise collide. `survey_published`/
- * `survey_closed` map to kind `other` — not one of `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds,
- * but real governance activity the client's existing "other" catch-all already surfaces rather
- * than silently dropping. `member_joined`/`member_left`/other deferred types: `CommitteeActivityService`
- * never actually constructs these today (see `DeferredActivityEvent`'s own doc comment), so this
+ * committee-document files/folders/links from meeting-attachment notes — but their ids DO carry
+ * the same namespace discriminants `committee-activity.service.ts`'s own `eventKey()` uses
+ * (`document_type` / `meeting_scope`), not just a `document_uid`, since — per `ActivityEvent`'s
+ * own doc comments — those are two distinct upstream uid namespaces that could otherwise collide
+ * (e.g. a folder and a meeting-attachment note coincidentally sharing a uid), and a collision here
+ * would produce two refs with the same `id` in the same rendered `doc` section (an Angular
+ * duplicate-`@for`-track-key error, not a silent dedupe). `survey_published`/`survey_closed` map
+ * to kind `other` — not one of `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds, but real governance
+ * activity the client's existing "other" catch-all already surfaces rather than silently
+ * dropping. `member_joined`/`member_left`/other deferred types: `CommitteeActivityService` never
+ * actually constructs these today (see `DeferredActivityEvent`'s own doc comment), so this
  * default branch is unreached in practice, not dead by construction.
  */
 function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBriefSourceRef | null {
@@ -144,9 +148,9 @@ function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBrief
     case 'vote_closed':
       return { id: `vote:${event.payload.vote_uid}`, kind: 'vote', title: event.payload.name };
     case 'document_uploaded':
-      return { id: `document:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
+      return { id: `document:${event.payload.document_type}:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
     case 'notes_added':
-      return { id: `note:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
+      return { id: `note:${event.payload.meeting_scope}:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
     case 'survey_published':
     case 'survey_closed':
       return { id: `survey:${event.payload.survey_uid}`, kind: 'other', title: event.payload.title };
@@ -274,43 +278,25 @@ export class WeeklyBriefService {
   private aiService: AiService = new AiService();
 
   /**
-   * GET /committees/:committeeId/weekly-briefs/current
-   *
-   * Upstream's own contract is 200-with-null-brief-and-throttle when no draft
-   * exists yet for the window — a 404 here means "committee not found", a
-   * real error the caller needs to see, not an empty-brief state to paper
-   * over.
+   * GET /committees/:committeeId/weekly-briefs/current — see `fetchBriefResponse` for the
+   * mock/live `brief`/`throttle` contract this builds on.
    */
   public async getCurrentBrief(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
-    let response: WeeklyBriefCurrentResponse;
-    if (!this.isLive(req)) {
-      const brief = currentMockBrief(committeeId);
-      response = {
-        brief,
-        throttle: {
-          ...WEEKLY_BRIEF_DEFAULT_THROTTLE,
-          generates_used: 1,
-          regenerations_used: brief.regeneration_count,
-          window_resets_at: nextSundayIso(),
-        },
-      };
-    } else {
-      logger.debug(req, 'get_weekly_brief_current', 'Proxying to committee-service', { committee_id: committeeId });
-      response = await this.microserviceProxy.proxyRequest<WeeklyBriefCurrentResponse>(
-        req,
-        'LFX_V2_SERVICE',
-        `/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`,
-        'GET'
-      );
-    }
-    // Sourced from CommitteeActivityService's existing live aggregation (GH-1922 rework) — runs
-    // identically in mock and live mode, since that service has no mock/live split of its own.
-    // Only the AI-generated brief_text above still differs between the two branches.
-    const currentActivity = await this.buildCurrentActivity(req, committeeId);
-    if (currentActivity) {
-      response = { ...response, current_activity: currentActivity };
-    }
-    return this.withCallerRating(req, committeeId, response);
+    // current_activity (GH-1922) is sourced from CommitteeActivityService's existing live
+    // aggregation — runs identically in mock and live mode, since that service has no mock/live
+    // split of its own; only fetchBriefResponse's own mock-vs-proxy branch (brief/throttle)
+    // differs between the two. Run in parallel with fetchBriefResponse, not after — the two are
+    // independent reads, so awaiting them sequentially would make this tally's latency fully
+    // additive on top of the brief fetch for no reason.
+    //
+    // Only built here, not inside fetchBriefResponse — every internal caller that reuses that
+    // helper (getActionItems, shareBrief, shareBriefToSlack, resolveRatableBrief) only ever reads
+    // brief/caller_rating off the result, so building the tally for them too would pay a real
+    // upstream fan-out (getCommitteeById, and for a governance committee, CommitteeActivityService's
+    // own multi-call aggregation) for a field they'd discard on every write path (share, rate) and
+    // every read of just the AI-extracted action items.
+    const [response, currentActivity] = await Promise.all([this.fetchBriefResponse(req, committeeId), this.buildCurrentActivity(req, committeeId)]);
+    return currentActivity ? { ...response, current_activity: currentActivity } : response;
   }
 
   /**
@@ -493,7 +479,7 @@ export class WeeklyBriefService {
    * (a miss, same as an actual cache miss) — that narrower case isn't covered here.
    */
   public async getActionItems(req: Request, committeeId: string): Promise<GetWeeklyBriefActionItemsResponse> {
-    const { brief } = await this.getCurrentBrief(req, committeeId);
+    const { brief } = await this.fetchBriefResponse(req, committeeId);
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state) || !brief.brief_text?.trim()) {
       return { items: [] };
     }
@@ -728,7 +714,7 @@ export class WeeklyBriefService {
    * this service — impersonation still shows staff what the target sees.
    */
   public async shareBrief(req: Request, committeeId: string, expectedRevision: number): Promise<ShareWeeklyBriefResult> {
-    const { brief } = await this.getCurrentBrief(req, committeeId);
+    const { brief } = await this.fetchBriefResponse(req, committeeId);
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) {
       throw new ResourceNotFoundError('Weekly brief', committeeId, {
         operation: 'share_weekly_brief',
@@ -966,7 +952,7 @@ export class WeeklyBriefService {
       });
     }
 
-    const { brief } = await this.getCurrentBrief(req, committeeId);
+    const { brief } = await this.fetchBriefResponse(req, committeeId);
     if (!brief || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) {
       throw new ResourceNotFoundError('Weekly brief', committeeId, {
         operation: 'share_weekly_brief_slack',
@@ -1136,6 +1122,42 @@ export class WeeklyBriefService {
   }
 
   /**
+   * Shared by `getCurrentBrief` and every internal caller that only needs `brief`/`throttle`/
+   * `caller_rating` — `getActionItems`, `shareBrief`, `shareBriefToSlack`, `resolveRatableBrief`.
+   * Deliberately does NOT build `current_activity` (see `getCurrentBrief`'s own doc comment for
+   * why that stays exclusive to the actual `GET /current` read path — those four callers would
+   * otherwise pay a real upstream fan-out for a field they immediately discard).
+   *
+   * Upstream's own contract is 200-with-null-brief-and-throttle when no draft exists yet for the
+   * window — a 404 here means "committee not found", a real error the caller needs to see, not an
+   * empty-brief state to paper over.
+   */
+  private async fetchBriefResponse(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
+    let response: WeeklyBriefCurrentResponse;
+    if (!this.isLive(req)) {
+      const brief = currentMockBrief(committeeId);
+      response = {
+        brief,
+        throttle: {
+          ...WEEKLY_BRIEF_DEFAULT_THROTTLE,
+          generates_used: 1,
+          regenerations_used: brief.regeneration_count,
+          window_resets_at: nextSundayIso(),
+        },
+      };
+    } else {
+      logger.debug(req, 'get_weekly_brief_current', 'Proxying to committee-service', { committee_id: committeeId });
+      response = await this.microserviceProxy.proxyRequest<WeeklyBriefCurrentResponse>(
+        req,
+        'LFX_V2_SERVICE',
+        `/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`,
+        'GET'
+      );
+    }
+    return this.withCallerRating(req, committeeId, response);
+  }
+
+  /**
    * Builds `WeeklyBriefCurrentResponse.current_activity` (GH-1922) from
    * `CommitteeActivityService.getCommitteeActivity` — the same live meeting/vote/document
    * aggregation that powers the committee "Recent Activity" feed, filtered to the current,
@@ -1145,6 +1167,17 @@ export class WeeklyBriefService {
    * error, matching the client's existing absent-vs-present distinction between "couldn't
    * determine" and "genuinely zero activity this week" (weekly-brief-card.component.ts's
    * `hasCurrentActivityData`).
+   *
+   * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
+   * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. A returned
+   * `page_token` means real events exist beyond it; unlike the paginated Recent Activity feed,
+   * this consumer renders a *count* ("N documents added"), so silently truncating would state a
+   * wrong number as fact — worse than the list-truncation the per-leg `saturated` flags already
+   * accept elsewhere in `CommitteeActivityService`. Treated as "couldn't determine" (`undefined`),
+   * not published truncated, matching this method's own fail-soft contract. Not looped to
+   * exhaustion — `decodePageToken`/`ActivityPageCursor` aren't exposed for a caller outside
+   * `committee-activity.service.ts` to do that today, and a committee clearing 50 events in one
+   * week is already an edge case this v1 tally accepts skipping.
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
     try {
@@ -1152,10 +1185,16 @@ export class WeeklyBriefService {
       if (!isGoverningBoard(committee.category)) return undefined;
 
       const { window_start, window_end } = currentWeekInProgressWindow();
-      const { data } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
+      const { data, page_token: pageToken } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
         since: window_start,
         limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
       });
+      if (pageToken) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Current-week activity exceeds one page — omitting rather than publishing a truncated count', {
+          committee_id: committeeId,
+        });
+        return undefined;
+      }
 
       const sourceRefs = data.reduce<WeeklyBriefSourceRef[]>((refs, event) => {
         const ref = mapActivityEventToCurrentActivityRef(event);
@@ -1221,7 +1260,7 @@ export class WeeklyBriefService {
     expectedRevision: number,
     operation: string
   ): Promise<{ brief: WeeklyBrief; callerRating: WeeklyBriefRating | null }> {
-    const response = await this.getCurrentBrief(req, committeeId);
+    const response = await this.fetchBriefResponse(req, committeeId);
     const { brief } = response;
     if (!brief || brief.uid !== briefUid || !WEEKLY_BRIEF_SHAREABLE_STATES.includes(brief.state)) {
       throw new ResourceNotFoundError('Weekly brief', briefUid, { operation, service: 'weekly_brief_service' });

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1199,9 +1199,13 @@ export class WeeklyBriefService {
    * empty — an unquantified reliability gap, and a false negative on it would hide the tally for a
    * real governance committee, worse than the extra calls this took instead. `getCommitteeById`
    * reads the authoritative committee-service record directly, accepting the known extra cost
-   * over that unverified gap. Fails soft to `undefined` (never an empty array) on any error,
-   * matching the client's existing absent-vs-present distinction between "couldn't determine" and
-   * "genuinely zero activity this week" (weekly-brief-card.component.ts's `hasCurrentActivityData`).
+   * over that unverified gap. Fails soft to `undefined` (never an empty array) on a genuine
+   * error — one of three states, not two: `undefined` is transient ("couldn't determine",
+   * worth asking again), `null` is settled ("known not to apply", see below), and a real object
+   * is "genuinely zero activity this week" or more. `weekly-brief-card.component.ts`'s
+   * `hasCurrentActivityData` collapses `undefined`/`null` alike for rendering (neither is a
+   * value to show), but its `pollUntilTerminal` poll loop depends on keeping them apart — see
+   * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the full contract.
    *
    * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
    * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. Deliberately
@@ -1214,9 +1218,11 @@ export class WeeklyBriefService {
    * hide the tally for exactly the long-lived, active committees it exists to help.
    *
    * Gate on `data.length` instead — the merged, window-filtered, already-capped-at-`limit` result:
-   * when it fills the page (`>= limit`), real in-window rows may have been cut, so this is treated
-   * as "couldn't determine" (`undefined`) rather than a truncated count stated as fact, matching
-   * this method's own fail-soft contract.
+   * when it fills the page (`>= limit`), real in-window rows may have been cut, so this returns
+   * `null` (a settled "can't state a count as fact" answer, not a transient "couldn't determine")
+   * rather than a truncated count stated as fact — see
+   * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for why `null` here, not
+   * `undefined`.
    *
    * Known v1 residual (accepted, not solved): `data.length < limit` is a heuristic, not a proof of
    * completeness. `committee-activity.service.ts` documents — in its own "Filter dimension" (its
@@ -1252,7 +1258,7 @@ export class WeeklyBriefService {
         logger.warning(
           req,
           'get_weekly_brief_current_activity',
-          'Current-week activity fills a full page — omitting rather than publishing a truncated count',
+          'Current-week activity fills a full page — publishing null (settled, not a count) rather than a truncated count stated as fact',
           {
             committee_id: committeeId,
           }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -134,17 +134,28 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * own doc comments — those are two distinct upstream uid namespaces that could otherwise collide
  * (e.g. a folder and a meeting-attachment note coincidentally sharing a uid), and a collision here
  * would produce two refs with the same `id` in the same rendered `doc` section (an Angular
- * duplicate-`@for`-track-key error, not a silent dedupe). `meeting` and `vote` do NOT carry this
- * same kind-prefix, deliberately — `weekly-brief.utils.ts`'s `resolveSourceRefAction` passes a
- * `meeting` ref's raw `id` straight through as `meetingId`, and a `vote` ref's as `voteUid`; both
- * are already unique on their own upstream uid (one uid namespace each, unlike doc's two), and a
- * `meeting:`/`vote:` prefix would reach that click-through action as a corrupted id instead of a
- * real one. `survey_published`/`survey_closed` map to kind `other` — not one of
+ * duplicate-`@for`-track-key error, not a silent dedupe). `vote` does NOT carry this same
+ * kind-prefix, deliberately — `weekly-brief.utils.ts`'s `resolveSourceRefAction` passes a `vote`
+ * ref's raw `id` straight through as `voteUid`, already unique on its own upstream uid (one uid
+ * namespace, unlike doc's two), and a `vote:` prefix would reach that click-through action as a
+ * corrupted id instead of a real one.
+ *
+ * `meeting` is unprefixed for the same collision-avoidance reason, but its `id` is deliberately
+ * `meeting_occurrence_id`, NOT the `meeting_id` `resolveSourceRefAction`'s `meetingId` actually
+ * needs (see `MeetingHeldActivityEvent`'s own doc comment: a recurring meeting's occurrences
+ * share one `meeting_id` but need distinct `@for` tracking keys, which is exactly what this
+ * `id` doubles as via `weekly-brief-card.component.html`'s `track ref.id`). Known v1 residual:
+ * wiring `current_activity.source_refs` into `mapWeeklyBriefSourceRefsToChips` (nothing does
+ * today) would click through to the wrong meeting for a recurring series — closing this needs
+ * `WeeklyBriefSourceRef` to carry the navigation id separately from the tracking id, not done
+ * here since nothing consumes this mapper's meeting refs as click targets yet.
+ *
+ * `survey_published`/`survey_closed` map to kind `other` — not one of
  * `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds, but real governance activity the client's existing
  * "other" catch-all already surfaces rather than silently dropping; `other` has no
  * `resolveSourceRefAction` case (falls to its `default: return null`), so it carries no id
  * contract to protect either way, but is left unprefixed for the same "already unique on its own
- * uid" reason as meeting/vote. `member_joined`/`member_left`/other deferred types:
+ * uid" reason as vote. `member_joined`/`member_left`/other deferred types:
  * `CommitteeActivityService` never actually constructs these today (see `DeferredActivityEvent`'s
  * own doc comment), so this default branch is unreached in practice, not dead by construction.
  */
@@ -1248,13 +1259,17 @@ export class WeeklyBriefService {
     try {
       logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
       const committee = await this.committeeService.getCommitteeBase(req, committeeId);
-      // undefined `committee` here means upstream resolved with no body at all (see
-      // getCommitteeBase's own doc comment) — a genuine 404/upstream error throws instead and
-      // is caught below, same as any other failure in this method. Either way this is an
-      // anomaly, not a governance verdict, so it falls through to undefined rather than being
-      // asserted as "not governance".
-      if (committee === undefined) {
-        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee lookup returned nothing, omitting the tally', {
+      // undefined `committee`, OR a resolved committee with no `category` (its type declares
+      // `category` required — committee.interface.ts — but that's a contract on well-formed
+      // upstream data, not a runtime guarantee against a malformed body), means upstream
+      // resolved with no usable category to classify on. A genuine 404/upstream error throws
+      // instead and is caught below, same as any other failure in this method. Either way this
+      // is an anomaly, not a governance verdict, so it falls through to undefined rather than
+      // being asserted as "not governance" — isGoverningBoard(undefined) below would otherwise
+      // return false and this would settle to `null` (permanent) for what might just be a
+      // transient partial response, worth asking again on the next poll tick.
+      if (committee === undefined || committee.category === undefined) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee lookup returned nothing usable to classify on, omitting the tally', {
           committee_id: committeeId,
         });
         return undefined;

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -303,10 +303,12 @@ export class WeeklyBriefService {
    * (GH-1922) fan-out entirely. Two independent client callers do, on two different signals —
    * see `WeeklyBriefService#getWeeklyBrief` (the Angular client, `app/shared/services/`) for the
    * full breakdown:
-   *   - `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on the
-   *     initial load for any committee its own `isGoverningBoardCommittee()` already reports as
-   *     non-governance — the tally section can never render for one regardless of what
-   *     current_activity holds, so the fan-out would be pure waste.
+   *   - `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on every
+   *     non-poll load (initial load, and every `refresh$`-triggered re-fetch — retry, a save,
+   *     a share, the 409 branch of onGenerate) for any committee its own
+   *     `isGoverningBoardCommittee()` already reports as non-governance — the tally section can
+   *     never render for one regardless of what current_activity holds, so the fan-out would be
+   *     pure waste.
    *   - `weekly-brief-card.component.ts`'s `pollUntilTerminal` is this endpoint's heaviest caller
    *     — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS` hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per
    *     generate/regenerate — and this week's activity cannot change mid-poll, so re-running the
@@ -321,7 +323,7 @@ export class WeeklyBriefService {
    *     governance-classified (so a deliberate initial-load opt-out, which also leaves the key
    *     absent, is never mistaken for a transient degrade worth re-asking for); or
    *     `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` re-asks have already been spent on a
-   *     governance committee whose fan-out keeps genuinely failing. Absent none of those, a
+   *     governance committee whose fan-out keeps genuinely failing. When none of those holds, a
    *     transient degrade on the initial load can still self-heal on a later tick rather than
    *     staying blank for the rest of the poll and beyond.
    */

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -134,26 +134,33 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * own doc comments — those are two distinct upstream uid namespaces that could otherwise collide
  * (e.g. a folder and a meeting-attachment note coincidentally sharing a uid), and a collision here
  * would produce two refs with the same `id` in the same rendered `doc` section (an Angular
- * duplicate-`@for`-track-key error, not a silent dedupe). `survey_published`/`survey_closed` map
- * to kind `other` — not one of `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds, but real governance
- * activity the client's existing "other" catch-all already surfaces rather than silently
- * dropping. `member_joined`/`member_left`/other deferred types: `CommitteeActivityService` never
- * actually constructs these today (see `DeferredActivityEvent`'s own doc comment), so this
- * default branch is unreached in practice, not dead by construction.
+ * duplicate-`@for`-track-key error, not a silent dedupe). `meeting` and `vote` do NOT carry this
+ * same kind-prefix, deliberately — `weekly-brief.utils.ts`'s `resolveSourceRefAction` passes a
+ * `meeting` ref's raw `id` straight through as `meetingId`, and a `vote` ref's as `voteUid`; both
+ * are already unique on their own upstream uid (one uid namespace each, unlike doc's two), and a
+ * `meeting:`/`vote:` prefix would reach that click-through action as a corrupted id instead of a
+ * real one. `survey_published`/`survey_closed` map to kind `other` — not one of
+ * `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds, but real governance activity the client's existing
+ * "other" catch-all already surfaces rather than silently dropping; `other` has no
+ * `resolveSourceRefAction` case (falls to its `default: return null`), so it carries no id
+ * contract to protect either way, but is left unprefixed for the same "already unique on its own
+ * uid" reason as meeting/vote. `member_joined`/`member_left`/other deferred types:
+ * `CommitteeActivityService` never actually constructs these today (see `DeferredActivityEvent`'s
+ * own doc comment), so this default branch is unreached in practice, not dead by construction.
  */
 function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBriefSourceRef | null {
   switch (event.type) {
     case 'meeting_held':
-      return { id: `meeting:${event.payload.meeting_occurrence_id}`, kind: 'meeting', title: event.payload.title };
+      return { id: event.payload.meeting_occurrence_id, kind: 'meeting', title: event.payload.title };
     case 'vote_closed':
-      return { id: `vote:${event.payload.vote_uid}`, kind: 'vote', title: event.payload.name };
+      return { id: event.payload.vote_uid, kind: 'vote', title: event.payload.name };
     case 'document_uploaded':
       return { id: `document:${event.payload.document_type}:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
     case 'notes_added':
       return { id: `note:${event.payload.meeting_scope}:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
     case 'survey_published':
     case 'survey_closed':
-      return { id: `survey:${event.payload.survey_uid}`, kind: 'other', title: event.payload.title };
+      return { id: event.payload.survey_uid, kind: 'other', title: event.payload.title };
     default:
       return null;
   }
@@ -286,8 +293,9 @@ export class WeeklyBriefService {
    * `pollUntilTerminal`) is this endpoint's heaviest caller — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS`
    * hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per generate/regenerate — and this week's
    * activity cannot change mid-poll, so re-running the tally on every tick multiplies its real
-   * upstream cost (getCommitteeCategory's one call, plus getCommitteeActivity's own multi-call
-   * aggregation for a governance committee) for a value that's already correct from the poll's
+   * upstream cost (getCommitteeBase's one call, plus getCommitteeActivity's own multi-call
+   * aggregation for a governance committee — see buildCurrentActivity's doc comment for how the
+   * two share a single committee fetch) for a value that's already correct from the poll's
    * first tick. The poll passes `includeCurrentActivity: false` only once the current_activity
    * KEY is present on what it already holds (see `WeeklyBriefCurrentResponse.current_activity`'s
    * doc comment for the absent/null/present contract this depends on — `null` is a settled
@@ -307,7 +315,7 @@ export class WeeklyBriefService {
     // Only built here, not inside fetchBriefResponse — every internal caller that reuses that
     // helper (getActionItems, shareBrief, shareToSlack, resolveRatableBrief) only ever reads
     // brief/caller_rating off the result, so building the tally for them too would pay a real
-    // upstream fan-out (getCommitteeCategory, and for a governance committee,
+    // upstream fan-out (getCommitteeBase, and for a governance committee,
     // CommitteeActivityService's own multi-call aggregation) for a field they'd discard on every
     // write path (share, rate) and every read of just the AI-extracted action items.
     const [response, currentActivity] = await Promise.all([
@@ -1185,13 +1193,17 @@ export class WeeklyBriefService {
    * not-yet-closed week. Gated to governance (Board/Government Advisory Council) committees only
    * — the only ones the client renders the tally for — so a non-Board committee's weekly-brief
    * load never pays for `getCommitteeActivity`'s own 9-call upstream fan-out. The gating read
-   * itself is `getCommitteeCategory` (a single plain GET), not `getCommitteeById` — this needs
-   * `category` alone, and `getCommitteeById`'s default options cost three upstream calls
-   * (base GET, settings, an access-check) for data this call would only discard.
-   * `getCommitteeCategory` performs no access check of its own — safe here only because this
-   * method's one caller, `getCurrentBrief`, is reachable exclusively through the controller's
-   * `assertCommitteeRead` gate; a new caller of `getCommitteeCategory` would need its own. Fails
-   * soft to `undefined` (never an empty array) on a genuine error — one of three states, not two:
+   * itself is `getCommitteeBase` (a single plain GET), not `getCommitteeById` — this needs the
+   * base record alone, and `getCommitteeById`'s default options cost three upstream calls
+   * (base GET, settings, an access-check) for data this call would only discard. The resolved
+   * committee is then passed into `getCommitteeActivity` below as its `knownCommittee` — that
+   * method's own `fetchCommittee` leg needs the same record (for `enable_voting`), and without
+   * passing it down explicitly a governance committee's weekly-brief load would pay for the
+   * identical `GET /committees/:id` twice. `getCommitteeBase` performs no access check of its
+   * own — safe here only because this method's one caller, `getCurrentBrief`, is reachable
+   * exclusively through the controller's `assertCommitteeRead` gate; a new caller of
+   * `getCommitteeBase` would need its own. Fails soft to `undefined` (never an empty array) on a
+   * genuine error — one of three states, not two:
    * `undefined` is transient ("couldn't determine", worth asking again), `null` is settled
    * ("known not to apply", see below), and a real object is "genuinely zero activity this week"
    * or more.
@@ -1235,14 +1247,14 @@ export class WeeklyBriefService {
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
     try {
       logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
-      const category = await this.committeeService.getCommitteeCategory(req, committeeId);
-      // undefined `category` here means upstream resolved with no `category` on the body —
-      // absent/null field, or an empty body (see getCommitteeCategory's own doc comment) — a
-      // genuine 404/upstream error throws instead and is caught below, same as any other
-      // failure in this method. Either way this is an anomaly, not a governance verdict, so it
-      // falls through to undefined rather than being asserted as "not governance".
-      if (category === undefined) {
-        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee category lookup returned nothing, omitting the tally', {
+      const committee = await this.committeeService.getCommitteeBase(req, committeeId);
+      // undefined `committee` here means upstream resolved with no body at all (see
+      // getCommitteeBase's own doc comment) — a genuine 404/upstream error throws instead and
+      // is caught below, same as any other failure in this method. Either way this is an
+      // anomaly, not a governance verdict, so it falls through to undefined rather than being
+      // asserted as "not governance".
+      if (committee === undefined) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Committee lookup returned nothing, omitting the tally', {
           committee_id: committeeId,
         });
         return undefined;
@@ -1250,13 +1262,20 @@ export class WeeklyBriefService {
       // null, not undefined — see WeeklyBriefCurrentResponse.current_activity's doc comment.
       // This committee will never become governance-classified mid-poll, so a caller (the
       // client's pollUntilTerminal) can treat this as a settled answer and stop asking.
-      if (!isGoverningBoard(category)) return null;
+      if (!isGoverningBoard(committee.category)) return null;
 
       const { window_start, window_end } = currentWeekInProgressWindow();
-      const { data } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
-        since: window_start,
-        limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
-      });
+      // Passing `committee` (already resolved above) as getCommitteeActivity's knownCommittee —
+      // see this method's own doc comment for why.
+      const { data } = await this.committeeActivityService.getCommitteeActivity(
+        req,
+        committeeId,
+        {
+          since: window_start,
+          limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
+        },
+        committee
+      );
       logger.debug(req, 'get_weekly_brief_current_activity', 'Fetched current-week activity', { committee_id: committeeId, event_count: data.length });
       if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
         logger.warning(

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1166,17 +1166,22 @@ export class WeeklyBriefService {
    * load never pays for `getCommitteeActivity`'s own 9-call upstream fan-out. The gating read
    * itself is NOT free, though: `getCommitteeById` fans out to three upstream calls of its own
    * (base committee GET, settings, access-check) to read a `category` a plain GET would suffice
-   * for — every committee, governance or not, pays that regardless. Reusing the
-   * already-instantiated `committeeService` was a deliberate choice over a bare `proxyRequest`
-   * (the pattern `shareToSlack` uses below, for the same lightweight need): this method is
-   * invoked from every `getCurrentBrief` call, concurrently with `fetchBriefResponse`'s own
-   * `proxyRequest` call in live mode, and `proxyRequest` is a single shared mock this spec file's
-   * dozens of other describe blocks assert call counts/order against — a second, path-dispatched
-   * consumer of it would need surgical updates across all of them for a request-volume win with
-   * no correctness stake. Accepted as a known v1 cost, isolated to this one gating read. Fails
-   * soft to `undefined` (never an empty array) on any error, matching the client's existing
-   * absent-vs-present distinction between "couldn't determine" and "genuinely zero activity this
-   * week" (weekly-brief-card.component.ts's `hasCurrentActivityData`).
+   * for — every committee, governance or not, pays that regardless. Two cheaper alternatives were
+   * considered and both declined: a bare `proxyRequest` GET (the pattern `shareToSlack` uses
+   * above, for the same lightweight need) would run concurrently with `fetchBriefResponse`'s own
+   * `proxyRequest` call in live mode via the `Promise.all` above, and this spec file already has
+   * over a dozen order-sensitive `proxyRequest.mockResolvedValueOnce` queues elsewhere that a
+   * second, path-dispatched consumer risks silently shifting; `getCommitteesByIds` (a single
+   * batched query-service call, used by `getMyCommittees`/`getMyPendingInvitations` for the same
+   * "just need `category`" need) avoids that mock entirely, but that same call site falls back to
+   * `membership.committee_category` when the indexed `category` comes back empty — a reliability
+   * gap not investigated here, and a false negative on it would hide the tally for a real
+   * governance committee, worse than the extra calls this took instead. Reusing the
+   * already-instantiated `committeeService.getCommitteeById` accepts the known extra cost in
+   * exchange for the same category reliability every other governance-gated read in this codebase
+   * already trusts. Fails soft to `undefined` (never an empty array) on any error, matching the
+   * client's existing absent-vs-present distinction between "couldn't determine" and "genuinely
+   * zero activity this week" (weekly-brief-card.component.ts's `hasCurrentActivityData`).
    *
    * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
    * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. Deliberately

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1303,19 +1303,23 @@ export class WeeklyBriefService {
    * notes/surveys, not whether THIS WEEK's activity was truncated. Gating on that would silently
    * hide the tally for exactly the long-lived, active committees it exists to help.
    *
-   * Gate on `data.length` instead — the merged, window-filtered, already-capped-at-`limit` result:
-   * when it fills the page (`>= limit`), real in-window rows may have been cut, so this returns
-   * `null` (a settled "can't state a count as fact" answer, not a transient "couldn't determine")
-   * rather than a truncated count stated as fact — see
+   * Gate on the filtered `sourceRefs.length`, not the raw merged/capped `data.length` — this
+   * method's body filters `data` to `occurred_at <= window_end` before the gate runs, specifically
+   * so a page saturated with administratively-closed, future-stamped votes (destined to be
+   * filtered out anyway) can't settle a comfortably-under-the-cap committee to `null`. When the
+   * filtered count itself fills the page (`>= limit`, which also implies nothing was filtered
+   * out — `sourceRefs.length` can never exceed `data.length`), real in-window rows may have been
+   * cut, so this returns `null` (a settled "can't state a count as fact" answer, not a transient
+   * "couldn't determine") rather than a truncated count stated as fact — see
    * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for why `null` here, not
    * `undefined`.
    *
-   * Known v1 residual (accepted, not solved): `data.length < limit` is a heuristic, not a proof of
-   * completeness. `committee-activity.service.ts` documents — in its own "Filter dimension" (its
-   * exact label), sort-dimension ("Votes, surveys, files, and notes are all in a different,
-   * genuinely-approximate bucket"), and FGA-post-filter comments — several ways an individual leg's
-   * single upstream page can under-report while the merged, capped `data.length` still lands under
-   * `limit`. Deliberately not re-derived here leg-by-leg — a summary of which mechanism hits which
+   * Known v1 residual (accepted, not solved): `sourceRefs.length < limit` is a heuristic, not a
+   * proof of completeness. `committee-activity.service.ts` documents — in its own "Filter
+   * dimension" (its exact label), sort-dimension ("Votes, surveys, files, and notes are all in a
+   * different, genuinely-approximate bucket"), and FGA-post-filter comments — several ways an
+   * individual leg's single upstream page can under-report while the merged, capped `data.length`
+   * still lands under `limit`. Deliberately not re-derived here leg-by-leg — a summary of which mechanism hits which
    * leg is exactly the kind of detail that silently drifts out of sync with its source as that
    * source evolves, and none of it crosses the `getCommitteeActivity` boundary as a signal this
    * caller could gate on regardless: only a single merged `page_token` comes back, no per-leg flag.
@@ -1370,20 +1374,6 @@ export class WeeklyBriefService {
         { knownCommittee: committee, quietAggregationLog: true }
       );
       logger.debug(req, 'get_weekly_brief_current_activity', 'Fetched current-week activity', { committee_id: committeeId, event_count: data.length });
-      if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
-        logger.warning(
-          req,
-          'get_weekly_brief_current_activity',
-          'Current-week activity fills a full page — publishing null (settled, not a count) rather than a truncated count stated as fact',
-          {
-            committee_id: committeeId,
-          }
-        );
-        // null, not undefined — more in-window activity only ever accumulates within a poll
-        // cycle, never un-fills a full page, so this can't resolve differently on a later tick
-        // within the same cycle either.
-        return null;
-      }
 
       // Filtered to occurred_at <= window_end, not just >= window_start (the `since` param
       // above already narrows that half) — getCommitteeActivity has no `before`/upper-bound
@@ -1403,6 +1393,13 @@ export class WeeklyBriefService {
       // timestamps via timestampValue !== -Infinity), kept so this filter stays correct on its
       // own terms if that ever changes, same rationale as mapActivityEventToCurrentActivityRef's
       // own "unreached in practice, not dead by construction" default branch.
+      //
+      // Deliberately runs BEFORE the truncation gate below, not after: gating on the raw,
+      // unfiltered `data.length` would count a page saturated with administratively-closed,
+      // future-stamped votes as "possibly truncated" even when every one of those events is about
+      // to be dropped here anyway, settling a comfortably-under-the-cap committee to `null` for no
+      // real reason. Gating on the filtered count instead only trips when the events that actually
+      // make it into the tally themselves fill the page.
       const windowEndMs = Date.parse(window_end);
       let droppedAfterWindowEnd = 0;
       const sourceRefs = data.reduce<WeeklyBriefSourceRef[]>((refs, event) => {
@@ -1430,6 +1427,22 @@ export class WeeklyBriefService {
           window_end,
         });
       }
+
+      if (sourceRefs.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
+        logger.warning(
+          req,
+          'get_weekly_brief_current_activity',
+          'Current-week activity fills a full page — publishing null (settled, not a count) rather than a truncated count stated as fact',
+          {
+            committee_id: committeeId,
+          }
+        );
+        // null, not undefined — more in-window activity only ever accumulates within a poll
+        // cycle, never un-fills a full page, so this can't resolve differently on a later tick
+        // within the same cycle either.
+        return null;
+      }
+
       return { window_start, window_end, source_refs: sourceRefs };
     } catch (err) {
       logger.warning(req, 'get_weekly_brief_current_activity', 'Failed to build current-week activity tally, omitting it', {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1316,23 +1316,25 @@ export class WeeklyBriefService {
    * notes/surveys, not whether THIS WEEK's activity was truncated. Gating on that would silently
    * hide the tally for exactly the long-lived, active committees it exists to help.
    *
-   * Gate on `sourceRefs.length + unmappedInWindow`, not the raw merged/capped `data.length` and
-   * not bare `sourceRefs.length` either — this method's body filters `data` to `occurred_at <=
-   * window_end` before the gate runs, specifically so a page saturated with administratively-
-   * closed, future-stamped votes (destined to be dropped anyway) can't settle a comfortably-
-   * under-the-cap committee to `null`. Only that window_end drop is safe to exclude, though:
-   * `unmappedInWindow` counts in-window events mapActivityEventToCurrentActivityRef doesn't
-   * recognize, which is NOT proof those events don't belong in the tally — just that this method
-   * can't render them yet — so the gate adds them back in rather than treating them the same as
-   * genuine out-of-window noise. When the sum fills the page (`>= limit`, which also implies
-   * nothing was dropped for the one proven-safe reason — window_end — since `sourceRefs.length +
-   * unmappedInWindow` can never exceed `data.length`), real in-window rows may have been cut, so
-   * this returns `null` (a settled "can't state a count as fact" answer, not a transient "couldn't
-   * determine") rather than a truncated count stated as fact — see
-   * `WeeklyBriefCurrentResponse.current_activity`'s doc comment for why `null` here, not
-   * `undefined`.
+   * Gate on the raw, unfiltered `data.length` hitting `limit` (Copilot review), NOT on
+   * `sourceRefs.length + unmappedInWindow` as this method originally did. That original gate
+   * assumed a page saturated with administratively-closed, future-stamped votes was always safe
+   * to treat as "not truncated", since those rows get dropped by the window_end filter below
+   * anyway. That assumption doesn't hold: `committee-activity.service.ts` sorts its merged pool
+   * *descending* by `occurred_at` before capping to `limit`, so future-stamped rows — having the
+   * largest timestamps — sort ABOVE real in-window rows and can occupy page slots a real event
+   * would otherwise have filled. A page full of nothing but soon-to-be-dropped future noise can
+   * therefore mean real in-window activity was pushed off the page entirely, before this method
+   * ever saw it — silently undercounting behind a gate that only looked at what survived the
+   * window_end filter. Gating on `data.length >= limit` instead catches that: a full raw page is
+   * treated as "possibly truncated" regardless of composition. The cost is the mirror-image false
+   * positive — a committee whose only this-week activity actually is `limit`-many future-stamped
+   * votes gets `null` instead of an honest small `sourceRefs`, since this method can't tell the two
+   * cases apart with the signal `getCommitteeActivity` exposes today. Consistent with this
+   * method's own bias (see `WeeklyBriefCurrentResponse.current_activity`'s doc comment): an
+   * unnecessary `null` is a safe, if slightly annoying, degradation; a false-complete count is not.
    *
-   * Known v1 residual (accepted, not solved): `sourceRefs.length + unmappedInWindow < limit` is a heuristic, not a
+   * Known v1 residual (accepted, not solved): `data.length < limit` is a heuristic, not a
    * proof of completeness. `committee-activity.service.ts` documents — in its own "Filter
    * dimension" (its exact label), sort-dimension ("Votes, surveys, files, and notes are all in a
    * different, genuinely-approximate bucket"), and FGA-post-filter comments — several ways an
@@ -1433,22 +1435,13 @@ export class WeeklyBriefService {
       // own terms if that ever changes, same rationale as mapActivityEventToCurrentActivityRef's
       // own "unreached in practice, not dead by construction" default branch.
       //
-      // Deliberately runs BEFORE the truncation gate below, not after: gating on the raw,
-      // unfiltered `data.length` would count a page saturated with administratively-closed,
-      // future-stamped votes as "possibly truncated" even when every one of those events is about
-      // to be dropped here anyway, settling a comfortably-under-the-cap committee to `null` for no
-      // real reason. Gating on the filtered count instead only trips when the events that actually
-      // make it into the tally themselves fill the page.
       // `unmappedInWindow` (events that pass the window_end filter but that
       // mapActivityEventToCurrentActivityRef's `default: return null` branch doesn't recognize —
       // unreached today, since CommitteeActivityService never constructs a DeferredActivityEvent,
-      // but type-legal) is tracked separately from droppedAfterWindowEnd and, unlike it, counts
-      // toward the truncation gate below. The two are NOT symmetric: a window-filtered event is
-      // *proven* not to belong in this week's tally (its occurred_at is after window_end), so
-      // excluding it from the gate is safe. An unmapped-but-in-window event is NOT proven
-      // irrelevant — it may well belong in the tally, this method just has no rendering for it —
-      // so a full raw page dominated by these must still be treated as possibly truncated, not
-      // waved through the way genuine future-noise is.
+      // but type-legal) and `droppedAfterWindowEnd` are tracked for the debug log below only — the
+      // truncation gate a few lines down no longer depends on either. See this method's own doc
+      // comment for why: it gates on the raw `data.length` instead, since a full raw page can mean
+      // real in-window events were pushed off before this loop ever saw them.
       const windowEndMs = Date.parse(window_end);
       let droppedAfterWindowEnd = 0;
       let unmappedInWindow = 0;
@@ -1474,15 +1467,16 @@ export class WeeklyBriefService {
       // already knows about and models on purpose, not a genuine data-quality problem worth an
       // operator's attention. Still logged (not silent) since a drop is still worth being able to
       // find while debugging a tally that looks short.
-      if (droppedAfterWindowEnd > 0) {
-        logger.debug(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
+      if (droppedAfterWindowEnd > 0 || unmappedInWindow > 0) {
+        logger.debug(req, 'get_weekly_brief_current_activity', 'Dropped or skipped one or more events while building source_refs', {
           committee_id: committeeId,
-          dropped_count: droppedAfterWindowEnd,
+          dropped_after_window_end: droppedAfterWindowEnd,
+          unmapped_in_window: unmappedInWindow,
           window_end,
         });
       }
 
-      if (sourceRefs.length + unmappedInWindow >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
+      if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
         logger.warning(
           req,
           'get_weekly_brief_current_activity',

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1200,23 +1200,38 @@ export class WeeklyBriefService {
    * not hold the whole `GET /current` response hostage). Resolving to `undefined` on a lost race,
    * not rejecting, is deliberate: it's the same value `buildCurrentActivity` itself already
    * produces for any other transient failure, so `getCurrentBrief`'s caller — and the client's
-   * poll self-heal — can't tell a timeout apart from any other degrade, and don't need to. The
-   * loser of the race is not cancelled (`buildCurrentActivity` has no cancellation hook — its
-   * underlying upstream calls keep running until they settle or their own timeout fires). The
-   * trailing `.catch()` on it is defense-in-depth, not a live path today: `buildCurrentActivity`'s
-   * own try/catch already wraps everything it does, so it can never actually reject as written —
-   * kept so a late rejection stays harmless rather than an unhandled one if that invariant ever
-   * changes, same rationale as this file's other "unreached in practice" guards.
+   * poll self-heal — can't tell a timeout apart from any other degrade, and don't need to. Still
+   * warns when the budget is the one that wins, matching this method's every sibling exit
+   * (`buildCurrentActivity` itself warns on each of its own omit-the-tally paths) — otherwise a
+   * budget that starts firing regularly in production would be invisible in CloudWatch. A
+   * dedicated sentinel (not plain `undefined`) distinguishes "the budget elapsed" from
+   * "`buildCurrentActivity` itself resolved to `undefined` well within budget", which needs no
+   * warning of its own (it already logs its own reason for degrading). The loser of the race is
+   * not cancelled (`buildCurrentActivity` has no cancellation hook — its underlying upstream
+   * calls keep running until they settle or their own timeout fires). The trailing `.catch()` on
+   * it is defense-in-depth, not a live path today: `buildCurrentActivity`'s own try/catch already
+   * wraps everything it does, so it can never actually reject as written — kept so a late
+   * rejection stays harmless rather than an unhandled one if that invariant ever changes, same
+   * rationale as this file's other "unreached in practice" guards.
    */
   private async buildCurrentActivityWithBudget(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
+    const BUDGET_ELAPSED = Symbol('current_activity_budget_elapsed');
     let timer: NodeJS.Timeout;
-    const timeout = new Promise<undefined>((resolve) => {
-      timer = setTimeout(() => resolve(undefined), WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS);
+    const timeout = new Promise<typeof BUDGET_ELAPSED>((resolve) => {
+      timer = setTimeout(() => resolve(BUDGET_ELAPSED), WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS);
     });
     const result = this.buildCurrentActivity(req, committeeId);
     result.catch(() => undefined);
     try {
-      return await Promise.race([result, timeout]);
+      const winner = await Promise.race([result, timeout]);
+      if (winner === BUDGET_ELAPSED) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Current-activity budget elapsed, omitting the tally', {
+          committee_id: committeeId,
+          budget_ms: WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS,
+        });
+        return undefined;
+      }
+      return winner;
     } finally {
       clearTimeout(timer!);
     }

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1183,32 +1183,20 @@ export class WeeklyBriefService {
    * as "couldn't determine" (`undefined`) rather than a truncated count stated as fact, matching
    * this method's own fail-soft contract.
    *
-   * Known v1 residual (accepted, not solved — same class of gap `committee-activity.service.ts`
-   * documents for this exact endpoint, across its filter-dimension, sort-dimension, and
-   * FGA-post-filter comments): `data.length < limit` is NOT an airtight completeness proof, for
-   * two independent reasons neither leg-specific check above rules out:
-   *   - Filter dimension (votes/documents): these legs push `since` upstream, but only via an
-   *     *approximating* `date_field` (not their real, multi-field `occurred_at`), and FGA
-   *     access-checking runs after OpenSearch paginates — both can leave a leg's single fetched
-   *     page short of every genuinely in-window row. FGA post-filtering can do this while
-   *     `saturated` stays true; the `date_field` approximation can do it either direction —
-   *     over-inclusion (stale rows the in-memory `since` pass trims, still costing a `fetchSize`
-   *     slot) or under-inclusion (a real in-window row excluded upstream before that pass ever
-   *     sees it, which the pass can only trim, never restore — `committee-activity.service.ts`
-   *     documents it as the backstop against over-inclusion, not under-inclusion). Meetings are
-   *     exempt from this bullet: their sort/filter field is derived identically to `occurred_at`,
-   *     so it's exact, not approximating.
-   *   - Sort dimension (votes/surveys/documents/notes): `sort: updated_desc` resolves to the
-   *     index's own write-audit `updated_at`, not a domain timestamp, for all four legs — an edit
-   *     or re-index of an old, out-of-window row can push a genuinely in-window row out of the top
-   *     `fetchSize` entirely. Each leg's own `saturated`/`page_token` flag is no help here either —
-   *     it's set for the same lifetime-volume reason that makes it unusable above (see this
-   *     method's own doc comment), not because this specific week's rows were displaced.
-   * Closing either fully would need `getCommitteeActivity` to expose a per-leg completeness signal
+   * Known v1 residual (accepted, not solved): `data.length < limit` is a heuristic, not a proof of
+   * completeness. `committee-activity.service.ts` documents — in its own "Filter dimension" (its
+   * exact label), sort-dimension ("Votes, surveys, files, and notes are all in a different,
+   * genuinely-approximate bucket"), and FGA-post-filter comments — several ways an individual leg's
+   * single upstream page can under-report while the merged, capped `data.length` still lands under
+   * `limit`. Deliberately not re-derived here leg-by-leg — a summary of which mechanism hits which
+   * leg is exactly the kind of detail that silently drifts out of sync with its source as that
+   * source evolves, and none of it crosses the `getCommitteeActivity` boundary as a signal this
+   * caller could gate on regardless: only a single merged `page_token` comes back, no per-leg flag.
+   * Closing this for real would need `getCommitteeActivity` to expose a per-leg completeness signal
    * it doesn't return today — not done here to avoid changing the public contract of an endpoint
-   * the real "Recent Activity" feed also consumes, for a v1 tally where any of these is already a
-   * narrow edge case relative to the `page_token`/`anyLegSaturated` gate this replaced (which fired
-   * on nearly every long-lived board, every week).
+   * the real "Recent Activity" feed also consumes, for a v1 tally where this is already a narrow
+   * edge case relative to the `page_token`/`anyLegSaturated` gate this replaced (which fired on
+   * nearly every long-lived board, every week).
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
     try {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -178,9 +178,9 @@ function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBrief
       return { id: event.payload.vote_uid, kind: 'vote', title: event.payload.name };
     // Folds into `other`, not dropped: an open-but-not-yet-closed vote isn't "vote closed" (the
     // tally's only vote phrase), but dropping it produced a same-page contradiction — the
-    // "Recent Activity" feed (mapActivityEventToDisplayText, activity-feed.utils.ts) already
-    // renders vote_opened, so a week that opened a vote and this tally alone showed "no activity
-    // yet" directly beneath a feed proving otherwise.
+    // "Recent Activity" feed (mapActivityEventToFeedItem, activity-feed.utils.ts) already renders
+    // vote_opened for any committee with voting enabled, so a week whose only activity was opening
+    // a vote would have shown "no activity yet" directly beneath a feed proving otherwise.
     // Prefixed, unlike `vote_closed` above: `other` now holds two upstream uid namespaces
     // (vote_uid here, survey_uid below), the same two-namespace situation `doc`'s prefixing
     // already exists to guard against, not the single-namespace case the unprefixed `vote` kind's

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -300,19 +300,30 @@ export class WeeklyBriefService {
    * mock/live `brief`/`throttle` contract this builds on.
    *
    * `includeCurrentActivity` (default true) lets a caller opt out of the current_activity
-   * (GH-1922) fan-out entirely. The client's own poll loop (weekly-brief-card.component.ts's
-   * `pollUntilTerminal`) is this endpoint's heaviest caller — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS`
-   * hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per generate/regenerate — and this week's
-   * activity cannot change mid-poll, so re-running the tally on every tick multiplies its real
-   * upstream cost (getCommitteeBase's one call, plus getCommitteeActivity's own multi-call
-   * aggregation for a governance committee — see buildCurrentActivity's doc comment for how the
-   * two share a single committee fetch) for a value that's already correct from the poll's
-   * first tick. The poll passes `includeCurrentActivity: false` only once the current_activity
-   * KEY is present on what it already holds (see `WeeklyBriefCurrentResponse.current_activity`'s
-   * doc comment for the absent/null/present contract this depends on — `null` is a settled
-   * answer and stops the asking same as a real value; only a genuinely absent key keeps the
-   * poll asking on every tick, so a transient degrade on the initial load can still self-heal on
-   * a later tick rather than staying blank for the rest of the poll and beyond).
+   * (GH-1922) fan-out entirely. Two independent client callers do, on two different signals —
+   * see `WeeklyBriefService#getWeeklyBrief` (the Angular client, `app/shared/services/`) for the
+   * full breakdown:
+   *   - `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on the
+   *     initial load for any committee its own `isGoverningBoardCommittee()` already reports as
+   *     non-governance — the tally section can never render for one regardless of what
+   *     current_activity holds, so the fan-out would be pure waste.
+   *   - `weekly-brief-card.component.ts`'s `pollUntilTerminal` is this endpoint's heaviest caller
+   *     — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS` hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per
+   *     generate/regenerate — and this week's activity cannot change mid-poll, so re-running the
+   *     tally on every tick multiplies its real upstream cost (getCommitteeBase's one call, plus
+   *     getCommitteeActivity's own multi-call aggregation for a governance committee — see
+   *     buildCurrentActivity's doc comment for how the two share a single committee fetch) for a
+   *     value that's already correct from the poll's first tick. It passes
+   *     `includeCurrentActivity: false` once ANY of three conditions holds: the current_activity
+   *     KEY is present on what it already holds (see `WeeklyBriefCurrentResponse.current_activity`'s
+   *     doc comment for the absent/null/present contract this depends on — `null` is a settled
+   *     answer and stops the asking same as a real value); the committee isn't
+   *     governance-classified (so a deliberate initial-load opt-out, which also leaves the key
+   *     absent, is never mistaken for a transient degrade worth re-asking for); or
+   *     `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` re-asks have already been spent on a
+   *     governance committee whose fan-out keeps genuinely failing. Absent none of those, a
+   *     transient degrade on the initial load can still self-heal on a later tick rather than
+   *     staying blank for the rest of the poll and beyond.
    */
   public async getCurrentBrief(req: Request, committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Promise<WeeklyBriefCurrentResponse> {
     const includeCurrentActivity = options.includeCurrentActivity ?? true;

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -290,7 +290,7 @@ export class WeeklyBriefService {
     // additive on top of the brief fetch for no reason.
     //
     // Only built here, not inside fetchBriefResponse — every internal caller that reuses that
-    // helper (getActionItems, shareBrief, shareBriefToSlack, resolveRatableBrief) only ever reads
+    // helper (getActionItems, shareBrief, shareToSlack, resolveRatableBrief) only ever reads
     // brief/caller_rating off the result, so building the tally for them too would pay a real
     // upstream fan-out (getCommitteeById, and for a governance committee, CommitteeActivityService's
     // own multi-call aggregation) for a field they'd discard on every write path (share, rate) and
@@ -1123,7 +1123,7 @@ export class WeeklyBriefService {
 
   /**
    * Shared by `getCurrentBrief` and every internal caller that only needs `brief`/`throttle`/
-   * `caller_rating` — `getActionItems`, `shareBrief`, `shareBriefToSlack`, `resolveRatableBrief`.
+   * `caller_rating` — `getActionItems`, `shareBrief`, `shareToSlack`, `resolveRatableBrief`.
    * Deliberately does NOT build `current_activity` (see `getCurrentBrief`'s own doc comment for
    * why that stays exclusive to the actual `GET /current` read path — those four callers would
    * otherwise pay a real upstream fan-out for a field they immediately discard).
@@ -1163,7 +1163,12 @@ export class WeeklyBriefService {
    * aggregation that powers the committee "Recent Activity" feed, filtered to the current,
    * not-yet-closed week. Gated to governance (Board/Government Advisory Council) committees only
    * — the only ones the client renders the tally for — so a non-Board committee's weekly-brief
-   * load never pays for the fan-out. Fails soft to `undefined` (never an empty array) on any
+   * load never pays for `getCommitteeActivity`'s own 9-call upstream fan-out. The one
+   * `getCommitteeById` call needed to read `category` and make that gating decision runs for every
+   * committee regardless — it's a single lightweight lookup (the same cost
+   * `CommitteeActivityService`'s own internal `fetchCommittee` already pays on the "Recent
+   * Activity" feed), not the fan-out this comment is scoping. Fails soft to `undefined` (never an
+   * empty array) on any
    * error, matching the client's existing absent-vs-present distinction between "couldn't
    * determine" and "genuinely zero activity this week" (weekly-brief-card.component.ts's
    * `hasCurrentActivityData`).
@@ -1200,6 +1205,7 @@ export class WeeklyBriefService {
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
     try {
+      logger.debug(req, 'get_weekly_brief_current_activity', 'Building current-week activity tally', { committee_id: committeeId });
       const committee = await this.committeeService.getCommitteeById(req, committeeId);
       if (!isGoverningBoard(committee.category)) return undefined;
 
@@ -1208,6 +1214,7 @@ export class WeeklyBriefService {
         since: window_start,
         limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
       });
+      logger.debug(req, 'get_weekly_brief_current_activity', 'Fetched current-week activity', { committee_id: committeeId, event_count: data.length });
       if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {
         logger.warning(
           req,

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -280,8 +280,19 @@ export class WeeklyBriefService {
   /**
    * GET /committees/:committeeId/weekly-briefs/current — see `fetchBriefResponse` for the
    * mock/live `brief`/`throttle` contract this builds on.
+   *
+   * `includeCurrentActivity` (default true) lets a caller opt out of the current_activity
+   * (GH-1922) fan-out entirely. The client's own poll loop (weekly-brief-card.component.ts's
+   * `pollUntilTerminal`) is this endpoint's heaviest caller — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS`
+   * hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per generate/regenerate — and this week's
+   * activity cannot change mid-poll, so re-running the tally on every tick multiplies its real
+   * upstream cost (getCommitteeById's 3 calls, plus getCommitteeActivity's own multi-call
+   * aggregation for a governance committee) for a value that's already correct from the poll's
+   * first tick. The poll passes `includeCurrentActivity: false` and merges the initial value
+   * forward client-side instead.
    */
-  public async getCurrentBrief(req: Request, committeeId: string): Promise<WeeklyBriefCurrentResponse> {
+  public async getCurrentBrief(req: Request, committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Promise<WeeklyBriefCurrentResponse> {
+    const includeCurrentActivity = options.includeCurrentActivity ?? true;
     // current_activity (GH-1922) is sourced from CommitteeActivityService's existing live
     // aggregation — runs identically in mock and live mode, since that service has no mock/live
     // split of its own; only fetchBriefResponse's own mock-vs-proxy branch (brief/throttle)
@@ -295,7 +306,10 @@ export class WeeklyBriefService {
     // upstream fan-out (getCommitteeById, and for a governance committee, CommitteeActivityService's
     // own multi-call aggregation) for a field they'd discard on every write path (share, rate) and
     // every read of just the AI-extracted action items.
-    const [response, currentActivity] = await Promise.all([this.fetchBriefResponse(req, committeeId), this.buildCurrentActivity(req, committeeId)]);
+    const [response, currentActivity] = await Promise.all([
+      this.fetchBriefResponse(req, committeeId),
+      includeCurrentActivity ? this.buildCurrentActivity(req, committeeId) : Promise.resolve(undefined),
+    ]);
     return currentActivity ? { ...response, current_activity: currentActivity } : response;
   }
 

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1184,16 +1184,26 @@ export class WeeklyBriefService {
    * this method's own fail-soft contract.
    *
    * Known v1 residual (accepted, not solved — same class of gap `committee-activity.service.ts`'s
-   * own "Known v1 limitation"/FGA-post-filter comments already document for this exact endpoint):
-   * `data.length < limit` is NOT a airtight completeness proof for the three legs that DO push
-   * `since` upstream (meetings/votes/documents) — `CommitteeActivityService`'s own docs note FGA
-   * access-checking runs after OpenSearch paginates, so one of those legs can come back under
-   * `fetchSize` visible rows on a single fetched page while `saturated` is still true, i.e. an
-   * under-count this guard won't catch. Closing that fully would need `getCommitteeActivity` to
-   * expose a window-bounded-only saturation signal (excluding notes/surveys) it doesn't return
-   * today — not done here to avoid changing the public contract of an endpoint the real "Recent
-   * Activity" feed also consumes, for a v1 tally where a committee generating ~50 in-window events
-   * in one week, right at the FGA-thinning boundary, is already a narrow edge case.
+   * own "Known v1 limitation" comment already documents for this exact endpoint): `data.length <
+   * limit` is NOT an airtight completeness proof, for two independent reasons neither leg-specific
+   * check above rules out:
+   *   - Meetings/votes/documents DO push `since` upstream, but `CommitteeActivityService`'s own
+   *     docs note two ways a leg can still under-report while `saturated` stays true: (a) FGA
+   *     access-checking runs after OpenSearch paginates, so a fetched page can come back with
+   *     fewer *visible* rows than requested; (b) votes/documents only narrow on an *approximating*
+   *     upstream `date_field` (not their real, multi-field `occurred_at`), so upstream can
+   *     over-include stale rows that the in-memory `since` pass then trims, again leaving
+   *     `data.length` under `limit` on a page that was genuinely truncated.
+   *   - Notes/surveys' `sort: updated_desc` resolves to the index's own audit `updated_at`, not a
+   *     domain timestamp — an edit or re-index of an old, out-of-window row can push a genuinely
+   *     in-window note/survey out of the top `fetchSize` entirely, with no `saturated` signal to
+   *     catch it at all (this is on top of, not instead of, why their `saturated` flag is ignored
+   *     above).
+   * Closing either fully would need `getCommitteeActivity` to expose a per-leg completeness signal
+   * it doesn't return today — not done here to avoid changing the public contract of an endpoint
+   * the real "Recent Activity" feed also consumes, for a v1 tally where any of these is already a
+   * narrow edge case relative to the false-negative this commit fixes (which fired on nearly every
+   * long-lived board, every week).
    */
   private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
     try {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1367,8 +1367,7 @@ export class WeeklyBriefService {
           since: window_start,
           limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
         },
-        committee,
-        /* quietAggregationLog */ true
+        { knownCommittee: committee, quietAggregationLog: true }
       );
       logger.debug(req, 'get_weekly_brief_current_activity', 'Fetched current-week activity', { committee_id: committeeId, event_count: data.length });
       if (data.length >= ACTIVITY_FEED_MAX_PAGE_SIZE) {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 import {
+  ACTIVITY_FEED_MAX_PAGE_SIZE,
   NEWSLETTER_BODY_MAX_LENGTH,
   NEWSLETTER_SUBJECT_MAX_LENGTH,
   VALKEY_CACHE,
@@ -11,6 +12,7 @@ import {
   WEEKLY_BRIEF_SHAREABLE_STATES,
 } from '@lfx-one/shared/constants';
 import {
+  ActivityEvent,
   Committee,
   GenerateWeeklyBriefRequest,
   GenerateWeeklyBriefResponse,
@@ -28,8 +30,9 @@ import {
   WeeklyBriefCurrentActivity,
   WeeklyBriefCurrentResponse,
   WeeklyBriefRating,
+  WeeklyBriefSourceRef,
 } from '@lfx-one/shared/interfaces';
-import { formatUtcDateRangeLabel } from '@lfx-one/shared/utils';
+import { formatUtcDateRangeLabel, isGoverningBoard } from '@lfx-one/shared/utils';
 import { Request } from 'express';
 
 import { WEEKLY_BRIEF_MOCK_QUIET_WEEK_COMMITTEE_UID } from '../constants';
@@ -39,6 +42,7 @@ import { getEffectiveSub, getEffectiveUsername, getRealEmail, resolveRealAccessT
 
 import { AccessCheckService } from './access-check.service';
 import { AiService } from './ai.service';
+import { CommitteeActivityService } from './committee-activity.service';
 import { CommitteeService } from './committee.service';
 import { logger } from './logger.service';
 import { MicroserviceProxyService } from './microservice-proxy.service';
@@ -115,23 +119,40 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
 }
 
 /**
- * Deterministic mock fixture for `WeeklyBriefCurrentResponse.current_activity` (GH-1922).
- * Non-zero on purpose — mirrors the issue's own worked example ("1 meeting held, 1 vote
- * closed, 1 document added") so mock mode exercises the multi-kind render, not just the
- * empty state. Mock-only: there is no upstream committee-service endpoint for in-progress-week
- * counts, so live mode never populates this field (see `getCurrentBrief`).
+ * Maps a `CommitteeActivityService` event to the weekly-brief tally's `WeeklyBriefSourceRef`
+ * shape (GH-1922 rework — this tally is sourced from the same live meeting/vote/document
+ * aggregation that already powers the committee "Recent Activity" feed, not a weekly-brief-
+ * specific upstream call).
+ *
+ * `vote_opened` returns `null` deliberately — the tally's phrase is literally "vote closed"
+ * (`WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`), and an in-progress, not-yet-closed vote isn't that
+ * yet. `document_uploaded` and `notes_added` both collapse to kind `doc` — both are "a
+ * document-like artifact was added this week," and the tally doesn't need to distinguish
+ * committee-document files/folders/links from meeting-attachment notes; their ids are prefixed
+ * per source (mirroring `committee-activity.service.ts`'s own `eventKey()` convention) since
+ * they're different upstream uid namespaces and could otherwise collide. `survey_published`/
+ * `survey_closed` map to kind `other` — not one of `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds,
+ * but real governance activity the client's existing "other" catch-all already surfaces rather
+ * than silently dropping. `member_joined`/`member_left`/other deferred types: `CommitteeActivityService`
+ * never actually constructs these today (see `DeferredActivityEvent`'s own doc comment), so this
+ * default branch is unreached in practice, not dead by construction.
  */
-function buildMockCurrentActivity(committeeId: string): WeeklyBriefCurrentActivity {
-  const { window_start, window_end } = currentWeekInProgressWindow();
-  return {
-    window_start,
-    window_end,
-    source_refs: [
-      { id: `mock-current-meeting-1-${committeeId}`, kind: 'meeting', title: 'Board Sync' },
-      { id: `mock-current-vote-1-${committeeId}`, kind: 'vote', title: 'Q3 Resolution' },
-      { id: `mock-current-doc-1-${committeeId}`, kind: 'doc', title: 'Meeting Minutes' },
-    ],
-  };
+function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBriefSourceRef | null {
+  switch (event.type) {
+    case 'meeting_held':
+      return { id: `meeting:${event.payload.meeting_occurrence_id}`, kind: 'meeting', title: event.payload.title };
+    case 'vote_closed':
+      return { id: `vote:${event.payload.vote_uid}`, kind: 'vote', title: event.payload.name };
+    case 'document_uploaded':
+      return { id: `document:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
+    case 'notes_added':
+      return { id: `note:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
+    case 'survey_published':
+    case 'survey_closed':
+      return { id: `survey:${event.payload.survey_uid}`, kind: 'other', title: event.payload.title };
+    default:
+      return null;
+  }
 }
 
 /**
@@ -247,6 +268,7 @@ function buildMockBrief(committeeId: string, overrides: Partial<WeeklyBrief> = {
 export class WeeklyBriefService {
   private microserviceProxy: MicroserviceProxyService = new MicroserviceProxyService();
   private committeeService: CommitteeService = new CommitteeService();
+  private committeeActivityService: CommitteeActivityService = new CommitteeActivityService();
   private newsletterService: NewsletterService = new NewsletterService();
   private accessCheckService: AccessCheckService = new AccessCheckService();
   private aiService: AiService = new AiService();
@@ -271,12 +293,8 @@ export class WeeklyBriefService {
           regenerations_used: brief.regeneration_count,
           window_resets_at: nextSundayIso(),
         },
-        current_activity: buildMockCurrentActivity(committeeId),
       };
     } else {
-      // No `current_activity` here — committee-service has no in-progress-week-counts
-      // endpoint yet (GH-1922), and this is a pure proxy passthrough, so the field is simply
-      // never present in the response rather than fabricated. Revisit once upstream adds it.
       logger.debug(req, 'get_weekly_brief_current', 'Proxying to committee-service', { committee_id: committeeId });
       response = await this.microserviceProxy.proxyRequest<WeeklyBriefCurrentResponse>(
         req,
@@ -284,6 +302,13 @@ export class WeeklyBriefService {
         `/committees/${encodeURIComponent(committeeId)}/weekly-briefs/current`,
         'GET'
       );
+    }
+    // Sourced from CommitteeActivityService's existing live aggregation (GH-1922 rework) — runs
+    // identically in mock and live mode, since that service has no mock/live split of its own.
+    // Only the AI-generated brief_text above still differs between the two branches.
+    const currentActivity = await this.buildCurrentActivity(req, committeeId);
+    if (currentActivity) {
+      response = { ...response, current_activity: currentActivity };
     }
     return this.withCallerRating(req, committeeId, response);
   }
@@ -1108,6 +1133,43 @@ export class WeeklyBriefService {
     }
     logger.warning(req, 'weekly_brief_mock_mode', 'Serving mock weekly-brief data — WEEKLY_BRIEF_BACKEND is not "live"', {});
     return false;
+  }
+
+  /**
+   * Builds `WeeklyBriefCurrentResponse.current_activity` (GH-1922) from
+   * `CommitteeActivityService.getCommitteeActivity` — the same live meeting/vote/document
+   * aggregation that powers the committee "Recent Activity" feed, filtered to the current,
+   * not-yet-closed week. Gated to governance (Board/Government Advisory Council) committees only
+   * — the only ones the client renders the tally for — so a non-Board committee's weekly-brief
+   * load never pays for the fan-out. Fails soft to `undefined` (never an empty array) on any
+   * error, matching the client's existing absent-vs-present distinction between "couldn't
+   * determine" and "genuinely zero activity this week" (weekly-brief-card.component.ts's
+   * `hasCurrentActivityData`).
+   */
+  private async buildCurrentActivity(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | undefined> {
+    try {
+      const committee = await this.committeeService.getCommitteeById(req, committeeId);
+      if (!isGoverningBoard(committee.category)) return undefined;
+
+      const { window_start, window_end } = currentWeekInProgressWindow();
+      const { data } = await this.committeeActivityService.getCommitteeActivity(req, committeeId, {
+        since: window_start,
+        limit: ACTIVITY_FEED_MAX_PAGE_SIZE,
+      });
+
+      const sourceRefs = data.reduce<WeeklyBriefSourceRef[]>((refs, event) => {
+        const ref = mapActivityEventToCurrentActivityRef(event);
+        if (ref) refs.push(ref);
+        return refs;
+      }, []);
+      return { window_start, window_end, source_refs: sourceRefs };
+    } catch (err) {
+      logger.warning(req, 'get_weekly_brief_current_activity', 'Failed to build current-week activity tally, omitting it', {
+        committee_id: committeeId,
+        err,
+      });
+      return undefined;
+    }
   }
 
   /**

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -1309,22 +1309,42 @@ export class WeeklyBriefService {
 
       // Filtered to occurred_at <= window_end, not just >= window_start (the `since` param
       // above already narrows that half) — getCommitteeActivity has no `before`/upper-bound
-      // param of its own, and at least one leg can report an occurred_at ahead of "now": a vote
-      // administratively ended (status ENDED) with its own end_time still in the future stamps
-      // occurred_at from that future end_time (see mapVoteToEvent). Without this filter,
-      // window_end would advertise a bound the response doesn't actually honor. Numeric (Date.parse),
-      // not string, comparison — matches committee-activity.service.ts's own timestampValue
-      // convention rather than assuming every occurred_at is byte-identically formatted to
-      // window_end's toISOString() output. An unparseable occurred_at (NaN) is let through rather
-      // than dropped — this filter exists to enforce a stated bound, not to validate the field.
+      // param of its own, and at least two legs can report an occurred_at ahead of "now": a
+      // vote administratively ended (status ENDED) with its own end_time still in the future
+      // stamps occurred_at from that future end_time (see mapVoteToEvent), and the survey leg's
+      // cutoff-driven occurred_at has the same shape (see fetchSurveyEvents in
+      // committee-activity.service.ts). Without this filter, window_end would advertise a bound
+      // the response doesn't actually honor. Numeric (Date.parse), not string, comparison —
+      // matches committee-activity.service.ts's own timestampValue convention rather than
+      // assuming every occurred_at is byte-identically formatted to window_end's toISOString()
+      // output. An unparseable occurred_at (NaN) is let through rather than dropped — unreachable
+      // through getCommitteeActivity today (its own merge pass already drops unparseable
+      // timestamps via timestampValue !== -Infinity), kept so this filter stays correct on its
+      // own terms if that ever changes, same rationale as mapActivityEventToCurrentActivityRef's
+      // own "unreached in practice, not dead by construction" default branch.
       const windowEndMs = Date.parse(window_end);
+      let droppedAfterWindowEnd = 0;
       const sourceRefs = data.reduce<WeeklyBriefSourceRef[]>((refs, event) => {
         const eventMs = Date.parse(event.occurred_at);
-        if (!Number.isNaN(eventMs) && eventMs > windowEndMs) return refs;
+        if (!Number.isNaN(eventMs) && eventMs > windowEndMs) {
+          droppedAfterWindowEnd += 1;
+          return refs;
+        }
         const ref = mapActivityEventToCurrentActivityRef(event);
         if (ref) refs.push(ref);
         return refs;
       }, []);
+      // A dropped event is a real upstream data-quality anomaly (a leg reporting an occurred_at
+      // ahead of "now" — see the filter's own comment above for which legs can do this), not an
+      // expected, silent case — matches this method's other degrade paths, which all warn rather
+      // than drop quietly.
+      if (droppedAfterWindowEnd > 0) {
+        logger.warning(req, 'get_weekly_brief_current_activity', 'Dropped one or more events stamped after window_end', {
+          committee_id: committeeId,
+          dropped_count: droppedAfterWindowEnd,
+          window_end,
+        });
+      }
       return { window_start, window_end, source_refs: sourceRefs };
     } catch (err) {
       logger.warning(req, 'get_weekly_brief_current_activity', 'Failed to build current-week activity tally, omitting it', {

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -304,11 +304,11 @@ export class WeeklyBriefService {
    * see `WeeklyBriefService#getWeeklyBrief` (the Angular client, `app/shared/services/`) for the
    * full breakdown:
    *   - `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on every
-   *     non-poll load (initial load, and every `refresh$`-triggered re-fetch — retry, a save,
-   *     a share, the 409 branch of onGenerate) for any committee its own
-   *     `isGoverningBoardCommittee()` already reports as non-governance — the tally section can
-   *     never render for one regardless of what current_activity holds, so the fan-out would be
-   *     pure waste.
+   *     non-poll load (initial load, and every `refresh$`-triggered re-fetch — see that
+   *     component's own `refresh$.next()` call sites, not re-listed here to avoid this comment
+   *     drifting stale as they change) for any committee its own `isGoverningBoardCommittee()`
+   *     already reports as non-governance — the tally section can never render for one
+   *     regardless of what current_activity holds, so the fan-out would be pure waste.
    *   - `weekly-brief-card.component.ts`'s `pollUntilTerminal` is this endpoint's heaviest caller
    *     — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS` hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per
    *     generate/regenerate — and this week's activity cannot change mid-poll, so re-running the
@@ -320,12 +320,12 @@ export class WeeklyBriefService {
    *     KEY is present on what it already holds (see `WeeklyBriefCurrentResponse.current_activity`'s
    *     doc comment for the absent/null/present contract this depends on — `null` is a settled
    *     answer and stops the asking same as a real value); the committee isn't
-   *     governance-classified (so a deliberate initial-load opt-out, which also leaves the key
+   *     governance-classified (so a deliberate non-poll-load opt-out, which also leaves the key
    *     absent, is never mistaken for a transient degrade worth re-asking for); or
    *     `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` re-asks have already been spent on a
    *     governance committee whose fan-out keeps genuinely failing. When none of those holds, a
-   *     transient degrade on the initial load can still self-heal on a later tick rather than
-   *     staying blank for the rest of the poll and beyond.
+   *     transient degrade on an earlier non-poll load can still self-heal on a later poll tick
+   *     rather than staying blank for the rest of the poll and beyond.
    */
   public async getCurrentBrief(req: Request, committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Promise<WeeklyBriefCurrentResponse> {
     const includeCurrentActivity = options.includeCurrentActivity ?? true;
@@ -1227,10 +1227,12 @@ export class WeeklyBriefService {
    * own — safe here only because this method's one caller, `getCurrentBrief`, is reachable
    * exclusively through the controller's `assertCommitteeRead` gate; a new caller of
    * `getCommitteeBase` would need its own. Fails soft to `undefined` (never an empty array) on a
-   * genuine error — one of three states, not two:
-   * `undefined` is transient ("couldn't determine", worth asking again), `null` is settled
-   * ("known not to apply", see below), and a real object is "genuinely zero activity this week"
-   * or more.
+   * genuine error — one of three states, not two: `undefined` is transient ("couldn't
+   * determine", worth asking again), `null` is settled ("known not to apply", see below), and a
+   * real object is "genuinely zero activity this week" or more. `undefined`'s three actual causes
+   * (see this method's body): `getCommitteeBase` resolves with no body at all; it resolves with a
+   * committee that carries no usable `category`; or any other error thrown by either upstream
+   * call, caught below.
    * `weekly-brief-card.component.ts`'s `hasCurrentActivityData` collapses `undefined`/`null`
    * alike for rendering (neither is a value to show), but its `pollUntilTerminal` poll loop
    * depends on keeping them apart — see `WeeklyBriefCurrentResponse.current_activity`'s doc

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -300,32 +300,15 @@ export class WeeklyBriefService {
    * mock/live `brief`/`throttle` contract this builds on.
    *
    * `includeCurrentActivity` (default true) lets a caller opt out of the current_activity
-   * (GH-1922) fan-out entirely. Two independent client callers do, on two different signals —
-   * see `WeeklyBriefService#getWeeklyBrief` (the Angular client, `app/shared/services/`) for the
-   * full breakdown:
-   *   - `weekly-brief-card.component.ts`'s `initBriefResponseSubscription` opts out on every
-   *     non-poll load (see that method's `combineLatest` sources for what triggers one — not
-   *     re-listed here, since it's exactly the kind of detail that drifts stale as those sources
-   *     change) for any committee its own `isGoverningBoardCommittee()` already reports as
-   *     non-governance — the tally section can never render for one regardless of what
-   *     current_activity holds, so the fan-out would be pure waste.
-   *   - `weekly-brief-card.component.ts`'s `pollUntilTerminal` is this endpoint's heaviest caller
-   *     — up to `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS` hits at `WEEKLY_BRIEF_POLL_INTERVAL_MS` apart per
-   *     generate/regenerate — and this week's activity cannot change mid-poll, so re-running the
-   *     tally on every tick multiplies its real upstream cost (getCommitteeBase's one call, plus
-   *     getCommitteeActivity's own multi-call aggregation for a governance committee — see
-   *     buildCurrentActivity's doc comment for how the two share a single committee fetch) for a
-   *     value that's already correct from the poll's first tick. It passes
-   *     `includeCurrentActivity: false` once ANY of three conditions holds: the current_activity
-   *     KEY is present on what it already holds (see `WeeklyBriefCurrentResponse.current_activity`'s
-   *     doc comment for the absent/null/present contract this depends on — `null` is a settled
-   *     answer and stops the asking same as a real value); the committee isn't
-   *     governance-classified (so a deliberate non-poll-load opt-out, which also leaves the key
-   *     absent, is never mistaken for a transient degrade worth re-asking for); or
-   *     `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` re-asks have already been spent on a
-   *     governance committee whose fan-out keeps genuinely failing. When none of those holds, a
-   *     transient degrade on an earlier non-poll load can still self-heal on a later poll tick
-   *     rather than staying blank for the rest of the poll and beyond.
+   * (GH-1922) fan-out entirely — worth having because `getCommitteeActivity`'s own multi-call
+   * aggregation isn't free, and this week's activity can't change within one poll cycle, so
+   * re-running it on every tick would multiply a real upstream cost for a value that's already
+   * correct from the first tick. Two independent client callers opt out, each on its own signal
+   * — see `WeeklyBriefService#getWeeklyBrief` (the Angular client, `app/shared/services/`) for
+   * which callers, when, and why — and see `WeeklyBriefCurrentResponse.current_activity`'s doc
+   * comment (`@lfx-one/shared/interfaces`) for the absent/null/present contract this option
+   * interacts with. Not re-derived here to avoid yet another copy of that contract drifting out
+   * of sync with the other five that already reference it.
    */
   public async getCurrentBrief(req: Request, committeeId: string, options: { includeCurrentActivity?: boolean } = {}): Promise<WeeklyBriefCurrentResponse> {
     const includeCurrentActivity = options.includeCurrentActivity ?? true;
@@ -1227,16 +1210,12 @@ export class WeeklyBriefService {
    * own — safe here only because this method's one caller, `getCurrentBrief`, is reachable
    * exclusively through the controller's `assertCommitteeRead` gate; a new caller of
    * `getCommitteeBase` would need its own. Fails soft to `undefined` (never an empty array) on a
-   * genuine error — one of three states, not two: `undefined` is transient ("couldn't
-   * determine", worth asking again), `null` is settled ("known not to apply", see below), and a
-   * real object is "genuinely zero activity this week" or more. `undefined`'s three actual causes
-   * (see this method's body): `getCommitteeBase` resolves with no body at all; it resolves with a
-   * committee that carries no usable `category`; or any other error thrown while building the
-   * tally, caught below.
-   * `weekly-brief-card.component.ts`'s `hasCurrentActivityData` collapses `undefined`/`null`
-   * alike for rendering (neither is a value to show), but its `pollUntilTerminal` poll loop
-   * depends on keeping them apart — see `WeeklyBriefCurrentResponse.current_activity`'s doc
-   * comment for the full contract.
+   * genuine error — see `WeeklyBriefCurrentResponse.current_activity`'s doc comment
+   * (`@lfx-one/shared/interfaces`) for the full absent/null/present contract that puts `undefined`
+   * here in context; not re-derived in this method. `undefined`'s three actual causes, specific
+   * to this method and not part of that shared contract: `getCommitteeBase` resolves with no
+   * body at all; it resolves with a committee that carries no usable `category`; or any other
+   * error thrown while building the tally, caught below.
    *
    * `limit: ACTIVITY_FEED_MAX_PAGE_SIZE` is a single, unfollowed page — `getCommitteeActivity`
    * hard-rejects any larger `limit`, so that's the ceiling one call can ever return. Deliberately
@@ -1328,7 +1307,20 @@ export class WeeklyBriefService {
         return null;
       }
 
+      // Filtered to occurred_at <= window_end, not just >= window_start (the `since` param
+      // above already narrows that half) — getCommitteeActivity has no `before`/upper-bound
+      // param of its own, and at least one leg can report an occurred_at ahead of "now": a vote
+      // administratively ended (status ENDED) with its own end_time still in the future stamps
+      // occurred_at from that future end_time (see mapVoteToEvent). Without this filter,
+      // window_end would advertise a bound the response doesn't actually honor. Numeric (Date.parse),
+      // not string, comparison — matches committee-activity.service.ts's own timestampValue
+      // convention rather than assuming every occurred_at is byte-identically formatted to
+      // window_end's toISOString() output. An unparseable occurred_at (NaN) is let through rather
+      // than dropped — this filter exists to enforce a stated bound, not to validate the field.
+      const windowEndMs = Date.parse(window_end);
       const sourceRefs = data.reduce<WeeklyBriefSourceRef[]>((refs, event) => {
+        const eventMs = Date.parse(event.occurred_at);
+        if (!Number.isNaN(eventMs) && eventMs > windowEndMs) return refs;
         const ref = mapActivityEventToCurrentActivityRef(event);
         if (ref) refs.push(ref);
         return refs;

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -130,13 +130,12 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * "vote opened" entry), and an in-progress, not-yet-closed vote isn't that yet. It still can't be
  * dropped outright (the `null` this file used to return here): the "Recent Activity" feed on the
  * same committee-overview page renders `vote_opened` directly for any voting-enabled committee, so
- * a week that opened but hasn't yet closed a vote must not report itself as "no activity yet"
- * while the feed right below it proves otherwise. `document_uploaded` and `notes_added` both
- * collapse to kind `doc` — both are
- * "a document-like artifact was added this week," and the tally doesn't need to distinguish
- * committee-document files/folders/links from meeting-attachment notes — but their ids DO carry
- * the same namespace discriminants `committee-activity.service.ts`'s own `eventKey()` uses
- * (`document_type` / `meeting_scope`), not just a `document_uid`, since — per `ActivityEvent`'s
+ * a week that opened but hasn't yet closed a vote must not report itself as "no activity yet" while
+ * the feed right below it proves otherwise. `document_uploaded` and `notes_added` both collapse to
+ * kind `doc` — both are "a document-like artifact was added this week," and the tally doesn't need
+ * to distinguish committee-document files/folders/links from meeting-attachment notes — but their
+ * ids DO carry the same namespace discriminants `committee-activity.service.ts`'s own `eventKey()`
+ * uses (`document_type` / `meeting_scope`), not just a `document_uid`, since — per `ActivityEvent`'s
  * own doc comments — those are two distinct upstream uid namespaces that could otherwise collide
  * (e.g. a folder and a meeting-attachment note coincidentally sharing a uid), and a collision here
  * would produce two refs with the same `id` in the same rendered `doc` section (an Angular

--- a/apps/lfx-one/src/server/services/weekly-brief.service.ts
+++ b/apps/lfx-one/src/server/services/weekly-brief.service.ts
@@ -125,10 +125,14 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * aggregation that already powers the committee "Recent Activity" feed, not a weekly-brief-
  * specific upstream call).
  *
- * `vote_opened` returns `null` deliberately — the tally's phrase is literally "vote closed"
- * (`WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`), and an in-progress, not-yet-closed vote isn't that
- * yet. `document_uploaded` and `notes_added` both collapse to kind `doc` — both are "a
- * document-like artifact was added this week," and the tally doesn't need to distinguish
+ * `vote_opened` folds into kind `other`, not the `vote` kind `vote_closed` uses — the tally's
+ * only vote phrase is literally "vote closed" (`WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES` has no
+ * "vote opened" entry), and an in-progress, not-yet-closed vote isn't that yet. It still can't be
+ * dropped outright (the `null` this file used to return here): the "Recent Activity" feed on the
+ * same committee-overview page renders `vote_opened` directly, so a week that opened but hasn't
+ * yet closed a vote must not report itself as "no activity yet" while the feed right below it
+ * proves otherwise. `document_uploaded` and `notes_added` both collapse to kind `doc` — both are
+ * "a document-like artifact was added this week," and the tally doesn't need to distinguish
  * committee-document files/folders/links from meeting-attachment notes — but their ids DO carry
  * the same namespace discriminants `committee-activity.service.ts`'s own `eventKey()` uses
  * (`document_type` / `meeting_scope`), not just a `document_uid`, since — per `ActivityEvent`'s
@@ -151,14 +155,17 @@ export function currentWeekInProgressWindow(): { window_start: string; window_en
  * `WeeklyBriefSourceRef` to carry the navigation id separately from the tracking id, not done
  * here since nothing consumes this mapper's meeting refs as click targets yet.
  *
- * `survey_published`/`survey_closed` map to kind `other` — not one of
+ * `survey_published`/`survey_closed` (and `vote_opened`, above) map to kind `other` — not one of
  * `WEEKLY_BRIEF_SOURCE_SECTIONS`' five kinds, but real governance activity the client's existing
  * "other" catch-all already surfaces rather than silently dropping; `other` has no
  * `resolveSourceRefAction` case (falls to its `default: return null`), so it carries no id
  * contract to protect either way, but is left unprefixed for the same "already unique on its own
- * uid" reason as vote. `member_joined`/`member_left`/other deferred types:
- * `CommitteeActivityService` never actually constructs these today (see `DeferredActivityEvent`'s
- * own doc comment), so this default branch is unreached in practice, not dead by construction.
+ * uid" reason as vote.
+ *
+ * `member_joined`/`member_left`/other deferred types are the only ones that actually reach the
+ * `default: return null` branch below in practice: `CommitteeActivityService` never constructs
+ * those today (see `DeferredActivityEvent`'s own doc comment). It exists to stay exhaustive
+ * against `ActivityEvent`'s full union, not because any currently-constructed event type needs it.
  */
 function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBriefSourceRef | null {
   switch (event.type) {
@@ -166,6 +173,13 @@ function mapActivityEventToCurrentActivityRef(event: ActivityEvent): WeeklyBrief
       return { id: event.payload.meeting_occurrence_id, kind: 'meeting', title: event.payload.title };
     case 'vote_closed':
       return { id: event.payload.vote_uid, kind: 'vote', title: event.payload.name };
+    // Folds into `other`, not dropped: an open-but-not-yet-closed vote isn't "vote closed" (the
+    // tally's only vote phrase), but dropping it produced a same-page contradiction — the
+    // "Recent Activity" feed (mapActivityEventToDisplayText, activity-feed.utils.ts) already
+    // renders vote_opened, so a week that opened a vote and this tally alone showed "no activity
+    // yet" directly beneath a feed proving otherwise (general-code-reviewer, full-branch sweep).
+    case 'vote_opened':
+      return { id: event.payload.vote_uid, kind: 'other', title: event.payload.name };
     case 'document_uploaded':
       return { id: `document:${event.payload.document_type}:${event.payload.document_uid}`, kind: 'doc', title: event.payload.name };
     case 'notes_added':
@@ -1208,11 +1222,16 @@ export class WeeklyBriefService {
    * "`buildCurrentActivity` itself resolved to `undefined` well within budget", which needs no
    * warning of its own (it already logs its own reason for degrading). The loser of the race is
    * not cancelled (`buildCurrentActivity` has no cancellation hook — its underlying upstream
-   * calls keep running until they settle or their own timeout fires). The trailing `.catch()` on
-   * it is defense-in-depth, not a live path today: `buildCurrentActivity`'s own try/catch already
-   * wraps everything it does, so it can never actually reject as written — kept so a late
-   * rejection stays harmless rather than an unhandled one if that invariant ever changes, same
-   * rationale as this file's other "unreached in practice" guards.
+   * calls keep running until they settle or their own timeout fires).
+   *
+   * The `catch` below is this method's OWN fail-soft guarantee, not defense-in-depth borrowed
+   * from `buildCurrentActivity`'s: `Promise.race` rejects if whichever promise wins the race
+   * rejects, and a `try/finally` with no `catch` re-throws, which would fail this method — and
+   * therefore `getCurrentBrief`'s whole `Promise.all` (the brief itself, not just the tally) —
+   * even though `buildCurrentActivity`'s own try/catch means that path isn't reachable as written
+   * today. This method doesn't lean on that distant invariant staying true; it degrades to
+   * `undefined` and warns on any rejection it sees directly, the same way it already does for a
+   * lost race.
    */
   private async buildCurrentActivityWithBudget(req: Request, committeeId: string): Promise<WeeklyBriefCurrentActivity | null | undefined> {
     const BUDGET_ELAPSED = Symbol('current_activity_budget_elapsed');
@@ -1232,6 +1251,12 @@ export class WeeklyBriefService {
         return undefined;
       }
       return winner;
+    } catch (err) {
+      logger.warning(req, 'get_weekly_brief_current_activity', 'Current-activity fan-out rejected unexpectedly, omitting the tally', {
+        committee_id: committeeId,
+        err,
+      });
+      return undefined;
     } finally {
       clearTimeout(timer!);
     }

--- a/packages/shared/src/constants/activity-event.constants.spec.ts
+++ b/packages/shared/src/constants/activity-event.constants.spec.ts
@@ -1,0 +1,19 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+// Pins ACTIVITY_FEED_MAX_PAGE_SIZE against the value weekly-brief.service.spec.ts's fixtures are
+// built from. That file mocks `@lfx-one/shared/constants` wholesale (same JIT-compilation-failure
+// avoidance as weekly-brief.constants.spec.ts's own header comment describes) and hand-copies this
+// constant's value into the mock factory — so a real-value change wouldn't be caught by that file's
+// own "built from the constant, not a bare literal" fixtures, which are really built from the
+// mock's copy. This is the one place the real value is loaded and checked.
+
+import { describe, expect, it } from 'vitest';
+
+import { ACTIVITY_FEED_MAX_PAGE_SIZE } from './activity-event.constants';
+
+describe('ACTIVITY_FEED_MAX_PAGE_SIZE', () => {
+  it("matches the value weekly-brief.service.spec.ts's mock factory hand-copies", () => {
+    expect(ACTIVITY_FEED_MAX_PAGE_SIZE).toBe(50);
+  });
+});

--- a/packages/shared/src/constants/activity-event.constants.spec.ts
+++ b/packages/shared/src/constants/activity-event.constants.spec.ts
@@ -2,8 +2,7 @@
 // SPDX-License-Identifier: MIT
 
 // Pins ACTIVITY_FEED_MAX_PAGE_SIZE against the value weekly-brief.service.spec.ts's fixtures are
-// built from. That file mocks `@lfx-one/shared/constants` wholesale (same JIT-compilation-failure
-// avoidance as weekly-brief.constants.spec.ts's own header comment describes) and hand-copies this
+// built from. That file mocks `@lfx-one/shared/constants` wholesale and hand-copies this
 // constant's value into the mock factory — so a real-value change wouldn't be caught by that file's
 // own "built from the constant, not a bare literal" fixtures, which are really built from the
 // mock's copy. This is the one place the real value is loaded and checked.

--- a/packages/shared/src/constants/weekly-brief.constants.spec.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.spec.ts
@@ -1,12 +1,13 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Pins WEEKLY_BRIEF_TEXT_MAX_LENGTH against upstream's documented bound, and
-// WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS against the value the server spec's mock hand-copies
-// (see that constant's own test below). The BFF's server-side vitest config mocks
-// `@lfx-one/shared/constants` wholesale (to avoid re-triggering an Angular JIT-compilation
-// failure — see weekly-brief.controller.spec.ts), so its mocked values can't catch drift if
-// either constant ever changes. This is the one place the real values are loaded and checked.
+// Pins this module's constants against the values their own consumers assume — either an
+// upstream-documented bound, or a value a server spec's `vi.mock('@lfx-one/shared/constants', ...)`
+// hand-copies (which real-value drift wouldn't otherwise be caught against; see each `it()` below
+// for which applies and why). NOT the BFF's vitest config that could otherwise be blamed for
+// needing this: that only aliases `@lfx-one/shared` to the real source
+// (`apps/lfx-one/vitest.config.ts`'s own comment: "server specs exercise the real shared barrels
+// instead of drift-prone vi.mock stubs") — any hand-copying happens per spec file, not centrally.
 
 import { describe, expect, it } from 'vitest';
 

--- a/packages/shared/src/constants/weekly-brief.constants.spec.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.spec.ts
@@ -1,11 +1,12 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Pins WEEKLY_BRIEF_TEXT_MAX_LENGTH against upstream's documented bound. The BFF's
-// server-side vitest config mocks `@lfx-one/shared/constants` wholesale (to avoid
-// re-triggering an Angular JIT-compilation failure — see weekly-brief.controller.spec.ts),
-// so its mocked value can't catch drift if this constant ever changes. This is the one
-// place the real value is loaded and checked.
+// Pins WEEKLY_BRIEF_TEXT_MAX_LENGTH against upstream's documented bound, and
+// WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS against the value the server spec's mock hand-copies
+// (see that constant's own test below). The BFF's server-side vitest config mocks
+// `@lfx-one/shared/constants` wholesale (to avoid re-triggering an Angular JIT-compilation
+// failure — see weekly-brief.controller.spec.ts), so its mocked values can't catch drift if
+// either constant ever changes. This is the one place the real values are loaded and checked.
 
 import { describe, expect, it } from 'vitest';
 
@@ -27,14 +28,15 @@ describe('WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS', () => {
     expect(WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS).toBeLessThan(WEEKLY_BRIEF_POLL_INTERVAL_MS);
   });
 
-  // Absolute pin, alongside the relative one above — weekly-brief.service.spec.ts's own budget
-  // test imports this identifier through that file's `vi.mock('@lfx-one/shared/constants', ...)`
-  // hand-copy (currently 3_000, kept in sync by hand), so a real-value change here would leave
-  // that test silently exercising a value production no longer uses, with only the relative
-  // ordering test above (which a value change could still satisfy) standing between that drift
-  // and going unnoticed. Same rationale as activity-event.constants.spec.ts's pin on
+  // Absolute pin, alongside the relative one above —
+  // apps/lfx-one/src/server/services/weekly-brief.service.spec.ts's own budget test imports this
+  // identifier through that file's `vi.mock('@lfx-one/shared/constants', ...)` hand-copy
+  // (currently 3_000, kept in sync by hand), so a real-value change here would leave that test
+  // silently exercising a value production no longer uses, with only the relative ordering test
+  // above (which a value change could still satisfy) standing between that drift and going
+  // unnoticed. Same rationale as activity-event.constants.spec.ts's pin on
   // ACTIVITY_FEED_MAX_PAGE_SIZE for the identical hand-copy hazard.
-  it('is 3000ms', () => {
+  it("matches the value weekly-brief.service.spec.ts's mock factory hand-copies", () => {
     expect(WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS).toBe(3_000);
   });
 });

--- a/packages/shared/src/constants/weekly-brief.constants.spec.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.spec.ts
@@ -9,11 +9,22 @@
 
 import { describe, expect, it } from 'vitest';
 
-import { WEEKLY_BRIEF_DEFAULT_THROTTLE, WEEKLY_BRIEF_TEXT_MAX_LENGTH } from './weekly-brief.constants';
+import {
+  WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS,
+  WEEKLY_BRIEF_DEFAULT_THROTTLE,
+  WEEKLY_BRIEF_POLL_INTERVAL_MS,
+  WEEKLY_BRIEF_TEXT_MAX_LENGTH,
+} from './weekly-brief.constants';
 
 describe('WEEKLY_BRIEF_TEXT_MAX_LENGTH', () => {
   it('matches upstream UpdateCurrentWeeklyBriefRequestBody.brief_text maxLength', () => {
     expect(WEEKLY_BRIEF_TEXT_MAX_LENGTH).toBe(20_000);
+  });
+});
+
+describe('WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS', () => {
+  it('stays under WEEKLY_BRIEF_POLL_INTERVAL_MS — its own doc comment claims a slow poll tick can now resolve server-side, inside this budget, before the client abandons the tick; a later edit to either constant that breaks that ordering would otherwise silently revert the claimed behavior with no other test failing', () => {
+    expect(WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS).toBeLessThan(WEEKLY_BRIEF_POLL_INTERVAL_MS);
   });
 });
 

--- a/packages/shared/src/constants/weekly-brief.constants.spec.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.spec.ts
@@ -1,13 +1,8 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-// Pins this module's constants against the values their own consumers assume — either an
-// upstream-documented bound, or a value a server spec's `vi.mock('@lfx-one/shared/constants', ...)`
-// hand-copies (which real-value drift wouldn't otherwise be caught against; see each `it()` below
-// for which applies and why). NOT the BFF's vitest config that could otherwise be blamed for
-// needing this: that only aliases `@lfx-one/shared` to the real source
-// (`apps/lfx-one/vitest.config.ts`'s own comment: "server specs exercise the real shared barrels
-// instead of drift-prone vi.mock stubs") — any hand-copying happens per spec file, not centrally.
+// Pins this module's constants against the values their own consumers assume. Each `it()` below
+// states its own rationale.
 
 import { describe, expect, it } from 'vitest';
 

--- a/packages/shared/src/constants/weekly-brief.constants.spec.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.spec.ts
@@ -26,6 +26,17 @@ describe('WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS', () => {
   it('stays under WEEKLY_BRIEF_POLL_INTERVAL_MS — its own doc comment claims a slow poll tick can now resolve server-side, inside this budget, before the client abandons the tick; a later edit to either constant that breaks that ordering would otherwise silently revert the claimed behavior with no other test failing', () => {
     expect(WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS).toBeLessThan(WEEKLY_BRIEF_POLL_INTERVAL_MS);
   });
+
+  // Absolute pin, alongside the relative one above — weekly-brief.service.spec.ts's own budget
+  // test imports this identifier through that file's `vi.mock('@lfx-one/shared/constants', ...)`
+  // hand-copy (currently 3_000, kept in sync by hand), so a real-value change here would leave
+  // that test silently exercising a value production no longer uses, with only the relative
+  // ordering test above (which a value change could still satisfy) standing between that drift
+  // and going unnoticed. Same rationale as activity-event.constants.spec.ts's pin on
+  // ACTIVITY_FEED_MAX_PAGE_SIZE for the identical hand-copy hazard.
+  it('is 3000ms', () => {
+    expect(WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS).toBe(3_000);
+  });
 });
 
 describe('WEEKLY_BRIEF_DEFAULT_THROTTLE', () => {

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -113,6 +113,15 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * list alone (not by cross-referencing `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind), so a kind
  * missing here can never render a phrase-less, blank-labeled toggle — see
  * `WeeklyBriefCurrentActivityPhrase`'s doc comment.
+ *
+ * `mailing-list` and `members` are forward-declared, not currently reachable: the server-side
+ * builder (`weekly-brief.service.ts#buildCurrentActivity`) sources `source_refs` from
+ * `CommitteeActivityService`, which has no mailing-list leg at all (tracked upstream —
+ * linuxfoundation/lfx-self-serve#1934) and never constructs a `member_joined`/`member_left`
+ * event (a known, permanently-deferred v1 limitation, not a tracked issue — no upstream
+ * membership-timestamp/deletion-history signal to build one from). A week whose only real
+ * activity was on one of these two kinds still renders "no activity yet" — an accepted v1 gap in
+ * what the tally can attest to, not a claim that no such activity occurred.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES: readonly WeeklyBriefCurrentActivityPhrase[] = [
   { kind: 'meeting', singular: 'meeting held', plural: 'meetings held' },

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -54,6 +54,19 @@ export const WEEKLY_BRIEF_ACTION_ITEM_OWNER_ROLE_MAX_LENGTH = 100;
 export const WEEKLY_BRIEF_POLL_INTERVAL_MS = 4000;
 export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
 
+/**
+ * Caps how many poll ticks (GH-1922) keep asking the BFF to rebuild `current_activity` while it
+ * stays absent (`undefined` — see `WeeklyBriefCurrentResponse.current_activity`'s doc comment).
+ * That fan-out isn't free — a governance committee's tally costs an upstream committee read plus
+ * `CommitteeActivityService`'s own multi-call aggregation — and a persistently failing upstream
+ * would otherwise get asked again on every one of `WEEKLY_BRIEF_MAX_POLL_ATTEMPTS` ticks for an
+ * answer that keeps failing the same way. Deliberately smaller than that cap: this only bounds the
+ * *tally's* self-heal retries, not the brief's own terminal-state poll, which keeps running
+ * regardless — a card can still finish generating and simply render without the "this week so
+ * far" line once this is exhausted.
+ */
+export const WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS = 3;
+
 /** States a poll of GET /current should stop on — everything else (`empty`, `generating`) keeps it running. */
 export const WEEKLY_BRIEF_TERMINAL_STATES: ReadonlySet<WeeklyBriefState> = new Set(['generated', 'edited', 'approved', 'error']);
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -61,31 +61,42 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * the same `Promise.all` as the brief fetch, `buildCurrentActivity` already degrades any error to
  * `undefined` (fails soft), but that only helps if the failure is fast — a slow-but-not-erroring
  * upstream (each of its several legs defaults to a much longer per-call timeout) would otherwise
- * add real seconds to a response that should return in well under one. Deliberately generous
- * relative to a normal aggregation (this isn't tuned from production latency data, just picked to
- * be comfortably longer than typical completion and clearly shorter than any single leg's own
- * timeout).
+ * add real seconds to a response that should return in well under one.
  *
- * In practice this only binds `weekly-brief-card.component.ts`'s initial (non-poll) load of
- * `GET /current`, which has no client-side timeout of its own — that's the truly unbounded case
- * this constant exists for. On the polling path (`pollUntilTerminal`), the client already wraps
- * every tick in its own `timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS)` (4s, well under this budget), so
- * a slow fan-out there gets abandoned client-side first; this budget never gets the chance to be
- * the thing that resolves it. It still isn't wasted work on that path — bounding the server-side
- * fan-out itself, independent of whether a client is still listening, is worth doing on its own
- * — just don't read it as protecting the poll response's timing, which the client's own timeout
- * already owns. When this constant's value resolves the race, it degrades to `undefined`, the
- * same transient/"worth asking again" value any other `buildCurrentActivity` failure produces —
- * self-heal from that is exactly as good (and exactly as limited) as
+ * Deliberately tighter than an aggregation's own per-leg timeout would suggest, and specifically
+ * NOT sized around "comfortably longer than typical completion" the way a generous fire-and-
+ * forget timeout would be: because the tally shares `getCurrentBrief`'s `Promise.all` with the
+ * brief fetch itself, this value is a direct, worst-case tax on the PRIMARY content — the AI-
+ * generated brief text a page load is actually waiting to see — not just on an optional
+ * enrichment. A larger budget (this constant started at 10s) buys the tally more time to recover
+ * on a slow-but-alive upstream, at the direct cost of making every viewer wait that much longer
+ * to see their brief on that upstream's bad days. 3s was chosen as a value still comfortably
+ * clear of any single leg's own 30s timeout, while keeping that worst-case tax small next to a
+ * page load a viewer already expects to take a moment.
+ *
+ * This also changes which path the budget actually binds. On `weekly-brief-card.component.ts`'s
+ * initial (non-poll) load — the truly unbounded case this constant exists for, since that GET has
+ * no client-side timeout of its own — it was always the deciding bound, before and after this
+ * value's tightening. On the polling path (`pollUntilTerminal`), each tick is separately wrapped
+ * in `timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS)` (4s client-side); at the original 10s this budget
+ * could never be what resolved a slow tick (the client gave up first), but at 3s — under that 4s
+ * client timeout — a slow-but-alive upstream now typically degrades server-side, inside this
+ * budget, before the client's own timeout would otherwise abandon the tick.
+ *
+ * When this constant's value resolves the race, it degrades to `undefined`, the same transient/
+ * "worth asking again" value any other `buildCurrentActivity` failure produces — self-heal from
+ * that is exactly as good (and exactly as limited) as
  * `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`'s own doc comment already describes: it only
  * happens while the card is actively polling (a generating brief), not on an initial load that
  * lands on an already-terminal one — that known v1 gap applies here unchanged, not restated.
  * Note the retries that budget enables are not free: the loser of the race in
  * `buildCurrentActivityWithBudget` is never cancelled, so a persistently slow upstream can end up
  * serving multiple overlapping fan-outs at once (one per ask attempt) rather than being asked
- * once and left alone.
+ * once and left alone. Structurally decoupling the tally into its own request — so a slow
+ * upstream delays only the enrichment, never the brief — would remove this tax entirely; not done
+ * here (see this branch's PR description for why it's a deferred, not a dismissed, trade-off).
  */
-export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 10_000;
+export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 3_000;
 
 /**
  * Caps how many poll ticks (GH-1922) keep asking the BFF to rebuild `current_activity` while it

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -68,9 +68,12 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * Known v1 gap this cap doesn't cover: `pollUntilTerminal` (where this budget lives) only runs
  * while the brief itself is `generating` — a page load onto an already-terminal brief (the far
  * more common case) never invokes it at all. A transient `current_activity` degrade on that load
- * has no DELIBERATE self-heal path here; the tally doesn't recover until the next authoritative
- * fetch — a navigation, a reload, or an incidental `refresh$` emission (a saved edit, a share/save
- * 409) that happens to re-run the same GET, none of which exist to retry this specifically. Not
+ * has no self-heal PURPOSE-BUILT for it — nothing in `weekly-brief-card.component.ts` exists to
+ * retry the tally specifically. It can still recover incidentally, any time something else causes
+ * `initBriefResponseSubscription`'s GET to re-run (a navigation, a reload, `refresh$`, or a
+ * visible retry control in another render branch) — deliberately not enumerated here, since which
+ * call sites/buttons do that is exactly the kind of detail that drifts out of sync with its
+ * source as the component evolves; see that file's own call sites for the current list. Not
  * solved by this constant — a real fix would need `initBriefResponseSubscription` to kick off its
  * own bounded re-ask, independent of the generating-poll's budget.
  */

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -55,6 +55,22 @@ export const WEEKLY_BRIEF_POLL_INTERVAL_MS = 4000;
 export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
 
 /**
+ * Bounds how long `WeeklyBriefService#buildCurrentActivity` (GH-1922) is allowed to run before
+ * `getCurrentBrief` gives up on it and renders the brief without the tally. Without this, a
+ * degraded upstream could hold the ENTIRE `GET /current` response hostage: the tally runs inside
+ * the same `Promise.all` as the brief fetch, `buildCurrentActivity` already degrades any error to
+ * `undefined` (fails soft), but that only helps if the failure is fast — a slow-but-not-erroring
+ * upstream (each of its several legs defaults to a much longer per-call timeout) would otherwise
+ * add real seconds to a response that should return in well under one. Deliberately generous
+ * relative to a normal aggregation (this isn't tuned from production latency data, just picked to
+ * be comfortably longer than typical completion and clearly shorter than any single leg's own
+ * timeout) — a timeout here resolves to `undefined`, the same transient/"worth asking again"
+ * value any other `buildCurrentActivity` failure produces, so the existing poll self-heal
+ * (`WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`) already knows how to recover from it.
+ */
+export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 10_000;
+
+/**
  * Caps how many poll ticks (GH-1922) keep asking the BFF to rebuild `current_activity` while it
  * stays absent (`undefined` — see `WeeklyBriefCurrentResponse.current_activity`'s doc comment).
  * That fan-out isn't free — a governance committee's tally costs an upstream committee read plus

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -190,13 +190,17 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * not by cross-referencing `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind for that part, so a kind present
  * here always gets a real countText, never a placeholder. That's not the WHOLE membership story,
  * though: the same method also appends a single trailing `other` section, its kind/label/countText
- * all hardcoded inline rather than sourced from this list, for any `source_refs` kind this list
- * doesn't recognize (currently `vote_opened` and `survey_published`/`survey_closed` — see
- * `mapActivityEventToCurrentActivityRef`'s own doc comment in `weekly-brief.service.ts`) — so a
- * kind missing from this list doesn't vanish, it just loses its own count text and its position in
- * the display order. The section's display LABEL, separately, IS looked up from
+ * all hardcoded inline rather than sourced from this list, for any `source_refs` entry whose kind
+ * this list doesn't recognize — today that's only the literal kind `other` itself, which the
+ * server-side mapper stamps on `vote_opened` and `survey_published`/`survey_closed` events (see
+ * `mapActivityEventToCurrentActivityRef`'s own doc comment in
+ * `apps/lfx-one/src/server/services/weekly-brief.service.ts`; no `source_ref` is ever literally
+ * `kind: 'vote_opened'` or `'survey_published'` — those are `ActivityEvent` types, already folded
+ * to `other` before this list ever sees them) — so a kind missing from this list doesn't vanish, it
+ * just loses its own count text and its position in the display order. The section's display
+ * LABEL, separately, IS looked up from
  * `WEEKLY_BRIEF_SOURCE_SECTIONS` (with a `?? kind` fallback covering the reverse gap — a kind
- * present here but missing there) — see `WeeklyBriefCurrentActivityPhrase`'s doc comment.
+ * present here but missing there).
  *
  * `mailing-list` and `members` are forward-declared, not currently reachable: the server-side
  * builder (`weekly-brief.service.ts#buildCurrentActivity`) sources `source_refs` from

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -185,10 +185,16 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * count text ("1 meeting held" / "2 meetings held"). Kept separate from
  * `WEEKLY_BRIEF_SOURCE_SECTIONS` because the two solve different problems: that constant is a
  * noun *label* for a disclosure section heading ("Meetings"), this is a verb *phrase* for a
- * count sentence — but `weekly-brief-card.component.ts` drives the tally's section MEMBERSHIP
- * (which kinds exist, and in what order) from THIS list alone, not by cross-referencing
- * `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind for that part, so a kind missing here can never render a
- * countText-less toggle. The section's display LABEL, separately, IS looked up from
+ * count sentence — but `weekly-brief-card.component.ts` drives the RECOGNIZED sections' order and
+ * membership from THIS list alone (via `initCurrentActivitySections`' `WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES.map(...)`),
+ * not by cross-referencing `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind for that part, so a kind present
+ * here always gets a real countText, never a placeholder. That's not the WHOLE membership story,
+ * though: the same method also appends a single trailing `other` section, its kind/label/countText
+ * all hardcoded inline rather than sourced from this list, for any `source_refs` kind this list
+ * doesn't recognize (currently `vote_opened` and `survey_published`/`survey_closed` — see
+ * `mapActivityEventToCurrentActivityRef`'s own doc comment in `weekly-brief.service.ts`) — so a
+ * kind missing from this list doesn't vanish, it just loses its own count text and its position in
+ * the display order. The section's display LABEL, separately, IS looked up from
  * `WEEKLY_BRIEF_SOURCE_SECTIONS` (with a `?? kind` fallback covering the reverse gap — a kind
  * present here but missing there) — see `WeeklyBriefCurrentActivityPhrase`'s doc comment.
  *

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -94,7 +94,7 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * serving multiple overlapping fan-outs at once (one per ask attempt) rather than being asked
  * once and left alone. Structurally decoupling the tally into its own request — so a slow
  * upstream delays only the enrichment, never the brief — would remove this tax entirely; not done
- * here (see this branch's PR description for why it's a deferred, not a dismissed, trade-off).
+ * here — a deferred, not a dismissed, trade-off (linuxfoundation/lfx-self-serve#1922).
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 3_000;
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -91,10 +91,15 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * lands on an already-terminal one — that known v1 gap applies here unchanged, not restated.
  * Note the retries that budget enables are not free: the loser of the race in
  * `buildCurrentActivityWithBudget` is never cancelled, so a persistently slow upstream can end up
- * serving multiple overlapping fan-outs at once (one per ask attempt) rather than being asked
- * once and left alone. Structurally decoupling the tally into its own request — so a slow
- * upstream delays only the enrichment, never the brief — would remove this tax entirely; not done
- * here — a deferred, not a dismissed, trade-off (linuxfoundation/lfx-self-serve#1922).
+ * serving multiple overlapping fan-outs at once (one per ask attempt, up to
+ * `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` + the initial load) rather than being asked
+ * once and left alone — a genuine retry-amplification risk against a struggling upstream, not
+ * mitigated here (no `AbortSignal` threading, no per-committee in-flight dedupe). Structurally
+ * decoupling the tally into its own request — so a slow upstream delays only the enrichment,
+ * never the brief, and a lost race can actually be cancelled — would remove this tax and the
+ * amplification risk entirely; deliberately not done here. A known, accepted v1 limitation, not
+ * an oversight: the machinery already in this file (the budget race, the sentinel, the ask-attempt
+ * cap, the poll's opt-out gate) exists specifically to manage this coupling, not to hide it.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 3_000;
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -76,11 +76,14 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * — just don't read it as protecting the poll response's timing, which the client's own timeout
  * already owns. When this constant's value resolves the race, it degrades to `undefined`, the
  * same transient/"worth asking again" value any other `buildCurrentActivity` failure produces —
- * on the initial-load path that's what lets `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`
- * self-heal on the next poll tick once the brief starts generating. Note the retries that budget
- * enables are not free: the loser of the race in `buildCurrentActivityWithBudget` is never
- * cancelled, so a persistently slow upstream can end up serving multiple overlapping fan-outs at
- * once (one per ask attempt) rather than being asked once and left alone.
+ * self-heal from that is exactly as good (and exactly as limited) as
+ * `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`'s own doc comment already describes: it only
+ * happens while the card is actively polling (a generating brief), not on an initial load that
+ * lands on an already-terminal one — that known v1 gap applies here unchanged, not restated.
+ * Note the retries that budget enables are not free: the loser of the race in
+ * `buildCurrentActivityWithBudget` is never cancelled, so a persistently slow upstream can end up
+ * serving multiple overlapping fan-outs at once (one per ask attempt) rather than being asked
+ * once and left alone.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 10_000;
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -64,9 +64,23 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * add real seconds to a response that should return in well under one. Deliberately generous
  * relative to a normal aggregation (this isn't tuned from production latency data, just picked to
  * be comfortably longer than typical completion and clearly shorter than any single leg's own
- * timeout) — a timeout here resolves to `undefined`, the same transient/"worth asking again"
- * value any other `buildCurrentActivity` failure produces, so the existing poll self-heal
- * (`WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`) already knows how to recover from it.
+ * timeout).
+ *
+ * In practice this only binds `weekly-brief-card.component.ts`'s initial (non-poll) load of
+ * `GET /current`, which has no client-side timeout of its own — that's the truly unbounded case
+ * this constant exists for. On the polling path (`pollUntilTerminal`), the client already wraps
+ * every tick in its own `timeout(WEEKLY_BRIEF_POLL_INTERVAL_MS)` (4s, well under this budget), so
+ * a slow fan-out there gets abandoned client-side first; this budget never gets the chance to be
+ * the thing that resolves it. It still isn't wasted work on that path — bounding the server-side
+ * fan-out itself, independent of whether a client is still listening, is worth doing on its own
+ * — just don't read it as protecting the poll response's timing, which the client's own timeout
+ * already owns. When this constant's value resolves the race, it degrades to `undefined`, the
+ * same transient/"worth asking again" value any other `buildCurrentActivity` failure produces —
+ * on the initial-load path that's what lets `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`
+ * self-heal on the next poll tick once the brief starts generating. Note the retries that budget
+ * enables are not free: the loser of the race in `buildCurrentActivityWithBudget` is never
+ * cancelled, so a persistently slow upstream can end up serving multiple overlapping fan-outs at
+ * once (one per ask attempt) rather than being asked once and left alone.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 10_000;
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -134,10 +134,12 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * count text ("1 meeting held" / "2 meetings held"). Kept separate from
  * `WEEKLY_BRIEF_SOURCE_SECTIONS` because the two solve different problems: that constant is a
  * noun *label* for a disclosure section heading ("Meetings"), this is a verb *phrase* for a
- * count sentence — but `weekly-brief-card.component.ts` drives the tally's sections from THIS
- * list alone (not by cross-referencing `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind), so a kind
- * missing here can never render a phrase-less, blank-labeled toggle — see
- * `WeeklyBriefCurrentActivityPhrase`'s doc comment.
+ * count sentence — but `weekly-brief-card.component.ts` drives the tally's section MEMBERSHIP
+ * (which kinds exist, and in what order) from THIS list alone, not by cross-referencing
+ * `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind for that part, so a kind missing here can never render a
+ * countText-less toggle. The section's display LABEL, separately, IS looked up from
+ * `WEEKLY_BRIEF_SOURCE_SECTIONS` (with a `?? kind` fallback covering the reverse gap — a kind
+ * present here but missing there) — see `WeeklyBriefCurrentActivityPhrase`'s doc comment.
  *
  * `mailing-list` and `members` are forward-declared, not currently reachable: the server-side
  * builder (`weekly-brief.service.ts#buildCurrentActivity`) sources `source_refs` from

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -102,3 +102,18 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
   { kind: 'doc', label: 'Documents' },
   { kind: 'members', label: 'Membership' },
 ] as const;
+
+/**
+ * Verb phrasing for the "this week so far" activity-tally caption (GH-1922) — one entry per
+ * `WEEKLY_BRIEF_SOURCE_SECTIONS` kind. Kept separate from that constant because the two solve
+ * different problems: `WEEKLY_BRIEF_SOURCE_SECTIONS` is a noun *label* for a disclosure section
+ * heading ("Meetings"), this is a verb *phrase* for a count sentence ("1 meeting held" / "2
+ * meetings held") — singular/plural forms a section label doesn't need.
+ */
+export const WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES: readonly { kind: string; singular: string; plural: string }[] = [
+  { kind: 'meeting', singular: 'meeting held', plural: 'meetings held' },
+  { kind: 'vote', singular: 'vote closed', plural: 'votes closed' },
+  { kind: 'mailing-list', singular: 'mailing-list post', plural: 'mailing-list posts' },
+  { kind: 'doc', singular: 'document added', plural: 'documents added' },
+  { kind: 'members', singular: 'membership change', plural: 'membership changes' },
+] as const;

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -198,9 +198,8 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
  * `kind: 'vote_opened'` or `'survey_published'` — those are `ActivityEvent` types, already folded
  * to `other` before this list ever sees them) — so a kind missing from this list doesn't vanish, it
  * just loses its own count text and its position in the display order. The section's display
- * LABEL, separately, IS looked up from
- * `WEEKLY_BRIEF_SOURCE_SECTIONS` (with a `?? kind` fallback covering the reverse gap — a kind
- * present here but missing there).
+ * LABEL, separately, IS looked up from `WEEKLY_BRIEF_SOURCE_SECTIONS` (with a `?? kind` fallback
+ * covering the reverse gap — a kind present here but missing there).
  *
  * `mailing-list` and `members` are forward-declared, not currently reachable: the server-side
  * builder (`weekly-brief.service.ts#buildCurrentActivity`) sources `source_refs` from

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -1,7 +1,7 @@
 // Copyright The Linux Foundation and each contributor to LFX.
 // SPDX-License-Identifier: MIT
 
-import { WeeklyBriefSourceSection, WeeklyBriefState } from '../interfaces/weekly-brief.interface';
+import { WeeklyBriefCurrentActivityPhrase, WeeklyBriefSourceSection, WeeklyBriefState } from '../interfaces/weekly-brief.interface';
 
 /**
  * Brief states a "Share to Mailing List" action may fire from — i.e. states
@@ -104,13 +104,17 @@ export const WEEKLY_BRIEF_SOURCE_SECTIONS: readonly WeeklyBriefSourceSection[] =
 ] as const;
 
 /**
- * Verb phrasing for the "this week so far" activity-tally caption (GH-1922) — one entry per
- * `WEEKLY_BRIEF_SOURCE_SECTIONS` kind. Kept separate from that constant because the two solve
- * different problems: `WEEKLY_BRIEF_SOURCE_SECTIONS` is a noun *label* for a disclosure section
- * heading ("Meetings"), this is a verb *phrase* for a count sentence ("1 meeting held" / "2
- * meetings held") — singular/plural forms a section label doesn't need.
+ * Verb phrasing for the "this week so far" activity-tally caption (GH-1922) — the single source
+ * of truth for which kinds the tally recognizes, their display order, and their singular/plural
+ * count text ("1 meeting held" / "2 meetings held"). Kept separate from
+ * `WEEKLY_BRIEF_SOURCE_SECTIONS` because the two solve different problems: that constant is a
+ * noun *label* for a disclosure section heading ("Meetings"), this is a verb *phrase* for a
+ * count sentence — but `weekly-brief-card.component.ts` drives the tally's sections from THIS
+ * list alone (not by cross-referencing `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind), so a kind
+ * missing here can never render a phrase-less, blank-labeled toggle — see
+ * `WeeklyBriefCurrentActivityPhrase`'s doc comment.
  */
-export const WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES: readonly { kind: string; singular: string; plural: string }[] = [
+export const WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES: readonly WeeklyBriefCurrentActivityPhrase[] = [
   { kind: 'meeting', singular: 'meeting held', plural: 'meetings held' },
   { kind: 'vote', singular: 'vote closed', plural: 'votes closed' },
   { kind: 'mailing-list', singular: 'mailing-list post', plural: 'mailing-list posts' },

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -64,6 +64,13 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * *tally's* self-heal retries, not the brief's own terminal-state poll, which keeps running
  * regardless — a card can still finish generating and simply render without the "this week so
  * far" line once this is exhausted.
+ *
+ * Known v1 gap this cap doesn't cover: `pollUntilTerminal` (where this budget lives) only runs
+ * while the brief itself is `generating` — a page load onto an already-terminal brief (the far
+ * more common case) never invokes it at all. A transient `current_activity` degrade on that load
+ * has no self-heal path here; the tally simply doesn't render until the next navigation or
+ * reload. Not solved by this constant — a fix would need `initBriefResponseSubscription` to kick
+ * off its own bounded re-ask, independent of the generating-poll's budget.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS = 3;
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -98,8 +98,10 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * decoupling the tally into its own request — so a slow upstream delays only the enrichment,
  * never the brief, and a lost race can actually be cancelled — would remove this tax and the
  * amplification risk entirely; deliberately not done here. A known, accepted v1 limitation, not
- * an oversight: the machinery already in this file (the budget race, the sentinel, the ask-attempt
- * cap, the poll's opt-out gate) exists specifically to manage this coupling, not to hide it.
+ * an oversight: the machinery already built around this coupling — the budget race and its
+ * `BUDGET_ELAPSED` sentinel in `weekly-brief.service.ts`'s `buildCurrentActivityWithBudget`, this
+ * file's own ask-attempt cap, and the poll's opt-out gate in `weekly-brief-card.component.ts` —
+ * exists specifically to manage it, not to hide it.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS = 3_000;
 

--- a/packages/shared/src/constants/weekly-brief.constants.ts
+++ b/packages/shared/src/constants/weekly-brief.constants.ts
@@ -68,9 +68,11 @@ export const WEEKLY_BRIEF_MAX_POLL_ATTEMPTS = 20;
  * Known v1 gap this cap doesn't cover: `pollUntilTerminal` (where this budget lives) only runs
  * while the brief itself is `generating` — a page load onto an already-terminal brief (the far
  * more common case) never invokes it at all. A transient `current_activity` degrade on that load
- * has no self-heal path here; the tally simply doesn't render until the next navigation or
- * reload. Not solved by this constant — a fix would need `initBriefResponseSubscription` to kick
- * off its own bounded re-ask, independent of the generating-poll's budget.
+ * has no DELIBERATE self-heal path here; the tally doesn't recover until the next authoritative
+ * fetch — a navigation, a reload, or an incidental `refresh$` emission (a saved edit, a share/save
+ * 409) that happens to re-run the same GET, none of which exist to retry this specifically. Not
+ * solved by this constant — a real fix would need `initBriefResponseSubscription` to kick off its
+ * own bounded re-ask, independent of the generating-poll's budget.
  */
 export const WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS = 3;
 

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -96,6 +96,19 @@ export interface WeeklyBriefSourceChipSection extends WeeklyBriefSourceSection {
   chips: WeeklyBriefSourceChip[];
 }
 
+/**
+ * A `WeeklyBriefSourceSection` populated with one kind's non-zero refs from
+ * `WeeklyBriefCurrentActivity.source_refs`, plus the precomputed verb-phrase count text for
+ * that kind (e.g. "1 meeting held") — the "this week so far" tally's analog to
+ * `WeeklyBriefSourceChipSection` (GH-1922). Omitted entirely (not zero-length) for a kind with
+ * no activity — `weekly-brief-card.component.ts`'s `currentActivitySections` only returns
+ * non-zero kinds, same filtering `initSourceChipSections` already does for the Sources row.
+ */
+export interface WeeklyBriefCurrentActivitySection extends WeeklyBriefSourceSection {
+  refs: WeeklyBriefSourceRef[];
+  countText: string;
+}
+
 export interface WeeklyBrief {
   uid: string;
   committee_uid: string;
@@ -154,6 +167,22 @@ export interface WeeklyBriefCurrentResponse {
    * per-user rating store, not upstream — see `weekly-brief.service.ts#getCurrentBrief`.
    */
   caller_rating?: WeeklyBriefRating | null;
+  /**
+   * BFF-side enrichment (not part of upstream's contract, same as `caller_rating`): a raw
+   * count of activity in the current, not-yet-closed week — distinct from `brief`'s own
+   * completed-week window (GH-1922). Only populated in mock mode: there is no upstream
+   * committee-service endpoint for in-progress-week counts yet, and live mode is a pure
+   * proxy passthrough that never fabricates one. Absent (not null) in live mode until that
+   * upstream support exists — see `weekly-brief.service.ts#getCurrentBrief`.
+   */
+  current_activity?: WeeklyBriefCurrentActivity;
+}
+
+/** See `WeeklyBriefCurrentResponse.current_activity`. */
+export interface WeeklyBriefCurrentActivity {
+  window_start: string;
+  window_end: string;
+  source_refs: WeeklyBriefSourceRef[];
 }
 
 /** A caller's one-tap quality rating on a specific weekly-brief revision. BFF-only — no upstream equivalent. */

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -191,18 +191,15 @@ export interface WeeklyBriefCurrentResponse {
    * `weekly-brief.service.ts#buildCurrentActivity`. Three states, not two — `null` and absent
    * are deliberately distinct:
    *   - **Absent** (key not present at all): two distinct classes of cause, only one worth
-   *     re-asking for. Either `buildCurrentActivity` genuinely couldn't produce an answer — see
-   *     that method's own doc comment for the exact taxonomy (lookup failure, activity-fetch
-   *     failure, or a resolved-but-unclassifiable committee) rather than re-deriving it here,
-   *     since it's the kind of detail that drifts out of sync with its source — which is
-   *     transient and worth asking again on a governance committee, up to
-   *     `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` poll ticks; OR the caller deliberately
-   *     asked the BFF to skip the fan-out via `includeCurrentActivity: false` (GH-1922 cost
-   *     optimization — `weekly-brief-card.component.ts` does this on every non-poll load — initial
-   *     load and any `refresh$`-triggered re-fetch — for any committee it already knows isn't
-   *     governance-classified, since the tally section can never render for one regardless),
-   *     which is never worth re-asking for. A caller re-asking on absent must also check whether
-   *     asking is worthwhile at all — see `weekly-brief-card.component.ts`'s `pollUntilTerminal`,
+   *     re-asking for. Either `buildCurrentActivity` genuinely couldn't produce an answer (see
+   *     that method's own doc comment for its three actual causes) — transient, worth asking
+   *     again on a governance committee, up to `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`
+   *     poll ticks; OR the caller deliberately asked the BFF to skip the fan-out via
+   *     `includeCurrentActivity: false` (GH-1922 cost optimization —
+   *     `weekly-brief-card.component.ts` does this on every non-poll load for any committee it
+   *     already knows isn't governance-classified, since the tally section can never render for
+   *     one regardless) — never worth re-asking for. A caller re-asking on absent must also check
+   *     whether asking is worthwhile at all — see `weekly-brief-card.component.ts`'s `pollUntilTerminal`,
    *     which additionally gates on `isGoverningBoardCommittee()` for exactly this reason.
    *   - **`null`**: known, definitively, not to apply — the committee isn't
    *     governance-classified, or the current week's activity exceeds what a single upstream

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -190,8 +190,16 @@ export interface WeeklyBriefCurrentResponse {
    * populated identically in mock and live mode — see
    * `weekly-brief.service.ts#buildCurrentActivity`. Three states, not two — `null` and absent
    * are deliberately distinct:
-   *   - **Absent** (key not present at all): couldn't determine — the committee lookup or
-   *     activity fetch failed. Transient; worth asking again.
+   *   - **Absent** (key not present at all): two distinct causes, only one worth re-asking for.
+   *     Either the committee lookup or activity fetch genuinely failed (transient; worth asking
+   *     again on a governance committee, up to `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`
+   *     poll ticks), OR the caller deliberately asked the BFF to skip the fan-out via
+   *     `includeCurrentActivity: false` (GH-1922 cost optimization — `weekly-brief-card.component.ts`'s
+   *     initial load does this for any committee it already knows isn't governance-classified,
+   *     since the tally section can never render for one regardless). A caller re-asking on
+   *     absent must also check whether asking is worthwhile at all — see
+   *     `weekly-brief-card.component.ts`'s `pollUntilTerminal`, which additionally gates on
+   *     `isGoverningBoardCommittee()` for exactly this reason.
    *   - **`null`**: known, definitively, not to apply — the committee isn't
    *     governance-classified, or the current week's activity exceeds what a single upstream
    *     page can return (never a silently-truncated count). Not transient; re-asking within the

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -101,12 +101,27 @@ export interface WeeklyBriefSourceChipSection extends WeeklyBriefSourceSection {
  * `WeeklyBriefCurrentActivity.source_refs`, plus the precomputed verb-phrase count text for
  * that kind (e.g. "1 meeting held") — the "this week so far" tally's analog to
  * `WeeklyBriefSourceChipSection` (GH-1922). Omitted entirely (not zero-length) for a kind with
- * no activity — `weekly-brief-card.component.ts`'s `currentActivitySections` only returns
- * non-zero kinds, same filtering `initSourceChipSections` already does for the Sources row.
+ * no activity — `weekly-brief-card.component.ts`'s `currentActivity` (built by
+ * `initCurrentActivitySections`) only returns non-zero kinds, same filtering
+ * `initSourceChipSections` already does for the Sources row.
  */
 export interface WeeklyBriefCurrentActivitySection extends WeeklyBriefSourceSection {
   refs: WeeklyBriefSourceRef[];
   countText: string;
+}
+
+/**
+ * Verb-phrase singular/plural for one activity kind in the "this week so far" tally caption
+ * (GH-1922) — see `WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`. This is the single source of truth
+ * for which kinds the tally recognizes and in what order; `weekly-brief-card.component.ts`
+ * drives its sections from this list directly rather than cross-referencing
+ * `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind, so a kind present in one list but not the other can
+ * never produce a phrase-less, blank-labeled toggle.
+ */
+export interface WeeklyBriefCurrentActivityPhrase {
+  kind: string;
+  singular: string;
+  plural: string;
 }
 
 export interface WeeklyBrief {

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -179,7 +179,7 @@ export interface WeeklyBriefCurrentResponse {
    * BFF-side enrichment (not part of upstream's contract): the calling user's own rating on
    * this specific `brief.uid` + `brief.revision`, or `null` if they haven't rated it (or no
    * `brief` was returned). Absent entirely when `brief` is null. Read from the BFF's
-   * per-user rating store, not upstream — see `weekly-brief.service.ts#getCurrentBrief`.
+   * per-user rating store, not upstream — see `weekly-brief.service.ts#fetchBriefResponse`.
    */
   caller_rating?: WeeklyBriefRating | null;
   /**

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -113,10 +113,13 @@ export interface WeeklyBriefCurrentActivitySection extends WeeklyBriefSourceSect
 /**
  * Verb-phrase singular/plural for one activity kind in the "this week so far" tally caption
  * (GH-1922) — see `WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`. This is the single source of truth
- * for which kinds the tally recognizes and in what order; `weekly-brief-card.component.ts`
- * drives its sections from this list directly rather than cross-referencing
- * `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind, so a kind present in one list but not the other can
- * never produce a phrase-less, blank-labeled toggle.
+ * for which kinds the tally recognizes and in what order — `weekly-brief-card.component.ts`
+ * drives its section MEMBERSHIP from this list directly, not by cross-referencing
+ * `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind for that part, so a kind present here but missing there
+ * can never produce a countText-less toggle. That component separately DOES look up the
+ * section's display label from `WEEKLY_BRIEF_SOURCE_SECTIONS` (with a `?? kind` fallback for the
+ * reverse gap), so this doc comment's "not by cross-referencing" claim is scoped to membership
+ * only, not the whole section.
  */
 export interface WeeklyBriefCurrentActivityPhrase {
   kind: string;

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -190,16 +190,20 @@ export interface WeeklyBriefCurrentResponse {
    * populated identically in mock and live mode — see
    * `weekly-brief.service.ts#buildCurrentActivity`. Three states, not two — `null` and absent
    * are deliberately distinct:
-   *   - **Absent** (key not present at all): two distinct causes, only one worth re-asking for.
-   *     Either the committee lookup or activity fetch genuinely failed (transient; worth asking
-   *     again on a governance committee, up to `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS`
-   *     poll ticks), OR the caller deliberately asked the BFF to skip the fan-out via
-   *     `includeCurrentActivity: false` (GH-1922 cost optimization — `weekly-brief-card.component.ts`'s
-   *     initial load does this for any committee it already knows isn't governance-classified,
-   *     since the tally section can never render for one regardless). A caller re-asking on
-   *     absent must also check whether asking is worthwhile at all — see
-   *     `weekly-brief-card.component.ts`'s `pollUntilTerminal`, which additionally gates on
-   *     `isGoverningBoardCommittee()` for exactly this reason.
+   *   - **Absent** (key not present at all): two distinct classes of cause, only one worth
+   *     re-asking for. Either `buildCurrentActivity` genuinely couldn't produce an answer — see
+   *     that method's own doc comment for the exact taxonomy (lookup failure, activity-fetch
+   *     failure, or a resolved-but-unclassifiable committee) rather than re-deriving it here,
+   *     since it's the kind of detail that drifts out of sync with its source — which is
+   *     transient and worth asking again on a governance committee, up to
+   *     `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` poll ticks; OR the caller deliberately
+   *     asked the BFF to skip the fan-out via `includeCurrentActivity: false` (GH-1922 cost
+   *     optimization — `weekly-brief-card.component.ts` does this on every non-poll load — initial
+   *     load and any `refresh$`-triggered re-fetch — for any committee it already knows isn't
+   *     governance-classified, since the tally section can never render for one regardless),
+   *     which is never worth re-asking for. A caller re-asking on absent must also check whether
+   *     asking is worthwhile at all — see `weekly-brief-card.component.ts`'s `pollUntilTerminal`,
+   *     which additionally gates on `isGoverningBoardCommittee()` for exactly this reason.
    *   - **`null`**: known, definitively, not to apply — the committee isn't
    *     governance-classified, or the current week's activity exceeds what a single upstream
    *     page can return (never a silently-truncated count). Not transient; re-asking within the

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -113,9 +113,9 @@ export interface WeeklyBriefCurrentActivitySection extends WeeklyBriefSourceSect
 /**
  * Verb-phrase singular/plural for one activity kind in the "this week so far" tally caption
  * (GH-1922) — see `WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`'s own doc comment for the full
- * membership/ordering/label contract (including its "recognized kinds only" scope and the
- * trailing `other` catch-all it doesn't cover) — not restated here to avoid the two drifting
- * apart.
+ * membership/ordering/label contract, including the "recognized kinds only" scope of this list
+ * and the trailing `other` catch-all for the kinds it doesn't cover — not restated here to avoid
+ * the two drifting apart.
  */
 export interface WeeklyBriefCurrentActivityPhrase {
   kind: string;

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -112,14 +112,10 @@ export interface WeeklyBriefCurrentActivitySection extends WeeklyBriefSourceSect
 
 /**
  * Verb-phrase singular/plural for one activity kind in the "this week so far" tally caption
- * (GH-1922) — see `WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`. This is the single source of truth
- * for which kinds the tally recognizes and in what order — `weekly-brief-card.component.ts`
- * drives its section MEMBERSHIP from this list directly, not by cross-referencing
- * `WEEKLY_BRIEF_SOURCE_SECTIONS` by kind for that part, so a kind present here but missing there
- * can never produce a countText-less toggle. That component separately DOES look up the
- * section's display label from `WEEKLY_BRIEF_SOURCE_SECTIONS` (with a `?? kind` fallback for the
- * reverse gap), so this doc comment's "not by cross-referencing" claim is scoped to membership
- * only, not the whole section.
+ * (GH-1922) — see `WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES`'s own doc comment for the full
+ * membership/ordering/label contract (including its "recognized kinds only" scope and the
+ * trailing `other` catch-all it doesn't cover) — not restated here to avoid the two drifting
+ * apart.
  */
 export interface WeeklyBriefCurrentActivityPhrase {
   kind: string;

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -185,10 +185,13 @@ export interface WeeklyBriefCurrentResponse {
   /**
    * BFF-side enrichment (not part of upstream's contract, same as `caller_rating`): a raw
    * count of activity in the current, not-yet-closed week — distinct from `brief`'s own
-   * completed-week window (GH-1922). Only populated in mock mode: there is no upstream
-   * committee-service endpoint for in-progress-week counts yet, and live mode is a pure
-   * proxy passthrough that never fabricates one. Absent (not null) in live mode until that
-   * upstream support exists — see `weekly-brief.service.ts#getCurrentBrief`.
+   * completed-week window (GH-1922). Sourced from `CommitteeActivityService`'s existing live
+   * meeting/vote/document aggregation (not a weekly-brief-specific upstream call), so it's
+   * populated identically in mock and live mode — see
+   * `weekly-brief.service.ts#buildCurrentActivity`. Absent (not null) when the committee isn't
+   * governance-classified, the underlying lookup/fetch fails, or the current week's activity
+   * exceeds what a single upstream page can return — never fabricated, and never a
+   * silently-truncated count.
    */
   current_activity?: WeeklyBriefCurrentActivity;
 }

--- a/packages/shared/src/interfaces/weekly-brief.interface.ts
+++ b/packages/shared/src/interfaces/weekly-brief.interface.ts
@@ -188,12 +188,20 @@ export interface WeeklyBriefCurrentResponse {
    * completed-week window (GH-1922). Sourced from `CommitteeActivityService`'s existing live
    * meeting/vote/document aggregation (not a weekly-brief-specific upstream call), so it's
    * populated identically in mock and live mode — see
-   * `weekly-brief.service.ts#buildCurrentActivity`. Absent (not null) when the committee isn't
-   * governance-classified, the underlying lookup/fetch fails, or the current week's activity
-   * exceeds what a single upstream page can return — never fabricated, and never a
-   * silently-truncated count.
+   * `weekly-brief.service.ts#buildCurrentActivity`. Three states, not two — `null` and absent
+   * are deliberately distinct:
+   *   - **Absent** (key not present at all): couldn't determine — the committee lookup or
+   *     activity fetch failed. Transient; worth asking again.
+   *   - **`null`**: known, definitively, not to apply — the committee isn't
+   *     governance-classified, or the current week's activity exceeds what a single upstream
+   *     page can return (never a silently-truncated count). Not transient; re-asking within the
+   *     same poll cycle can't change either answer, so a caller that retries on any falsy value
+   *     without checking for this distinction (e.g. `weekly-brief-card.component.ts`'s
+   *     `pollUntilTerminal`) would spend calls forever for no reason.
+   *   - **Present**: the real tally, possibly with an empty `source_refs` (a genuine quiet week
+   *     — still a real answer, not absence).
    */
-  current_activity?: WeeklyBriefCurrentActivity;
+  current_activity?: WeeklyBriefCurrentActivity | null;
 }
 
 /** See `WeeklyBriefCurrentResponse.current_activity`. */


### PR DESCRIPTION
## Summary

Adds a live "This week so far" activity tally above the AI Assistant weekly brief card, sourced from `CommitteeActivityService`'s existing meeting/vote/document/notes aggregation (the same data that already powers the "Recent Activity" feed) rather than a new upstream dependency. Meeting, vote, and document counts are genuinely live in both mock and live weekly-brief mode; the feature no longer depends on `WEEKLY_BRIEF_BACKEND`.

- Group/Committee level only (v1 scope per the issue's own acceptance criteria) — governance-classified committees (Board of Directors / Governing Board), gated server-side via `isGoverningBoard`.
- Project and Foundation altitude rollups from the issue are **not** in this PR — those "Uber Brief" levels are still in design per the issue's own open questions.
- `mailing-list` and `members` (`member_joined`/`member_left`) counts stay at zero — see **Known gaps** below.

Closes #1922

## What changed

- **`CommitteeActivityService.getCommitteeActivity`** is now called directly from `WeeklyBriefService.getCurrentBrief`, gated to governance committees only, windowed to the current in-progress week (`currentWeekInProgressWindow()`), single unfollowed page (`ACTIVITY_FEED_MAX_PAGE_SIZE`).
- Three-state contract for `current_activity`: **absent** (transient — worth re-asking), **`null`** (settled — known not to apply or genuinely truncated), **object** (the tally). See `WeeklyBriefCurrentResponse.current_activity`'s doc comment for the full breakdown.
- Client polls for the tally alongside the existing brief-generation poll, capped at `WEEKLY_BRIEF_CURRENT_ACTIVITY_MAX_ASK_ATTEMPTS` retries, opting out once settled or once the cap is hit.
- `CommitteeActivityService.getCommitteeActivity` gained a `callerOptions` bag (`knownCommittee`, `quietAggregationLog`) to avoid a duplicate `GET /committees/:id` and to keep per-poll-tick aggregation logging at DEBUG rather than INFO.
- `CommitteeService.getCommitteeBase` — new lightweight single-call committee lookup, used by the tally to resolve the committee before passing it into `getCommitteeActivity` as `knownCommittee` (avoiding a duplicate `GET /committees/:id`). `CommitteeActivityService`'s own internal `fetchCommittee` (used when no `knownCommittee` is supplied, e.g. by the "Recent Activity" feed) is unchanged on this branch and still does its own direct `proxyRequest` — deliberately not switched to `getCommitteeBase`, since `fetchCommittee` is fail-closed (throws on an empty body) where `getCommitteeBase` returns `undefined`.

## Known gaps / deferred trade-offs

Documenting these explicitly rather than expanding scope further on an already large branch:

1. **Mailing-list activity has no signal anywhere reachable from the BFF.** Filed as [#1934](https://github.com/linuxfoundation/lfx-self-serve/issues/1934) (sub-issue of #1294), targeting `lfx-v2-committee-service` (GitHub issues disabled there, same pattern as #1605/#1606).
2. **Membership changes are a documented, permanently-deferred v1 limitation**, not a tracked issue — `member_joined` is reachable via `CommitteeMember.created_at` (a small future addition, same shape as the existing `notes_added` leg) but `member_left` has no upstream tombstone/deletion-history to read.
3. **The tally's budget (`WEEKLY_BRIEF_CURRENT_ACTIVITY_BUDGET_MS`, 3s) races against `getCurrentBrief`'s primary brief fetch inside the same `Promise.all`**, so a slow tally is a direct tax on primary content on the initial (non-poll) load. The losing leg of that race is never cancelled, and there's no per-committee in-flight dedupe — a persistently slow (not erroring) upstream can accumulate multiple overlapping fan-outs across a poll cycle. Both are named in the constant's own doc comment; not mitigated in this PR (would need `AbortSignal` threading through `getCommitteeActivity`'s legs, or a short-TTL dedupe).
4. **A full, unfollowed page (`>= 50` events, after excluding provably-irrelevant window_end noise) settles the tally to `null`**, which the client renders as nothing at all — the busiest governance committees currently get no tally line, indistinguishable from a non-governance committee. Filed as [#1998](https://github.com/linuxfoundation/lfx-self-serve/issues/1998) — likely fix is a third explicit state on `current_activity` (mirroring PR #1967's `event_count_is_floor` pattern for its own staleness signal) rather than collapsing truncation into the existing `null` case.
5. **`WEEKLY_BRIEF_CURRENT_ACTIVITY_PHRASES` and `WEEKLY_BRIEF_SOURCE_SECTIONS`** are two hand-maintained arrays holding the same five kinds in the same order, with no mechanism keeping them in sync — a real DRY gap flagged by review, left as a follow-up rather than restructured on this branch.
6. **`quietAggregationLog`'s INFO→DEBUG downgrade** for the per-poll-tick aggregation call is a judgment call (log-volume control for a call that can fire every 4s during a poll), not something `logging-patterns.md`'s frequency-agnostic INFO rule explicitly sanctions. The controller-driven "Recent Activity" feed read still logs INFO.
7. **`getCommitteeBase` is a new public method with no access check of its own** — safety rests entirely on its one caller (`getCurrentBrief`) sitting behind the controller's `assertCommitteeRead` gate. Reviewed and confirmed safe for the current caller; a future caller would need its own check.
8. **`weekly-brief-card-robust.spec.ts` (structural e2e pairing) doesn't exist for this component** — a pre-existing repo-wide gap (roughly 12 of ~76 e2e spec files have the `-robust` pairing) that this branch extends rather than introduces.
9. **The e2e suite could not be run end-to-end this session** (missing `TEST_USERNAME`/`TEST_PASSWORD` locally) — content-based e2e coverage for the new tally was written and reviewed, but not executed against a live browser this session.
10. **Comment-to-code ratio is high** in `weekly-brief.constants.ts`, `weekly-brief.service.ts`, and the card component — a deliberate trade-off toward review-time verification thoroughness (this branch went through many review-driven correction rounds) over long-term terseness. Flagged repeatedly by review as a maintenance cost worth naming rather than silently carrying.
11. **Diff size (~2850 insertions, 87 commits) exceeds the repo's documented ~1000-line PR target.** The commit history is almost entirely `fix(review):`/`docs(...)`/`test(...)` iteration driven by an unusually thorough multi-pass review (general + repo-convention + empirical-pattern reviewers, run repeatedly across the branch's lifetime, plus two full-branch sweeps). Not split at this stage given the interdependence of the changes; flagging for reviewer awareness rather than treating as resolved.
12. **34 of 87 commit headers exceed the 72-char team-style soft target** (none exceed commitlint's 100-char hard limit). Not reworded given the volume and the risk of rewriting history for a style nit this late.
13. **"documents added" can include edits, not just creations.** `CommitteeActivityService`'s document/notes legs derive `occurred_at` preferring `updated_at` over `created_at` (`firstValidTimestamp`) — pre-existing behavior, not introduced by this branch, shared with the "Recent Activity" feed. This tally's "documents added" wording implies creation specifically; editing an existing file/folder/link/note this week can also surface it. Flagged by review; not fixed here since it needs either a real creation-vs-edit signal from the upstream data or a wording change, both product decisions.

## Testing

- `yarn lint && yarn check-types && yarn format:check && yarn test && yarn build` all pass.
- Full monorepo suite: 1361 tests / 72 files passing (server + shared + app).
- New/changed tests are mutation-tested throughout (temporarily broke the logic under test, confirmed the right test failure, reverted, confirmed a clean diff) per this repo's testing conventions.
- Manual verification against a prod-backed local session earlier in this branch's life confirmed real live data (not the old mock fixture) rendering for The Linux Foundation's Board of Directors committee.
- e2e: written and reviewed, not executed this session (see gap #9 above).

## Review

Went through the repo's full pre-PR work cycle: post-commit reviewer trio (general + repo-convention + empirical-pattern) after every commit, multiple full-branch sweeps against `origin/main`, `/lfx-self-serve-pr-readiness` (branch renamed to `feat/issue-1922` and rebased onto `origin/main` as a result), and `/preflight`.

