### PR TITLE
fix(meetings): hide rsvp ui for pre-feature meetings

### DIFF
--- a/apps/lfx-one/e2e/meeting-rsvp-pre-feature.spec.ts
+++ b/apps/lfx-one/e2e/meeting-rsvp-pre-feature.spec.ts
@@ -1,0 +1,188 @@
+// Copyright The Linux Foundation and each contributor to LFX.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Pre-feature vs invite-response-enabled RSVP UI (GH-1951).
+ *
+ * Meetings that predate LFX invite-response tracking must not show RSVP buttons,
+ * Yes/Maybe/No counts, or guest-drawer RSVP filter/chips. Meetings with the flag
+ * explicitly true keep the full RSVP UI.
+ */
+
+import { expect, Page, Route, test } from '@playwright/test';
+
+const MEETINGS_URL = '/meetings';
+const LENS_COOKIE = 'lfx-active-lens';
+const FUTURE_START = '2099-03-04T15:00:00Z';
+
+test.setTimeout(120_000);
+
+const GUEST = {
+  uid: 'guest-rsvp-1',
+  first_name: 'Pat',
+  last_name: 'Guest',
+  email: 'pat-guest@example.com',
+  rsvp: { response_type: 'accepted', meeting_id: 'placeholder', registrant_id: 'guest-rsvp-1' },
+};
+
+function fulfillJson(route: Route, body: unknown): Promise<void> {
+  return route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(body) });
+}
+
+function skipWhenAuthMissing(page: Page): void {
+  try {
+    const { hostname } = new URL(page.url());
+    if (hostname === 'auth0.com' || hostname.endsWith('.auth0.com')) {
+      test.skip(true, 'TEST_USERNAME / TEST_PASSWORD not configured — see global-setup.ts');
+    }
+  } catch {
+    // Let malformed URLs fail naturally.
+  }
+}
+
+async function seedMeLensCookie(page: Page): Promise<void> {
+  await page.context().addCookies([{ name: LENS_COOKIE, value: 'me', domain: 'localhost', path: '/' }]);
+}
+
+async function readViewerLfid(page: Page): Promise<string | null> {
+  const raw = await page.locator('#ng-state').textContent();
+  if (!raw) {
+    return null;
+  }
+  try {
+    const state = JSON.parse(raw) as Record<string, { user?: Record<string, string> }>;
+    const user = state['auth']?.user;
+    return user?.['username'] || user?.['https://sso.linuxfoundation.org/claims/username'] || null;
+  } catch {
+    return null;
+  }
+}
+
+function upcomingMeeting(id: string, title: string, createdBy: { name: string; username: string; email: string }, extra: Record<string, unknown> = {}) {
+  return {
+    id,
+    uid: id,
+    title,
+    description: title,
+    start_time: FUTURE_START,
+    duration: 60,
+    timezone: 'UTC',
+    meeting_type: 'Board',
+    visibility: 'public',
+    restricted: false,
+    project_uid: 'proj-e2e',
+    project_name: 'E2E Project',
+    is_foundation: false,
+    committees: [],
+    occurrences: [],
+    recurrence: null,
+    created_by: createdBy,
+    registrant_count: 1,
+    ...extra,
+  };
+}
+
+async function gotoMeetingsWithFixtures(page: Page, extras: { organizer: Record<string, unknown>; invited: Record<string, unknown> }): Promise<void> {
+  await seedMeLensCookie(page);
+
+  await page.route('**/api/user/personas*', (route) =>
+    fulfillJson(route, {
+      personas: ['contributor'],
+      personaProjects: {},
+      projects: [],
+      organizations: [],
+      isRootWriter: false,
+    })
+  );
+  await page.route('**/api/user/pending-actions*', (route) => fulfillJson(route, []));
+  await page.route('**/api/meetings/*/attachments*', (route) => route.fulfill({ status: 404, body: '{}' }));
+  await page.route('**/api/past-meetings/**', (route) => route.fulfill({ status: 404, body: '{}' }));
+  await page.route('**/api/meetings/*/registrants*', (route) => fulfillJson(route, [{ ...GUEST, meeting_id: 'fixture' }]));
+  await page.route('**/api/meetings/*/rsvp*', (route) => fulfillJson(route, []));
+
+  await page.goto('/', { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+
+  const viewerLfid = await readViewerLfid(page);
+  if (!viewerLfid) {
+    test.skip(true, 'Could not resolve the signed-in LFID from the SSR auth state');
+    return;
+  }
+
+  const viewer = { name: 'E2E Viewer', username: viewerLfid, email: 'viewer-e2e@example.com' };
+
+  await page.route('**/api/user/meetings*', (route) =>
+    fulfillJson(route, [
+      upcomingMeeting('rsvp-org-1', 'Organizer Fixture', viewer, { organizer: true, invited: true, ...extras.organizer }),
+      upcomingMeeting('rsvp-inv-1', 'Invited Fixture', viewer, { organizer: false, invited: true, ...extras.invited }),
+    ])
+  );
+  await page.route('**/api/user/past-meetings*', (route) => fulfillJson(route, []));
+
+  await page.goto(MEETINGS_URL, { waitUntil: 'domcontentloaded' });
+  skipWhenAuthMissing(page);
+  await expect(page).not.toHaveURL(/auth0\.com/);
+  if (!page.url().includes('/meetings')) {
+    test.skip(true, 'Me lens is not available for this user — /meetings redirected away');
+  }
+}
+
+const card = (page: Page, id: string) => page.locator(`#meeting-${id}`);
+
+test.describe('Meeting RSVP UI — pre-feature vs invite-response enabled (GH-1951)', () => {
+  test('absent/false flag hides RSVP card controls, guest-drawer filter, and chips', async ({ page }) => {
+    await gotoMeetingsWithFixtures(page, {
+      organizer: { is_invite_responses_enabled: false },
+      invited: {},
+    });
+
+    const organizerCard = card(page, 'rsvp-org-1');
+    const invitedCard = card(page, 'rsvp-inv-1');
+    await expect(organizerCard).toBeVisible();
+    await expect(invitedCard).toBeVisible();
+
+    await organizerCard.getByTestId('rsvp-details-card').scrollIntoViewIfNeeded();
+    await expect(organizerCard.getByTestId('rsvp-details-invitee-count')).toBeVisible();
+    await expect(organizerCard.getByTestId('rsvp-details-breakdown')).toHaveCount(0);
+    await expect(organizerCard.getByTestId('meeting-rsvp-button-yes')).toHaveCount(0);
+    await expect(organizerCard.getByTestId('toggle-rsvp-view-button')).toHaveCount(0);
+
+    await expect(invitedCard.getByTestId('meeting-rsvp-button-yes')).toHaveCount(0);
+
+    await organizerCard.getByTestId('view-guests-button').click();
+    const drawer = page.getByTestId('meeting-registrants-drawer');
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByTestId('registrant-guest-rsvp-1')).toBeVisible();
+    await expect(drawer.getByTestId('rsvp-filter-select')).toHaveCount(0);
+    await expect(drawer.getByTestId('registrant-rsvp-status')).toHaveCount(0);
+  });
+
+  test('explicit true flag keeps RSVP card controls, guest-drawer filter, and chips', async ({ page }) => {
+    await gotoMeetingsWithFixtures(page, {
+      organizer: { is_invite_responses_enabled: true },
+      invited: { is_invite_responses_enabled: true },
+    });
+
+    const organizerCard = card(page, 'rsvp-org-1');
+    const invitedCard = card(page, 'rsvp-inv-1');
+    await expect(organizerCard).toBeVisible();
+    await expect(invitedCard).toBeVisible();
+
+    await organizerCard.getByTestId('rsvp-details-card').scrollIntoViewIfNeeded();
+    await expect(organizerCard.getByTestId('rsvp-details-card')).toBeVisible();
+    await expect(organizerCard.getByTestId('rsvp-details-breakdown')).toBeVisible();
+    await expect(organizerCard.getByTestId('rsvp-details-invitee-count')).toHaveCount(0);
+    await expect(organizerCard.getByTestId('toggle-rsvp-view-button')).toBeVisible();
+
+    await invitedCard.getByTestId('meeting-rsvp-button-yes').scrollIntoViewIfNeeded();
+    await expect(invitedCard.getByTestId('meeting-rsvp-button-yes')).toBeVisible();
+    await expect(invitedCard.getByTestId('meeting-rsvp-button-no')).toBeVisible();
+    await expect(invitedCard.getByTestId('meeting-rsvp-button-maybe')).toBeVisible();
+
+    await organizerCard.getByTestId('view-guests-button').click();
+    const drawer = page.getByTestId('meeting-registrants-drawer');
+    await expect(drawer).toBeVisible();
+    await expect(drawer.getByTestId('rsvp-filter-select')).toBeVisible();
+    await expect(drawer.getByTestId('registrant-rsvp-status')).toBeVisible();
+  });
+});

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.html
@@ -346,7 +346,7 @@
           }
         } @else if (!pastMeeting()) {
           <!-- Show RSVP Selection for authenticated invited non-organizers (upcoming meetings only) -->
-          @if (effectivelyInvited()) {
+          @if (effectivelyInvited() && inviteResponsesEnabled()) {
             @defer (on viewport) {
               <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="occurrence()?.occurrence_id"> </lfx-rsvp-button-group>
             } @placeholder {

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -48,7 +48,6 @@ import {
   getPastMeetingResourceId,
   getPastMeetingTranscriptUrl,
   getUpcomingMeetingStartTime,
-  isMeetingInviteResponsesEnabled,
   isPastMeetingSummaryAwaitingApproval,
   isPastMeetingSummaryVisible,
   Meeting,
@@ -66,6 +65,7 @@ import {
   resolveOccurrenceRecurrence,
   TagSeverity,
 } from '@lfx-one/shared';
+import { isMeetingInviteResponsesEnabled } from '@lfx-one/shared/utils';
 import { RecordingModalComponent } from '@components/recording-modal/recording-modal.component';
 import { SummaryModalComponent } from '@components/summary-modal/summary-modal.component';
 import { LinkifyPipe } from '@pipes/linkify.pipe';

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-card/meeting-card.component.ts
@@ -48,6 +48,7 @@ import {
   getPastMeetingResourceId,
   getPastMeetingTranscriptUrl,
   getUpcomingMeetingStartTime,
+  isMeetingInviteResponsesEnabled,
   isPastMeetingSummaryAwaitingApproval,
   isPastMeetingSummaryVisible,
   Meeting,
@@ -182,12 +183,15 @@ export class MeetingCardComponent implements OnInit {
   // True when the user is invited OR has just registered in this session (optimistic, before the
   // meeting refetch settles invited:true). Used to show RSVP options immediately after registration.
   public readonly effectivelyInvited: Signal<boolean> = computed(() => this.isInvited() || this.optimisticInvited());
+  public readonly inviteResponsesEnabled: Signal<boolean> = computed(() => isMeetingInviteResponsesEnabled(this.meeting()));
   public readonly canRegisterForMeeting: Signal<boolean> = computed(
     () => this.authenticated() && !this.effectivelyInvited() && !this.meeting().restricted && this.meeting().visibility === 'public'
   );
   // Computed signal to check if user can toggle between RSVP Details and RSVP Button Group
-  // True when user is both an organizer AND invited to the meeting (for non-past meetings)
-  public readonly canToggleRsvpView: Signal<boolean> = computed(() => !!this.meeting().organizer && this.isInvited() && !this.pastMeeting());
+  // True when user is both an organizer AND invited, and this meeting collects LFX RSVPs.
+  public readonly canToggleRsvpView: Signal<boolean> = computed(
+    () => !!this.meeting().organizer && this.isInvited() && !this.pastMeeting() && this.inviteResponsesEnabled()
+  );
   public readonly guestCount: Signal<number> = this.initGuestCount();
 
   public readonly meetingTitle: Signal<string> = this.initMeetingTitle();

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -19,17 +19,19 @@
       <!-- Filter Dropdowns -->
       <div class="flex flex-wrap items-start gap-2">
         @if (!pastMeeting()) {
-          <!-- RSVP Filter (upcoming meetings) -->
-          <lfx-select
-            [form]="filterForm"
-            control="rsvpFilter"
-            [options]="rsvpFilterOptions"
-            optionLabel="label"
-            optionValue="value"
-            [styleClass]="'text-[10px]'"
-            placeholder="RSVP"
-            data-testid="rsvp-filter-select">
-          </lfx-select>
+          @if (inviteResponsesEnabled()) {
+            <!-- RSVP Filter (upcoming meetings that collect LFX RSVPs) -->
+            <lfx-select
+              [form]="filterForm"
+              control="rsvpFilter"
+              [options]="rsvpFilterOptions"
+              optionLabel="label"
+              optionValue="value"
+              [styleClass]="'text-[10px]'"
+              placeholder="RSVP"
+              data-testid="rsvp-filter-select">
+            </lfx-select>
+          }
         } @else {
           <!-- Attendance Filter (past meetings) -->
           <lfx-select
@@ -103,22 +105,24 @@
               shape="circle"></lfx-avatar>
 
             <!-- RSVP Status Badge Overlay -->
-            <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center">
-              @switch (registrant.attendanceStatus) {
-                @case ('accepted') {
-                  <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>
+            @if (inviteResponsesEnabled()) {
+              <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center">
+                @switch (registrant.attendanceStatus) {
+                  @case ('accepted') {
+                    <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>
+                  }
+                  @case ('maybe') {
+                    <i class="fa-solid fa-circle-question text-amber-600 text-base" pTooltip="Maybe"></i>
+                  }
+                  @case ('declined') {
+                    <i class="fa-solid fa-times-circle text-red-600 text-base" pTooltip="Declined"></i>
+                  }
+                  @default {
+                    <i class="fa-solid fa-clock text-gray-400 text-sm" pTooltip="Pending"></i>
+                  }
                 }
-                @case ('maybe') {
-                  <i class="fa-solid fa-circle-question text-amber-600 text-base" pTooltip="Maybe"></i>
-                }
-                @case ('declined') {
-                  <i class="fa-solid fa-times-circle text-red-600 text-base" pTooltip="Declined"></i>
-                }
-                @default {
-                  <i class="fa-solid fa-clock text-gray-400 text-sm" pTooltip="Pending"></i>
-                }
-              }
-            </div>
+              </div>
+            }
           </div>
 
           <!-- Name + Company + Voting Status -->

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.html
@@ -106,7 +106,7 @@
 
             <!-- RSVP Status Badge Overlay -->
             @if (inviteResponsesEnabled()) {
-              <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center">
+              <div class="absolute -bottom-0.5 -right-0.5 w-4 h-4 bg-white rounded-full flex items-center justify-center" data-testid="registrant-rsvp-status">
                 @switch (registrant.attendanceStatus) {
                   @case ('accepted') {
                     <i class="fa-solid fa-check-circle text-emerald-600 text-base" pTooltip="Accepted"></i>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -176,6 +176,12 @@ export class MeetingRegistrantsDisplayComponent {
       .subscribe((hosts) => this.resolvedHostsChange.emit(hosts));
 
     effect(() => {
+      if (!this.inviteResponsesEnabled() && this.rsvpFilterControl.value !== 'all') {
+        this.rsvpFilterControl.setValue('all');
+      }
+    });
+
+    effect(() => {
       if (!this.visible()) return;
       // Past-meeting participants always self-fetch.
       if (this.pastMeeting()) {
@@ -309,9 +315,10 @@ export class MeetingRegistrantsDisplayComponent {
               const meeting = this.meeting() as Meeting;
               const occurrenceId = resolveRsvpOccurrenceId(meeting);
               // Use access-controlled endpoint for meeting join page, regular endpoint for organizer views
+              const includeRsvp = this.inviteResponsesEnabled();
               const registrantsObservable = useMyEndpoint
-                ? this.meetingService.getMyMeetingRegistrants(meeting.id, true, occurrenceId)
-                : this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId);
+                ? this.meetingService.getMyMeetingRegistrants(meeting.id, includeRsvp, occurrenceId)
+                : this.meetingService.getMeetingRegistrants(meeting.id, includeRsvp, occurrenceId);
 
               return registrantsObservable.pipe(
                 catchError(() => of([])),
@@ -461,9 +468,11 @@ export class MeetingRegistrantsDisplayComponent {
             registrant.email?.toLowerCase().includes(query) ||
             registrant.org_name?.toLowerCase().includes(query);
 
-          // RSVP filter — must match chip rendering via attendanceStatus
+          // RSVP filter — must match chip rendering via attendanceStatus.
+          // Skip when tracking is off: the selector is hidden, but a reused join-page
+          // instance can still hold "Accepted" from the previous meeting (GH-1951).
           let matchesRsvp = true;
-          if (rsvp !== 'all') {
+          if (this.inviteResponsesEnabled() && rsvp !== 'all') {
             const status = registrant.attendanceStatus;
             if (rsvp === 'yes') {
               matchesRsvp = status === 'accepted';

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -175,11 +175,13 @@ export class MeetingRegistrantsDisplayComponent {
       .pipe(takeUntilDestroyed(this.destroyRef))
       .subscribe((hosts) => this.resolvedHostsChange.emit(hosts));
 
-    effect(() => {
-      if (!this.inviteResponsesEnabled() && this.rsvpFilterControl.value !== 'all') {
-        this.rsvpFilterControl.setValue('all');
-      }
-    });
+    toObservable(this.inviteResponsesEnabled)
+      .pipe(takeUntilDestroyed(this.destroyRef))
+      .subscribe((enabled) => {
+        if (!enabled && this.rsvpFilterControl.value !== 'all') {
+          this.rsvpFilterControl.setValue('all');
+        }
+      });
 
     effect(() => {
       if (!this.visible()) return;

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-registrants-display/meeting-registrants-display.component.ts
@@ -25,6 +25,7 @@ import {
   filterPastMeetingParticipants,
   getRegistrantAttendanceStatus,
   getPastMeetingResourceId,
+  isMeetingInviteResponsesEnabled,
   markFormControlsAsTouched,
   resolveMeetingBaseCount,
   resolveRsvpOccurrenceId,
@@ -73,6 +74,7 @@ export class MeetingRegistrantsDisplayComponent {
   private readonly internalRegistrants: Signal<MeetingRegistrant[]> = this.initRegistrantsList();
   public readonly pastMeetingParticipants: Signal<EnrichedPastMeetingParticipant[]> = this.initPastMeetingParticipantsList();
   public readonly registrants: Signal<MeetingRegistrant[]> = this.initRegistrants();
+  public readonly inviteResponsesEnabled: Signal<boolean> = computed(() => !this.pastMeeting() && isMeetingInviteResponsesEnabled(this.meeting()));
   public readonly registrantsLoading: Signal<boolean> = computed(() => {
     if (this.externallyManaged() && !this.pastMeeting()) {
       return this.initialRegistrantsLoading();
@@ -446,7 +448,9 @@ export class MeetingRegistrantsDisplayComponent {
       return registrants
         .map((registrant) => ({
           ...registrant,
-          attendanceStatus: getRegistrantAttendanceStatus(registrant),
+          attendanceStatus: getRegistrantAttendanceStatus(registrant, {
+            inviteResponsesEnabled: this.inviteResponsesEnabled(),
+          }),
         }))
         .filter((registrant) => {
           // Search filter

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.html
@@ -86,7 +86,7 @@
 
       <!-- Response Breakdown -->
       @if (!pastMeeting()) {
-        <div class="flex items-center justify-between text-gray-600">
+        <div class="flex items-center justify-between text-gray-600" data-testid="rsvp-details-breakdown">
           <div class="flex items-center gap-1">
             <i class="flex fa-light fa-check-circle text-xs text-blue-500"></i>
             <span class="text-xs tracking-wide">{{ acceptedCount() }} Yes</span>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.html
@@ -36,7 +36,7 @@
         <div class="h-3 w-8 rounded bg-gray-300 animate-pulse"></div>
       </div>
       <div class="w-full h-[5.25px] rounded-full bg-gray-300 animate-pulse"></div>
-      @if (!pastMeeting()) {
+      @if (!pastMeeting() && inviteResponsesEnabled()) {
         <div class="flex items-center justify-between">
           <div class="h-3 w-12 rounded bg-gray-300 animate-pulse"></div>
           <div class="h-3 w-16 rounded bg-gray-300 animate-pulse"></div>
@@ -44,7 +44,7 @@
         </div>
       }
     </div>
-  } @else {
+  } @else if (pastMeeting() || inviteResponsesEnabled()) {
     <div class="flex flex-col gap-2">
       <!-- Attendance Summary -->
       <div class="flex items-center justify-between">
@@ -109,6 +109,11 @@
           <p class="text-xs tracking-wide text-amber-900">This meeting was poorly attended</p>
         </div>
       }
+    </div>
+  } @else {
+    <!-- Pre-RSVP-tracking meetings: invitee count only, matching PCC (GH-1951). -->
+    <div class="flex items-center justify-between" data-testid="rsvp-details-invitee-count">
+      <span class="text-[12.25px] leading-tight tracking-tight text-gray-900">{{ meetingRegistrantCount() }} invited</span>
     </div>
   }
 </div>

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -8,7 +8,6 @@ import { ButtonComponent } from '@components/button/button.component';
 import {
   calculateRsvpCounts,
   countRegistrantAttendance,
-  isMeetingInviteResponsesEnabled,
   Meeting,
   MeetingOccurrence,
   MeetingRegistrant,
@@ -18,7 +17,7 @@ import {
   Project,
   RsvpCounts,
 } from '@lfx-one/shared';
-import { resolveRsvpOccurrenceId } from '@lfx-one/shared/utils';
+import { isMeetingInviteResponsesEnabled, resolveRsvpOccurrenceId } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { UserService } from '@services/user.service';
 import { catchError, distinctUntilChanged, map, of, switchMap, tap } from 'rxjs';

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -8,6 +8,7 @@ import { ButtonComponent } from '@components/button/button.component';
 import {
   calculateRsvpCounts,
   countRegistrantAttendance,
+  isMeetingInviteResponsesEnabled,
   Meeting,
   MeetingOccurrence,
   MeetingRegistrant,
@@ -55,6 +56,7 @@ export class MeetingRsvpDetailsComponent {
   public readonly rsvps: Signal<MeetingRsvp[]> = computed(() => this.upcomingData().rsvps);
   public readonly pastParticipants: Signal<PastMeetingParticipant[]> = this.initializePastParticipants();
   public readonly registrants: Signal<MeetingRegistrant[]> = computed(() => this.upcomingData().registrants);
+  public readonly inviteResponsesEnabled: Signal<boolean> = computed(() => isMeetingInviteResponsesEnabled(this.meeting()));
   // Tracks across both rsvps data AND user identity; re-emits whenever either changes so the
   // parent card's "Set My RSVP" / "Update My RSVP" label stays in sync with login/impersonation.
   public readonly currentUserHasRsvp: Signal<boolean> = computed(() => {
@@ -92,22 +94,26 @@ export class MeetingRsvpDetailsComponent {
           if (this.pastMeeting()) {
             return of({ rsvps: [] as MeetingRsvp[], registrants: [] as MeetingRegistrant[] });
           }
+          const inviteResponsesEnabled = isMeetingInviteResponsesEnabled(meeting);
           // Me lens (backend counts not populated) — one call for both registrants + RSVPs inline.
           if (!this.hasBackendRegistrantCounts(meeting)) {
             // Resolve RSVPs against the target occurrence so a `single` decline for a
             // future date doesn't overwrite the current occurrence's per-registrant
-            // chip (LFXV2-2864).
+            // chip (LFXV2-2864). Skip attaching RSVPs when tracking is disabled (GH-1951).
             const occurrenceId = resolveRsvpOccurrenceId(meeting, { occurrence: this.currentOccurrence() });
-            return this.meetingService.getMeetingRegistrants(meeting.id, true, occurrenceId).pipe(
+            return this.meetingService.getMeetingRegistrants(meeting.id, inviteResponsesEnabled, occurrenceId).pipe(
               map((registrants) => ({
                 registrants,
-                rsvps: registrants.map((r) => r.rsvp).filter((r): r is MeetingRsvp => r != null),
+                rsvps: inviteResponsesEnabled ? registrants.map((r) => r.rsvp).filter((r): r is MeetingRsvp => r != null) : [],
               })),
               catchError((error) => {
                 console.error('Failed to fetch meeting registrants:', error);
                 return of({ rsvps: [] as MeetingRsvp[], registrants: [] as MeetingRegistrant[] });
               })
             );
+          }
+          if (!inviteResponsesEnabled) {
+            return of({ rsvps: [] as MeetingRsvp[], registrants: [] as MeetingRegistrant[] });
           }
           // Non-Me lens — counts are already on the meeting object, only need RSVPs.
           return this.meetingService.getMeetingRsvps(meeting.id).pipe(
@@ -164,7 +170,7 @@ export class MeetingRsvpDetailsComponent {
       // with the drawer's per-registrant chips (LFXV2-2864).
       const registrants = this.registrants();
       if (registrants.length > 0) {
-        return countRegistrantAttendance(registrants);
+        return countRegistrantAttendance(registrants, { inviteResponsesEnabled: this.inviteResponsesEnabled() });
       }
       // Non-Me lens: no registrant array available (detail page — counts come off
       // meeting.individual_registrants_count). Fall back to RSVP-only tallying;

--- a/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/meeting-rsvp-details/meeting-rsvp-details.component.ts
@@ -94,8 +94,13 @@ export class MeetingRsvpDetailsComponent {
             return of({ rsvps: [] as MeetingRsvp[], registrants: [] as MeetingRegistrant[] });
           }
           const inviteResponsesEnabled = isMeetingInviteResponsesEnabled(meeting);
-          // Me lens (backend counts not populated) — one call for both registrants + RSVPs inline.
+          // Me lens (backend split counts not populated) — one call for both registrants + RSVPs.
           if (!this.hasBackendRegistrantCounts(meeting)) {
+            // Pre-feature Me-lens cards already carry aggregate `registrant_count`; the
+            // invitee-count-only UI reads that field, so skip the roster fetch (GH-1951).
+            if (!inviteResponsesEnabled && meeting.registrant_count !== undefined) {
+              return of({ rsvps: [] as MeetingRsvp[], registrants: [] as MeetingRegistrant[] });
+            }
             // Resolve RSVPs against the target occurrence so a `single` decline for a
             // future date doesn't overwrite the current occurrence's per-registrant
             // chip (LFXV2-2864). Skip attaching RSVPs when tracking is disabled (GH-1951).

--- a/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.html
@@ -1,146 +1,148 @@
 <!-- Copyright The Linux Foundation and each contributor to LFX. -->
 <!-- SPDX-License-Identifier: MIT -->
 
-@if (compact()) {
-  <!-- Compact mode: bare outlined CTA buttons with colored icon + label per response (no surrounding container). -->
-  <!--
+@if (inviteResponsesEnabled()) {
+  @if (compact()) {
+    <!-- Compact mode: bare outlined CTA buttons with colored icon + label per response (no surrounding container). -->
+    <!--
     Selected-state Tailwind classes use the `!` important modifier to win over the always-applied base classes
     (e.g. `bg-white`); class names containing `!` are wired through `[ngClass]` object keys to keep template
     parsing unambiguous across Angular compiler versions.
   -->
-  <div class="flex items-center gap-2" [attr.data-testid]="'meeting-rsvp-buttons-compact'">
-    <button
-      type="button"
-      (click)="handleRsvpClick('accepted')"
-      [disabled]="isLoading() || disabled()"
-      class="inline-flex items-center gap-1.5 px-3 h-8 rounded-md border border-blue-300 bg-white text-blue-700 hover:bg-blue-50 hover:border-blue-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors text-xs font-medium"
-      [ngClass]="{
-        '!bg-blue-600': selectedResponse() === 'accepted',
-        '!border-blue-600': selectedResponse() === 'accepted',
-        '!text-white': selectedResponse() === 'accepted',
-      }"
-      [attr.data-testid]="'meeting-rsvp-button-yes'">
-      <i class="fa-light fa-circle-check text-sm"></i>
-      <span>Yes</span>
-    </button>
-    <button
-      type="button"
-      (click)="handleRsvpClick('declined')"
-      [disabled]="isLoading() || disabled()"
-      class="inline-flex items-center gap-1.5 px-3 h-8 rounded-md border border-red-300 bg-white text-red-700 hover:bg-red-50 hover:border-red-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors text-xs font-medium"
-      [ngClass]="{
-        '!bg-red-600': selectedResponse() === 'declined',
-        '!border-red-600': selectedResponse() === 'declined',
-        '!text-white': selectedResponse() === 'declined',
-      }"
-      [attr.data-testid]="'meeting-rsvp-button-no'">
-      <i class="fa-light fa-circle-xmark text-sm"></i>
-      <span>No</span>
-    </button>
-    <button
-      type="button"
-      (click)="handleRsvpClick('maybe')"
-      [disabled]="isLoading() || disabled()"
-      class="inline-flex items-center gap-1.5 px-3 h-8 rounded-md border border-amber-300 bg-white text-amber-700 hover:bg-amber-50 hover:border-amber-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors text-xs font-medium"
-      [ngClass]="{
-        '!bg-amber-500': selectedResponse() === 'maybe',
-        '!border-amber-500': selectedResponse() === 'maybe',
-        '!text-white': selectedResponse() === 'maybe',
-      }"
-      [attr.data-testid]="'meeting-rsvp-button-maybe'">
-      <i class="fa-light fa-circle-question text-sm"></i>
-      <span>Maybe</span>
-    </button>
-  </div>
-} @else {
-  <!-- RSVP Container -->
-  <div
-    [ngClass]="{
-      'bg-blue-50 border border-blue-300': selectedResponse() === null && !disabled() && !isLoading(),
-      'bg-gray-100/60': disabled() && !isLoading(),
-      'bg-blue-50/40 border border-blue-200': isLoading(),
-      'bg-gray-200/50': selectedResponse() !== null && !disabled() && !isLoading(),
-    }"
-    class="rounded-[6px] p-[12px] flex flex-col gap-2 flex-1"
-    [attr.data-testid]="'meeting-rsvp-container'">
-    <!-- Header -->
-    <div
-      [ngClass]="{
-        'text-blue-600': selectedResponse() === null && !disabled() && !isLoading(),
-        'text-gray-400': disabled() && !isLoading(),
-        'text-blue-500': isLoading(),
-        'text-gray-500': selectedResponse() !== null && !disabled() && !isLoading(),
-      }"
-      class="flex items-center gap-[7px]"
-      [attr.data-testid]="'meeting-rsvp-header'">
-      @if (isLoading()) {
-        <i class="fa-light fa-spinner-third fa-spin text-[10.5px]"></i>
-      } @else {
-        <i class="fa-light fa-users text-[10.5px]"></i>
-      }
-      <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">{{ isLoading() ? 'Saving RSVP...' : 'RSVP' }}</span>
-      @if (disabled() && disabledMessage()) {
-        <span
-          class="inline-flex items-center gap-0.5 text-[10px] font-medium text-gray-400 bg-gray-100 border border-gray-200 px-1.5 py-0.5 rounded-full"
-          [attr.data-testid]="'meeting-rsvp-disabled-badge'">
-          <i class="fa-light fa-clock text-[8px]"></i>
-          {{ disabledMessage() }}
-        </span>
-      }
-    </div>
-
-    <!-- RSVP Buttons -->
-    <div class="flex gap-[7px]" [attr.data-testid]="'meeting-rsvp-buttons'">
-      <!-- Yes Button -->
+    <div class="flex items-center gap-2" [attr.data-testid]="'meeting-rsvp-buttons-compact'">
       <button
         type="button"
         (click)="handleRsvpClick('accepted')"
         [disabled]="isLoading() || disabled()"
+        class="inline-flex items-center gap-1.5 px-3 h-8 rounded-md border border-blue-300 bg-white text-blue-700 hover:bg-blue-50 hover:border-blue-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors text-xs font-medium"
         [ngClass]="{
-          'bg-blue-500 border-blue-500 text-white': selectedResponse() === 'accepted' && !disabled() && !isLoading(),
-          'bg-white border-blue-500 text-blue-700 hover:bg-blue-50': selectedResponse() !== 'accepted' && !disabled() && !isLoading(),
-          'bg-white border-gray-300 text-gray-400 cursor-not-allowed': disabled() && !isLoading(),
-          'bg-blue-100/50 border-blue-200 text-blue-300 cursor-wait animate-pulse': isLoading(),
+          '!bg-blue-600': selectedResponse() === 'accepted',
+          '!border-blue-600': selectedResponse() === 'accepted',
+          '!text-white': selectedResponse() === 'accepted',
         }"
-        class="flex-1 inline-flex items-center justify-center gap-[3.5px] px-[7px] py-[5.25px] rounded-[3.5px] h-[28px] border transition-colors"
         [attr.data-testid]="'meeting-rsvp-button-yes'">
-        <i class="fa-light fa-circle-check text-[14px]"></i>
-        <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">Yes</span>
+        <i class="fa-light fa-circle-check text-sm"></i>
+        <span>Yes</span>
       </button>
-
-      <!-- No Button -->
       <button
         type="button"
         (click)="handleRsvpClick('declined')"
         [disabled]="isLoading() || disabled()"
+        class="inline-flex items-center gap-1.5 px-3 h-8 rounded-md border border-red-300 bg-white text-red-700 hover:bg-red-50 hover:border-red-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors text-xs font-medium"
         [ngClass]="{
-          'bg-red-500 border-red-500 text-white': selectedResponse() === 'declined' && !disabled() && !isLoading(),
-          'bg-white border-red-500 text-red-700 hover:bg-red-50': selectedResponse() !== 'declined' && !disabled() && !isLoading(),
-          'bg-white border-gray-300 text-gray-400 cursor-not-allowed': disabled() && !isLoading(),
-          'bg-blue-100/50 border-blue-200 text-blue-300 cursor-wait animate-pulse': isLoading(),
+          '!bg-red-600': selectedResponse() === 'declined',
+          '!border-red-600': selectedResponse() === 'declined',
+          '!text-white': selectedResponse() === 'declined',
         }"
-        class="flex-1 inline-flex items-center justify-center gap-[3.5px] px-[7px] py-[5.25px] rounded-[3.5px] h-[28px] border transition-colors"
         [attr.data-testid]="'meeting-rsvp-button-no'">
-        <i class="fa-light fa-circle-xmark text-[14px]"></i>
-        <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">No</span>
+        <i class="fa-light fa-circle-xmark text-sm"></i>
+        <span>No</span>
       </button>
-
-      <!-- Maybe Button -->
       <button
         type="button"
         (click)="handleRsvpClick('maybe')"
         [disabled]="isLoading() || disabled()"
+        class="inline-flex items-center gap-1.5 px-3 h-8 rounded-md border border-amber-300 bg-white text-amber-700 hover:bg-amber-50 hover:border-amber-500 disabled:opacity-60 disabled:cursor-not-allowed transition-colors text-xs font-medium"
         [ngClass]="{
-          'bg-amber-500 border-amber-500 text-white': selectedResponse() === 'maybe' && !disabled() && !isLoading(),
-          'bg-white border-amber-500 text-amber-700 hover:bg-amber-50': selectedResponse() !== 'maybe' && !disabled() && !isLoading(),
-          'bg-white border-gray-300 text-gray-400 cursor-not-allowed': disabled() && !isLoading(),
-          'bg-blue-100/50 border-blue-200 text-blue-300 cursor-wait animate-pulse': isLoading(),
+          '!bg-amber-500': selectedResponse() === 'maybe',
+          '!border-amber-500': selectedResponse() === 'maybe',
+          '!text-white': selectedResponse() === 'maybe',
         }"
-        class="flex-1 inline-flex items-center justify-center gap-[3.5px] px-[7px] py-[5.25px] rounded-[3.5px] h-[28px] border transition-colors"
         [attr.data-testid]="'meeting-rsvp-button-maybe'">
-        <i class="fa-light fa-circle-question text-[14px]"></i>
-        <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">Maybe</span>
+        <i class="fa-light fa-circle-question text-sm"></i>
+        <span>Maybe</span>
       </button>
     </div>
-  </div>
+  } @else {
+    <!-- RSVP Container -->
+    <div
+      [ngClass]="{
+        'bg-blue-50 border border-blue-300': selectedResponse() === null && !disabled() && !isLoading(),
+        'bg-gray-100/60': disabled() && !isLoading(),
+        'bg-blue-50/40 border border-blue-200': isLoading(),
+        'bg-gray-200/50': selectedResponse() !== null && !disabled() && !isLoading(),
+      }"
+      class="rounded-[6px] p-[12px] flex flex-col gap-2 flex-1"
+      [attr.data-testid]="'meeting-rsvp-container'">
+      <!-- Header -->
+      <div
+        [ngClass]="{
+          'text-blue-600': selectedResponse() === null && !disabled() && !isLoading(),
+          'text-gray-400': disabled() && !isLoading(),
+          'text-blue-500': isLoading(),
+          'text-gray-500': selectedResponse() !== null && !disabled() && !isLoading(),
+        }"
+        class="flex items-center gap-[7px]"
+        [attr.data-testid]="'meeting-rsvp-header'">
+        @if (isLoading()) {
+          <i class="fa-light fa-spinner-third fa-spin text-[10.5px]"></i>
+        } @else {
+          <i class="fa-light fa-users text-[10.5px]"></i>
+        }
+        <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">{{ isLoading() ? 'Saving RSVP...' : 'RSVP' }}</span>
+        @if (disabled() && disabledMessage()) {
+          <span
+            class="inline-flex items-center gap-0.5 text-[10px] font-medium text-gray-400 bg-gray-100 border border-gray-200 px-1.5 py-0.5 rounded-full"
+            [attr.data-testid]="'meeting-rsvp-disabled-badge'">
+            <i class="fa-light fa-clock text-[8px]"></i>
+            {{ disabledMessage() }}
+          </span>
+        }
+      </div>
+
+      <!-- RSVP Buttons -->
+      <div class="flex gap-[7px]" [attr.data-testid]="'meeting-rsvp-buttons'">
+        <!-- Yes Button -->
+        <button
+          type="button"
+          (click)="handleRsvpClick('accepted')"
+          [disabled]="isLoading() || disabled()"
+          [ngClass]="{
+            'bg-blue-500 border-blue-500 text-white': selectedResponse() === 'accepted' && !disabled() && !isLoading(),
+            'bg-white border-blue-500 text-blue-700 hover:bg-blue-50': selectedResponse() !== 'accepted' && !disabled() && !isLoading(),
+            'bg-white border-gray-300 text-gray-400 cursor-not-allowed': disabled() && !isLoading(),
+            'bg-blue-100/50 border-blue-200 text-blue-300 cursor-wait animate-pulse': isLoading(),
+          }"
+          class="flex-1 inline-flex items-center justify-center gap-[3.5px] px-[7px] py-[5.25px] rounded-[3.5px] h-[28px] border transition-colors"
+          [attr.data-testid]="'meeting-rsvp-button-yes'">
+          <i class="fa-light fa-circle-check text-[14px]"></i>
+          <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">Yes</span>
+        </button>
+
+        <!-- No Button -->
+        <button
+          type="button"
+          (click)="handleRsvpClick('declined')"
+          [disabled]="isLoading() || disabled()"
+          [ngClass]="{
+            'bg-red-500 border-red-500 text-white': selectedResponse() === 'declined' && !disabled() && !isLoading(),
+            'bg-white border-red-500 text-red-700 hover:bg-red-50': selectedResponse() !== 'declined' && !disabled() && !isLoading(),
+            'bg-white border-gray-300 text-gray-400 cursor-not-allowed': disabled() && !isLoading(),
+            'bg-blue-100/50 border-blue-200 text-blue-300 cursor-wait animate-pulse': isLoading(),
+          }"
+          class="flex-1 inline-flex items-center justify-center gap-[3.5px] px-[7px] py-[5.25px] rounded-[3.5px] h-[28px] border transition-colors"
+          [attr.data-testid]="'meeting-rsvp-button-no'">
+          <i class="fa-light fa-circle-xmark text-[14px]"></i>
+          <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">No</span>
+        </button>
+
+        <!-- Maybe Button -->
+        <button
+          type="button"
+          (click)="handleRsvpClick('maybe')"
+          [disabled]="isLoading() || disabled()"
+          [ngClass]="{
+            'bg-amber-500 border-amber-500 text-white': selectedResponse() === 'maybe' && !disabled() && !isLoading(),
+            'bg-white border-amber-500 text-amber-700 hover:bg-amber-50': selectedResponse() !== 'maybe' && !disabled() && !isLoading(),
+            'bg-white border-gray-300 text-gray-400 cursor-not-allowed': disabled() && !isLoading(),
+            'bg-blue-100/50 border-blue-200 text-blue-300 cursor-wait animate-pulse': isLoading(),
+          }"
+          class="flex-1 inline-flex items-center justify-center gap-[3.5px] px-[7px] py-[5.25px] rounded-[3.5px] h-[28px] border transition-colors"
+          [attr.data-testid]="'meeting-rsvp-button-maybe'">
+          <i class="fa-light fa-circle-question text-[14px]"></i>
+          <span class="text-[10.5px] tracking-[0.0923px] leading-[14px]">Maybe</span>
+        </button>
+      </div>
+    </div>
+  }
 }

--- a/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/components/rsvp-button-group/rsvp-button-group.component.ts
@@ -7,7 +7,7 @@ import { Component, computed, inject, input, InputSignal, output, OutputEmitterR
 import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { RsvpScopeModalComponent } from '@app/modules/meetings/components/rsvp-scope-modal/rsvp-scope-modal.component';
 import { CreateMeetingRsvpRequest, Meeting, MeetingRsvp, RsvpResponse, RsvpScope, User } from '@lfx-one/shared';
-import { resolveRsvpOccurrenceId } from '@lfx-one/shared/utils';
+import { isMeetingInviteResponsesEnabled, resolveRsvpOccurrenceId } from '@lfx-one/shared/utils';
 import { MeetingService } from '@services/meeting.service';
 import { UserService } from '@services/user.service';
 import { MessageService } from 'primeng/api';
@@ -58,8 +58,12 @@ export class RsvpButtonGroupComponent {
   public readonly isRecurring: Signal<boolean> = this.initializeIsRecurring();
   public readonly currentRsvp: Signal<MeetingRsvp | null> = this.initializeCurrentRsvp();
   public readonly selectedResponse: Signal<RsvpResponse | null> = this.initializeSelectedResponse();
+  public readonly inviteResponsesEnabled: Signal<boolean> = computed(() => isMeetingInviteResponsesEnabled(this.meeting()));
 
   public handleRsvpClick(response: RsvpResponse): void {
+    if (!this.inviteResponsesEnabled()) {
+      return;
+    }
     // For recurring meetings, show scope modal
     if (this.isRecurring()) {
       this.showScopeModal(response);
@@ -172,8 +176,8 @@ export class RsvpButtonGroupComponent {
     return toSignal(
       combineLatest([toObservable(this.meeting), toObservable(this.authenticated), toObservable(this.refreshTrigger)]).pipe(
         switchMap(([meeting, authenticated]) => {
-          // Skip fetch when component is disabled
-          if (this.disabled()) {
+          // Skip fetch when component is disabled or the meeting predates RSVP tracking.
+          if (this.disabled() || !isMeetingInviteResponsesEnabled(meeting)) {
             return of(null);
           }
           const occurrenceId = resolveRsvpOccurrenceId(meeting, { occurrenceId: this.occurrenceId() });

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.html
@@ -462,7 +462,7 @@
               } @else if (authenticated() && !isPastMeeting()) {
                 <!-- RSVP Container - Future Meeting (Authenticated Non-Organizers) -->
                 <div class="w-full md:w-[296px]">
-                  @if (effectivelyInvited()) {
+                  @if (effectivelyInvited() && inviteResponsesEnabled()) {
                     @defer (when meeting()) {
                       <lfx-rsvp-button-group [meeting]="meeting()" [occurrenceId]="currentOccurrence()?.occurrence_id"> </lfx-rsvp-button-group>
                     }

--- a/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meeting-join/meeting-join.component.ts
@@ -55,7 +55,7 @@ import {
   TagSeverity,
   User,
 } from '@lfx-one/shared';
-import { getUserTimezone, isHostKeyVisible, isPastMeetingCompositeId } from '@lfx-one/shared/utils';
+import { getUserTimezone, isHostKeyVisible, isMeetingInviteResponsesEnabled, isPastMeetingCompositeId } from '@lfx-one/shared/utils';
 import { FileTypeDisplayPipe } from '@pipes/file-type-display.pipe';
 import { LinkifyPipe } from '@pipes/linkify.pipe';
 import { MeetingTimePipe } from '@pipes/meeting-time.pipe';
@@ -240,7 +240,10 @@ export class MeetingJoinComponent implements OnInit {
   protected rsvpAcceptedCount = computed(() => this.meeting()?.registrants_accepted_count ?? 0);
   protected rsvpDeclinedCount = computed(() => this.meeting()?.registrants_declined_count ?? 0);
   protected rsvpPendingCount = computed(() => this.meeting()?.registrants_pending_count ?? 0);
-  protected hasRsvpData = computed(() => this.rsvpAcceptedCount() > 0 || this.rsvpDeclinedCount() > 0 || this.rsvpPendingCount() > 0);
+  protected inviteResponsesEnabled = computed(() => isMeetingInviteResponsesEnabled(this.meeting()));
+  protected hasRsvpData = computed(
+    () => this.inviteResponsesEnabled() && (this.rsvpAcceptedCount() > 0 || this.rsvpDeclinedCount() > 0 || this.rsvpPendingCount() > 0)
+  );
   protected userInitials = computed(() => {
     const name = this.user()?.name || 'User';
     return name.substring(0, 2).toUpperCase();
@@ -1120,7 +1123,7 @@ export class MeetingJoinComponent implements OnInit {
   }
 
   private initializeCanToggleRsvpView(): Signal<boolean> {
-    return computed(() => !!this.meeting()?.organizer && this.isInvited());
+    return computed(() => !!this.meeting()?.organizer && this.isInvited() && this.inviteResponsesEnabled());
   }
 
   private initializeCurrentUserRsvp(): Signal<MeetingRsvp | null> {

--- a/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
+++ b/apps/lfx-one/src/app/modules/meetings/meetings-dashboard/meetings-dashboard.component.ts
@@ -21,6 +21,7 @@ import {
   getPastMeetingResourceId,
   getPastMeetingStartTimeMs,
   hasMeetingEnded,
+  isMeetingInviteResponsesEnabled,
   isMeetingOrganizedByViewer,
   meetingToCalendarEvents,
   resolveMeetingCalendarClickRoute,
@@ -701,8 +702,9 @@ export class MeetingsDashboardComponent {
     }
 
     if (pendingRsvpOnly) {
-      // Pending = no RSVP recorded. accepted, declined, and maybe are all valid responses.
-      filtered = filtered.filter((m) => !m.my_rsvp);
+      // Pending = no RSVP recorded on meetings that collect LFX RSVPs. Pre-feature meetings
+      // never collected responses, so they must not appear as "pending" (GH-1951).
+      filtered = filtered.filter((m) => isMeetingInviteResponsesEnabled(m) && !m.my_rsvp);
     }
 
     if (organizerOnly) {

--- a/apps/lfx-one/src/server/services/meeting.service.spec.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.spec.ts
@@ -19,7 +19,8 @@ vi.mock('@lfx-one/shared/utils', () => ({
   buildRecurrenceNeverEndDate: vi.fn(),
   getPastMeetingTranscriptUrl: vi.fn(),
   mapITXResponseToMeetingRsvp: vi.fn(),
-  normalizeIndexedMeetingAiSummary: vi.fn(),
+  normalizeIndexedMeetingAiSummary: vi.fn((meeting) => meeting),
+  normalizeIndexedMeetingInviteResponses: vi.fn((meeting) => meeting),
   selectPrimaryPastMeetingSummary: vi.fn(),
   // getMeetingRsvps / getMeetingRegistrants(includeRsvp) delegate occurrence selection to the real
   // resolver — stubbed here to the "most recent rsvp" since these tests cover roster/page-walk

--- a/apps/lfx-one/src/server/services/meeting.service.ts
+++ b/apps/lfx-one/src/server/services/meeting.service.ts
@@ -43,6 +43,7 @@ import {
   getPastMeetingTranscriptUrl,
   mapITXResponseToMeetingRsvp,
   normalizeIndexedMeetingAiSummary,
+  normalizeIndexedMeetingInviteResponses,
   selectApplicableRsvp,
   selectPrimaryPastMeetingSummary,
 } from '@lfx-one/shared/utils';
@@ -110,10 +111,12 @@ export class MeetingService {
     });
 
     let meetings: Meeting[] = resources.map((resource) =>
-      normalizeIndexedMeetingAiSummary({
-        ...resource.data,
-        id: resource.data.id || resource.id?.split(':').pop() || resource.id,
-      })
+      normalizeIndexedMeetingInviteResponses(
+        normalizeIndexedMeetingAiSummary({
+          ...resource.data,
+          id: resource.data.id || resource.id?.split(':').pop() || resource.id,
+        })
+      )
     );
 
     // Enrich meetings with project names and committee data in parallel (independent enrichments)
@@ -203,7 +206,9 @@ export class MeetingService {
     });
 
     // All meetings are now ITX-managed, use the ITX endpoint
-    const meeting = await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}`, 'GET');
+    const meeting = normalizeIndexedMeetingInviteResponses(
+      await this.microserviceProxy.proxyRequest<Meeting>(req, 'LFX_V2_SERVICE', `/itx/meetings/${meetingUid}`, 'GET')
+    );
 
     // Set the meeting ID from the URL param
     meeting.id = meetingUid;

--- a/apps/lfx-one/src/server/services/user.service.spec.ts
+++ b/apps/lfx-one/src/server/services/user.service.spec.ts
@@ -399,14 +399,14 @@ describe('UserService.getPendingActions RSVP gating (GH-1951)', () => {
       id: 'legacy-meeting',
       title: 'Legacy Board',
       start_time: tomorrow,
-      duration: '60',
+      duration: 60,
       use_new_invite_email_address: false,
     };
     const trackedMeeting: Partial<Meeting> = {
       id: 'tracked-meeting',
       title: 'Tracked Board',
       start_time: tomorrow,
-      duration: '60',
+      duration: 60,
       use_new_invite_email_address: true,
     };
     const registrants: Partial<MeetingRegistrant>[] = [
@@ -446,7 +446,7 @@ describe('UserService.getPendingActions RSVP gating (GH-1951)', () => {
             id: 'legacy-meeting',
             title: 'Legacy Board',
             start_time: tomorrow,
-            duration: '60',
+            duration: 60,
             use_new_invite_email_address: false,
           } satisfies Partial<Meeting>,
         ]);

--- a/apps/lfx-one/src/server/services/user.service.spec.ts
+++ b/apps/lfx-one/src/server/services/user.service.spec.ts
@@ -435,5 +435,34 @@ describe('UserService.getPendingActions RSVP gating (GH-1951)', () => {
       'Review Legacy Board Agenda and Materials',
       'Review Tracked Board Agenda and Materials',
     ]);
+    expect(queriedTypes()).toEqual(expect.arrayContaining(['v1_meeting', 'v1_meeting_registrant', 'v1_meeting_rsvp']));
+  });
+
+  it('skips RSVP and registrant scans when every in-window meeting predates invite-response tracking', async () => {
+    proxyRequest.mockImplementation((_req: Request, _svc: string, _path: string, _method: string, params?: { type?: string }) => {
+      if (params?.type === 'v1_meeting') {
+        return queryPage([
+          {
+            id: 'legacy-meeting',
+            title: 'Legacy Board',
+            start_time: tomorrow,
+            duration: '60',
+            use_new_invite_email_address: false,
+          } satisfies Partial<Meeting>,
+        ]);
+      }
+      return queryPage([]);
+    });
+
+    const actions = await service.getPendingActions(req, undefined, email, undefined);
+
+    expect(actions.filter((action) => action.type === 'RSVP')).toHaveLength(0);
+    expect(actions.some((action) => action.type === 'Agenda')).toBe(true);
+    expect(queriedTypes()).not.toContain('v1_meeting_registrant');
+    expect(queriedTypes()).not.toContain('v1_meeting_rsvp');
   });
 });
+
+function queriedTypes(): string[] {
+  return proxyRequest.mock.calls.map((call) => (call[4] as { type?: string } | undefined)?.type).filter((type): type is string => !!type);
+}

--- a/apps/lfx-one/src/server/services/user.service.spec.ts
+++ b/apps/lfx-one/src/server/services/user.service.spec.ts
@@ -8,23 +8,50 @@ import '@angular/compiler';
 import { PROFILE_VISIBILITY_DEFAULTS, VISIBILITY_PREFERENCE_APP_NAME, VISIBILITY_PREFERENCE_NAME } from '@lfx-one/shared/constants';
 import {
   ApiGatewayUserProfile,
+  Meeting,
+  MeetingRegistrant,
   ProfileVisibilitySections,
   ProfileVisibilityUpdateRequest,
+  QueryServiceResponse,
   UserMetadata,
   UserServicePreference,
 } from '@lfx-one/shared/interfaces';
 import type { Request } from 'express';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
+const { proxyRequest, getPendingActionSurveys, getMyPendingInvitations, getUsernameFromAuth } = vi.hoisted(() => ({
+  proxyRequest: vi.fn(),
+  getPendingActionSurveys: vi.fn(),
+  getMyPendingInvitations: vi.fn(),
+  getUsernameFromAuth: vi.fn(),
+}));
+
 // Stub the constructor collaborators (NATS, Snowflake, etc.) so `new UserService()` is cheap and
 // side-effect-free — validateUserMetadata is pure and synchronous and touches none of them.
 vi.mock('./nats.service', () => ({ NatsService: vi.fn() }));
 vi.mock('./snowflake.service', () => ({ SnowflakeService: { getInstance: vi.fn(() => ({})) } }));
 vi.mock('./meeting.service', () => ({ MeetingService: vi.fn() }));
-vi.mock('./project.service', () => ({ ProjectService: vi.fn() }));
-vi.mock('./microservice-proxy.service', () => ({ MicroserviceProxyService: vi.fn() }));
+vi.mock('./project.service', () => ({
+  ProjectService: class {
+    public getPendingActionSurveys = getPendingActionSurveys;
+  },
+}));
+vi.mock('./microservice-proxy.service', () => ({
+  MicroserviceProxyService: class {
+    public proxyRequest = proxyRequest;
+  },
+}));
 vi.mock('./access-check.service', () => ({ AccessCheckService: vi.fn() }));
-vi.mock('./committee.service', () => ({ CommitteeService: vi.fn() }));
+vi.mock('./committee.service', () => ({
+  CommitteeService: class {
+    public getMyPendingInvitations = getMyPendingInvitations;
+  },
+}));
+vi.mock('../utils/auth-helper', () => ({
+  getUsernameFromAuth,
+  getEffectiveEmail: vi.fn(),
+  stripAuthPrefix: (value: string) => value,
+}));
 vi.mock('./logger.service', () => ({
   logger: {
     startOperation: vi.fn(() => 0),
@@ -337,5 +364,76 @@ describe('UserService profile visibility', () => {
       const meCall = gw.mock.calls.find((c) => c[2].method === 'PATCH' && c[1].endsWith('/me'));
       expect(meCall?.[2].body).toEqual({ IsPublic: true, AccountID: 'acct-1' });
     });
+  });
+});
+
+function queryPage<T>(items: T[]): QueryServiceResponse<T> {
+  return { resources: items.map((data, index) => ({ id: `item:${index}`, data })) } as QueryServiceResponse<T>;
+}
+
+describe('UserService.getPendingActions RSVP gating (GH-1951)', () => {
+  const req = {} as unknown as Request;
+  const email = 'invitee@example.com';
+  const tomorrow = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+  let service: UserService;
+
+  beforeEach(() => {
+    proxyRequest.mockReset();
+    getPendingActionSurveys.mockReset();
+    getMyPendingInvitations.mockReset();
+    getUsernameFromAuth.mockReset();
+
+    getPendingActionSurveys.mockResolvedValue([]);
+    getMyPendingInvitations.mockResolvedValue([]);
+    getUsernameFromAuth.mockResolvedValue('testuser');
+
+    service = new UserService();
+  });
+
+  it('emits a Set RSVP action only for meetings whose indexed invite-response flag is true', async () => {
+    // Indexed query-service docs carry `use_new_invite_email_address`, not the ITX field.
+    // Leaving `is_invite_responses_enabled` unset proves getUserMeetings normalization is wired
+    // into this path — without it both meetings would skip RSVP actions.
+    const legacyMeeting: Partial<Meeting> = {
+      id: 'legacy-meeting',
+      title: 'Legacy Board',
+      start_time: tomorrow,
+      duration: '60',
+      use_new_invite_email_address: false,
+    };
+    const trackedMeeting: Partial<Meeting> = {
+      id: 'tracked-meeting',
+      title: 'Tracked Board',
+      start_time: tomorrow,
+      duration: '60',
+      use_new_invite_email_address: true,
+    };
+    const registrants: Partial<MeetingRegistrant>[] = [
+      { uid: 'reg-legacy', meeting_id: 'legacy-meeting' },
+      { uid: 'reg-tracked', meeting_id: 'tracked-meeting' },
+    ];
+
+    proxyRequest.mockImplementation((_req: Request, _svc: string, _path: string, _method: string, params?: { type?: string }) => {
+      switch (params?.type) {
+        case 'v1_meeting':
+          return queryPage([legacyMeeting, trackedMeeting]);
+        case 'v1_meeting_registrant':
+          return queryPage(registrants);
+        default:
+          return queryPage([]);
+      }
+    });
+
+    const actions = await service.getPendingActions(req, undefined, email, undefined);
+    const rsvpActions = actions.filter((action) => action.type === 'RSVP');
+
+    expect(rsvpActions).toHaveLength(1);
+    expect(rsvpActions[0].meetingUid).toBe('tracked-meeting');
+    expect(rsvpActions[0].buttonText).toBe('Set RSVP');
+    expect(actions.filter((action) => action.type === 'Agenda').map((action) => action.text)).toEqual([
+      'Review Legacy Board Agenda and Materials',
+      'Review Tracked Board Agenda and Materials',
+    ]);
   });
 });

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -49,7 +49,9 @@ import {
   codePointLength,
   getCurrentOrNextOccurrence,
   hasMeetingEnded,
+  isMeetingInviteResponsesEnabled,
   normalizeIndexedMeetingAiSummary,
+  normalizeIndexedMeetingInviteResponses,
   parseToInt,
   resolveRsvpOccurrenceId,
   selectApplicableRsvp,
@@ -514,7 +516,7 @@ export class UserService {
 
     logger.debug(req, 'get_user_meetings', 'Fetched meetings from query service', { count: meetings.length });
 
-    const normalizedMeetings = meetings.map(normalizeIndexedMeetingAiSummary);
+    const normalizedMeetings = meetings.map((meeting) => normalizeIndexedMeetingInviteResponses(normalizeIndexedMeetingAiSummary(meeting)));
 
     // Enrich each meeting with the current user's RSVP (null when no response). Reuses the same
     // query-service pattern that powers `getUserPendingActions` → `transformMissingRsvpsToActions`.
@@ -1577,6 +1579,8 @@ export class UserService {
     for (const meeting of meetings) {
       if (!meeting.id) continue;
       if (respondedMeetingIds.has(meeting.id)) continue;
+      // Meetings that predate LFX RSVP tracking have no collectable response (GH-1951).
+      if (!isMeetingInviteResponsesEnabled(meeting)) continue;
       // Suppress the action when the user is not a registrant for this specific meeting.
       // The pending-actions list comes from `filter_grants: 'direct'` on `v1_meeting`, which
       // includes hosts/organizers and committee-inherited grants — none of which carry a

--- a/apps/lfx-one/src/server/services/user.service.ts
+++ b/apps/lfx-one/src/server/services/user.service.ts
@@ -1335,21 +1335,22 @@ export class UserService {
     const voteActions = this.transformVotesToActions(pendingVotes);
     const invitationActions = this.transformInvitationsToActions(pendingInvitations);
 
-    // Phase 2: RSVP + registrant lookups are only meaningful when there are in-window meetings
-    // to evaluate. Skip them otherwise — avoids two full paginated per-user scans per request
-    // for users with no upcoming meetings in the window.
+    // Phase 2: RSVP + registrant lookups only pay off when at least one in-window meeting
+    // collects LFX RSVPs. Pre-feature series still produce Review Agenda actions, but they
+    // cannot emit Set RSVP — skip the two paginated scans in that case (GH-1951).
     //
     // Fail closed on the RSVP prerequisites: if either lookup errors, we can't distinguish
     // "user hasn't RSVPed" from "we don't know", and a transient failure must not turn every
     // in-window meeting into a bogus Set RSVP nag. Suppress the whole source on error.
     let rsvpActions: PendingActionItem[] = [];
-    if (inWindowMeetings.length > 0) {
+    const rsvpEligibleMeetings = inWindowMeetings.filter((meeting) => isMeetingInviteResponsesEnabled(meeting));
+    if (rsvpEligibleMeetings.length > 0) {
       try {
         const [userRsvps, activeRegistrants] = await Promise.all([
           this.fetchAllUserRsvps(req, email, username),
           this.fetchUserActiveRegistrantIdentities(req, email, username),
         ]);
-        rsvpActions = this.transformMissingRsvpsToActions(inWindowMeetings, userRsvps, activeRegistrants);
+        rsvpActions = this.transformMissingRsvpsToActions(rsvpEligibleMeetings, userRsvps, activeRegistrants);
       } catch (error) {
         logger.warning(req, 'get_user_pending_actions', 'RSVP prerequisite lookup failed, suppressing Set RSVP actions', { err: error });
       }

--- a/packages/shared/src/interfaces/meeting.interface.ts
+++ b/packages/shared/src/interfaces/meeting.interface.ts
@@ -295,6 +295,20 @@ export interface Meeting {
   youtube_upload_enabled: boolean | null;
   /** Show meeting attendees on meeting details page */
   show_meeting_attendees?: boolean | null;
+  /**
+   * Whether LFX invite-response (RSVP) tracking is enabled for this meeting.
+   * ITX GET `/itx/meetings/:uid` returns this field (omitted when false via Go `omitempty`).
+   * False/absent for meetings created before the January 2024 invite-responses release.
+   * Self Serve must hide RSVP counts/UI when this is not true
+   * (linuxfoundation/lfx-self-serve-ops#4, GH-1951).
+   */
+  is_invite_responses_enabled?: boolean;
+  /**
+   * Indexed `v1_meeting` name for the same flag as `is_invite_responses_enabled`.
+   * The BFF maps this onto `is_invite_responses_enabled` via
+   * `normalizeIndexedMeetingInviteResponses`; UI should read the latter.
+   */
+  use_new_invite_email_address?: boolean;
   /** Who can access meeting artifacts (recordings, transcripts, AI summaries) */
   artifact_visibility: ArtifactVisibility | null;
   /** Per-meeting override for cancelling registration on committee removal; "inherit" defers to the project default */

--- a/packages/shared/src/utils/meeting.utils.spec.ts
+++ b/packages/shared/src/utils/meeting.utils.spec.ts
@@ -50,6 +50,7 @@ import {
   fromMeetingApiVotingStatuses,
   getMeetingOrganizerDisplayName,
   isCalendarDeadlinePast,
+  isMeetingInviteResponsesEnabled,
   isMeetingOccurrenceCancelled,
   isMeetingOrganizedByViewer,
   isOccurrencePast,
@@ -57,6 +58,7 @@ import {
   isUnresolvableParticipantName,
   isVoteCalendarEventPast,
   normalizeIndexedMeetingAiSummary,
+  normalizeIndexedMeetingInviteResponses,
   normalizeMeetingApiVotingStatuses,
   resolveMeetingOrganizer,
   resolveMeetingOwner,
@@ -426,6 +428,44 @@ describe('normalizeIndexedMeetingAiSummary', () => {
     const result = normalizeIndexedMeetingAiSummary(meeting);
     expect(result.ai_summary_enabled).toBeUndefined();
     expect(result.require_ai_summary_approval).toBeUndefined();
+  });
+});
+
+describe('normalizeIndexedMeetingInviteResponses', () => {
+  it('maps indexed use_new_invite_email_address true onto is_invite_responses_enabled', () => {
+    const meeting = { use_new_invite_email_address: true } as Meeting;
+
+    expect(normalizeIndexedMeetingInviteResponses(meeting).is_invite_responses_enabled).toBe(true);
+  });
+
+  it('maps indexed use_new_invite_email_address false onto is_invite_responses_enabled', () => {
+    const meeting = { use_new_invite_email_address: false } as Meeting;
+
+    expect(normalizeIndexedMeetingInviteResponses(meeting).is_invite_responses_enabled).toBe(false);
+  });
+
+  it('treats a missing indexed flag as false', () => {
+    const meeting = {} as Meeting;
+
+    expect(normalizeIndexedMeetingInviteResponses(meeting).is_invite_responses_enabled).toBe(false);
+  });
+
+  it('preserves an explicit ITX is_invite_responses_enabled value', () => {
+    const enabled = { is_invite_responses_enabled: true, use_new_invite_email_address: false } as Meeting;
+    expect(normalizeIndexedMeetingInviteResponses(enabled).is_invite_responses_enabled).toBe(true);
+
+    const disabled = { is_invite_responses_enabled: false, use_new_invite_email_address: true } as Meeting;
+    expect(normalizeIndexedMeetingInviteResponses(disabled).is_invite_responses_enabled).toBe(false);
+  });
+});
+
+describe('isMeetingInviteResponsesEnabled', () => {
+  it('is true only for an explicit true flag', () => {
+    expect(isMeetingInviteResponsesEnabled({ is_invite_responses_enabled: true } as Meeting)).toBe(true);
+    expect(isMeetingInviteResponsesEnabled({ is_invite_responses_enabled: false } as Meeting)).toBe(false);
+    expect(isMeetingInviteResponsesEnabled({} as Meeting)).toBe(false);
+    expect(isMeetingInviteResponsesEnabled(null)).toBe(false);
+    expect(isMeetingInviteResponsesEnabled(undefined)).toBe(false);
   });
 });
 

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -999,6 +999,39 @@ export function parseTranscriptVtt(vtt: string | null | undefined): TranscriptCu
 }
 
 /**
+ * Maps the indexed `v1_meeting` flag `use_new_invite_email_address` onto
+ * `is_invite_responses_enabled` when the ITX field is absent.
+ *
+ * ITX GET omits `is_invite_responses_enabled` when false (Go `omitempty`); the
+ * query-service projection stores the same boolean as `use_new_invite_email_address`.
+ * Explicit `is_invite_responses_enabled` wins. Missing both layers becomes `false`
+ * so Self Serve can hide RSVP UI for pre-feature meetings (GH-1951).
+ */
+export function normalizeIndexedMeetingInviteResponses<
+  T extends {
+    is_invite_responses_enabled?: boolean;
+    use_new_invite_email_address?: boolean;
+  },
+>(meeting: T): T {
+  if (meeting.is_invite_responses_enabled !== undefined) {
+    return meeting;
+  }
+
+  return {
+    ...meeting,
+    is_invite_responses_enabled: meeting.use_new_invite_email_address === true,
+  };
+}
+
+/**
+ * True only when LFX invite-response (RSVP) tracking is enabled for the meeting.
+ * Missing/undefined is treated as false to match PCC's `*ngIf="meeting.is_invite_responses_enabled"`.
+ */
+export function isMeetingInviteResponsesEnabled(meeting: Pick<Meeting, 'is_invite_responses_enabled'> | null | undefined): boolean {
+  return meeting?.is_invite_responses_enabled === true;
+}
+
+/**
  * Derives top-level AI-summary fields from indexed `zoom_config` when the query-service projection omits them.
  * Explicit top-level values win (`??`); returns the input unchanged when `zoom_config` is absent.
  */

--- a/packages/shared/src/utils/meeting.utils.ts
+++ b/packages/shared/src/utils/meeting.utils.ts
@@ -1002,10 +1002,14 @@ export function parseTranscriptVtt(vtt: string | null | undefined): TranscriptCu
  * Maps the indexed `v1_meeting` flag `use_new_invite_email_address` onto
  * `is_invite_responses_enabled` when the ITX field is absent.
  *
- * ITX GET omits `is_invite_responses_enabled` when false (Go `omitempty`); the
- * query-service projection stores the same boolean as `use_new_invite_email_address`.
+ * PCC gates RSVP UI on ITX `is_invite_responses_enabled`, which is mapped 1:1 from
+ * DynamoDB `use_new_invite_email_address` (set true only for meetings created after
+ * the January 2024 invite-responses release). The indexer stores that same DynamoDB
+ * attribute as `use_new_invite_email_address`; ITX GET exposes it as
+ * `is_invite_responses_enabled` and omits the field when false (Go `omitempty`).
  * Explicit `is_invite_responses_enabled` wins. Missing both layers becomes `false`
- * so Self Serve can hide RSVP UI for pre-feature meetings (GH-1951).
+ * so Self Serve can hide RSVP UI for pre-feature meetings (GH-1951 / InterUSS
+ * `91098305796`).
  */
 export function normalizeIndexedMeetingInviteResponses<
   T extends {

--- a/packages/shared/src/utils/rsvp-calculator.util.spec.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.spec.ts
@@ -459,6 +459,15 @@ describe('getRegistrantAttendanceStatus', () => {
     expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'accepted' }, invite_accepted: false })).toBe('accepted');
     expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'declined' }, invite_accepted: true })).toBe('declined');
   });
+
+  it('does not treat calendar invite_accepted as an RSVP when invite responses are disabled', () => {
+    expect(getRegistrantAttendanceStatus({ rsvp: null, invite_accepted: true }, { inviteResponsesEnabled: false })).toBe('pending');
+    expect(getRegistrantAttendanceStatus({ rsvp: null, invite_accepted: false }, { inviteResponsesEnabled: false })).toBe('pending');
+  });
+
+  it('still honours an explicit LFX RSVP when invite responses are disabled', () => {
+    expect(getRegistrantAttendanceStatus({ rsvp: { response_type: 'accepted' }, invite_accepted: false }, { inviteResponsesEnabled: false })).toBe('accepted');
+  });
 });
 
 describe('countRegistrantAttendance', () => {
@@ -485,5 +494,19 @@ describe('countRegistrantAttendance', () => {
       { rsvp: { response_type: 'declined' }, invite_accepted: null }, // Explicit LFX decline
     ];
     expect(countRegistrantAttendance(registrants)).toEqual({ accepted: 1, declined: 2, maybe: 0, total: 3 });
+  });
+
+  it('does not count calendar invite_accepted when invite responses are disabled', () => {
+    const registrants = [
+      { rsvp: null, invite_accepted: true },
+      { rsvp: null, invite_accepted: false },
+      { rsvp: { response_type: 'accepted' }, invite_accepted: null },
+    ];
+    expect(countRegistrantAttendance(registrants, { inviteResponsesEnabled: false })).toEqual({
+      accepted: 1,
+      declined: 0,
+      maybe: 0,
+      total: 3,
+    });
   });
 });

--- a/packages/shared/src/utils/rsvp-calculator.util.ts
+++ b/packages/shared/src/utils/rsvp-calculator.util.ts
@@ -210,20 +210,29 @@ export type RegistrantAttendanceStatus = 'accepted' | 'declined' | 'maybe' | 'pe
  * - An explicit RSVP `response_type` (accepted / declined / maybe) is authoritative.
  * - When there is no RSVP response — either the registrant has no RSVP at all,
  *   or none of their RSVPs are applicable to the target occurrence — fall back
- *   to `invite_accepted` (the series-level Google Calendar / Zoom invite state).
+ *   to `invite_accepted` (the series-level Google Calendar / Zoom invite state)
+ *   unless `options.inviteResponsesEnabled` is `false` (pre-feature meetings
+ *   never collected LFX RSVPs; GH-1951).
  * - Otherwise pending.
  *
  * The caller is responsible for pre-resolving the passed-in `rsvp` (typically
  * via {@link selectApplicableRsvp} against the target occurrence) — this helper
  * doesn't know about scopes.
  */
-export function getRegistrantAttendanceStatus(registrant: {
-  rsvp?: { response_type?: string | null } | null;
-  invite_accepted?: boolean | null;
-}): RegistrantAttendanceStatus {
+export function getRegistrantAttendanceStatus(
+  registrant: {
+    rsvp?: { response_type?: string | null } | null;
+    invite_accepted?: boolean | null;
+  },
+  options?: { inviteResponsesEnabled?: boolean }
+): RegistrantAttendanceStatus {
   const rsvpResponse = registrant.rsvp?.response_type;
   if (rsvpResponse === 'accepted' || rsvpResponse === 'declined' || rsvpResponse === 'maybe') {
     return rsvpResponse;
+  }
+  // Pre-feature meetings never collected LFX RSVPs; calendar invite state is not an RSVP (GH-1951).
+  if (options?.inviteResponsesEnabled === false) {
+    return 'pending';
   }
   if (registrant.invite_accepted === true) return 'accepted';
   if (registrant.invite_accepted === false) return 'declined';
@@ -246,11 +255,12 @@ export function getRegistrantAttendanceStatus(registrant: {
  * the denominator matches the meeting's invited count.
  */
 export function countRegistrantAttendance(
-  registrants: ReadonlyArray<{ rsvp?: { response_type?: string | null } | null; invite_accepted?: boolean | null }>
+  registrants: ReadonlyArray<{ rsvp?: { response_type?: string | null } | null; invite_accepted?: boolean | null }>,
+  options?: { inviteResponsesEnabled?: boolean }
 ): RsvpCounts {
   const counts: RsvpCounts = { accepted: 0, declined: 0, maybe: 0, total: registrants.length };
   for (const r of registrants) {
-    const status = getRegistrantAttendanceStatus(r);
+    const status = getRegistrantAttendanceStatus(r, options);
     if (status === 'accepted') counts.accepted++;
     else if (status === 'declined') counts.declined++;
     else if (status === 'maybe') counts.maybe++;


### PR DESCRIPTION
## Summary
- Hide RSVP counts, Yes/Maybe/No breakdown, RSVP buttons, and guest-drawer response chips for meetings that predate LFX invite-response tracking (`is_invite_responses_enabled` is not true), matching PCC.
- Keep the invitee count so organizers can still see who is invited.
- Stop treating calendar `invite_accepted` as an LFX RSVP on those older series, which was producing misleading counts like "1 of 20 attending".

Closes #1951
Refs linuxfoundation/lfx-self-serve-ops#4

## Test plan
- [ ] Open InterUSS Governing Board Meeting (PCC meeting ID `91098305796`): organizer card shows invitee count only, not "X of Y attending" / Yes/Maybe/No
- [ ] Confirm a meeting created after January 2024 still shows the full RSVP UI (counts, buttons, guest chips)
- [ ] Invited non-organizer on a pre-feature meeting does not see Yes/Maybe/No RSVP buttons
- [ ] Pending actions and the Me-lens "Pending RSVP" filter do not include pre-feature meetings
- [ ] Guest drawer for a pre-feature meeting has no Response chips or RSVP filter


Made with [Cursor](https://cursor.com)